### PR TITLE
Don't make GraphQL filter list fields required

### DIFF
--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -240,9 +240,7 @@ fn field_scalar_filter_input_values(
     .map(|filter_type| {
         let field_type = Type::NamedType(field_type.name.to_owned());
         let value_type = match filter_type {
-            "in" | "not_in" => Type::NonNullType(Box::new(Type::ListType(Box::new(
-                Type::NonNullType(Box::new(field_type)),
-            )))),
+            "in" | "not_in" => Type::ListType(Box::new(Type::NonNullType(Box::new(field_type)))),
             _ => field_type,
         };
         input_value(&field.name, filter_type, value_type)


### PR DESCRIPTION
Fixes #412 by generating list fields in `SomeType_filter` filters that are not required. Instead of generating
```graphql
input SomeType_filter {
  listAttr_in: [OtherType!]!
  listAttr_not_in: [OtherType!]!
}
```
we now generate
```graphql
input SomeType_filter {
  listAttr_in: [OtherType!]
  listAttr_not_in: [OtherType!]
}
```

This allows `where` arguments without `listAttr_in` and `listAttr_not_in` being set, which is what you want: all filter arguments are optional.