### PR TITLE
Ford/store errors to interface

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -282,11 +282,11 @@ pub trait Store: Send + Sync {
 
     /// Looks up an entity using the given store key.
     // TODO need to validate block ptr
-    fn get(&self, key: StoreKey) -> Result<Entity, Error>;
+    fn get(&self, key: StoreKey) -> Result<Entity, QueryExecutionError>;
 
     /// Queries the store for entities that match the store query.
     // TODO need to validate block ptr
-    fn find(&self, query: StoreQuery) -> Result<Vec<Entity>, ()>;
+    fn find(&self, query: StoreQuery) -> Result<Vec<Entity>, QueryExecutionError>;
 
     /// Updates the block pointer.  Careful: this is only safe to use if it is known that no store
     /// changes are needed to go from `block_ptr_from` to `block_ptr_to`.

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -14,12 +14,17 @@ pub enum QueryExecutionError {
     NoRootQueryObjectType,
     NoRootSubscriptionObjectType,
     ResolveEntityError(Pos, String),
+    ResolveListError,
     NonNullError(Pos, String),
     ListValueError(Pos, String),
     NamedTypeError(String),
+    ObjectFieldError,
     AbstractTypeError(String),
     InvalidArgumentError(Pos, String, q::Value),
     MissingArgumentError(Pos, String),
+    StoreQueryError(String),
+    FilterNotSupportedError(String, String),
+    //    ExecutionErrorList(Vec<QueryExecutionError>),
     UnknownField(Pos, String, String),
     EmptyQuery,
     MultipleSubscriptionFields,
@@ -61,6 +66,7 @@ impl fmt::Display for QueryExecutionError {
             QueryExecutionError::NamedTypeError(s) => {
                 write!(f, "Failed to resolve named type: {}", s)
             }
+            QueryExecutionError::ObjectFieldError => write!(f, "Object field contains 0 types"),
             QueryExecutionError::AbstractTypeError(s) => {
                 write!(f, "Failed to resolve abstract type: {}", s)
             }
@@ -69,6 +75,17 @@ impl fmt::Display for QueryExecutionError {
             }
             QueryExecutionError::MissingArgumentError(_, s) => {
                 write!(f, "No value provided for required argument: {}", s)
+            }
+            QueryExecutionError::StoreQueryError(s) => {
+                write!(f, "Failed to resolve store query, error: {}", s)
+            }
+            QueryExecutionError::FilterNotSupportedError(value, filter) => write!(
+                f,
+                "Value does not support this filter, value: {}, filter: {}",
+                value, filter
+            ),
+            QueryExecutionError::ResolveListError => {
+                write!(f, "Failed to resolve named type within list type")
             }
             QueryExecutionError::UnknownField(_, t, s) => {
                 write!(f, "Type \"{}\" has no field \"{}\"", t, s)
@@ -79,6 +96,12 @@ impl fmt::Display for QueryExecutionError {
                 "Only a single top-level field is allowed in subscriptions"
             ),
         }
+    }
+}
+
+impl From<QueryExecutionError> for Vec<QueryExecutionError> {
+    fn from(e: QueryExecutionError) -> Self {
+        vec![e]
     }
 }
 

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -83,7 +83,7 @@ impl fmt::Display for QueryExecutionError {
                 write!(f, "Failed to get entity from store: {}", s)
             }
             QueryExecutionError::FilterNotSupportedError(value, filter) => {
-                write!(f, "Filter not supported by value {}:{}", value, filter)
+                write!(f, "Filter not supported by value {} : {}", value, filter)
             }
             QueryExecutionError::UnknownField(_, t, s) => {
                 write!(f, "Type \"{}\" has no field \"{}\"", t, s)
@@ -117,7 +117,7 @@ impl fmt::Display for QueryExecutionError {
                 write!(f, "Failed to decode {} value: {}", t, e)
             }
             QueryExecutionError::AttributeTypeError(value, ty) => {
-                write!(f, "Query contains value with invalid type {}:{}", ty, value)
+                write!(f, "Query contains value with invalid type {} : {}", ty, value)
             }
             QueryExecutionError::EntityParseError(s) => {
                 write!(f, "Broken entity found in store: {}", s)

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -1,8 +1,10 @@
+use data::store::Value;
 use graphql_parser::{query as q, Pos};
 use serde::ser::*;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
+use std::mem::Discriminant;
 use std::string::FromUtf8Error;
 
 /// Error caused while executing a [Query](struct.Query.html).
@@ -31,6 +33,9 @@ pub enum QueryExecutionError {
     SubgraphParseError(String),
     BuildRangeTypeError,
     BuildFilterError,
+    EntityAttributeError,
+    ListTypesError(Discriminant<Value>, Discriminant<Value>),
+    ListFilterError,
 }
 
 impl Error for QueryExecutionError {
@@ -98,9 +103,24 @@ impl fmt::Display for QueryExecutionError {
                 f,
                 "Only a single top-level field is allowed in subscriptions"
             ),
-            QueryExecutionError::SubgraphParseError(s) => write!(f, "Failed to get subgraph ID from type: {}", s),
-            QueryExecutionError::BuildRangeTypeError => write!(f, "Range inputs must be an integer"),
-            QueryExecutionError::BuildFilterError=> write!(f, "Filter must by an object"),
+            QueryExecutionError::SubgraphParseError(s) => {
+                write!(f, "Failed to get subgraph ID from type: {}", s)
+            }
+            QueryExecutionError::BuildRangeTypeError => {
+                write!(f, "Range inputs must be an integer")
+            }
+            QueryExecutionError::BuildFilterError => write!(f, "Filter must by an object"),
+            QueryExecutionError::EntityAttributeError => {
+                write!(f, "Attribute does not belong to entity")
+            }
+            QueryExecutionError::ListTypesError(t, d) => {
+                write!(f, "List field contains inconsistent Value types")
+            }
+            QueryExecutionError::ListFilterError => write!(
+                f,
+                "Non-list value resolved for list filter  \
+                 *Hint*: IN and NOT_IN filters take an array of values"
+            ),
         }
     }
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 use std::mem::Discriminant;
-use std::string::{FromUtf8Error};
 use std::str::FromStr;
+use std::string::FromUtf8Error;
 
 /// Error caused while executing a [Query](struct.Query.html).
 #[derive(Debug)]

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -29,8 +29,8 @@ pub enum QueryExecutionError {
     SupgraphIdError(String),
     RangeArgumentsError(Vec<String>),
     InvalidFilterError,
-    EntityAttributeError(String, String),
-    ListTypesError(String),
+    EntityFieldError(String, String),
+    ListTypesError(String, Vec<String>),
     ListFilterError(String),
     ValueParseError(String, String),
     AttributeTypeError(String, String),
@@ -83,7 +83,7 @@ impl fmt::Display for QueryExecutionError {
                 write!(f, "Failed to get entity from store: {}", s)
             }
             QueryExecutionError::FilterNotSupportedError(value, filter) => {
-                write!(f, "Filter not supported by value, {}:{}", value, filter)
+                write!(f, "Filter not supported by value {}:{}", value, filter)
             }
             QueryExecutionError::UnknownField(_, t, s) => {
                 write!(f, "Type \"{}\" has no field \"{}\"", t, s)
@@ -96,31 +96,29 @@ impl fmt::Display for QueryExecutionError {
             QueryExecutionError::SupgraphIdError(s) => {
                 write!(f, "Failed to get subgraph ID from type: {}", s)
             }
-            QueryExecutionError::RangeArgumentsError(s) => write!(
-                f,
-                "Range inputs must be an integer, {:}",
-                s.iter().fold(String::new(), |acc, value| acc + &value)
-            ),
+            QueryExecutionError::RangeArgumentsError(s) => {
+                write!(f, "Range arguments must be properly formed integer: {:}", s.join(", "))
+            }
             QueryExecutionError::InvalidFilterError => write!(f, "Filter must by an object"),
-            QueryExecutionError::EntityAttributeError(e, a) => {
+            QueryExecutionError::EntityFieldError(e, a) => {
                 write!(f, "Entity {} has no attribute {}", e, a)
             }
-            QueryExecutionError::ListTypesError(s) => write!(
+
+            QueryExecutionError::ListTypesError(s, v) => write!(
                 f,
-                "Values passed to filter {} must be of the same type but are of different types",
-                s
+                "Values passed to filter {} must be of the same type but are of different types: {}",
+                s,
+                v.join(", ")
             ),
             QueryExecutionError::ListFilterError(s) => {
                 write!(f, "Non-list value passed to {} filter", s)
             }
             QueryExecutionError::ValueParseError(t, e) => {
-                write!(f, "Failed to decode {} value, {}", t, e)
+                write!(f, "Failed to decode {} value: {}", t, e)
             }
-            QueryExecutionError::AttributeTypeError(value, ty) => write!(
-                f,
-                "Query contains attribute with invalid type, {}:{}",
-                value, ty
-            ),
+            QueryExecutionError::AttributeTypeError(value, ty) => {
+                write!(f, "Query contains value with invalid type {}:{}", ty, value)
+            }
             QueryExecutionError::EntityParseError(s) => {
                 write!(f, "Broken entity found in store: {}", s)
             }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -34,6 +34,7 @@ pub enum QueryExecutionError {
     ListFilterError(String),
     ValueParseError(String, String),
     AttributeTypeError(String, String),
+    EntityParseError(String),
 }
 
 impl Error for QueryExecutionError {
@@ -79,7 +80,7 @@ impl fmt::Display for QueryExecutionError {
                 write!(f, "No value provided for required argument: {}", s)
             }
             QueryExecutionError::ResolveEntitiesError(s) => {
-                write!(f, "Failed to resolve entities: {}", s)
+                write!(f, "Failed to get entity from store: {}", s)
             }
             QueryExecutionError::FilterNotSupportedError(value, filter) => {
                 write!(f, "Filter not supported by value, {}:{}", value, filter)
@@ -120,6 +121,9 @@ impl fmt::Display for QueryExecutionError {
                 "Query contains attribute with invalid type, {}:{}",
                 value, ty
             ),
+            QueryExecutionError::EntityParseError(s) => {
+                write!(f, "Broken entity found in store: {}", s)
+            }
         }
     }
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -36,7 +36,7 @@ pub enum QueryExecutionError {
     BuildRangeTypeError,
     BuildFilterError,
     EntityAttributeError,
-    ListTypesError(Discriminant<Value>, Discriminant<Value>),
+    ListTypesError(),
     ListFilterError,
 }
 
@@ -115,7 +115,7 @@ impl fmt::Display for QueryExecutionError {
             QueryExecutionError::EntityAttributeError => {
                 write!(f, "Attribute does not belong to entity")
             }
-            QueryExecutionError::ListTypesError(t, d) => {
+            QueryExecutionError::ListTypesError() => {
                 write!(f, "List field contains inconsistent Value types")
             }
             QueryExecutionError::ListFilterError => write!(

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -28,6 +28,9 @@ pub enum QueryExecutionError {
     UnknownField(Pos, String, String),
     EmptyQuery,
     MultipleSubscriptionFields,
+    SubgraphParseError(String),
+    BuildRangeTypeError,
+    BuildFilterError,
 }
 
 impl Error for QueryExecutionError {
@@ -95,6 +98,9 @@ impl fmt::Display for QueryExecutionError {
                 f,
                 "Only a single top-level field is allowed in subscriptions"
             ),
+            QueryExecutionError::SubgraphParseError(s) => write!(f, "Failed to get subgraph ID from type: {}", s),
+            QueryExecutionError::BuildRangeTypeError => write!(f, "Range inputs must be an integer"),
+            QueryExecutionError::BuildFilterError=> write!(f, "Filter must by an object"),
         }
     }
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -31,7 +31,7 @@ pub enum QueryExecutionError {
     InvalidFilterError,
     EntityAttributeError(String, String),
     ListTypesError(String),
-    ListFilterError,
+    ListFilterError(String),
     ValueParseError(String, String),
     AttributeTypeError(String, String),
 }
@@ -109,11 +109,9 @@ impl fmt::Display for QueryExecutionError {
                 "Values passed to filter {} must be of the same type but are of different types",
                 s
             ),
-            QueryExecutionError::ListFilterError => write!(
-                f,
-                "Non-list value passed to list filter. \
-                 Hint: _in and _not_in filters take a list of values."
-            ),
+            QueryExecutionError::ListFilterError(s) => {
+                write!(f, "Non-list value passed to {} filter", s)
+            }
             QueryExecutionError::ValueParseError(t, e) => {
                 write!(f, "Failed to decode {} value, {}", t, e)
             }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -1,11 +1,14 @@
 use data::store::Value;
 use graphql_parser::{query as q, Pos};
+use hex::FromHexError;
+use num_bigint;
 use serde::ser::*;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 use std::mem::Discriminant;
-use std::string::FromUtf8Error;
+use std::string::{FromUtf8Error};
+use std::str::FromStr;
 
 /// Error caused while executing a [Query](struct.Query.html).
 #[derive(Debug)]
@@ -26,7 +29,6 @@ pub enum QueryExecutionError {
     MissingArgumentError(Pos, String),
     StoreQueryError(String),
     FilterNotSupportedError(String, String),
-    //    ExecutionErrorList(Vec<QueryExecutionError>),
     UnknownField(Pos, String, String),
     EmptyQuery,
     MultipleSubscriptionFields,
@@ -128,6 +130,18 @@ impl fmt::Display for QueryExecutionError {
 impl From<QueryExecutionError> for Vec<QueryExecutionError> {
     fn from(e: QueryExecutionError) -> Self {
         vec![e]
+    }
+}
+
+impl From<FromHexError> for QueryExecutionError {
+    fn from(_e: FromHexError) -> Self {
+        QueryExecutionError::NamedTypeError("Bytes".to_string())
+    }
+}
+
+impl From<num_bigint::ParseBigIntError> for QueryExecutionError {
+    fn from(_e: num_bigint::ParseBigIntError) -> Self {
+        QueryExecutionError::NamedTypeError("BigInt".to_string())
     }
 }
 

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -27,17 +27,20 @@ impl QueryResult {
     pub fn new(data: Option<q::Value>) -> Self {
         QueryResult { data, errors: None }
     }
-
-    pub fn add_error(&mut self, e: QueryError) {
-        let errors = self.errors.get_or_insert(vec![]);
-        errors.push(e);
-    }
 }
 
 impl From<QueryExecutionError> for QueryResult {
     fn from(e: QueryExecutionError) -> Self {
         let mut result = Self::new(None);
         result.errors = Some(vec![QueryError::from(e)]);
+        result
+    }
+}
+
+impl From<Vec<QueryExecutionError>> for QueryResult {
+    fn from(e: Vec<QueryExecutionError>) -> Self {
+        let mut result = Self::new(None);
+        result.errors = Some(e.into_iter().map(|error| QueryError::from(error)).collect());
         result
     }
 }

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -39,8 +39,9 @@ impl From<QueryExecutionError> for QueryResult {
 
 impl From<Vec<QueryExecutionError>> for QueryResult {
     fn from(e: Vec<QueryExecutionError>) -> Self {
-        let mut result = Self::new(None);
-        result.errors = Some(e.into_iter().map(|error| QueryError::from(error)).collect());
-        result
+        QueryResult {
+            data: None,
+            errors: Some(e.into_iter().map(|error| QueryError::from(error)).collect()),
+        }
     }
 }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -51,7 +51,19 @@ impl Value {
                     .map(|value| Self::from_query_value(value, &NamedType(n.to_string())))
                     .collect(),
             ),
-
+            (query::Value::Enum(e), NamedType(n)) => {
+                // Check if `ty` is a custom scalar type, otherwise assume it's
+                // just a string.
+                match n.as_str() {
+                    BYTES_SCALAR => {
+                        Value::Bytes(scalar::Bytes::from_str(e).expect("Value is not a hex string"))
+                    }
+                    BIG_INT_SCALAR => {
+                        Value::BigInt(scalar::BigInt::from_str(e).expect("Value is not a number"))
+                    }
+                    _ => Value::String(e.clone()),
+                }
+            }
             (query::Value::String(s), NamedType(n)) => {
                 // Check if `ty` is a custom scalar type, otherwise assume it's
                 // just a string.
@@ -74,7 +86,7 @@ impl Value {
             (query::Value::Float(f), _) => Value::Float(f.to_owned() as f32),
             (query::Value::Boolean(b), _) => Value::Bool(b.to_owned()),
             (query::Value::Null, _) => Value::Null,
-            _ => unimplemented!(),
+            _ => Value::Null,
         }
     }
 }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -3,10 +3,10 @@ use graphql_parser::schema;
 use prelude::QueryExecutionError;
 
 use std::collections::{BTreeMap, HashMap};
+use std::fmt;
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
-use std::fmt;
 
 /// Custom scalars in GraphQL.
 pub mod scalar;
@@ -101,9 +101,10 @@ impl fmt::Display for Value {
             Value::Float(f) => f.to_string(),
             Value::Bool(b) => b.to_string(),
             Value::Null => "null".to_string(),
-            Value::List(ref values) => {
-                values.into_iter().map(|value| format!("{}", value)).collect()
-            }
+            Value::List(ref values) => values
+                .into_iter()
+                .map(|value| format!("{}", value))
+                .collect(),
             Value::Bytes(ref bytes) => bytes.to_string(),
             Value::BigInt(ref number) => number.to_string(),
         };

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -6,6 +6,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
+use std::fmt;
 
 /// Custom scalars in GraphQL.
 pub mod scalar;
@@ -82,8 +83,31 @@ impl Value {
             (query::Value::Float(f), _) => Value::Float(f.to_owned() as f32),
             (query::Value::Boolean(b), _) => Value::Bool(b.to_owned()),
             (query::Value::Null, _) => Value::Null,
-            _ => Value::Null,
+            _ => {
+                return Err(QueryExecutionError::AttributeTypeError(
+                    value.to_string(),
+                    ty.to_string(),
+                ))
+            }
         })
+    }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let printable = match self {
+            Value::String(s) => s.to_string(),
+            Value::Int(i) => i.to_string(),
+            Value::Float(f) => f.to_string(),
+            Value::Bool(b) => b.to_string(),
+            Value::Null => "null".to_string(),
+            Value::List(ref values) => {
+                values.into_iter().map(|value| format!("{}", value)).collect()
+            }
+            Value::Bytes(ref bytes) => bytes.to_string(),
+            Value::BigInt(ref number) => number.to_string(),
+        };
+        write!(f, "{}", printable)
     }
 }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,6 +1,6 @@
-use prelude::QueryExecutionError;
 use graphql_parser::query;
 use graphql_parser::schema;
+use prelude::QueryExecutionError;
 
 use std::collections::{BTreeMap, HashMap};
 use std::iter::FromIterator;
@@ -32,7 +32,10 @@ pub enum Value {
 }
 
 impl Value {
-    pub fn from_query_value(value: &query::Value, ty: &schema::Type) -> Result<Value, QueryExecutionError>{
+    pub fn from_query_value(
+        value: &query::Value,
+        ty: &schema::Type,
+    ) -> Result<Value, QueryExecutionError> {
         use self::schema::Type::{ListType, NamedType, NonNullType};
 
         Ok(match (value, ty) {
@@ -56,12 +59,8 @@ impl Value {
                 // Check if `ty` is a custom scalar type, otherwise assume it's
                 // just a string.
                 match n.as_str() {
-                    BYTES_SCALAR => {
-                        Value::Bytes(scalar::Bytes::from_str(e)?)
-                    }
-                    BIG_INT_SCALAR => {
-                        Value::BigInt(scalar::BigInt::from_str(e)?)
-                    }
+                    BYTES_SCALAR => Value::Bytes(scalar::Bytes::from_str(e)?),
+                    BIG_INT_SCALAR => Value::BigInt(scalar::BigInt::from_str(e)?),
                     _ => Value::String(e.clone()),
                 }
             }
@@ -69,12 +68,8 @@ impl Value {
                 // Check if `ty` is a custom scalar type, otherwise assume it's
                 // just a string.
                 match n.as_str() {
-                    BYTES_SCALAR => {
-                        Value::Bytes(scalar::Bytes::from_str(s)?)
-                    }
-                    BIG_INT_SCALAR => {
-                        Value::BigInt(scalar::BigInt::from_str(s)?)
-                    }
+                    BYTES_SCALAR => Value::Bytes(scalar::Bytes::from_str(s)?),
+                    BIG_INT_SCALAR => Value::BigInt(scalar::BigInt::from_str(s)?),
                     _ => Value::String(s.clone()),
                 }
             }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -95,20 +95,23 @@ impl Value {
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let printable = match self {
-            Value::String(s) => s.to_string(),
-            Value::Int(i) => i.to_string(),
-            Value::Float(f) => f.to_string(),
-            Value::Bool(b) => b.to_string(),
-            Value::Null => "null".to_string(),
-            Value::List(ref values) => values
-                .into_iter()
-                .map(|value| format!("{}", value))
-                .collect(),
-            Value::Bytes(ref bytes) => bytes.to_string(),
-            Value::BigInt(ref number) => number.to_string(),
-        };
-        write!(f, "{}", printable)
+        write!(
+            f,
+            "{}",
+            match self {
+                Value::String(s) => s.to_string(),
+                Value::Int(i) => i.to_string(),
+                Value::Float(f) => f.to_string(),
+                Value::Bool(b) => b.to_string(),
+                Value::Null => "null".to_string(),
+                Value::List(ref values) => values
+                    .into_iter()
+                    .map(|value| format!("{}", value))
+                    .collect(),
+                Value::Bytes(ref bytes) => bytes.to_string(),
+                Value::BigInt(ref number) => number.to_string(),
+            }
+        )
     }
 }
 

--- a/graph/src/data/subscription/error.rs
+++ b/graph/src/data/subscription/error.rs
@@ -7,6 +7,8 @@ use prelude::QueryExecutionError;
 pub enum SubscriptionError {
     #[fail(display = "GraphQL error: {}", _0)]
     GraphQLError(QueryExecutionError),
+    #[fail(display = "GraphQL errors: {:?}", _0)]
+    GraphQLErrorList(Vec<QueryExecutionError>),
 }
 
 impl From<QueryExecutionError> for SubscriptionError {
@@ -15,6 +17,11 @@ impl From<QueryExecutionError> for SubscriptionError {
     }
 }
 
+impl From<Vec<QueryExecutionError>> for SubscriptionError {
+    fn from(e: Vec<QueryExecutionError>) -> Self {
+        SubscriptionError::GraphQLErrorList(e)
+    }
+}
 impl Serialize for SubscriptionError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/graph/src/data/subscription/error.rs
+++ b/graph/src/data/subscription/error.rs
@@ -5,21 +5,19 @@ use prelude::QueryExecutionError;
 /// Error caused while processing a [Subscription](struct.Subscription.html) request.
 #[derive(Debug, Fail)]
 pub enum SubscriptionError {
-    #[fail(display = "GraphQL error: {}", _0)]
-    GraphQLError(QueryExecutionError),
-    #[fail(display = "GraphQL errors: {:?}", _0)]
-    GraphQLErrorList(Vec<QueryExecutionError>),
+    #[fail(display = "GraphQL error: {:?}", _0)]
+    GraphQLError(Vec<QueryExecutionError>),
 }
 
 impl From<QueryExecutionError> for SubscriptionError {
     fn from(e: QueryExecutionError) -> Self {
-        SubscriptionError::GraphQLError(e)
+        SubscriptionError::GraphQLError(vec![e])
     }
 }
 
 impl From<Vec<QueryExecutionError>> for SubscriptionError {
     fn from(e: Vec<QueryExecutionError>) -> Self {
-        SubscriptionError::GraphQLErrorList(e)
+        SubscriptionError::GraphQLError(e)
     }
 }
 impl Serialize for SubscriptionError {

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -660,8 +660,7 @@ where
             },
             abstract_type,
             object_value,
-        )
-        .ok_or(vec![QueryExecutionError::AbstractTypeError(
+        ).ok_or(vec![QueryExecutionError::AbstractTypeError(
             sast::get_type_name(abstract_type).to_string(),
         )])
 }

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -14,7 +14,7 @@ pub trait Resolver: Clone + Send + Sync {
         field_definition: &s::Field,
         object_type: &s::ObjectType,
         arguments: &HashMap<&q::Name, q::Value>,
-    ) -> q::Value;
+    ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an entity referenced by a parent object.
     fn resolve_object(
@@ -24,7 +24,7 @@ pub trait Resolver: Clone + Send + Sync {
         field_definition: &s::Field,
         object_type: &s::ObjectType,
         arguments: &HashMap<&q::Name, q::Value>,
-    ) -> q::Value;
+    ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an enum value for a given enum type.
     fn resolve_enum_value(&self, enum_type: &s::EnumType, value: Option<&q::Value>) -> q::Value {

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -506,11 +506,11 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
                             .collect(),
                     ))
                 } else {
-                    Err(QueryExecutionError::ObjectFieldError)
+                    Ok(q::Value::Null)
                 }
             }
             _ => object_field(parent, field.as_str())
-                .map_or(Err(QueryExecutionError::ObjectFieldError), |value| {
+                .map_or(Ok(q::Value::Null), |value| {
                     Ok(value.clone())
                 }),
         }

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -510,9 +510,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
                 }
             }
             _ => object_field(parent, field.as_str())
-                .map_or(Ok(q::Value::Null), |value| {
-                    Ok(value.clone())
-                }),
+                .map_or(Ok(q::Value::Null), |value| Ok(value.clone())),
         }
     }
 

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -49,7 +49,7 @@ where
         fields: vec![],
     };
 
-    match operation {
+    let result = match operation {
         // Execute top-level `query { ... }` expressions
         &q::OperationDefinition::Query(q::Query {
             ref selection_set, ..
@@ -61,8 +61,13 @@ where
         }
 
         // Everything else (e.g. mutations) is unsupported
-        _ => QueryResult::from(QueryExecutionError::NotSupported(
+        _ => Err(vec![QueryExecutionError::NotSupported(
             "Only queries are supported".to_string(),
-        )),
+        )]),
+    };
+
+    match result {
+        Ok(value) => QueryResult::new(Some(value)),
+        Err(e) => QueryResult::from(e),
     }
 }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -1,7 +1,8 @@
 use graph::prelude::*;
 use graphql_parser::{query as q, schema as s};
-use schema::ast as sast;
+use schema::sast;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::mem::discriminant;
 
 /// Builds a StoreQuery from GraphQL arguments.
 pub fn build_query(entity: &s::ObjectType, arguments: &HashMap<&q::Name, q::Value>) -> StoreQuery {
@@ -94,7 +95,20 @@ fn build_filter_from_object(
 /// Parses a list of GraphQL values into a vector of entity attribute values.
 fn list_values(value: Value) -> Vec<Value> {
     match value {
-        Value::List(values) => values,
+        Value::List(ref values) if !values.is_empty() => {
+            // Check that all values in list are of the same type
+            // let value_type = discriminant(&values[0]);
+            values
+                .into_iter()
+                .map(|value| {
+                    if discriminant(&values[0]) == discriminant(value) {
+                        value.clone()
+                    } else {
+                        panic!("list value contains multiple value types");
+                    }
+                })
+                .collect::<Vec<Value>>()
+        }
         _ => panic!("value is not a list"),
     }
 }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -127,7 +127,7 @@ fn build_filter_from_object(
     })))
 }
 
-/// Parses a list of GraphQL values into a vector of entity attribute values.
+/// Parses a list of GraphQL values into a vector of entity field values.
 fn list_values(value: Value, filter_type: &str) -> Result<Vec<Value>, QueryExecutionError> {
     match value {
         Value::List(ref values) if !values.is_empty() => {
@@ -140,7 +140,7 @@ fn list_values(value: Value, filter_type: &str) -> Result<Vec<Value>, QueryExecu
                     if root_discriminant == current_discriminant {
                         Ok(value.clone())
                     } else {
-                        Err(QueryExecutionError::ListTypesError(filter_type.to_string()))
+                        Err(QueryExecutionError::ListTypesError(filter_type.to_string(), vec![values[0].to_string(), value.to_string()]))
                     }
                 }).collect::<Result<Vec<_>, _>>()
         }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -1,5 +1,5 @@
 use graph::prelude::*;
-use graphql_parser::{query as q, schema as s, Pos};
+use graphql_parser::{query as q, schema as s};
 use schema::ast as sast;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::mem::discriminant;
@@ -92,7 +92,7 @@ fn build_filter_from_object(
                     .ok_or(QueryExecutionError::EntityAttributeError)?;
 
                 let ty = &field.field_type;
-                let store_value = Value::from_query_value(value, &ty);
+                let store_value = Value::from_query_value(value, &ty)?;
 
                 Ok(match op {
                     Not => StoreFilter::Not(attribute, store_value),
@@ -110,7 +110,7 @@ fn build_filter_from_object(
                     NotEndsWith => StoreFilter::NotEndsWith(attribute, store_value),
                     Equal => StoreFilter::Equal(attribute, store_value),
                 })
-            }).collect::<Result<Vec<_>, _>>()?
+            }).collect::<Result<Vec<StoreFilter>, QueryExecutionError>>()?
     })))
 }
 

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -127,10 +127,7 @@ fn list_values(value: Value) -> Result<Vec<Value>, QueryExecutionError> {
                     if root_discriminant == current_discriminant {
                         Ok(value.clone())
                     } else {
-                        Err(QueryExecutionError::ListTypesError(
-                            root_discriminant,
-                            current_discriminant,
-                        ))
+                        Err(QueryExecutionError::ListTypesError())
                     }
                 }).collect::<Result<Vec<_>, _>>()
         }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -1,65 +1,68 @@
 use graph::prelude::*;
 use graphql_parser::{query as q, schema as s};
-use schema::sast;
+use schema::ast as sast;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::mem::discriminant;
 
 /// Builds a StoreQuery from GraphQL arguments.
-pub fn build_query(entity: &s::ObjectType, arguments: &HashMap<&q::Name, q::Value>) -> StoreQuery {
-    StoreQuery {
-        subgraph: parse_subgraph_id(entity)
-            .expect(format!("Failed to get subgraph ID from type: {}", entity.name).as_str()),
+pub fn build_query(entity: &s::ObjectType, arguments: &HashMap<&q::Name, q::Value>) -> Result<StoreQuery, QueryExecutionError> {
+    Ok(StoreQuery {
+        subgraph: parse_subgraph_id(entity)?,
         entity: entity.name.to_owned(),
-        range: build_range(arguments),
-        filter: build_filter(entity, arguments),
-        order_by: build_order_by(arguments),
-        order_direction: build_order_direction(arguments),
-    }
+        range: build_range(arguments)?,
+        filter: build_filter(entity, arguments)?,
+        order_by: build_order_by(arguments)?,
+        order_direction: build_order_direction(arguments)?,
+    })
 }
 
 /// Parses GraphQL arguments into a StoreRange, if present.
-fn build_range(arguments: &HashMap<&q::Name, q::Value>) -> Option<StoreRange> {
+fn build_range(arguments: &HashMap<&q::Name, q::Value>) -> Result<Option<StoreRange>, QueryExecutionError> {
     let first = arguments
         .get(&"first".to_string())
         .and_then(|value| match value {
             q::Value::Int(n) => n.as_i64(),
             _ => None,
-        }).and_then(|n| if n > 0 { Some(n as usize) } else { None });
+        }).ok_or(QueryExecutionError::BuildRangeTypeError)
+        .and_then(|n| if n > 0 { Ok(Some(n as usize)) } else { Ok(None) });
 
     let skip = arguments
         .get(&"skip".to_string())
         .and_then(|value| match value {
             q::Value::Int(n) => n.as_i64(),
             _ => None,
-        }).and_then(|n| if n >= 0 { Some(n as usize) } else { None });
+        }).ok_or(QueryExecutionError::BuildRangeTypeError)
+        .and_then(|n| if n >= 0 { Ok(Some(n as usize)) } else { Ok(None) });
 
-    match (first, skip) {
+    Ok(match (first?, skip?) {
         (None, None) => None,
         (Some(first), None) => Some(StoreRange { first, skip: 0 }),
         (Some(first), Some(skip)) => Some(StoreRange { first, skip }),
         (None, Some(skip)) => Some(StoreRange { first: 100, skip }),
-    }
+    })
 }
 
 /// Parses GraphQL arguments into a StoreFilter, if present.
 fn build_filter(
     entity: &s::ObjectType,
     arguments: &HashMap<&q::Name, q::Value>,
-) -> Option<StoreFilter> {
+) -> Result<Option<StoreFilter>, QueryExecutionError> {
     arguments
         .get(&"where".to_string())
         .and_then(|value| match value {
             q::Value::Object(object) => Some(object),
             _ => None,
-        }).map(|object| build_filter_from_object(entity, object))
+        })
+        .ok_or(QueryExecutionError::BuildFilterError)
+        .and_then(|object| build_filter_from_object(entity, object))
 }
 
 /// Parses a GraphQL input object into a StoreFilter, if present.
 fn build_filter_from_object(
     entity: &s::ObjectType,
     object: &BTreeMap<q::Name, q::Value>,
-) -> StoreFilter {
-    StoreFilter::And(
+) -> Result<Option<StoreFilter>, QueryExecutionError> {
+    Ok(Some(StoreFilter::And(
         object
             .iter()
             .map(|(key, value)| {
@@ -89,7 +92,7 @@ fn build_filter_from_object(
                     Equal => StoreFilter::Equal(attribute, store_value),
                 }
             }).collect::<Vec<StoreFilter>>(),
-    )
+    )))
 }
 
 /// Parses a list of GraphQL values into a vector of entity attribute values.
@@ -97,7 +100,6 @@ fn list_values(value: Value) -> Vec<Value> {
     match value {
         Value::List(ref values) if !values.is_empty() => {
             // Check that all values in list are of the same type
-            // let value_type = discriminant(&values[0]);
             values
                 .into_iter()
                 .map(|value| {
@@ -114,28 +116,28 @@ fn list_values(value: Value) -> Vec<Value> {
 }
 
 /// Parses GraphQL arguments into an attribute name to order by, if present.
-fn build_order_by(arguments: &HashMap<&q::Name, q::Value>) -> Option<String> {
-    arguments
+fn build_order_by(arguments: &HashMap<&q::Name, q::Value>) -> Result<Option<String>, QueryExecutionError> {
+    Ok(arguments
         .get(&"orderBy".to_string())
         .and_then(|value| match value {
             q::Value::Enum(name) => Some(name.to_owned()),
             _ => None,
-        })
+        }))
 }
 
 /// Parses GraphQL arguments into a StoreOrder, if present.
-fn build_order_direction(arguments: &HashMap<&q::Name, q::Value>) -> Option<StoreOrder> {
-    arguments
+fn build_order_direction(arguments: &HashMap<&q::Name, q::Value>) -> Result<Option<StoreOrder>, QueryExecutionError> {
+    Ok(arguments
         .get(&"orderDirection".to_string())
         .and_then(|value| match value {
             q::Value::Enum(name) if name == "asc" => Some(StoreOrder::Ascending),
             q::Value::Enum(name) if name == "desc" => Some(StoreOrder::Descending),
             _ => None,
-        })
+        }))
 }
 
 /// Parses the subgraph ID from the ObjectType directives.
-pub fn parse_subgraph_id(entity: &s::ObjectType) -> Option<String> {
+pub fn parse_subgraph_id(entity: &s::ObjectType) -> Result<String, QueryExecutionError> {
     entity
         .clone()
         .directives
@@ -149,7 +151,7 @@ pub fn parse_subgraph_id(entity: &s::ObjectType) -> Option<String> {
         }).and_then(|(_, value)| match value {
             s::Value::String(id) => Some(id),
             _ => None,
-        })
+        }).ok_or(QueryExecutionError::SubgraphParseError(entity.clone().name))
 }
 
 /// Recursively collects entities involved in a query field as `(subgraph ID, name)` tuples.
@@ -182,7 +184,7 @@ pub fn collect_entities_from_query_field(
                         .is_some()
                     {
                         // Obtain the subgraph ID from the object type
-                        if let Some(subgraph_id) = parse_subgraph_id(object_type) {
+                        if let Ok(subgraph_id) = parse_subgraph_id(&object_type) {
                             // Add the (subgraph_id, entity_name) tuple to the result set
                             entities.insert((subgraph_id, object_type.name.to_owned()));
                         }
@@ -192,7 +194,7 @@ pub fn collect_entities_from_query_field(
                     // need to recursively process it
                     for selection in field.selection_set.items.iter() {
                         if let q::Selection::Field(sub_field) = selection {
-                            queue.push_back((object_type, sub_field))
+                            queue.push_back((&object_type, sub_field))
                         }
                     }
                 }
@@ -258,11 +260,11 @@ mod tests {
     #[test]
     fn build_query_uses_the_entity_name() {
         assert_eq!(
-            build_query(&object("Entity1"), &HashMap::new()).entity,
+            build_query(&object("Entity1"), &HashMap::new()).unwrap().entity,
             "Entity1".to_string()
         );
         assert_eq!(
-            build_query(&object("Entity2"), &HashMap::new()).entity,
+            build_query(&object("Entity2"), &HashMap::new()).unwrap().entity,
             "Entity2".to_string()
         );
     }
@@ -270,11 +272,11 @@ mod tests {
     #[test]
     fn build_query_yields_no_order_if_order_arguments_are_missing() {
         assert_eq!(
-            build_query(&default_object(), &HashMap::new()).order_by,
+            build_query(&default_object(), &HashMap::new()).unwrap().order_by,
             None,
         );
         assert_eq!(
-            build_query(&default_object(), &HashMap::new()).order_direction,
+            build_query(&default_object(), &HashMap::new()).unwrap().order_direction,
             None,
         );
     }
@@ -287,7 +289,7 @@ mod tests {
                 &HashMap::from_iter(
                     vec![(&"orderBy".to_string(), q::Value::Enum("name".to_string()))].into_iter(),
                 )
-            ).order_by,
+            ).unwrap().order_by,
             Some("name".to_string())
         );
         assert_eq!(
@@ -296,7 +298,7 @@ mod tests {
                 &HashMap::from_iter(
                     vec![(&"orderBy".to_string(), q::Value::Enum("email".to_string()))].into_iter()
                 )
-            ).order_by,
+            ).unwrap().order_by,
             Some("email".to_string())
         );
     }
@@ -310,7 +312,7 @@ mod tests {
                     vec![(&"orderBy".to_string(), q::Value::String("name".to_string()))]
                         .into_iter()
                 ),
-            ).order_by,
+            ).unwrap().order_by,
             None,
         );
         assert_eq!(
@@ -322,7 +324,7 @@ mod tests {
                         q::Value::String("email".to_string()),
                     )].into_iter(),
                 )
-            ).order_by,
+            ).unwrap().order_by,
             None,
         );
     }
@@ -338,7 +340,7 @@ mod tests {
                         q::Value::Enum("asc".to_string()),
                     )].into_iter(),
                 )
-            ).order_direction,
+            ).unwrap().order_direction,
             Some(StoreOrder::Ascending)
         );
         assert_eq!(
@@ -350,7 +352,7 @@ mod tests {
                         q::Value::Enum("desc".to_string()),
                     )].into_iter()
                 )
-            ).order_direction,
+            ).unwrap().order_direction,
             Some(StoreOrder::Descending)
         );
         assert_eq!(
@@ -362,7 +364,7 @@ mod tests {
                         q::Value::Enum("ascending...".to_string()),
                     )].into_iter()
                 )
-            ).order_direction,
+            ).unwrap().order_direction,
             None,
         );
     }
@@ -378,7 +380,7 @@ mod tests {
                         q::Value::String("asc".to_string()),
                     )].into_iter()
                 ),
-            ).order_direction,
+            ).unwrap().order_direction,
             None,
         );
         assert_eq!(
@@ -390,14 +392,14 @@ mod tests {
                         q::Value::String("desc".to_string()),
                     )].into_iter(),
                 )
-            ).order_direction,
+            ).unwrap().order_direction,
             None,
         );
     }
 
     #[test]
     fn build_query_yields_no_range_if_none_is_present() {
-        assert_eq!(build_query(&default_object(), &HashMap::new()).range, None,);
+        assert_eq!(build_query(&default_object(), &HashMap::new()).unwrap().range, None,);
     }
 
     #[test]
@@ -408,7 +410,7 @@ mod tests {
                 &HashMap::from_iter(
                     vec![(&"skip".to_string(), q::Value::Int(q::Number::from(50)))].into_iter()
                 )
-            ).range,
+            ).unwrap().range,
             Some(StoreRange {
                 first: 100,
                 skip: 50,
@@ -424,7 +426,7 @@ mod tests {
                 &HashMap::from_iter(
                     vec![(&"first".to_string(), q::Value::Int(q::Number::from(70)))].into_iter()
                 )
-            ).range,
+            ).unwrap().range,
             Some(StoreRange { first: 70, skip: 0 }),
         );
     }
@@ -446,7 +448,7 @@ mod tests {
                         )])),
                     )].into_iter(),
                 )
-            ).filter,
+            ).unwrap().filter,
             Some(StoreFilter::And(vec![StoreFilter::EndsWith(
                 "name".to_string(),
                 Value::String("ello".to_string()),

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -144,7 +144,10 @@ fn list_values(value: Value, filter_type: &str) -> Result<Vec<Value>, QueryExecu
                     }
                 }).collect::<Result<Vec<_>, _>>()
         }
-        _ => Err(QueryExecutionError::ListFilterError),
+        Value::List(ref values) if values.is_empty() => Ok(vec![]),
+        _ => Err(QueryExecutionError::ListFilterError(
+            filter_type.to_string(),
+        )),
     }
 }
 

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -113,8 +113,8 @@ fn build_filter_from_object(
                     LessThan => StoreFilter::LessThan(attribute, store_value),
                     GreaterOrEqual => StoreFilter::GreaterOrEqual(attribute, store_value),
                     LessOrEqual => StoreFilter::LessOrEqual(attribute, store_value),
-                    In => StoreFilter::In(attribute, list_values(store_value)?),
-                    NotIn => StoreFilter::NotIn(attribute, list_values(store_value)?),
+                    In => StoreFilter::In(attribute, list_values(store_value, "_in")?),
+                    NotIn => StoreFilter::NotIn(attribute, list_values(store_value, "_not_in")?),
                     Contains => StoreFilter::Contains(attribute, store_value),
                     NotContains => StoreFilter::NotContains(attribute, store_value),
                     StartsWith => StoreFilter::StartsWith(attribute, store_value),
@@ -128,7 +128,7 @@ fn build_filter_from_object(
 }
 
 /// Parses a list of GraphQL values into a vector of entity attribute values.
-fn list_values(value: Value) -> Result<Vec<Value>, QueryExecutionError> {
+fn list_values(value: Value, filter_type: &str) -> Result<Vec<Value>, QueryExecutionError> {
     match value {
         Value::List(ref values) if !values.is_empty() => {
             // Check that all values in list are of the same type
@@ -140,7 +140,7 @@ fn list_values(value: Value) -> Result<Vec<Value>, QueryExecutionError> {
                     if root_discriminant == current_discriminant {
                         Ok(value.clone())
                     } else {
-                        Err(QueryExecutionError::ListTypesError())
+                        Err(QueryExecutionError::ListTypesError(filter_type.to_string()))
                     }
                 }).collect::<Result<Vec<_>, _>>()
         }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -23,35 +23,38 @@ pub fn build_query(
 fn build_range(
     arguments: &HashMap<&q::Name, q::Value>,
 ) -> Result<Option<StoreRange>, QueryExecutionError> {
-    let first = match arguments.get(&"first".to_string()) {
-        Some(value) => match value {
-            q::Value::Int(n) => Ok(n.as_i64()),
-            _ => Err("first".to_string()),
-        },
-        None => Ok(None),
-    }.map(|n| match n {
-        Some(n) => if n > 0 {
-            Some(n as usize)
-        } else {
-            None
-        },
-        None => None,
-    });
+    let first = arguments
+        .get(&"first".to_string())
+        .map_or(Ok(None), |value| {
+            if let q::Value::Int(n) = value {
+                match n.as_i64() {
+                    Some(n) => Ok(Some(n)),
+                    None => Err("first".to_string())
+                }
+            } else {
+                Err("first".to_string())
+            }
+        }).map(|n| match n {
+            Some(n) if n >= 0 => Some(n as usize),
+            _ => None
+        });
 
-    let skip = match arguments.get(&"skip".to_string()) {
-        Some(value) => match value {
-            q::Value::Int(n) => Ok(n.as_i64()),
-            _ => Err("skip".to_string()),
-        },
-        None => Ok(None),
-    }.map(|n| match n {
-        Some(n) => if n >= 0 {
-            Some(n as usize)
-        } else {
-            None
-        },
-        None => None,
-    });
+    let skip = arguments
+        .get(&"skip".to_string())
+        .map_or(Ok(None), |value| {
+            if let q::Value::Int(n) = value {
+                match n.as_i64() {
+                    Some(n) => Ok(Some(n)),
+                    None => Err("first".to_string())
+                }
+            } else {
+                Err("skip".to_string())
+            }
+        })
+        .map(|n| match n {
+            Some(n) if n >= 0 => Some(n as usize),
+            _ => None
+        });
 
     if first.is_err() || skip.is_err() {
         let errors: Vec<String> = vec![first.clone(), skip.clone()]

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -29,13 +29,13 @@ fn build_range(
             _ => Err("first".to_string()),
         },
         None => Ok(None),
-    }.and_then(|n| match n {
+    }.map(|n| match n {
         Some(n) => if n > 0 {
-            Ok(Some(n as usize))
+            Some(n as usize)
         } else {
-            Ok(None)
+            None
         },
-        None => Ok(None),
+        None => None,
     });
 
     let skip = match arguments.get(&"skip".to_string()) {
@@ -44,13 +44,13 @@ fn build_range(
             _ => Err("skip".to_string()),
         },
         None => Ok(None),
-    }.and_then(|n| match n {
+    }.map(|n| match n {
         Some(n) => if n >= 0 {
-            Ok(Some(n as usize))
+            Some(n as usize)
         } else {
-            Ok(None)
+            None
         },
-        None => Ok(None),
+        None => None,
     });
 
     if first.is_err() || skip.is_err() {

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -181,20 +181,20 @@ fn build_order_direction(
 
 /// Parses the subgraph ID from the ObjectType directives.
 pub fn parse_subgraph_id(entity: &s::ObjectType) -> Result<String, QueryExecutionError> {
+    let entity_name = entity.name.clone();
     entity
-        .clone()
         .directives
-        .into_iter()
+        .iter()
         .find(|directive| directive.name == "subgraphId".to_string())
         .and_then(|directive| {
             directive
                 .arguments
-                .into_iter()
+                .iter()
                 .find(|(name, _)| name == &"id".to_string())
         }).and_then(|(_, value)| match value {
-            s::Value::String(id) => Some(id),
+            s::Value::String(id) => Some(id.clone()),
             _ => None,
-        }).ok_or(QueryExecutionError::SupgraphIdError(entity.clone().name))
+        }).ok_or(QueryExecutionError::SupgraphIdError(entity_name))
 }
 
 /// Recursively collects entities involved in a query field as `(subgraph ID, name)` tuples.

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -196,7 +196,7 @@ where
         object_type: &s::ObjectType,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
-        let mut query = build_query(&object_type, arguments);
+        let mut query = build_query(&object_type, arguments)?;
 
         // Add matching filter for derived fields
         let is_derived =
@@ -271,7 +271,7 @@ where
                 _ => Ok(q::Value::Null),
             },
             _ => {
-                let mut query = build_query(&object_type, arguments);
+                let mut query = build_query(&object_type, arguments)?;
 
                 // Add matching filter for derived fields
                 Self::add_filter_for_derived_field(

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -217,9 +217,7 @@ where
             Self::add_filter_for_reference_field(&mut query, parent, field_definition, object_type);
         }
 
-        self.store
-            .find(query)
-            .map(|entities| {
+        self.store.find(query).map(|entities| {
             q::Value::List(
                 entities
                     .into_iter()
@@ -282,9 +280,7 @@ where
 
                 query.range = Some(StoreRange { first: 1, skip: 0 });
 
-                self.store
-                    .find(query)
-                    .map(|entities| {
+                self.store.find(query).map(|entities| {
                     entities
                         .into_iter()
                         .next()

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -268,7 +268,7 @@ where
                         id: id.to_owned(),
                     })
                     .map(|entity| entity.into()),
-                _ => Err(QueryExecutionError::ObjectFieldError),
+                _ => Ok(q::Value::Null),
             },
             _ => {
                 let mut query = build_query(&object_type, arguments);

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -266,8 +266,7 @@ where
                         ),
                         entity: object_type.name.to_owned(),
                         id: id.to_owned(),
-                    })
-                    .map(|entity| entity.into()),
+                    }).map(|entity| entity.into()),
                 _ => Ok(q::Value::Null),
             },
             _ => {

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -172,6 +172,10 @@ where
     // We have established that this exists earlier in the subscription execution
     let subscription_type = sast::get_root_subscription_type(&ctx.schema.document).unwrap();
 
-    execute_selection_set(ctx, &subscription.selection_set, subscription_type, &None)
-        .unwrap_or_else(QueryResult::from)
+    let result = execute_selection_set(ctx, &subscription.selection_set, subscription_type, &None);
+
+    match result {
+        Ok(value) => QueryResult::new(Some(value)),
+        Err(e) => QueryResult::from(e),
+    }
 }

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -23,8 +23,8 @@ impl Resolver for MockResolver {
         _field_definition: &s::Field,
         _object_type: &s::ObjectType,
         _arguments: &HashMap<&q::Name, q::Value>,
-    ) -> q::Value {
-        q::Value::Null
+    ) -> Result<q::Value, QueryExecutionError> {
+        Ok(q::Value::Null)
     }
 
     fn resolve_object(
@@ -34,8 +34,8 @@ impl Resolver for MockResolver {
         _field_definition: &s::Field,
         _object_type: &s::ObjectType,
         _arguments: &HashMap<&q::Name, q::Value>,
-    ) -> q::Value {
-        q::Value::Null
+    ) -> Result<q::Value, QueryExecutionError> {
+        Ok(q::Value::Null)
     }
 }
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -183,7 +183,7 @@ impl Store for TestStore {
                 Err(QueryExecutionError::ResolveEntitiesError(String::from(
                     "Mock get query error",
                 ))),
-            |entity| Ok(entity.clone()),
+                |entity| Ok(entity.clone()),
             )
     }
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -173,16 +173,21 @@ impl Store for TestStore {
         unimplemented!()
     }
 
-    fn get(&self, key: StoreKey) -> Result<Entity, Error> {
+    fn get(&self, key: StoreKey) -> Result<Entity, QueryExecutionError> {
         self.entities
             .iter()
             .find(|entity| {
                 entity.get("id") == Some(&Value::String(key.id.clone()))
                     && entity.get("__typename") == Some(&Value::String(key.entity.clone()))
-            }).map_or(Err(format_err!("")), |entity| Ok(entity.clone()))
+            }).map_or(
+        Err(QueryExecutionError::StoreQueryError(String::from(
+                    "Mock get query error",
+                ))),
+            |entity| Ok(entity.clone()),
+            )
     }
 
-    fn find(&self, query: StoreQuery) -> Result<Vec<Entity>, ()> {
+    fn find(&self, query: StoreQuery) -> Result<Vec<Entity>, QueryExecutionError> {
         let entity_name = Value::String(query.entity.clone());
 
         let entities = self.entities

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -180,7 +180,7 @@ impl Store for TestStore {
                 entity.get("id") == Some(&Value::String(key.id.clone()))
                     && entity.get("__typename") == Some(&Value::String(key.entity.clone()))
             }).map_or(
-        Err(QueryExecutionError::StoreQueryError(String::from(
+                Err(QueryExecutionError::ResolveEntitiesError(String::from(
                     "Mock get query error",
                 ))),
             |entity| Ok(entity.clone()),

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -52,7 +52,7 @@ impl Store for MockStore {
                         _ => false,
                     }
                 }).map(|entity| entity.clone())
-                .ok_or(QueryExecutionError::StoreQueryError(String::from(
+                .ok_or(QueryExecutionError::ResolveEntitiesError(String::from(
                     "Mock store error",
                 )))
         } else {

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -41,7 +41,7 @@ impl MockStore {
 }
 
 impl Store for MockStore {
-    fn get(&self, key: StoreKey) -> Result<Entity, Error> {
+    fn get(&self, key: StoreKey) -> Result<Entity, QueryExecutionError> {
         if key.entity == "User" {
             self.entities
                 .iter()
@@ -52,13 +52,15 @@ impl Store for MockStore {
                         _ => false,
                     }
                 }).map(|entity| entity.clone())
-                .ok_or(format_err!("Failed to get entity from mock store"))
+                .ok_or(QueryExecutionError::StoreQueryError(String::from(
+                    "Mock store error",
+                )))
         } else {
             unimplemented!()
         }
     }
 
-    fn find(&self, _query: StoreQuery) -> Result<Vec<Entity>, ()> {
+    fn find(&self, _query: StoreQuery) -> Result<Vec<Entity>, QueryExecutionError> {
         Ok(self.entities.clone())
     }
 
@@ -145,11 +147,11 @@ impl ChainStore for MockStore {
 pub struct FakeStore;
 
 impl Store for FakeStore {
-    fn get(&self, _: StoreKey) -> Result<Entity, Error> {
+    fn get(&self, _: StoreKey) -> Result<Entity, QueryExecutionError> {
         unimplemented!();
     }
 
-    fn find(&self, _: StoreQuery) -> Result<Vec<Entity>, ()> {
+    fn find(&self, _: StoreQuery) -> Result<Vec<Entity>, QueryExecutionError> {
         unimplemented!();
     }
 

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -290,12 +290,6 @@ where
                                     let msg =
                                         OutgoingMessage::from_query_result(err_id.clone(), result);
                                     error_sink.unbounded_send(msg.into()).unwrap();
-                                },
-                                SubscriptionError::GraphQLErrorList(e) => {
-                                    let result = QueryResult::from(e);
-                                    let msg =
-                                        OutgoingMessage::from_query_result(err_id.clone(), result);
-                                    error_sink.unbounded_send(msg.into()).unwrap();
                                 }
                             };
                         }).and_then(move |result_stream| {

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -290,6 +290,12 @@ where
                                     let msg =
                                         OutgoingMessage::from_query_result(err_id.clone(), result);
                                     error_sink.unbounded_send(msg.into()).unwrap();
+                                },
+                                SubscriptionError::GraphQLErrorList(e) => {
+                                    let result = QueryResult::from(e);
+                                    let msg =
+                                        OutgoingMessage::from_query_result(err_id.clone(), result);
+                                    error_sink.unbounded_send(msg.into()).unwrap();
                                 }
                             };
                         }).and_then(move |result_stream| {

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -269,7 +269,7 @@ fn store_filter_by_mode<'a>(
         StoreFilter::In(attribute, query_values) => {
             let op = " = ANY (";
             if query_values.is_empty() {
-                return Ok(add_filter(query, filter_mode, sql("true")));
+                return Ok(add_filter(query, filter_mode, sql("false")));
             }
             match query_values[0].clone() {
                 Value::Bool(_) => add_filter(

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -268,6 +268,9 @@ fn store_filter_by_mode<'a>(
         // Is `attribute` equal to some `v` in `query_values`?
         StoreFilter::In(attribute, query_values) => {
             let op = " = ANY (";
+            if query_values.is_empty() {
+                return Ok(add_filter(query, filter_mode, sql("true")));
+            }
             match query_values[0].clone() {
                 Value::Bool(_) => add_filter(
                     query,
@@ -336,6 +339,9 @@ fn store_filter_by_mode<'a>(
         }
         // Is `attribute` different from all `query_values`?
         StoreFilter::NotIn(attribute, query_values) => {
+            if query_values.is_empty() {
+                return Ok(add_filter(query, filter_mode, sql("true")));
+            }
             query_values.into_iter().try_fold(query, |q, v| {
                 store_filter_by_mode(q, StoreFilter::Not(attribute.clone(), v), FilterMode::And)
             })?

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -529,7 +529,7 @@ impl StoreTrait for Store {
                         serde_json::from_value::<Entity>(value)
                             .expect("Error to deserialize entity")
                     }).collect()
-            }).map_err(|e| QueryExecutionError::StoreQueryError(e.to_string()))
+            }).map_err(|e| QueryExecutionError::ResolveEntitiesError(e.to_string()))
     }
 
     fn set_block_ptr_with_no_changes(

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -491,8 +491,7 @@ impl StoreTrait for Store {
         // Add specified filter to query
         if let Some(filter) = query.filter {
             diesel_query = store_filter(diesel_query, filter).map_err(|e| {
-                QueryExecutionError::FilterNotSupportedError(format!("{:?}", e.value), e.filter
-                )
+                QueryExecutionError::FilterNotSupportedError(format!("{}", e.value), e.filter)
             })?;
         }
 


### PR DESCRIPTION
Resolves #48 

This PR solves the issue query building and execution errors causing an unrecoverable error without  providing context to the end user.  Errors no longer poison the thread and are now caught and displayed in the interface to help troubleshoot issues with the query. 

  - All store methods return a `Result<_, QueryExecutionError>`.
  - Resolver and StoreResolver return `Result<_, QueryExecutionError>`.
  - All GraphQL execution functions that call the resolver return `Result<q::Value, Vec<GraphQlError>>`.
  - Execute_query and execute_subscription build `QueryResult` using the vector of `QueryExecutionErrors`. 
  - All expect() and unwrap() have been removed. `?` is your friend