### PR TITLE
Update code formatting to Rust 1.28.0 standards

### DIFF
--- a/core/src/subgraph/manager.rs
+++ b/core/src/subgraph/manager.rs
@@ -48,11 +48,7 @@ impl RuntimeManager where {
                     store
                         .lock()
                         .unwrap()
-                        .set(
-                            store_key,
-                            entity,
-                            event_source,
-                        )
+                        .set(store_key, entity, event_source)
                         .expect("Failed to set entity in the store");
                 }
                 RuntimeHostEvent::EntityRemoved(store_key, event_source) => {

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -54,7 +54,8 @@ pub mod prelude {
     pub use components::schema::{SchemaProvider, SchemaProviderEvent};
     pub use components::server::GraphQLServer;
     pub use components::store::{
-        BasicStore, EventSource, Store, StoreEvent, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange,
+        BasicStore, EventSource, Store, StoreEvent, StoreFilter, StoreKey, StoreOrder, StoreQuery,
+        StoreRange,
     };
     pub use components::subgraph::{
         RuntimeHost, RuntimeHostBuilder, RuntimeHostEvent, RuntimeManager, SchemaEvent,

--- a/runtime/wasm/src/module.rs
+++ b/runtime/wasm/src/module.rs
@@ -255,7 +255,11 @@ where
         let logger = self.logger.clone();
         self.event_sink
             .clone()
-            .send(RuntimeHostEvent::EntitySet(store_key, entity_data, EventSource::EthereumBlock(block_hash)))
+            .send(RuntimeHostEvent::EntitySet(
+                store_key,
+                entity_data,
+                EventSource::EthereumBlock(block_hash),
+            ))
             .map_err(move |e| {
                 error!(logger, "Failed to forward runtime host event";
                         "error" => format!("{}", e));
@@ -285,7 +289,10 @@ where
         let logger = self.logger.clone();
         self.event_sink
             .clone()
-            .send(RuntimeHostEvent::EntityRemoved(store_key, EventSource::EthereumBlock(block_hash)))
+            .send(RuntimeHostEvent::EntityRemoved(
+                store_key,
+                EventSource::EthereumBlock(block_hash),
+            ))
             .map_err(move |e| {
                 error!(logger, "Failed to forward runtime host event";
                         "error" => format!("{}", e));
@@ -945,7 +952,9 @@ mod tests {
                             vec![(String::from("exampleAttribute"), Value::from("some data"))]
                                 .into_iter()
                         )),
-                        EventSource::EthereumBlock(util::ethereum::string_to_h256("example block hash")),
+                        EventSource::EthereumBlock(util::ethereum::string_to_h256(
+                            "example block hash",
+                        )),
                     )
                 );
             })


### PR DESCRIPTION
The recent changes to the `RuntimeHostEvent` definition and implementations were not formatted using the latest version of rustfmt.  This PR uses `Rust 1.28.0` to format the code, which now passes all tests in `Travis CI`.