### PR TITLE
BuildKite, resources: Add Kubernetes deployment for the standalone node

### DIFF
--- a/.buildkite/pipeline.deploy-staging.yaml
+++ b/.buildkite/pipeline.deploy-staging.yaml
@@ -1,0 +1,13 @@
+steps:
+  - label: Build and push Docker image
+    command: >
+      cp resources/docker/thegraph-standalone-node/Dockerfile .
+      && gcloud container builds submit \
+           --tag gcr.io/the-graph-staging/thegraph-standalone-node ./
+  - wait
+  - label: Deploy the standalone node
+    command: >
+      kubectl apply \
+        --cluster=$BUILDKITE_TARGET_CLUSTER \
+        --user=$BUILDKITE_TARGET_CLUSTER \
+        -f resources/kubernetes/thegraph-standalone-node/deployment.yaml

--- a/resources/docker/thegraph-standalone-node/Dockerfile
+++ b/resources/docker/thegraph-standalone-node/Dockerfile
@@ -1,0 +1,4 @@
+FROM rust:latest
+COPY . .
+RUN cd thegraph-standalone-node && cargo install --bins
+CMD ["thegraph-standalone-node"]

--- a/resources/kubernetes/thegraph-standalone-node/deployment.yaml
+++ b/resources/kubernetes/thegraph-standalone-node/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: thegraph-standalone-node
+spec:
+  selector:
+    matchLabels:
+      app: thegraph-standalone-node
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: thegraph-standalone-node
+    spec:
+      containers:
+        - name: thegraph-standalone-node
+          image: gcr.io/the-graph-staging/thegraph-standalone-node:latest


### PR DESCRIPTION
This resolves #7 by adding a separate pipeline that is only run for commits pushed to `master`. It first runs the regular pipeline and then kicks off a Docker image build, uploads the Docker image to the Google Container Registry (GCR) and creates a Kubernetes deployment for it.

This requires a fair amount of configuration (kubectl, auth etc.) upfront, so next week we'll set up a bunch of hosted and preconfigured BuildKite agents and move away from running agents locally.