### PR TITLE
Simple auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,7 @@ version = "0.1.0"
 dependencies = [
  "graph 0.1.0",
  "jsonrpc-http-server 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -985,7 +986,7 @@ dependencies = [
  "http 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1706,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2203,7 +2204,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2530,7 +2531,7 @@ dependencies = [
  "input_buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf-8 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2666,7 +2667,7 @@ name = "uuid"
 version = "0.7.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3010,7 +3011,7 @@ dependencies = [
 "checksum quote 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b71f9f575d55555aa9c06188be9d4e2bfc83ed02537948ac0d520c24d0419f1a"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
-"checksum rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "12397506224b2f93e6664ffc4f664b29be8208e5157d3d90b44f09b5fae470ea"
+"checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"

--- a/graph/src/components/server/admin.rs
+++ b/graph/src/components/server/admin.rs
@@ -1,16 +1,11 @@
 use std::io;
 use std::sync::Arc;
 
-use components::subgraph::SubgraphProvider;
 use prelude::Logger;
 
 /// Common trait for JSON-RPC admin server implementations.
-pub trait JsonRpcServer {
+pub trait JsonRpcServer<T> {
     type Server;
 
-    fn serve(
-        port: u16,
-        provider: Arc<impl SubgraphProvider>,
-        logger: Logger,
-    ) -> Result<Self::Server, io::Error>;
+    fn serve(port: u16, provider: Arc<T>, logger: Logger) -> Result<Self::Server, io::Error>;
 }

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -5,7 +5,6 @@ extern crate graphql_parser;
 extern crate http;
 extern crate hyper;
 
-use futures::prelude::*;
 use graphql_parser::query as q;
 use http::StatusCode;
 use hyper::{Body, Client, Request};

--- a/server/json-rpc/Cargo.toml
+++ b/server/json-rpc/Cargo.toml
@@ -8,3 +8,4 @@ graph = { path = "../../graph" }
 jsonrpc-http-server = { git = "https://github.com/paritytech/jsonrpc" }
 serde = "1.0"
 serde_derive = "1.0"
+rand = "0.5.5"


### PR DESCRIPTION
If the `GRAPH_MASTER_TOKEN` is not set, no auth will be checked. If it is set, then first to authorize the deployment of a subgraph the `subgraph_authorize` endpoint must be called with a `name` parameter which will return a fresh token that must be sent along any deploy or remove requests for a subgraph with that name. All auth tokens must be provided with the header `Authorization: Bearer TOKEN`.

Right now removal by id doesn't make sense since we need the name to authorize, but it's still supported by the rest of the codebase since we don't yet have a final design for auth.

Resolves #304 at least for now.