### PR TITLE
node: Test IPFS node connection on start up

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -19,6 +19,8 @@ use std::env;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
 
 use graph::components::forward;
 use graph::prelude::*;
@@ -108,7 +110,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     let ethereum_ws = matches.value_of("ethereum-ws");
 
     let ipfs_socket_addr = SocketAddr::from_str(matches.value_of("ipfs").unwrap())
-        .expect("could not parse IPFS address, expected format is host:port");
+        .expect("could not parse IPFS address, expected format is ipaddress:port");
 
     debug!(logger, "Setting up Sentry");
 
@@ -128,13 +130,27 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
 
     info!(logger, "Starting up");
 
-    // Create system components
+    // Create and test IPFS client
+    info!(logger, "Connecting to IPFS node...");
     let resolver = Arc::new(
         IpfsClient::new(
             &format!("{}", ipfs_socket_addr.ip()),
             ipfs_socket_addr.port(),
         ).expect("Failed to start IPFS client"),
     );
+    let ipfs_test = resolver.cat("/ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/readme");
+    if let Err(e) = ipfs_test.concat2().wait() {
+        error!(logger, "Failed to connect to IPFS: {}", e);
+        error!(
+            logger,
+            "Is there an IPFS node running at '{}'?", ipfs_socket_addr
+        );
+        thread::sleep(Duration::from_millis(50)); // small delay to let logger finish writing
+        panic!();
+    }
+    info!(logger, "Connected to IPFS node.");
+
+    // Create subgraph provider
     let (mut subgraph_provider, subgraph_provider_events) = IpfsSubgraphProvider::new(
         logger.clone(),
         &format!("/ipfs/{}", subgraph_hash.clone()),


### PR DESCRIPTION
Provide better error message to user if IPFS connection fails.

Resolves #268 

New error message looks like this:

```
Aug 16 15:46:47.190 INFO Connecting to IPFS node...
Aug 16 15:46:47.193 ERRO Failed to connect to IPFS: hyper client error 'an error occurred trying to connect: Connection refused (os error 111)'
Aug 16 15:46:47.193 ERRO Is there an IPFS node running at '127.0.0.1:5002'?
```

Normal operation:

```
Aug 16 15:47:29.025 INFO Connecting to IPFS node...
Aug 16 15:47:29.028 INFO Connected to IPFS node.
```

I included these two messages in case the client hangs trying to connect (I haven't observed that behaviour, but just in case).