### PR TITLE
json-rpc: Take auth list directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,7 +783,6 @@ version = "0.1.0"
 dependencies = [
  "graph 0.1.0",
  "jsonrpc-http-server 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/server/json-rpc/Cargo.toml
+++ b/server/json-rpc/Cargo.toml
@@ -8,4 +8,3 @@ graph = { path = "../../graph" }
 jsonrpc-http-server = { git = "https://github.com/paritytech/jsonrpc" }
 serde = "1.0"
 serde_derive = "1.0"
-rand = "0.5.5"

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -3,7 +3,6 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate graph;
-extern crate rand;
 
 use graph::prelude::{JsonRpcServer as JsonRpcServerTrait, *};
 use graph::serde_json;
@@ -14,9 +13,6 @@ use jsonrpc_http_server::{
     },
     RequestMiddlewareAction, RestApi, Server, ServerBuilder,
 };
-
-use rand::distributions::Alphanumeric;
-use rand::Rng;
 
 use std::collections::BTreeMap;
 use std::net::{Ipv4Addr, SocketAddrV4};
@@ -53,7 +49,7 @@ impl fmt::Display for SubgraphRemoveParams {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct SubgraphAuthorizeParams {
-    name: String,
+    subgraph_api_keys: BTreeMap<String, String>,
 }
 
 impl fmt::Display for SubgraphAuthorizeParams {
@@ -161,17 +157,10 @@ impl<T: SubgraphProvider> JsonRpcServer<T> {
                 ))
             }
         }
-        // Generate a random token of 50 ASCII alphanumerics.
-        let mut rng = rand::thread_rng();
-        let mut token = String::new();
-        for _ in 0..50 {
-            token.push(rng.sample(Alphanumeric));
-        }
-        self.subgraph_api_keys
-            .write()
-            .unwrap()
-            .insert(params.name, token.clone());
-        Ok(Value::String(token))
+
+        *self.subgraph_api_keys.write().unwrap() = params.subgraph_api_keys;
+
+        Ok(Value::Null)
     }
 }
 


### PR DESCRIPTION
Auth should be done with a POST to the json-rpc port with a body such as:
```
{
   "jsonrpc":"2.0",
   "method":"subgraph_authorize",
   "params":{
      "subgraph_api_keys":{
         "brubels":"secret",
        "such_auth": "much_safe"
      }
   },
   "id":"1"
}
```

