### PR TITLE
Improve contract call type mismatch error

### DIFF
--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -7,7 +7,6 @@ extern crate ipfs_api;
 
 use graph::components::ethereum::*;
 use graph::prelude::*;
-use graph::util::log::logger;
 use graph_core::RuntimeManager;
 use graph_mock::FakeStore;
 use graph_runtime_wasm::RuntimeHostBuilder;


### PR DESCRIPTION
And refactor the errors to use `failure`.