### PR TITLE
Remove only by name, lookup subgraph in url by name first

### DIFF
--- a/datasource/ethereum/src/block_ingestor.rs
+++ b/datasource/ethereum/src/block_ingestor.rs
@@ -64,7 +64,8 @@ where
                             BlockIngestorError::BlockUnavailable(_) => {
                                 trace!(
                                     static_self.logger,
-                                    "Trying again after block polling failed: {}", err
+                                    "Trying again after block polling failed: {}",
+                                    err
                                 );
                             }
                             BlockIngestorError::Unknown(inner_err) => {

--- a/graph/src/components/subgraph/provider.rs
+++ b/graph/src/components/subgraph/provider.rs
@@ -30,7 +30,7 @@ pub trait SubgraphProvider:
 
     fn remove(
         &self,
-        name_or_id: String,
+        name: String,
     ) -> Box<Future<Item = (), Error = SubgraphProviderError> + Send + 'static>;
 
     fn list(&self) -> Vec<(String, String)>;

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -39,7 +39,7 @@ impl fmt::Display for SubgraphDeployParams {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct SubgraphRemoveParams {
-    name_or_id: String,
+    name: String,
 }
 
 impl fmt::Display for SubgraphRemoveParams {
@@ -128,11 +128,8 @@ impl<T: SubgraphProvider> JsonRpcServer<T> {
     ) -> Box<Future<Item = Value, Error = jsonrpc_core::Error> + Send> {
         info!(self.logger, "Received subgraph_remove request"; "params" => params.to_string());
 
-        let name_or_id = params.name_or_id;
-        // We need a name for auth so `name_or_id` being an id is not supported
-        // if we're checking auth.
         if should_check_auth()
-            && Some(&auth.bearer_token) != self.subgraph_api_keys.read().unwrap().get(&name_or_id)
+            && Some(&auth.bearer_token) != self.subgraph_api_keys.read().unwrap().get(&params.name)
         {
             return Box::new(future::err(json_rpc_error(
                 JSON_RPC_UNAUTHORIZED_ERROR,
@@ -142,7 +139,7 @@ impl<T: SubgraphProvider> JsonRpcServer<T> {
 
         Box::new(
             self.provider
-                .remove(name_or_id)
+                .remove(params.name)
                 .map_err(|e| json_rpc_error(JSON_RPC_REMOVE_ERROR, e.to_string()))
                 .map(|_| Ok(Value::Null))
                 .flatten(),


### PR DESCRIPTION
First commit changes subgraph removal to work only by name, removal by id doesn't have much of a use case and it didn't with auth.

Second commit prevents a subgraph from impersonating another by looking up subgraphs identifiers in urls by id first and then by name.