### PR TITLE
travis: Don't cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ matrix:
     - env: CHECK_FORMATTING=true
       if: group = stable
 
-# Cache dependencies
-cache: cargo
-
 env:
   global:
   - PGPORT=5433


### PR DESCRIPTION
Rust build outputs are very large, uploading and downloading them is taking 3 minutes on each build, and for nothing because our cache uploading always times out. We could increase the timeout, but the tradeoff probably weights against caching, at least until Travis can do it outside of the actual build.