### PR TITLE
Show debug logs in release builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,6 @@ dependencies = [
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -617,7 +616,6 @@ dependencies = [
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -627,7 +625,6 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.1.0",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -648,7 +645,6 @@ dependencies = [
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -666,7 +662,6 @@ dependencies = [
  "num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "web3 0.3.1 (git+https://github.com/tomusdrw/rust-web3)",
@@ -684,7 +679,6 @@ dependencies = [
  "hyper 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -701,7 +695,6 @@ dependencies = [
  "graph 0.1.0",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.1.0"
 ethereum-types = "0.3"
 futures = "0.1.21"
 graphql-parser = "0.2.0"
-slog = "2.2.3"
 graph = { path = "../graph" }
 graph-graphql = { path = "../graphql" }
 graph-runtime-wasm = { path = "../runtime/wasm" }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,11 +1,9 @@
 extern crate ethereum_types;
 extern crate futures;
-extern crate graphql_parser;
-#[macro_use]
-extern crate slog;
 extern crate graph;
 extern crate graph_graphql;
 extern crate graph_runtime_wasm;
+extern crate graphql_parser;
 extern crate serde;
 extern crate serde_yaml;
 

--- a/core/src/query/runner.rs
+++ b/core/src/query/runner.rs
@@ -1,14 +1,12 @@
-use futures::prelude::*;
 use futures::sync::mpsc::{channel, Receiver, Sender};
-use slog;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
-use graph::prelude::{tokio, Query, QueryRunner as QueryRunnerTrait, Store};
+use graph::prelude::{QueryRunner as QueryRunnerTrait, *};
 use graph_graphql::prelude::*;
 
 /// Common query runner implementation for The Graph.
 pub struct QueryRunner<S> {
-    logger: slog::Logger,
+    logger: Logger,
     query_sink: Sender<Query>,
     store: Arc<Mutex<S>>,
 }
@@ -18,7 +16,7 @@ where
     S: Store + Sized + 'static,
 {
     /// Creates a new query runner.
-    pub fn new(logger: &slog::Logger, store: Arc<Mutex<S>>) -> Self {
+    pub fn new(logger: &Logger, store: Arc<Mutex<S>>) -> Self {
         let (sink, stream) = channel(100);
         let runner = QueryRunner {
             logger: logger.new(o!("component" => "QueryRunner")),

--- a/core/src/schema/provider.rs
+++ b/core/src/schema/provider.rs
@@ -1,13 +1,7 @@
-use futures::prelude::*;
 use futures::sync::mpsc::{channel, Receiver, Sender};
-use graph::tokio;
-use slog::Logger;
 use std::collections::HashMap;
 
-use graph::components::schema::{SchemaProvider as SchemaProviderTrait, SchemaProviderEvent};
-use graph::components::subgraph::SchemaEvent;
-use graph::components::{EventConsumer, EventProducer};
-use graph::data::schema::Schema;
+use graph::prelude::{SchemaProvider as SchemaProviderTrait, *};
 
 use graph_graphql::prelude::*;
 
@@ -127,11 +121,8 @@ impl SchemaProvider {
 mod tests {
     use graphql_parser;
 
-    use graph::components::schema::SchemaProviderEvent;
-    use graph::components::subgraph::SchemaEvent;
     use graph::prelude::*;
     use graph_graphql::schema::ast;
-    use slog;
 
     use super::SchemaProvider as CoreSchemaProvider;
 
@@ -140,7 +131,7 @@ mod tests {
         tokio::run(future::lazy(|| {
             Ok({
                 // Set up the schema provider
-                let logger = slog::Logger::root(slog::Discard, o!());
+                let logger = Logger::root(slog::Discard, o!());
                 let mut schema_provider = CoreSchemaProvider::new(&logger);
                 let schema_sink = schema_provider.event_sink();
                 let schema_stream = schema_provider.take_event_stream().unwrap();

--- a/core/src/subgraph/manager.rs
+++ b/core/src/subgraph/manager.rs
@@ -1,7 +1,6 @@
 use ethereum_types::H256;
 use futures::sync::mpsc::{channel, Receiver, Sender};
-use slog::Logger;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use graph::components::store::EventSource;
 use graph::components::subgraph::RuntimeHostEvent;

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -5,7 +5,6 @@ extern crate graph_core;
 extern crate graph_mock;
 extern crate graph_runtime_wasm;
 extern crate ipfs_api;
-extern crate slog;
 
 use futures::{Future, Sink};
 use graph::components::ethereum::*;

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -15,7 +15,7 @@ num-bigint = { version = "0.2.0", features = ["serde"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_yaml = "0.7"
-slog = "2.2.3"
+slog = { version = "2.2.3", features = ["release_max_level_debug"] }
 slog-async = "2.3.0"
 slog-term = "2.4.0"
 tiny-keccak = "1.0"

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -9,7 +9,7 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_yaml;
 #[macro_use]
-extern crate slog;
+pub extern crate slog;
 extern crate failure;
 extern crate ipfs_api;
 extern crate parity_wasm;
@@ -36,6 +36,12 @@ pub mod util;
 /// use graph::prelude::*;
 /// ```
 pub mod prelude {
+    // Glob import from `slog` to re-export the macros, but prevent
+    // `slog::Result` from shadowing `Result`. Rust 2018 will have proper macro
+    // imports then we can remove `slog::*` in favor of something fine-grained.
+    pub use slog;
+    pub use slog::*;
+    pub use std::result::Result;
     pub use tokio;
     pub use tokio::prelude::*;
 
@@ -50,8 +56,8 @@ pub mod prelude {
         BasicStore, Store, StoreEvent, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange,
     };
     pub use components::subgraph::{
-        RuntimeHost, RuntimeHostBuilder, RuntimeHostEvent, RuntimeManager, SubgraphProvider,
-        SubgraphProviderEvent,
+        RuntimeHost, RuntimeHostBuilder, RuntimeHostEvent, RuntimeManager, SchemaEvent,
+        SubgraphProvider, SubgraphProviderEvent,
     };
     pub use components::{EventConsumer, EventProducer};
 

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -7,7 +7,6 @@ graphql-parser = "0.2.0"
 indexmap = "1.0"
 Inflector = "0.11.3"
 serde = "1.0"
-slog = "2.2.3"
 graph = { path = "../graph" }
 
 [dev-dependencies]

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -1,5 +1,4 @@
 use graphql_parser::{query as q, schema as s};
-use slog;
 use std::collections::{BTreeMap, HashMap};
 
 use graph::prelude::*;

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -1,10 +1,8 @@
+extern crate graph;
 extern crate graphql_parser;
 extern crate indexmap;
 extern crate inflector;
 extern crate serde;
-#[macro_use]
-extern crate slog;
-extern crate graph;
 
 /// Utilities for working with GraphQL schemas.
 pub mod schema;

--- a/graphql/src/query/execution.rs
+++ b/graphql/src/query/execution.rs
@@ -1,7 +1,6 @@
 use graphql_parser::query as q;
 use graphql_parser::schema as s;
 use indexmap::IndexMap;
-use slog;
 use std::cmp;
 use std::collections::{BTreeMap, HashMap, HashSet};
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -1,11 +1,10 @@
 use graphql_parser::{query as q, schema as s};
-use slog;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 
 use graph::components::store::*;
-use graph::prelude::{BasicStore, Value};
+use graph::prelude::{slog::*, BasicStore, Value};
 
 use prelude::*;
 use query::ast as qast;
@@ -15,12 +14,12 @@ use store::query::build_subgraph_id;
 /// A resolver that fetches entities from a `Store`.
 #[derive(Clone)]
 pub struct StoreResolver {
-    logger: slog::Logger,
+    logger: Logger,
     store: Arc<Mutex<BasicStore>>,
 }
 
 impl StoreResolver {
-    pub fn new(logger: &slog::Logger, store: Arc<Mutex<BasicStore>>) -> Self {
+    pub fn new(logger: &Logger, store: Arc<Mutex<BasicStore>>) -> Self {
         StoreResolver {
             logger: logger.new(o!("component" => "StoreResolver")),
             store,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -1,17 +1,15 @@
 #[macro_use]
 extern crate pretty_assertions;
 extern crate futures;
-extern crate graphql_parser;
-#[macro_use]
-extern crate slog;
 extern crate graph;
 extern crate graph_graphql;
+extern crate graphql_parser;
 
 use futures::sync::oneshot;
 use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 
-use graph::prelude::{Query, QueryResult, Schema};
+use graph::prelude::*;
 use graph_graphql::prelude::*;
 
 /// Mock resolver used in tests that don't need a resolver.

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -2,16 +2,13 @@ extern crate futures;
 extern crate graphql_parser;
 #[macro_use]
 extern crate pretty_assertions;
-#[macro_use]
-extern crate slog;
 extern crate graph;
 extern crate graph_graphql;
 extern crate graph_node;
 
 use futures::sync::oneshot;
 use graphql_parser::query as q;
-use slog::Logger;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use graph::components::store::EventSource;
 use graph::prelude::*;

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -5,5 +5,4 @@ version = "0.1.0"
 [dependencies]
 futures = "0.1.21"
 graphql-parser = "0.2.0"
-slog = "2.2.3"
 graph = { path = "../graph" }

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -1,8 +1,6 @@
 extern crate futures;
-extern crate graphql_parser;
-#[macro_use]
-extern crate slog;
 extern crate graph;
+extern crate graphql_parser;
 
 mod query;
 mod schema;

--- a/mock/src/query.rs
+++ b/mock/src/query.rs
@@ -1,6 +1,5 @@
 use futures::sync::mpsc::{channel, Receiver, Sender};
 use graphql_parser::query as gqlq;
-use slog;
 use std::collections::BTreeMap;
 
 use graph::prelude::*;

--- a/mock/src/schema.rs
+++ b/mock/src/schema.rs
@@ -1,9 +1,5 @@
 use futures::sync::mpsc::{channel, Receiver, Sender};
-use slog::Logger;
 
-use graph::components::schema::SchemaProviderEvent;
-use graph::components::subgraph::SchemaEvent;
-use graph::components::{EventConsumer, EventProducer};
 use graph::prelude::*;
 
 /// A mock `SchemaProvider`.

--- a/mock/src/server.rs
+++ b/mock/src/server.rs
@@ -1,7 +1,6 @@
 use futures::sync::mpsc::{channel, Receiver, Sender};
 use futures::sync::oneshot;
 use graphql_parser;
-use slog;
 use std::error::Error;
 use std::fmt;
 use std::sync::Mutex;
@@ -32,7 +31,7 @@ impl fmt::Display for MockServeError {
 
 /// A mock `GraphQLServer`.
 pub struct MockGraphQLServer {
-    logger: slog::Logger,
+    logger: Logger,
     query_sink: Option<Sender<Query>>,
     schema_provider_event_sink: Sender<SchemaProviderEvent>,
     store_event_sink: Sender<StoreEvent>,
@@ -41,7 +40,7 @@ pub struct MockGraphQLServer {
 
 impl MockGraphQLServer {
     /// Creates a new mock `GraphQLServer`.
-    pub fn new(logger: &slog::Logger) -> Self {
+    pub fn new(logger: &Logger) -> Self {
         // Create channels for handling incoming events from the schema provider and the store
         let (store_sink, store_stream) = channel(100);
         let (schema_provider_sink, schema_provider_stream) = channel(100);

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -1,7 +1,5 @@
 use futures::sync::mpsc::{channel, Receiver, Sender};
-use slog;
 
-use graph::components::schema::SchemaProviderEvent;
 use graph::components::store::*;
 use graph::prelude::*;
 

--- a/mock/src/subgraph.rs
+++ b/mock/src/subgraph.rs
@@ -1,9 +1,6 @@
-use futures::prelude::*;
 use futures::sync::mpsc::{channel, Receiver, Sender};
 use graphql_parser;
-use slog;
 
-use graph::components::subgraph::{SchemaEvent, SubgraphProviderEvent};
 use graph::prelude::*;
 use graphql_parser::schema::Document;
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -8,7 +8,6 @@ env_logger = "0.5.10"
 futures = "0.1.21"
 graphql-parser = "0.2.1"
 sentry = "0.3.1"
-slog = "2.2.3"
 ipfs-api = "0.5.0-alpha2"
 graph = { path = "../graph" }
 graph-core = { path = "../core" }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,9 +1,7 @@
 extern crate futures;
-extern crate graphql_parser;
-#[macro_use]
-extern crate slog;
 extern crate graph;
 extern crate graph_core;
+extern crate graphql_parser;
 
 mod subgraph;
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -4,8 +4,6 @@ extern crate futures;
 extern crate graph_node;
 #[macro_use]
 extern crate sentry;
-#[macro_use]
-extern crate slog;
 extern crate graph;
 extern crate graph_core;
 extern crate graph_datasource_ethereum;

--- a/node/src/subgraph.rs
+++ b/node/src/subgraph.rs
@@ -1,9 +1,6 @@
-use futures::prelude::*;
 use futures::sync::mpsc::{channel, Receiver};
 use graphql_parser::{schema, Pos};
-use slog;
 
-use graph::components::subgraph::{SchemaEvent, SubgraphProviderEvent};
 use graph::data::subgraph::SubgraphManifestResolveError;
 use graph::prelude::{SubgraphProvider as SubgraphProviderTrait, *};
 

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -10,7 +10,6 @@ hex = "0.3.2"
 nan-preserving-float = "0.1.0"
 num-bigint = "0.2.0"
 serde_json = "1.0"
-slog = "2.2.3"
 graph = { path = "../../graph" }
 uuid = { version = "0.6", features = ["v4"] }
 wasmi = "0.3"

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -1,6 +1,5 @@
 use ethereum_types::Address;
 use futures::sync::mpsc::{channel, Receiver};
-use slog::Logger;
 use std::str::FromStr;
 use std::sync::Mutex;
 use std::thread;

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -1,13 +1,11 @@
+extern crate ethabi;
 extern crate ethereum_types;
 extern crate futures;
-extern crate serde_json;
-#[macro_use]
-extern crate slog;
-extern crate ethabi;
 extern crate graph;
 extern crate hex;
 extern crate nan_preserving_float;
 extern crate num_bigint;
+extern crate serde_json;
 extern crate uuid;
 extern crate wasmi;
 extern crate web3;

--- a/runtime/wasm/src/module.rs
+++ b/runtime/wasm/src/module.rs
@@ -1,8 +1,6 @@
 use ethereum_types::{H160, H256, U256};
-use futures::prelude::*;
 use futures::sync::mpsc::Sender;
 use serde_json;
-use slog::Logger;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, Mutex};
@@ -706,7 +704,6 @@ mod tests {
     use ethabi::{LogParam, Token};
     use ethereum_types::Address;
     use futures::sync::mpsc::channel;
-    use slog;
     use std::collections::HashMap;
     use std::iter::FromIterator;
     use std::sync::Mutex;

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -9,7 +9,6 @@ http = "0.1.5"
 hyper = "0.12.7"
 serde = "1.0"
 serde_json = "1.0"
-slog = "2.2.3"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
 

--- a/server/http/src/lib.rs
+++ b/server/http/src/lib.rs
@@ -1,13 +1,11 @@
 extern crate futures;
+extern crate graph;
+extern crate graph_graphql;
 extern crate graphql_parser;
 extern crate http;
 extern crate hyper;
 extern crate serde;
 extern crate serde_json;
-#[macro_use]
-extern crate slog;
-extern crate graph;
-extern crate graph_graphql;
 
 mod request;
 mod response;

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -1,22 +1,17 @@
-use futures::future;
-use futures::prelude::*;
 use futures::sync::mpsc::{channel, Receiver, Sender};
 use hyper;
 use hyper::Server;
 
-use slog;
 use std::error::Error;
 use std::fmt;
 use std::net::{Ipv4Addr, SocketAddrV4};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use graph::components::schema::SchemaProviderEvent;
 use graph::components::store::StoreEvent;
 use graph::data::query::Query;
 use graph::data::schema::Schema;
-use graph::prelude::GraphQLServer as GraphQLServerTrait;
-use graph::tokio;
-use graph::util::stream::StreamError;
+use graph::prelude::{GraphQLServer as GraphQLServerTrait, *};
 
 use service::GraphQLService;
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -1,7 +1,7 @@
 use futures::sync::mpsc::Sender;
 use hyper::service::Service;
 use hyper::{Body, Method, Request, Response, StatusCode};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use graph::components::server::GraphQLServerError;
 use graph::prelude::*;

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -1,12 +1,10 @@
 extern crate futures;
+extern crate graph;
+extern crate graph_server_http;
 extern crate graphql_parser;
 extern crate http;
 extern crate hyper;
 extern crate serde_json;
-#[macro_use]
-extern crate slog;
-extern crate graph;
-extern crate graph_server_http;
 extern crate tokio_executor;
 
 use futures::prelude::*;

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -9,7 +9,6 @@ diesel_migrations = "1.3.0"
 ethereum-types = "0.3"
 diesel-dynamic-schema = { git = "https://github.com/diesel-rs/diesel-dynamic-schema" }
 futures = "0.1.21"
-slog = "2.2.3"
 serde_json = "1.0"
 graph = { path = "../../graph" }
 

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -5,8 +5,6 @@ extern crate diesel_dynamic_schema;
 #[macro_use]
 extern crate diesel_migrations;
 extern crate futures;
-#[macro_use]
-extern crate slog;
 extern crate graph;
 extern crate serde_json;
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -5,17 +5,14 @@ use diesel::prelude::*;
 use diesel::sql_types::Text;
 use diesel::{delete, insert_into, result, select};
 use filter::store_filter;
-use futures::prelude::*;
 use futures::sync::mpsc::{channel, Receiver, Sender};
 use graph::tokio;
 use serde_json;
-use slog;
 
 use functions::{revert_block, set_config};
-use graph::components::schema::SchemaProviderEvent;
-use graph::components::store::{Store as StoreTrait, *};
-use graph::data::store::*;
-use graph::util::stream::StreamError;
+
+use graph::components::store::{EventSource, Store as StoreTrait};
+use graph::prelude::*;
 
 embed_migrations!("./migrations");
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -6,14 +6,11 @@ extern crate lazy_static;
 extern crate graph;
 extern crate graph_store_postgres;
 extern crate serde_json;
-#[macro_use]
-extern crate slog;
 
 use diesel::pg::PgConnection;
 use diesel::*;
 use ethereum_types::H256;
 use futures::sync::oneshot;
-use slog::Logger;
 use std::panic;
 use std::sync::Mutex;
 


### PR DESCRIPTION
At least in this early stage we want all the logs we can get. First commit re-exports `slog` from `graph` so we can control this configuration from a single place.

Resolves #238