### PR TITLE
Postgres order_by attribute cast to correct data type before performing comparisons

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1,7 +1,7 @@
 use failure::Error;
 use futures::Future;
 use futures::Stream;
-use graphql_parser::{schema as s};
+use graphql_parser::schema as s;
 use web3::types::{Block, Transaction, H256};
 
 use data::store::*;

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1,16 +1,12 @@
 use failure::Error;
 use futures::Future;
 use futures::Stream;
-use graphql_parser::schema as s;
-use web3::types::{Block, Transaction, H256};
-
-use data::store::*;
 use std::fmt;
 use std::str::FromStr;
 use web3::types::H256;
 
+use data::store::*;
 use prelude::*;
-use std::ops::Deref;
 
 /// Key by which an individual entity in the store can be accessed.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -101,19 +101,6 @@ impl FromStr for ValueType {
         }
     }
 }
-impl From<s::Type> for ValueType {
-    fn from(schema_type: s::Type) -> ValueType {
-        match schema_type {
-            s::Type::NamedType(ref name) => ValueType::from_str(&name).unwrap(),
-            s::Type::NonNullType(inner) => match *inner {
-                s::Type::NamedType(ref name) => ValueType::from_str(&name).unwrap(),
-                s::Type::NonNullType(inner) => panic!(ValueTypeError::NestedNonNullType),
-                s::Type::ListType(inner) => panic!(ValueTypeError::CannotConvertFromListType),
-            },
-            s::Type::ListType(inner) => panic!(ValueTypeError::CannotConvertFromListType),
-        }
-    }
-}
 
 /// A query for entities in a store.
 #[derive(Clone, Debug, PartialEq)]

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -68,7 +68,7 @@ pub mod prelude {
     pub use components::store::{
         ChainStore, EntityChange, EntityChangeOperation, EntityChangeStream, EntityOperation,
         EventSource, Store, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange,
-        SubgraphEntityPair, ValueType
+        SubgraphEntityPair, ValueType,
     };
     pub use components::subgraph::{
         RuntimeHost, RuntimeHostBuilder, SchemaEvent, SubgraphInstance, SubgraphInstanceManager,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -68,7 +68,7 @@ pub mod prelude {
     pub use components::store::{
         ChainStore, EntityChange, EntityChangeOperation, EntityChangeStream, EntityOperation,
         EventSource, Store, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange,
-        SubgraphEntityPair,
+        SubgraphEntityPair, ValueType
     };
     pub use components::subgraph::{
         RuntimeHost, RuntimeHostBuilder, SchemaEvent, SubgraphInstance, SubgraphInstanceManager,

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -111,11 +111,7 @@ pub fn get_field_type<'a>(object_type: &'a ObjectType, name: &Name) -> Option<&'
 pub fn get_value_type(schema_type: Type) -> Result<ValueType, ValueTypeError> {
     match schema_type {
         Type::NamedType(ref name) => Ok(ValueType::from_str(&name).unwrap()),
-        Type::NonNullType(inner) => match *inner {
-            Type::NamedType(ref name) => Ok(ValueType::from_str(&name).unwrap()),
-            Type::NonNullType(_) => Err(ValueTypeError::NestedNonNullType),
-            Type::ListType(_) => Err(ValueTypeError::CannotConvertFromListType),
-        },
+        Type::NonNullType(inner) => get_value_type(*inner),
         Type::ListType(_) => Err(ValueTypeError::CannotConvertFromListType),
     }
 }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -164,7 +164,7 @@ fn build_order_by(
             q::Value::Enum(name) => {
                 let field = sast::get_field_type(entity, &name)
                     .expect("order by attribute does not belong to entity");
-                Some((name.to_owned(), ValueType::from(field.clone().field_type)))
+                Some((name.to_owned(), ValueType::from(field.field_type.clone())))
             }
             _ => None,
         }))

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -164,7 +164,11 @@ fn build_order_by(
             q::Value::Enum(name) => {
                 let field = sast::get_field_type(entity, &name)
                     .expect("order by attribute does not belong to entity");
-                Some((name.to_owned(), ValueType::from(field.field_type.clone())))
+                let value = sast::get_value_type(field.field_type.clone());
+                match value {
+                    Ok(v) => Some((name.to_owned(), v)),
+                    Err(_) => None,
+                }
             }
             _ => None,
         }))

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -157,7 +157,7 @@ fn list_values(value: Value, filter_type: &str) -> Result<Vec<Value>, QueryExecu
 fn build_order_by(
     entity: &s::ObjectType,
     arguments: &HashMap<&q::Name, q::Value>,
-) -> Result<Option<String>, QueryExecutionError> {
+) -> Result<Option<(String, ValueType)>, QueryExecutionError> {
     Ok(arguments
         .get(&"orderBy".to_string())
         .and_then(|value| match value {
@@ -372,14 +372,14 @@ mod tests {
             &HashMap::from_iter(
                 vec![(&"orderBy".to_string(), q::Value::Enum("name".to_string()))].into_iter(),
             ),
-        ).order_by;
+        ).unwrap().order_by;
         assert_eq!(
             build_query(
                 &default_object(),
                 &HashMap::from_iter(
                     vec![(&"orderBy".to_string(), q::Value::Enum("name".to_string()))].into_iter(),
                 )
-            ).order_by,
+            ).unwrap().order_by,
             Some(("name".to_string(), ValueType::String))
         );
         assert_eq!(
@@ -388,7 +388,7 @@ mod tests {
                 &HashMap::from_iter(
                     vec![(&"orderBy".to_string(), q::Value::Enum("email".to_string()))].into_iter()
                 )
-            ).order_by,
+            ).unwrap().order_by,
             Some(("email".to_string(), ValueType::String))
         );
     }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -367,7 +367,7 @@ mod tests {
             &default_object(),
             &HashMap::from_iter(
                 vec![(&"orderBy".to_string(), q::Value::Enum("name".to_string()))].into_iter(),
-            )
+            ),
         ).order_by;
         assert_eq!(
             build_query(

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -503,43 +503,21 @@ impl StoreTrait for Store {
                     StoreOrder::Ascending => String::from("ASC"),
                     StoreOrder::Descending => String::from("DESC"),
                 }).unwrap_or(String::from("ASC"));
-            diesel_query = match value_type {
-                ValueType::BigInt => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(")::bigint {} NULLS LAST", direction)),
-                ),
-                ValueType::Int => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(")::bigint {} NULLS LAST", direction)),
-                ),
-                ValueType::String => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(") {} NULLS LAST", direction)),
-                ),
-                ValueType::Float => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(")::numeric {} NULLS LAST", direction)),
-                ),
-                ValueType::ID => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(") {} NULLS LAST", direction)),
-                ),
-                ValueType::Bytes => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(") {} NULLS LAST", direction)),
-                ),
-                ValueType::Boolean => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(")::boolean {} NULLS LAST", direction)),
-                ),
+            let cast_type = match value_type {
+                ValueType::BigInt => "::bigint".to_string(),
+                ValueType::Boolean => "::boolean".to_string(),
+                ValueType::Bytes => "".to_string(),
+                ValueType::Float => "::numeric".to_string(),
+                ValueType::ID => "".to_string(),
+                ValueType::Int => "::bigint".to_string(),
+                ValueType::String => "".to_string(),
+                _ => "",
             };
+            diesel_query = diesel_query.order(
+                sql::<Text>("(data ->>")
+                    .bind::<Text, _>(order_attribute)
+                    .sql(&format!("){} {} NULLS LAST", cast_type, direction)),
+            );
         }
 
         // Add range filter to query

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -496,19 +496,50 @@ impl StoreTrait for Store {
         }
 
         // Add order by filters to query
-        if let Some(order_attribute) = query.order_by {
+        if let Some((order_attribute, value_type)) = query.order_by {
             let direction = query
                 .order_direction
                 .map(|direction| match direction {
                     StoreOrder::Ascending => String::from("ASC"),
                     StoreOrder::Descending => String::from("DESC"),
                 }).unwrap_or(String::from("ASC"));
-
-            diesel_query = diesel_query.order(
-                sql::<Text>("data ->> ")
-                    .bind::<Text, _>(order_attribute)
-                    .sql(&format!(" {} ", direction)),
-            )
+            diesel_query = match value_type {
+                ValueType::BigInt => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(")::bigint {} NULLS LAST", direction)),
+                ),
+                ValueType::Int => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(")::bigint {} NULLS LAST", direction)),
+                ),
+                ValueType::String => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(") {} NULLS LAST", direction)),
+                ),
+                ValueType::Float => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(")::numeric {} NULLS LAST", direction)),
+                ),
+                ValueType::ID => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(") {} NULLS LAST", direction)),
+                ),
+                ValueType::Bytes => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(") {} NULLS LAST", direction)),
+                ),
+                ValueType::Boolean => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(")::boolean {} NULLS LAST", direction)),
+                ),
+            };
         }
 
         // Add range filter to query

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -500,18 +500,17 @@ impl StoreTrait for Store {
             let direction = query
                 .order_direction
                 .map(|direction| match direction {
-                    StoreOrder::Ascending => String::from("ASC"),
-                    StoreOrder::Descending => String::from("DESC"),
-                }).unwrap_or(String::from("ASC"));
+                    StoreOrder::Ascending => "ASC",
+                    StoreOrder::Descending => "DESC",
+                }).unwrap_or("ASC");
             let cast_type = match value_type {
-                ValueType::BigInt => "::bigint".to_string(),
-                ValueType::Boolean => "::boolean".to_string(),
-                ValueType::Bytes => "".to_string(),
-                ValueType::Float => "::numeric".to_string(),
-                ValueType::ID => "".to_string(),
-                ValueType::Int => "::bigint".to_string(),
-                ValueType::String => "".to_string(),
-                _ => "",
+                ValueType::BigInt => "::numeric",
+                ValueType::Boolean => "::boolean",
+                ValueType::Bytes => "",
+                ValueType::Float => "::float",
+                ValueType::ID => "",
+                ValueType::Int => "::bigint",
+                ValueType::String => "",
             };
             diesel_query = diesel_query.order(
                 sql::<Text>("(data ->>")

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -521,7 +521,7 @@ fn find_string_less_than_order_by_asc() {
                 String::from("name"),
                 Value::String(String::from("Kundi")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Ascending),
             range: None,
         };
@@ -561,7 +561,7 @@ fn find_string_less_than_order_by_desc() {
                 String::from("name"),
                 Value::String(String::from("Kundi")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -601,7 +601,7 @@ fn find_string_less_than_range() {
                 String::from("name"),
                 Value::String(String::from("ZZZ")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 1, skip: 1 }),
         };
@@ -631,7 +631,7 @@ fn find_string_multiple_and() {
                 StoreFilter::LessThan(String::from("name"), Value::String(String::from("Cz"))),
                 StoreFilter::Equal(String::from("name"), Value::String(String::from("Cindini"))),
             ])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -661,7 +661,7 @@ fn find_string_ends_with() {
                 String::from("name"),
                 Value::String(String::from("ini")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -691,7 +691,7 @@ fn find_string_not_ends_with() {
                 String::from("name"),
                 Value::String(String::from("ini")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -721,7 +721,7 @@ fn find_string_in() {
                 String::from("name"),
                 vec![Value::String(String::from("Johnton"))],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -751,7 +751,7 @@ fn find_string_not_in() {
                 String::from("name"),
                 vec![Value::String(String::from("Shaqueeena"))],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -812,7 +812,7 @@ fn find_float_not_equal() {
                 String::from("weight"),
                 Value::Float(184.4 as f32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -872,7 +872,7 @@ fn find_float_less_than() {
                 String::from("weight"),
                 Value::Float(160 as f32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Ascending),
             range: None,
         };
@@ -902,7 +902,7 @@ fn find_float_less_than_order_by_desc() {
                 String::from("weight"),
                 Value::Float(160 as f32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -932,7 +932,7 @@ fn find_float_less_than_range() {
                 String::from("weight"),
                 Value::Float(161 as f32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 1, skip: 1 }),
         };
@@ -961,7 +961,7 @@ fn find_float_in() {
                 String::from("weight"),
                 vec![Value::Float(184.4 as f32), Value::Float(111.7 as f32)],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 5, skip: 0 }),
         };
@@ -991,7 +991,7 @@ fn find_float_not_in() {
                 String::from("weight"),
                 vec![Value::Float(184.4 as f32), Value::Float(111.7 as f32)],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 5, skip: 0 }),
         };
@@ -1021,7 +1021,7 @@ fn find_int_equal() {
                 String::from("age"),
                 Value::Int(67 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -1051,7 +1051,7 @@ fn find_int_not_equal() {
                 String::from("age"),
                 Value::Int(67 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -1111,7 +1111,7 @@ fn find_int_greater_or_equal() {
                 String::from("age"),
                 Value::Int(43 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Ascending),
             range: None,
         };
@@ -1141,7 +1141,7 @@ fn find_int_less_than() {
                 String::from("age"),
                 Value::Int(50 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Ascending),
             range: None,
         };
@@ -1171,7 +1171,7 @@ fn find_int_less_or_equal() {
                 String::from("age"),
                 Value::Int(43 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Ascending),
             range: None,
         };
@@ -1201,7 +1201,7 @@ fn find_int_less_than_order_by_desc() {
                 String::from("age"),
                 Value::Int(50 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -1231,7 +1231,7 @@ fn find_int_less_than_range() {
                 String::from("age"),
                 Value::Int(67 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 1, skip: 1 }),
         };
@@ -1261,7 +1261,7 @@ fn find_int_in() {
                 String::from("age"),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 5, skip: 0 }),
         };
@@ -1291,7 +1291,7 @@ fn find_int_not_in() {
                 String::from("age"),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 5, skip: 0 }),
         };
@@ -1321,7 +1321,7 @@ fn find_bool_equal() {
                 String::from("coffee"),
                 Value::Bool(true),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -1351,7 +1351,7 @@ fn find_bool_not_equal() {
                 String::from("coffee"),
                 Value::Bool(true),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Ascending),
             range: None,
         };
@@ -1381,7 +1381,7 @@ fn find_bool_in() {
                 String::from("coffee"),
                 vec![Value::Bool(true)],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 5, skip: 0 }),
         };
@@ -1411,7 +1411,7 @@ fn find_bool_not_in() {
                 String::from("coffee"),
                 vec![Value::Bool(true)],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 5, skip: 0 }),
         };
@@ -1441,7 +1441,7 @@ fn revert_block() {
                 String::from("name"),
                 Value::String(String::from("Shaqueeena")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -1488,7 +1488,7 @@ fn revert_block_with_delete() {
                 String::from("name"),
                 Value::String(String::from("Cindini")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some(("name".to_string(), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };


### PR DESCRIPTION
Resolves #331 

This PR fixes the filter query bug where all `order_by` comparisons were done in alphabetical order because the `jsonb` objects are returned as `text`; when adding an `order_by` filter the `jsonb` attribute must be cast from text to the correct data type before performing comparisons 

A new enum was created, `ValueType`, with a variant for each supported data type.  `ValueType` is now passed into the `order_by` query fragment builder and used to decide which data cast to perform before ordering.  The `order_by` queries have all been updated to now include `NULLS LAST`, so null values will not appear in the beginning of the filtered set.

Data casting from `jsonb::text` before comparing:
  - BigInt -> cast to `numeric`
  - Int -> cast to `bigint`
  - String -> leave as `text`
  - Float -> cast to `double precision`
  - Id -> leave as `text`
  - Bytes -> leave as `text`
  - Boolean -> cast to `boolean`



