### PR TITLE
BuildKite: Ensure we're always recreating local node pods

### DIFF
--- a/.buildkite/pipeline.deploy-staging.yaml
+++ b/.buildkite/pipeline.deploy-staging.yaml
@@ -8,7 +8,7 @@ steps:
   - wait
   - label: Deploy the local node
     command: |
-      kubectl apply \
+      kubectl apply --force \
          --cluster=$BUILDKITE_TARGET_CLUSTER \
          --user=$BUILDKITE_TARGET_CLUSTER \
          -f resources/kubernetes/thegraph-local-node/deployment.yaml \


### PR DESCRIPTION
This is just a small change to make sure that we always recreate local node staging deployment pods in order to have them pull in the latest image (instead of staying on the old).