### PR TITLE
Support updating subgraphs

### DIFF
--- a/core/src/subgraph/manager.rs
+++ b/core/src/subgraph/manager.rs
@@ -90,10 +90,10 @@ impl RuntimeManager where {
                         runtime_hosts.push(new_host);
                     }
                 }
-                SubgraphProviderEvent::SubgraphRemoved(ref manifest) => {
+                SubgraphProviderEvent::SubgraphRemoved(id) => {
                     // Destroy all runtime hosts for this subgraph; this will
                     // also terminate the host's event stream
-                    runtime_hosts.retain(|host| host.subgraph_manifest() != manifest);
+                    runtime_hosts.retain(|host| host.subgraph_manifest().id != id);
                 }
             }
 

--- a/graph/src/components/subgraph/provider.rs
+++ b/graph/src/components/subgraph/provider.rs
@@ -8,8 +8,8 @@ use tokio::prelude::*;
 pub enum SubgraphProviderEvent {
     /// A subgraph was added to the provider.
     SubgraphAdded(SubgraphManifest),
-    /// A subgraph was removed from the provider.
-    SubgraphRemoved(SubgraphManifest),
+    /// A subgraph with the given id was removed from the provider.
+    SubgraphRemoved(String),
 }
 
 /// Schema-only events emitted by a [SubgraphProvider](trait.SubgraphProvider.html).

--- a/graph/src/components/subgraph/provider.rs
+++ b/graph/src/components/subgraph/provider.rs
@@ -8,7 +8,7 @@ use tokio::prelude::*;
 pub enum SubgraphProviderEvent {
     /// A subgraph was added to the provider.
     SubgraphAdded(SubgraphManifest),
-    /// A subgraph with the given id was removed from the provider.
+    /// A subgraph with the given ID was removed from the provider.
     SubgraphRemoved(String),
 }
 

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -121,8 +121,9 @@ impl RuntimeHost {
                         .map(|_| panic!("sent into cancel guard"))
                         .map_err(|_| ()),
                 )
+                .for_each(|_| Ok(()))
                 .wait()
-                .for_each(drop);
+                .ok();
 
             info!(logger, "shutting down WASM runtime"; "data_source" => name);
         });

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -99,15 +99,11 @@ impl GraphQLServer {
                     },
                     Err(e) => return Ok(error!(logger, "error deriving schema {}", e)),
                 };
-                if schemas
+
+                schemas
                     .write()
                     .unwrap()
-                    .insert(derived_schema.name.clone(), derived_schema)
-                    .is_some()
-                {
-                    // We need to support clean shutdown of a subgraph before update support.
-                    panic!("updating a subgraph is not supported yet")
-                }
+                    .insert(derived_schema.name.clone(), derived_schema);
 
                 names
                     .write()


### PR DESCRIPTION
If the admin endpoint `subgraph_add` is called twice with the same subgraph name, it will shutdown the previous subgraph and host the new one.

Open question: Do we want to separate the `update` endpoint or keep it unified with `add`? If they are unified, should it be renamed to `set` or some other name? Opinions welcome, I'd like to settle this before merging. Ping @html5cat you might have an opinion on API design.

The implementation consists of:
- Properly shutting down the host thread when the host is dropped.
- Keeping track of added sugraphs in `SubgraphProvider` and sending a message to the `RuntimeManager` signaling the removal of the old subgraph when a subgraph is overwritten.

The "update" part of #282