### PR TITLE
Add a generated OrderDirection enum to the GraphQL API schema

### DIFF
--- a/thegraph-graphql-utils/src/api.rs
+++ b/thegraph-graphql-utils/src/api.rs
@@ -44,6 +44,7 @@ pub fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
 
     let mut schema = input_schema.clone();
     add_builtin_scalar_types(&mut schema)?;
+    add_order_direction_enum(&mut schema);
     add_types_for_object_types(&mut schema, &object_types)?;
     add_types_for_interface_types(&mut schema, &interface_types)?;
     add_query_type(&mut schema, &object_types, &interface_types)?;
@@ -71,6 +72,27 @@ fn add_builtin_scalar_types(schema: &mut Document) -> Result<(), APISchemaError>
     Ok(())
 }
 
+/// Adds a global `OrderDirection` type to the schema.
+fn add_order_direction_enum(schema: &mut Document) {
+    let typedef = TypeDefinition::Enum(EnumType {
+        position: Pos::default(),
+        description: None,
+        name: "OrderDirection".to_string(),
+        directives: vec![],
+        values: ["asc", "desc"]
+            .into_iter()
+            .map(|name| EnumValue {
+                position: Pos::default(),
+                description: None,
+                name: name.to_string(),
+                directives: vec![],
+            })
+            .collect(),
+    });
+    let def = Definition::TypeDefinition(typedef);
+    schema.definitions.push(def);
+}
+
 /// Adds `*_orderBy` and `*_filter` enum types for the given object types to the schema.
 fn add_types_for_object_types(
     schema: &mut Document,
@@ -78,7 +100,6 @@ fn add_types_for_object_types(
 ) -> Result<(), APISchemaError> {
     for object_type in object_types {
         add_order_by_type(schema, &object_type.name, &object_type.fields)?;
-        add_order_direction_type(schema, &object_type.name, &object_type.fields)?;
         add_filter_type(schema, &object_type.name, &object_type.fields)?;
     }
     Ok(())
@@ -91,7 +112,6 @@ fn add_types_for_interface_types(
 ) -> Result<(), APISchemaError> {
     for interface_type in interface_types {
         add_order_by_type(schema, &interface_type.name, &interface_type.fields)?;
-        add_order_direction_type(schema, &interface_type.name, &interface_type.fields)?;
         add_filter_type(schema, &interface_type.name, &interface_type.fields)?;
     }
     Ok(())
@@ -131,35 +151,6 @@ fn add_order_by_type(
     Ok(())
 }
 
-/// Adds a `<type_name>_orderDirection` enum type for the given fields to the schema.
-fn add_order_direction_type(schema: &mut Document, type_name: &Name, fields: &Vec<Field>,) -> Result<(), APISchemaError>{
-    let type_name = format!("{}_orderDirection", type_name).to_string();
-
-    match ast::get_named_type(schema, &type_name) {
-        None => {
-            let typedef = TypeDefinition::Enum(EnumType {
-                position: Pos::default(),
-                description: None,
-                name: type_name,
-                directives: vec![],
-                values: fields
-                    .iter()
-                    .map(|field| &field.name)
-                    .map(|name| EnumValue {
-                        position: Pos::default(),
-                        description: None,
-                        name: name.to_owned(),
-                        directives: vec![]
-                    })
-                    .collect(),
-            });
-            let def = Definition::TypeDefinition(typedef);
-            schema.definitions.push(def);
-        }
-        Some(_) => return Err(APISchemaError::TypeExists(type_name)),
-    }
-    Ok(())
-}
 /// Adds a `<type_name>_filter` enum type for the given fields to the schema.
 fn add_filter_type(
     schema: &mut Document,
@@ -332,6 +323,11 @@ fn query_fields_for_type(_schema: &Document, type_name: &Name) -> Vec<Field> {
                     Type::NamedType(format!("{}_orderBy", type_name)),
                 ),
                 input_value(
+                    &"orderDirection".to_string(),
+                    "",
+                    Type::NamedType("OrderDirection".to_string()),
+                ),
+                input_value(
                     &"where".to_string(),
                     "",
                     Type::NamedType(format!("{}_filter", type_name)),
@@ -370,6 +366,23 @@ mod tests {
     }
 
     #[test]
+    fn api_schema_contains_order_direction_enum() {
+        let input_schema = parse_schema("type User { id: ID!, name: String! }")
+            .expect("Failed to parse input schema");
+        let schema = api_schema(&input_schema).expect("Failed to derived API schema");
+
+        let order_direction = ast::get_named_type(&schema, &"OrderDirection".to_string())
+            .expect("OrderDirection type is missing in derived API schema");
+        let enum_type = match order_direction {
+            TypeDefinition::Enum(t) => Some(t),
+            _ => None,
+        }.expect("OrderDirection type is not an enum");
+
+        let values: Vec<&Name> = enum_type.values.iter().map(|value| &value.name).collect();
+        assert_eq!(values, [&"asc".to_string(), &"desc".to_string()]);
+    }
+
+    #[test]
     fn api_schema_contains_query_type() {
         let input_schema =
             parse_schema("type User { id: ID! }").expect("Failed to parse input schema");
@@ -391,24 +404,6 @@ mod tests {
             TypeDefinition::Enum(t) => Some(t),
             _ => None,
         }.expect("User_orderBy type is not an enum");
-
-        let values: Vec<&Name> = enum_type.values.iter().map(|value| &value.name).collect();
-        assert_eq!(values, [&"id".to_string(), &"name".to_string()]);
-    }
-
-    #[test]
-    fn api_schema_contains_field_order_direction_enum() {
-        let input_schema = parse_schema("type User { id: ID!, name: String! }")
-            .expect("Failed to parse input schema");
-        let schema = api_schema(&input_schema).expect("Failed to derived API schema");
-
-        let user_order_direction = ast::get_named_type(&schema, &"User_orderDirection".to_string())
-            .expect("User_orderDirection type is missing in derived API schema");
-
-        let enum_type = match user_order_direction {
-            TypeDefinition::Enum(t) => Some(t),
-            _ => None,
-        }.expect("User_orderDirection type is not an enum");
 
         let values: Vec<&Name> = enum_type.values.iter().map(|value| &value.name).collect();
         assert_eq!(values, [&"id".to_string(), &"name".to_string()]);
@@ -487,8 +482,16 @@ mod tests {
                 .iter()
                 .map(|input_value| input_value.name.to_owned())
                 .collect::<Vec<String>>(),
-            ["skip", "first", "last", "after", "before", "orderBy", "where",]
-                .into_iter()
+            [
+                "skip",
+                "first",
+                "last",
+                "after",
+                "before",
+                "orderBy",
+                "orderDirection",
+                "where",
+            ].into_iter()
                 .map(|name| name.to_string())
                 .collect::<Vec<String>>()
         );
@@ -544,8 +547,16 @@ mod tests {
                 .iter()
                 .map(|input_value| input_value.name.to_owned())
                 .collect::<Vec<String>>(),
-            ["skip", "first", "last", "after", "before", "orderBy", "where",]
-                .into_iter()
+            [
+                "skip",
+                "first",
+                "last",
+                "after",
+                "before",
+                "orderBy",
+                "orderDirection",
+                "where",
+            ].into_iter()
                 .map(|name| name.to_string())
                 .collect::<Vec<String>>()
         );


### PR DESCRIPTION
Resolves #71

Add Order Direction to queries built from GraphQL arguments. 
* Include Order Direction in Interface and Object types during processing of GraphQL input into StoreQuery
* Test to confirm that Order Direction enum is contained in a field of the API schema