### PR TITLE
datasource, store: Fix block ingestion on short chains

### DIFF
--- a/datasource/ethereum/src/block_ingestor.rs
+++ b/datasource/ethereum/src/block_ingestor.rs
@@ -142,7 +142,9 @@ where
         web3.eth()
             .block_with_txs(BlockNumber::Latest.into())
             .map_err(|e| format_err!("could not get latest block from Ethereum: {}", e))
-            .and_then(|block_opt| block_opt.ok_or(format_err!("no block returned from Ethereum")))
+            .and_then(|block_opt| {
+                block_opt.ok_or(format_err!("no latest block returned from Ethereum"))
+            })
     }
 
     fn get_transaction_receipt<'a>(

--- a/store/postgres/migrations/2018-08-22-140000_create_chain_head_update_procedure/up.sql
+++ b/store/postgres/migrations/2018-08-22-140000_create_chain_head_update_procedure/up.sql
@@ -50,7 +50,8 @@ BEGIN
     WHERE
         block1.network_name = net_name
         AND block2.hash IS NULL -- cases where no block2 was found
-        AND block1.number > (new_head_number - ancestor_count);
+        AND block1.number > (new_head_number - ancestor_count)
+        AND block1.number > 0;
 
     -- Stop now if there are any recent blocks with missing parents
     IF array_length(missing_parents, 1) > 0 THEN


### PR DESCRIPTION
Should solve issue with Parity dev nodes returning "no block returned from Ethereum".