### PR TITLE
Bump and re-export web3 from the graph crate, clean up Ethereum type usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,32 +461,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "error-chain"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "error-chain"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ethabi"
-version = "5.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -513,20 +491,6 @@ dependencies = [
  "fixed-hash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types-serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fixed-hash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "uint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -740,7 +704,6 @@ dependencies = [
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "web3 0.3.1 (git+https://github.com/tomusdrw/rust-web3)",
 ]
 
 [[package]]
@@ -2589,17 +2552,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uint"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "uint"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2765,34 +2717,6 @@ dependencies = [
  "memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "web3"
-version = "0.3.1"
-source = "git+https://github.com/tomusdrw/rust-web3#d7e577ef6f1254192939e21ec8e795efa0061b1a"
-dependencies = [
- "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "websocket 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2970,12 +2894,9 @@ dependencies = [
 "checksum encoding_rs 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98fd0f24d1fb71a4a6b9330c8ca04cbd4e7cc5d846b54ca74ff376bc7c9f798d"
 "checksum env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7873e292d20e8778f951278972596b3df36ac72a65c5b406f6d4961070a870c1"
 "checksum environment 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee"
-"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
-"checksum ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05e33a914b94b763f0a92333e4e5c95c095563f06ef7d6b295b3d3c2cf31e21f"
 "checksum ethabi 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "36c7bf66bd7ff02c3bc512a276a0f95300e3abb87060704fddf588ae11b86d99"
 "checksum ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a93a43ce2e9f09071449da36bfa7a1b20b950ee344b6904ff23de493b03b386"
-"checksum ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c48729b8aea8aedb12cf4cb2e5cef439fdfe2dda4a89e47eeebd15778ef53b6"
 "checksum ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "35b3c5a18bc5e73a32a110ac743ec04b02bbbcd3b71d3118d40a6113d509378a"
 "checksum ethereum-types-serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ac59a21a9ce98e188f3dace9eb67a6c4a3c67ec7fbc7218cb827852679dc002"
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
@@ -3180,7 +3101,6 @@ dependencies = [
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
-"checksum uint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "38051a96565903d81c9a9210ce11076b2218f3b352926baa1f5f6abbdfce8273"
 "checksum uint 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "754ba11732b9161b94c41798e5197e5e75388d012f760c42adb5000353e98646"
 "checksum uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
@@ -3204,7 +3124,6 @@ dependencies = [
 "checksum want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a05d9d966753fa4b5c8db73fcab5eed4549cfe0e1e4e66911e5564a0085c35d1"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum wasmi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b4a6d379e9332b1b1f52c5a87f2481c85c7c931d8ec411963dfb8f26b1ec1e3"
-"checksum web3 0.3.1 (git+https://github.com/tomusdrw/rust-web3)" = "<none>"
 "checksum web3 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a618ea95d1f68185720c8a8f778f4a8371bba36e2370d3a331167fdf28dd5135"
 "checksum websocket 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9234b4e667c19995475227172446884f516ec0963380afa960d962ab9f4c0bfa"
 "checksum which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,6 @@ dependencies = [
  "diesel 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel-dynamic-schema 1.0.0 (git+https://github.com/diesel-rs/diesel-dynamic-schema)",
  "diesel_migrations 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -855,7 +854,6 @@ dependencies = [
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "web3 0.3.1 (git+https://github.com/tomusdrw/rust-web3)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,13 +718,11 @@ dependencies = [
 name = "graph-datasource-ethereum"
 version = "0.1.0"
 dependencies = [
- "ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.1.0",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "web3 0.3.1 (git+https://github.com/tomusdrw/rust-web3)",
 ]
 
 [[package]]
@@ -783,8 +781,7 @@ dependencies = [
 name = "graph-runtime-wasm"
 version = "0.1.0"
 dependencies = [
- "ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.1.0",
@@ -794,7 +791,6 @@ dependencies = [
  "parity-wasm 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "web3 0.3.1 (git+https://github.com/tomusdrw/rust-web3)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ethabi"
 version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +483,20 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethabi"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -505,6 +527,19 @@ dependencies = [
  "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "uint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types-serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -642,8 +677,7 @@ name = "graph"
 version = "0.1.0"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -660,15 +694,14 @@ dependencies = [
  "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "web3 0.3.1 (git+https://github.com/tomusdrw/rust-web3)",
+ "web3 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "graph-core"
 version = "0.1.0"
 dependencies = [
- "ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.1.0",
@@ -720,7 +753,6 @@ dependencies = [
  "graph 0.1.0",
  "graph-graphql 0.1.0",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "web3 0.3.1 (git+https://github.com/tomusdrw/rust-web3)",
 ]
 
 [[package]]
@@ -1830,6 +1862,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc-hex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,6 +2605,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uint"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "uname"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,6 +2802,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "web3"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "websocket 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "websocket"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,9 +2977,12 @@ dependencies = [
 "checksum env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7873e292d20e8778f951278972596b3df36ac72a65c5b406f6d4961070a870c1"
 "checksum environment 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05e33a914b94b763f0a92333e4e5c95c095563f06ef7d6b295b3d3c2cf31e21f"
+"checksum ethabi 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "36c7bf66bd7ff02c3bc512a276a0f95300e3abb87060704fddf588ae11b86d99"
 "checksum ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a93a43ce2e9f09071449da36bfa7a1b20b950ee344b6904ff23de493b03b386"
 "checksum ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c48729b8aea8aedb12cf4cb2e5cef439fdfe2dda4a89e47eeebd15778ef53b6"
+"checksum ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "35b3c5a18bc5e73a32a110ac743ec04b02bbbcd3b71d3118d40a6113d509378a"
 "checksum ethereum-types-serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ac59a21a9ce98e188f3dace9eb67a6c4a3c67ec7fbc7218cb827852679dc002"
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
 "checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
@@ -3028,6 +3107,7 @@ dependencies = [
 "checksum reqwest 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e7e237e32c3bfa55c95e29af872c8f481471d70b8a5ec15d85f4d274ffd92dd9"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0ceb8ce7a5e520de349e1fa172baeba4a9e8d5ef06c47471863530bc4972ee1e"
+"checksum rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "403bb3a286107a04825a5f82e1270acc1e14028d3d554d7a1e08914549575ab8"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
@@ -3107,6 +3187,7 @@ dependencies = [
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum uint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "38051a96565903d81c9a9210ce11076b2218f3b352926baa1f5f6abbdfce8273"
+"checksum uint 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "754ba11732b9161b94c41798e5197e5e75388d012f760c42adb5000353e98646"
 "checksum uname 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
@@ -3130,6 +3211,7 @@ dependencies = [
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum wasmi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b4a6d379e9332b1b1f52c5a87f2481c85c7c931d8ec411963dfb8f26b1ec1e3"
 "checksum web3 0.3.1 (git+https://github.com/tomusdrw/rust-web3)" = "<none>"
+"checksum web3 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a618ea95d1f68185720c8a8f778f4a8371bba36e2370d3a331167fdf28dd5135"
 "checksum websocket 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9234b4e667c19995475227172446884f516ec0963380afa960d962ab9f4c0bfa"
 "checksum which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,7 +3,6 @@ name = "graph-core"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = "0.3"
 futures = "0.1.21"
 graph = { path = "../graph" }
 graph-graphql = { path = "../graphql" }
@@ -13,7 +12,7 @@ serde_yaml = "0.7"
 
 [dev-dependencies]
 failure = "0.1.2"
-ethabi = "5.1.1"
+ethabi = "6.0"
 graphql-parser = "0.2.0"
 ipfs-api = "0.5.0-alpha2"
 graph-mock = { path = "../mock" }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate ethereum_types;
 extern crate futures;
 extern crate graph;
 extern crate graph_graphql;

--- a/datasource/ethereum/Cargo.toml
+++ b/datasource/ethereum/Cargo.toml
@@ -3,10 +3,8 @@ name = "graph-datasource-ethereum"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = "0.3"
-ethabi = "5.1.1"
+ethabi = "6.0"
 failure = "0.1.2"
 futures = "0.1.21"
 jsonrpc-core = "8.0.1"
 graph = { path = "../../graph" }
-web3 = { git = "https://github.com/tomusdrw/rust-web3" }

--- a/datasource/ethereum/src/lib.rs
+++ b/datasource/ethereum/src/lib.rs
@@ -1,13 +1,9 @@
 extern crate ethabi;
-extern crate ethereum_types;
 #[macro_use]
 extern crate failure;
 extern crate futures;
 extern crate graph;
 extern crate jsonrpc_core;
-
-/// Re-export of the `web3` crate.
-pub extern crate web3;
 
 mod block_ingestor;
 mod ethereum_adapter;

--- a/datasource/ethereum/src/transport.rs
+++ b/datasource/ethereum/src/transport.rs
@@ -22,7 +22,7 @@ impl Transport {
     pub fn new_ipc(ipc: &str) -> (EventLoopHandle, Self) {
         ipc::Ipc::new(ipc)
             .map(|(event_loop, transport)| (event_loop, Transport::IPC(transport)))
-            .expect("Failed to connect to Ethereum RPC")
+            .expect("Failed to connect to Ethereum IPC")
     }
 
     /// Creates a WebSocket transport.
@@ -39,7 +39,7 @@ impl Transport {
     pub fn new_rpc(rpc: &str) -> (EventLoopHandle, Self) {
         http::Http::new(rpc)
             .map(|(event_loop, transport)| (event_loop, Transport::RPC(transport)))
-            .expect("Failed to connect to Ethereum WS")
+            .expect("Failed to connect to Ethereum RPC")
     }
 }
 

--- a/datasource/ethereum/src/transport.rs
+++ b/datasource/ethereum/src/transport.rs
@@ -1,13 +1,12 @@
 use futures::prelude::*;
 use graph::serde_json::Value;
 use jsonrpc_core::types::Call;
-use web3;
-use web3::transports::http;
-use web3::transports::ipc;
-use web3::transports::ws;
-use web3::RequestId;
 
-pub use web3::transports::EventLoopHandle;
+use graph::web3;
+use graph::web3::transports::{http, ipc, ws};
+use graph::web3::RequestId;
+
+pub use graph::web3::transports::EventLoopHandle;
 
 /// Abstraction over the different web3 transports.
 #[derive(Clone, Debug)]

--- a/datasource/ethereum/tests/adapter.rs
+++ b/datasource/ethereum/tests/adapter.rs
@@ -3,22 +3,22 @@ extern crate futures;
 extern crate graph;
 extern crate graph_datasource_ethereum;
 extern crate jsonrpc_core;
-extern crate web3;
 
 use ethabi::{Function, Param, ParamType, Token};
 use futures::prelude::*;
 use futures::{failed, finished};
-use graph::components::ethereum::EthereumContractCall;
-use graph::prelude::EthereumAdapter as EthereumAdapterTrait;
-use graph::serde_json;
-use graph_datasource_ethereum::{EthereumAdapter, EthereumAdapterConfig};
 use std::collections::VecDeque;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
-use web3::error::{Error, ErrorKind};
-use web3::helpers::*;
-use web3::types::*;
-use web3::{RequestId, Transport};
+
+use graph::components::ethereum::EthereumContractCall;
+use graph::prelude::EthereumAdapter as EthereumAdapterTrait;
+use graph::serde_json;
+use graph::web3::error::{Error, ErrorKind};
+use graph::web3::helpers::*;
+use graph::web3::types::*;
+use graph::web3::{RequestId, Transport};
+use graph_datasource_ethereum::{EthereumAdapter, EthereumAdapterConfig};
 
 pub type Result<T> = Box<Future<Item = T, Error = Error> + Send + 'static>;
 

--- a/datasource/ethereum/tests/adapter.rs
+++ b/datasource/ethereum/tests/adapter.rs
@@ -1,5 +1,4 @@
 extern crate ethabi;
-extern crate ethereum_types;
 extern crate futures;
 extern crate graph;
 extern crate graph_datasource_ethereum;

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 
 [dependencies]
 backtrace = "0.3.9"
-ethabi = "5.1"
-ethereum-types = "0.3"
+ethabi = "6.0"
 hex = "0.3.2"
 futures = "0.1.21"
 graphql-parser = "0.2.1"
@@ -22,4 +21,4 @@ slog-async = "2.3.0"
 slog-term = "2.4.0"
 tiny-keccak = "1.0"
 tokio = "0.1.7"
-web3 = { git = "https://github.com/tomusdrw/rust-web3" }
+web3 = "0.4.0"

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -1,9 +1,8 @@
 use ethabi::{Bytes, Error as ABIError, Event, Function, LogParam, ParamType, Token};
-use ethereum_types::{Address, H256};
-use failure::SyncFailure;
+use failure::{Error, SyncFailure};
 use futures::{Future, Stream};
 use web3::error::Error as Web3Error;
-use web3::types::{BlockId, BlockNumber};
+use web3::types::{Address, BlockId, BlockNumber, H256};
 
 /// A request for the state of a contract at a specific block hash and address.
 pub struct EthereumContractStateRequest {
@@ -44,6 +43,8 @@ pub enum EthereumContractCallError {
         _1
     )]
     TypeError(Token, ParamType),
+    #[fail(display = "call error: {}", _0)]
+    Error(Error),
 }
 
 impl From<Web3Error> for EthereumContractCallError {
@@ -55,6 +56,12 @@ impl From<Web3Error> for EthereumContractCallError {
 impl From<ABIError> for EthereumContractCallError {
     fn from(e: ABIError) -> Self {
         EthereumContractCallError::ABIError(SyncFailure::new(e))
+    }
+}
+
+impl From<Error> for EthereumContractCallError {
+    fn from(e: Error) -> Self {
+        EthereumContractCallError::Error(e)
     }
 }
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1,9 +1,7 @@
-use ethereum_types::H256;
 use failure::Error;
 use futures::Future;
 use futures::Stream;
-use web3::types::Block;
-use web3::types::Transaction;
+use web3::types::{Block, Transaction, H256};
 
 use data::store::*;
 use std::fmt;

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -1,6 +1,5 @@
 extern crate backtrace;
 extern crate ethabi;
-extern crate ethereum_types;
 extern crate futures;
 extern crate graphql_parser;
 extern crate hex;
@@ -20,7 +19,7 @@ extern crate slog_async;
 extern crate slog_term;
 extern crate tiny_keccak;
 pub extern crate tokio;
-extern crate web3;
+pub extern crate web3;
 
 /// Traits and types for all system components.
 pub mod components;

--- a/graph/src/util/ethereum.rs
+++ b/graph/src/util/ethereum.rs
@@ -1,6 +1,6 @@
 use ethabi::{Contract, Event};
-use ethereum_types::H256;
 use tiny_keccak::Keccak;
+use web3::types::H256;
 
 /// Hashes a string to a H256 hash.
 pub fn string_to_h256(s: &str) -> H256 {

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -16,4 +16,3 @@ serde_derive = "1.0"
 pretty_assertions = "0.5.1"
 graph-mock = { path = "../mock" }
 graph-core = { path = "../core" }
-web3 = { git = "https://github.com/tomusdrw/rust-web3" }

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -5,16 +5,13 @@ extern crate pretty_assertions;
 extern crate graph;
 extern crate graph_core;
 extern crate graph_graphql;
-extern crate web3;
 
 use graphql_parser::query as q;
 use std::sync::Mutex;
-use web3::types::Block;
-use web3::types::Transaction;
-use web3::types::H256;
 
 use graph::components::store::EventSource;
 use graph::prelude::*;
+use graph::web3::types::{Block, Transaction, H256};
 use graph_graphql::prelude::*;
 
 fn test_schema() -> Schema {

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -7,4 +7,3 @@ futures = "0.1.21"
 graphql-parser = "0.2.0"
 graph = { path = "../graph" }
 graph-graphql = { path = "../graphql" }
-web3 = { git = "https://github.com/tomusdrw/rust-web3" }

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -2,7 +2,6 @@ extern crate futures;
 extern crate graph;
 extern crate graph_graphql;
 extern crate graphql_parser;
-extern crate web3;
 
 mod graphql;
 mod server;

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -1,9 +1,6 @@
-use web3::types::Block;
-use web3::types::Transaction;
-use web3::types::H256;
-
 use graph::components::store::*;
 use graph::prelude::*;
+use graph::web3::types::{Block, Transaction, H256};
 
 /// A mock `Store`.
 pub struct MockStore {

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -3,15 +3,13 @@ name = "graph-runtime-wasm"
 version = "0.1.0"
 
 [dependencies]
-ethabi = "5.1.1"
-ethereum-types = "0.3"
+ethabi = "6.0"
 futures = "0.1.21"
 hex = "0.3.2"
 nan-preserving-float = "0.1.0"
 graph = { path = "../../graph" }
 uuid = { version = "0.6", features = ["v4"] }
 wasmi = "0.3"
-web3 = { git = "https://github.com/tomusdrw/rust-web3" }
 
 [dev-dependencies]
 failure = "0.1.2"

--- a/runtime/wasm/src/asc_abi/test.rs
+++ b/runtime/wasm/src/asc_abi/test.rs
@@ -1,14 +1,16 @@
 extern crate parity_wasm;
 
-use super::class::*;
-use super::{AscHeap, AscPtr};
 use ethabi::Token;
-use ethereum_types::{H160, U256};
 use nan_preserving_float::F32;
 use wasmi::{
     self, ImportsBuilder, MemoryRef, ModuleImportResolver, ModuleInstance, ModuleRef, NopExternals,
     RuntimeValue, Signature,
 };
+
+use graph::web3::types::{H160, U256};
+
+use super::class::*;
+use super::{AscHeap, AscPtr};
 
 struct TestModule {
     module: ModuleRef,

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -1,4 +1,3 @@
-use ethereum_types::Address;
 use futures::sync::mpsc::{channel, Receiver};
 use futures::sync::oneshot;
 use std::str::FromStr;
@@ -13,6 +12,7 @@ use graph::prelude::{
     RuntimeHost as RuntimeHostTrait, RuntimeHostBuilder as RuntimeHostBuilderTrait, *,
 };
 use graph::util;
+use graph::web3::types::Address;
 
 use module::{WasmiModule, WasmiModuleConfig};
 

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -1,25 +1,25 @@
 extern crate ethabi;
-extern crate ethereum_types;
 extern crate futures;
 extern crate graph;
 extern crate hex;
 extern crate nan_preserving_float;
 extern crate uuid;
 extern crate wasmi;
-extern crate web3;
 
 mod asc_abi;
 mod host;
 mod module;
 mod to_from;
 
+use self::graph::web3::types::{Address, H256};
+
 pub use self::host::{RuntimeHost, RuntimeHostBuilder, RuntimeHostConfig};
 
 #[derive(Clone, Debug)]
 pub(crate) struct UnresolvedContractCall {
-    pub block_hash: ethereum_types::H256,
+    pub block_hash: H256,
     pub contract_name: String,
-    pub contract_address: ethereum_types::Address,
+    pub contract_address: Address,
     pub function_name: String,
     pub function_args: Vec<ethabi::Token>,
 }

--- a/runtime/wasm/src/module.rs
+++ b/runtime/wasm/src/module.rs
@@ -1,18 +1,14 @@
-use ethereum_types::{H160, H256, U256};
 use futures::sync::mpsc::Sender;
-use graph::serde_json;
 use nan_preserving_float::F64;
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Mutex;
-
 use wasmi::{
     Error, Externals, FuncInstance, FuncRef, HostError, ImportsBuilder, MemoryRef, Module,
     ModuleImportResolver, ModuleInstance, ModuleRef, NopExternals, RuntimeArgs, RuntimeValue,
     Signature, Trap, TrapKind, ValueType,
 };
-use web3::types::BlockId;
 
 use graph::components::ethereum::*;
 use graph::components::store::{EventSource, StoreKey};
@@ -20,6 +16,8 @@ use graph::components::subgraph::RuntimeHostEvent;
 use graph::data::store::scalar;
 use graph::data::subgraph::DataSource;
 use graph::prelude::*;
+use graph::serde_json;
+use graph::web3::types::{BlockId, H160, H256, U256};
 
 use super::UnresolvedContractCall;
 use asc_abi::asc_ptr::*;
@@ -801,9 +799,7 @@ mod tests {
     extern crate graphql_parser;
     extern crate parity_wasm;
 
-    use self::graphql_parser::schema::Document;
     use ethabi::{LogParam, Token};
-    use ethereum_types::Address;
     use futures::sync::mpsc::channel;
     use std::collections::HashMap;
     use std::iter::FromIterator;
@@ -814,8 +810,11 @@ mod tests {
     use graph::components::subgraph::*;
     use graph::data::subgraph::*;
     use graph::util;
+    use graph::web3::types::Address;
 
     use super::*;
+
+    use self::graphql_parser::schema::Document;
 
     #[derive(Default)]
     struct MockEthereumAdapter {}

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -1,78 +1,78 @@
 use ethabi;
-use ethereum_types;
 use graph::serde_json;
 
 use graph::components::ethereum::EthereumEvent;
 use graph::data::store;
+use graph::web3::types as web3;
 
 use asc_abi::class::*;
 use asc_abi::{AscHeap, AscPtr, FromAscObj, ToAscObj};
 
 use UnresolvedContractCall;
 
-impl ToAscObj<ArrayBuffer<u8>> for ethereum_types::H160 {
+impl ToAscObj<ArrayBuffer<u8>> for web3::H160 {
     fn to_asc_obj<H: AscHeap>(&self, heap: &H) -> ArrayBuffer<u8> {
         self.0.to_asc_obj(heap)
     }
 }
 
-impl FromAscObj<ArrayBuffer<u8>> for ethereum_types::H160 {
+impl FromAscObj<ArrayBuffer<u8>> for web3::H160 {
     fn from_asc_obj<H: AscHeap>(array_buffer: ArrayBuffer<u8>, heap: &H) -> Self {
-        ethereum_types::H160(<[u8; 20]>::from_asc_obj(array_buffer, heap))
+        web3::H160(<[u8; 20]>::from_asc_obj(array_buffer, heap))
     }
 }
 
-impl ToAscObj<Uint8Array> for ethereum_types::H160 {
+impl ToAscObj<Uint8Array> for web3::H160 {
     fn to_asc_obj<H: AscHeap>(&self, heap: &H) -> Uint8Array {
         self.0.to_asc_obj(heap)
     }
 }
 
-impl FromAscObj<Uint8Array> for ethereum_types::H160 {
+impl FromAscObj<Uint8Array> for web3::H160 {
     fn from_asc_obj<H: AscHeap>(typed_array: Uint8Array, heap: &H) -> Self {
-        ethereum_types::H160(<[u8; 20]>::from_asc_obj(typed_array, heap))
+        web3::H160(<[u8; 20]>::from_asc_obj(typed_array, heap))
     }
 }
 
-impl FromAscObj<Uint8Array> for ethereum_types::H256 {
+impl FromAscObj<Uint8Array> for web3::H256 {
     fn from_asc_obj<H: AscHeap>(typed_array: Uint8Array, heap: &H) -> Self {
-        ethereum_types::H256(<[u8; 32]>::from_asc_obj(typed_array, heap))
+        web3::H256(<[u8; 32]>::from_asc_obj(typed_array, heap))
     }
 }
 
-impl ToAscObj<ArrayBuffer<u8>> for ethereum_types::H256 {
+impl ToAscObj<ArrayBuffer<u8>> for web3::H256 {
     fn to_asc_obj<H: AscHeap>(&self, heap: &H) -> ArrayBuffer<u8> {
         self.0.to_asc_obj(heap)
     }
 }
 
-impl ToAscObj<Uint8Array> for ethereum_types::H256 {
+impl ToAscObj<Uint8Array> for web3::H256 {
     fn to_asc_obj<H: AscHeap>(&self, heap: &H) -> Uint8Array {
         self.0.to_asc_obj(heap)
     }
 }
 
-impl ToAscObj<ArrayBuffer<u64>> for ethereum_types::U256 {
+impl ToAscObj<ArrayBuffer<u64>> for web3::U256 {
     fn to_asc_obj<H: AscHeap>(&self, heap: &H) -> ArrayBuffer<u64> {
         self.0.to_asc_obj(heap)
     }
 }
 
-impl FromAscObj<ArrayBuffer<u64>> for ethereum_types::U256 {
+impl FromAscObj<ArrayBuffer<u64>> for web3::U256 {
     fn from_asc_obj<H: AscHeap>(array_buffer: ArrayBuffer<u64>, heap: &H) -> Self {
-        ethereum_types::U256(<[u64; 4]>::from_asc_obj(array_buffer, heap))
+        web3::U256(<[u64; 4]>::from_asc_obj(array_buffer, heap))
     }
 }
 
-impl ToAscObj<Uint64Array> for ethereum_types::U256 {
+impl ToAscObj<Uint64Array> for web3::U256 {
     fn to_asc_obj<H: AscHeap>(&self, heap: &H) -> Uint64Array {
         self.0.to_asc_obj(heap)
     }
 }
 
-impl FromAscObj<Uint64Array> for ethereum_types::U256 {
+impl FromAscObj<Uint64Array> for web3::U256 {
     fn from_asc_obj<H: AscHeap>(array_buffer: Uint64Array, heap: &H) -> Self {
-        ethereum_types::U256(<[u64; 4]>::from_asc_obj(array_buffer, heap))
+        web3::U256(<[u64; 4]>::from_asc_obj(array_buffer, heap))
     }
 }
 

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.1.0"
 bigdecimal = "0.0.11"
 diesel = { version = "1.3.2", features = ["postgres", "serde_json", "numeric"] }
 diesel_migrations = "1.3.0"
-ethereum-types = "0.3"
 diesel-dynamic-schema = { git = "https://github.com/diesel-rs/diesel-dynamic-schema" }
 failure = "0.1.2"
 fallible-iterator = "0.1.4"
@@ -16,7 +15,6 @@ postgres = "0.15.2"
 serde = "1.0"
 serde_json = "1.0"
 uuid = { version = "0.6", features = ["v4"] }
-web3 = { git = "https://github.com/tomusdrw/rust-web3" }
 
 [dev-dependencies]
 lazy_static = "1.1"

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -11,7 +11,6 @@ extern crate graph;
 extern crate postgres;
 extern crate serde;
 extern crate uuid;
-extern crate web3;
 
 pub mod db_schema;
 mod entity_changes;

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -10,13 +10,11 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
-use web3::types::Block;
-use web3::types::Transaction;
-use web3::types::H256;
 
 use graph::components::store::{EventSource, Store as StoreTrait};
 use graph::prelude::*;
 use graph::serde_json;
+use graph::web3::types::{Block, Transaction, H256};
 use graph::{tokio, tokio::timer::Interval};
 
 use entity_changes::EntityChangeListener;

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1,5 +1,4 @@
 extern crate diesel;
-extern crate ethereum_types;
 extern crate futures;
 #[macro_use]
 extern crate lazy_static;
@@ -8,7 +7,6 @@ extern crate graph_store_postgres;
 
 use diesel::pg::PgConnection;
 use diesel::*;
-use ethereum_types::H256;
 use std::fmt::Debug;
 use std::panic;
 use std::sync::Mutex;
@@ -17,6 +15,7 @@ use graph::components::store::{
     EventSource, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange,
 };
 use graph::prelude::*;
+use graph::web3::types::H256;
 use graph_store_postgres::{db_schema, Store as DieselStore, StoreConfig};
 
 /// Helper function to ensure and obtain the Postgres URL to use for testing.


### PR DESCRIPTION
Previously, we were using the same types from `ethereum-types`, `ethabi` and `web3` in various places. Most of our crates would depend on `web3` separately. Altogether, this made it hard to be consistent and bump any of these dependencies, because this would introduce version conflicts.

This PR makes it so that only the `graph` crate depends on `web3`. It re-exports it for all other crates to use. The dependency on `ethereum-types` is dropped altogether and `ethabi` is only used for those types that are not re-exported by `web3`.