### PR TITLE
Add build_subgraph_id to StoreKey in graphql resolver

### DIFF
--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -128,7 +128,7 @@ fn build_order_direction(arguments: &HashMap<&q::Name, q::Value>) -> Option<Stor
 }
 
 /// Parses the subgraph ID from the ObjectType directives.
-fn build_subgraph_id(entity: &schema::ObjectType) -> Option<String> {
+pub fn build_subgraph_id(entity: &schema::ObjectType) -> Option<String> {
     entity
         .clone()
         .directives

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -10,6 +10,7 @@ use graph::prelude::{BasicStore, Value};
 use prelude::*;
 use query::ast as qast;
 use schema::ast as sast;
+use store::query::build_subgraph_id;
 
 /// A resolver that fetches entities from a `Store`.
 #[derive(Clone)]
@@ -238,7 +239,8 @@ impl Resolver for StoreResolver {
             let store = self.store.lock().unwrap();
             return store
                 .get(StoreKey {
-                    subgraph: String::from("stub_subgraph"),
+                    subgraph: build_subgraph_id(object_type)
+                        .expect(format!("Failed to get subgraph ID from type: {}", object_type.name).as_str()),
                     entity: object_type.name.to_owned(),
                     id: id.to_owned(),
                 })
@@ -252,7 +254,8 @@ impl Resolver for StoreResolver {
                     .lock()
                     .unwrap()
                     .get(StoreKey {
-                        subgraph: String::from("stub_subgraph"),
+                        subgraph: build_subgraph_id(object_type)
+                            .expect(format!("Failed to get subgraph ID from type: {}", object_type.name).as_str()),
                         entity: object_type.name.to_owned(),
                         id: id.to_owned(),
                     })


### PR DESCRIPTION
Use the build_subgraph_id function to pull the subgraph_id out of `ObjectType` in the graphql resolver for use in `StoreKey`. 