### PR TITLE
Add __typename fields to the API schema, set __typename in store.set()

### DIFF
--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -103,9 +103,33 @@ pub fn get_interface_type_definitions<'a>(schema: &'a Document) -> Vec<&'a Inter
         }).collect()
 }
 
+/// Returns all interface definitions in the schema.
+pub fn get_interface_type_definitions_mut<'a>(
+    schema: &'a mut Document,
+) -> Vec<&'a mut InterfaceType> {
+    schema
+        .definitions
+        .iter_mut()
+        .filter_map(|d| match d {
+            Definition::TypeDefinition(TypeDefinition::Interface(t)) => Some(t),
+            _ => None,
+        }).collect()
+}
+
 /// Returns the type of a field of an object type.
 pub fn get_field_type<'a>(object_type: &'a ObjectType, name: &Name) -> Option<&'a Field> {
     object_type.fields.iter().find(|field| &field.name == name)
+}
+
+/// Returns the type of a field of an interface type.
+pub fn get_interface_field_type<'a>(
+    interface_type: &'a InterfaceType,
+    name: &Name,
+) -> Option<&'a Field> {
+    interface_type
+        .fields
+        .iter()
+        .find(|field| &field.name == name)
 }
 
 /// Returns the value type for a GraphQL field type.

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -92,6 +92,17 @@ pub fn get_object_type_definitions<'a>(schema: &'a Document) -> Vec<&'a ObjectTy
         }).collect()
 }
 
+/// Returns all object type definitions in the schema.
+pub fn get_object_type_definitions_mut<'a>(schema: &'a mut Document) -> Vec<&'a mut ObjectType> {
+    schema
+        .definitions
+        .iter_mut()
+        .filter_map(|d| match d {
+            Definition::TypeDefinition(TypeDefinition::Object(t)) => Some(t),
+            _ => None,
+        }).collect()
+}
+
 /// Returns all interface definitions in the schema.
 pub fn get_interface_type_definitions<'a>(schema: &'a Document) -> Vec<&'a InterfaceType> {
     schema

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -71,7 +71,7 @@ pub fn get_root_subscription_type(schema: &Document) -> Option<&ObjectType> {
 }
 
 /// Returns all type definitions in the schema.
-pub fn get_type_definitions<'a>(schema: &'a Document) -> Vec<&'a TypeDefinition> {
+pub fn get_type_definitions(schema: &Document) -> Vec<&TypeDefinition> {
     schema
         .definitions
         .iter()
@@ -82,7 +82,7 @@ pub fn get_type_definitions<'a>(schema: &'a Document) -> Vec<&'a TypeDefinition>
 }
 
 /// Returns all object type definitions in the schema.
-pub fn get_object_type_definitions<'a>(schema: &'a Document) -> Vec<&'a ObjectType> {
+pub fn get_object_type_definitions(schema: &Document) -> Vec<&ObjectType> {
     schema
         .definitions
         .iter()
@@ -93,7 +93,7 @@ pub fn get_object_type_definitions<'a>(schema: &'a Document) -> Vec<&'a ObjectTy
 }
 
 /// Returns all object type definitions in the schema.
-pub fn get_object_type_definitions_mut<'a>(schema: &'a mut Document) -> Vec<&'a mut ObjectType> {
+pub fn get_object_type_definitions_mut(schema: &mut Document) -> Vec<&mut ObjectType> {
     schema
         .definitions
         .iter_mut()
@@ -104,7 +104,7 @@ pub fn get_object_type_definitions_mut<'a>(schema: &'a mut Document) -> Vec<&'a 
 }
 
 /// Returns all interface definitions in the schema.
-pub fn get_interface_type_definitions<'a>(schema: &'a Document) -> Vec<&'a InterfaceType> {
+pub fn get_interface_type_definitions(schema: &Document) -> Vec<&InterfaceType> {
     schema
         .definitions
         .iter()
@@ -115,9 +115,7 @@ pub fn get_interface_type_definitions<'a>(schema: &'a Document) -> Vec<&'a Inter
 }
 
 /// Returns all interface definitions in the schema.
-pub fn get_interface_type_definitions_mut<'a>(
-    schema: &'a mut Document,
-) -> Vec<&'a mut InterfaceType> {
+pub fn get_interface_type_definitions_mut(schema: &mut Document) -> Vec<&mut InterfaceType> {
     schema
         .definitions
         .iter_mut()

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -71,11 +71,23 @@ where
         id: String,
         mut data: HashMap<String, Value>,
     ) -> Result<(), HostExportError<impl ExportError>> {
+        // Automatically add an "id" value
         match data.insert("id".to_string(), Value::String(id.clone())) {
             Some(ref v) if v != &Value::String(id.clone()) => {
                 return Err(HostExportError(format!(
                     "Conflicting 'id' value set by mapping for {} entity: {} != {}",
                     entity, v, id,
+                )))
+            }
+            _ => (),
+        }
+
+        // Automatically add a "__typename" value
+        match data.insert("__typename".to_string(), Value::String(entity.clone())) {
+            Some(ref v) if v != &Value::String(entity.clone()) => {
+                return Err(HostExportError(format!(
+                    "Conflicting '__typename' value set by mapping for {} entity: {} != {}",
+                    entity, v, entity
                 )))
             }
             _ => (),

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -204,8 +204,8 @@ mod tests {
 
                     // The output schema must include the input schema types
                     assert_eq!(
-                        ast::get_named_type(&input_schema.document, &"User".to_string()),
-                        ast::get_named_type(&output_schema.document, &"User".to_string())
+                        ast::get_named_type(&input_schema.document, &"User".to_string()).is_some(),
+                        ast::get_named_type(&output_schema.document, &"User".to_string()).is_some(),
                     );
 
                     // The output schema must include a Query type


### PR DESCRIPTION
Resolves #431, allowing everyone to use Graph Node with Apollo, without having to disable the `addTypename` flag of `InMemoryCache` (see https://www.apollographql.com/docs/react/advanced/caching.html#configuration).