### PR TITLE
Improve IPFS startup errors and implement custom panic hook with guarded logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,7 @@ dependencies = [
 name = "graph"
 version = "0.1.0"
 dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -3,6 +3,7 @@ name = "graph"
 version = "0.1.0"
 
 [dependencies]
+backtrace = "0.3.9"
 ethabi = "5.1"
 ethereum-types = "0.3"
 hex = "0.3.2"

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate backtrace;
 extern crate ethabi;
 extern crate ethereum_types;
 extern crate futures;

--- a/graph/src/util/log.rs
+++ b/graph/src/util/log.rs
@@ -1,6 +1,7 @@
 use slog;
 use slog_async;
 use slog_term;
+use std::panic;
 
 use slog::Drain;
 
@@ -16,4 +17,19 @@ pub fn guarded_logger() -> (slog::Logger, slog_async::AsyncGuard) {
     let drain = slog_term::CompactFormat::new(decorator).build().fuse();
     let (drain, guard) = slog_async::Async::new(drain).build_with_guard();
     (slog::Logger::root(drain.fuse(), o!()), guard)
+}
+
+pub fn register_panic_hook(panic_logger: slog::Logger) {
+    panic::set_hook(Box::new(move |panic_info| {
+        let panic_payload = panic_info.payload().downcast_ref::<String>();
+        let panic_location = if let Some(location) = panic_info.location() {
+            format!("{}:{}", location.file(), location.line().to_string())
+        } else {
+            "NA".to_string()
+        };
+        error!(panic_logger, "Node error";
+            "error" => panic_payload.clone(),
+            "location" => panic_location.clone()
+           );
+    }));
 }

--- a/graph/src/util/log.rs
+++ b/graph/src/util/log.rs
@@ -28,20 +28,16 @@ pub fn register_panic_hook(panic_logger: slog::Logger) {
         } else {
             "NA".to_string()
         };
-        error!(panic_logger, "Node error";
+        crit!(panic_logger, "Node error";
             "error" => panic_payload.clone(),
             "location" => panic_location.clone()
            );
         match env::var_os("RUST_BACKTRACE") {
-            Some(val) => {
-                if &val == "0" {
-                    ()
-                } else {
-                    error!(panic_logger, "Backtrace";
+            Some(ref val) if val != "0" => {
+                crit!(panic_logger, "Backtrace";
                     "trace" => format!("{:?}", Backtrace::new()));
-                }
             }
-            None => (),
+            _ => (),
         }
     }));
 }

--- a/graph/src/util/log.rs
+++ b/graph/src/util/log.rs
@@ -10,3 +10,10 @@ pub fn logger() -> slog::Logger {
     let drain = slog_async::Async::new(drain).build().fuse();
     slog::Logger::root(drain, o!())
 }
+
+pub fn guarded_logger() -> (slog::Logger, slog_async::AsyncGuard) {
+    let decorator = slog_term::TermDecorator::new().build();
+    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
+    let (drain, guard) = slog_async::Async::new(drain).build_with_guard();
+    (slog::Logger::root(drain.fuse(), o!()), guard)
+}

--- a/graph/src/util/log.rs
+++ b/graph/src/util/log.rs
@@ -1,7 +1,8 @@
+use backtrace::Backtrace;
 use slog;
 use slog_async;
 use slog_term;
-use std::panic;
+use std::{env, panic};
 
 use slog::Drain;
 
@@ -31,5 +32,16 @@ pub fn register_panic_hook(panic_logger: slog::Logger) {
             "error" => panic_payload.clone(),
             "location" => panic_location.clone()
            );
+        match env::var_os("RUST_BACKTRACE") {
+            Some(val) => {
+                if &val == "0" {
+                    ()
+                } else {
+                    error!(panic_logger, "Backtrace";
+                    "trace" => format!("{:?}", Backtrace::new()));
+                }
+            }
+            None => (),
+        }
     }));
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -16,17 +16,21 @@ extern crate ipfs_api;
 extern crate url;
 
 use clap::{App, Arg};
+use futures::sync::mpsc;
 use ipfs_api::IpfsClient;
 use reqwest::Client;
 use std::env;
+use std::io;
 use std::net::SocketAddr;
+use std::panic;
+use std::process;
 use std::str::FromStr;
 use std::sync::Mutex;
 use url::Url;
 
 use graph::components::forward;
 use graph::prelude::{JsonRpcServer as JsonRpcServerTrait, *};
-use graph::util::log::logger;
+use graph::util::log::{guarded_logger, logger};
 use graph_core::SubgraphProvider as IpfsSubgraphProvider;
 use graph_datasource_ethereum::Transport;
 use graph_runtime_wasm::RuntimeHostBuilder as WASMRuntimeHostBuilder;
@@ -35,8 +39,39 @@ use graph_server_json_rpc::{subgraph_add_request, JsonRpcServer};
 use graph_store_postgres::{Store as DieselStore, StoreConfig};
 
 fn main() {
-    // Run `async_main` inside the context of an executor.
-    tokio::run(future::lazy(|| async_main()))
+    let (shutdown_sender, _shutdown_receiver) = mpsc::channel(1);
+    let (panic_logger, panic_guard) = guarded_logger();
+    let mut runtime = tokio::runtime::Runtime::new().expect("Failed to create runtime");
+
+    // Create our own panic hook that logs before sending shutdown signal
+    panic::set_hook(Box::new(move |panic_info| {
+        let panic_payload = panic_info.payload().downcast_ref::<String>();
+        let panic_location = if let Some(location) = panic_info.location() {
+            format!("{}:{}", location.file(), location.line().to_string())
+        } else {
+            "NA".to_string()
+        };
+        error!(panic_logger, "Panic info";
+            "payload" => panic_payload.clone(),
+            "location" => panic_location.clone()
+           );
+
+        // Signal an event loop shutdown
+        shutdown_sender
+            .clone()
+            .send(())
+            .map(|_| ())
+            .map_err(|_| ())
+            .wait()
+            .expect("Failed to signal shutdown");
+    }));
+
+    let _result = runtime.block_on(future::lazy(|| async_main()));
+
+    // Drop logger, shutdown tokio event loop, and exit process
+    drop(panic_guard);
+    runtime.shutdown_now().wait().unwrap();
+    process::exit(1);
 }
 
 fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
@@ -146,14 +181,26 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     info!(logger, "Starting up");
 
     // Create system components
+    info!(logger, "Connecting to IPFS node...");
     let resolver = Arc::new(
         IpfsClient::new(
             &format!("{}", ipfs_socket_addr.ip()),
             ipfs_socket_addr.port(),
         ).expect("Failed to start IPFS client"),
     );
+    let ipfs_test = resolver.add(io::Cursor::new("test"));
+    if let Err(e) = ipfs_test.wait() {
+        //        error!(logger, "Failed to connect to IPFS: {}", e);
+        error!(
+            logger,
+            "Is there an IPFS node running at '{}'?", ipfs_socket_addr
+        );
+        panic!("Failed to connect to IPFS: {}", e);
+    }
+
     let mut subgraph_provider = IpfsSubgraphProvider::new(logger.clone(), resolver.clone());
 
+    info!(logger, "Connecting to Postgres db...");
     let store = DieselStore::new(StoreConfig { url: postgres_url }, &logger);
     let protected_store = Arc::new(Mutex::new(store));
     let mut graphql_server = HyperGraphQLServer::new(&logger);


### PR DESCRIPTION
Resolves #268 

Return clear error messaging to the user if the IPFS connection fails on startup.  

An attempt to add a file to the IPFS node is used to test the connection before moving on to the rest of the node setup. To facilitate the improved error messaging a few general changes were also made: 
- implement custom panic hook 
- use guarded async slog in panic logging to ensure logs are returned to the user
