### PR TITLE
resources/kubernetes: Remove the invalid nodePort

### DIFF
--- a/resources/kubernetes/thegraph-local-node/service.yaml
+++ b/resources/kubernetes/thegraph-local-node/service.yaml
@@ -11,4 +11,3 @@ spec:
       protocol: TCP
       port: 80
       targetPort: 8000
-      nodePort: 8000


### PR DESCRIPTION
This fixes the local node service created on Kubernetes.