### PR TITLE
Add network identifier check on startup

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -145,7 +145,12 @@ pub type SubgraphEntityPair = (String, String);
 /// Common trait for block data store implementations.
 pub trait BlockStore {
     /// Add a new network, but only if one with this name does not already exist in the block store
-    fn add_network_if_missing(&self, network_name: &str) -> Result<(), Error>;
+    fn add_network_if_missing(
+        &self,
+        network_name: &str,
+        net_version: &str,
+        genesis_block_hash: H256,
+    ) -> Result<(), Error>;
 
     /// Insert blocks into the store (or update if they are already present).
     fn upsert_blocks<'a, B: Stream<Item = Block<Transaction>, Error = Error> + Send + 'a>(

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -190,7 +190,7 @@ impl BasicStore for TestStore {
 }
 
 impl BlockStore for TestStore {
-    fn add_network_if_missing(&self, _network_name: &str) -> Result<(), Error> {
+    fn add_network_if_missing(&self, _: &str, _: &str, _: H256) -> Result<(), Error> {
         unimplemented!()
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -55,7 +55,7 @@ impl BasicStore for MockStore {
 }
 
 impl BlockStore for MockStore {
-    fn add_network_if_missing(&self, _: &str) -> Result<(), Error> {
+    fn add_network_if_missing(&self, _: &str, _: &str, _: H256) -> Result<(), Error> {
         unimplemented!()
     }
 
@@ -102,7 +102,7 @@ impl BasicStore for FakeStore {
 }
 
 impl BlockStore for FakeStore {
-    fn add_network_if_missing(&self, _: &str) -> Result<(), Error> {
+    fn add_network_if_missing(&self, _: &str, _: &str, _: H256) -> Result<(), Error> {
         panic!("called FakeStore")
     }
 

--- a/store/postgres/migrations/2018-09-18-180000_add_ethereum_network_identifiers/down.sql
+++ b/store/postgres/migrations/2018-09-18-180000_add_ethereum_network_identifiers/down.sql
@@ -1,0 +1,7 @@
+/**************************************************************
+* REMOVE etherum_networks COLUMNS
+**************************************************************/
+
+ALTER TABLE ethereum_networks
+	DROP COLUMN net_version,
+	DROP COLUMN genesis_block_hash;

--- a/store/postgres/migrations/2018-09-18-180000_add_ethereum_network_identifiers/up.sql
+++ b/store/postgres/migrations/2018-09-18-180000_add_ethereum_network_identifiers/up.sql
@@ -1,0 +1,8 @@
+/**************************************************************
+* ADD etherum_networks COLUMNS
+**************************************************************/
+
+ALTER TABLE ethereum_networks
+	ADD COLUMN net_version VARCHAR,
+	ADD COLUMN genesis_block_hash VARCHAR,
+	ADD CHECK ((net_version IS NULL) = (genesis_block_hash IS NULL));

--- a/store/postgres/src/db_schema.rs
+++ b/store/postgres/src/db_schema.rs
@@ -13,6 +13,8 @@ table! {
         name -> Varchar,
         head_block_hash -> Nullable<Varchar>,
         head_block_number -> Nullable<BigInt>,
+        net_version -> Nullable<Varchar>,
+        genesis_block_hash -> Nullable<Varchar>,
     }
 }
 


### PR DESCRIPTION
Check that we are connected to the same Ethereum network as the last time this network name was used. Panic block ingestor if, for example, the user switches from mainnet to kovan but does not use a new network name.

`add_network_if_missing` will be refactored away when the new block processing work gets merged in, but I'm sticking with that design for now

Maybe @nenadjaja could test this?

Closes #377 