### PR TITLE
Deprecation notice for the `--subgraph` option

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -328,6 +328,11 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
 
     // Add the CLI subgraph with a REST request to the admin server.
     if let Some(subgraph) = subgraph {
+        warn!(
+            logger,
+            "The `--subgraph` option is deprecated and will be removed. \
+             Please use the `graph deploy` command of `graph-cli` instead."
+        );
         let (name, hash) = if subgraph.contains(':') {
             let mut split = subgraph.split(':');
             (split.next().unwrap(), split.next().unwrap())

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -197,7 +197,7 @@ mod tests {
                         } else if Instant::now().duration_since(start_time) > max_wait {
                             panic!("Timed out, schema not received")
                         }
-                        ::std::thread::yield_now();
+                        ::std::thread::sleep(Duration::from_millis(10));
                     };
 
                     assert_eq!(output_schema.id, input_schema.id);

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -188,9 +188,9 @@ mod tests {
                     schema_sink.send(input_event).wait().unwrap();
 
                     // Wait for the schema to be received and extract it.
-                    // Wait for thirty seconds for that to happen, otherwise fail the test.
+                    // Wait a while for that to happen, otherwise fail the test.
                     let start_time = Instant::now();
-                    let max_wait = Duration::from_secs(30);
+                    let max_wait = Duration::from_secs(60);
                     let output_schema = loop {
                         if let Some(schema) = server.schemas.read().unwrap().get("input-schema") {
                             break schema.clone();


### PR DESCRIPTION
Now that `graph deploy` exists this has mostly lost its purpose and we'd rather not maintain this code through all the incoming changes for the hosted service.