### PR TITLE
Handle transaction removed from main chain

### DIFF
--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -93,5 +93,5 @@ pub mod prelude {
         CancelGuard, CancelHandle, CancelableError, FutureExtension, SharedCancelGuard,
         StreamExtension,
     };
-    pub use util::futures::{with_retry, with_retry_log_after};
+    pub use util::futures::{with_retry, with_retry_log_after, with_retry_max_retry};
 }


### PR DESCRIPTION
Previous PR handled case where transactions were excluded from the main chain in a reorg, then readded in a different block. This PR handles the case where those transactions never make it back into the main chain. Annoyingly, it's hard to distinguish this case from the case where a receipt is missing because it is not yet available. To work around that, this retries getting the receipt for a reasonable amount of time before giving up and retrying the whole block.

Aside: there seems to be a fundamental limitation of Ethereum RPC -- you can only get tx receipts for blocks that the Ethereum node currently considers to be part of the main chain.

Resolves #491 