### PR TITLE
Organize logging by block & by subgraph

### DIFF
--- a/datasource/ethereum/src/block_ingestor.rs
+++ b/datasource/ethereum/src/block_ingestor.rs
@@ -195,7 +195,7 @@ where
         // Retry, but eventually give up.
         // The receipt might be missing because the block was uncled, and the transaction never
         // made it back into the main chain.
-        retry("block ingestor eth_getTransactionReceipt RPC call", logger)
+        retry("block ingestor eth_getTransactionReceipt RPC call", &logger)
             .limit(16)
             .no_logging()
             .timeout_secs(60)

--- a/datasource/ethereum/src/lib.rs
+++ b/datasource/ethereum/src/lib.rs
@@ -11,5 +11,5 @@ mod transport;
 
 pub use self::block_ingestor::BlockIngestor;
 pub use self::block_stream::{BlockStream, BlockStreamBuilder};
-pub use self::ethereum_adapter::{EthereumAdapter, EthereumAdapterConfig};
+pub use self::ethereum_adapter::EthereumAdapter;
 pub use self::transport::{EventLoopHandle, Transport};

--- a/datasource/ethereum/tests/adapter.rs
+++ b/datasource/ethereum/tests/adapter.rs
@@ -18,7 +18,7 @@ use graph::web3::error::{Error, ErrorKind};
 use graph::web3::helpers::*;
 use graph::web3::types::*;
 use graph::web3::{RequestId, Transport};
-use graph_datasource_ethereum::{EthereumAdapter, EthereumAdapterConfig};
+use graph_datasource_ethereum::EthereumAdapter;
 
 pub type Result<T> = Box<Future<Item = T, Error = Error> + Send + 'static>;
 
@@ -128,7 +128,7 @@ fn contract_call() {
     )));
 
     let logger = slog::Logger::root(slog::Discard, o!());
-    let adapter = EthereumAdapter::new(&logger, EthereumAdapterConfig { transport });
+    let adapter = EthereumAdapter::new(transport);
     let balance_of = Function {
         name: "balanceOf".to_owned(),
         inputs: vec![Param {
@@ -150,7 +150,7 @@ fn contract_call() {
         function: function,
         args: vec![Token::Address(holder_addr)],
     };
-    let call_result = adapter.contract_call(call).wait().unwrap();
+    let call_result = adapter.contract_call(&logger, call).wait().unwrap();
 
     assert_eq!(call_result[0], Token::Uint(U256::from(100000)));
 }

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -1,6 +1,7 @@
 use ethabi::{Bytes, Error as ABIError, Function, ParamType, Token};
 use failure::{Error, SyncFailure};
 use futures::Future;
+use slog::Logger;
 use std::collections::HashSet;
 use std::iter::FromIterator;
 use web3::error::Error as Web3Error;
@@ -141,11 +142,13 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     /// connected to.
     fn net_identifiers(
         &self,
+        logger: &Logger,
     ) -> Box<Future<Item = EthereumNetworkIdentifier, Error = Error> + Send>;
 
     /// Find a block by its hash.
     fn block_by_hash(
         &self,
+        logger: &Logger,
         block_hash: H256,
     ) -> Box<Future<Item = Option<EthereumBlock>, Error = Error> + Send>;
 
@@ -160,6 +163,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     /// reorgs.
     fn block_hash_by_block_number(
         &self,
+        logger: &Logger,
         block_number: u64,
     ) -> Box<Future<Item = Option<H256>, Error = Error> + Send>;
 
@@ -175,6 +179,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     /// reorgs.
     fn is_on_main_chain(
         &self,
+        logger: &Logger,
         block_ptr: EthereumBlockPointer,
     ) -> Box<Future<Item = bool, Error = Error> + Send>;
 
@@ -192,6 +197,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     /// node is aware of.
     fn find_first_blocks_with_logs(
         &self,
+        logger: &Logger,
         from: u64,
         to: u64,
         log_filter: EthereumLogFilter,
@@ -200,6 +206,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     /// Call the function of a smart contract.
     fn contract_call(
         &self,
+        logger: &Logger,
         call: EthereumContractCall,
     ) -> Box<Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send>;
 }

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -16,6 +16,7 @@ pub trait RuntimeHost: Send + Sync {
     /// Process an Ethereum event and return a vector of entity operations.
     fn process_log(
         &self,
+        logger: &Logger,
         block: Arc<EthereumBlock>,
         transaction: Arc<Transaction>,
         log: Arc<Log>,
@@ -27,5 +28,10 @@ pub trait RuntimeHostBuilder: Clone + Send + 'static {
     type Host: RuntimeHost;
 
     /// Build a new runtime host for a subgraph data source.
-    fn build(&self, subgraph_manifest: SubgraphManifest, data_source: DataSource) -> Self::Host;
+    fn build(
+        &self,
+        logger: &Logger,
+        subgraph_manifest: SubgraphManifest,
+        data_source: DataSource,
+    ) -> Self::Host;
 }

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -11,7 +11,7 @@ where
     T: RuntimeHostBuilder,
 {
     /// Creates a subgraph instance from a manifest.
-    fn from_manifest(manifest: SubgraphManifest, host_builder: T) -> Self;
+    fn from_manifest(logger: &Logger, manifest: SubgraphManifest, host_builder: T) -> Self;
 
     /// Returns true if the subgraph has a handler for an Ethereum event.
     fn matches_log(&self, log: &Log) -> bool;
@@ -19,6 +19,7 @@ where
     /// Process an Ethereum event and return the resulting entity operations as a future.
     fn process_log(
         &self,
+        logger: &Logger,
         block: Arc<EthereumBlock>,
         transaction: Arc<Transaction>,
         log: Log,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -236,10 +236,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
 
     // Create Ethereum adapter
     let ethereum = Arc::new(graph_datasource_ethereum::EthereumAdapter::new(
-        &logger,
-        graph_datasource_ethereum::EthereumAdapterConfig {
-            transport: transport.clone(),
-        },
+        transport.clone(),
     ));
 
     // Ask Ethereum node for network identifiers
@@ -248,7 +245,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
         "network" => &ethereum_network_name,
         "node" => &ethereum_node_url,
     );
-    let eth_net_identifiers = match ethereum.net_identifiers().wait() {
+    let eth_net_identifiers = match ethereum.net_identifiers(&logger).wait() {
         Ok(net) => {
             info!(
                 logger, "Connected to Ethereum";
@@ -296,12 +293,8 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
         BlockStreamBuilder::new(store.clone(), store.clone(), ethereum.clone());
 
     // Prepare for hosting WASM runtimes and managing subgraph instances
-    let runtime_host_builder = WASMRuntimeHostBuilder::new(
-        &logger,
-        ethereum.clone(),
-        ipfs_client.clone(),
-        store.clone(),
-    );
+    let runtime_host_builder =
+        WASMRuntimeHostBuilder::new(ethereum.clone(), ipfs_client.clone(), store.clone());
     let subgraph_instance_manager = SubgraphInstanceManager::new(
         &logger,
         store.clone(),

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -32,6 +32,7 @@ pub(crate) struct UnresolvedContractCall {
 
 #[derive(Debug)]
 pub(crate) struct EventHandlerContext {
+    logger: Logger,
     block: Arc<EthereumBlock>,
     transaction: Arc<Transaction>,
     entity_operations: Vec<EntityOperation>,

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -172,7 +172,6 @@ where
         let mut externals = HostExternals {
             heap: heap.clone(),
             host_exports: host_exports::HostExports::new(
-                logger.clone(),
                 config.subgraph,
                 config.data_source,
                 config.ethereum_adapter.clone(),

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -32,12 +32,14 @@ struct MockEthereumAdapter {}
 impl EthereumAdapter for MockEthereumAdapter {
     fn net_identifiers(
         &self,
+        _: &Logger,
     ) -> Box<Future<Item = EthereumNetworkIdentifier, Error = Error> + Send> {
         unimplemented!();
     }
 
     fn block_by_hash(
         &self,
+        _: &Logger,
         block_hash: H256,
     ) -> Box<Future<Item = Option<EthereumBlock>, Error = Error> + Send> {
         unimplemented!();
@@ -45,6 +47,7 @@ impl EthereumAdapter for MockEthereumAdapter {
 
     fn block_hash_by_block_number(
         &self,
+        _: &Logger,
         block_number: u64,
     ) -> Box<Future<Item = Option<H256>, Error = Error> + Send> {
         unimplemented!();
@@ -52,6 +55,7 @@ impl EthereumAdapter for MockEthereumAdapter {
 
     fn is_on_main_chain(
         &self,
+        _: &Logger,
         block_ptr: EthereumBlockPointer,
     ) -> Box<Future<Item = bool, Error = Error> + Send> {
         unimplemented!();
@@ -59,6 +63,7 @@ impl EthereumAdapter for MockEthereumAdapter {
 
     fn find_first_blocks_with_logs(
         &self,
+        _: &Logger,
         from: u64,
         to: u64,
         log_filter: EthereumLogFilter,
@@ -68,6 +73,7 @@ impl EthereumAdapter for MockEthereumAdapter {
 
     fn contract_call(
         &self,
+        _: &Logger,
         call: EthereumContractCall,
     ) -> Box<Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send> {
         unimplemented!();

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -81,11 +81,11 @@ impl<Q, S> GraphQLServer<Q, S> {
         let schemas = self.schemas.clone();
 
         tokio::spawn(stream.for_each(move |event| {
-            info!(logger, "Received schema event");
-
             let mut schemas = schemas.write().unwrap();
             match event {
                 SchemaEvent::SchemaAdded(new_schema) => {
+                    debug!(logger, "Received SchemaAdded event"; "id" => &new_schema.id);
+
                     let derived_schema = match api_schema(&new_schema.document) {
                         Ok(document) => Schema {
                             id: new_schema.id.clone(),
@@ -100,6 +100,8 @@ impl<Q, S> GraphQLServer<Q, S> {
                     schemas.insert(new_schema.id.clone(), derived_schema);
                 }
                 SchemaEvent::SchemaRemoved(id) => {
+                    debug!(logger, "Received SchemaRemoved event"; "id" => &id);
+
                     // If the event got this far, the subgraph must be hosted.
                     schemas.remove(&id).expect("subgraph not hosted");
                 }

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -66,10 +66,10 @@ where
         let mut subgraphs = self.subgraphs.clone();
 
         tokio::spawn(stream.for_each(move |event| {
-            info!(logger, "Received schema event");
-
             match event {
                 SchemaEvent::SchemaAdded(new_schema) => {
+                    debug!(logger, "Received SchemaAdded event"; "id" => &new_schema.id);
+
                     let derived_schema = match api_schema(&new_schema.document) {
                         Ok(document) => Schema {
                             id: new_schema.id.clone(),
@@ -88,6 +88,8 @@ where
                     );
                 }
                 SchemaEvent::SchemaRemoved(id) => {
+                    debug!(logger, "Received SchemaRemoved event"; "id" => &id);
+
                     // On removal, the `GuardedSchema` will be dropped and all
                     // connections to it will be terminated.
                     subgraphs.remove_id(id);

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -191,8 +191,8 @@ impl Store {
         let subscriptions = self.subscriptions.clone();
 
         tokio::spawn(entity_changes.for_each(move |change| {
-            debug!(logger, "Entity change";
-                           "subgraph" => &change.subgraph,
+            trace!(logger, "Received entity change event";
+                           "subgraph_id" => &change.subgraph,
                            "entity" => &change.entity,
                            "id" => &change.id);
 


### PR DESCRIPTION
Create one new Logger per subgraph, and use that Logger (or a descendant) in every component related to the processing of that subgraph.
Also, create a descendant of the subgraph Logger for each block to encapsulate the processing of one block of events.

Resolves #529 

Example log output (note how everything has a `subgraph_id` property):

```
component: SubgraphInstanceManager
 subgraph_id: QmaMUYb8GBZBrK6664P822xYyfN2nqR5VVfpkWFyvtwyD9
  Nov 01 14:25:47.300 INFO Start subgraph
  component: RuntimeHost
   data_source: LANDRegistry
    Nov 01 14:25:47.312 DEBG Start WASM runtime
  component: BlockStream
   Nov 01 14:25:47.313 DEBG Identify next step
   Nov 01 14:25:47.324 DEBG Chain head pointer, number: 6625114, hash: 0xd4bb84cfd456636d30530db946346766da72fbb6538f7504401b5a951e55c414
   Nov 01 14:25:47.324 DEBG Subgraph pointer, number: 5295698, hash: 0x6983e5d2a6257c506a9f51667eeae5b2a87e0f1bf9405b998d7d43a3d4ef0041
  component: RuntimeHost
   data_source: Marketplace
    Nov 01 14:25:47.324 DEBG Start WASM runtime
  component: BlockStream
   Nov 01 14:25:47.466 DEBG Finding next blocks with relevant events...
   Nov 01 14:25:47.467 DEBG Starting request for logs in block range [5295699,5305698]
   Nov 01 14:25:47.467 DEBG Starting request for logs in block range [5305699,5315698]
   Nov 01 14:25:47.467 DEBG Starting request for logs in block range [5315699,5325698]
   Nov 01 14:25:47.467 DEBG Starting request for logs in block range [5325699,5335698]
   Nov 01 14:25:47.467 DEBG Starting request for logs in block range [5335699,5345698]
   Nov 01 14:25:49.080 DEBG Received logs for [5325699, 5335698].
   Nov 01 14:25:49.291 DEBG Received logs for [5335699, 5345698].
   Nov 01 14:25:50.863 DEBG Received logs for [5315699, 5325698].
   Nov 01 14:25:51.171 DEBG Received logs for [5305699, 5315698].
   Nov 01 14:25:51.847 DEBG Received logs for [5295699, 5305698].
   Nov 01 14:25:52.334 DEBG Done finding next blocks.
   Nov 01 14:25:52.334 DEBG Found 3822 block(s) with events.
   Nov 01 14:25:52.335 DEBG Requesting 50 block(s) in parallel...
  block_number: 5295699
   block_hash: 0x08a70b69aa2662724afc6b53453f84cb56043188d0a4c392883023a364acf165
    Nov 01 14:25:52.713 INFO Processing events from block
    Nov 01 14:25:52.714 INFO 2 events found for this subgraph
    Nov 01 14:25:52.715 DEBG Process Ethereum event, handler: handleAuctionCreated, signature: AuctionCreated(bytes32,uint256,address,uint256,uint256)
    Nov 01 14:25:52.987 DEBG Process Ethereum event, handler: handleAuctionCreated, signature: AuctionCreated(bytes32,uint256,address,uint256,uint256)
    Nov 01 14:25:53.291 INFO Applying 4 entity operation(s)
  component: BlockStream
   Nov 01 14:25:54.480 DEBG Skipping 1 block(s) with no relevant events...
  block_number: 5295701
   block_hash: 0x007936c7e3757e1b9889746281ea2d56b51d233b034a5aa67c2ca29f143decd5
    Nov 01 14:25:54.485 INFO Processing events from block
    Nov 01 14:25:54.485 INFO 1 event found for this subgraph
    Nov 01 14:25:54.487 DEBG Process Ethereum event, handler: handleAuctionCreated, signature: AuctionCreated(bytes32,uint256,address,uint256,uint256)
    Nov 01 14:25:54.763 INFO Applying 2 entity operation(s)
  component: BlockStream
   Nov 01 14:25:55.062 DEBG Skipping 1 block(s) with no relevant events...
  block_number: 5295703
   block_hash: 0x76c484b5722d6f4339d4b5bc5d29d5b3f33107301e48c425a17e77653dcb5027
    Nov 01 14:25:55.065 INFO Processing events from block
    Nov 01 14:25:55.065 INFO 1 event found for this subgraph
    Nov 01 14:25:55.067 DEBG Process Ethereum event, handler: handleLandUpdate, signature: Update(uint256,address,address,string)
    Nov 01 14:25:55.265 DEBG Call smart contract, function: decodeTokenId, contract: LANDRegistry, address: 0xf87e…5d4d
    Nov 01 14:26:05.763 INFO Applying 2 entity operation(s)
```