### PR TITLE
Add basic BuildKite pipeline to check coding style and run tests

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,3 +4,5 @@ steps:
   - wait
   - label: Check coding style
     command: cargo fmt --all -- --write-mode=diff
+  - label: Run tests
+    command: cargo test


### PR DESCRIPTION
This resolves #3 by adding a simple pipeline that:

1. Installs `rustfmt-preview` and then runs it to check the coding style.
2. Runs any Rust tests.