### PR TITLE
WIP: `EthereumAdapter` contract call and subscriptions

### DIFF
--- a/thegraph-ethereum/Cargo.toml
+++ b/thegraph-ethereum/Cargo.toml
@@ -8,5 +8,6 @@ ethabi = "5.1.1"
 futures = "0.1.21"
 serde_json = "1.0"
 thegraph = { path = "../thegraph" }
+tiny-keccak = "1.0"
 tokio-core = "0.1.6"
 web3 = { git = "https://github.com/tomusdrw/rust-web3" }

--- a/thegraph-ethereum/src/lib.rs
+++ b/thegraph-ethereum/src/lib.rs
@@ -2,6 +2,7 @@ extern crate ethabi;
 extern crate futures;
 extern crate serde_json;
 extern crate thegraph;
+extern crate tiny_keccak;
 extern crate tokio_core;
 extern crate web3;
 
@@ -168,6 +169,9 @@ mod tests {
         let work = adapter.contract_call(call_request);
         let call_result = core.run(work).unwrap();
 
-        println!("Result from calling GNT.balanceOf(0x00d04c4b12C4686305bb4F4fC93487CdFBa62580): {:?}", call_result[0]);
+        println!(
+            "Result from calling GNT.balanceOf(0x00d04c4b12C4686305bb4F4fC93487CdFBa62580): {:?}",
+            call_result[0]
+        );
     }
 }

--- a/thegraph/Cargo.toml
+++ b/thegraph/Cargo.toml
@@ -13,6 +13,7 @@ serde_yaml = "0.7"
 slog = "2.2.3"
 slog-async = "2.3.0"
 slog-term = "2.4.0"
+tiny-keccak = "1.0"
 tokio = "0.1.6"
 tokio-core = "0.1.17"
 web3 = { git = "https://github.com/tomusdrw/rust-web3" }

--- a/thegraph/src/components/ethereum/adapter.rs
+++ b/thegraph/src/components/ethereum/adapter.rs
@@ -1,4 +1,5 @@
-use ethabi::{Bytes, Event, EventParam, Function, LogParam, Token};
+use ethabi;
+use ethabi::{Bytes, Event, Function, LogParam, Token};
 use ethereum_types::{Address, H256};
 use futures::{Future, Stream};
 use web3::error::Error as Web3Error;
@@ -34,6 +35,12 @@ pub enum EthereumContractCallError {
     Failed,
 }
 
+#[derive(Debug)]
+pub enum EthereumSubscriptionError {
+    RpcError(Web3Error),
+    ParseError(ethabi::Error),
+}
+
 /// A range to allow event subscriptions to limit the block numbers to consider.
 #[derive(Debug)]
 pub struct BlockNumberRange {
@@ -47,7 +54,6 @@ pub struct EthereumEventSubscription {
     /// An ID that uniquely identifies the subscription (e.g. a GUID).
     pub subscription_id: String,
     pub address: Address,
-    pub event_signature: String,
     pub range: BlockNumberRange,
     pub event: Event,
 }
@@ -81,7 +87,7 @@ pub trait EthereumAdapter {
     fn subscribe_to_event(
         &mut self,
         subscription: EthereumEventSubscription,
-    ) -> Box<Stream<Item = EthereumEvent, Error = Web3Error>>;
+    ) -> Box<Stream<Item = EthereumEvent, Error = EthereumSubscriptionError>>;
 
     /// Cancel a specific event subscription. Returns true when the subscription existed before.
     fn unsubscribe_from_event(&mut self, subscription_id: String) -> bool;

--- a/thegraph/src/components/ethereum/mod.rs
+++ b/thegraph/src/components/ethereum/mod.rs
@@ -3,4 +3,8 @@ mod adapter;
 pub use self::adapter::{BlockNumberRange, EthereumAdapter, EthereumContractCallError,
                         EthereumContractCallRequest, EthereumContractState,
                         EthereumContractStateError, EthereumContractStateRequest, EthereumEvent,
-                        EthereumEventSubscription};
+                        EthereumEventSubscription, EthereumSubscriptionError};
+
+pub use web3::types::BlockNumber;
+
+pub use ethabi::{Contract, Event};

--- a/thegraph/src/data/data_sources.rs
+++ b/thegraph/src/data/data_sources.rs
@@ -7,7 +7,7 @@ pub struct Location {
 
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct DataStructure {
-    abi: String,
+    pub abi: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize)]

--- a/thegraph/src/lib.rs
+++ b/thegraph/src/lib.rs
@@ -10,6 +10,7 @@ extern crate serde_yaml;
 extern crate slog;
 extern crate slog_async;
 extern crate slog_term;
+extern crate tiny_keccak;
 extern crate tokio;
 extern crate tokio_core;
 extern crate web3;

--- a/thegraph/src/util/ethereum.rs
+++ b/thegraph/src/util/ethereum.rs
@@ -1,0 +1,19 @@
+use ethabi::{Contract, Event};
+use ethereum_types::H256;
+use tiny_keccak::sha3_256;
+
+fn string_to_H256(string: &str) -> H256 {
+    let bytes = string.as_bytes();
+    let hash = sha3_256(bytes);
+    H256::from_slice(&hash[0..32])
+}
+
+// Checks if an ethabi Contract contains an event with a particular signature, and returns
+// that event, if present.
+pub fn get_contract_event_by_signature(contract: &Contract, signature: &str) -> Option<Event> {
+    contract
+        .events()
+        .filter(|event| event.signature() == string_to_H256(signature))
+        .next()
+        .map(|event| event.clone())
+}

--- a/thegraph/src/util/mod.rs
+++ b/thegraph/src/util/mod.rs
@@ -3,3 +3,6 @@ pub mod stream;
 
 /// Logging facilities based on `slog`.
 pub mod log;
+
+/// Utils for working with ethereum data types
+pub mod ethereum;


### PR DESCRIPTION
This PR implements functions for calling Ethereum contract methods and subscribing to Ethereum contract events using the `EthereumAdapter`.

In general I would like to see this code cleaned up and more useful tests added before it's merged (some tests currently fail because dependent on local dev environment), but I wanted to push something up so @Jannis can start working on integration.

I'm also particularly interested in whether the way that we are wrapping/ dealing with Errors is idiomatic. 

The PR also makes some assumptions about what is stored in `DataStructure.abi` which I'm not sure is correct and should also be further tested.