### PR TITLE
runtime: Remove `block_hash` param from contract calls

### DIFF
--- a/runtime/wasm/src/asc_abi/class.rs
+++ b/runtime/wasm/src/asc_abi/class.rs
@@ -398,7 +398,6 @@ pub(crate) type AscJson = AscTypedMap<AscString, AscEnum<JsonValueKind>>;
 
 #[repr(C)]
 pub(crate) struct AscUnresolvedContractCall {
-    pub block_hash: AscPtr<AscH256>,
     pub contract_name: AscPtr<AscString>,
     pub contract_address: AscPtr<AscAddress>,
     pub function_name: AscPtr<AscString>,

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -11,13 +11,12 @@ mod host;
 mod module;
 mod to_from;
 
-use self::graph::web3::types::{Address, H256};
+use self::graph::web3::types::Address;
 
 pub use self::host::{RuntimeHost, RuntimeHostBuilder, RuntimeHostConfig};
 
 #[derive(Clone, Debug)]
 pub(crate) struct UnresolvedContractCall {
-    pub block_hash: H256,
     pub contract_name: String,
     pub contract_address: Address,
     pub function_name: String,

--- a/runtime/wasm/src/module.rs
+++ b/runtime/wasm/src/module.rs
@@ -336,7 +336,6 @@ where
               "address" => &unresolved_call.contract_address.to_string(),
               "contract" => &unresolved_call.contract_name,
               "function" => &unresolved_call.function_name,
-              "block_hash" => &unresolved_call.block_hash.to_string(),
               );
 
         // Obtain the path to the contract ABI
@@ -363,7 +362,7 @@ where
 
         let call = EthereumContractCall {
             address: unresolved_call.contract_address.clone(),
-            block_id: BlockId::Hash(unresolved_call.block_hash.clone()),
+            block_id: BlockId::Hash(self.block_hash.clone()),
             function: function.clone(),
             args: unresolved_call.function_args.clone(),
         };

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -271,7 +271,6 @@ impl ToAscObj<AscEthereumEvent> for EthereumEvent {
 impl FromAscObj<AscUnresolvedContractCall> for UnresolvedContractCall {
     fn from_asc_obj<H: AscHeap>(asc_call: AscUnresolvedContractCall, heap: &H) -> Self {
         UnresolvedContractCall {
-            block_hash: heap.asc_get(asc_call.block_hash),
             contract_name: heap.asc_get(asc_call.contract_name),
             contract_address: heap.asc_get(asc_call.contract_address),
             function_name: heap.asc_get(asc_call.function_name),


### PR DESCRIPTION
We already have that information in the `self.block_hash` field. Breaks compatibility with older versions of graph-cli.