### PR TITLE
Update Diesel.rs to latest version: v1.3.2

### DIFF
--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 [dependencies]
 bigdecimal = "0.0.11"
-diesel = { version = "1.3.0", features = ["postgres", "serde_json", "numeric"] }
+diesel = { version = "1.3.2", features = ["postgres", "serde_json", "numeric"] }
 diesel_migrations = "1.3.0"
 ethereum-types = "0.3"
 diesel-dynamic-schema = { git = "https://github.com/diesel-rs/diesel-dynamic-schema" }


### PR DESCRIPTION
This resolves #206 

No more `EmbedMigrations` macro warnings during build!