### PR TITLE
README: Use --ethereum-rpc instead of --ethereum-ws in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Once you have all the dependencies set up you can run the following:
 ```
 cargo run -p graph-node --release -- \
   --postgres-url postgresql://USERNAME[:PASSWORD]@localhost:5432/graph-node \
-  --ethereum-ws mainnet:wss://mainnet.infura.io/_ws \
+  --ethereum-rpc mainnet:https://mainnet.infura.io/ \
   --ipfs 127.0.0.1:5001 \
 ```
 


### PR DESCRIPTION
We should no longer advocate using `--ethereum-ws`.