### PR TITLE
datasource, graph: Add retry deadline

### DIFF
--- a/datasource/ethereum/src/block_ingestor.rs
+++ b/datasource/ethereum/src/block_ingestor.rs
@@ -178,7 +178,14 @@ where
                         })
                     })
             },
-        )
+        ).map_err(move |e| {
+            e.into_inner().unwrap_or_else(move || {
+                format_err!(
+                    "Ethereum node took too long to return transaction receipt {}",
+                    tx_hash
+                )
+            })
+        })
     }
 
     /// Put some blocks into the block store (if they are not there already), and try to update the

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -46,6 +46,7 @@ where
         event_signatures: Vec<H256>,
     ) -> impl Future<Item = Vec<Log>, Error = Error> {
         let eth_adapter = self.clone();
+        let event_sig_count = event_signatures.len();
         with_retry(
             self.logger.clone(),
             "eth_getLogs RPC call".to_owned(),
@@ -69,7 +70,11 @@ where
                     }).map_err(SyncFailure::new)
                     .from_err()
             },
-        )
+        ).map_err(move |e| {
+            e.into_inner().unwrap_or_else(move || {
+                format_err!("Ethereum node took too long to respond to eth_getLogs (from = {}, to = {}, # of event sigs = {})", from, to, event_sig_count)
+            })
+        })
     }
 
     fn log_stream(
@@ -208,7 +213,11 @@ where
                     .map_err(SyncFailure::new)
                     .from_err()
             },
-        )
+        ).map_err(|e| {
+            e.into_inner().unwrap_or_else(|| {
+                format_err!("Ethereum node took too long to perform function call")
+            })
+        })
     }
 }
 
@@ -246,12 +255,20 @@ where
             },
         );
 
-        Box::new(net_version_future.join(gen_block_hash_future).map(
-            |(net_version, genesis_block_hash)| EthereumNetworkIdentifier {
-                net_version,
-                genesis_block_hash,
-            },
-        ))
+        Box::new(
+            net_version_future
+                .join(gen_block_hash_future)
+                .map(
+                    |(net_version, genesis_block_hash)| EthereumNetworkIdentifier {
+                        net_version,
+                        genesis_block_hash,
+                    },
+                ).map_err(|e| {
+                    e.into_inner().unwrap_or_else(|| {
+                        format_err!("Ethereum node took too long to read network identifiers")
+                    })
+                }),
+        )
     }
 
     fn block_by_hash(
@@ -270,7 +287,11 @@ where
                     .map_err(SyncFailure::new)
                     .from_err()
             },
-        );
+        ).map_err(move |e| {
+            e.into_inner().unwrap_or_else(move || {
+                format_err!("Ethereum node took too long to return block {}", block_hash)
+            })
+        });
 
         let web3 = self.web3.clone();
         Box::new(block_future.and_then(move |block_opt| {
@@ -301,7 +322,14 @@ where
                                         })
                                     })
                             },
-                        )
+                        ).map_err(move |e| {
+                            e.into_inner().unwrap_or_else(move || {
+                                format_err!(
+                                    "Ethereum node took too long to return transaction receipt {}",
+                                    tx_hash
+                                )
+                            })
+                        })
                     }).collect::<Vec<_>>();
 
                 stream::futures_ordered(receipt_futures).collect().map(
@@ -320,17 +348,26 @@ where
     ) -> Box<Future<Item = Option<H256>, Error = Error> + Send> {
         let web3 = self.web3.clone();
 
-        Box::new(with_retry(
-            self.logger.clone(),
-            "eth_getBlockByNumber RPC call".to_owned(),
-            move || {
-                web3.eth()
-                    .block(BlockId::Number(block_number.into()))
-                    .map_err(SyncFailure::new)
-                    .from_err()
-                    .map(|block_opt| block_opt.map(|block| block.hash.unwrap()))
-            },
-        ))
+        Box::new(
+            with_retry(
+                self.logger.clone(),
+                "eth_getBlockByNumber RPC call".to_owned(),
+                move || {
+                    web3.eth()
+                        .block(BlockId::Number(block_number.into()))
+                        .map_err(SyncFailure::new)
+                        .from_err()
+                        .map(|block_opt| block_opt.map(|block| block.hash.unwrap()))
+                },
+            ).map_err(move |e| {
+                e.into_inner().unwrap_or_else(move || {
+                    format_err!(
+                        "Ethereum node took too long to return data for block #{}",
+                        block_number
+                    )
+                })
+            }),
+        )
     }
 
     fn is_on_main_chain(

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -55,7 +55,7 @@ where
         attempt_count += 1;
 
         try_it()
-            .deadline(Instant::now() + Duration::from_secs(60))
+            .deadline(Instant::now() + Duration::from_secs(30))
             .map_err(move |e| {
                 if e.is_elapsed() {
                     if attempt_count >= log_after {


### PR DESCRIPTION
It looks like the tokio retry crate doesn't do as much as I thought it did, so this adds a 60-second `deadline` to the `with_retry` util, which should help with Eth RPC calls getting stuck sometimes.