### PR TITLE
Refactor implementation of host exports into separate module

### DIFF
--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -1,0 +1,495 @@
+use ethabi::Token;
+use futures::sync::oneshot;
+use graph::components::ethereum::*;
+use graph::components::store::StoreKey;
+use graph::data::store::scalar;
+use graph::data::subgraph::DataSource;
+use graph::prelude::*;
+use graph::serde_json;
+use graph::web3::types::{H160, U256};
+use std::collections::HashMap;
+use std::fmt;
+use std::mem;
+use std::ops::Deref;
+use std::str::FromStr;
+use EventHandlerContext;
+use UnresolvedContractCall;
+
+pub(crate) trait ExportError: fmt::Debug + fmt::Display + Send + Sync + 'static {}
+impl<E> ExportError for E where E: fmt::Debug + fmt::Display + Send + Sync + 'static {}
+
+/// Error raised in host functions.
+#[derive(Debug)]
+pub(crate) struct HostExportError<E>(E);
+
+impl<E: fmt::Display> fmt::Display for HostExportError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+pub(crate) struct HostExports<E, L, S, U> {
+    logger: Logger,
+    subgraph: SubgraphManifest,
+    data_source: DataSource,
+    ethereum_adapter: Arc<E>,
+    link_resolver: Arc<L>,
+    store: Arc<S>,
+    task_sink: U,
+    pub(crate) ctx: Option<EventHandlerContext>,
+}
+
+impl<E, L, S, U> HostExports<E, L, S, U>
+where
+    E: EthereumAdapter,
+    L: LinkResolver,
+    S: Store + Send + Sync,
+    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone,
+{
+    pub(crate) fn new(
+        logger: Logger,
+        subgraph: SubgraphManifest,
+        data_source: DataSource,
+        ethereum_adapter: Arc<E>,
+        link_resolver: Arc<L>,
+        store: Arc<S>,
+        task_sink: U,
+        ctx: Option<EventHandlerContext>,
+    ) -> Self {
+        HostExports {
+            logger,
+            subgraph,
+            data_source,
+            ethereum_adapter,
+            link_resolver,
+            store,
+            task_sink,
+            ctx,
+        }
+    }
+
+    pub(crate) fn store_set(
+        &mut self,
+        entity: String,
+        id: String,
+        mut data: HashMap<String, Value>,
+    ) -> Result<(), HostExportError<impl ExportError>> {
+        match data.insert("id".to_string(), Value::String(id.clone())) {
+            Some(ref v) if v != &Value::String(id.clone()) => {
+                return Err(HostExportError(format!(
+                    "Conflicting 'id' value set by mapping for {} entity: {} != {}",
+                    entity, v, id,
+                )))
+            }
+            _ => (),
+        }
+
+        self.ctx
+            .as_mut()
+            .map(|ctx| &mut ctx.entity_operations)
+            .expect("processing event without context")
+            .push(EntityOperation::Set {
+                subgraph: self.subgraph.id.clone(),
+                entity,
+                id,
+                data: Entity::from(data),
+            });
+
+        Ok(())
+    }
+
+    pub(crate) fn store_remove(&mut self, entity: String, id: String) {
+        self.ctx
+            .as_mut()
+            .map(|ctx| &mut ctx.entity_operations)
+            .expect("processing event without context")
+            .push(EntityOperation::Remove {
+                subgraph: self.subgraph.id.clone(),
+                entity,
+                id,
+            });
+    }
+
+    pub(crate) fn store_get(
+        &self,
+        entity: String,
+        id: String,
+    ) -> Result<Option<Entity>, HostExportError<impl ExportError>> {
+        let store_key = StoreKey {
+            subgraph: self.subgraph.id.clone(),
+            entity,
+            id,
+        };
+
+        // Get all operations for this entity
+        let matching_operations: Vec<_> = self
+            .ctx
+            .as_ref()
+            .map(|ctx| &ctx.entity_operations)
+            .expect("processing event without context")
+            .clone()
+            .iter()
+            .cloned()
+            .filter(|op| op.matches_entity(&store_key))
+            .collect();
+
+        // Shortcut 1: If the latest operation for this entity was a removal,
+        // return 0 (= null) to the runtime
+        if matching_operations
+            .iter()
+            .peekable()
+            .peek()
+            .map(|op| op.is_remove())
+            .unwrap_or(false)
+        {
+            return Ok(None);
+        }
+
+        // Shortcut 2: If there is a removal in the operations, the
+        // entity will be the result of the operations after that, so we
+        // don't have to hit the store for anything
+        if matching_operations
+            .iter()
+            .find(|op| op.is_remove())
+            .is_some()
+        {
+            return Ok(EntityOperation::apply_all(None, &matching_operations));
+        }
+
+        // No removal in the operations => read the entity from the store, then apply
+        // the operations to it to obtain the result
+        Ok(self
+            .store
+            .get(store_key)
+            .map(|entity| EntityOperation::apply_all(entity, &matching_operations))
+            .map_err(HostExportError)?)
+    }
+
+    pub(crate) fn ethereum_call(
+        &self,
+        unresolved_call: UnresolvedContractCall,
+    ) -> Result<Vec<Token>, HostExportError<impl ExportError>> {
+        info!(self.logger, "Call smart contract";
+              "address" => &unresolved_call.contract_address.to_string(),
+              "contract" => &unresolved_call.contract_name,
+              "function" => &unresolved_call.function_name);
+
+        // Obtain the path to the contract ABI
+        let contract = self
+            .data_source
+            .mapping
+            .abis
+            .iter()
+            .find(|abi| abi.name == unresolved_call.contract_name)
+            .ok_or(HostExportError(format!(
+                "Unknown contract \"{}\" called from WASM runtime",
+                unresolved_call.contract_name
+            )))?.contract
+            .clone();
+
+        let function = contract
+            .function(unresolved_call.function_name.as_str())
+            .map_err(|e| {
+                HostExportError(format!(
+                    "Unknown function \"{}::{}\" called from WASM runtime: {}",
+                    unresolved_call.contract_name, unresolved_call.function_name, e
+                ))
+            })?;
+
+        let call = EthereumContractCall {
+            address: unresolved_call.contract_address.clone(),
+            block_ptr: self
+                .ctx
+                .as_ref()
+                .map(|ctx| ctx.block.as_ref())
+                .expect("processing event without context")
+                .deref()
+                .into(),
+            function: function.clone(),
+            args: unresolved_call.function_args.clone(),
+        };
+
+        // Run Ethereum call in tokio runtime
+        let eth_adapter = self.ethereum_adapter.clone();
+        self.block_on(future::lazy(move || {
+            eth_adapter.contract_call(call).map_err(move |e| {
+                HostExportError(format!(
+                    "Failed to call function \"{}\" of contract \"{}\": {}",
+                    unresolved_call.function_name, unresolved_call.contract_name, e
+                ))
+            })
+        }))
+    }
+
+    pub(crate) fn convert_bytes_to_string(
+        &self,
+        bytes: Vec<u8>,
+    ) -> Result<String, HostExportError<impl ExportError>> {
+        let s = String::from_utf8(bytes).map_err(HostExportError)?;
+        // The string may have been encoded in a fixed length
+        // buffer and padded with null characters, so trim
+        // trailing nulls.
+        Ok(s.trim_right_matches('\u{0000}').to_string())
+    }
+
+    pub(crate) fn u64_array_to_string(
+        &self,
+        u64_array: Vec<u64>,
+    ) -> Result<String, HostExportError<impl ExportError>> {
+        let mut bytes: Vec<u8> = Vec::new();
+        for x in u64_array {
+            // This is just `x.to_bytes()` which is unstable.
+            let x_bytes: [u8; 8] = unsafe { mem::transmute(x) };
+            bytes.extend(x_bytes.iter());
+        }
+        self.convert_bytes_to_string(bytes)
+    }
+
+    pub(crate) fn u64_array_to_hex(&self, u64_array: Vec<u64>) -> String {
+        let mut bytes: Vec<u8> = Vec::new();
+        for x in u64_array {
+            // This is just `x.to_bytes()` which is unstable.
+            let x_bytes: [u8; 8] = unsafe { mem::transmute(x) };
+            bytes.extend(x_bytes.iter());
+        }
+
+        // Even an empty string must be prefixed with `0x`.
+        // Encodes each byte as a two hex digits.
+        format!("0x{}", ::hex::encode(bytes))
+    }
+
+    pub(crate) fn string_to_h160(
+        &self,
+        string: &str,
+    ) -> Result<H160, HostExportError<impl ExportError>> {
+        H160::from_str(string).map_err(|e| {
+            HostExportError(format!("Failed to convert string to Address/H160: {}", e))
+        })
+    }
+
+    /// This works for both U256 and I256.
+    pub(crate) fn int256_to_big_int(&self, int256: U256) -> [u8; 32] {
+        let mut buffer = [0; 32];
+        int256.to_little_endian(&mut buffer);
+        buffer
+    }
+
+    /// FIXME: This should be able to handle size up to 32, rather
+    /// than only exactly 32.
+    pub(crate) fn big_int_to_int256(
+        &self,
+        big_int: Vec<u8>,
+    ) -> Result<U256, HostExportError<impl ExportError>> {
+        let size = big_int.len();
+        if size != 32 {
+            Err(HostExportError(format!(
+                "expected byte array of size 32, found size {}",
+                size
+            )))
+        } else {
+            Ok(U256::from_little_endian(&big_int))
+        }
+    }
+
+    /// Converts bytes to a hex string.
+    /// References:
+    /// https://godoc.org/github.com/ethereum/go-ethereum/common/hexutil#hdr-Encoding_Rules
+    /// https://github.com/ethereum/web3.js/blob/f98fe1462625a6c865125fecc9cb6b414f0a5e83/packages/web3-utils/src/utils.js#L283
+    pub(crate) fn bytes_to_hex(&self, bytes: Vec<u8>) -> String {
+        // Even an empty string must be prefixed with `0x`.
+        // Encodes each byte as a two hex digits.
+        format!("0x{}", ::hex::encode(bytes))
+    }
+
+    pub(crate) fn json_from_bytes(
+        &self,
+        bytes: Vec<u8>,
+    ) -> Result<serde_json::Value, HostExportError<impl ExportError>> {
+        serde_json::from_reader(&*bytes).map_err(HostExportError)
+    }
+
+    pub(crate) fn ipfs_cat(
+        &self,
+        link: String,
+    ) -> Result<Vec<u8>, HostExportError<impl ExportError>> {
+        self.block_on(
+            self.link_resolver
+                .cat(&Link { link })
+                .map_err(HostExportError),
+        )
+    }
+
+    /// Expects a decimal string.
+    pub(crate) fn json_to_i64(
+        &self,
+        json: String,
+    ) -> Result<i64, HostExportError<impl ExportError>> {
+        i64::from_str(&json)
+            .map_err(|_| HostExportError(format!("JSON `{}` cannot be parsed as i64", json)))
+    }
+
+    /// Expects a decimal string.
+    pub(crate) fn json_to_u64(
+        &self,
+        json: String,
+    ) -> Result<u64, HostExportError<impl ExportError>> {
+        u64::from_str(&json)
+            .map_err(|_| HostExportError(format!("JSON `{}` cannot be parsed as u64", json)))
+    }
+
+    /// Expects a decimal string.
+    pub(crate) fn json_to_f64(
+        &self,
+        json: String,
+    ) -> Result<f64, HostExportError<impl ExportError>> {
+        f64::from_str(&json)
+            .map_err(|_| HostExportError(format!("JSON `{}` cannot be parsed as f64", json)))
+    }
+
+    /// Expects a decimal string.
+    pub(crate) fn json_to_big_int(
+        &self,
+        json: String,
+    ) -> Result<Vec<u8>, HostExportError<impl ExportError>> {
+        let big_int = scalar::BigInt::from_str(&json)
+            .map_err(|_| HostExportError(format!("JSON `{}` is not a decimal string", json)))?;
+        Ok(big_int.to_signed_bytes_le())
+    }
+
+    pub(crate) fn crypto_keccak_256(&self, input: Vec<u8>) -> [u8; 32] {
+        ::tiny_keccak::keccak256(&input)
+    }
+
+    pub(crate) fn i64_to_u256(&self, x: i64) -> U256 {
+        // Sign extension: pad with 0s or 1s depending on sign of x.
+        let mut bytes = if x > 0 { [0; 32] } else { [255; 32] };
+
+        // This is just `x.to_bytes()` which is unstable.
+        let x_bytes: [u8; 8] = unsafe { mem::transmute(x) };
+        bytes[..8].copy_from_slice(&x_bytes);
+        U256::from_little_endian(&bytes)
+    }
+
+    pub(crate) fn u256_to_u8(&self, x: U256) -> Result<u8, HostExportError<impl ExportError>> {
+        Ok(u256_as_u64(x, u8::max_value().into(), "u8")? as u8)
+    }
+
+    pub(crate) fn u256_to_u16(&self, x: U256) -> Result<u16, HostExportError<impl ExportError>> {
+        Ok(u256_as_u64(x, u16::max_value().into(), "u16")? as u16)
+    }
+
+    pub(crate) fn u256_to_u32(&self, x: U256) -> Result<u32, HostExportError<impl ExportError>> {
+        Ok(u256_as_u64(x, u32::max_value().into(), "u32")? as u32)
+    }
+
+    pub(crate) fn u256_to_u64(&self, x: U256) -> Result<u64, HostExportError<impl ExportError>> {
+        u256_as_u64(x, u64::max_value().into(), "u64")
+    }
+
+    pub(crate) fn u256_to_i8(&self, x: U256) -> Result<i8, HostExportError<impl ExportError>> {
+        let bytes = u256_checked_bytes(x, i8::min_value().into(), i8::max_value().into(), "i8")?;
+
+        // This is just `i8::from_bytes` which is unstable.
+        let value: i8 = unsafe { mem::transmute(bytes[0]) };
+        Ok(value)
+    }
+
+    pub(crate) fn u256_to_i16(&self, x: U256) -> Result<i16, HostExportError<impl ExportError>> {
+        let bytes = u256_checked_bytes(x, i16::min_value().into(), i16::max_value().into(), "i16")?;
+
+        // This is just `i16::from_bytes` which is unstable.
+        let value: i16 = unsafe { mem::transmute([bytes[0], bytes[1]]) };
+        Ok(value)
+    }
+
+    pub(crate) fn u256_to_i32(&self, x: U256) -> Result<i32, HostExportError<impl ExportError>> {
+        let bytes = u256_checked_bytes(x, i32::min_value().into(), i32::max_value().into(), "i32")?;
+
+        // This is just `i32::from_bytes` which is unstable.
+        let value: i32 = unsafe { mem::transmute([bytes[0], bytes[1], bytes[2], bytes[3]]) };
+        Ok(value)
+    }
+
+    pub(crate) fn u256_to_i64(&self, x: U256) -> Result<i64, HostExportError<impl ExportError>> {
+        let bytes = u256_checked_bytes(x, i64::min_value(), i64::max_value(), "i64")?;
+
+        // This is just `i64::from_bytes` which is unstable.
+        let value: i64 = unsafe {
+            mem::transmute([
+                bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+            ])
+        };
+        Ok(value)
+    }
+
+    pub(crate) fn block_on<I: Send + 'static, ER: Send + 'static>(
+        &self,
+        future: impl Future<Item = I, Error = ER> + Send + 'static,
+    ) -> Result<I, ER> {
+        let (return_sender, return_receiver) = oneshot::channel();
+        self.task_sink
+            .clone()
+            .send(Box::new(future.then(|res| {
+                return_sender.send(res).map_err(|_| unreachable!())
+            }))).wait()
+            .map_err(|_| panic!("task receiver dropped"))
+            .unwrap();
+        return_receiver.wait().expect("`return_sender` dropped")
+    }
+}
+
+/// Cast U256 to u64, checking that it respects `max_value`.
+fn u256_as_u64(
+    u256: U256,
+    max_value: u64,
+    n_name: &str,
+) -> Result<u64, HostExportError<impl ExportError>> {
+    // Check for overflow.
+    let max_value = U256::from(max_value);
+    if u256 > max_value {
+        return Err(HostExportError(format!(
+            "number `{}` is too large for an {}",
+            u256, n_name
+        )));
+    }
+    Ok(u64::from(u256))
+}
+
+/// Checks that `x >= min_value` and `x <= max_value`
+/// and returns the byte representation of `x`.
+pub(crate) fn u256_checked_bytes(
+    u256: U256,
+    min_value: i64,
+    max_value: i64,
+    n_name: &str,
+) -> Result<[u8; 8], HostExportError<impl ExportError>> {
+    // The number is negative if the most-significant bit is set.
+    let is_negative = u256.bit(255);
+    if !is_negative {
+        // Check for overflow.
+        let max_value = U256::from(max_value);
+        if u256 > max_value {
+            return Err(HostExportError(format!(
+                "number `{}` is too large for an {}",
+                u256, n_name
+            )));
+        }
+    } else {
+        // Check for underflow.
+        // Do two's complement to get the absolute value.
+        let u256_abs = !u256 + 1;
+
+        // The absolute value of `T::min_value` is `T::max_value + 1` for a primitive `T`,
+        // so we do a math trick to get around that, the `+ 1`s here cancel each other.
+        let min_value_abs = U256::from((min_value + 1).abs()) + 1;
+        if u256_abs > min_value_abs {
+            return Err(HostExportError(format!(
+                "number `-{}` is too small for an {}",
+                u256_abs, n_name
+            )));
+        }
+    }
+
+    // This is just `u256.low_u64().to_bytes()` which is unstable.
+    Ok(unsafe { mem::transmute(u256.low_u64()) })
+}

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -14,6 +14,9 @@ mod host;
 mod module;
 mod to_from;
 
+/// Runtime-agnostic implementation of exports to WASM.
+mod host_exports;
+
 use self::graph::prelude::*;
 use self::graph::web3::types::{Address, Transaction};
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -1,34 +1,25 @@
 use failure::Error as FailureError;
 use nan_preserving_float::F64;
-use std::collections::HashMap;
 use std::fmt;
-use std::mem;
 use std::ops::Deref;
-use std::str::FromStr;
-use tiny_keccak;
 
 use wasmi::{
     Error, Externals, FuncInstance, FuncRef, HostError, ImportsBuilder, MemoryRef, Module,
     ModuleImportResolver, ModuleInstance, ModuleRef, NopExternals, RuntimeArgs, RuntimeValue,
-    Signature, Trap, TrapKind, ValueType,
+    Signature, Trap, ValueType,
 };
 
-use futures::sync::oneshot;
 use graph::components::ethereum::*;
-use graph::components::store::StoreKey;
-use graph::data::store::scalar;
 use graph::data::subgraph::DataSource;
 use graph::ethabi::LogParam;
 use graph::prelude::*;
-use graph::serde_json;
 use graph::web3::types::{Log, H160, H256, U256};
-
-use super::{EventHandlerContext, UnresolvedContractCall};
+use host_exports;
+use EventHandlerContext;
 
 use asc_abi::asc_ptr::*;
 use asc_abi::class::*;
 use asc_abi::*;
-use hex;
 
 #[cfg(test)]
 mod test;
@@ -136,8 +127,8 @@ impl<T, L, S, U> WasmiModule<T, L, S, U>
 where
     T: EthereumAdapter,
     L: LinkResolver,
-    S: Store + Send + Sync,
-    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone,
+    S: Store + Send + Sync + 'static,
+    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone + 'static,
 {
     /// Creates a new wasmi module
     pub fn new(logger: &Logger, config: WasmiModuleConfig<T, L, S>, task_sink: U) -> Self {
@@ -179,15 +170,17 @@ where
 
         // Create new instance of externally hosted functions invoker
         let mut externals = HostExternals {
-            subgraph: config.subgraph,
-            data_source: config.data_source,
-            logger: logger.clone(),
             heap: heap.clone(),
-            ethereum_adapter: config.ethereum_adapter.clone(),
-            link_resolver: config.link_resolver.clone(),
-            store: config.store.clone(),
-            task_sink,
-            ctx: None,
+            host_exports: host_exports::HostExports::new(
+                logger.clone(),
+                config.subgraph,
+                config.data_source,
+                config.ethereum_adapter.clone(),
+                config.link_resolver.clone(),
+                config.store.clone(),
+                task_sink,
+                None,
+            ),
         };
 
         let module = module
@@ -209,13 +202,28 @@ where
         log: Arc<Log>,
         params: Vec<LogParam>,
     ) -> Result<Vec<EntityOperation>, FailureError> {
-        self.externals.ctx = Some(ctx);
+        self.externals.host_exports.ctx = Some(ctx);
 
         // Prepare an EthereumEvent for the WASM runtime
         let event = EthereumEventData {
-            block: EthereumBlockData::from(&self.externals.ctx.as_ref().unwrap().block.block),
+            block: EthereumBlockData::from(
+                &self
+                    .externals
+                    .host_exports
+                    .ctx
+                    .as_ref()
+                    .unwrap()
+                    .block
+                    .block,
+            ),
             transaction: EthereumTransactionData::from(
-                self.externals.ctx.as_ref().unwrap().transaction.deref(),
+                self.externals
+                    .host_exports
+                    .ctx
+                    .as_ref()
+                    .unwrap()
+                    .transaction
+                    .deref(),
             ),
             address: log.address.clone(),
             params,
@@ -232,6 +240,7 @@ where
         result
             .map(|_| {
                 self.externals
+                    .host_exports
                     .ctx
                     .take()
                     .expect("processing event without context")
@@ -246,43 +255,22 @@ where
     }
 }
 
-/// Error raised in host functions.
-#[derive(Debug)]
-struct HostExternalsError<E>(E);
-
-impl<E> HostError for HostExternalsError<E> where
+impl<E> HostError for host_exports::HostExportError<E> where
     E: fmt::Debug + fmt::Display + Send + Sync + 'static
 {}
 
-impl<E: fmt::Display> fmt::Display for HostExternalsError<E> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-fn host_error(message: String) -> Trap {
-    Trap::new(TrapKind::Host(Box::new(HostExternalsError(message))))
-}
-
 /// Hosted functions for external use by wasm module
 pub struct HostExternals<T, L, S, U> {
-    logger: Logger,
-    subgraph: SubgraphManifest,
-    data_source: DataSource,
     heap: WasmiAscHeap,
-    ethereum_adapter: Arc<T>,
-    link_resolver: Arc<L>,
-    store: Arc<S>,
-    task_sink: U,
-    ctx: Option<EventHandlerContext>,
+    host_exports: host_exports::HostExports<T, L, S, U>,
 }
 
 impl<T, L, S, U> HostExternals<T, L, S, U>
 where
     T: EthereumAdapter,
     L: LinkResolver,
-    S: Store + Send + Sync,
-    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone,
+    S: Store + Send + Sync + 'static,
+    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone + 'static,
 {
     /// function store.set(entity: string, id: string, data: Entity): void
     fn store_set(
@@ -291,31 +279,11 @@ where
         id_ptr: AscPtr<AscString>,
         data_ptr: AscPtr<AscEntity>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let entity: String = self.heap.asc_get(entity_ptr);
-        let id: String = self.heap.asc_get(id_ptr);
-        let mut data: HashMap<String, Value> = self.heap.asc_get(data_ptr);
-
-        match data.insert("id".to_string(), Value::String(id.clone())) {
-            Some(ref v) if v != &Value::String(id.clone()) => {
-                return Err(host_error(format!(
-                    "Conflicting 'id' value set by mapping for {} entity: {} != {}",
-                    entity, v, id,
-                )))
-            }
-            _ => (),
-        }
-
-        self.ctx
-            .as_mut()
-            .map(|ctx| &mut ctx.entity_operations)
-            .expect("processing event without context")
-            .push(EntityOperation::Set {
-                subgraph: self.subgraph.id.clone(),
-                entity,
-                id,
-                data: Entity::from(data),
-            });
-
+        self.host_exports.store_set(
+            self.heap.asc_get(entity_ptr),
+            self.heap.asc_get(id_ptr),
+            self.heap.asc_get(data_ptr),
+        )?;
         Ok(None)
     }
 
@@ -325,19 +293,8 @@ where
         entity_ptr: AscPtr<AscString>,
         id_ptr: AscPtr<AscString>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let entity: String = self.heap.asc_get(entity_ptr);
-        let id: String = self.heap.asc_get(id_ptr);
-
-        self.ctx
-            .as_mut()
-            .map(|ctx| &mut ctx.entity_operations)
-            .expect("processing event without context")
-            .push(EntityOperation::Remove {
-                subgraph: self.subgraph.id.clone(),
-                entity,
-                id,
-            });
-
+        self.host_exports
+            .store_remove(self.heap.asc_get(entity_ptr), self.heap.asc_get(id_ptr));
         Ok(None)
     }
 
@@ -347,59 +304,14 @@ where
         entity_ptr: AscPtr<AscString>,
         id_ptr: AscPtr<AscString>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let store_key = StoreKey {
-            subgraph: self.subgraph.id.clone(),
-            entity: self.heap.asc_get(entity_ptr),
-            id: self.heap.asc_get(id_ptr),
-        };
+        let entity_option = self
+            .host_exports
+            .store_get(self.heap.asc_get(entity_ptr), self.heap.asc_get(id_ptr))?;
 
-        // Get all operations for this entity
-        let matching_operations: Vec<_> = self
-            .ctx
-            .as_ref()
-            .map(|ctx| &ctx.entity_operations)
-            .expect("processing event without context")
-            .clone()
-            .iter()
-            .cloned()
-            .filter(|op| op.matches_entity(&store_key))
-            .collect();
-
-        // Shortcut 1: If the latest operation for this entity was a removal,
-        // return 0 (= null) to the runtime
-        if matching_operations
-            .iter()
-            .peekable()
-            .peek()
-            .map(|op| op.is_remove())
-            .unwrap_or(false)
-        {
-            return Ok(Some(RuntimeValue::from(0)));
-        }
-
-        // Shortcut 2: If there is a removal in the operations, the
-        // entity will be the result of the operations after that, so we
-        // don't have to hit the store for anything
-        if matching_operations
-            .iter()
-            .find(|op| op.is_remove())
-            .is_some()
-        {
-            return Ok(EntityOperation::apply_all(None, &matching_operations)
-                .map(|entity| RuntimeValue::from(self.heap.asc_new(&entity)))
-                .or(Some(RuntimeValue::from(0))));
-        }
-
-        // No removal in the operations => read the entity from the store, then apply
-        // the operations to it to obtain the result
-        Ok(self
-            .store
-            .get(store_key)
-            .map(|entity| {
-                EntityOperation::apply_all(entity, &matching_operations)
-                    .map(|entity| RuntimeValue::from(self.heap.asc_new(&entity)))
-                    .or(Some(RuntimeValue::from(0)))
-            }).map_err(HostExternalsError)?)
+        Ok(Some(match entity_option {
+            Some(entity) => RuntimeValue::from(self.heap.asc_new(&entity)),
+            None => RuntimeValue::from(0),
+        }))
     }
 
     /// function ethereum.call(call: SmartContractCall): Array<Token>
@@ -407,57 +319,10 @@ where
         &self,
         call_ptr: AscPtr<AscUnresolvedContractCall>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let unresolved_call: UnresolvedContractCall = self.heap.asc_get(call_ptr);
-        info!(self.logger, "Call smart contract";
-              "address" => &unresolved_call.contract_address.to_string(),
-              "contract" => &unresolved_call.contract_name,
-              "function" => &unresolved_call.function_name);
-
-        // Obtain the path to the contract ABI
-        let contract = self
-            .data_source
-            .mapping
-            .abis
-            .iter()
-            .find(|abi| abi.name == unresolved_call.contract_name)
-            .ok_or(host_error(format!(
-                "Unknown contract \"{}\" called from WASM runtime",
-                unresolved_call.contract_name
-            )))?.contract
-            .clone();
-
-        let function = contract
-            .function(unresolved_call.function_name.as_str())
-            .map_err(|e| {
-                host_error(format!(
-                    "Unknown function \"{}::{}\" called from WASM runtime: {}",
-                    unresolved_call.contract_name, unresolved_call.function_name, e
-                ))
-            })?;
-
-        let call = EthereumContractCall {
-            address: unresolved_call.contract_address.clone(),
-            block_ptr: self
-                .ctx
-                .as_ref()
-                .map(|ctx| ctx.block.as_ref())
-                .expect("processing event without context")
-                .deref()
-                .into(),
-            function: function.clone(),
-            args: unresolved_call.function_args.clone(),
-        };
-
-        // Run Ethereum call in tokio runtime
-        let eth_adapter = self.ethereum_adapter.clone();
-        self.block_on(future::lazy(move || {
-            eth_adapter.contract_call(call).map_err(move |e| {
-                host_error(format!(
-                    "Failed to call function \"{}\" of contract \"{}\": {}",
-                    unresolved_call.function_name, unresolved_call.contract_name, e
-                ))
-            })
-        })).map(|result| Some(RuntimeValue::from(self.heap.asc_new(&*result))))
+        let result = self
+            .host_exports
+            .ethereum_call(self.heap.asc_get(call_ptr))?;
+        Ok(Some(RuntimeValue::from(self.heap.asc_new(&*result))))
     }
 
     /// function typeConversion.bytesToString(bytes: Bytes): string
@@ -465,13 +330,10 @@ where
         &self,
         bytes_ptr: AscPtr<Uint8Array>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let bytes: Vec<u8> = self.heap.asc_get(bytes_ptr);
-        let s = String::from_utf8_lossy(&*bytes);
-        // The string may have been encoded in a fixed length
-        // buffer and padded with null characters, so trim
-        // trailing nulls.
-        let trimmed_s = s.trim_right_matches('\u{0000}');
-        Ok(Some(RuntimeValue::from(self.heap.asc_new(trimmed_s))))
+        let string = self
+            .host_exports
+            .convert_bytes_to_string(self.heap.asc_get(bytes_ptr))?;
+        Ok(Some(RuntimeValue::from(self.heap.asc_new(&string))))
     }
 
     /// function typeConversion.u64ArrayToString(u64_array: U64Array): string
@@ -479,17 +341,10 @@ where
         &self,
         u64_array_ptr: AscPtr<Uint64Array>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let u64_array: Vec<u64> = self.heap.asc_get(u64_array_ptr);
-        let mut bytes: Vec<u8> = Vec::new();
-        for x in u64_array {
-            // This is just `x.to_bytes()` which is unstable.
-            let x_bytes: [u8; 8] = unsafe { mem::transmute(x) };
-            bytes.extend(x_bytes.iter());
-        }
-
-        let s = String::from_utf8_lossy(&*bytes);
-        let trimmed_s = s.trim_right_matches('\u{0000}');
-        Ok(Some(RuntimeValue::from(self.heap.asc_new(trimmed_s))))
+        let string = self
+            .host_exports
+            .u64_array_to_string(self.heap.asc_get(u64_array_ptr))?;
+        Ok(Some(RuntimeValue::from(self.heap.asc_new(&string))))
     }
 
     /// function typeConversion.u64ArrayToHex(u64_array: U64Array): string
@@ -497,19 +352,10 @@ where
         &self,
         u64_array_ptr: AscPtr<Uint64Array>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let u64_array: Vec<u64> = self.heap.asc_get(u64_array_ptr);
-        let mut bytes: Vec<u8> = Vec::new();
-        for x in u64_array {
-            // This is just `x.to_bytes()` which is unstable.
-            let x_bytes: [u8; 8] = unsafe { mem::transmute(x) };
-            bytes.extend(x_bytes.iter());
-        }
-
-        // Even an empty string must be prefixed with `0x`.
-        // Encodes each byte as a two hex digits.
-        let hex_string = format!("0x{}", hex::encode(bytes));
-        let hex_string_obj = self.heap.asc_new(hex_string.as_str());
-        Ok(Some(RuntimeValue::from(hex_string_obj)))
+        let result = self
+            .host_exports
+            .u64_array_to_hex(self.heap.asc_get(u64_array_ptr));
+        Ok(Some(RuntimeValue::from(self.heap.asc_new(&*result))))
     }
 
     /// function typeConversion.h256ToH160(h256: H256): H160
@@ -548,8 +394,7 @@ where
     /// function typeConversion.stringToH160(s: String): H160
     fn string_to_h160(&self, str_ptr: AscPtr<AscString>) -> Result<Option<RuntimeValue>, Trap> {
         let s: String = self.heap.asc_get(str_ptr);
-        let h160 = H160::from_str(s.as_str())
-            .map_err(|e| host_error(format!("Failed to convert string to Address/H160: {}", e)))?;
+        let h160 = self.host_exports.string_to_h160(&s)?;
         let h160_obj: AscPtr<AscH160> = self.heap.asc_new(&h160);
         Ok(Some(RuntimeValue::from(h160_obj)))
     }
@@ -560,64 +405,40 @@ where
         &self,
         int256_ptr: AscPtr<Uint64Array>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        // Read as a U256 to use the convenient `to_little_endian` method.
-        let int256: U256 = self.heap.asc_get(int256_ptr);
-        let mut buffer = [0; 32];
-        int256.to_little_endian(&mut buffer);
+        let buffer = self
+            .host_exports
+            .int256_to_big_int(self.heap.asc_get(int256_ptr));
         let big_int_obj: AscPtr<BigInt> = self.heap.asc_new(&buffer[..]);
         Ok(Some(RuntimeValue::from(big_int_obj)))
     }
 
     /// function typeConversion.bigIntToInt256(i: BigInt): Uint64Array
     fn big_int_to_int256(&self, big_int_ptr: AscPtr<BigInt>) -> Result<Option<RuntimeValue>, Trap> {
-        let bytes: Vec<u8> = self.heap.asc_get(big_int_ptr);
-        let size = bytes.len();
-        if size != 32 {
-            Err(host_error(format!(
-                "expected byte array of size 32, found size {}",
-                size
-            )))
-        } else {
-            let int256 = U256::from_little_endian(&*bytes);
-            let int256_ptr: AscPtr<Uint64Array> = self.heap.asc_new(&int256);
-            Ok(Some(RuntimeValue::from(int256_ptr)))
-        }
+        let int256 = self
+            .host_exports
+            .big_int_to_int256(self.heap.asc_get(big_int_ptr))?;
+        let int256_ptr: AscPtr<Uint64Array> = self.heap.asc_new(&int256);
+        Ok(Some(RuntimeValue::from(int256_ptr)))
     }
 
     /// Converts bytes to a hex string.
-    /// References:
-    /// https://godoc.org/github.com/ethereum/go-ethereum/common/hexutil#hdr-Encoding_Rules
-    /// https://github.com/ethereum/web3.js/blob/f98fe1462625a6c865125fecc9cb6b414f0a5e83/packages/web3-utils/src/utils.js#L283
-    ///
     /// function typeConversion.bytesToHex(bytes: Bytes): string
     fn bytes_to_hex(&self, bytes_ptr: AscPtr<Uint8Array>) -> Result<Option<RuntimeValue>, Trap> {
-        let bytes: Vec<u8> = self.heap.asc_get(bytes_ptr);
-
-        // Even an empty string must be prefixed with `0x`.
-        // Encodes each byte as a two hex digits.
-        let hex_string = format!("0x{}", hex::encode(bytes));
-        let hex_string_obj = self.heap.asc_new(hex_string.as_str());
-
-        Ok(Some(RuntimeValue::from(hex_string_obj)))
+        let result = self.host_exports.bytes_to_hex(self.heap.asc_get(bytes_ptr));
+        Ok(Some(RuntimeValue::from(self.heap.asc_new(&result))))
     }
 
     /// function json.fromBytes(bytes: Bytes): JSONValue
     fn json_from_bytes(&self, bytes_ptr: AscPtr<Uint8Array>) -> Result<Option<RuntimeValue>, Trap> {
-        let bytes: Vec<u8> = self.heap.asc_get(bytes_ptr);
-        let json: serde_json::Value =
-            serde_json::from_reader(&*bytes).map_err(HostExternalsError)?;
-        let json_obj = self.heap.asc_new(&json);
-        Ok(Some(RuntimeValue::from(json_obj)))
+        let result = self
+            .host_exports
+            .json_from_bytes(self.heap.asc_get(bytes_ptr))?;
+        Ok(Some(RuntimeValue::from(self.heap.asc_new(&result))))
     }
 
     /// function ipfs.cat(link: String): Bytes
     fn ipfs_cat(&self, link_ptr: AscPtr<AscString>) -> Result<Option<RuntimeValue>, Trap> {
-        let link = self.heap.asc_get(link_ptr);
-        let bytes = self.block_on(
-            self.link_resolver
-                .cat(&Link { link })
-                .map_err(|e| HostExternalsError(e.to_string())),
-        )?;
+        let bytes = self.host_exports.ipfs_cat(self.heap.asc_get(link_ptr))?;
         let bytes_obj: AscPtr<Uint8Array> = self.heap.asc_new(&*bytes);
         Ok(Some(RuntimeValue::from(bytes_obj)))
     }
@@ -625,45 +446,43 @@ where
     /// Expects a decimal string.
     /// function json.toI64(json: String): i64
     fn json_to_i64(&self, json_ptr: AscPtr<AscString>) -> Result<Option<RuntimeValue>, Trap> {
-        let json: String = self.heap.asc_get(json_ptr);
-        let number = i64::from_str(&json)
-            .map_err(|_| host_error(format!("JSON `{}` cannot be parsed as i64", json)))?;
+        let number = self.host_exports.json_to_i64(self.heap.asc_get(json_ptr))?;
         Ok(Some(RuntimeValue::from(number)))
     }
 
     /// Expects a decimal string.
     /// function json.toU64(json: String): u64
     fn json_to_u64(&self, json_ptr: AscPtr<AscString>) -> Result<Option<RuntimeValue>, Trap> {
-        let json: String = self.heap.asc_get(json_ptr);
-        let number = u64::from_str(&json)
-            .map_err(|_| host_error(format!("JSON `{}` cannot be parsed as u64", json)))?;
+        let number = self.host_exports.json_to_u64(self.heap.asc_get(json_ptr))?;
         Ok(Some(RuntimeValue::from(number)))
     }
 
     /// Expects a decimal string.
     /// function json.toF64(json: String): f64
     fn json_to_f64(&self, json_ptr: AscPtr<AscString>) -> Result<Option<RuntimeValue>, Trap> {
-        let json: String = self.heap.asc_get(json_ptr);
-        let number = f64::from_str(&json)
-            .map_err(|_| host_error(format!("JSON `{}` cannot be parsed as f64", json)))?;
+        let number = self.host_exports.json_to_f64(self.heap.asc_get(json_ptr))?;
         Ok(Some(RuntimeValue::from(F64::from(number))))
     }
 
     /// Expects a decimal string.
     /// function json.toBigInt(json: String): BigInt
-    fn json_to_big_int(&self, json: AscPtr<AscString>) -> Result<Option<RuntimeValue>, Trap> {
-        let json: String = self.heap.asc_get(json);
-        let big_int = scalar::BigInt::from_str(&json)
-            .map_err(|_| host_error(format!("JSON `{}` is not a decimal string", json)))?;
-        let big_int_ptr: AscPtr<BigInt> = self.heap.asc_new(&*big_int.to_signed_bytes_le());
+    fn json_to_big_int(&self, json_ptr: AscPtr<AscString>) -> Result<Option<RuntimeValue>, Trap> {
+        let big_int = self
+            .host_exports
+            .json_to_big_int(self.heap.asc_get(json_ptr))?;
+        let big_int_ptr: AscPtr<BigInt> = self.heap.asc_new(&*big_int);
         Ok(Some(RuntimeValue::from(big_int_ptr)))
     }
 
     /// function crypto.keccak256(input: Bytes): Bytes
-    fn crypto_keccak_256(&self, input: AscPtr<Uint8Array>) -> Result<Option<RuntimeValue>, Trap> {
-        let input: Vec<u8> = self.heap.asc_get(input);
-        let hash_ptr: AscPtr<Uint8Array> =
-            self.heap.asc_new(tiny_keccak::keccak256(&input).as_ref());
+    fn crypto_keccak_256(
+        &self,
+        input_ptr: AscPtr<Uint8Array>,
+    ) -> Result<Option<RuntimeValue>, Trap> {
+        let input = self
+            .host_exports
+            .crypto_keccak_256(self.heap.asc_get(input_ptr));
+        let hash_ptr: AscPtr<Uint8Array> = self.heap.asc_new(input.as_ref());
         Ok(Some(RuntimeValue::from(hash_ptr)))
     }
 
@@ -676,159 +495,57 @@ where
 
     /// function typeConversion.i64ToU256(x: i64): U64Array
     fn i64_to_u256(&self, x: i64) -> Result<Option<RuntimeValue>, Trap> {
-        // Sign extension: pad with 0s or 1s depending on sign of x.
-        let mut bytes = if x > 0 { [0; 32] } else { [255; 32] };
-
-        // This is just `x.to_bytes()` which is unstable.
-        let x_bytes: [u8; 8] = unsafe { mem::transmute(x) };
-        bytes[..8].copy_from_slice(&x_bytes);
-        let u256 = U256::from_little_endian(&bytes);
+        let u256 = self.host_exports.i64_to_u256(x);
         let u256_ptr: AscPtr<Uint64Array> = self.heap.asc_new(&u256);
         Ok(Some(RuntimeValue::from(u256_ptr)))
     }
 
-    /// Cast U256 to u64, checking that it respects `max_value`.
-    fn u256_as_u64(
-        &self,
-        x: AscPtr<Uint64Array>,
-        max_value: u64,
-        n_name: &str,
-    ) -> Result<u64, Trap> {
-        let u256: U256 = self.heap.asc_get(x);
-
-        // Check for overflow.
-        let max_value = U256::from(max_value);
-        if u256 > max_value {
-            return Err(host_error(format!(
-                "number `{}` is too large for an {}",
-                u256, n_name
-            )));
-        }
-        Ok(u64::from(u256))
-    }
-
     /// function typeConversion.u256ToU8(x: U64Array): u8
     fn u256_to_u8(&self, x: AscPtr<Uint64Array>) -> Result<Option<RuntimeValue>, Trap> {
-        let value = self.u256_as_u64(x, u8::max_value().into(), "u8")? as u8;
-        Ok(Some(RuntimeValue::from(value)))
+        let number = self.host_exports.u256_to_u8(self.heap.asc_get(x))?;
+        Ok(Some(RuntimeValue::from(number)))
     }
 
     /// function typeConversion.u256ToU16(x: U64Array): u16
     fn u256_to_u16(&self, x: AscPtr<Uint64Array>) -> Result<Option<RuntimeValue>, Trap> {
-        let value = self.u256_as_u64(x, u16::max_value().into(), "u16")? as u16;
-        Ok(Some(RuntimeValue::from(value)))
+        let number = self.host_exports.u256_to_u16(self.heap.asc_get(x))?;
+        Ok(Some(RuntimeValue::from(number)))
     }
 
     /// function typeConversion.u256ToU32(x: U64Array): u32
     fn u256_to_u32(&self, x: AscPtr<Uint64Array>) -> Result<Option<RuntimeValue>, Trap> {
-        let value = self.u256_as_u64(x, u32::max_value().into(), "u32")? as u32;
-        Ok(Some(RuntimeValue::from(value)))
+        let number = self.host_exports.u256_to_u32(self.heap.asc_get(x))?;
+        Ok(Some(RuntimeValue::from(number)))
     }
 
     /// function typeConversion.u256ToU64(x: U64Array): u64
     fn u256_to_u64(&self, x: AscPtr<Uint64Array>) -> Result<Option<RuntimeValue>, Trap> {
-        let value = self.u256_as_u64(x, u64::max_value().into(), "u64")?;
-        Ok(Some(RuntimeValue::from(value)))
-    }
-
-    /// Checks that `x >= min_value` and `x <= max_value`
-    /// and returns the byte representation of `x`.
-    fn u256_checked_bytes(
-        &self,
-        x: AscPtr<Uint64Array>,
-        min_value: i64,
-        max_value: i64,
-        n_name: &str,
-    ) -> Result<[u8; 8], Trap> {
-        let u256: U256 = self.heap.asc_get(x);
-
-        // The number is negative if the most-significant bit is set.
-        let is_negative = u256.bit(255);
-        if !is_negative {
-            // Check for overflow.
-            let max_value = U256::from(max_value);
-            if u256 > max_value {
-                return Err(host_error(format!(
-                    "number `{}` is too large for an {}",
-                    u256, n_name
-                )));
-            }
-        } else {
-            // Check for underflow.
-            // Do two's complement to get the absolute value.
-            let u256_abs = !u256 + 1;
-
-            // The absolute value of `T::min_value` is `T::max_value + 1` for a primitive `T`,
-            // so we do a math trick to get around that, the `+ 1`s here cancel each other.
-            let min_value_abs = U256::from((min_value + 1).abs()) + 1;
-            if u256_abs > min_value_abs {
-                return Err(host_error(format!(
-                    "number `-{}` is too small for an {}",
-                    u256_abs, n_name
-                )));
-            }
-        }
-
-        // This is just `u256.low_u64().to_bytes()` which is unstable.
-        Ok(unsafe { mem::transmute(u256.low_u64()) })
+        let number = self.host_exports.u256_to_u64(self.heap.asc_get(x))?;
+        Ok(Some(RuntimeValue::from(number)))
     }
 
     /// function typeConversion.u256ToI8(x: U64Array): i8
     fn u256_to_i8(&self, x: AscPtr<Uint64Array>) -> Result<Option<RuntimeValue>, Trap> {
-        let bytes =
-            self.u256_checked_bytes(x, i8::min_value().into(), i8::max_value().into(), "i8")?;
-
-        // This is just `i8::from_bytes` which is unstable.
-        let value: i8 = unsafe { mem::transmute(bytes[0]) };
-        Ok(Some(RuntimeValue::from(value)))
+        let number = self.host_exports.u256_to_i8(self.heap.asc_get(x))?;
+        Ok(Some(RuntimeValue::from(number)))
     }
 
     /// function typeConversion.u256ToI16(x: U64Array): i16
     fn u256_to_i16(&self, x: AscPtr<Uint64Array>) -> Result<Option<RuntimeValue>, Trap> {
-        let bytes =
-            self.u256_checked_bytes(x, i16::min_value().into(), i16::max_value().into(), "i16")?;
-
-        // This is just `i16::from_bytes` which is unstable.
-        let value: i16 = unsafe { mem::transmute([bytes[0], bytes[1]]) };
-        Ok(Some(RuntimeValue::from(value)))
+        let number = self.host_exports.u256_to_i16(self.heap.asc_get(x))?;
+        Ok(Some(RuntimeValue::from(number)))
     }
 
     /// function typeConversion.u256ToI32(x: U64Array): i32
     fn u256_to_i32(&self, x: AscPtr<Uint64Array>) -> Result<Option<RuntimeValue>, Trap> {
-        let bytes =
-            self.u256_checked_bytes(x, i32::min_value().into(), i32::max_value().into(), "i32")?;
-
-        // This is just `i32::from_bytes` which is unstable.
-        let value: i32 = unsafe { mem::transmute([bytes[0], bytes[1], bytes[2], bytes[3]]) };
-        Ok(Some(RuntimeValue::from(value)))
+        let number = self.host_exports.u256_to_i32(self.heap.asc_get(x))?;
+        Ok(Some(RuntimeValue::from(number)))
     }
 
     /// function typeConversion.u256ToI64(x: U64Array): i64
     fn u256_to_i64(&self, x: AscPtr<Uint64Array>) -> Result<Option<RuntimeValue>, Trap> {
-        let bytes = self.u256_checked_bytes(x, i64::min_value(), i64::max_value(), "i64")?;
-
-        // This is just `i64::from_bytes` which is unstable.
-        let value: i64 = unsafe {
-            mem::transmute([
-                bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
-            ])
-        };
-        Ok(Some(RuntimeValue::from(value)))
-    }
-
-    fn block_on<I: Send + 'static, E: Send + 'static>(
-        &self,
-        future: impl Future<Item = I, Error = E> + Send + 'static,
-    ) -> Result<I, E> {
-        let (return_sender, return_receiver) = oneshot::channel();
-        self.task_sink
-            .clone()
-            .send(Box::new(future.then(|res| {
-                return_sender.send(res).map_err(|_| unreachable!())
-            }))).wait()
-            .map_err(|_| panic!("task receiver dropped"))
-            .unwrap();
-        return_receiver.wait().expect("`return_sender` dropped")
+        let number = self.host_exports.u256_to_i64(self.heap.asc_get(x))?;
+        Ok(Some(RuntimeValue::from(number)))
     }
 }
 
@@ -836,8 +553,8 @@ impl<T, L, S, U> Externals for HostExternals<T, L, S, U>
 where
     T: EthereumAdapter,
     L: LinkResolver,
-    S: Store + Send + Sync,
-    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone,
+    S: Store + Send + Sync + 'static,
+    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone + 'static,
 {
     fn invoke_index(
         &mut self,


### PR DESCRIPTION
To make `module/mod.rs` thinner and to make it easier to add new exports, a new module `host_exports.rs` is created, with a function for each export dealing only with Rust types, so the corresponding function in `module/mod.rs` only needs to pull the arguments from the asc heap and then allocate the return value on the asc heap.