### PR TITLE
Store::get and Store::get_entity return Result<Option<Entity>, Error>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,7 @@ name = "graph"
 version = "0.1.0"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 [dependencies]
 backtrace = "0.3.9"
 ethabi = "6.0"
+diesel = { version = "1.3.2", features = ["postgres", "serde_json", "numeric"]}
 hex = "0.3.2"
 futures = "0.1.21"
 graphql-parser = "0.2.1"

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -282,7 +282,7 @@ pub trait Store: Send + Sync {
 
     /// Looks up an entity using the given store key.
     // TODO need to validate block ptr
-    fn get(&self, key: StoreKey) -> Result<Entity, QueryExecutionError>;
+    fn get(&self, key: StoreKey) -> Result<Option<Entity>, QueryExecutionError>;
 
     /// Queries the store for entities that match the store query.
     // TODO need to validate block ptr

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate backtrace;
+extern crate diesel;
 pub extern crate ethabi;
 extern crate futures;
 extern crate graphql_parser;

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,3 +1,4 @@
+use failure::Error;
 use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -241,30 +241,24 @@ where
         });
 
         if let Some(id) = id {
-            return self
+            return Ok(self
                 .store
                 .get(StoreKey {
-                    subgraph: parse_subgraph_id(object_type).expect(
-                        format!("Failed to get subgraph ID from type: {}", object_type.name)
-                            .as_str(),
-                    ),
+                    subgraph: parse_subgraph_id(object_type)?,
                     entity: object_type.name.to_owned(),
                     id: id.to_owned(),
-                }).map(|entity| entity.into());
+                })?.map_or(q::Value::Null, |entity| entity.into()));
         }
 
         match parent {
             Some(q::Value::Object(parent_object)) => match parent_object.get(field) {
-                Some(q::Value::String(id)) => self
+                Some(q::Value::String(id)) => Ok(self
                     .store
                     .get(StoreKey {
-                        subgraph: parse_subgraph_id(object_type).expect(
-                            format!("Failed to get subgraph ID from type: {}", object_type.name)
-                                .as_str(),
-                        ),
+                        subgraph: parse_subgraph_id(object_type)?,
                         entity: object_type.name.to_owned(),
                         id: id.to_owned(),
-                    }).map(|entity| entity.into()),
+                    })?.map_or(q::Value::Null, |entity| entity.into())),
                 _ => Ok(q::Value::Null),
             },
             _ => {

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -173,7 +173,7 @@ impl Store for TestStore {
         unimplemented!()
     }
 
-    fn get(&self, key: StoreKey) -> Result<Entity, QueryExecutionError> {
+    fn get(&self, key: StoreKey) -> Result<Option<Entity>, QueryExecutionError> {
         self.entities
             .iter()
             .find(|entity| {
@@ -183,7 +183,7 @@ impl Store for TestStore {
                 Err(QueryExecutionError::ResolveEntitiesError(String::from(
                     "Mock get query error",
                 ))),
-                |entity| Ok(entity.clone()),
+                |entity| Ok(Some(entity.clone())),
             )
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -41,9 +41,9 @@ impl MockStore {
 }
 
 impl Store for MockStore {
-    fn get(&self, key: StoreKey) -> Result<Entity, QueryExecutionError> {
+    fn get(&self, key: StoreKey) -> Result<Option<Entity>, QueryExecutionError> {
         if key.entity == "User" {
-            self.entities
+            Ok(self.entities
                 .iter()
                 .find(|entity| {
                     let id = entity.get("id").unwrap();
@@ -51,10 +51,7 @@ impl Store for MockStore {
                         &Value::String(ref s) => s == &key.id,
                         _ => false,
                     }
-                }).map(|entity| entity.clone())
-                .ok_or(QueryExecutionError::ResolveEntitiesError(String::from(
-                    "Mock store error",
-                )))
+                }).map(|entity| entity.clone()))
         } else {
             unimplemented!()
         }
@@ -147,7 +144,7 @@ impl ChainStore for MockStore {
 pub struct FakeStore;
 
 impl Store for FakeStore {
-    fn get(&self, _: StoreKey) -> Result<Entity, QueryExecutionError> {
+    fn get(&self, _: StoreKey) -> Result<Option<Entity>, QueryExecutionError> {
         unimplemented!();
     }
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -394,7 +394,7 @@ where
         self.store
             .get(store_key)
             .and_then(|entity| {
-                let entity = EntityOperation::apply_all(Some(entity), &matching_operations);
+                let entity = EntityOperation::apply_all(entity, &matching_operations);
                 Ok(entity.map(|entity| RuntimeValue::from(self.heap.asc_new(&entity))))
             }).or(Ok(Some(RuntimeValue::from(0))))
     }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -464,19 +464,23 @@ impl StoreTrait for Store {
             }).map_err(Error::from)
     }
 
-    fn get(&self, key: StoreKey) -> Result<Entity, QueryExecutionError> {
+    fn get(&self, key: StoreKey) -> Result<Option<Entity>, QueryExecutionError> {
         use db_schema::entities::dsl::*;
 
         // Use primary key fields to get the entity; deserialize the result JSON
         entities
-            .find((key.id, key.subgraph, key.entity))
+            .find((&key.id, &key.subgraph, &key.entity))
             .select(data)
             .first::<serde_json::Value>(&*self.conn.lock().unwrap())
-            .map_err(|e| QueryExecutionError::ResolveEntitiesError(e.to_string()))
-            .and_then(|value| {
-                serde_json::from_value::<Entity>(value)
-                    .map_err(|e| QueryExecutionError::EntityParseError(e.to_string()))
-            })
+            .optional()
+            .and_then(move |option| {
+                Ok(option.map(|value| {
+                    serde_json::from_value::<Entity>(value)
+                        .map_err(|e| {
+                            return QueryExecutionError::InvalidEntityError(key.subgraph, key.entity, key.id, format!("{}", e))
+                        }).unwrap()
+                }))
+            }).map_err(QueryExecutionError::from)
     }
 
     fn find(&self, query: StoreQuery) -> Result<Vec<Entity>, QueryExecutionError> {


### PR DESCRIPTION
Resolves #423 

`Store::get` and `Store::get_entity` now return `Result<Option<Entity>, Error>` allowing handling of query errors and returning `None` if no data is found. 