### PR TITLE
Test Ethereum endpoint with get current block_number call

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -172,6 +172,16 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     let ethereum_watcher = graph_datasource_ethereum::EthereumAdapter::new(
         graph_datasource_ethereum::EthereumAdapterConfig { transport },
     );
+
+    match ethereum_watcher.block_number().wait() {
+        Ok(number) => info!(logger, "Connected to Ethereum node";
+                            "most_recent_block" => &number.to_string()),
+        Err(e) => {
+            error!(logger, "Was a valid Ethereum node endpoint provided?");
+            panic!("Failed to connect to Ethereum node: {}", e);
+        }
+    }
+
     let runtime_host_builder =
         WASMRuntimeHostBuilder::new(&logger, Arc::new(Mutex::new(ethereum_watcher)), resolver);
     let runtime_manager =


### PR DESCRIPTION
Resolves #269 

In the case of an invalid Ethereum endpoint being supplied the application previously did not fail quickly, instead providing RPC errors on each event subscription call.  The continued operation and indirect errors made for inobvious debugging of a simple programmer error. 

Now a test call is made immediately after creating the Ethereum Adapter that gets the current block_number or upon an error stops the application and returns a helpful error.  

Unfortunately Web3 also logs a `WebSocketError` which I could not keep from firing.

