### PR TITLE
Store.set() merges id into the entity before pushing the `EntityOperation`

### DIFF
--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -293,7 +293,17 @@ where
     ) -> Result<Option<RuntimeValue>, Trap> {
         let entity: String = self.heap.asc_get(entity_ptr);
         let id: String = self.heap.asc_get(id_ptr);
-        let data: HashMap<String, Value> = self.heap.asc_get(data_ptr);
+        let mut data: HashMap<String, Value> = self.heap.asc_get(data_ptr);
+
+        match data.insert("id".to_string(), Value::String(id.clone())) {
+            Some(ref v) if v != &Value::String(id.clone()) => {
+                return Err(host_error(format!(
+                    "Conflicting 'id' value set by mapping for '{}' entity: {} : {}",
+                    entity, v, id,
+                )))
+            }
+            _ => (),
+        }
 
         self.ctx
             .as_mut()

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -298,7 +298,7 @@ where
         match data.insert("id".to_string(), Value::String(id.clone())) {
             Some(ref v) if v != &Value::String(id.clone()) => {
                 return Err(host_error(format!(
-                    "Conflicting 'id' value set by mapping for '{}' entity: {} : {}",
+                    "Conflicting 'id' value set by mapping for {} entity: {} != {}",
                     entity, v, id,
                 )))
             }


### PR DESCRIPTION
Resolves #386

`Store.set()` uses input to add an `id` attribute to the `entity` or if already exists ensures they  are equal.

