### PR TITLE
Fix filtering with a GraphQL "where" argument

### DIFF
--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -51,7 +51,7 @@ fn build_filter(
     arguments: &HashMap<&q::Name, q::Value>,
 ) -> Option<StoreFilter> {
     arguments
-        .get(&"filter".to_string())
+        .get(&"where".to_string())
         .and_then(|value| match value {
             q::Value::Object(object) => Some(object),
             _ => None,
@@ -380,7 +380,7 @@ mod tests {
                 },
                 &HashMap::from_iter(
                     vec![(
-                        &"filter".to_string(),
+                        &"where".to_string(),
                         q::Value::Object(BTreeMap::from_iter(vec![(
                             "name_ends_with".to_string(),
                             q::Value::String("ello".to_string()),


### PR DESCRIPTION
Somehow, the GraphQL query to Store query conversion assumed filters were passed in via `"filter"`, not `"where"`. Also, when converting from GraphQL values to attribute values, handling non-null types wasn't accounted for.