### PR TITLE
Return `null` from store.get if the entity wasn't found

### DIFF
--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -333,8 +333,8 @@ where
             .lock()
             .unwrap()
             .get(store_key)
-            .map_err(|_| host_error("Error getting entity".to_string()))
             .and_then(|result| Ok(Some(RuntimeValue::from(self.heap.asc_new(&result)))))
+            .or(Ok(Some(RuntimeValue::from(0))))
     }
 
     /// function ethereum.call(call: SmartContractCall): Array<Token>


### PR DESCRIPTION
This allows to conditionally create entities if they don't exist
yet, via e.g.

```typescript
let entity = store.get('MyEntity', 'some-id')
if (entity === null) {
  entity = new Entity()
  entity.setString('id', 'some-id')
}
entity.setString('someAttr', 'someValue')
store.set('MyEntity', entity.getString('id'), entity as Entity)
```

