### PR TITLE
Use cancelable to shut down BlockStream

### DIFF
--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -88,6 +88,9 @@ pub mod prelude {
     pub use data::subscription::{
         QueryResultStream, Subscription, SubscriptionError, SubscriptionResult,
     };
-    pub use ext::futures::{CancelGuard, FutureExtension, SharedCancelGuard, StreamExtension};
+    pub use ext::futures::{
+        CancelGuard, CancelHandle, CancelableError, FutureExtension, SharedCancelGuard,
+        StreamExtension,
+    };
     pub use util::futures::with_retry;
 }


### PR DESCRIPTION
Shut down block stream gracefully when subgraph is removed.

Resolves #427 