### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,7 +97,7 @@ dataSources:
     entities:
     - Token
     abis:
-    - name: ER721
+    - name: ERC721
       file: ./abis/ERC721ABI.json
     eventHandlers:
     - event: Transfer(address,address,uint256)


### PR DESCRIPTION
I found this entertaining / ironic because you later go on to say "The name `ERC721` under `source > abi` must match the name of the displayed underneath `abis >name`"

