### PR TITLE
Improve event signature matching: event handlers.event no longer sensitive to whitespace

### DIFF
--- a/graph/src/util/ethereum.rs
+++ b/graph/src/util/ethereum.rs
@@ -5,7 +5,7 @@ use tiny_keccak::Keccak;
 /// Hashes a string to a H256 hash.
 pub fn string_to_h256(s: &str) -> H256 {
     let mut result = [0u8; 32];
-
+    let ss = &s.replace(" ", "")[..];
     let data: Vec<u8> = From::from(s);
     let mut sponge = Keccak::new_keccak256();
     sponge.update(&data);

--- a/graph/src/util/ethereum.rs
+++ b/graph/src/util/ethereum.rs
@@ -5,8 +5,7 @@ use tiny_keccak::Keccak;
 /// Hashes a string to a H256 hash.
 pub fn string_to_h256(s: &str) -> H256 {
     let mut result = [0u8; 32];
-    let ss = &s.replace(" ", "")[..];
-    let data: Vec<u8> = From::from(s);
+    let data = s.replace(" ", "").into_bytes();
     let mut sponge = Keccak::new_keccak256();
     sponge.update(&data);
     sponge.finalize(&mut result);


### PR DESCRIPTION
Resolves #229 

The event signature specified in the event handler of the subgraph manifest is compared against Ethereum events by comparing the hash.  The comparison process was sensitive to whitespace which has made it more difficult to debug event signature mismatch errors.  Rather than require developers to remove all whitespace we are stripping whitespace when the event signature hash is built from the user provided string.