### PR TITLE
Less logging in block ingestor

### DIFF
--- a/datasource/ethereum/src/block_ingestor.rs
+++ b/datasource/ethereum/src/block_ingestor.rs
@@ -167,28 +167,26 @@ where
     ) -> impl Future<Item = TransactionReceipt, Error = Error> + 'a {
         let web3 = Web3::new(self.web3_transport.clone());
 
-        with_retry(
-            self.logger.clone(),
-            "eth_getTransactionReceipt RPC call".to_owned(),
-            move || {
-                web3.eth()
-                    .transaction_receipt(tx_hash)
-                    .map_err(move |e| {
+        // Infura frequently fails to find transaction receipts for new blocks,
+        // so retry without logging failed attempts.
+        with_retry_no_logging(move || {
+            web3.eth()
+                .transaction_receipt(tx_hash)
+                .map_err(move |e| {
+                    format_err!(
+                        "could not get transaction receipt {} from Ethereum: {}",
+                        tx_hash,
+                        e
+                    )
+                }).and_then(move |receipt_opt| {
+                    receipt_opt.ok_or_else(move || {
                         format_err!(
-                            "could not get transaction receipt {} from Ethereum: {}",
-                            tx_hash,
-                            e
+                            "Ethereum node could not find transaction receipt {}",
+                            tx_hash
                         )
-                    }).and_then(move |receipt_opt| {
-                        receipt_opt.ok_or_else(move || {
-                            format_err!(
-                                "Ethereum node could not find transaction receipt {}",
-                                tx_hash
-                            )
-                        })
                     })
-            },
-        )
+                })
+        })
     }
 
     /// Put some blocks into the block store (if they are not there already), and try to update the

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -92,5 +92,5 @@ pub mod prelude {
         CancelGuard, CancelHandle, CancelableError, FutureExtension, SharedCancelGuard,
         StreamExtension,
     };
-    pub use util::futures::with_retry;
+    pub use util::futures::{with_retry, with_retry_no_logging};
 }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -92,5 +92,5 @@ pub mod prelude {
         CancelGuard, CancelHandle, CancelableError, FutureExtension, SharedCancelGuard,
         StreamExtension,
     };
-    pub use util::futures::{with_retry, with_retry_no_logging};
+    pub use util::futures::{with_retry, with_retry_log_after};
 }

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -52,7 +52,7 @@ where
 
         try_it().map_err(move |e| {
             if attempt_count >= log_after {
-                warn!(
+                debug!(
                     logger,
                     "Trying again in ~{} seconds after {} failed (attempt #{})",
                     (delay_ms as f64 / 1000.0).round(),


### PR DESCRIPTION
Infura often doesn't have transaction receipts right away for new blocks, and that results in lots of warnings getting logged during normal operation