### PR TITLE
Store updates: log event source of removal operations and make string formatting of block hashes consistent

### DIFF
--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -328,7 +328,7 @@ impl Store {
                 entity.eq(op_entity),
                 subgraph.eq(op_subgraph),
                 data.eq(&updated_json),
-                event_source.eq(block_ptr_to.hash.to_string()),
+                event_source.eq(block_ptr_to.hash_hex()),
             )).on_conflict((id, entity, subgraph))
             .do_update()
             .set((
@@ -336,7 +336,7 @@ impl Store {
                 entity.eq(op_entity),
                 subgraph.eq(op_subgraph),
                 data.eq(&updated_json),
-                event_source.eq(block_ptr_to.hash.to_string()),
+                event_source.eq(block_ptr_to.hash_hex()),
             )).execute(conn)
             .map_err(|e| {
                 format_err!(


### PR DESCRIPTION
This PR uses `set_config()` to set a run-time configuration parameter, `current_event_source`, without it the` log_delete` trigger procedure cannot track the event source.

Revert operations were failing because block hashes were being stored in the db with differing formats, now all store operations convert the block hash to string using `hash_hex()`.