### PR TITLE
Add schema validation, require @entity in schema types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,7 @@ name = "graph-graphql"
 version = "0.1.0"
 dependencies = [
  "Inflector 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.1.0",
  "graph-core 0.1.0",
@@ -706,6 +707,7 @@ dependencies = [
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -62,10 +62,8 @@ impl<L: LinkResolver> SubgraphProviderTrait for SubgraphProvider<L> {
                 .and_then(
                     // Validate the subgraph schema before deploying the subgraph
                     |subgraph| match validate_schema(&subgraph.schema.document) {
-                        Err(e) => future::err::<_, SubgraphProviderError>(
-                            SubgraphProviderError::SchemaValidationError(e),
-                        ),
-                        _ => future::ok::<_, _>(subgraph),
+                        Err(e) => Err(SubgraphProviderError::SchemaValidationError(e)),
+                        _ => Ok(subgraph),
                     },
                 )
                 .and_then(move |mut subgraph| {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,12 +69,12 @@ Before proceeding, follow the instructions in the [Graph CLI Readme](https://git
 ### 3.1 Defining your GraphQL schema
 GraphQL schemas are defined using the GraphQL interface definition language (IDL). If you've never written a GraphQL schema, we recommend checking out a [quick primer](https://graphql.org/learn/schema/#type-language) on the GraphQL type system.
 
-With The Graph, you don't have to define your own top-level `Query` type, you simply define entity types, and Graph Node will generate top level fields for querying single instances and collections of that entity type.
+With The Graph, you don't have to define your own top-level `Query` type, you simply define entity types, and Graph Node will generate top level fields for querying single instances and collections of that entity type. Each type that should be an entity is required to be annotated with an `@entity` directive.
 
 ##### Example
 Define a simple Token entity type:
 ```graphql
-type Token {
+type Token @entity {
   id: ID!
   name: String!
   minted: Int!

--- a/docs/graphql-api.md
+++ b/docs/graphql-api.md
@@ -153,13 +153,13 @@ It is typical for developers to define their own root `Query` and `Subscription`
 
 ## 3.2 Entities
 
-All GraphQL types in your schema will be treated as entities, and must have an `ID` field.
+All GraphQL types with `@entity` directives in your schema will be treated as entities, and must have an `ID` field.
 
 #### Example
 Define a `Token` entity:
 
 ```graphql
-type Token {
+type Token @entity {
   # The unique ID of this entity
   id: ID!
   name: String!
@@ -193,12 +193,12 @@ Relationships are defined on entities just like any other scalar type, except th
 #### Example
 Define a `Transaction` entity type with an (optional) one-to-one relationship with a `TransactionReceipt` entity type:
 ```graphql
-type Transaction {
+type Transaction @entity {
   id: ID!
   transactionReceipt: TransactionReceipt
 }
 
-type TransactionReceipt {
+type TransactionReceipt @entity {
   id: ID!
   transaction: Transaction
 }
@@ -207,12 +207,12 @@ type TransactionReceipt {
 #### Example
 Define a `Token` entity type with a  (required) one-to-many relationship with a `TokenBalance` entity type.
 ```graphql
-type Token {
+type Token @entity {
   id: ID!
   tokenBalances: [TokenBalance!]!
 }
 
-type TokenBalance {
+type TokenBalance @entity {
   id: ID!
   amount: Int!
 }
@@ -226,13 +226,13 @@ The type of a `@derivedFrom` field must be a collection, since multiple entities
 #### Example
 Define a reverse lookup from a `User` entity type to a `Organization` entity type:
 ```graphql
-type Organization {
+type Organization @entity {
   id: ID!
   name: String!
   members: [User]!
 }
 
-type User {
+type User @entity {
   id: ID!
   name: String!
   organizations: [Organization!] @derivedFrom(field: "members")

--- a/graph/src/data/subgraph.rs
+++ b/graph/src/data/subgraph.rs
@@ -21,6 +21,9 @@ pub enum SubgraphProviderError {
     /// Occurs when attempting to remove a subgraph that's not hosted.
     #[fail(display = "subgraph not found: {}", _0)]
     NotFound(String),
+    /// Occurs when a subgraph's GraphQL schema is invalid.
+    #[fail(display = "GraphQL schema error: {}", _0)]
+    SchemaValidationError(failure::Error),
 }
 
 #[derive(Fail, Debug)]

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -3,12 +3,14 @@ name = "graph-graphql"
 version = "0.1.0"
 
 [dependencies]
+failure = "0.1"
 futures = "0.1.21"
 graph = { path = "../graph" }
 graphql-parser = "0.2.0"
 indexmap = "1.0"
 Inflector = "0.11.3"
 serde = "1.0"
+serde_derive = "1.0"
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -4,6 +4,10 @@ extern crate graphql_parser;
 extern crate indexmap;
 extern crate inflector;
 extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate failure;
 
 /// Utilities for working with GraphQL schemas.
 pub mod schema;
@@ -31,7 +35,7 @@ pub mod prelude {
     pub use super::execution::{ExecutionContext, Resolver};
     pub use super::introspection::{introspection_schema, IntrospectionResolver};
     pub use super::query::{execute_query, QueryExecutionOptions};
-    pub use super::schema::{api_schema, APISchemaError};
+    pub use super::schema::{api_schema, validate_schema, APISchemaError, SchemaValidationError};
     pub use super::store::{build_query, StoreResolver};
     pub use super::subscription::{execute_subscription, SubscriptionExecutionOptions};
     pub use super::values::{object_value, MaybeCoercible};

--- a/graphql/src/schema/mod.rs
+++ b/graphql/src/schema/mod.rs
@@ -4,4 +4,8 @@ pub mod api;
 /// Utilities for working with GraphQL schema ASTs.
 pub mod ast;
 
+/// Utilities for validating GraphQL schemas.
+pub mod validation;
+
 pub use self::api::{api_schema, APISchemaError};
+pub use self::validation::{validate_schema, SchemaValidationError};

--- a/graphql/src/schema/validation.rs
+++ b/graphql/src/schema/validation.rs
@@ -1,0 +1,46 @@
+use failure::Error;
+use graphql_parser::schema::*;
+use std::fmt;
+
+use schema::ast;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Strings(Vec<String>);
+
+impl fmt::Display for Strings {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let s = (&self.0).join(", ");
+        write!(f, "{}", s)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Fail)]
+pub enum SchemaValidationError {
+    #[fail(display = "@entity directive missing on the following types: {}", _0)]
+    EntityDirectivesMissing(Strings),
+}
+
+/// Validates whether a GraphQL schema is compatible with The Graph.
+pub fn validate_schema(schema: &Document) -> Result<(), Error> {
+    validate_schema_types(schema)?;
+    Ok(())
+}
+
+/// Validates whether all object types in the schema are declared with an @entity directive.
+fn validate_schema_types(schema: &Document) -> Result<(), SchemaValidationError> {
+    use self::SchemaValidationError::*;
+
+    let types_without_entity_directive = ast::get_object_type_definitions(schema)
+        .iter()
+        .filter(|t| ast::get_object_type_directive(t, String::from("entity")).is_none())
+        .map(|t| t.name.to_owned())
+        .collect::<Vec<_>>();
+
+    if types_without_entity_directive.is_empty() {
+        Ok(())
+    } else {
+        Err(EntityDirectivesMissing(Strings(
+            types_without_entity_directive,
+        )))
+    }
+}

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -166,16 +166,17 @@ pub fn collect_entities_from_query_field(
             if let Some(type_definition) =
                 sast::get_type_definition_from_field_type(schema, field_type)
             {
-                // Check if the field's type is that of an entity
-                //
-                // FIXME: We must check for the `@entity` directive here once we have that,
-                // otherwise the check below will also be true for the root Query and
-                // Subscription objects as well as all filter object types
+                // If the field's type definition is an object type, extract that type
                 if let s::TypeDefinition::Object(object_type) = type_definition {
-                    // Obtain the subgraph ID from the object type
-                    if let Some(subgraph_id) = parse_subgraph_id(object_type) {
-                        // Add the (subgraph_id, entity_name) tuple to the result set
-                        entities.insert((subgraph_id, object_type.name.to_owned()));
+                    // Only collect whether the field's type has an @entity directive
+                    if sast::get_object_type_directive(object_type, String::from("entity"))
+                        .is_some()
+                    {
+                        // Obtain the subgraph ID from the object type
+                        if let Some(subgraph_id) = parse_subgraph_id(object_type) {
+                            // Add the (subgraph_id, entity_name) tuple to the result set
+                            entities.insert((subgraph_id, object_type.name.to_owned()));
+                        }
                     }
 
                     // If the query field has a non-empty selection set, this means we


### PR DESCRIPTION
Resolves #236. Depends on #320. Last puzzle piece in finishing #279.

This makes `@entity` mandatory on all `type` definitions in subgraph schemas. If we later want to distinguish between embeddable/inline types that are not represented as entities, we can relax this requirement again. (In that case we should e.g. verify that the inline types are actually referenced anywhere.)

Subgraph schemas are now validated (with the above being checked) when subgraphs are deployed. If a subgraph schema fails to validate, the subgraph is rejected.

Now that it's mandator, we can use the `@entity` directive to properly collect entity types involved in subscription queries, and only subscribe to entity change events from the store for these entities. For example, the subscription
```graphql
subscription { memes { id } }
```
would result in a store subscription for `[(<subgraph ID>, Meme)]`. The subscription
```graphql
subscription { memes { id regEntry_creator { id } } }
```
would result in a store subscription for `[(<subgraph ID>, Meme), (<subgraph ID>, User)]`.