### PR TITLE
Add retry for transient Infura eth_call issues

### DIFF
--- a/datasource/ethereum/src/block_ingestor.rs
+++ b/datasource/ethereum/src/block_ingestor.rs
@@ -195,7 +195,14 @@ where
         // Retry, but eventually give up.
         // The receipt might be missing because the block was uncled, and the transaction never
         // made it back into the main chain.
-        with_retry_max_retry(16, move || {
+        retry(
+            "block ingestor eth_getTransactionReceipt RPC call",
+            self.logger.clone(),
+        ).when_err()
+        .limit(16)
+        .no_logging()
+        .timeout_secs(60)
+        .run(move || {
             web3.eth()
                 .transaction_receipt(tx_hash)
                 .map_err(move |e| {

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -48,7 +48,6 @@ where
         let event_sig_count = event_signatures.len();
 
         retry("eth_getLogs RPC call", self.logger.clone())
-            .when_err()
             .no_limit()
             .timeout_secs(60)
             .run(move || {
@@ -220,7 +219,6 @@ where
                 let call_data = call_data.clone();
 
                 retry("eth_call RPC call", logger.clone())
-                    .when_err()
                     .no_limit()
                     .timeout_secs(60)
                     .run(move || {
@@ -254,32 +252,30 @@ where
         &self,
     ) -> Box<Future<Item = EthereumNetworkIdentifier, Error = Error> + Send> {
         let web3 = self.web3.clone();
-        let net_version_future = retry("net_version RPC call", self.logger.clone())
-            .when_err()
+        let logger = self.logger.clone();
+        let net_version_future = retry("net_version RPC call", logger)
             .no_limit()
             .timeout_secs(20)
             .run(move || web3.net().version().map_err(SyncFailure::new).from_err());
 
         let web3 = self.web3.clone();
-        let gen_block_hash_future = retry(
-            "eth_getBlockByNumber(0, false) RPC call",
-            self.logger.clone(),
-        ).when_err()
-        .no_limit()
-        .timeout_secs(30)
-        .run(move || {
-            web3.eth()
-                .block(BlockNumber::Earliest.into())
-                .map_err(SyncFailure::new)
-                .from_err()
-                .and_then(|gen_block_opt| {
-                    future::result(
-                        gen_block_opt
-                            .ok_or(format_err!("Ethereum node could not find genesis block"))
-                            .map(|gen_block| gen_block.hash.unwrap()),
-                    )
-                })
-        });
+        let logger = self.logger.clone();
+        let gen_block_hash_future = retry("eth_getBlockByNumber(0, false) RPC call", logger)
+            .no_limit()
+            .timeout_secs(30)
+            .run(move || {
+                web3.eth()
+                    .block(BlockNumber::Earliest.into())
+                    .map_err(SyncFailure::new)
+                    .from_err()
+                    .and_then(|gen_block_opt| {
+                        future::result(
+                            gen_block_opt
+                                .ok_or(format_err!("Ethereum node could not find genesis block"))
+                                .map(|gen_block| gen_block.hash.unwrap()),
+                        )
+                    })
+            });
 
         Box::new(
             net_version_future
@@ -305,7 +301,6 @@ where
         let logger = self.logger.clone();
 
         let block_opt_future = retry("eth_getBlockByHash RPC call", logger.clone())
-            .when_err()
             .no_limit()
             .timeout_secs(60)
             .run(move || {
@@ -336,7 +331,6 @@ where
                     // The receipt might be missing because the block was uncled, and the
                     // transaction never made it back into the main chain.
                     retry("eth_getTransactionReceipt RPC call", logger.clone())
-                        .when_err()
                         .limit(32)
                         .no_logging()
                         .timeout_secs(60)
@@ -397,7 +391,6 @@ where
 
         Box::new(
             retry("eth_getBlockByNumber RPC call", self.logger.clone())
-                .when_err()
                 .no_limit()
                 .timeout_secs(60)
                 .run(move || {

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -46,10 +46,12 @@ where
     ) -> impl Future<Item = Vec<Log>, Error = Error> {
         let eth_adapter = self.clone();
         let event_sig_count = event_signatures.len();
-        with_retry(
-            self.logger.clone(),
-            "eth_getLogs RPC call".to_owned(),
-            move || {
+
+        retry("eth_getLogs RPC call", self.logger.clone())
+            .when_err()
+            .no_limit()
+            .timeout_secs(60)
+            .run(move || {
                 // Create a log filter
                 let log_filter: Filter = FilterBuilder::default()
                     .from_block(from.into())
@@ -68,18 +70,17 @@ where
                         logs
                     }).map_err(SyncFailure::new)
                     .from_err()
-            },
-        ).map_err(move |e| {
-            e.into_inner().unwrap_or_else(move || {
-                format_err!(
-                    "Ethereum node took too long to respond to eth_getLogs \
-                     (from block {}, to block {}, {} event signatures)",
-                    from,
-                    to,
-                    event_sig_count
-                )
+            }).map_err(move |e| {
+                e.into_inner().unwrap_or_else(move || {
+                    format_err!(
+                        "Ethereum node took too long to respond to eth_getLogs \
+                         (from block {}, to block {}, {} event signatures)",
+                        from,
+                        to,
+                        event_sig_count
+                    )
+                })
             })
-        })
     }
 
     fn log_stream(
@@ -197,10 +198,11 @@ where
     ) -> impl Future<Item = Bytes, Error = Error> + Send {
         let web3 = self.web3.clone();
 
-        with_retry(
-            self.logger.clone(),
-            "eth_call RPC call".to_owned(),
-            move || {
+        retry("eth_call RPC call", self.logger.clone())
+            .when_err()
+            .no_limit()
+            .timeout_secs(60)
+            .run(move || {
                 let req = CallRequest {
                     from: None,
                     to: contract_address,
@@ -213,12 +215,11 @@ where
                     .call(req, block_number_opt)
                     .map_err(SyncFailure::new)
                     .from_err()
-            },
-        ).map_err(|e| {
-            e.into_inner().unwrap_or_else(|| {
-                format_err!("Ethereum node took too long to perform function call")
+            }).map_err(|e| {
+                e.into_inner().unwrap_or_else(|| {
+                    format_err!("Ethereum node took too long to perform function call")
+                })
             })
-        })
     }
 }
 
@@ -231,30 +232,32 @@ where
         &self,
     ) -> Box<Future<Item = EthereumNetworkIdentifier, Error = Error> + Send> {
         let web3 = self.web3.clone();
-        let net_version_future = with_retry(
-            self.logger.clone(),
-            "net_version RPC call".to_owned(),
-            move || web3.net().version().map_err(SyncFailure::new).from_err(),
-        );
+        let net_version_future = retry("net_version RPC call", self.logger.clone())
+            .when_err()
+            .no_limit()
+            .timeout_secs(20)
+            .run(move || web3.net().version().map_err(SyncFailure::new).from_err());
 
         let web3 = self.web3.clone();
-        let gen_block_hash_future = with_retry(
+        let gen_block_hash_future = retry(
+            "eth_getBlockByNumber(0, false) RPC call",
             self.logger.clone(),
-            "eth_getBlockByNumber(0, false) RPC call".to_owned(),
-            move || {
-                web3.eth()
-                    .block(BlockNumber::Earliest.into())
-                    .map_err(SyncFailure::new)
-                    .from_err()
-                    .and_then(|gen_block_opt| {
-                        future::result(
-                            gen_block_opt
-                                .ok_or(format_err!("Ethereum node could not find genesis block"))
-                                .map(|gen_block| gen_block.hash.unwrap()),
-                        )
-                    })
-            },
-        );
+        ).when_err()
+        .no_limit()
+        .timeout_secs(30)
+        .run(move || {
+            web3.eth()
+                .block(BlockNumber::Earliest.into())
+                .map_err(SyncFailure::new)
+                .from_err()
+                .and_then(|gen_block_opt| {
+                    future::result(
+                        gen_block_opt
+                            .ok_or(format_err!("Ethereum node could not find genesis block"))
+                            .map(|gen_block| gen_block.hash.unwrap()),
+                    )
+                })
+        });
 
         Box::new(
             net_version_future
@@ -279,20 +282,20 @@ where
         let web3 = self.web3.clone();
         let logger = self.logger.clone();
 
-        let block_opt_future = with_retry(
-            logger.clone(),
-            "eth_getBlockByHash RPC call".to_owned(),
-            move || {
+        let block_opt_future = retry("eth_getBlockByHash RPC call", logger.clone())
+            .when_err()
+            .no_limit()
+            .timeout_secs(60)
+            .run(move || {
                 web3.eth()
                     .block_with_txs(BlockId::Hash(block_hash))
                     .map_err(SyncFailure::new)
                     .from_err()
-            },
-        ).map_err(move |e| {
-            e.into_inner().unwrap_or_else(move || {
-                format_err!("Ethereum node took too long to return block {}", block_hash)
-            })
-        });
+            }).map_err(move |e| {
+                e.into_inner().unwrap_or_else(move || {
+                    format_err!("Ethereum node took too long to return block {}", block_hash)
+                })
+            });
 
         let web3 = self.web3.clone();
         Box::new(block_opt_future.and_then(move |block_opt| {
@@ -310,8 +313,12 @@ where
                     // Retry, but eventually give up.
                     // The receipt might be missing because the block was uncled, and the
                     // transaction never made it back into the main chain.
-                    with_retry_max_retry(32,
-                        move || {
+                    retry("eth_getTransactionReceipt RPC call", logger.clone())
+                        .when_err()
+                        .limit(32)
+                        .no_logging()
+                        .timeout_secs(60)
+                        .run(move || {
                             web3.eth()
                                 .transaction_receipt(tx_hash)
                                 .map_err(SyncFailure::new)
@@ -325,37 +332,38 @@ where
                                         )
                                     })
                                 })
-                        }
-                    ).map_err(move |e| {
-                        e.into_inner().unwrap_or_else(move || {
-                            format_err!(
-                                "Ethereum node took too long to return transaction receipt {}",
-                                tx_hash
-                            )
+                        }).map_err(move |e| {
+                            e.into_inner().unwrap_or_else(move || {
+                                format_err!(
+                                    "Ethereum node took too long to return transaction receipt {}",
+                                    tx_hash
+                                )
+                            })
+                        }).and_then(move |receipt| {
+                            // Check if receipt is for the right block
+                            if receipt.block_hash != block_hash {
+                                // If the receipt came from a different block, then the Ethereum
+                                // node no longer considers this block to be in the main chain.
+                                // Nothing we can do from here except give up trying to ingest this
+                                // block.
+                                // There is no way to get the transaction receipt from this block.
+                                Err(format_err!(
+                                    "could not get receipt for block {:?} \
+                                     because block is off the main chain",
+                                    block_hash
+                                ))
+                            } else {
+                                Ok(receipt)
+                            }
                         })
-                    }).and_then(move |receipt| {
-                        // Check if receipt is for the right block
-                        if receipt.block_hash != block_hash {
-                            // If the receipt came from a different block, then the Ethereum node
-                            // no longer considers this block to be in the main chain.
-                            // Nothing we can do from here except give up trying to ingest this
-                            // block.
-                            // There is no way to get the transaction receipt from this block.
-                            Err(format_err!("could not get receipt for block {:?} because block is off the main chain", block_hash))
-                        } else {
-                            Ok(receipt)
-                        }
-                    })
                 }).collect::<Vec<_>>();
 
-            Some(
-                stream::futures_ordered(receipt_futures).collect().map(
-                    move |transaction_receipts| EthereumBlock {
-                        block,
-                        transaction_receipts,
-                    },
-                )
-            )
+            Some(stream::futures_ordered(receipt_futures).collect().map(
+                move |transaction_receipts| EthereumBlock {
+                    block,
+                    transaction_receipts,
+                },
+            ))
         }))
     }
 
@@ -366,24 +374,24 @@ where
         let web3 = self.web3.clone();
 
         Box::new(
-            with_retry(
-                self.logger.clone(),
-                "eth_getBlockByNumber RPC call".to_owned(),
-                move || {
+            retry("eth_getBlockByNumber RPC call", self.logger.clone())
+                .when_err()
+                .no_limit()
+                .timeout_secs(60)
+                .run(move || {
                     web3.eth()
                         .block(BlockId::Number(block_number.into()))
                         .map_err(SyncFailure::new)
                         .from_err()
                         .map(|block_opt| block_opt.map(|block| block.hash.unwrap()))
-                },
-            ).map_err(move |e| {
-                e.into_inner().unwrap_or_else(move || {
-                    format_err!(
-                        "Ethereum node took too long to return data for block #{}",
-                        block_number
-                    )
-                })
-            }),
+                }).map_err(move |e| {
+                    e.into_inner().unwrap_or_else(move || {
+                        format_err!(
+                            "Ethereum node took too long to return data for block #{}",
+                            block_number
+                        )
+                    })
+                }),
         )
     }
 

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -197,28 +197,50 @@ where
         block_number_opt: Option<BlockNumber>,
     ) -> impl Future<Item = Bytes, Error = Error> + Send {
         let web3 = self.web3.clone();
+        let logger = self.logger.clone();
 
-        retry("eth_call RPC call", self.logger.clone())
-            .when_err()
-            .no_limit()
-            .timeout_secs(60)
+        // Outer retry used only for 0-byte responses,
+        // where we can't guarantee the problem is temporary.
+        // If we keep getting back 0-byte responses,
+        // eventually we assume it's right and return it.
+        retry("eth_call RPC call (outer)", logger.clone())
+            .when(|result: &Result<Bytes, _>| {
+                match result {
+                    // Retry only if zero-length response received
+                    Ok(bytes) => bytes.0.is_empty(),
+
+                    // Errors are retried in the inner retry
+                    Err(_) => false,
+                }
+            }).limit(16)
+            .no_logging()
+            .no_timeout()
             .run(move || {
-                let req = CallRequest {
-                    from: None,
-                    to: contract_address,
-                    gas: None,
-                    gas_price: None,
-                    value: None,
-                    data: Some(call_data.clone()),
-                };
-                web3.eth()
-                    .call(req, block_number_opt)
-                    .map_err(SyncFailure::new)
-                    .from_err()
-            }).map_err(|e| {
-                e.into_inner().unwrap_or_else(|| {
-                    format_err!("Ethereum node took too long to perform function call")
-                })
+                let web3 = web3.clone();
+                let call_data = call_data.clone();
+
+                retry("eth_call RPC call", logger.clone())
+                    .when_err()
+                    .no_limit()
+                    .timeout_secs(60)
+                    .run(move || {
+                        let req = CallRequest {
+                            from: None,
+                            to: contract_address,
+                            gas: None,
+                            gas_price: None,
+                            value: None,
+                            data: Some(call_data.clone()),
+                        };
+                        web3.eth()
+                            .call(req, block_number_opt)
+                            .map_err(SyncFailure::new)
+                            .from_err()
+                    }).map_err(|e| {
+                        e.into_inner().unwrap_or_else(|| {
+                            format_err!("Ethereum node took too long to perform function call")
+                        })
+                    })
             })
     }
 }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -93,5 +93,5 @@ pub mod prelude {
         CancelGuard, CancelHandle, CancelableError, FutureExtension, SharedCancelGuard,
         StreamExtension,
     };
-    pub use util::futures::{with_retry, with_retry_log_after, with_retry_max_retry};
+    pub use util::futures::retry;
 }

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -1,4 +1,7 @@
 use slog::Logger;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::prelude::*;
 use tokio::timer::DeadlineError;
@@ -6,69 +9,295 @@ use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Error as RetryError;
 use tokio_retry::Retry;
 
-/// Repeatedly invoke `try_it` until the future it returns resolves to an `Ok`.
-/// `operation_name` is used in log messages.
-/// Warnings will be logged after failed attempts.
-pub fn with_retry<F, R, I, E>(
-    logger: Logger,
-    operation_name: String,
-    try_it: F,
-) -> impl Future<Item = I, Error = DeadlineError<E>> + Send
-where
-    F: Fn() -> R + Send,
-    R: Future<Item = I, Error = E> + Send,
-    I: Send,
-    E: Send,
-{
-    // Start logging immediately after first failed attempt
-    with_retry_log_after(logger, operation_name, 1, try_it)
+/// Generic helper function for retrying async operations with built-in logging.
+///
+/// To use this helper, do the following:
+///
+/// 1. Call this function with an operation name (used for logging) and a `Logger`.
+/// 2. Chain a call to `.when_err()` or `.when(...)`.
+/// 3. Optional: call `.log_after(...)` or `.no_logging()`.
+/// 4. Call either `.limit(...)` or `.no_limit()`.
+/// 5. Call one of `.timeout_secs(...)`, `.timeout_millis(...)`, `.timeout(...)`, and
+///    `.no_timeout()`.
+/// 6. Call `.run(...)`.
+///
+/// All steps are required, except Step 3.
+///
+/// Example usage:
+/// ```
+/// # extern crate graph;
+/// # use graph::prelude::*;
+/// # use graph::tokio::timer::DeadlineError;
+/// #
+/// # type Memes = (); // the memes are a lie :(
+/// #
+/// # fn download_the_memes() -> impl Future<Item=(), Error=()> {
+/// #     future::ok(())
+/// # }
+///
+/// fn async_function(logger: Logger) -> impl Future<Item=Memes, Error=DeadlineError<()>> {
+///     retry("download memes", logger.clone())
+///         .when_err() // Retry on all errors
+///         .no_limit() // Retry forever
+///         .timeout_secs(30) // Retry if an attempt takes > 30 seconds
+///         .run(|| {
+///             download_the_memes() // Return a Future
+///         })
+/// }
+/// ```
+pub fn retry(operation_name: impl ToString, logger: Logger) -> RetryConfig {
+    RetryConfig {
+        operation_name: operation_name.to_string(),
+        logger,
+    }
 }
 
-/// Repeatedly invoke `try_it` until the future it returns resolves to an `Ok`.
-/// `operation_name` is used in log messages.
-/// Warnings will be logged after failed attempts, but only after at least
-/// `log_after` failed attempts.
-pub fn with_retry_log_after<F, R, I, E>(
-    logger: Logger,
+pub struct RetryConfig {
     operation_name: String,
-    log_after: u64,
-    try_it: F,
-) -> impl Future<Item = I, Error = DeadlineError<E>> + Send
+    logger: Logger,
+}
+
+impl RetryConfig {
+    /// Retry any time the future resolves to an error (or on time out).
+    ///
+    /// See `.when(...)` for fine-grained control over when to retry.
+    pub fn when_err<I, E>(self) -> RetryConfigWithPredicate<impl Fn(&Result<I, E>) -> bool, I, E> {
+        self.when(|result: &Result<I, E>| result.is_err())
+    }
+
+    /// Sets a function used to determine if a retry is needed.
+    /// Note: timeouts always trigger a retry.
+    pub fn when<P, I, E>(self, predicate: P) -> RetryConfigWithPredicate<P, I, E>
+    where
+        P: Fn(&Result<I, E>) -> bool,
+    {
+        RetryConfigWithPredicate {
+            inner: self,
+            predicate,
+            log_after: 1,
+            limit: RetryConfigProperty::Unknown,
+            phantom_item: PhantomData,
+            phantom_error: PhantomData,
+        }
+    }
+}
+
+pub struct RetryConfigWithPredicate<P, I, E>
 where
-    F: Fn() -> R + Send,
-    R: Future<Item = I, Error = E> + Send,
+    P: Fn(&Result<I, E>) -> bool,
+{
+    inner: RetryConfig,
+    predicate: P,
+    log_after: u64,
+    limit: RetryConfigProperty<usize>,
+    phantom_item: PhantomData<I>,
+    phantom_error: PhantomData<E>,
+}
+
+impl<P, I, E> RetryConfigWithPredicate<P, I, E>
+where
+    P: Fn(&Result<I, E>) -> bool,
     I: Send,
     E: Send,
 {
-    trace!(logger, "with_retry_log_after: {}", operation_name);
+    /// Only log retries after `min_attempts` failed attempts.
+    pub fn log_after(mut self, min_attempts: u64) -> Self {
+        self.log_after = min_attempts;
+        self
+    }
 
-    let max_delay_ms = 30_000;
-    let retry_strategy = ExponentialBackoff::from_millis(2)
-        .max_delay(Duration::from_millis(max_delay_ms))
-        .map(jitter);
+    /// Never log failed attempts.
+    /// May still log at `trace` logging level.
+    pub fn no_logging(mut self) -> Self {
+        self.log_after = u64::max_value();
+        self
+    }
+
+    /// Set a limit on how many retry attempts to make.
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit.set(limit);
+        self
+    }
+
+    /// Allow unlimited retry attempts.
+    pub fn no_limit(mut self) -> Self {
+        self.limit.clear();
+        self
+    }
+
+    /// Set how long (in seconds) to wait for an attempt to complete before giving up on that
+    /// attempt.
+    pub fn timeout_secs(self, timeout_secs: u64) -> RetryConfigWithTimeout<P, I, E> {
+        self.timeout(Duration::from_secs(timeout_secs))
+    }
+
+    /// Set how long (in milliseconds) to wait for an attempt to complete before giving up on that
+    /// attempt.
+    pub fn timeout_millis(self, timeout_ms: u64) -> RetryConfigWithTimeout<P, I, E> {
+        self.timeout(Duration::from_millis(timeout_ms))
+    }
+
+    /// Set how long to wait for an attempt to complete before giving up on that attempt.
+    pub fn timeout(self, timeout: Duration) -> RetryConfigWithTimeout<P, I, E> {
+        RetryConfigWithTimeout {
+            inner: self,
+            timeout,
+        }
+    }
+
+    /// Allow attempts to take as long as they need (or potentially hang forever).
+    pub fn no_timeout(self) -> RetryConfigNoTimeout<P, I, E> {
+        RetryConfigNoTimeout { inner: self }
+    }
+}
+
+pub struct RetryConfigWithTimeout<P, I, E>
+where
+    P: Fn(&Result<I, E>) -> bool,
+{
+    inner: RetryConfigWithPredicate<P, I, E>,
+    timeout: Duration,
+}
+
+impl<P, I, E> RetryConfigWithTimeout<P, I, E>
+where
+    P: Fn(&Result<I, E>) -> bool + Send + Sync,
+    I: Debug + Send,
+    E: Debug + Send,
+{
+    /// Rerun the provided function as many times as needed.
+    pub fn run<F, R>(self, try_it: F) -> impl Future<Item = I, Error = DeadlineError<E>>
+    where
+        F: Fn() -> R + Send,
+        R: Future<Item = I, Error = E> + Send,
+    {
+        let operation_name = self.inner.inner.operation_name;
+        let logger = self.inner.inner.logger.clone();
+        let predicate = self.inner.predicate;
+        let log_after = self.inner.log_after;
+        let limit_opt = self.inner.limit.unwrap(&operation_name, "limit");
+        let timeout = self.timeout;
+
+        trace!(logger, "Run with retry: {}", operation_name);
+
+        run_retry(
+            operation_name,
+            logger,
+            predicate,
+            log_after,
+            limit_opt,
+            move || try_it().deadline(Instant::now() + timeout),
+        )
+    }
+}
+
+pub struct RetryConfigNoTimeout<P, I, E>
+where
+    P: Fn(&Result<I, E>) -> bool,
+{
+    inner: RetryConfigWithPredicate<P, I, E>,
+}
+
+impl<P, I, E> RetryConfigNoTimeout<P, I, E>
+where
+    P: Fn(&Result<I, E>) -> bool + Send + Sync,
+{
+    /// Rerun the provided function as many times as needed.
+    pub fn run<F, R>(self, try_it: F) -> impl Future<Item = I, Error = E>
+    where
+        I: Debug + Send,
+        E: Debug + Send,
+        F: Fn() -> R + Send,
+        R: Future<Item = I, Error = E> + Send,
+    {
+        let operation_name = self.inner.inner.operation_name;
+        let logger = self.inner.inner.logger.clone();
+        let predicate = self.inner.predicate;
+        let log_after = self.inner.log_after;
+        let limit_opt = self.inner.limit.unwrap(&operation_name, "limit");
+
+        trace!(logger, "Run with retry: {}", operation_name);
+
+        run_retry(
+            operation_name,
+            logger,
+            predicate,
+            log_after,
+            limit_opt,
+            move || {
+                try_it().map_err(|e| {
+                    // No timeout, so all errors are inner errors
+                    DeadlineError::inner(e)
+                })
+            },
+        ).map_err(|e| {
+            // No timeout, so all errors are inner errors
+            e.into_inner().unwrap()
+        })
+    }
+}
+
+fn run_retry<P, I, E, F, R>(
+    operation_name: String,
+    logger: Logger,
+    predicate: P,
+    log_after: u64,
+    limit_opt: Option<usize>,
+    try_it_with_deadline: F,
+) -> impl Future<Item = I, Error = DeadlineError<E>> + Send
+where
+    I: Debug + Send,
+    E: Debug + Send,
+    P: Fn(&Result<I, E>) -> bool + Send + Sync,
+    F: Fn() -> R + Send,
+    R: Future<Item = I, Error = DeadlineError<E>> + Send,
+{
+    let predicate = Arc::new(predicate);
 
     let mut attempt_count = 0;
-    Retry::spawn(retry_strategy, move || {
+    Retry::spawn(retry_strategy(limit_opt), move || {
         let operation_name = operation_name.clone();
         let logger = logger.clone();
+        let predicate = predicate.clone();
 
         attempt_count += 1;
 
-        try_it()
-            .deadline(Instant::now() + Duration::from_secs(60))
-            .map_err(move |e| {
-                if e.is_elapsed() {
-                    if attempt_count >= log_after {
-                        debug!(
-                            logger,
-                            "Trying again after {} timed out (attempt #{})",
-                            &operation_name,
-                            attempt_count + 1,
-                        );
-                    }
+        try_it_with_deadline().then(move |result_with_deadline| {
+            let is_elapsed = result_with_deadline
+                .as_ref()
+                .err()
+                .map(|e| e.is_elapsed())
+                .unwrap_or(false);
+            let is_timer_err = result_with_deadline
+                .as_ref()
+                .err()
+                .map(|e| e.is_timer())
+                .unwrap_or(false);
 
-                    e
-                } else {
+            if is_elapsed {
+                if attempt_count >= log_after {
+                    debug!(
+                        logger,
+                        "Trying again after {} timed out (attempt #{})",
+                        &operation_name,
+                        attempt_count + 1,
+                    );
+                }
+
+                // Wrap in Err to force retry
+                Err(result_with_deadline)
+            } else if is_timer_err {
+                // Should never happen
+                let timer_error = result_with_deadline.unwrap_err().into_timer().unwrap();
+                panic!("tokio timer error: {}", timer_error)
+            } else {
+                // Any error must now be an inner error.
+                // Unwrap the inner error so that the predicate doesn't need to think
+                // about DeadlineError.
+                let result = result_with_deadline.map_err(|e| e.into_inner().unwrap());
+
+                // If needs retry
+                if predicate(&result) {
                     if attempt_count >= log_after {
                         debug!(
                             logger,
@@ -78,37 +307,194 @@ where
                         );
                     }
 
-                    e
+                    // Wrap in Err to force retry
+                    Err(result.map_err(|e| DeadlineError::inner(e)))
+                } else {
+                    // Wrap in Ok to prevent retry
+                    Ok(result.map_err(|e| DeadlineError::inner(e)))
                 }
-            })
-    }).map_err(|e| match e {
-        RetryError::OperationError(e) => e,
-        RetryError::TimerError(e) => panic!("tokio timer error: {}", e),
+            }
+        })
+    }).then(|retry_result| {
+        // Unwrap the inner result.
+        // The outer Ok/Err is only used for retry control flow.
+        match retry_result {
+            Ok(r) => r,
+            Err(RetryError::OperationError(r)) => r,
+            Err(RetryError::TimerError(e)) => panic!("tokio timer error: {}", e),
+        }
     })
 }
 
-/// Repeatedly invoke `try_it` until the future it returns resolves to an `Ok`,
-/// or `max_retry` consecutive invocations all returned futures that resolved to an `Err`.
-pub fn with_retry_max_retry<F, R, I, E>(
-    max_retry_count: usize,
-    try_it: F,
-) -> impl Future<Item = I, Error = DeadlineError<E>> + Send
-where
-    F: Fn() -> R + Send,
-    R: Future<Item = I, Error = E> + Send,
-    I: Send,
-    E: Send,
-{
+fn retry_strategy(limit_opt: Option<usize>) -> Box<Iterator<Item = Duration> + Send> {
+    // Exponential backoff, but with a maximum
     let max_delay_ms = 30_000;
-    let retry_strategy = ExponentialBackoff::from_millis(2)
+    let backoff = ExponentialBackoff::from_millis(2)
         .max_delay(Duration::from_millis(max_delay_ms))
-        .map(jitter)
-        .take(max_retry_count);
+        .map(jitter);
 
-    Retry::spawn(retry_strategy, move || {
-        try_it().deadline(Instant::now() + Duration::from_secs(60))
-    }).map_err(|e| match e {
-        RetryError::OperationError(e) => e,
-        RetryError::TimerError(e) => panic!("tokio timer error: {}", e),
-    })
+    // Apply limit (maximum retry count)
+    match limit_opt {
+        Some(limit) => {
+            // Items are delays *between* attempts,
+            // so subtract 1 from limit.
+            Box::new(backoff.take(limit - 1))
+        }
+        None => Box::new(backoff),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RetryConfigProperty<V> {
+    /// Property was explicitly set
+    Set(V),
+
+    /// Property was explicitly unset
+    Clear,
+
+    /// Property was not explicitly set or unset
+    Unknown,
+}
+
+impl<V> RetryConfigProperty<V>
+where
+    V: PartialEq + Eq,
+{
+    fn set(&mut self, v: V) {
+        if *self != RetryConfigProperty::Unknown {
+            panic!("Retry config properties must be configured only once");
+        }
+
+        *self = RetryConfigProperty::Set(v);
+    }
+
+    fn clear(&mut self) {
+        if *self != RetryConfigProperty::Unknown {
+            panic!("Retry config properties must be configured only once");
+        }
+
+        *self = RetryConfigProperty::Clear;
+    }
+
+    fn unwrap(self, operation_name: &str, property_name: &str) -> Option<V> {
+        match self {
+            RetryConfigProperty::Set(v) => Some(v),
+            RetryConfigProperty::Clear => None,
+            RetryConfigProperty::Unknown => panic!(
+                "Retry helper for {} must have {} parameter configured",
+                operation_name, property_name
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Mutex;
+
+    #[test]
+    fn test() {
+        let logger = Logger::root(::slog::Discard, o!());
+        let mut runtime = ::tokio::runtime::Runtime::new().unwrap();
+
+        let result = runtime.block_on(future::lazy(|| {
+            let c = Mutex::new(0);
+            retry("test", logger)
+                .when_err()
+                .no_logging()
+                .no_limit()
+                .no_timeout()
+                .run(move || {
+                    let mut c_guard = c.lock().unwrap();
+                    *c_guard += 1;
+
+                    if *c_guard >= 10 {
+                        future::ok(*c_guard)
+                    } else {
+                        future::err(())
+                    }
+                })
+        }));
+        assert_eq!(result, Ok(10));
+    }
+
+    #[test]
+    fn limit_reached() {
+        let logger = Logger::root(::slog::Discard, o!());
+        let mut runtime = ::tokio::runtime::Runtime::new().unwrap();
+
+        let result = runtime.block_on(future::lazy(|| {
+            let c = Mutex::new(0);
+            retry("test", logger)
+                .when_err()
+                .no_logging()
+                .limit(5)
+                .no_timeout()
+                .run(move || {
+                    let mut c_guard = c.lock().unwrap();
+                    *c_guard += 1;
+
+                    if *c_guard >= 10 {
+                        future::ok(*c_guard)
+                    } else {
+                        future::err(*c_guard)
+                    }
+                })
+        }));
+        assert_eq!(result, Err(5));
+    }
+
+    #[test]
+    fn limit_not_reached() {
+        let logger = Logger::root(::slog::Discard, o!());
+        let mut runtime = ::tokio::runtime::Runtime::new().unwrap();
+
+        let result = runtime.block_on(future::lazy(|| {
+            let c = Mutex::new(0);
+            retry("test", logger)
+                .when_err()
+                .no_logging()
+                .limit(20)
+                .no_timeout()
+                .run(move || {
+                    let mut c_guard = c.lock().unwrap();
+                    *c_guard += 1;
+
+                    if *c_guard >= 10 {
+                        future::ok(*c_guard)
+                    } else {
+                        future::err(*c_guard)
+                    }
+                })
+        }));
+        assert_eq!(result, Ok(10));
+    }
+
+    #[test]
+    fn custom_when() {
+        let logger = Logger::root(::slog::Discard, o!());
+        let mut runtime = ::tokio::runtime::Runtime::new().unwrap();
+
+        let result = runtime.block_on(future::lazy(|| {
+            let c = Mutex::new(0);
+
+            retry("test", logger)
+                .when(|result| result.unwrap() < 10)
+                .no_logging()
+                .limit(20)
+                .no_timeout()
+                .run(move || {
+                    let mut c_guard = c.lock().unwrap();
+                    *c_guard += 1;
+                    if *c_guard > 30 {
+                        future::err(())
+                    } else {
+                        future::ok(*c_guard)
+                    }
+                })
+        }));
+        assert_eq!(result, Ok(10));
+    }
 }


### PR DESCRIPTION
`eth_call` is supposed to return a string of hex bytes with the result of the call. At ethsf, there were some issues with that string temporarily coming back zero-length. A zero-length return value seems to be how Infura (and possibly others?) indicates some error conditions, e.g. "function not found".

This PR checks for `result == "0x"` (a zero-length hex string) and retries up to 16 times. The retry limit is due to the fact that this can be caused by a legitimate programming error in the subgraph, and there is no way to distinguish the two cases. There is a still an infinite retry for any other `eth_call` error conditions.

Resolves #465 

Also: adds and uses a newly configurable `retry(...)` helper with documentation! Replaces the old `with_retry`, `with_retry_log_after`, and `with_retry_max_retry` helpers.