### PR TITLE
BuildKite, resources: Deploy docs via a thegraph-docs deployment (staging)

### DIFF
--- a/.buildkite/pipeline.deploy-staging-docs.yaml
+++ b/.buildkite/pipeline.deploy-staging-docs.yaml
@@ -1,0 +1,18 @@
+steps:
+  - label: Build and push Docker image
+    command: |
+      cp resources/docker/thegraph-docs/Dockerfile . \
+      && gcloud container builds submit \
+         --timeout=25m \
+         --tag gcr.io/the-graph-staging/thegraph-docs .
+  - wait
+  - label: Deploy the docs
+    command: |
+      kubectl apply \
+         --cluster=$BUILDKITE_TARGET_CLUSTER \
+         --user=$BUILDKITE_TARGET_CLUSTER \
+         -f resources/kubernetes/thegraph-docs/deployment.yaml \
+      && kubectl apply \
+         --cluster=$BUILDKITE_TARGET_CLUSTER \
+         --user=$BUILDKITE_TARGET_CLUSTER \
+         -f resources/kubernetes/thegraph-docs/service.yaml

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -6,6 +6,10 @@ steps:
     command: cargo fmt --all -- --write-mode=diff
   - label: Run tests
     command: cargo test
+  - wait
   - label: Deploy to staging
     trigger: the-graph-network-staging-deployment
+    branches: master
+  - label: Deploy staging docs
+    trigger: the-graph-network-staging-docs
     branches: master

--- a/resources/docker/thegraph-docs/Dockerfile
+++ b/resources/docker/thegraph-docs/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:latest
+
+# Install clang (required for dependencies)
+RUN apt-get update \
+    && apt-get install -y clang libclang-dev
+
+# Install Python to serve the docs
+RUN apt-get install python
+
+# Copy, build, install and run thegraph-local-node
+COPY . .
+RUN cd thegraph-local-node && cargo doc --no-deps -p thegraph
+WORKDIR target/doc/
+CMD ["python", "-m", "SimpleHTTPServer", "8000"]

--- a/resources/kubernetes/thegraph-docs/deployment.yaml
+++ b/resources/kubernetes/thegraph-docs/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: thegraph-docs
+spec:
+  selector:
+    matchLabels:
+      app: thegraph-docs
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: thegraph-docs
+    spec:
+      containers:
+        - name: thegraph-docs
+          image: gcr.io/the-graph-staging/thegraph-docs:latest
+          ports:
+            - name: http
+              containerPort: 8000

--- a/resources/kubernetes/thegraph-docs/service.yaml
+++ b/resources/kubernetes/thegraph-docs/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: thegraph-docs
+spec:
+  type: LoadBalancer
+  selector:
+    app: thegraph-docs
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
This resolves #21. The generated Rust docs are now available via http://35.232.79.134/, and http://35.232.79.134/thegraph/ in particular.