### PR TITLE
fix various clippy warnings

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -175,7 +175,7 @@ impl SubgraphInstanceManager {
                             let transaction = block
                                 .transaction_for_log(&log)
                                 .map(Arc::new)
-                                .ok_or(format_err!("Found no transaction for event"));
+                                .ok_or_else(|| format_err!("Found no transaction for event"));
 
                             future::result(transaction).and_then(move |transaction| {
                                 instance

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -23,7 +23,7 @@ impl<L: LinkResolver> SubgraphProvider<L> {
         let (event_sink, event_stream) = channel(100);
 
         // Create the subgraph provider
-        let provider = SubgraphProvider {
+        SubgraphProvider {
             _logger: logger.new(o!("component" => "SubgraphProvider")),
             event_stream: Some(event_stream),
             event_sink,
@@ -31,9 +31,7 @@ impl<L: LinkResolver> SubgraphProvider<L> {
             schema_event_sink,
             resolver,
             subgraphs: Arc::new(Mutex::new(BTreeMap::new())),
-        };
-
-        provider
+        }
     }
 
     fn send_remove_events(

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -137,8 +137,8 @@ where
     ) -> Self {
         let logger = logger.new(o!(
             "component" => "BlockStream",
-            "subgraph_name" => format!("{}", subgraph_name),
-            "subgraph_id" => format!("{}", subgraph_id),
+            "subgraph_name" => subgraph_name.to_string(),
+            "subgraph_id" => subgraph_id.to_string(),
         ));
 
         let (chain_head_update_sink, chain_head_update_stream) = channel(100);
@@ -674,7 +674,7 @@ where
 
                             // If too many errors without progress, give up
                             if self.consecutive_err_count >= 100 {
-                                return Err(e.into());
+                                return Err(e);
                             }
 
                             warn!(
@@ -725,7 +725,7 @@ where
 
                             // If too many errors without progress, give up
                             if self.consecutive_err_count >= 100 {
-                                return Err(e.into());
+                                return Err(e);
                             }
 
                             warn!(
@@ -759,9 +759,7 @@ where
                         // Chain head update stream ended
                         Ok(Async::Ready(None)) => {
                             // Should not happen
-                            return Err(
-                                format_err!("chain head update stream ended unexpectedly").into()
-                            );
+                            return Err(format_err!("chain head update stream ended unexpectedly"));
                         }
 
                         Ok(Async::NotReady) => {
@@ -773,7 +771,7 @@ where
                         // mpsc channel failed
                         Err(()) => {
                             // Should not happen
-                            return Err(format_err!("chain head update Receiver failed").into());
+                            return Err(format_err!("chain head update Receiver failed"));
                         }
                     }
                 }

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -290,8 +290,9 @@ where
                     .and_then(|gen_block_opt| {
                         future::result(
                             gen_block_opt
-                                .ok_or(format_err!("Ethereum node could not find genesis block"))
-                                .map(|gen_block| gen_block.hash.unwrap()),
+                                .ok_or_else(|| {
+                                    format_err!("Ethereum node could not find genesis block")
+                                }).map(|gen_block| gen_block.hash.unwrap()),
                         )
                     })
             });
@@ -436,10 +437,9 @@ where
         Box::new(self.block_hash_by_block_number(block_ptr.number).and_then(
             move |block_hash_opt| {
                 block_hash_opt
-                    .ok_or(format_err!(
-                        "Ethereum node is missing block #{}",
-                        block_ptr.number
-                    )).map(|block_hash| block_hash == block_ptr.hash)
+                    .ok_or_else(|| {
+                        format_err!("Ethereum node is missing block #{}", block_ptr.number)
+                    }).map(|block_hash| block_hash == block_ptr.hash)
             },
         ))
     }

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -36,19 +36,19 @@ pub struct EthereumBlockData {
 impl<'a, T> From<&'a Block<T>> for EthereumBlockData {
     fn from(block: &'a Block<T>) -> EthereumBlockData {
         EthereumBlockData {
-            hash: block.hash.clone().unwrap(),
-            parent_hash: block.parent_hash.clone(),
-            uncles_hash: block.uncles_hash.clone(),
-            author: block.author.clone(),
-            state_root: block.state_root.clone(),
-            transactions_root: block.transactions_root.clone(),
-            receipts_root: block.receipts_root.clone(),
-            number: block.number.clone().unwrap(),
-            gas_used: block.gas_used.clone(),
-            gas_limit: block.gas_limit.clone(),
-            timestamp: block.timestamp.clone(),
-            difficulty: block.difficulty.clone(),
-            total_difficulty: block.total_difficulty.clone(),
+            hash: block.hash.unwrap(),
+            parent_hash: block.parent_hash,
+            uncles_hash: block.uncles_hash,
+            author: block.author,
+            state_root: block.state_root,
+            transactions_root: block.transactions_root,
+            receipts_root: block.receipts_root,
+            number: block.number.unwrap(),
+            gas_used: block.gas_used,
+            gas_limit: block.gas_limit,
+            timestamp: block.timestamp,
+            difficulty: block.difficulty,
+            total_difficulty: block.total_difficulty,
         }
     }
 }
@@ -65,10 +65,10 @@ pub struct EthereumTransactionData {
 impl<'a> From<&'a Transaction> for EthereumTransactionData {
     fn from(tx: &'a Transaction) -> EthereumTransactionData {
         EthereumTransactionData {
-            hash: tx.hash.clone(),
-            block_hash: tx.block_hash.clone().unwrap(),
-            block_number: tx.block_number.clone().unwrap(),
-            gas_used: tx.gas.clone(),
+            hash: tx.hash,
+            block_hash: tx.block_hash.unwrap(),
+            block_number: tx.block_number.unwrap(),
+            gas_used: tx.gas,
         }
     }
 }
@@ -85,7 +85,7 @@ pub struct EthereumEventData {
 impl Clone for EthereumEventData {
     fn clone(&self) -> Self {
         EthereumEventData {
-            address: self.address.clone(),
+            address: self.address,
             block: self.block.clone(),
             transaction: self.transaction.clone(),
             params: self

--- a/graph/src/components/server/query.rs
+++ b/graph/src/components/server/query.rs
@@ -43,11 +43,11 @@ impl From<String> for GraphQLServerError {
 
 impl fmt::Display for GraphQLServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            &GraphQLServerError::Canceled(_) => write!(f, "Query was canceled"),
-            &GraphQLServerError::ClientError(ref s) => write!(f, "{}", s),
-            &GraphQLServerError::QueryError(ref e) => write!(f, "{}", e),
-            &GraphQLServerError::InternalError(ref s) => write!(f, "{}", s),
+        match *self {
+            GraphQLServerError::Canceled(_) => write!(f, "Query was canceled"),
+            GraphQLServerError::ClientError(ref s) => write!(f, "{}", s),
+            GraphQLServerError::QueryError(ref e) => write!(f, "{}", e),
+            GraphQLServerError::InternalError(ref s) => write!(f, "{}", s),
         }
     }
 }
@@ -58,11 +58,11 @@ impl Error for GraphQLServerError {
     }
 
     fn cause(&self) -> Option<&Error> {
-        match self {
-            &GraphQLServerError::Canceled(ref e) => Some(e),
-            &GraphQLServerError::ClientError(_) => None,
-            &GraphQLServerError::QueryError(ref e) => Some(e),
-            &GraphQLServerError::InternalError(_) => None,
+        match *self {
+            GraphQLServerError::Canceled(ref e) => Some(e),
+            GraphQLServerError::ClientError(_) => None,
+            GraphQLServerError::QueryError(ref e) => Some(e),
+            GraphQLServerError::InternalError(_) => None,
         }
     }
 }
@@ -72,7 +72,7 @@ impl Serialize for GraphQLServerError {
     where
         S: Serializer,
     {
-        if let &GraphQLServerError::QueryError(ref e) = self {
+        if let GraphQLServerError::QueryError(ref e) = *self {
             serializer.serialize_some(e)
         } else {
             let mut map = serializer.serialize_map(Some(1))?;

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -177,7 +177,7 @@ impl EntityOperation {
                         let mut entity = entity.clone();
                         entity.merge(data.clone());
                         entity
-                    }).unwrap_or(data.clone()),
+                    }).unwrap_or_else(|| data.clone()),
             ),
             Remove { .. } => None,
         }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -184,9 +184,9 @@ impl Error for QueryError {
     }
 
     fn cause(&self) -> Option<&Error> {
-        match self {
-            &QueryError::EncodingError(ref e) => Some(e),
-            &QueryError::ExecutionError(ref e) => Some(e),
+        match *self {
+            QueryError::EncodingError(ref e) => Some(e),
+            QueryError::ExecutionError(ref e) => Some(e),
             _ => None,
         }
     }
@@ -194,10 +194,10 @@ impl Error for QueryError {
 
 impl fmt::Display for QueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            &QueryError::EncodingError(ref e) => write!(f, "{}", e),
-            &QueryError::ExecutionError(ref e) => write!(f, "{}", e),
-            &QueryError::ParseError(ref e) => write!(f, "{}", e),
+        match *self {
+            QueryError::EncodingError(ref e) => write!(f, "{}", e),
+            QueryError::ExecutionError(ref e) => write!(f, "{}", e),
+            QueryError::ParseError(ref e) => write!(f, "{}", e),
         }
     }
 }
@@ -218,10 +218,10 @@ impl Serialize for QueryError {
                 let mut msg = format!("{}", self);
                 let inner_msg = msg.replace("query parse error:", "");
                 let inner_msg = inner_msg.trim();
-                let parts: Vec<&str> = inner_msg.splitn(2, "\n").collect();
+                let parts: Vec<&str> = inner_msg.splitn(2, '\n').collect();
 
                 // Find the colon in the first line and split there
-                let colon_pos = parts[0].rfind(":").unwrap();
+                let colon_pos = parts[0].rfind(':').unwrap();
                 let (a, b) = parts[0].split_at(colon_pos);
 
                 // Find the line and column numbers and convert them to u32

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -42,12 +42,12 @@ impl<'a> From<&'a str> for QueryVariableValue {
 }
 
 /// Variable values for a GraphQL query.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct QueryVariables(HashMap<String, QueryVariableValue>);
 
 impl QueryVariables {
     pub fn new() -> Self {
-        QueryVariables(HashMap::new())
+        Default::default()
     }
 }
 

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -41,7 +41,7 @@ impl From<Vec<QueryExecutionError>> for QueryResult {
     fn from(e: Vec<QueryExecutionError>) -> Self {
         QueryResult {
             data: None,
-            errors: Some(e.into_iter().map(|error| QueryError::from(error)).collect()),
+            errors: Some(e.into_iter().map(QueryError::from).collect()),
         }
     }
 }

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -21,24 +21,21 @@ impl Schema {
                 arguments: vec![subgraph_id_argument],
             };
 
-            match definition {
-                schema::Definition::TypeDefinition(ref mut type_definition) => {
-                    match type_definition {
-                        schema::TypeDefinition::Object(ref mut object_type) => {
-                            object_type.directives.push(subgraph_id_directive);
-                        }
-                        schema::TypeDefinition::Interface(ref mut interface_type) => {
-                            interface_type.directives.push(subgraph_id_directive);
-                        }
-                        schema::TypeDefinition::Enum(ref mut enum_type) => {
-                            enum_type.directives.push(subgraph_id_directive);
-                        }
-                        schema::TypeDefinition::Scalar(_scalar_type) => (),
-                        schema::TypeDefinition::InputObject(_input_object_type) => (),
-                        schema::TypeDefinition::Union(_union_type) => (),
+            if let schema::Definition::TypeDefinition(ref mut type_definition) = definition {
+                match type_definition {
+                    schema::TypeDefinition::Object(ref mut object_type) => {
+                        object_type.directives.push(subgraph_id_directive);
                     }
+                    schema::TypeDefinition::Interface(ref mut interface_type) => {
+                        interface_type.directives.push(subgraph_id_directive);
+                    }
+                    schema::TypeDefinition::Enum(ref mut enum_type) => {
+                        enum_type.directives.push(subgraph_id_directive);
+                    }
+                    schema::TypeDefinition::Scalar(_scalar_type) => (),
+                    schema::TypeDefinition::InputObject(_input_object_type) => (),
+                    schema::TypeDefinition::Union(_union_type) => (),
                 }
-                _ => (),
             };
         }
     }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -105,7 +105,7 @@ impl Value {
             (query::Value::Int(i), _) => Value::Int(
                 i.to_owned()
                     .as_i64()
-                    .ok_or(QueryExecutionError::NamedTypeError("Int".to_string()))?
+                    .ok_or_else(|| QueryExecutionError::NamedTypeError("Int".to_string()))?
                     as i32,
             ),
             (query::Value::Float(f), _) => Value::Float(f.to_owned() as f32),
@@ -179,12 +179,12 @@ impl<'a> From<&'a String> for Value {
 }
 
 /// An entity is represented as a map of attribute names to values.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Entity(HashMap<Attribute, Value>);
 impl Entity {
     /// Creates a new entity with no attributes set.
     pub fn new() -> Self {
-        Entity(HashMap::new())
+        Default::default()
     }
 
     /// Merges an entity update `update` into this entity.

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -28,7 +28,7 @@ impl FromStr for BigInt {
     type Err = <num_bigint::BigInt as FromStr>::Err;
 
     fn from_str(s: &str) -> Result<BigInt, Self::Err> {
-        num_bigint::BigInt::from_str(s).map(|x| BigInt(x))
+        num_bigint::BigInt::from_str(s).map(BigInt)
     }
 }
 

--- a/graph/src/data/subgraph.rs
+++ b/graph/src/data/subgraph.rs
@@ -244,7 +244,7 @@ impl SubgraphManifest {
     ) -> impl Future<Item = Self, Error = SubgraphManifestResolveError> + Send {
         resolver
             .cat(&link)
-            .map_err(|e| SubgraphManifestResolveError::ResolveError(e))
+            .map_err(SubgraphManifestResolveError::ResolveError)
             .and_then(move |file_bytes| {
                 let file = String::from_utf8(file_bytes.to_vec())
                     .map_err(|_| SubgraphManifestResolveError::NonUtf8)?;
@@ -274,7 +274,7 @@ impl SubgraphManifest {
             }).and_then(move |unresolved| {
                 unresolved
                     .resolve(name, &*resolver)
-                    .map_err(|e| SubgraphManifestResolveError::ResolveError(e))
+                    .map_err(SubgraphManifestResolveError::ResolveError)
             })
     }
 }

--- a/graph/src/util/ethereum.rs
+++ b/graph/src/util/ethereum.rs
@@ -20,6 +20,5 @@ pub fn contract_event_with_signature<'a>(
 ) -> Option<&'a Event> {
     contract
         .events()
-        .filter(|event| event.signature() == string_to_h256(signature))
-        .next()
+        .find(|event| event.signature() == string_to_h256(signature))
 }

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -281,10 +281,10 @@ where
                     }
 
                     // Wrap in Err to force retry
-                    Err(result.map_err(|e| DeadlineError::inner(e)))
+                    Err(result.map_err(DeadlineError::inner))
                 } else {
                     // Wrap in Ok to prevent retry
-                    Ok(result.map_err(|e| DeadlineError::inner(e)))
+                    Ok(result.map_err(DeadlineError::inner))
                 }
             }
         })

--- a/graph/src/util/log.rs
+++ b/graph/src/util/log.rs
@@ -20,7 +20,7 @@ pub fn logger(show_debug: bool) -> slog::Logger {
             },
         ).parse(
             env::var_os("GRAPH_LOG")
-                .unwrap_or("".into())
+                .unwrap_or_else(|| "".into())
                 .to_str()
                 .unwrap(),
         ).build();
@@ -41,10 +41,12 @@ pub fn register_panic_hook(panic_logger: slog::Logger) {
             .payload()
             .downcast_ref::<String>()
             .cloned()
-            .or(panic_info
-                .payload()
-                .downcast_ref::<&str>()
-                .map(|s| s.to_string()));
+            .or_else(|| {
+                panic_info
+                    .payload()
+                    .downcast_ref::<&str>()
+                    .map(|s| s.to_string())
+            });
 
         let panic_location = if let Some(location) = panic_info.location() {
             format!("{}:{}", location.file(), location.line().to_string())

--- a/graphql/src/introspection/schema.rs
+++ b/graphql/src/introspection/schema.rs
@@ -1,7 +1,7 @@
 use graphql_parser;
 use graphql_parser::schema as s;
 
-const INTROSPECTION_SCHEMA: &'static str = "
+const INTROSPECTION_SCHEMA: &str = "
 scalar Boolean
 scalar Float
 scalar Int

--- a/graphql/src/query/ast.rs
+++ b/graphql/src/query/ast.rs
@@ -17,7 +17,7 @@ pub fn get_operation<'a>(
             .find(|op| match get_operation_name(op) {
                 Some(n) => s == n,
                 None => false,
-            }).ok_or(QueryExecutionError::OperationNotFound(s.to_string())),
+            }).ok_or_else(|| QueryExecutionError::OperationNotFound(s.to_string())),
         _ => Err(QueryExecutionError::OperationNameRequired),
     }
 }
@@ -57,7 +57,7 @@ pub fn get_directive(selection: &Selection, name: Name) -> Option<&Directive> {
 }
 
 /// Looks up the value of an argument in a vector of (name, value) tuples.
-pub fn get_argument_value<'a>(arguments: &'a Vec<(Name, Value)>, name: &Name) -> Option<&'a Value> {
+pub fn get_argument_value<'a>(arguments: &'a [(Name, Value)], name: &Name) -> Option<&'a Value> {
     arguments.iter().find(|(n, _)| n == name).map(|(_, v)| v)
 }
 

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -49,14 +49,14 @@ where
         fields: vec![],
     };
 
-    let result = match operation {
+    let result = match *operation {
         // Execute top-level `query { ... }` expressions
-        &q::OperationDefinition::Query(q::Query {
+        q::OperationDefinition::Query(q::Query {
             ref selection_set, ..
         }) => execute_root_selection_set(ctx, selection_set, &None),
 
         // Execute top-level `{ ... }` expressions
-        &q::OperationDefinition::SelectionSet(ref selection_set) => {
+        q::OperationDefinition::SelectionSet(ref selection_set) => {
             execute_root_selection_set(ctx, selection_set, &None)
         }
 

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -89,7 +89,7 @@ fn add_types_for_object_types(
 /// Adds `*_orderBy` and `*_filter` enum types for the given interfaces to the schema.
 fn add_types_for_interface_types(
     schema: &mut Document,
-    interface_types: &Vec<&InterfaceType>,
+    interface_types: &[&InterfaceType],
 ) -> Result<(), APISchemaError> {
     for interface_type in interface_types {
         add_order_by_type(schema, &interface_type.name, &interface_type.fields)?;
@@ -102,7 +102,7 @@ fn add_types_for_interface_types(
 fn add_order_by_type(
     schema: &mut Document,
     type_name: &Name,
-    fields: &Vec<Field>,
+    fields: &[Field],
 ) -> Result<(), APISchemaError> {
     let type_name = format!("{}_orderBy", type_name).to_string();
 
@@ -135,7 +135,7 @@ fn add_order_by_type(
 fn add_filter_type(
     schema: &mut Document,
     type_name: &Name,
-    fields: &Vec<Field>,
+    fields: &[Field],
 ) -> Result<(), APISchemaError> {
     let filter_type_name = format!("{}_filter", type_name).to_string();
 
@@ -160,7 +160,7 @@ fn add_filter_type(
 /// Generates `*_filter` input values for the given set of fields.
 fn field_input_values(
     schema: &Document,
-    fields: &Vec<Field>,
+    fields: &[Field],
 ) -> Result<Vec<InputValue>, APISchemaError> {
     let mut input_values = vec![];
     for field in fields {
@@ -182,7 +182,7 @@ fn field_filter_input_values(
     match field_type {
         Type::NamedType(ref name) => {
             let named_type = ast::get_named_type(schema, name)
-                .ok_or(APISchemaError::TypeNotFound(name.clone()))?;
+                .ok_or_else(|| APISchemaError::TypeNotFound(name.clone()))?;
             Ok(match named_type {
                 TypeDefinition::Scalar(ref t) => field_scalar_filter_input_values(schema, field, t),
                 TypeDefinition::Enum(ref t) => field_enum_filter_input_values(schema, field, t),
@@ -286,8 +286,8 @@ fn input_value(name: &Name, suffix: &'static str, value_type: Type) -> InputValu
 /// Adds a root `Query` object type to the schema.
 fn add_query_type(
     schema: &mut Document,
-    object_types: &Vec<&ObjectType>,
-    interface_types: &Vec<&InterfaceType>,
+    object_types: &[&ObjectType],
+    interface_types: &[&InterfaceType],
 ) -> Result<(), APISchemaError> {
     let type_name = String::from("Query");
 
@@ -316,8 +316,8 @@ fn add_query_type(
 /// Adds a root `Subscription` object type to the schema.
 fn add_subscription_type(
     schema: &mut Document,
-    object_types: &Vec<&ObjectType>,
-    interface_types: &Vec<&InterfaceType>,
+    object_types: &[&ObjectType],
+    interface_types: &[&InterfaceType],
 ) -> Result<(), APISchemaError> {
     let type_name = String::from("Subscription");
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -149,12 +149,12 @@ where
                             .collect(),
                     )),
                     _ => None,
-                }).expect(
-                    format!(
+                }).unwrap_or_else(|| {
+                    panic!(
                         "Field \"{}\" missing in parent object",
                         field_definition.name
-                    ).as_str(),
-                );
+                    )
+                });
 
             // Add the `Or` filter to the top-level `And` filter, creating one if necessary
             let top_level_filter = query.filter.get_or_insert(StoreFilter::And(vec![]));
@@ -244,10 +244,9 @@ where
             return Ok(self
                 .store
                 .get(StoreKey {
-                    subgraph: parse_subgraph_id(object_type).expect(
-                        format!("Failed to get subgraph ID from type: {}", object_type.name)
-                            .as_str(),
-                    ),
+                    subgraph: parse_subgraph_id(object_type).unwrap_or_else(|_| {
+                        panic!("Failed to get subgraph ID from type: {}", object_type.name)
+                    }),
                     entity: object_type.name.to_owned(),
                     id: id.to_owned(),
                 })?.map_or(q::Value::Null, |entity| entity.into()));
@@ -258,10 +257,9 @@ where
                 Some(q::Value::String(id)) => Ok(self
                     .store
                     .get(StoreKey {
-                        subgraph: parse_subgraph_id(object_type).expect(
-                            format!("Failed to get subgraph ID from type: {}", object_type.name)
-                                .as_str(),
-                        ),
+                        subgraph: parse_subgraph_id(object_type).unwrap_or_else(|_| {
+                            panic!("Failed to get subgraph ID from type: {}", object_type.name)
+                        }),
                         entity: object_type.name.to_owned(),
                         id: id.to_owned(),
                     })?.map_or(q::Value::Null, |entity| entity.into())),
@@ -300,7 +298,7 @@ where
         // Fail if the field does not exist on the object type
         if sast::get_field_type(object_type, &field.name).is_none() {
             return Err(QueryExecutionError::UnknownField(
-                field.position.clone(),
+                field.position,
                 object_type.name.clone(),
                 field.name.clone(),
             ));

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -50,9 +50,9 @@ where
         fields: vec![],
     };
 
-    match operation {
+    match *operation {
         // Execute top-level `subscription { ... }` expressions
-        &q::OperationDefinition::Subscription(ref subscription) => {
+        q::OperationDefinition::Subscription(ref subscription) => {
             let source_stream = create_source_event_stream(&ctx, subscription)?;
             let response_stream = map_source_to_response_stream(&ctx, subscription, source_stream)?;
             Ok(response_stream)
@@ -83,7 +83,7 @@ where
         None,
     );
 
-    if grouped_field_set.len() == 0 {
+    if grouped_field_set.is_empty() {
         return Err(SubscriptionError::from(QueryExecutionError::EmptyQuery));
     } else if grouped_field_set.len() > 1 {
         return Err(SubscriptionError::from(

--- a/mock/src/server.rs
+++ b/mock/src/server.rs
@@ -71,7 +71,10 @@ impl<Q> MockGraphQLServer<Q> {
                         id: new_schema.id.clone(),
                         document,
                     },
-                    Err(e) => return Ok(error!(logger, "Error deriving schema {}", e)),
+                    Err(e) => {
+                        error!(logger, "Error deriving schema {}", e);
+                        return Ok(());
+                    }
                 };
                 *schema = Some(derived_schema);
             } else {

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -47,8 +47,8 @@ impl Store for MockStore {
                 .iter()
                 .find(|entity| {
                     let id = entity.get("id").unwrap();
-                    match id {
-                        &Value::String(ref s) => s == &key.id,
+                    match *id {
+                        Value::String(ref s) => s == &key.id,
                         _ => false,
                     }
                 }).map(|entity| Some(entity.clone()))

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -135,12 +135,12 @@ where
         let logger = logger.new(o!("component" => "WasmiModule"));
 
         let module = Module::from_parity_wasm_module(config.data_source.mapping.runtime.clone())
-            .expect(
-                format!(
+            .unwrap_or_else(|_| {
+                panic!(
                     "Wasmi could not interpret module of data source: {}",
                     config.data_source.name
-                ).as_str(),
-            );
+                )
+            });
 
         // Build import resolver
         let mut imports = ImportsBuilder::new();
@@ -225,7 +225,7 @@ where
                     .transaction
                     .deref(),
             ),
-            address: log.address.clone(),
+            address: log.address,
             params,
         };
 

--- a/server/http/src/response.rs
+++ b/server/http/src/response.rs
@@ -22,18 +22,16 @@ impl GraphQLResponse {
     fn status_code_from_result(&self) -> StatusCode {
         match self.result {
             Ok(ref result) => {
-                if let Some(_) = result.errors {
+                if result.errors.is_some() {
                     StatusCode::BAD_REQUEST
                 } else {
                     StatusCode::OK
                 }
             }
-            Err(ref e) => match e {
-                &GraphQLServerError::ClientError(_) | &GraphQLServerError::QueryError(_) => {
-                    StatusCode::BAD_REQUEST
-                }
-                _ => StatusCode::INTERNAL_SERVER_ERROR,
-            },
+            Err(GraphQLServerError::ClientError(_)) | Err(GraphQLServerError::QueryError(_)) => {
+                StatusCode::BAD_REQUEST
+            }
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -95,7 +95,10 @@ impl<Q> GraphQLServer<Q> {
                             id: new_schema.id.clone(),
                             document,
                         },
-                        Err(e) => return Ok(error!(logger, "Error deriving schema {}", e)),
+                        Err(e) => {
+                            error!(logger, "Error deriving schema {}", e);
+                            return Ok(());
+                        }
                     };
 
                     schemas.insert(derived_schema.name.clone(), derived_schema);

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -44,7 +44,7 @@ where
 
     fn index(&self) -> GraphQLServiceResponse {
         let len = self.schemas.read().unwrap().len();
-        match self.schemas.read().unwrap().values().next().clone() {
+        match self.schemas.read().unwrap().values().next() {
             // If there's only 1 schema, redirect to it.
             Some(schema) if len == 1 => Box::new(future::ok(
                 Response::builder()
@@ -106,8 +106,8 @@ where
                     // Run the query using the query runner
                     graphql_runner
                         .run_query(query)
-                        .map_err(|e| GraphQLServerError::from(e))
-                }).then(|result| GraphQLResponse::new(result)),
+                        .map_err(GraphQLServerError::from)
+                }).then(GraphQLResponse::new),
         )
     }
 

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -84,12 +84,13 @@ impl ChainHeadUpdateListener {
                     let value: serde_json::Value =
                         serde_json::from_str(notification.payload.as_str())
                             .expect("Invalid JSON chain head update received from database");
-                    let update: ChainHeadUpdate = serde_json::from_value(value.clone()).expect(
-                        format!(
-                            "Invalid chain head update received from the database: {:?}",
-                            value
-                        ).as_str(),
-                    );
+                    let update: ChainHeadUpdate = serde_json::from_value(value.clone())
+                        .unwrap_or_else(|_| {
+                            panic!(
+                                "Invalid chain head update received from the database: {:?}",
+                                value
+                            )
+                        });
 
                     // Skip networks that we are not interested in
                     if update.network_name != network_name {

--- a/store/postgres/src/entity_changes.rs
+++ b/store/postgres/src/entity_changes.rs
@@ -90,12 +90,13 @@ impl EntityChangeListener {
                     let value: serde_json::Value =
                         serde_json::from_str(notification.payload.as_str())
                             .expect("Invalid JSON entity change data received from database");
-                    let change: EntityChange = serde_json::from_value(value.clone()).expect(
-                        format!(
-                            "Invalid entity change received from the database: {:?}",
-                            value
-                        ).as_str(),
-                    );
+                    let change: EntityChange = serde_json::from_value(value.clone())
+                        .unwrap_or_else(|_| {
+                            panic!(
+                                "Invalid entity change received from the database: {:?}",
+                                value
+                            )
+                        });
 
                     // We'll assume here that if sending fails, this means that the
                     // entity change listener has already been dropped, the receiving

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -26,10 +26,10 @@ enum FilterMode {
 }
 
 /// Adds `filter` to a `SELECT data FROM entities` statement.
-pub(crate) fn store_filter<'a>(
-    query: BoxedSelectStatement<'a, Jsonb, entities::table, Pg>,
+pub(crate) fn store_filter(
+    query: BoxedSelectStatement<Jsonb, entities::table, Pg>,
     filter: StoreFilter,
-) -> Result<BoxedSelectStatement<'a, Jsonb, entities::table, Pg>, UnsupportedFilter> {
+) -> Result<BoxedSelectStatement<Jsonb, entities::table, Pg>, UnsupportedFilter> {
     store_filter_by_mode(query, filter, FilterMode::And)
 }
 
@@ -51,11 +51,11 @@ where
 }
 
 /// Adds `filter` to a `SELECT data FROM entities` statement.
-fn store_filter_by_mode<'a>(
-    query: BoxedSelectStatement<'a, Jsonb, entities::table, Pg>,
+fn store_filter_by_mode(
+    query: BoxedSelectStatement<Jsonb, entities::table, Pg>,
     filter: StoreFilter,
     filter_mode: FilterMode,
-) -> Result<BoxedSelectStatement<'a, Jsonb, entities::table, Pg>, UnsupportedFilter> {
+) -> Result<BoxedSelectStatement<Jsonb, entities::table, Pg>, UnsupportedFilter> {
     Ok(match filter {
         StoreFilter::And(filters) => filters
             .into_iter()

--- a/store/postgres/src/models.rs
+++ b/store/postgres/src/models.rs
@@ -29,7 +29,7 @@ pub struct SqlValue(Value);
 
 impl SqlValue {
     pub fn new_array(values: Vec<Value>) -> Vec<Self> {
-        values.into_iter().map(|value| SqlValue(value)).collect()
+        values.into_iter().map(SqlValue).collect()
     }
 }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -45,7 +45,7 @@ fn initiate_schema(logger: &slog::Logger, conn: &PgConnection) {
     // If there was any migration output, log it now
     if !output.is_empty() {
         debug!(logger, "Postgres migration output";
-               "output" => String::from_utf8(output).unwrap_or(String::from("<unreadable>")));
+               "output" => String::from_utf8(output).unwrap_or_else(|_| String::from("<unreadable>")));
     }
 }
 


### PR DESCRIPTION
There are many, but each is fairly trivial. There are some removed clones and some closured-out code paths which should improve perf a small bit, plus some readability improvements. I've erred on the safe side choosing not to implement API changes for now, where e.g. clippy reports needless ref for copy types.