### PR TITLE
Refactor event traits and implement them for `DataSourceProvider`

### DIFF
--- a/thegraph-core/src/data_sources/manager.rs
+++ b/thegraph-core/src/data_sources/manager.rs
@@ -125,10 +125,8 @@ impl RuntimeManager where {
 }
 
 impl EventConsumer<DataSourceProviderEvent> for RuntimeManager {
-    type EventSink = Box<Sink<SinkItem = DataSourceProviderEvent, SinkError = ()>>;
-
     /// Get the wrapped event sink.
-    fn event_sink(&self) -> Self::EventSink {
+    fn event_sink(&self) -> Box<Sink<SinkItem = DataSourceProviderEvent, SinkError = ()>> {
         let logger = self.logger.clone();
         Box::new(self.input.clone().sink_map_err(move |e| {
             error!(logger, "Component was dropped: {}", e);

--- a/thegraph-graphql-utils/src/store/resolver.rs
+++ b/thegraph-graphql-utils/src/store/resolver.rs
@@ -195,8 +195,7 @@ impl Resolver for StoreResolver {
         // Return an empty list if we're dealing with a non-derived field that
         // holds an empty list of references; there's no point in querying the store
         // if the result will be empty anyway
-        if !is_derived
-            && parent.is_some()
+        if !is_derived && parent.is_some()
             && Self::references_field_is_empty(parent, &field_definition.name)
         {
             return q::Value::List(vec![]);

--- a/thegraph-runtime/src/host.rs
+++ b/thegraph-runtime/src/host.rs
@@ -238,10 +238,10 @@ impl RuntimeHost {
 }
 
 impl EventProducer<RuntimeHostEvent> for RuntimeHost {
-    type EventStream = Receiver<RuntimeHostEvent>;
-
-    fn take_event_stream(&mut self) -> Option<Self::EventStream> {
-        self.output.take()
+    fn take_event_stream(&mut self) -> Option<Box<Stream<Item = RuntimeHostEvent, Error = ()>>> {
+        self.output
+            .take()
+            .map(|s| Box::new(s) as Box<Stream<Item = RuntimeHostEvent, Error = ()>>)
     }
 }
 

--- a/thegraph/src/components/data_sources/provider.rs
+++ b/thegraph/src/components/data_sources/provider.rs
@@ -1,8 +1,6 @@
-use futures::sync::mpsc::Receiver;
-
+use components::EventProducer;
 use data::data_sources::DataSourceDefinition;
 use data::schema::Schema;
-use util::stream::StreamError;
 
 /// Events emitted by [DataSourceProvider](trait.DataSourceProvider.html) implementations.
 #[derive(Clone, Debug)]
@@ -23,12 +21,7 @@ pub enum SchemaEvent {
 }
 
 /// Common trait for data source providers.
-pub trait DataSourceProvider {
-    /// Receiver from which others can read events emitted by the data source provider.
-    /// Can only be called once. Any consecutive call will result in a StreamError.
-    fn event_stream(&mut self) -> Result<Receiver<DataSourceProviderEvent>, StreamError>;
-
-    /// Receiver from whith others can read schema-only events emitted by the data source provider.
-    /// Can only be called once. Any consecutive call will result in a StreamError.
-    fn schema_event_stream(&mut self) -> Result<Receiver<SchemaEvent>, StreamError>;
+pub trait DataSourceProvider:
+    EventProducer<DataSourceProviderEvent> + EventProducer<SchemaEvent>
+{
 }

--- a/thegraph/src/components/mod.rs
+++ b/thegraph/src/components/mod.rs
@@ -86,22 +86,18 @@ pub fn forward2<E: Clone, O: EventProducer<E>, I1: EventConsumer<E>, I2: EventCo
 
 /// A component that receives events of type `T`.
 pub trait EventConsumer<E> {
-    type EventSink: Sink<SinkItem = E, SinkError = ()>;
-
     /// Get the event sink.
     ///
     /// Avoid calling directly, prefer helpers such as `forward`.
-    fn event_sink(&self) -> Self::EventSink;
+    fn event_sink(&self) -> Box<Sink<SinkItem = E, SinkError = ()>>;
 }
 
 /// A component that outputs events of type `T`.
 pub trait EventProducer<E> {
-    type EventStream: Stream<Item = E, Error = ()>;
-
     /// Get the event stream. Because we use single-consumer semantics, the
     /// first caller will take the output stream and any further calls will
     /// return `None`.
     ///
     /// Avoid calling directly, prefer helpers such as `forward`.
-    fn take_event_stream(&mut self) -> Option<Self::EventStream>;
+    fn take_event_stream(&mut self) -> Option<Box<Stream<Item = E, Error = ()>>>;
 }


### PR DESCRIPTION
Got a bit carried away while toying with this. Part of #102.

Because `DataSourceProvider` implements `EventProducer` twice I was getting weird inference errors. So the traits are refactored to return a boxed `Stream` or `Sink` object rather than an associated type.

It's nice that we can now use the `forward` function.