### PR TITLE
Allow failures on Rust beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
 # Allow nightly to fail
   allow_failures:
     - rust: nightly
+    - rust: beta # until ipfs-api is un-regressed
   # Only check formatting when running against stable
   include:
     - env: CHECK_FORMATTING=true


### PR DESCRIPTION
ipfs-api is regressed on 1.30 beta, ignore that until it's un-regressed.

