### PR TITLE
Initial multiple subgraph support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,7 @@ version = "0.1.0"
 dependencies = [
  "ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.1.0",
  "graph-graphql 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -947,6 +948,14 @@ dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2566,6 +2575,7 @@ dependencies = [
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)" = "4c3de361878aab0937e68b84ca02b93e1c38f053e95b622a732da04214399308"
 "checksum isatty 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6c324313540cd4d7ba008d43dc6606a32a5579f13cc17b2804c13096f0a5c522"
+"checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 "checksum jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc)" = "<none>"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,7 @@ serde = "1.0"
 serde_yaml = "0.7"
 
 [dev-dependencies]
+failure = "0.1.2"
 ethabi = "5.1.1"
 graphql-parser = "0.2.0"
 ipfs-api = "0.5.0-alpha2"

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -34,13 +34,14 @@ impl<L: LinkResolver> SubgraphProvider<L> {
 impl<L: LinkResolver> SubgraphProviderTrait for SubgraphProvider<L> {
     fn add(
         &self,
+        name: String,
         link: String,
     ) -> Box<Future<Item = (), Error = SubgraphProviderError> + Send + 'static> {
         let send_logger = self.logger.clone();
         let schema_event_sink = self.schema_event_sink.clone();
         let event_sink = self.event_sink.clone();
         Box::new(
-            SubgraphManifest::resolve(Link { link }, self.resolver.clone())
+            SubgraphManifest::resolve(name, Link { link }, self.resolver.clone())
                 .map_err(SubgraphProviderError::ResolveError)
                 .and_then(move |mut subgraph| {
                     subgraph

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -97,6 +97,7 @@ fn multiple_data_sources_per_subgraph() {
                     // Load a subgraph with two data sets, one listening for `ExampleEvent`
                     // and the other for `ExampleEvent2`.
                     SubgraphManifest::resolve(
+                        "example_subgraph".to_owned(),
                         Link {
                             link: subgraph_link,
                         },

--- a/graph/src/components/subgraph/provider.rs
+++ b/graph/src/components/subgraph/provider.rs
@@ -27,6 +27,7 @@ pub trait SubgraphProvider:
 {
     fn add(
         &self,
+        name: String,
         link: String,
     ) -> Box<Future<Item = (), Error = SubgraphProviderError> + Send + 'static>;
 }

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -3,6 +3,7 @@ use graphql_parser::{schema, Pos};
 /// A GraphQL schema with additional meta data.
 #[derive(Clone, Debug)]
 pub struct Schema {
+    pub name: String,
     pub id: String,
     pub document: schema::Document,
 }

--- a/graph/src/data/subgraph.rs
+++ b/graph/src/data/subgraph.rs
@@ -18,6 +18,8 @@ pub enum SubgraphProviderError {
     ResolveError(SubgraphManifestResolveError),
     #[fail(display = "error sending subgraph")]
     SendError,
+    #[fail(display = "name {} is invalid, only ASCII alphanumerics, `-` and `_` are allowed", _0)]
+    InvalidName(String),
 }
 
 #[derive(Fail, Debug)]

--- a/graph/src/data/subgraph.rs
+++ b/graph/src/data/subgraph.rs
@@ -55,11 +55,10 @@ pub struct SchemaData {
 impl SchemaData {
     pub fn resolve(
         self,
+        id: String,
         name: String,
         resolver: &impl LinkResolver,
     ) -> impl Future<Item = Schema, Error = failure::Error> + Send {
-        let id = self.file.link.clone();
-
         resolver.cat(&self.file).and_then(|schema_bytes| {
             Ok(
                 graphql_parser::parse_schema(&String::from_utf8(schema_bytes)?)
@@ -279,7 +278,7 @@ impl UnresolvedSubgraphManifest {
                 .into_iter()
                 .map(|data_set| data_set.resolve(resolver)),
         ).collect()
-            .join(schema.resolve(name, resolver))
+            .join(schema.resolve(id.clone(), name, resolver))
             .map(|(data_sources, schema)| SubgraphManifest {
                 id,
                 location,

--- a/graph/src/data/subgraph.rs
+++ b/graph/src/data/subgraph.rs
@@ -56,11 +56,12 @@ impl SchemaData {
         resolver: &impl LinkResolver,
     ) -> impl Future<Item = Schema, Error = failure::Error> + Send {
         let id = self.file.link.clone();
+        let name = id.clone();
 
         resolver.cat(&self.file).and_then(|schema_bytes| {
             Ok(
                 graphql_parser::parse_schema(&String::from_utf8(schema_bytes)?)
-                    .map(|document| Schema { id, document })?,
+                    .map(|document| Schema { name, id, document })?,
             )
         })
     }

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -44,6 +44,7 @@ impl Resolver for MockResolver {
 /// enums, interfaces, input objects, object types and field arguments.
 fn mock_schema() -> Schema {
     Schema {
+        name: "mock-schema".to_string(),
         id: "mock-schema".to_string(),
         document: graphql_parser::parse_schema(
             "
@@ -1044,6 +1045,7 @@ type Parameter {
     let api_document = api_schema(&document).unwrap();
 
     let schema = Schema {
+        name: String::from("complex-schema"),
         id: String::from("complex-schema"),
         document: api_document,
     };

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -16,6 +16,7 @@ use graph_graphql::prelude::*;
 
 fn test_schema() -> Schema {
     let mut schema = Schema {
+        name: String::from("test-schema"),
         id: String::from("test-schema"),
         document: api_schema(
             &graphql_parser::parse_schema(

--- a/mock/src/server.rs
+++ b/mock/src/server.rs
@@ -72,6 +72,7 @@ impl MockGraphQLServer {
                 let mut schema = schema.lock().unwrap();
                 let derived_schema = match api_schema(&new_schema.document) {
                     Ok(document) => Schema {
+                        name: new_schema.name.clone(),
                         id: new_schema.id.clone(),
                         document,
                     },

--- a/mock/src/subgraph.rs
+++ b/mock/src/subgraph.rs
@@ -21,6 +21,7 @@ impl MockSubgraphProvider {
 
         let (schema_event_sink, schema_event_stream) = channel(100);
 
+        let id = "176dbd4fdeb8407b899be5d456ababc0".to_string();
         MockSubgraphProvider {
             logger: logger.new(o!("component" => "MockSubgraphProvider")),
             event_sink,
@@ -28,7 +29,8 @@ impl MockSubgraphProvider {
             event_stream: Some(event_stream),
             schema_event_stream: Some(schema_event_stream),
             schemas: vec![Schema {
-                id: "176dbd4fdeb8407b899be5d456ababc0".to_string(),
+                name: id.clone(),
+                id,
                 document: graphql_parser::parse_schema(
                     "type User {
                            id: ID!
@@ -48,6 +50,7 @@ impl MockSubgraphProvider {
             location: String::from("/tmp/example-data-source.yaml"),
             spec_version: String::from("0.1"),
             schema: Schema {
+                name: String::from("exampled name"),
                 id: String::from("exampled id"),
                 document: Document {
                     definitions: vec![],

--- a/runtime/wasm/src/module.rs
+++ b/runtime/wasm/src/module.rs
@@ -833,6 +833,7 @@ mod tests {
             location: String::from("/path/to/example-subgraph.yaml"),
             spec_version: String::from("0.1.0"),
             schema: Schema {
+                name: String::from("exampled name"),
                 id: String::from("exampled id"),
                 document: Document {
                     definitions: vec![],

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -7,6 +7,7 @@ futures = "0.1.21"
 graphql-parser = "0.2.0"
 http = "0.1.5"
 hyper = "0.12.7"
+itertools = "0.7.8"
 serde = "1.0"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }

--- a/server/http/assets/index.html
+++ b/server/http/assets/index.html
@@ -110,7 +110,7 @@
          function graphQLFetcher(graphQLParams) {
              // This example expects a GraphQL server at the path /graphql.
              // Change this to point wherever you host your GraphQL server.
-             return fetch('/graphql', {
+             return fetch(window.location.pathname + '/graphql', {
                  method: 'post',
                  headers: {
                      'Accept': 'application/json',

--- a/server/http/src/lib.rs
+++ b/server/http/src/lib.rs
@@ -4,6 +4,7 @@ extern crate graph_graphql;
 extern crate graphql_parser;
 extern crate http;
 extern crate hyper;
+extern crate itertools;
 extern crate serde;
 
 mod request;

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -95,10 +95,15 @@ impl GraphQLServer {
                     },
                     Err(e) => return Ok(error!(logger, "error deriving schema {}", e)),
                 };
-                schemas
+                if schemas
                     .write()
                     .unwrap()
-                    .insert(derived_schema.name.clone(), derived_schema);
+                    .insert(derived_schema.name.clone(), derived_schema)
+                    .is_some()
+                {
+                    // We need to support clean shutdown of a subgraph before update support.
+                    panic!("updating a subgraph is not supported yet")
+                }
             } else {
                 panic!("schema removal is yet not supported")
             }

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -1,7 +1,9 @@
 use futures::sync::mpsc::Sender;
 use hyper::service::Service;
 use hyper::{Body, Method, Request, Response, StatusCode};
-use std::sync::Mutex;
+use itertools::Itertools;
+use std::collections::BTreeMap;
+use std::sync::RwLock;
 
 use graph::components::server::GraphQLServerError;
 use graph::prelude::*;
@@ -16,14 +18,17 @@ pub type GraphQLServiceResponse =
 /// A Hyper Service that serves GraphQL over a POST / endpoint.
 #[derive(Debug)]
 pub struct GraphQLService {
-    schema: Arc<Mutex<Option<Schema>>>,
+    schemas: Arc<RwLock<BTreeMap<String, Schema>>>,
     query_sink: Sender<Query>,
 }
 
 impl GraphQLService {
     /// Creates a new GraphQL service.
-    pub fn new(schema: Arc<Mutex<Option<Schema>>>, query_sink: Sender<Query>) -> Self {
-        GraphQLService { schema, query_sink }
+    pub fn new(schemas: Arc<RwLock<BTreeMap<String, Schema>>>, query_sink: Sender<Query>) -> Self {
+        GraphQLService {
+            schemas,
+            query_sink,
+        }
     }
 
     /// Serves a GraphiQL index.html.
@@ -37,19 +42,22 @@ impl GraphQLService {
     }
 
     /// Handles GraphQL queries received via POST /.
-    fn handle_graphql_query(&self, request: Request<Body>) -> GraphQLServiceResponse {
+    fn handle_graphql_query(&self, name: &str, request: Request<Body>) -> GraphQLServiceResponse {
         let query_sink = self.query_sink.clone();
-        let schema = self.schema.clone();
+        let schema = self
+            .schemas
+            .read()
+            .unwrap()
+            .get(name)
+            .expect("schema not found")
+            .clone();
 
         Box::new(
             request
                 .into_body()
                 .concat2()
                 .map_err(|_| GraphQLServerError::from("Failed to read request body"))
-                .and_then(move |body| {
-                    let schema = schema.lock().unwrap();
-                    GraphQLRequest::new(body, schema.clone())
-                })
+                .and_then(move |body| GraphQLRequest::new(body, schema.clone()))
                 .and_then(move |(query, receiver)| {
                     // Forward the query to the system
                     query_sink
@@ -94,24 +102,41 @@ impl Service for GraphQLService {
     type Future = GraphQLServiceResponse;
 
     fn call(&mut self, req: Request<Self::ReqBody>) -> Self::Future {
-        match (req.method(), req.uri().path()) {
-            // GraphiQL
-            (&Method::GET, "/") => self.serve_file(include_str!("../assets/index.html")),
-            (&Method::GET, "/graphiql.css") => {
+        let method = req.method().clone();
+        let uri = req.uri().clone();
+        match (method, uri.path()) {
+            (Method::GET, "/graphiql.css") => {
                 self.serve_file(include_str!("../assets/graphiql.css"))
             }
-            (&Method::GET, "/graphiql.min.js") => {
+            (Method::GET, "/graphiql.min.js") => {
                 self.serve_file(include_str!("../assets/graphiql.min.js"))
             }
 
-            // POST / receives GraphQL queries
-            (&Method::POST, "/graphql") => self.handle_graphql_query(req),
+            // Request is relative to a subgraph.
+            (method, path) => {
+                let mut path = path.split('/');
+                let _empty = path.next();
+                let name = path.next();
+                let rest = path.join("/");
 
-            // OPTIONS / allows to check for GraphQL HTTP features
-            (&Method::OPTIONS, "/graphql") => self.handle_graphql_options(req),
+                println!("got name {:?}", name);
+                println!("got rest {:?}", rest);
+                match (method, name, rest.as_str()) {
+                    // GraphiQL
+                    (Method::GET, Some(_), "") => {
+                        self.serve_file(include_str!("../assets/index.html"))
+                    }
 
-            // Everything else results in a 404
-            _ => self.handle_not_found(req),
+                    // POST / receives GraphQL queries
+                    (Method::POST, Some(name), "graphql") => self.handle_graphql_query(&name, req),
+
+                    // OPTIONS / allows to check for GraphQL HTTP features
+                    (Method::OPTIONS, Some(_), "graphql") => self.handle_graphql_options(req),
+
+                    // Everything else results in a 404
+                    _ => self.handle_not_found(req),
+                }
+            }
         }
     }
 }
@@ -125,7 +150,9 @@ mod tests {
     use hyper::service::Service;
     use hyper::{Body, Method, Request};
     use std::collections::BTreeMap;
-    use std::sync::Mutex;
+    use std::iter::once;
+    use std::iter::FromIterator;
+    use std::sync::RwLock;
 
     use graph::prelude::*;
 
@@ -134,21 +161,26 @@ mod tests {
 
     #[test]
     fn posting_invalid_query_yields_error_response() {
-        let schema = Arc::new(Mutex::new(Some(Schema {
-            id: "test-schema".to_string(),
-            document: graphql_parser::parse_schema(
-                "\
-                 scalar String \
-                 type Query { name: String } \
-                 ",
-            ).unwrap(),
-        })));
+        let id = "test-schema".to_string();
+        let schema = Arc::new(RwLock::new(BTreeMap::from_iter(once((
+            id.clone(),
+            Schema {
+                name: id.clone(),
+                id: id.clone(),
+                document: graphql_parser::parse_schema(
+                    "\
+                     scalar String \
+                     type Query { name: String } \
+                     ",
+                ).unwrap(),
+            },
+        )))));
         let (query_sink, _) = channel(1);
         let mut service = GraphQLService::new(schema, query_sink);
 
         let request = Request::builder()
             .method(Method::POST)
-            .uri("http://localhost:8000/graphql")
+            .uri(format!("http://localhost:8000/{}/graphql", id))
             .body(Body::from("{}"))
             .unwrap();
 
@@ -171,54 +203,63 @@ mod tests {
 
     #[test]
     fn posting_valid_queries_yields_result_response() {
-        tokio::run(future::lazy(|| {
-            Ok({
-                let schema = Arc::new(Mutex::new(Some(Schema {
-                    id: "test-schema".to_string(),
-                    document: graphql_parser::parse_schema(
-                        "\
-                         scalar String \
-                         type Query { name: String } \
-                         ",
-                    ).unwrap(),
-                })));
-                let (query_sink, query_stream) = channel(1);
-                let mut service = GraphQLService::new(schema, query_sink);
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime
+            .block_on(future::lazy(|| {
+                let res: Result<_, ()> = Ok({
+                    let id = "test-schema".to_string();
+                    let schema = Arc::new(RwLock::new(BTreeMap::from_iter(once((
+                        id.clone(),
+                        Schema {
+                            name: id.clone(),
+                            id: id.clone(),
+                            document: graphql_parser::parse_schema(
+                                "\
+                                 scalar String \
+                                 type Query { name: String } \
+                                 ",
+                            ).unwrap(),
+                        },
+                    )))));
+                    let (query_sink, query_stream) = channel(1);
+                    let mut service = GraphQLService::new(schema, query_sink);
 
-                tokio::spawn(
-                    query_stream
-                        .for_each(move |query| {
-                            let mut map = BTreeMap::new();
-                            map.insert("name".to_string(), Value::String("Jordi".to_string()));
-                            let data = Value::Object(map);
-                            let result = QueryResult::new(Some(data));
-                            query.result_sender.send(result).unwrap();
-                            Ok(())
-                        })
-                        .fuse(),
-                );
+                    tokio::spawn(
+                        query_stream
+                            .for_each(move |query| {
+                                let mut map = BTreeMap::new();
+                                map.insert("name".to_string(), Value::String("Jordi".to_string()));
+                                let data = Value::Object(map);
+                                let result = QueryResult::new(Some(data));
+                                query.result_sender.send(result).unwrap();
+                                Ok(())
+                            })
+                            .fuse(),
+                    );
 
-                let request = Request::builder()
-                    .method(Method::POST)
-                    .uri("http://localhost:8000/graphql")
-                    .body(Body::from("{\"query\": \"{ name }\"}"))
-                    .unwrap();
+                    let request = Request::builder()
+                        .method(Method::POST)
+                        .uri(format!("http://localhost:8000/{}/graphql", id))
+                        .body(Body::from("{\"query\": \"{ name }\"}"))
+                        .unwrap();
 
-                // The response must be a 200
-                let response = service
-                    .call(request)
-                    .wait()
-                    .expect("Should return a response");
-                let data = test_utils::assert_successful_response(response);
+                    // The response must be a 200
+                    let response = service
+                        .call(request)
+                        .wait()
+                        .expect("Should return a response");
+                    let data = test_utils::assert_successful_response(response);
 
-                // The body should match the simulated query result
-                let name = data
-                    .get("name")
-                    .expect("Query result data has no \"name\" field")
-                    .as_str()
-                    .expect("Query result field \"name\" is not a string");
-                assert_eq!(name, "Jordi".to_string());
-            })
-        }))
+                    // The body should match the simulated query result
+                    let name = data
+                        .get("name")
+                        .expect("Query result data has no \"name\" field")
+                        .as_str()
+                        .expect("Query result field \"name\" is not a string");
+                    assert_eq!(name, "Jordi".to_string());
+                });
+                res
+            }))
+            .unwrap()
     }
 }

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -215,7 +215,7 @@ mod tests {
             },
         )))));
         let (query_sink, _) = channel(1);
-        let mut service = GraphQLService::new(schema, query_sink);
+        let mut service = GraphQLService::new(Default::default(), schema, query_sink);
 
         let request = Request::builder()
             .method(Method::POST)
@@ -261,7 +261,7 @@ mod tests {
                         },
                     )))));
                     let (query_sink, query_stream) = channel(1);
-                    let mut service = GraphQLService::new(schema, query_sink);
+                    let mut service = GraphQLService::new(Default::default(), schema, query_sink);
 
                     tokio::spawn(
                         query_stream

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -38,7 +38,7 @@ impl GraphQLService {
             // If there's only 1 schema, redirect to it.
             Some(schema) if len == 1 => Box::new(future::ok(
                 Response::builder()
-                    .status(StatusCode::PERMANENT_REDIRECT)
+                    .status(StatusCode::SEE_OTHER)
                     .header(
                         header::LOCATION,
                         header::HeaderValue::from_str(&format!("/{}", schema.name))

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -50,7 +50,7 @@ impl JsonRpcServerTrait for JsonRpcServer {
             let provider = add_provider.clone();
             info!(add_logger, "Received subgraph_add request"; "params" => params.to_string());
             provider
-                .add(format!("/ipfs/{}", params.ipfs_hash))
+                .add(params.name, format!("/ipfs/{}", params.ipfs_hash))
                 .map_err(|e| json_rpc_error(0, e.to_string()))
                 .map(|_| Ok(Value::Null))
                 .flatten()


### PR DESCRIPTION
This is a first implementation of support for hosting multiple subgraphs, according to [this plan](https://github.com/graphprotocol/graph-node/issues/227#issuecomment-413149755).

Only the `add` operation is supported. Subgraph must have a name when added, and the GraphQL server keeps a map from name to schema. Each subgraph is mounted relative to it's name, so graphiql for subgraph "foo" is mounted at `/foo/`. Because we don't have an index page yet and to not disrupt the current workflow, if only one subgraph is hosted then the root will redirect to it.

At the store level we're already selecting by subgraph id as @fordN informs me so no changes seem necessary there.

Notably remaining work is to support more operations #282 and to have an index page for subgraphs #303.

resolves #226