### PR TITLE
Include block_hash in RuntimeHostEvents

### DIFF
--- a/core/src/subgraph/manager.rs
+++ b/core/src/subgraph/manager.rs
@@ -1,8 +1,6 @@
-use ethereum_types::H256;
 use futures::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Mutex;
 
-use graph::components::store::EventSource;
 use graph::components::subgraph::RuntimeHostEvent;
 use graph::components::subgraph::SubgraphProviderEvent;
 use graph::prelude::*;
@@ -46,22 +44,22 @@ impl RuntimeManager where {
         // Handles each incoming event from the subgraph.
         fn handle_event<S: Store + 'static>(store: Arc<Mutex<S>>, event: RuntimeHostEvent) {
             match event {
-                RuntimeHostEvent::EntitySet(store_key, entity) => {
+                RuntimeHostEvent::EntitySet(store_key, entity, event_source) => {
                     store
                         .lock()
                         .unwrap()
                         .set(
                             store_key,
                             entity,
-                            EventSource::EthereumBlock(H256::random()),
+                            event_source,
                         )
                         .expect("Failed to set entity in the store");
                 }
-                RuntimeHostEvent::EntityRemoved(store_key) => {
+                RuntimeHostEvent::EntityRemoved(store_key, event_source) => {
                     store
                         .lock()
                         .unwrap()
-                        .delete(store_key, EventSource::EthereumBlock(H256::random()))
+                        .delete(store_key, event_source)
                         .expect("Failed to delete entity from the store");
                 }
             }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -93,6 +93,7 @@ pub enum StoreEvent {
 }
 
 /// The source of the events being sent to the store
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EventSource {
     EthereumBlock(H256),
 }

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -4,9 +4,9 @@ use prelude::*;
 #[derive(Debug, Clone, PartialEq)]
 pub enum RuntimeHostEvent {
     /// An entity should be created or updated.
-    EntitySet(StoreKey, Entity),
+    EntitySet(StoreKey, Entity, EventSource),
     /// An entity should be removed.
-    EntityRemoved(StoreKey),
+    EntityRemoved(StoreKey, EventSource),
 }
 
 /// Common trait for runtime host implementations.

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -54,7 +54,7 @@ pub mod prelude {
     pub use components::schema::{SchemaProvider, SchemaProviderEvent};
     pub use components::server::GraphQLServer;
     pub use components::store::{
-        BasicStore, Store, StoreEvent, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange,
+        BasicStore, EventSource, Store, StoreEvent, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange,
     };
     pub use components::subgraph::{
         RuntimeHost, RuntimeHostBuilder, RuntimeHostEvent, RuntimeManager, SchemaEvent,


### PR DESCRIPTION
Resolves #259 

The Ethereum `block_hash` is needed to track the source of events and revert entity changes in the event of a block reorganization.  This PR updates the `RuntimeHostEvents` to now include `EventSource::EthereumBlock(block_hash)`  along with `StoreKey` and `Entity` data.  