### PR TITLE
Faster block loading

### DIFF
--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -366,11 +366,6 @@ where
                         1 => {
                             let mut block_ptrs = vec![];
                             for log in chunks[0].iter() {
-                                if block_ptrs.len() >= 100 {
-                                    // That's enough to process in one iteration
-                                    break;
-                                }
-
                                 let hash = log
                                     .block_hash
                                     .expect("log from Eth node is missing block hash");

--- a/datasource/ethereum/src/transport.rs
+++ b/datasource/ethereum/src/transport.rs
@@ -36,7 +36,7 @@ impl Transport {
     /// Note: JSON-RPC over HTTP doesn't always support subscribing to new
     /// blocks (one such example is Infura's HTTP endpoint).
     pub fn new_rpc(rpc: &str) -> (EventLoopHandle, Self) {
-        http::Http::new(rpc)
+        http::Http::with_max_parallel(rpc, 2048)
             .map(|(event_loop, transport)| (event_loop, Transport::RPC(transport)))
             .expect("Failed to connect to Ethereum RPC")
     }


### PR DESCRIPTION
Overlay block loading with block processing to keep as many Ethereum RPC calls in flight as possible. Also, increase Web3 parallel request limit from 64 to 2048.

Resolves #425 