### PR TITLE
Add Bytes and BigInt scalars to API schema

### DIFF
--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -54,7 +54,7 @@ pub fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
 
 /// Adds built-in GraphQL scalar types (`Int`, `String` etc.) to the schema.
 fn add_builtin_scalar_types(schema: &mut Document) -> Result<(), APISchemaError> {
-    for name in ["Boolean", "ID", "Int", "Float", "String"].into_iter() {
+    for name in ["Boolean", "ID", "Int", "Float", "String", "Bytes", "BigInt"].into_iter() {
         match ast::get_named_type(schema, &name.to_string()) {
             None => {
                 let typedef = TypeDefinition::Scalar(ScalarType {


### PR DESCRIPTION
Mini-PR to add missing `scalar Bytes` and `scalar BigInt` definitions to the generated API schema.