### PR TITLE
Improve cancellation helpers

### DIFF
--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -57,7 +57,7 @@ pub trait Canceler {
 pub struct CancelGuard {
     /// This is the only non-temporary strong reference to this `Arc`, therefore
     /// the `Vec` should be dropped shortly after `self` is dropped.
-    cancelers: Arc<Mutex<Vec<oneshot::Sender<()>>>>,
+    cancel_senders: Arc<Mutex<Vec<oneshot::Sender<()>>>>,
 }
 
 impl CancelGuard {
@@ -71,14 +71,14 @@ impl CancelGuard {
 
     pub fn handle(&self) -> CancelHandle {
         CancelHandle {
-            guard: Arc::downgrade(&self.cancelers),
+            guard: Arc::downgrade(&self.cancel_senders),
         }
     }
 }
 
 impl Canceler for CancelGuard {
     fn add_canceler(&self, cancel_sender: oneshot::Sender<()>) {
-        self.cancelers.lock().unwrap().push(cancel_sender);
+        self.cancel_senders.lock().unwrap().push(cancel_sender);
     }
 }
 

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -303,11 +303,11 @@ where
                         });
 
                     // Setup cancelation.
-                    let mut guard = CancelGuard::new();
+                    let guard = CancelGuard::new();
                     let logger = logger.clone();
                     let cancel_id = id.clone();
                     let connection_id = connection_id.clone();
-                    let run_subscription = run_subscription.cancelable(&mut guard, move || {
+                    let run_subscription = run_subscription.cancelable(&guard, move || {
                         debug!(logger, "Stopped operation";
                                        "connection" => &connection_id,
                                        "id" => &cancel_id)

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -302,15 +302,18 @@ where
                                 .map(|_| ())
                         });
 
+                    // Setup cancelation.
+                    let mut guard = CancelGuard::new();
                     let logger = logger.clone();
                     let cancel_id = id.clone();
                     let connection_id = connection_id.clone();
-                    let (run_subscription, guard) = run_subscription.cancelable(move || {
+                    let run_subscription = run_subscription.cancelable(&mut guard, move || {
                         debug!(logger, "Stopped operation";
                                        "connection" => &connection_id,
                                        "id" => &cancel_id)
                     });
                     operations.insert(id, guard);
+
                     tokio::spawn(run_subscription);
                     Ok(())
                 }

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -163,15 +163,14 @@ where
                             );
 
                             // Setup cancelation.
-                            let mut guard = CancelGuard::new();
+                            let guard = CancelGuard::new();
                             let cancel_subgraph = subgraph.clone();
-                            let connection =
-                                service.into_future().cancelable(&mut guard, move || {
-                                    debug!(
+                            let connection = service.into_future().cancelable(&guard, move || {
+                                debug!(
                                         logger,
                                         "Canceling subscriptions"; "subgraph" => &cancel_subgraph
                                     )
-                                });
+                            });
                             subgraphs.mutate(&subgraph, |subgraph| {
                                 subgraph.connection_guards.push(guard)
                             });


### PR DESCRIPTION
`cancelabe` takes the guard as an argument, so cancelling multiple things with one guard is supported. It's also nice that we no longer return tuples allowing `cancelable` to be chained with other methods.

Resolves #392.

