### PR TITLE
Disambiguate entity field deserialization, fix order_by, return option from Store::get

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1,7 +1,7 @@
 use failure::Error;
 use futures::Future;
 use futures::Stream;
-use graphql_parser::{schema as s};
+use graphql_parser::schema as s;
 use web3::types::{Block, Transaction, H256};
 
 use data::store::*;

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -282,7 +282,7 @@ pub trait Store: Send + Sync {
 
     /// Looks up an entity using the given store key.
     // TODO need to validate block ptr
-    fn get(&self, key: StoreKey) -> Result<Entity, QueryExecutionError>;
+    fn get(&self, key: StoreKey) -> Result<Option<Entity>, QueryExecutionError>;
 
     /// Queries the store for entities that match the store query.
     // TODO need to validate block ptr

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1,16 +1,12 @@
 use failure::Error;
 use futures::Future;
 use futures::Stream;
-use graphql_parser::schema as s;
-use web3::types::{Block, Transaction, H256};
-
-use data::store::*;
 use std::fmt;
 use std::str::FromStr;
 use web3::types::H256;
 
+use data::store::*;
 use prelude::*;
-use std::ops::Deref;
 
 /// Key by which an individual entity in the store can be accessed.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -2,7 +2,6 @@ use failure::Error;
 use futures::Future;
 use futures::Stream;
 use std::fmt;
-use std::str::FromStr;
 use web3::types::H256;
 
 use data::store::*;
@@ -57,45 +56,6 @@ pub struct StoreRange {
 
     /// How many entities to skip.
     pub skip: usize,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum ValueType {
-    Boolean,
-    BigInt,
-    Bytes,
-    Float,
-    ID,
-    Int,
-    String,
-}
-
-#[derive(Debug, Fail)]
-pub enum ValueTypeError {
-    #[fail(display = "Found unexpected type name: {}", name)]
-    UnexpectedTypeName { name: String },
-    #[fail(display = "Cannot convert from ListType to ValueType")]
-    CannotConvertFromListType,
-    #[fail(display = "Found invalid schema type: nested NonNull type")]
-    NestedNonNullType,
-}
-
-impl FromStr for ValueType {
-    type Err = ValueTypeError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "Boolean" => Ok(ValueType::Boolean),
-            "BigInt" => Ok(ValueType::BigInt),
-            "Bytes" => Ok(ValueType::Bytes),
-            "Float" => Ok(ValueType::Float),
-            "ID" => Ok(ValueType::ID),
-            "Int" => Ok(ValueType::Int),
-            "String" => Ok(ValueType::String),
-            e => Err(ValueTypeError::UnexpectedTypeName {
-                name: e.to_string(),
-            }),
-        }
-    }
 }
 
 /// A query for entities in a store.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -101,19 +101,6 @@ impl FromStr for ValueType {
         }
     }
 }
-impl From<s::Type> for ValueType {
-    fn from(schema_type: s::Type) -> ValueType {
-        match schema_type {
-            s::Type::NamedType(ref name) => ValueType::from_str(&name).unwrap(),
-            s::Type::NonNullType(inner) => match *inner {
-                s::Type::NamedType(ref name) => ValueType::from_str(&name).unwrap(),
-                s::Type::NonNullType(inner) => panic!(ValueTypeError::NestedNonNullType),
-                s::Type::ListType(inner) => panic!(ValueTypeError::CannotConvertFromListType),
-            },
-            s::Type::ListType(inner) => panic!(ValueTypeError::CannotConvertFromListType),
-        }
-    }
-}
 
 /// A query for entities in a store.
 #[derive(Clone, Debug, PartialEq)]

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -23,6 +23,7 @@ pub enum QueryExecutionError {
     MissingArgumentError(Pos, String),
     ResolveEntityError(String, String, String, String),
     ResolveEntitiesError(String),
+    OrderByNotSupportedError(String, String),
     FilterNotSupportedError(String, String),
     UnknownField(Pos, String, String),
     EmptyQuery,
@@ -85,6 +86,9 @@ impl fmt::Display for QueryExecutionError {
             }
             QueryExecutionError::ResolveEntitiesError(e) => {
                 write!(f, "Failed to get entities from store: {}", e)
+            }
+            QueryExecutionError::OrderByNotSupportedError(entity, field) => {
+                write!(f, "Ordering by \"{}\" is not supported for type \"{}\"", field, entity)
             }
             QueryExecutionError::FilterNotSupportedError(value, filter) => {
                 write!(f, "Filter not supported by value {} : {}", value, filter)

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -21,6 +21,7 @@ pub enum QueryExecutionError {
     AbstractTypeError(String),
     InvalidArgumentError(Pos, String, q::Value),
     MissingArgumentError(Pos, String),
+    ResolveEntityError(String, String, String, String),
     ResolveEntitiesError(String),
     FilterNotSupportedError(String, String),
     UnknownField(Pos, String, String),
@@ -79,8 +80,11 @@ impl fmt::Display for QueryExecutionError {
             QueryExecutionError::MissingArgumentError(_, s) => {
                 write!(f, "No value provided for required argument: {}", s)
             }
-            QueryExecutionError::ResolveEntitiesError(s) => {
-                write!(f, "Failed to get entity from store: {}", s)
+            QueryExecutionError::ResolveEntityError(_, entity, id, e) => {
+                write!(f, "Failed to get {} entity with ID \"{}\" from store: {}", entity, id, e)
+            }
+            QueryExecutionError::ResolveEntitiesError(e) => {
+                write!(f, "Failed to get entities from store: {}", e)
             }
             QueryExecutionError::FilterNotSupportedError(value, filter) => {
                 write!(f, "Filter not supported by value {} : {}", value, filter)

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,3 +1,4 @@
+use failure::Error;
 use graphql_parser::query;
 use graphql_parser::schema;
 use prelude::QueryExecutionError;
@@ -28,18 +29,9 @@ pub enum ValueType {
     String,
 }
 
-#[derive(Debug, Fail)]
-pub enum ValueTypeError {
-    #[fail(display = "Found unexpected type name: {}", name)]
-    UnexpectedTypeName { name: String },
-    #[fail(display = "Cannot convert from ListType to ValueType")]
-    CannotConvertFromListType,
-    #[fail(display = "Found invalid schema type: nested NonNull type")]
-    NestedNonNullType,
-}
-
 impl FromStr for ValueType {
-    type Err = ValueTypeError;
+    type Err = Error;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "Boolean" => Ok(ValueType::Boolean),
@@ -49,9 +41,7 @@ impl FromStr for ValueType {
             "ID" => Ok(ValueType::ID),
             "Int" => Ok(ValueType::Int),
             "String" => Ok(ValueType::String),
-            e => Err(ValueTypeError::UnexpectedTypeName {
-                name: e.to_string(),
-            }),
+            s => Err(format_err!("Type not available in this context: {}", s)),
         }
     }
 }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,7 +1,6 @@
 use graphql_parser::query;
 use graphql_parser::schema;
 use prelude::QueryExecutionError;
-
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::iter::FromIterator;
@@ -17,6 +16,45 @@ pub type Attribute = String;
 pub const ID: &str = "ID";
 pub const BYTES_SCALAR: &str = "Bytes";
 pub const BIG_INT_SCALAR: &str = "BigInt";
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ValueType {
+    Boolean,
+    BigInt,
+    Bytes,
+    Float,
+    ID,
+    Int,
+    String,
+}
+
+#[derive(Debug, Fail)]
+pub enum ValueTypeError {
+    #[fail(display = "Found unexpected type name: {}", name)]
+    UnexpectedTypeName { name: String },
+    #[fail(display = "Cannot convert from ListType to ValueType")]
+    CannotConvertFromListType,
+    #[fail(display = "Found invalid schema type: nested NonNull type")]
+    NestedNonNullType,
+}
+
+impl FromStr for ValueType {
+    type Err = ValueTypeError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Boolean" => Ok(ValueType::Boolean),
+            "BigInt" => Ok(ValueType::BigInt),
+            "Bytes" => Ok(ValueType::Bytes),
+            "Float" => Ok(ValueType::Float),
+            "ID" => Ok(ValueType::ID),
+            "Int" => Ok(ValueType::Int),
+            "String" => Ok(ValueType::String),
+            e => Err(ValueTypeError::UnexpectedTypeName {
+                name: e.to_string(),
+            }),
+        }
+    }
+}
 
 /// An attribute value is represented as an enum with variants for all supported value types.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -20,7 +20,7 @@ pub const BIG_INT_SCALAR: &str = "BigInt";
 
 /// An attribute value is represented as an enum with variants for all supported value types.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-#[serde(untagged)]
+#[serde(tag = "type", content = "data")]
 pub enum Value {
     String(String),
     Int(i32),

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -87,7 +87,7 @@ impl<'de> Deserialize<'de> for Bytes {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use serde::de::Error;
 
-        let hex_string: &str = Deserialize::deserialize(deserializer)?;
-        Bytes::from_str(hex_string).map_err(D::Error::custom)
+        let hex_string = <String>::deserialize(deserializer)?;
+        Bytes::from_str(&hex_string).map_err(D::Error::custom)
     }
 }

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -42,8 +42,8 @@ impl<'de> Deserialize<'de> for BigInt {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use serde::de::Error;
 
-        let decimal_string: &str = Deserialize::deserialize(deserializer)?;
-        BigInt::from_str(decimal_string).map_err(D::Error::custom)
+        let decimal_string = <String>::deserialize(deserializer)?;
+        BigInt::from_str(&decimal_string).map_err(D::Error::custom)
     }
 }
 

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -68,7 +68,7 @@ pub mod prelude {
     pub use components::store::{
         ChainStore, EntityChange, EntityChangeOperation, EntityChangeStream, EntityOperation,
         EventSource, Store, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange,
-        SubgraphEntityPair, ValueType,
+        SubgraphEntityPair,
     };
     pub use components::subgraph::{
         RuntimeHost, RuntimeHostBuilder, SchemaEvent, SubgraphInstance, SubgraphInstanceManager,
@@ -81,7 +81,7 @@ pub mod prelude {
         Query, QueryError, QueryExecutionError, QueryResult, QueryVariableValue, QueryVariables,
     };
     pub use data::schema::Schema;
-    pub use data::store::{Attribute, Entity, Value};
+    pub use data::store::{Attribute, Entity, Value, ValueType, ValueTypeError};
     pub use data::subgraph::{
         DataSource, Link, MappingABI, MappingEventHandler, SubgraphId, SubgraphManifest,
         SubgraphManifestResolveError, SubgraphProviderError,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -68,7 +68,7 @@ pub mod prelude {
     pub use components::store::{
         ChainStore, EntityChange, EntityChangeOperation, EntityChangeStream, EntityOperation,
         EventSource, Store, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange,
-        SubgraphEntityPair, ValueType
+        SubgraphEntityPair, ValueType,
     };
     pub use components::subgraph::{
         RuntimeHost, RuntimeHostBuilder, SchemaEvent, SubgraphInstance, SubgraphInstanceManager,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -68,7 +68,7 @@ pub mod prelude {
     pub use components::store::{
         ChainStore, EntityChange, EntityChangeOperation, EntityChangeStream, EntityOperation,
         EventSource, Store, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange,
-        SubgraphEntityPair,
+        SubgraphEntityPair, ValueType
     };
     pub use components::subgraph::{
         RuntimeHost, RuntimeHostBuilder, SchemaEvent, SubgraphInstance, SubgraphInstanceManager,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -81,7 +81,7 @@ pub mod prelude {
         Query, QueryError, QueryExecutionError, QueryResult, QueryVariableValue, QueryVariables,
     };
     pub use data::schema::Schema;
-    pub use data::store::{Attribute, Entity, Value, ValueType, ValueTypeError};
+    pub use data::store::{Attribute, Entity, Value, ValueType};
     pub use data::subgraph::{
         DataSource, Link, MappingABI, MappingEventHandler, SubgraphId, SubgraphManifest,
         SubgraphManifestResolveError, SubgraphProviderError,

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -1,6 +1,7 @@
 use graphql_parser::schema::*;
-use graph::components::store::{ValueType, ValueTypeError};
 use std::str::FromStr;
+
+use graph::prelude::{ValueType, ValueTypeError};
 
 pub(crate) enum FilterOp {
     Not,
@@ -106,7 +107,6 @@ pub fn get_field_type<'a>(object_type: &'a ObjectType, name: &Name) -> Option<&'
     object_type.fields.iter().find(|field| &field.name == name)
 }
 
-
 /// Returns the ValueType of a schema field
 pub fn get_value_type(schema_type: Type) -> Result<ValueType, ValueTypeError> {
     match schema_type {
@@ -119,7 +119,6 @@ pub fn get_value_type(schema_type: Type) -> Result<ValueType, ValueTypeError> {
         Type::ListType(_) => Err(ValueTypeError::CannotConvertFromListType),
     }
 }
-
 
 /// Returns the type with the given name.
 pub fn get_named_type<'a>(schema: &'a Document, name: &Name) -> Option<&'a TypeDefinition> {

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -164,7 +164,7 @@ fn build_order_by(
             q::Value::Enum(name) => {
                 let field = sast::get_field_type(entity, &name)
                     .expect("order by attribute does not belong to entity");
-                Some((name.to_owned(), ValueType::from(field.clone().field_type)))
+                Some((name.to_owned(), ValueType::from(field.field_type.clone())))
             }
             _ => None,
         }))

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -164,7 +164,11 @@ fn build_order_by(
             q::Value::Enum(name) => {
                 let field = sast::get_field_type(entity, &name)
                     .expect("order by attribute does not belong to entity");
-                Some((name.to_owned(), ValueType::from(field.field_type.clone())))
+                let value = sast::get_value_type(field.field_type.clone());
+                match value {
+                    Ok(v) => Some((name.to_owned(), v)),
+                    Err(_) => None,
+                }
             }
             _ => None,
         }))

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -157,7 +157,7 @@ fn list_values(value: Value, filter_type: &str) -> Result<Vec<Value>, QueryExecu
 fn build_order_by(
     entity: &s::ObjectType,
     arguments: &HashMap<&q::Name, q::Value>,
-) -> Result<Option<String>, QueryExecutionError> {
+) -> Result<Option<(String, ValueType)>, QueryExecutionError> {
     Ok(arguments
         .get(&"orderBy".to_string())
         .and_then(|value| match value {
@@ -372,14 +372,14 @@ mod tests {
             &HashMap::from_iter(
                 vec![(&"orderBy".to_string(), q::Value::Enum("name".to_string()))].into_iter(),
             ),
-        ).order_by;
+        ).unwrap().order_by;
         assert_eq!(
             build_query(
                 &default_object(),
                 &HashMap::from_iter(
                     vec![(&"orderBy".to_string(), q::Value::Enum("name".to_string()))].into_iter(),
                 )
-            ).order_by,
+            ).unwrap().order_by,
             Some(("name".to_string(), ValueType::String))
         );
         assert_eq!(
@@ -388,7 +388,7 @@ mod tests {
                 &HashMap::from_iter(
                     vec![(&"orderBy".to_string(), q::Value::Enum("email".to_string()))].into_iter()
                 )
-            ).order_by,
+            ).unwrap().order_by,
             Some(("email".to_string(), ValueType::String))
         );
     }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -367,7 +367,7 @@ mod tests {
             &default_object(),
             &HashMap::from_iter(
                 vec![(&"orderBy".to_string(), q::Value::Enum("name".to_string()))].into_iter(),
-            )
+            ),
         ).order_by;
         assert_eq!(
             build_query(

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -241,7 +241,7 @@ where
         });
 
         if let Some(id) = id {
-            return self
+            return Ok(self
                 .store
                 .get(StoreKey {
                     subgraph: parse_subgraph_id(object_type).expect(
@@ -250,12 +250,12 @@ where
                     ),
                     entity: object_type.name.to_owned(),
                     id: id.to_owned(),
-                }).map(|entity| entity.into());
+                })?.map_or(q::Value::Null, |entity| entity.into()));
         }
 
         match parent {
             Some(q::Value::Object(parent_object)) => match parent_object.get(field) {
-                Some(q::Value::String(id)) => self
+                Some(q::Value::String(id)) => Ok(self
                     .store
                     .get(StoreKey {
                         subgraph: parse_subgraph_id(object_type).expect(
@@ -264,7 +264,7 @@ where
                         ),
                         entity: object_type.name.to_owned(),
                         id: id.to_owned(),
-                    }).map(|entity| entity.into()),
+                    })?.map_or(q::Value::Null, |entity| entity.into())),
                 _ => Ok(q::Value::Null),
             },
             _ => {

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -173,7 +173,7 @@ impl Store for TestStore {
         unimplemented!()
     }
 
-    fn get(&self, key: StoreKey) -> Result<Entity, QueryExecutionError> {
+    fn get(&self, key: StoreKey) -> Result<Option<Entity>, QueryExecutionError> {
         self.entities
             .iter()
             .find(|entity| {
@@ -183,7 +183,7 @@ impl Store for TestStore {
                 Err(QueryExecutionError::ResolveEntitiesError(String::from(
                     "Mock get query error",
                 ))),
-                |entity| Ok(entity.clone()),
+                |entity| Ok(Some(entity.clone())),
             )
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -41,7 +41,7 @@ impl MockStore {
 }
 
 impl Store for MockStore {
-    fn get(&self, key: StoreKey) -> Result<Entity, QueryExecutionError> {
+    fn get(&self, key: StoreKey) -> Result<Option<Entity>, QueryExecutionError> {
         if key.entity == "User" {
             self.entities
                 .iter()
@@ -51,10 +51,8 @@ impl Store for MockStore {
                         &Value::String(ref s) => s == &key.id,
                         _ => false,
                     }
-                }).map(|entity| entity.clone())
-                .ok_or(QueryExecutionError::ResolveEntitiesError(String::from(
-                    "Mock store error",
-                )))
+                }).map(|entity| Some(entity.clone()))
+                .ok_or_else(|| unimplemented!())
         } else {
             unimplemented!()
         }
@@ -147,7 +145,7 @@ impl ChainStore for MockStore {
 pub struct FakeStore;
 
 impl Store for FakeStore {
-    fn get(&self, _: StoreKey) -> Result<Entity, QueryExecutionError> {
+    fn get(&self, _: StoreKey) -> Result<Option<Entity>, QueryExecutionError> {
         unimplemented!();
     }
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -394,7 +394,7 @@ where
         self.store
             .get(store_key)
             .and_then(|entity| {
-                let entity = EntityOperation::apply_all(Some(entity), &matching_operations);
+                let entity = EntityOperation::apply_all(entity, &matching_operations);
                 Ok(entity.map(|entity| RuntimeValue::from(self.heap.asc_new(&entity))))
             }).or(Ok(Some(RuntimeValue::from(0))))
     }

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -74,26 +74,28 @@ fn store_filter_by_mode<'a>(
                 Value::String(query_value) => add_filter(
                     query,
                     filter_mode,
-                    sql("data ->> ")
+                    sql("data -> ")
                         .bind::<Text, _>(attribute)
+                        .sql("->> 'data'")
                         .sql(op)
                         .bind::<Text, _>(query_value),
                 ),
                 Value::Bytes(query_value) => add_filter(
                     query,
                     filter_mode,
-                    sql("data ->> ")
+                    sql("data -> ")
                         .bind::<Text, _>(attribute)
+                        .sql("->> 'data'")
                         .sql(op)
                         .bind::<Text, _>(query_value.to_string()),
                 ),
                 Value::List(query_value) => {
                     let query_array =
                         serde_json::to_string(&query_value).expect("Failed to serialize Value");
-                    // Is `query_array` contained in array `data ->> attribute`?
-                    let predicate = sql("data ->> ")
+                    // Is `query_array` contained in array `data -> attribute -> 'data'`?
+                    let predicate = sql("data -> ")
                         .bind::<Text, _>(attribute)
-                        .sql(" @> ")
+                        .sql("->> 'data' @> ")
                         .bind::<Text, _>(query_array);
                     if not {
                         add_filter(query, filter_mode, dsl::not(predicate))
@@ -125,9 +127,9 @@ fn store_filter_by_mode<'a>(
                     query,
                     filter_mode,
                     sql("(")
-                        .sql("data ->> ")
+                        .sql("data -> ")
                         .bind::<Text, _>(attribute)
-                        .sql(")")
+                        .sql("->> 'data')")
                         .sql(op)
                         .bind::<Text, _>(query_value),
                 ),
@@ -135,9 +137,9 @@ fn store_filter_by_mode<'a>(
                     query,
                     filter_mode,
                     sql("(")
-                        .sql("data ->> ")
+                        .sql("data -> ")
                         .bind::<Text, _>(attribute)
-                        .sql(")")
+                        .sql("->> 'data')")
                         .sql("::float")
                         .sql(op)
                         .bind::<Float, _>(query_value),
@@ -145,9 +147,9 @@ fn store_filter_by_mode<'a>(
                 Value::Int(query_value) => add_filter(
                     query,
                     filter_mode,
-                    sql("(data ->> ")
+                    sql("(data -> ")
                         .bind::<Text, _>(attribute)
-                        .sql(")")
+                        .sql("->> 'data')")
                         .sql("::int")
                         .sql(op)
                         .bind::<Integer, _>(query_value),
@@ -155,9 +157,9 @@ fn store_filter_by_mode<'a>(
                 Value::Bool(query_value) => add_filter(
                     query,
                     filter_mode,
-                    sql("(data ->> ")
+                    sql("(data -> ")
                         .bind::<Text, _>(attribute)
-                        .sql(")")
+                        .sql("-> 'data')")
                         .sql("::boolean")
                         .sql(op)
                         .bind::<Bool, _>(query_value),
@@ -165,7 +167,9 @@ fn store_filter_by_mode<'a>(
                 Value::Null => add_filter(
                     query,
                     filter_mode,
-                    sql("data -> ").bind::<Text, _>(attribute).sql(" = 'null' "),
+                    sql("data -> ")
+                        .bind::<Text, _>(attribute)
+                        .sql(" -> 'data' = 'null' "),
                 ),
                 Value::List(query_value) => {
                     // Note that lists with the same elements but in different order
@@ -175,8 +179,9 @@ fn store_filter_by_mode<'a>(
                     add_filter(
                         query,
                         filter_mode,
-                        sql("data ->> ")
+                        sql("data -> ")
                             .bind::<Text, _>(attribute)
+                            .sql("->> 'data'")
                             .sql(op)
                             .bind::<Text, _>(query_array),
                     )
@@ -184,23 +189,24 @@ fn store_filter_by_mode<'a>(
                 Value::Bytes(query_value) => add_filter(
                     query,
                     filter_mode,
-                    sql("data ->> ")
+                    sql("data -> ")
                         .bind::<Text, _>(attribute)
+                        .sql("->> 'data'")
                         .sql(op)
                         .bind::<Text, _>(query_value.to_string()),
                 ),
                 Value::BigInt(query_value) => add_filter(
                     query,
                     filter_mode,
-                    sql("(data ->> ")
-                    .bind::<Text, _>(attribute)
-                .sql(")")
-                .sql("::numeric")
-                .sql(op)
-                // Using `BigDecimal::new(query_value.0, 0)` results in a
-                // mismatch of `bignum` versions, go through the string
-                // representation to work around that.
-                .bind::<Numeric, _>(BigDecimal::from_str(&query_value.to_string()).unwrap()),
+                    sql("(data -> ")
+                        .bind::<Text, _>(attribute)
+                        .sql("->> 'data')")
+                        .sql("::numeric")
+                        .sql(op)
+                    // Using `BigDecimal::new(query_value.0, 0)` results in a
+                    // mismatch of `bignum` versions, go through the string
+                    // representation to work around that.
+                        .bind::<Numeric, _>(BigDecimal::from_str(&query_value.to_string()).unwrap()),
                 ),
             }
         }
@@ -219,16 +225,18 @@ fn store_filter_by_mode<'a>(
                 Value::String(query_value) => add_filter(
                     query,
                     filter_mode,
-                    sql("data ->> ")
+                    sql("data -> ")
                         .bind::<Text, _>(attribute)
+                        .sql("->> 'data'")
                         .sql(op)
                         .bind::<Text, _>(query_value),
                 ),
                 Value::Float(query_value) => add_filter(
                     query,
                     filter_mode,
-                    sql("(data ->> ")
+                    sql("(data -> ")
                         .bind::<Text, _>(attribute)
+                        .sql("->> 'data'")
                         .sql(")")
                         .sql("::float")
                         .sql(op)
@@ -237,9 +245,9 @@ fn store_filter_by_mode<'a>(
                 Value::Int(query_value) => add_filter(
                     query,
                     filter_mode,
-                    sql("(data ->> ")
+                    sql("(data -> ")
                         .bind::<Text, _>(attribute)
-                        .sql(")")
+                        .sql("->> 'data')")
                         .sql("::int")
                         .sql(op)
                         .bind::<Integer, _>(query_value),
@@ -247,9 +255,9 @@ fn store_filter_by_mode<'a>(
                 Value::BigInt(query_value) => add_filter(
                     query,
                     filter_mode,
-                    sql("(data ->> ")
+                    sql("(data -> ")
                     .bind::<Text, _>(attribute)
-                .sql(")")
+                .sql("->> 'data')")
                 .sql("::numeric")
                 .sql(op)
                 // Using `BigDecimal::new(query_value.0, 0)` results in a
@@ -275,9 +283,9 @@ fn store_filter_by_mode<'a>(
                 Value::Bool(_) => add_filter(
                     query,
                     filter_mode,
-                    sql("(data ->> ")
+                    sql("(data -> ")
                         .bind::<Text, _>(attribute)
-                        .sql(")")
+                        .sql("->> 'data')")
                         .sql("::boolean")
                         .sql(op)
                         .bind::<Array<Bool>, _>(SqlValue::new_array(query_values))
@@ -286,9 +294,9 @@ fn store_filter_by_mode<'a>(
                 Value::BigInt(_) => add_filter(
                     query,
                     filter_mode,
-                    sql("data ->> ")
+                    sql("data -> ")
                         .bind::<Text, _>(attribute)
-                        .sql(")")
+                        .sql("->> 'data')")
                         .sql("::numeric")
                         .sql(op)
                         .bind::<Array<Numeric>, _>(SqlValue::new_array(query_values))
@@ -297,8 +305,9 @@ fn store_filter_by_mode<'a>(
                 Value::Bytes(_) => add_filter(
                     query,
                     filter_mode,
-                    sql("data ->> ")
+                    sql("data -> ")
                         .bind::<Text, _>(attribute)
+                        .sql("->> 'data'")
                         .sql(op)
                         .bind::<Array<Text>, _>(SqlValue::new_array(query_values))
                         .sql(")"),
@@ -306,9 +315,9 @@ fn store_filter_by_mode<'a>(
                 Value::Float(_) => add_filter(
                     query,
                     filter_mode,
-                    sql("(data ->> ")
+                    sql("(data -> ")
                         .bind::<Text, _>(attribute)
-                        .sql(")")
+                        .sql("->> 'data')")
                         .sql("::float")
                         .sql(op)
                         .bind::<Array<Float>, _>(SqlValue::new_array(query_values))
@@ -317,9 +326,9 @@ fn store_filter_by_mode<'a>(
                 Value::Int(_) => add_filter(
                     query,
                     filter_mode,
-                    sql("(data ->> ")
+                    sql("(data -> ")
                         .bind::<Text, _>(attribute)
-                        .sql(")")
+                        .sql("->> 'data')")
                         .sql("::int")
                         .sql(op)
                         .bind::<Array<Integer>, _>(SqlValue::new_array(query_values))
@@ -328,8 +337,9 @@ fn store_filter_by_mode<'a>(
                 Value::String(_) => add_filter(
                     query,
                     filter_mode,
-                    sql("data ->> ")
+                    sql("data -> ")
                         .bind::<Text, _>(attribute)
+                        .sql("->> 'data'")
                         .sql(op)
                         .bind::<Array<Text>, _>(SqlValue::new_array(query_values))
                         .sql(")"),
@@ -356,8 +366,9 @@ fn store_filter_by_mode<'a>(
                 Value::String(query_value) => add_filter(
                     query,
                     filter_mode,
-                    sql("data ->> ")
+                    sql("data -> ")
                         .bind::<Text, _>(attribute)
+                        .sql("->> 'data'")
                         .sql(op)
                         .bind::<Text, _>(format!("{}%", query_value)),
                 ),
@@ -390,8 +401,9 @@ fn store_filter_by_mode<'a>(
                 Value::String(query_value) => add_filter(
                     query,
                     filter_mode,
-                    sql("data ->> ")
+                    sql("data -> ")
                         .bind::<Text, _>(attribute)
+                        .sql("->> 'data'")
                         .sql(op)
                         .bind::<Text, _>(format!("%{}", query_value)),
                 ),

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -502,43 +502,21 @@ impl StoreTrait for Store {
                     StoreOrder::Ascending => String::from("ASC"),
                     StoreOrder::Descending => String::from("DESC"),
                 }).unwrap_or(String::from("ASC"));
-            diesel_query = match value_type {
-                ValueType::BigInt => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(")::bigint {} NULLS LAST", direction)),
-                ),
-                ValueType::Int => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(")::bigint {} NULLS LAST", direction)),
-                ),
-                ValueType::String => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(") {} NULLS LAST", direction)),
-                ),
-                ValueType::Float => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(")::numeric {} NULLS LAST", direction)),
-                ),
-                ValueType::ID => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(") {} NULLS LAST", direction)),
-                ),
-                ValueType::Bytes => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(") {} NULLS LAST", direction)),
-                ),
-                ValueType::Boolean => diesel_query.order(
-                    sql::<Text>("(data ->>")
-                        .bind::<Text, _>(order_attribute)
-                        .sql(&format!(")::boolean {} NULLS LAST", direction)),
-                ),
+            let cast_type = match value_type {
+                ValueType::BigInt => "::bigint".to_string(),
+                ValueType::Boolean => "::boolean".to_string(),
+                ValueType::Bytes => "".to_string(),
+                ValueType::Float => "::numeric".to_string(),
+                ValueType::ID => "".to_string(),
+                ValueType::Int => "::bigint".to_string(),
+                ValueType::String => "".to_string(),
+                _ => "",
             };
+            diesel_query = diesel_query.order(
+                sql::<Text>("(data ->>")
+                    .bind::<Text, _>(order_attribute)
+                    .sql(&format!("){} {} NULLS LAST", cast_type, direction)),
+            );
         }
 
         // Add range filter to query

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -499,18 +499,17 @@ impl StoreTrait for Store {
             let direction = query
                 .order_direction
                 .map(|direction| match direction {
-                    StoreOrder::Ascending => String::from("ASC"),
-                    StoreOrder::Descending => String::from("DESC"),
-                }).unwrap_or(String::from("ASC"));
+                    StoreOrder::Ascending => "ASC",
+                    StoreOrder::Descending => "DESC",
+                }).unwrap_or("ASC");
             let cast_type = match value_type {
-                ValueType::BigInt => "::bigint".to_string(),
-                ValueType::Boolean => "::boolean".to_string(),
-                ValueType::Bytes => "".to_string(),
-                ValueType::Float => "::numeric".to_string(),
-                ValueType::ID => "".to_string(),
-                ValueType::Int => "::bigint".to_string(),
-                ValueType::String => "".to_string(),
-                _ => "",
+                ValueType::BigInt => "::numeric",
+                ValueType::Boolean => "::boolean",
+                ValueType::Bytes => "",
+                ValueType::Float => "::float",
+                ValueType::ID => "",
+                ValueType::Int => "::bigint",
+                ValueType::String => "",
             };
             diesel_query = diesel_query.order(
                 sql::<Text>("(data ->>")

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -495,19 +495,50 @@ impl StoreTrait for Store {
         }
 
         // Add order by filters to query
-        if let Some(order_attribute) = query.order_by {
+        if let Some((order_attribute, value_type)) = query.order_by {
             let direction = query
                 .order_direction
                 .map(|direction| match direction {
                     StoreOrder::Ascending => String::from("ASC"),
                     StoreOrder::Descending => String::from("DESC"),
                 }).unwrap_or(String::from("ASC"));
-
-            diesel_query = diesel_query.order(
-                sql::<Text>("data ->> ")
-                    .bind::<Text, _>(order_attribute)
-                    .sql(&format!(" {} ", direction)),
-            )
+            diesel_query = match value_type {
+                ValueType::BigInt => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(")::bigint {} NULLS LAST", direction)),
+                ),
+                ValueType::Int => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(")::bigint {} NULLS LAST", direction)),
+                ),
+                ValueType::String => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(") {} NULLS LAST", direction)),
+                ),
+                ValueType::Float => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(")::numeric {} NULLS LAST", direction)),
+                ),
+                ValueType::ID => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(") {} NULLS LAST", direction)),
+                ),
+                ValueType::Bytes => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(") {} NULLS LAST", direction)),
+                ),
+                ValueType::Boolean => diesel_query.order(
+                    sql::<Text>("(data ->>")
+                        .bind::<Text, _>(order_attribute)
+                        .sql(&format!(")::boolean {} NULLS LAST", direction)),
+                ),
+            };
         }
 
         // Add range filter to query

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -521,7 +521,7 @@ fn find_string_less_than_order_by_asc() {
                 String::from("name"),
                 Value::String(String::from("Kundi")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Ascending),
             range: None,
         };
@@ -561,7 +561,7 @@ fn find_string_less_than_order_by_desc() {
                 String::from("name"),
                 Value::String(String::from("Kundi")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -601,7 +601,7 @@ fn find_string_less_than_range() {
                 String::from("name"),
                 Value::String(String::from("ZZZ")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 1, skip: 1 }),
         };
@@ -631,7 +631,7 @@ fn find_string_multiple_and() {
                 StoreFilter::LessThan(String::from("name"), Value::String(String::from("Cz"))),
                 StoreFilter::Equal(String::from("name"), Value::String(String::from("Cindini"))),
             ])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -661,7 +661,7 @@ fn find_string_ends_with() {
                 String::from("name"),
                 Value::String(String::from("ini")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -691,7 +691,7 @@ fn find_string_not_ends_with() {
                 String::from("name"),
                 Value::String(String::from("ini")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -721,7 +721,7 @@ fn find_string_in() {
                 String::from("name"),
                 vec![Value::String(String::from("Johnton"))],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -751,7 +751,7 @@ fn find_string_not_in() {
                 String::from("name"),
                 vec![Value::String(String::from("Shaqueeena"))],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -812,7 +812,7 @@ fn find_float_not_equal() {
                 String::from("weight"),
                 Value::Float(184.4 as f32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -872,7 +872,7 @@ fn find_float_less_than() {
                 String::from("weight"),
                 Value::Float(160 as f32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::From("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Ascending),
             range: None,
         };
@@ -902,7 +902,7 @@ fn find_float_less_than_order_by_desc() {
                 String::from("weight"),
                 Value::Float(160 as f32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -932,7 +932,7 @@ fn find_float_less_than_range() {
                 String::from("weight"),
                 Value::Float(161 as f32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 1, skip: 1 }),
         };
@@ -961,7 +961,7 @@ fn find_float_in() {
                 String::from("weight"),
                 vec![Value::Float(184.4 as f32), Value::Float(111.7 as f32)],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 5, skip: 0 }),
         };
@@ -991,7 +991,7 @@ fn find_float_not_in() {
                 String::from("weight"),
                 vec![Value::Float(184.4 as f32), Value::Float(111.7 as f32)],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 5, skip: 0 }),
         };
@@ -1021,7 +1021,7 @@ fn find_int_equal() {
                 String::from("age"),
                 Value::Int(67 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -1051,7 +1051,7 @@ fn find_int_not_equal() {
                 String::from("age"),
                 Value::Int(67 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -1111,7 +1111,7 @@ fn find_int_greater_or_equal() {
                 String::from("age"),
                 Value::Int(43 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Ascending),
             range: None,
         };
@@ -1141,7 +1141,7 @@ fn find_int_less_than() {
                 String::from("age"),
                 Value::Int(50 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Ascending),
             range: None,
         };
@@ -1171,7 +1171,7 @@ fn find_int_less_or_equal() {
                 String::from("age"),
                 Value::Int(43 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Ascending),
             range: None,
         };
@@ -1201,7 +1201,7 @@ fn find_int_less_than_order_by_desc() {
                 String::from("age"),
                 Value::Int(50 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -1231,7 +1231,7 @@ fn find_int_less_than_range() {
                 String::from("age"),
                 Value::Int(67 as i32),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 1, skip: 1 }),
         };
@@ -1261,7 +1261,7 @@ fn find_int_in() {
                 String::from("age"),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 5, skip: 0 }),
         };
@@ -1291,7 +1291,7 @@ fn find_int_not_in() {
                 String::from("age"),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 5, skip: 0 }),
         };
@@ -1321,7 +1321,7 @@ fn find_bool_equal() {
                 String::from("coffee"),
                 Value::Bool(true),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -1351,7 +1351,7 @@ fn find_bool_not_equal() {
                 String::from("coffee"),
                 Value::Bool(true),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Ascending),
             range: None,
         };
@@ -1381,7 +1381,7 @@ fn find_bool_in() {
                 String::from("coffee"),
                 vec![Value::Bool(true)],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 5, skip: 0 }),
         };
@@ -1411,7 +1411,7 @@ fn find_bool_not_in() {
                 String::from("coffee"),
                 vec![Value::Bool(true)],
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: Some(StoreRange { first: 5, skip: 0 }),
         };
@@ -1441,7 +1441,7 @@ fn revert_block() {
                 String::from("name"),
                 Value::String(String::from("Shaqueeena")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };
@@ -1488,7 +1488,7 @@ fn revert_block_with_delete() {
                 String::from("name"),
                 Value::String(String::from("Cindini")),
             )])),
-            order_by: Some(String::from("name")),
+            order_by: Some((String::from("name"), ValueType::String)),
             order_direction: Some(StoreOrder::Descending),
             range: None,
         };


### PR DESCRIPTION
Obsoletes #376, obsoletes #480.

Fixes #331, making `orderBy`, `_lt`, `_lte` and other filters work for all supported entity attribute types.

## Fix ambiguous (and broken) entity deserialization

Previously, we were deserializing entity attributes of type `Value::Bytes` incorrectly as `Value::String`. This wasn't noticeable in the GraphQL API, since we're representing `Bytes` as strings there. However, it made using a `Bytes` value returned by `store.get` in mappings impossible (handlers would crash).

This PR changes the way entities are stored in Postgres: Instead of storing
```json
{"id": "...",
 "owner": "0x..."}
```
we now store tagged versions of the attribute values:
```json
`{"id": {"type": "String", "data": "..."},
  "owner": {"type": "Bytes", "data": "0x..."}}
```
This is certainly more verbose but we will change how entities are stored soon anyway (e.g. one row per attribute). Until then, this change removes all ambiguity from loading/deserializing entities from Postgres and should make mappings that use attributes returned by `store.get` work again.

## `Store::get` now returns a `Result<Option<Entity>, QueryExecutionError>`

From the original PR (#480):

> `Store::get` and `Store::get_entity` now return `Result<Option<Entity>, ...>`, allowing handling of query errors and returning `None` if no data is found.

This also allows mappings to distinguish between no entity being returned from `store.get` and `store.get` failing.

## `orderBy` fix

From the original PR (#376):

> This PR fixes the filter query bug where all order_by comparisons were done in alphabetical order because the jsonb objects are returned as text; when adding an order_by filter the jsonb attribute must be cast from text to the correct data type before performing comparisons
>
> A new enum was created, ValueType, with a variant for each supported data type. ValueType is now passed into the order_by query fragment builder and used to decide which data cast to perform before ordering. The order_by queries have all been updated to now include NULLS LAST, so null values will not appear in the beginning of the filtered set.
>
> Data casting from jsonb::text before comparing:
>
> BigInt -> cast to `numeric`
> Int -> cast to `bigint`
> String -> leave as `text`
> Float -> cast to `double precision`
> Id -> leave as `text`
> Bytes -> leave as `text`
> Boolean -> cast to `boolean`
