### PR TITLE
store/postgres: Include subgraph id as input to block revert functions

### DIFF
--- a/store/postgres/src/functions.rs
+++ b/store/postgres/src/functions.rs
@@ -4,7 +4,7 @@ use diesel::sql_types::*;
 sql_function! {
     revert_block,
     RevertBlock,
-    (block_hash: Text)
+    (block_hash: Text, subgraph: Text)
 }
 sql_function! {
     current_setting,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -176,8 +176,8 @@ impl Store {
 
     /// Handles block reorganizations.
     /// Revert all store events related to the given block
-    pub fn revert_events(&self, block_hash: String) {
-        select(revert_block(block_hash))
+    pub fn revert_events(&self, block_hash: String, subgraph_id: String) {
+        select(revert_block(block_hash, subgraph_id))
             .execute(&*self.conn.lock().unwrap())
             .unwrap();
     }


### PR DESCRIPTION
Let's get this in master and then we can bring it up to feature/block-stream