### PR TITLE
runtime: `big_int_to_hex` prints in big endian and trims zeros

### DIFF
--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -27,6 +27,10 @@ impl BigInt {
         self.0.to_bytes_le()
     }
 
+    pub fn to_bytes_be(&self) -> (BigIntSign, Vec<u8>) {
+        self.0.to_bytes_be()
+    }
+
     pub fn to_signed_bytes_le(&self) -> Vec<u8> {
         self.0.to_signed_bytes_le()
     }

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -238,12 +238,18 @@ where
         format!("{}", n)
     }
 
+    /// Prints the module of `n` in hex.
+    /// Integers are encoded using the least amount of digits (no leading zero digits).
+    /// Their encoding may be of uneven length. The number zero encodes as "0x0".
+    ///
+    /// https://godoc.org/github.com/ethereum/go-ethereum/common/hexutil#hdr-Encoding_Rules
     pub(crate) fn big_int_to_hex(&self, n: BigInt) -> String {
-        let bytes = n.to_bytes_le().1;
+        if n == 0.into() {
+            return "0x0".to_string();
+        }
 
-        // Even an empty string must be prefixed with `0x`.
-        // Encodes each byte as a two hex digits.
-        format!("0x{}", ::hex::encode(bytes))
+        let bytes = n.to_bytes_be().1;
+        format!("0x{}", ::hex::encode(bytes).trim_left_matches('0'))
     }
 
     pub(crate) fn string_to_h160(

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -425,7 +425,7 @@ fn big_int_to_hex() {
         .try_into()
         .expect("call did not return pointer");
     let zero_hex_str: String = module.heap.asc_get(zero_hex_ptr);
-    assert_eq!(zero_hex_str, "0x00");
+    assert_eq!(zero_hex_str, "0x0");
 
     // Convert 1 to hex
     let one = BigInt::from_unsigned_u256(&U256::one());
@@ -441,7 +441,7 @@ fn big_int_to_hex() {
         .try_into()
         .expect("call did not return pointer");
     let one_hex_str: String = module.heap.asc_get(one_hex_ptr);
-    assert_eq!(one_hex_str, "0x01");
+    assert_eq!(one_hex_str, "0x1");
 
     // Convert U256::max_value() to hex
     let u256_max = BigInt::from_unsigned_u256(&U256::max_value());


### PR DESCRIPTION
Resolves #481 