### PR TITLE
Refactor schema providers towards better abstracting components

### DIFF
--- a/thegraph-local-node/src/main.rs
+++ b/thegraph-local-node/src/main.rs
@@ -23,6 +23,7 @@ use tokio::prelude::*;
 use tokio_core::reactor::Core;
 
 use thegraph::components::data_sources::RuntimeAdapterEvent;
+use thegraph::components::{EventConsumer, EventProducer};
 use thegraph::prelude::*;
 use thegraph::util::log::logger;
 use thegraph_hyper::GraphQLServer as HyperGraphQLServer;
@@ -102,7 +103,7 @@ fn main() {
 
     // Forward schema events from the data source provider to the schema provider
     let schema_stream = data_source_provider.schema_event_stream().unwrap();
-    let schema_sink = schema_provider.schema_event_sink();
+    let schema_sink = schema_provider.event_sink();
     core.handle().spawn({
         schema_stream
             .forward(schema_sink.sink_map_err(|e| {
@@ -112,7 +113,7 @@ fn main() {
     });
 
     // Forward schema events from the schema provider to the store and GraphQL server
-    let schema_stream = schema_provider.event_stream().unwrap();
+    let schema_stream = schema_provider.take_event_stream().unwrap();
     core.handle().spawn({
         schema_stream
             .forward(

--- a/thegraph/src/components/mod.rs
+++ b/thegraph/src/components/mod.rs
@@ -1,3 +1,40 @@
+//! The Graph network nodes are internally structured as a layers of reusable
+//! components with non-blocking communication, with each component having a
+//! corresponding trait defining it's interface.
+//!
+//! As examples of components, at the top layer component there is the GraphQL
+//! server which interacts with clients, and at the lowest layer we have data
+//! sources that interact with storage backends.
+//!
+//! The layers are not well defined, but it's expected that a higher-level
+//! component will make requests for a lower-level component to respond, and
+//! that a lower-level component will sent events to interested higher-level
+//! components when it's state changes.
+//!
+//! A request/response interaction between C1 and C2 is made by C1 requiring an
+//! `Arc<C2>` in it's constructor and then calling the functions defined on C2.
+//!
+//! Event-based interactions propagate changes in the underlining data upwards
+//! in the component graph, with low level components generating event streams
+//! based on changes in external systems, mid level components transforming
+//! these streams and high level components finally consuming the received
+//! events.
+//!
+//! These events are communicated through sinks and streams (typically senders
+//! and receivers of channels), which are managed by long-running Tokio tasks.
+//! Each component may have an internal task for handling input events and
+//! sending out output events, and the "dumb pipes" that plug together components
+//! are tasks that send out events in the order that they are received.
+//!
+//! A component declares it's inputs and outputs by having `EventConsumer<U>` and
+//! `EventProducer<T>` traits as supertraits.
+//!
+//! Components should use the helper functions in this module (e.g. `forward`)
+//! that define common operations on event streams, facilitating the
+//! configuration of component graphs.
+
+use futures::prelude::*;
+
 /// Components dealing with data sources.
 pub mod data_sources;
 
@@ -15,3 +52,54 @@ pub mod server;
 
 /// Components dealing with storing entities.
 pub mod store;
+
+/// Plug the outputs of `output` of type `E` to the matching inputs in `input`.
+/// This is a lazy operation, nothing will be sent until you spawn the returned
+/// future. Returns `Some` in the first call and `None` on any further calls.
+///
+/// See `Stream::forward` for details.
+pub fn forward<E, O: EventProducer<E>, I: EventConsumer<E>>(
+    output: &mut O,
+    input: &I,
+) -> Option<impl Future<Item = (), Error = ()>> {
+    output
+        .take_event_stream()
+        .map(|stream| stream.forward(input.event_sink()).map(|_| ()))
+}
+
+/// Like `forward`, but forwards outputs to two components by cloning the
+/// events. If you need more, create more versions of this or manipulate
+/// `event_sink()` and `take_event_stream()` directly.
+pub fn forward2<E: Clone, O: EventProducer<E>, I1: EventConsumer<E>, I2: EventConsumer<E>>(
+    output: &mut O,
+    input1: &I1,
+    input2: &I2,
+) -> Option<impl Future<Item = (), Error = ()>> {
+    output.take_event_stream().map(|stream| {
+        stream
+            .forward(input1.event_sink().fanout(input2.event_sink()))
+            .map(|_| ())
+    })
+}
+
+/// A component that receives events of type `T`.
+pub trait EventConsumer<E> {
+    type EventSink: Sink<SinkItem = E, SinkError = ()>;
+
+    /// Get the event sink.
+    ///
+    /// Avoid calling directly, prefer helpers such as `forward`.
+    fn event_sink(&self) -> Self::EventSink;
+}
+
+/// A component that outputs events of type `T`.
+pub trait EventProducer<E> {
+    type EventStream: Stream<Item = E, Error = ()>;
+
+    /// Get the event stream. Because we use single-consumer semantics, the
+    /// first caller will take the output stream and any further calls will
+    /// return `None`.
+    ///
+    /// Avoid calling directly, prefer helpers such as `forward`.
+    fn take_event_stream(&mut self) -> Option<Self::EventStream>;
+}


### PR DESCRIPTION
Closes #91. I don't think we want that anymore, this abstraction is more general.

This does a few things:
- Document a mental model for components.
- Introduce the `InEvent<E>` and `OutEvent<E>` traits to abstract the passing of events among components.
- Introduce the `forward` helper to showcase how this abstraction can help us configure components, though we don't use it yet.
- Prototype these new traits on the `SchemaProvider` trait and it's implementations.
- Refactor the schema provider implementations. There were some internal `Mutex`es which seemed to be operating on the assumption that the same component instance could be spawned twice. We never do that and imo don't want to, we can have multiple instances of a component but each instance should be spawned only once.

If this looks good, next directions would be:
1. Incrementally applying this mental model and abstractions to old and new components.
2. Abstracting direct dependency among components for request/response communication (e.g. when the server requests a query to the query runner).