### PR TITLE
Rewrite tests based on new Store, SubgraphInstanceManager, RuntimeHost, etc interfaces

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -108,7 +108,7 @@ pub struct EntityChange {
 pub type EntityChangeStream = Box<Stream<Item = EntityChange, Error = ()> + Send>;
 
 /// An entity operation that can be transacted into the store.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum EntityOperation {
     /// An entity is created or updated.
     Set { key: EntityKey, data: Entity },

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -67,8 +67,7 @@ pub mod prelude {
     pub use components::server::subscription::SubscriptionServer;
     pub use components::store::{
         ChainStore, EntityChange, EntityChangeOperation, EntityChangeStream, EntityOperation,
-        EventSource, Store, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange,
-        SubgraphEntityPair,
+        Store, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange, SubgraphEntityPair,
     };
     pub use components::subgraph::{
         RuntimeHost, RuntimeHostBuilder, SchemaEvent, SubgraphInstance, SubgraphInstanceManager,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -66,8 +66,9 @@ pub mod prelude {
     pub use components::server::query::GraphQLServer;
     pub use components::server::subscription::SubscriptionServer;
     pub use components::store::{
-        ChainStore, EntityChange, EntityChangeOperation, EntityChangeStream, EntityOperation,
-        Store, StoreFilter, StoreKey, StoreOrder, StoreQuery, StoreRange, SubgraphEntityPair,
+        ChainStore, EntityChange, EntityChangeOperation, EntityChangeStream, EntityFilter,
+        EntityKey, EntityOperation, EntityOrder, EntityQuery, EntityRange, Store,
+        SubgraphEntityPair,
     };
     pub use components::subgraph::{
         RuntimeHost, RuntimeHostBuilder, SchemaEvent, SubgraphInstance, SubgraphInstanceManager,

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -371,13 +371,6 @@ mod tests {
 
     #[test]
     fn build_query_parses_order_by_from_enum_values_correctly() {
-        let order_test = build_query(
-            &default_object(),
-            &HashMap::from_iter(
-                vec![(&"orderBy".to_string(), q::Value::Enum("name".to_string()))].into_iter(),
-            ),
-        ).unwrap()
-        .order_by;
         assert_eq!(
             build_query(
                 &default_object(),

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -244,11 +244,11 @@ where
             return Ok(self
                 .store
                 .get(StoreKey {
-                    subgraph: parse_subgraph_id(object_type).unwrap_or_else(|_| {
+                    subgraph_id: parse_subgraph_id(object_type).unwrap_or_else(|_| {
                         panic!("Failed to get subgraph ID from type: {}", object_type.name)
                     }),
-                    entity: object_type.name.to_owned(),
-                    id: id.to_owned(),
+                    entity_type: object_type.name.to_owned(),
+                    entity_id: id.to_owned(),
                 })?.map_or(q::Value::Null, |entity| entity.into()));
         }
 
@@ -257,11 +257,11 @@ where
                 Some(q::Value::String(id)) => Ok(self
                     .store
                     .get(StoreKey {
-                        subgraph: parse_subgraph_id(object_type).unwrap_or_else(|_| {
+                        subgraph_id: parse_subgraph_id(object_type).unwrap_or_else(|_| {
                             panic!("Failed to get subgraph ID from type: {}", object_type.name)
                         }),
-                        entity: object_type.name.to_owned(),
-                        id: id.to_owned(),
+                        entity_type: object_type.name.to_owned(),
+                        entity_id: id.to_owned(),
                     })?.map_or(q::Value::Null, |entity| entity.into())),
                 _ => Ok(q::Value::Null),
             },

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -199,7 +199,7 @@ impl Store for TestStore {
         unimplemented!()
     }
 
-    fn get(&self, key: StoreKey) -> Result<Option<Entity>, QueryExecutionError> {
+    fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError> {
         self.entities
             .iter()
             .find(|entity| {
@@ -213,8 +213,8 @@ impl Store for TestStore {
             )
     }
 
-    fn find(&self, query: StoreQuery) -> Result<Vec<Entity>, QueryExecutionError> {
-        let entity_name = Value::String(query.entity.clone());
+    fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
+        let entity_name = Value::String(query.entity_type.clone());
 
         let entities = self
             .entities
@@ -231,16 +231,16 @@ impl Store for TestStore {
                     .filter
                     .as_ref()
                     .and_then(|filter| match filter {
-                        StoreFilter::And(filters) => filters.get(0),
+                        EntityFilter::And(filters) => filters.get(0),
                         _ => None,
                     }).map(|filter| match filter {
-                        StoreFilter::Equal(k, v) => entity.get(k) == Some(&v),
-                        StoreFilter::Contains(k, v) => match entity.get(k) {
+                        EntityFilter::Equal(k, v) => entity.get(k) == Some(&v),
+                        EntityFilter::Contains(k, v) => match entity.get(k) {
                             Some(Value::List(values)) => values.contains(v),
                             _ => false,
                         },
-                        StoreFilter::Or(filters) => filters.iter().any(|filter| match filter {
-                            StoreFilter::Equal(k, v) => entity.get(k) == Some(&v),
+                        EntityFilter::Or(filters) => filters.iter().any(|filter| match filter {
+                            EntityFilter::Equal(k, v) => entity.get(k) == Some(&v),
                             _ => unimplemented!(),
                         }),
                         _ => unimplemented!(),

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate failure;
 extern crate futures;
 extern crate graphql_parser;
@@ -9,10 +8,8 @@ extern crate graph_core;
 extern crate graph_graphql;
 
 use graphql_parser::query as q;
-use std::sync::Mutex;
 
 use graph::prelude::*;
-use graph::web3::types::{Block, Transaction, H256};
 use graph_graphql::prelude::*;
 
 fn test_schema() -> Schema {
@@ -252,47 +249,6 @@ impl Store for TestStore {
     }
 }
 
-#[cfg(any())]
-impl ChainStore for TestStore {
-    type ChainHeadUpdateListener = graph::store::ChainHeadUpdateListener;
-
-    fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error> {
-        unimplemented!()
-    }
-
-    fn upsert_blocks<'a, B: Stream<Item = EthereumBlock, Error = Error> + Send + 'a>(
-        &self,
-        _: B,
-    ) -> Box<Future<Item = (), Error = Error> + Send + 'a> {
-        unimplemented!()
-    }
-
-    fn attempt_chain_head_update(&self, _: u64) -> Result<Vec<H256>, Error> {
-        unimplemented!()
-    }
-
-    fn chain_head_updates(&self) -> Self::ChainHeadUpdateListener {
-        unimplemented!()
-    }
-
-    fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error> {
-        unimplemented!()
-    }
-
-    fn block(&self, _: H256) -> Result<Option<EthereumBlock>, Error> {
-        unimplemented!()
-    }
-
-    fn ancestor_block(
-        &self,
-        _: EthereumBlockPointer,
-        _: u64,
-    ) -> Result<Option<EthereumBlock>, Error> {
-        unimplemented!()
-    }
-}
-
-#[cfg(any())]
 fn execute_query_document(query: q::Document) -> QueryResult {
     let query = Query {
         schema: test_schema(),
@@ -301,7 +257,7 @@ fn execute_query_document(query: q::Document) -> QueryResult {
     };
 
     let logger = Logger::root(slog::Discard, o!());
-    let store = Arc::new(Mutex::new(TestStore::new()));
+    let store = Arc::new(TestStore::new());
     let store_resolver = StoreResolver::new(&logger, store);
 
     let options = QueryExecutionOptions {
@@ -313,7 +269,6 @@ fn execute_query_document(query: q::Document) -> QueryResult {
 }
 
 #[test]
-#[cfg(any())]
 fn can_query_one_to_one_relationship() {
     let result = execute_query_document(
         graphql_parser::parse_query(
@@ -380,7 +335,6 @@ fn can_query_one_to_one_relationship() {
 }
 
 #[test]
-#[cfg(any())]
 fn can_query_one_to_many_relationships_in_both_directions() {
     let result = execute_query_document(
         graphql_parser::parse_query(
@@ -475,7 +429,6 @@ fn can_query_one_to_many_relationships_in_both_directions() {
 }
 
 #[test]
-#[cfg(any())]
 fn can_query_many_to_many_relationship() {
     let result = execute_query_document(
         graphql_parser::parse_query(

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -11,7 +11,6 @@ extern crate graph_graphql;
 use graphql_parser::query as q;
 use std::sync::Mutex;
 
-use graph::components::store::EventSource;
 use graph::prelude::*;
 use graph::web3::types::{Block, Transaction, H256};
 use graph_graphql::prelude::*;
@@ -148,7 +147,7 @@ impl Store for TestStore {
         unimplemented!()
     }
 
-    fn write_subgraph_name(&self, _: String, id: Option<SubgraphId>) -> Result<(), Error> {
+    fn write_subgraph_name(&self, _: String, _: Option<SubgraphId>) -> Result<(), Error> {
         unimplemented!()
     }
 
@@ -204,8 +203,8 @@ impl Store for TestStore {
         self.entities
             .iter()
             .find(|entity| {
-                entity.get("id") == Some(&Value::String(key.id.clone()))
-                    && entity.get("__typename") == Some(&Value::String(key.entity.clone()))
+                entity.get("id") == Some(&Value::String(key.entity_id.clone()))
+                    && entity.get("__typename") == Some(&Value::String(key.entity_type.clone()))
             }).map_or(
                 Err(QueryExecutionError::ResolveEntitiesError(String::from(
                     "Mock get query error",

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -1,0 +1,53 @@
+use futures::sync::mpsc::{channel, Receiver, Sender};
+
+use graph::prelude::*;
+
+pub struct MockBlockStream {
+    chain_head_update_sink: Sender<ChainHeadUpdate>,
+    chain_head_update_stream: Receiver<ChainHeadUpdate>,
+}
+
+impl MockBlockStream {
+    fn new() -> Self {
+        let (chain_head_update_sink, chain_head_update_stream) = channel(100);
+
+        Self {
+            chain_head_update_sink,
+            chain_head_update_stream,
+        }
+    }
+}
+
+impl Stream for MockBlockStream {
+    type Item = EthereumBlock;
+    type Error = Error;
+
+    fn poll(&mut self) -> Result<Async<Option<EthereumBlock>>, Error> {
+        Ok(Async::Ready(None))
+    }
+}
+
+impl EventConsumer<ChainHeadUpdate> for MockBlockStream {
+    fn event_sink(&self) -> Box<Sink<SinkItem = ChainHeadUpdate, SinkError = ()> + Send> {
+        Box::new(self.chain_head_update_sink.clone().sink_map_err(|_| ()))
+    }
+}
+
+impl BlockStream for MockBlockStream {}
+
+#[derive(Clone)]
+pub struct MockBlockStreamBuilder;
+
+impl MockBlockStreamBuilder {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl BlockStreamBuilder for MockBlockStreamBuilder {
+    type Stream = MockBlockStream;
+
+    fn from_subgraph(&self, manifest: &SubgraphManifest, logger: Logger) -> Self::Stream {
+        unimplemented!()
+    }
+}

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -4,7 +4,7 @@ use graph::prelude::*;
 
 pub struct MockBlockStream {
     chain_head_update_sink: Sender<ChainHeadUpdate>,
-    chain_head_update_stream: Receiver<ChainHeadUpdate>,
+    _chain_head_update_stream: Receiver<ChainHeadUpdate>,
 }
 
 impl MockBlockStream {
@@ -13,7 +13,7 @@ impl MockBlockStream {
 
         Self {
             chain_head_update_sink,
-            chain_head_update_stream,
+            _chain_head_update_stream: chain_head_update_stream,
         }
     }
 }
@@ -47,7 +47,7 @@ impl MockBlockStreamBuilder {
 impl BlockStreamBuilder for MockBlockStreamBuilder {
     type Stream = MockBlockStream;
 
-    fn from_subgraph(&self, manifest: &SubgraphManifest, logger: Logger) -> Self::Stream {
-        unimplemented!()
+    fn from_subgraph(&self, _manifest: &SubgraphManifest, _logger: Logger) -> Self::Stream {
+        MockBlockStream::new()
     }
 }

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -4,11 +4,13 @@ extern crate graph;
 extern crate graph_graphql;
 extern crate graphql_parser;
 
+mod block_stream;
 mod graphql;
 mod server;
 mod store;
 mod subgraph;
 
+pub use self::block_stream::{MockBlockStream, MockBlockStreamBuilder};
 pub use self::graphql::MockGraphQlRunner;
 pub use self::server::MockGraphQLServer;
 pub use self::store::{FakeStore, MockStore};

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -47,7 +47,7 @@ impl MockStore {
 }
 
 impl Store for MockStore {
-    fn get(&self, key: StoreKey) -> Result<Option<Entity>, QueryExecutionError> {
+    fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError> {
         if key.entity_type == "User" {
             self.entities
                 .iter()
@@ -64,7 +64,7 @@ impl Store for MockStore {
         }
     }
 
-    fn find(&self, _query: StoreQuery) -> Result<Vec<Entity>, QueryExecutionError> {
+    fn find(&self, _query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
         Ok(self.entities.clone())
     }
 
@@ -194,11 +194,11 @@ impl ChainStore for MockStore {
 pub struct FakeStore;
 
 impl Store for FakeStore {
-    fn get(&self, _: StoreKey) -> Result<Option<Entity>, QueryExecutionError> {
+    fn get(&self, _: EntityKey) -> Result<Option<Entity>, QueryExecutionError> {
         unimplemented!();
     }
 
-    fn find(&self, _: StoreQuery) -> Result<Vec<Entity>, QueryExecutionError> {
+    fn find(&self, _: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
         unimplemented!();
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -48,13 +48,13 @@ impl MockStore {
 
 impl Store for MockStore {
     fn get(&self, key: StoreKey) -> Result<Option<Entity>, QueryExecutionError> {
-        if key.entity == "User" {
+        if key.entity_type == "User" {
             self.entities
                 .iter()
                 .find(|entity| {
                     let id = entity.get("id").unwrap();
                     match *id {
-                        Value::String(ref s) => s == &key.id,
+                        Value::String(ref s) => s == &key.entity_id,
                         _ => false,
                     }
                 }).map(|entity| Some(entity.clone()))

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -95,27 +95,27 @@ where
 
     pub(crate) fn store_set(
         &mut self,
-        entity: String,
-        id: String,
+        entity_type: String,
+        entity_id: String,
         mut data: HashMap<String, Value>,
     ) -> Result<(), HostExportError<impl ExportError>> {
         // Automatically add an "id" value
-        match data.insert("id".to_string(), Value::String(id.clone())) {
-            Some(ref v) if v != &Value::String(id.clone()) => {
+        match data.insert("id".to_string(), Value::String(entity_id.clone())) {
+            Some(ref v) if v != &Value::String(entity_id.clone()) => {
                 return Err(HostExportError(format!(
                     "Conflicting 'id' value set by mapping for {} entity: {} != {}",
-                    entity, v, id,
+                    entity_type, v, entity_id,
                 )))
             }
             _ => (),
         }
 
         // Automatically add a "__typename" value
-        match data.insert("__typename".to_string(), Value::String(entity.clone())) {
-            Some(ref v) if v != &Value::String(entity.clone()) => {
+        match data.insert("__typename".to_string(), Value::String(entity_type.clone())) {
+            Some(ref v) if v != &Value::String(entity_type.clone()) => {
                 return Err(HostExportError(format!(
                     "Conflicting '__typename' value set by mapping for {} entity: {} != {}",
-                    entity, v, entity
+                    entity_type, v, entity_type
                 )))
             }
             _ => (),
@@ -126,36 +126,36 @@ where
             .map(|ctx| &mut ctx.entity_operations)
             .expect("processing event without context")
             .push(EntityOperation::Set {
-                subgraph: self.subgraph.id.clone(),
-                entity,
-                id,
+                subgraph_id: self.subgraph.id.clone(),
+                entity_type,
+                entity_id,
                 data: Entity::from(data),
             });
 
         Ok(())
     }
 
-    pub(crate) fn store_remove(&mut self, entity: String, id: String) {
+    pub(crate) fn store_remove(&mut self, entity_type: String, entity_id: String) {
         self.ctx
             .as_mut()
             .map(|ctx| &mut ctx.entity_operations)
             .expect("processing event without context")
             .push(EntityOperation::Remove {
-                subgraph: self.subgraph.id.clone(),
-                entity,
-                id,
+                subgraph_id: self.subgraph.id.clone(),
+                entity_type,
+                entity_id,
             });
     }
 
     pub(crate) fn store_get(
         &self,
-        entity: String,
-        id: String,
+        entity_type: String,
+        entity_id: String,
     ) -> Result<Option<Entity>, HostExportError<impl ExportError>> {
         let store_key = StoreKey {
-            subgraph: self.subgraph.id.clone(),
-            entity,
-            id,
+            subgraph_id: self.subgraph.id.clone(),
+            entity_type,
+            entity_id,
         };
 
         // Get all operations for this entity

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -1,7 +1,7 @@
 use ethabi::Token;
 use futures::sync::oneshot;
 use graph::components::ethereum::*;
-use graph::components::store::StoreKey;
+use graph::components::store::EntityKey;
 use graph::data::store::scalar;
 use graph::data::subgraph::DataSource;
 use graph::prelude::*;
@@ -126,9 +126,11 @@ where
             .map(|ctx| &mut ctx.entity_operations)
             .expect("processing event without context")
             .push(EntityOperation::Set {
-                subgraph_id: self.subgraph.id.clone(),
-                entity_type,
-                entity_id,
+                key: EntityKey {
+                    subgraph_id: self.subgraph.id.clone(),
+                    entity_type,
+                    entity_id,
+                },
                 data: Entity::from(data),
             });
 
@@ -141,9 +143,11 @@ where
             .map(|ctx| &mut ctx.entity_operations)
             .expect("processing event without context")
             .push(EntityOperation::Remove {
-                subgraph_id: self.subgraph.id.clone(),
-                entity_type,
-                entity_id,
+                key: EntityKey {
+                    subgraph_id: self.subgraph.id.clone(),
+                    entity_type,
+                    entity_id,
+                },
             });
     }
 
@@ -152,7 +156,7 @@ where
         entity_type: String,
         entity_id: String,
     ) -> Result<Option<Entity>, HostExportError<impl ExportError>> {
-        let store_key = StoreKey {
+        let store_key = EntityKey {
             subgraph_id: self.subgraph.id.clone(),
             entity_type,
             entity_id,

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -160,14 +160,8 @@ where
     }
 }
 
-#[test]
-fn call_invalid_event_handler_and_dont_crash() {
-    // This test passing means the module doesn't crash when an invalid
-    // event handler is called or when the event handler execution fails.
-
-    let mut module = test_module(mock_data_source("wasm_test/example_event_handler.wasm"));
-
-    // Create mock Ethereum data
+/// Create mock Ethereum data
+fn generate_fake_block() -> (EthereumBlock, Transaction, Log) {
     let block_hash = H256::random();
     let transaction = Transaction {
         hash: H256::random(),
@@ -214,11 +208,23 @@ fn call_invalid_event_handler_and_dont_crash() {
             total_difficulty: 0.into(),
             seal_fields: vec![],
             uncles: vec![],
-            transactions: vec![],
+            transactions: vec![transaction.clone()],
             size: None,
         },
         transaction_receipts: vec![],
     };
+
+    (block, transaction, log)
+}
+
+#[test]
+fn call_invalid_event_handler_and_dont_crash() {
+    // This test passing means the module doesn't crash when an invalid
+    // event handler is called or when the event handler execution fails.
+
+    let mut module = test_module(mock_data_source("wasm_test/example_event_handler.wasm"));
+
+    let (block, transaction, log) = generate_fake_block();
 
     let ctx = EventHandlerContext {
         logger: Logger::root(slog::Discard, o!()),
@@ -252,58 +258,7 @@ fn call_event_handler_and_receive_store_event() {
 
     let mut module = test_module(mock_data_source("wasm_test/example_event_handler.wasm"));
 
-    // Create mock Ethereum data
-    let block_hash = H256::random();
-    let transaction = Transaction {
-        hash: H256::random(),
-        nonce: U256::zero(),
-        block_hash: Some(block_hash),
-        block_number: Some(5.into()),
-        transaction_index: Some(0.into()),
-        from: H160::random(),
-        to: None,
-        value: 0.into(),
-        gas_price: 0.into(),
-        gas: 0.into(),
-        input: Bytes::default(),
-    };
-    let log = Log {
-        address: Address::from("22843e74c59580b3eaf6c233fa67d8b7c561a835"),
-        topics: vec![util::ethereum::string_to_h256("ExampleEvent(string)")],
-        data: Bytes::default(),
-        block_hash: Some(block_hash),
-        block_number: Some(5.into()),
-        transaction_hash: Some(transaction.hash),
-        transaction_index: Some(0.into()),
-        log_index: Some(0.into()),
-        transaction_log_index: Some(0.into()),
-        log_type: None,
-        removed: None,
-    };
-    let block = EthereumBlock {
-        block: Block {
-            hash: Some(block_hash),
-            parent_hash: H256::random(),
-            uncles_hash: H256::zero(),
-            author: H160::random(),
-            state_root: H256::random(),
-            transactions_root: H256::random(),
-            receipts_root: H256::random(),
-            number: Some(5.into()),
-            gas_used: 0.into(),
-            gas_limit: 0.into(),
-            extra_data: Bytes::default(),
-            logs_bloom: H2048::random(),
-            timestamp: 42.into(),
-            difficulty: 0.into(),
-            total_difficulty: 0.into(),
-            seal_fields: vec![],
-            uncles: vec![],
-            transactions: vec![],
-            size: None,
-        },
-        transaction_receipts: vec![],
-    };
+    let (block, transaction, log) = generate_fake_block();
 
     let ctx = EventHandlerContext {
         logger: Logger::root(slog::Discard, o!()),

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -238,7 +238,6 @@ fn call_event_handler_and_receive_store_event() {
             Entity::from(HashMap::from_iter(
                 vec![(String::from("exampleAttribute"), Value::from("some data"))].into_iter()
             )),
-            EventSource::EthereumBlock(util::ethereum::string_to_h256("example block hash",)),
         )
     );
 }

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -161,8 +161,8 @@ where
     }
 }
 
-#[cfg(any())]
 #[test]
+#[cfg(any())]
 fn call_invalid_event_handler_and_dont_crash() {
     // This test passing means the module doesn't crash when an invalid
     // event handler is called or when the event handler execution fails.
@@ -189,8 +189,8 @@ fn call_invalid_event_handler_and_dont_crash() {
     );
 }
 
-#[cfg(any())]
 #[test]
+#[cfg(any())]
 fn call_event_handler_and_receive_store_event() {
     // Load the example_event_handler.wasm test module. All this module does
     // is implement an `handleExampleEvent` function that calls `store.set()`

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -334,6 +334,7 @@ fn call_event_handler_and_receive_store_event() {
             data: Entity::from(HashMap::from_iter(
                 vec![
                     ("id".to_owned(), "example id".into()),
+                    ("__typename".to_owned(), "ExampleEntity".into()),
                     ("exampleAttribute".to_owned(), "some data".into()),
                 ].into_iter()
             )),

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -1,10 +1,9 @@
 use ethabi;
-use std::cmp;
 use std::collections::HashMap;
 
 use graph::components::ethereum::{EthereumBlockData, EthereumEventData, EthereumTransactionData};
 use graph::data::store;
-use graph::prelude::{BigInt, BigIntSign};
+use graph::prelude::BigInt;
 use graph::serde_json;
 use graph::web3::types as web3;
 

--- a/store/postgres/migrations/2018-08-16-143800_create_entity_change_triggers/up.sql
+++ b/store/postgres/migrations/2018-08-16-143800_create_entity_change_triggers/up.sql
@@ -11,9 +11,9 @@ $$
 DECLARE
 BEGIN
     PERFORM pg_notify('entity_changes', json_build_object(
-      'subgraph', NEW.subgraph,
-      'entity', NEW.entity,
-      'id', NEW.id,
+      'subgraph_id', NEW.subgraph,
+      'entity_type', NEW.entity,
+      'entity_id', NEW.id,
       'operation', 'added'
     )::text);
     RETURN NEW;
@@ -33,9 +33,9 @@ $$
 DECLARE
 BEGIN
     PERFORM pg_notify('entity_changes', json_build_object(
-        'subgraph', NEW.subgraph,
-        'entity', NEW.entity,
-        'id', NEW.id,
+        'subgraph_id', NEW.subgraph,
+        'entity_type', NEW.entity,
+        'entity_id', NEW.id,
         'operation', 'updated'
     )::text);
     RETURN NEW;
@@ -55,9 +55,9 @@ $$
 DECLARE
 BEGIN
     PERFORM pg_notify('entity_changes', json_build_object(
-        'subgraph', OLD.subgraph,
-        'entity', OLD.entity,
-        'id', OLD.id,
+        'subgraph_id', OLD.subgraph,
+        'entity_type', OLD.entity,
+        'entity_id', OLD.id,
         'operation', 'removed'
     )::text);
     RETURN NEW;

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -4,7 +4,6 @@ extern crate diesel;
 extern crate diesel_dynamic_schema;
 #[macro_use]
 extern crate diesel_migrations;
-#[macro_use]
 extern crate failure;
 extern crate fallible_iterator;
 extern crate futures;

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -650,8 +650,7 @@ impl StoreTrait for Store {
                 values
                     .into_iter()
                     .map(|value| {
-                        serde_json::from_value::<Entity>(value)
-                            .expect("Error to deserialize entity")
+                        serde_json::from_value::<Entity>(value).expect("Error parsing entity JSON")
                     }).collect()
             }).map_err(|e| QueryExecutionError::ResolveEntitiesError(e.to_string()))
     }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -582,7 +582,7 @@ impl StoreTrait for Store {
 
     fn get(&self, key: StoreKey) -> Result<Option<Entity>, QueryExecutionError> {
         let conn = self.conn.lock().unwrap();
-        self.get_entity(&*conn, &key.subgraph, &key.entity, &key.id)
+        self.get_entity(&*conn, &key.subgraph_id, &key.entity_type, &key.entity_id)
     }
 
     fn find(&self, query: StoreQuery) -> Result<Vec<Entity>, QueryExecutionError> {
@@ -664,6 +664,11 @@ impl StoreTrait for Store {
         block_ptr_to: EthereumBlockPointer,
         operations: Vec<EntityOperation>,
     ) -> Result<(), Error> {
+        // Sanity check on block numbers
+        if block_ptr_from.number != block_ptr_to.number - 1 {
+            panic!("transact_block_operations must transact a single block only");
+        }
+
         // Fold the operations of each entity into a single one
         let operations = EntityOperation::fold(&operations);
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -125,10 +125,10 @@ fn insert_test_data(store: Arc<DieselStore>) {
         .unwrap();
 
     let test_entity_1 = create_test_entity(
-        String::from("1"),
-        String::from("user"),
-        String::from("Johnton"),
-        String::from("tonofjohn@email.com"),
+        "1",
+        "user",
+        "Johnton",
+        "tonofjohn@email.com",
         67 as i32,
         184.4 as f32,
         false,
@@ -142,37 +142,36 @@ fn insert_test_data(store: Arc<DieselStore>) {
         ).unwrap();
 
     let test_entity_2 = create_test_entity(
-        String::from("2"),
-        String::from("user"),
-        String::from("Cindini"),
-        String::from("dinici@email.com"),
+        "2",
+        "user",
+        "Cindini",
+        "dinici@email.com",
         43 as i32,
         159.1 as f32,
         true,
+    );
+    let test_entity_3_1 = create_test_entity(
+        "3",
+        "user",
+        "Shaqueeena",
+        "queensha@email.com",
+        28 as i32,
+        111.7 as f32,
+        false,
     );
     store
         .transact_block_operations(
             TEST_SUBGRAPH_ID.clone(),
             *TEST_BLOCK_1_PTR,
             *TEST_BLOCK_2_PTR,
-            vec![test_entity_2],
+            vec![test_entity_2, test_entity_3_1],
         ).unwrap();
 
-    let test_entity_3_1 = create_test_entity(
-        String::from("3"),
-        String::from("user"),
-        String::from("Shaqueeena"),
-        String::from("queensha@email.com"),
-        28 as i32,
-        111.7 as f32,
-        false,
-    );
-
     let test_entity_3_2 = create_test_entity(
-        String::from("3"),
-        String::from("user"),
-        String::from("Shaqueeena"),
-        String::from("teeko@email.com"),
+        "3",
+        "user",
+        "Shaqueeena",
+        "teeko@email.com",
         28 as i32,
         111.7 as f32,
         false,
@@ -182,35 +181,36 @@ fn insert_test_data(store: Arc<DieselStore>) {
             TEST_SUBGRAPH_ID.clone(),
             *TEST_BLOCK_2_PTR,
             *TEST_BLOCK_3_PTR,
-            vec![test_entity_3_1, test_entity_3_2],
+            vec![test_entity_3_2],
         ).unwrap();
 }
 
 /// Creates a test entity.
 fn create_test_entity(
-    id: String,
-    entity_type: String,
-    name: String,
-    email: String,
+    id: &str,
+    entity_type: &str,
+    name: &str,
+    email: &str,
     age: i32,
     weight: f32,
     coffee: bool,
 ) -> EntityOperation {
     let mut test_entity = Entity::new();
 
-    let bin_name = scalar::Bytes::from_str(&hex::encode(&name)).unwrap();
-    test_entity.insert(String::from("name"), Value::String(name));
-    test_entity.insert(String::from("bin_name"), Value::Bytes(bin_name));
-    test_entity.insert(String::from("email"), Value::String(email));
-    test_entity.insert(String::from("age"), Value::Int(age));
-    test_entity.insert(String::from("weight"), Value::Float(weight));
-    test_entity.insert(String::from("coffee"), Value::Bool(coffee));
+    test_entity.insert("id".to_owned(), Value::String(id.to_owned()));
+    test_entity.insert("name".to_owned(), Value::String(name.to_owned()));
+    let bin_name = scalar::Bytes::from_str(&hex::encode(name)).unwrap();
+    test_entity.insert("bin_name".to_owned(), Value::Bytes(bin_name));
+    test_entity.insert("email".to_owned(), Value::String(email.to_owned()));
+    test_entity.insert("age".to_owned(), Value::Int(age));
+    test_entity.insert("weight".to_owned(), Value::Float(weight));
+    test_entity.insert("coffee".to_owned(), Value::Bool(coffee));
 
     EntityOperation::Set {
         key: EntityKey {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type,
-            entity_id: id,
+            entity_type: entity_type.to_owned(),
+            entity_id: id.to_owned(),
         },
         data: test_entity,
     }
@@ -257,7 +257,7 @@ fn delete_entity() {
             .unwrap();
 
         // Check that that the deleted entity id is not present
-        assert!(!all_ids.contains(&String::from("3")));
+        assert!(!all_ids.contains(&"3".to_owned()));
 
         Ok(())
     })
@@ -268,26 +268,23 @@ fn get_entity() {
     run_test(|store| -> Result<(), ()> {
         let key = EntityKey {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: String::from("user"),
-            entity_id: String::from("1"),
+            entity_type: "user".to_owned(),
+            entity_id: "1".to_owned(),
         };
         let result = store.get(key).unwrap();
 
         let mut expected_entity = Entity::new();
 
-        let name = "Johnton".to_owned();
+        expected_entity.insert("id".to_owned(), "1".into());
+        expected_entity.insert("name".to_owned(), "Johnton".into());
         expected_entity.insert(
-            String::from("bin_name"),
-            Value::Bytes(name.as_bytes().into()),
+            "bin_name".to_owned(),
+            Value::Bytes("Johnton".as_bytes().into()),
         );
-        expected_entity.insert(String::from("name"), Value::String(name));
-        expected_entity.insert(
-            String::from("email"),
-            Value::String(String::from("tonofjohn@email.com")),
-        );
-        expected_entity.insert(String::from("age"), Value::Int(67 as i32));
-        expected_entity.insert(String::from("weight"), Value::Float(184.4 as f32));
-        expected_entity.insert(String::from("coffee"), Value::Bool(false));
+        expected_entity.insert("email".to_owned(), "tonofjohn@email.com".into());
+        expected_entity.insert("age".to_owned(), Value::Int(67 as i32));
+        expected_entity.insert("weight".to_owned(), Value::Float(184.4 as f32));
+        expected_entity.insert("coffee".to_owned(), Value::Bool(false));
 
         // Check that the expected entity was returned
         assert_eq!(result, Some(expected_entity));
@@ -302,10 +299,10 @@ fn insert_entity() {
         use db_schema::entities::dsl::*;
 
         let test_entity = create_test_entity(
-            String::from("7"),
-            String::from("user"),
-            String::from("Wanjon"),
-            String::from("wanawana@email.com"),
+            "7",
+            "user",
+            "Wanjon",
+            "wanawana@email.com",
             76 as i32,
             111.7 as f32,
             true,
@@ -323,7 +320,7 @@ fn insert_entity() {
             .select(id)
             .load::<String>(&*store.conn.lock().unwrap())
             .unwrap();
-        assert!(all_ids.iter().any(|x| x == &String::from("7")));
+        assert!(all_ids.iter().any(|x| x == &"7".to_owned()));
 
         Ok(())
     })
@@ -334,15 +331,15 @@ fn update_existing() {
     run_test(|store| -> Result<(), ()> {
         let entity_key = EntityKey {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: String::from("user"),
-            entity_id: String::from("1"),
+            entity_type: "user".to_owned(),
+            entity_id: "1".to_owned(),
         };
 
         let op = create_test_entity(
-            String::from("1"),
-            String::from("user"),
-            String::from("Wanjon"),
-            String::from("wanawana@email.com"),
+            "1",
+            "user",
+            "Wanjon",
+            "wanawana@email.com",
             76 as i32,
             111.7 as f32,
             true,
@@ -369,7 +366,7 @@ fn update_existing() {
             Some(Value::Bytes(bytes)) => bytes.clone(),
             _ => unreachable!(),
         };
-        new_data.insert(String::from("bin_name"), Value::Bytes(bin_name));
+        new_data.insert("bin_name".to_owned(), Value::Bytes(bin_name));
         assert_eq!(store.get(entity_key).unwrap(), Some(new_data));
 
         Ok(())
@@ -381,8 +378,8 @@ fn partially_update_existing() {
     run_test(|store| -> Result<(), ()> {
         let entity_key = EntityKey {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: String::from("user"),
-            entity_id: String::from("1"),
+            entity_type: "user".to_owned(),
+            entity_id: "1".to_owned(),
         };
 
         let partial_entity = Entity::from(vec![
@@ -426,1108 +423,695 @@ fn partially_update_existing() {
     })
 }
 
+fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
+    let expected_entity_ids: Vec<String> =
+        expected_entity_ids.into_iter().map(str::to_owned).collect();
+
+    run_test(move |store| -> Result<(), ()> {
+        let entities = store
+            .find(query)
+            .expect("store.find failed to execute query");
+
+        let entity_ids: Vec<_> = entities
+            .into_iter()
+            .map(|entity| match entity.get("id") {
+                Some(Value::String(id)) => id.to_owned(),
+                Some(_) => panic!("store.find returned entity with non-string ID attribute"),
+                None => panic!("store.find returned entity with no ID attribute"),
+            }).collect();
+
+        assert_eq!(entity_ids, expected_entity_ids);
+
+        Ok(())
+    })
+}
+
 #[test]
-#[cfg(any())]
 fn find_string_contains() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::Contains(
-                String::from("name"),
-                Value::String(String::from("%ind%")),
+                "name".into(),
+                "%ind%".into(),
             )])),
             order_by: None,
             order_direction: None,
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Make sure the first user in the result vector is "Cindini"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_string_equal() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
-                String::from("name"),
-                Value::String(String::from("Cindini")),
+                "name".to_owned(),
+                "Cindini".into(),
             )])),
             order_by: None,
             order_direction: None,
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Make sure the first user in the result vector is "Cindini"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_string_not_equal() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["1", "3"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::Not(
-                String::from("name"),
-                Value::String(String::from("Cindini")),
+                "name".to_owned(),
+                "Cindini".into(),
             )])),
-            order_by: None,
-            order_direction: None,
-            range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Cindini"; fail if it is
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_ne!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
-}
-
-#[test]
-#[cfg(any())]
-fn find_string_greater_than() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
-            filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
-                String::from("name"),
-                Value::String(String::from("Kundi")),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Cindini"; fail if it is
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_ne!(&test_value, returned_name.unwrap());
-
-        // There should be 1 user returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
-}
-
-#[test]
-#[cfg(any())]
-fn find_string_less_than() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
-                String::from("name"),
-                Value::String(String::from("Kundi")),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Cindini"; fail if it is
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_ne!(&test_value, returned_name.unwrap());
-
-        //There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
-}
-
-#[test]
-#[cfg(any())]
-fn find_string_less_than_order_by_asc() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
-                String::from("name"),
-                Value::String(String::from("Kundi")),
-            )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: None,
-        };
-        let result = store
-            .find(this_query)
-            .expect("Failed to fetch entities from the store");
-
-        // Check that the number and order of users is correct
-        assert_eq!(2, result.len());
-        let names: Vec<&Value> = result
-            .iter()
-            .map(|entity| {
-                entity
-                    .get(&String::from("name"))
-                    .expect("Entity without \"name\" attribute returned")
-            }).collect();
-        assert_eq!(
-            names,
-            vec![
-                &Value::String(String::from("Cindini")),
-                &Value::String(String::from("Johnton")),
-            ]
-        );
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
-fn find_string_less_than_order_by_desc() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
-                String::from("name"),
-                Value::String(String::from("Kundi")),
+fn find_string_greater_than() {
+    test_find(
+        vec!["3"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
+                "name".to_owned(),
+                "Kundi".into(),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: None,
+            order_direction: None,
+            range: None,
+        },
+    )
+}
+
+#[test]
+fn find_string_less_than_order_by_asc() {
+    test_find(
+        vec!["2", "1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+                "name".to_owned(),
+                "Kundi".into(),
+            )])),
+            order_by: Some(("name".to_owned(), ValueType::String)),
+            order_direction: Some(EntityOrder::Ascending),
+            range: None,
+        },
+    )
+}
+
+#[test]
+fn find_string_less_than_order_by_desc() {
+    test_find(
+        vec!["1", "2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+                "name".to_owned(),
+                "Kundi".into(),
+            )])),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
-        };
-        let result = store
-            .find(this_query)
-            .expect("Failed to fetch entities from the store");
-
-        // Check that the number and order of users is correct
-        assert_eq!(2, result.len());
-        let names: Vec<&Value> = result
-            .iter()
-            .map(|entity| {
-                entity
-                    .get(&String::from("name"))
-                    .expect("Entity without \"name\" attribute returned")
-            }).collect();
-        assert_eq!(
-            names,
-            vec![
-                &Value::String(String::from("Johnton")),
-                &Value::String(String::from("Cindini")),
-            ]
-        );
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_string_less_than_range() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
-                String::from("name"),
-                Value::String(String::from("ZZZ")),
+                "name".to_owned(),
+                "ZZZ".into(),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: Some(EntityRange { first: 1, skip: 1 }),
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Johnton"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Johnton"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 user returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_string_multiple_and() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![
-                EntityFilter::LessThan(String::from("name"), Value::String(String::from("Cz"))),
-                EntityFilter::Equal(String::from("name"), Value::String(String::from("Cindini"))),
+                EntityFilter::LessThan("name".to_owned(), "Cz".into()),
+                EntityFilter::Equal("name".to_owned(), "Cindini".into()),
             ])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Cindini"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 user returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_string_ends_with() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::EndsWith(
-                String::from("name"),
-                Value::String(String::from("ini")),
+                "name".to_owned(),
+                "ini".into(),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Cindini"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 user returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_string_not_ends_with() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["3", "1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::NotEndsWith(
-                String::from("name"),
-                Value::String(String::from("ini")),
+                "name".to_owned(),
+                "ini".into(),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Shaqueeena"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Shaqueeena"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_string_in() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::In(
-                String::from("name"),
-                vec![Value::String(String::from("Johnton"))],
+                "name".to_owned(),
+                vec!["Johnton".into()],
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Johnton"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Johnton"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 user returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_string_not_in() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["1", "2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
-                String::from("name"),
-                vec![Value::String(String::from("Shaqueeena"))],
+                "name".to_owned(),
+                vec!["Shaqueeena".into()],
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Johnton"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-
-        let test_value = Value::String(String::from("Johnton"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 user returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_float_equal() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
-                String::from("weight"),
+                "weight".to_owned(),
                 Value::Float(184.4 as f32),
             )])),
             order_by: None,
             order_direction: None,
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Johnton"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Johnton"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 user returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_float_not_equal() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["3", "2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::Not(
-                String::from("weight"),
+                "weight".to_owned(),
                 Value::Float(184.4 as f32),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Shaqueeena"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Shaqueeena"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_float_greater_than() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
-                String::from("weight"),
+                "weight".to_owned(),
                 Value::Float(160 as f32),
             )])),
             order_by: None,
             order_direction: None,
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Johnton"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Johnton"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 user returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_float_less_than() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2", "3"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
-                String::from("weight"),
+                "weight".to_owned(),
                 Value::Float(160 as f32),
             )])),
-            order_by: Some((String::From("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Cindini";
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_float_less_than_order_by_desc() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["3", "2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
-                String::from("weight"),
+                "weight".to_owned(),
                 Value::Float(160 as f32),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Shaqueeena"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Shaqueeena"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_float_less_than_range() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
-                String::from("weight"),
+                "weight".to_owned(),
                 Value::Float(161 as f32),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: Some(EntityRange { first: 1, skip: 1 }),
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-        // Check if the first user in the result vector is "Cindini"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 user returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_float_in() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["3", "1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::In(
-                String::from("weight"),
+                "weight".to_owned(),
                 vec![Value::Float(184.4 as f32), Value::Float(111.7 as f32)],
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: Some(EntityRange { first: 5, skip: 0 }),
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Shaqueeena"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Shaqueeena"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_float_not_in() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
-                String::from("weight"),
+                "weight".to_owned(),
                 vec![Value::Float(184.4 as f32), Value::Float(111.7 as f32)],
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: Some(EntityRange { first: 5, skip: 0 }),
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Cindini"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 users returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_int_equal() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
-                String::from("age"),
+                "age".to_owned(),
                 Value::Int(67 as i32),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Johnton"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Johnton"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 users returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_int_not_equal() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["3", "2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::Not(
-                String::from("age"),
+                "age".to_owned(),
                 Value::Int(67 as i32),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Shaqueeena"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Shaqueeena"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_int_greater_than() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
-                String::from("age"),
+                "age".to_owned(),
                 Value::Int(43 as i32),
             )])),
             order_by: None,
             order_direction: None,
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Johnton"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Johnton"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 user returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_int_greater_or_equal() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2", "1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::GreaterOrEqual(
-                String::from("age"),
+                "age".to_owned(),
                 Value::Int(43 as i32),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Cindini"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_int_less_than() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2", "3"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
-                String::from("age"),
+                "age".to_owned(),
                 Value::Int(50 as i32),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Cindini"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        //There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_int_less_or_equal() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2", "3"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::LessOrEqual(
-                String::from("age"),
+                "age".to_owned(),
                 Value::Int(43 as i32),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Cindini";
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_int_less_than_order_by_desc() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["3", "2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
-                String::from("age"),
+                "age".to_owned(),
                 Value::Int(50 as i32),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Shaqueeena"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Shaqueeena"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_int_less_than_range() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
-                String::from("age"),
+                "age".to_owned(),
                 Value::Int(67 as i32),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: Some(EntityRange { first: 1, skip: 1 }),
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Johnton"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 user returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_int_in() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["1", "2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::In(
-                String::from("age"),
+                "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: Some(EntityRange { first: 5, skip: 0 }),
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Johnton"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Johnton"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_int_not_in() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["3"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
-                String::from("age"),
+                "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: Some(EntityRange { first: 5, skip: 0 }),
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Shaqueeena"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Shaqueeena"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 users returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
+#[ignore]
 fn find_bool_equal() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
-                String::from("coffee"),
+                "coffee".to_owned(),
                 Value::Bool(true),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Cindini"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 user returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
+#[ignore]
 fn find_bool_not_equal() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["1", "3"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::Not(
-                String::from("coffee"),
+                "coffee".to_owned(),
                 Value::Bool(true),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find query failed");
-
-        // Check if the first user in the result vector is "Johnton"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Johnton"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
 fn find_bool_in() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::In(
-                String::from("coffee"),
+                "coffee".to_owned(),
                 vec![Value::Bool(true)],
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: Some(EntityRange { first: 5, skip: 0 }),
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Cindini"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Cindini"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 user returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
+#[ignore]
 fn find_bool_not_in() {
-    run_test(|store| -> Result<(), ()> {
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+    test_find(
+        vec!["3", "1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
-                String::from("coffee"),
+                "coffee".to_owned(),
                 vec![Value::Bool(true)],
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: Some(EntityRange { first: 5, skip: 0 }),
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Shaqueeena"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Shaqueeena"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 2 users returned in results
-        assert_eq!(2, returned_entities.len());
-
-        Ok(())
-    })
+        },
+    )
 }
 
 #[test]
-#[cfg(any())]
+fn find_bytes_equal() {
+    test_find(
+        vec!["1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
+                "bin_name".to_owned(),
+                Value::Bytes("Johnton".as_bytes().into()),
+            )])),
+            order_by: Some(("name".to_owned(), ValueType::String)),
+            order_direction: Some(EntityOrder::Descending),
+            range: None,
+        },
+    )
+}
+
+#[test]
 fn revert_block() {
     run_test(|store| -> Result<(), ()> {
         let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
-                String::from("name"),
-                Value::String(String::from("Shaqueeena")),
+                "name".to_owned(),
+                Value::String("Shaqueeena".to_owned()),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
         };
 
-        let block_hash = "znuyjijnezBiGFuZAW9Q";
-        let event_source =
-            EventSource::EthereumBlock(H256::from_slice(&block_hash.as_bytes())).to_string();
-
-        // Revert all events associated with event_source, "znuyjijnezBiGFuZAW9Q"
-        store.revert_events(event_source, this_query.subgraph.clone());
+        // Revert block 3
+        store
+            .revert_block_operations(
+                TEST_SUBGRAPH_ID.clone(),
+                *TEST_BLOCK_3_PTR,
+                *TEST_BLOCK_2_PTR,
+            ).unwrap();
 
         let returned_entities = store
             .find(this_query.clone())
             .expect("store.find operation failed");
 
-        // Check if the first user in the result vector has email "queensha@email.com"
-        let returned_name = returned_entities[0].get(&String::from("email"));
-        let test_value = Value::String(String::from("queensha@email.com"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
         // There should be 1 user returned in results
         assert_eq!(1, returned_entities.len());
 
-        // Perform revert operation again to confirm idempotent nature of revert_events()
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-        let returned_name = returned_entities[0].get(&String::from("email"));
-        let test_value = Value::String(String::from("queensha@email.com"));
+        // Check if the first user in the result vector has email "queensha@email.com"
+        let returned_name = returned_entities[0].get(&"email".to_owned());
+        let test_value = Value::String("queensha@email.com".to_owned());
         assert!(returned_name.is_some());
         assert_eq!(&test_value, returned_name.unwrap());
 
@@ -1536,65 +1120,55 @@ fn revert_block() {
 }
 
 #[test]
-#[cfg(any())]
 fn revert_block_with_delete() {
     run_test(|store| -> Result<(), ()> {
         let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
-                String::from("name"),
-                Value::String(String::from("Cindini")),
+                "name".to_owned(),
+                Value::String("Cindini".to_owned()),
             )])),
-            order_by: Some((String::from("name"), ValueType::String)),
+            order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: None,
         };
 
-        // Delete an entity using a randomly created event source
+        // Delete entity with id=2
         let del_key = EntityKey {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
-            id: String::from("2"),
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            entity_id: "2".to_owned(),
         };
 
-        let block_hash = "test_block_to_revert";
-        let event_source = EventSource::EthereumBlock(H256::from_slice(&block_hash.as_bytes()));
-        let revert_event_source = event_source.to_string();
+        // Process deletion
         store
-            .delete(del_key.clone(), event_source)
-            .expect("Store.delete operation failed");
+            .transact_block_operations(
+                TEST_SUBGRAPH_ID.clone(),
+                *TEST_BLOCK_3_PTR,
+                *TEST_BLOCK_4_PTR,
+                vec![EntityOperation::Remove { key: del_key }],
+            ).unwrap();
 
-        // Revert all events associated with our random event_source
-        store.revert_events(revert_event_source, this_query.subgraph.clone());
+        // Revert deletion
+        store
+            .revert_block_operations(
+                TEST_SUBGRAPH_ID.clone(),
+                *TEST_BLOCK_4_PTR,
+                *TEST_BLOCK_3_PTR,
+            ).unwrap();
 
+        // Query after revert
         let returned_entities = store
             .find(this_query.clone())
             .expect("store.find operation failed");
-
-        // Check if "dinici@email.com" is in result set
-        let returned_name = returned_entities[0].get(&String::from("email"));
-        let test_value = Value::String(String::from("dinici@email.com"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
 
         // There should be 1 entity returned in results
         assert_eq!(1, returned_entities.len());
 
-        // Perform revert operation again to confirm idempotent nature of revert_events()
-        // Delete an entity using a randomly created event source
-        let block_hash = "test_block_to_revert";
-        let event_source = EventSource::EthereumBlock(H256::from_slice(&block_hash.as_bytes()));
-        let revert_event_source = event_source.to_string();
-        store
-            .delete(del_key.clone(), event_source)
-            .expect("Store.delete operation failed");
-        store.revert_events(revert_event_source, this_query.subgraph.clone());
-        let returned_entities = store
-            .find(this_query.clone())
-            .expect("store.find operation failed");
-        let returned_name = returned_entities[0].get(&String::from("email"));
-        let test_value = Value::String(String::from("dinici@email.com"));
+        // Check if "dinici@email.com" is in result set
+        let returned_name = returned_entities[0].get(&"email".to_owned());
+        let test_value = Value::String("dinici@email.com".to_owned());
         assert!(returned_name.is_some());
         assert_eq!(&test_value, returned_name.unwrap());
 
@@ -1603,13 +1177,12 @@ fn revert_block_with_delete() {
 }
 
 #[test]
-#[cfg(any())]
 fn revert_block_with_partial_update() {
     run_test(|store| -> Result<(), ()> {
         let entity_key = EntityKey {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
-            id: String::from("1"),
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            entity_id: "1".to_owned(),
         };
 
         let partial_entity = Entity::from(vec![
@@ -1618,31 +1191,38 @@ fn revert_block_with_partial_update() {
             ("email", Value::Null),
         ]);
 
-        let original_entity = store.get(entity_key.clone()).unwrap();
-        let event_source = EventSource::EthereumBlock(H256::random());
-        let revert_event_source = event_source.to_string();
-
-        // Verify that the entity before updating is different from what we expect afterwards
-        assert_ne!(original_entity, partial_entity);
+        let original_entity = store
+            .get(entity_key.clone())
+            .unwrap()
+            .expect("missing entity");
 
         // Set test entity; as the entity already exists an update should be performed
         store
-            .set(entity_key.clone(), partial_entity, event_source)
-            .expect("Failed to update entity that already exists");
+            .transact_block_operations(
+                TEST_SUBGRAPH_ID.clone(),
+                *TEST_BLOCK_3_PTR,
+                *TEST_BLOCK_4_PTR,
+                vec![EntityOperation::Set {
+                    key: entity_key.clone(),
+                    data: partial_entity.clone(),
+                }],
+            ).unwrap();
 
         // Perform revert operation, reversing the partial update
-        store.revert_events(revert_event_source.clone(), entity_key.subgraph.clone());
+        store
+            .revert_block_operations(
+                TEST_SUBGRAPH_ID.clone(),
+                *TEST_BLOCK_4_PTR,
+                *TEST_BLOCK_3_PTR,
+            ).unwrap();
 
         // Obtain the reverted entity from the store
-        let reverted_entity = store.get(entity_key.clone()).unwrap();
+        let reverted_entity = store
+            .get(entity_key.clone())
+            .unwrap()
+            .expect("missing entity");
 
         // Verify that the entity has been returned to its original state
-        assert_eq!(reverted_entity, original_entity);
-
-        // Perform revert operation again and verify the same results to confirm the
-        // idempotent nature of the revert_events function
-        store.revert_events(revert_event_source, entity_key.subgraph.clone());
-        let reverted_entity = store.get(entity_key).unwrap();
         assert_eq!(reverted_entity, original_entity);
 
         Ok(())
@@ -1650,6 +1230,7 @@ fn revert_block_with_partial_update() {
 }
 
 #[test]
+#[ignore]
 fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
     run_test(|store| {
         let subgraph_id: SubgraphId = "entity-change-test-subgraph".to_owned();
@@ -1741,25 +1322,25 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
                     vec![
                         EntityChange {
                             subgraph_id: subgraph_id.clone(),
-                            entity_type: String::from("User"),
+                            entity_type: "User".to_owned(),
                             entity_id: added_entities[0].clone().0,
                             operation: EntityChangeOperation::Added,
                         },
                         EntityChange {
                             subgraph_id: subgraph_id.clone(),
-                            entity_type: String::from("User"),
+                            entity_type: "User".to_owned(),
                             entity_id: added_entities[1].clone().0,
                             operation: EntityChangeOperation::Added,
                         },
                         EntityChange {
                             subgraph_id: subgraph_id.clone(),
-                            entity_type: String::from("User"),
-                            entity_id: String::from("1"),
+                            entity_type: "User".to_owned(),
+                            entity_id: "1".to_owned(),
                             operation: EntityChangeOperation::Updated,
                         },
                         EntityChange {
                             subgraph_id: subgraph_id.clone(),
-                            entity_type: String::from("User"),
+                            entity_type: "User".to_owned(),
                             entity_id: added_entities[1].clone().0,
                             operation: EntityChangeOperation::Removed,
                         },
@@ -1768,38 +1349,5 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
 
                 Ok(())
             }).and_then(|_| Ok(()))
-    })
-}
-
-#[cfg(any())]
-#[test]
-fn find_bytes_equal() {
-    run_test(|| -> Result<(), ()> {
-        let logger = Logger::root(slog::Discard, o!());
-        let url = postgres_test_url();
-        let store = DieselStore::new(StoreConfig { url }, &logger);
-        let this_query = EntityQuery {
-            subgraph: TEST_SUBGRAPH_ID.clone(),
-            entity: String::from("user"),
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
-                String::from("hex_name"),
-                Value::Bytes(scalar::Bytes::from_str(&hex::encode("Johnton")).unwrap()),
-            )])),
-            order_by: Some(String::from("name")),
-            order_direction: Some(EntityOrder::Descending),
-            range: None,
-        };
-        let returned_entities = store.find(this_query).expect("store.find operation failed");
-
-        // Check if the first user in the result vector is "Johnton"
-        let returned_name = returned_entities[0].get(&String::from("name"));
-        let test_value = Value::String(String::from("Johnton"));
-        assert!(returned_name.is_some());
-        assert_eq!(&test_value, returned_name.unwrap());
-
-        // There should be 1 users returned in results
-        assert_eq!(1, returned_entities.len());
-
-        Ok(())
     })
 }

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1080,6 +1080,7 @@ fn find_bytes_equal() {
 }
 
 #[test]
+#[ignore]
 fn revert_block() {
     run_test(|store| -> Result<(), ()> {
         let this_query = EntityQuery {
@@ -1120,6 +1121,7 @@ fn revert_block() {
 }
 
 #[test]
+#[ignore]
 fn revert_block_with_delete() {
     run_test(|store| -> Result<(), ()> {
         let this_query = EntityQuery {
@@ -1177,6 +1179,7 @@ fn revert_block_with_delete() {
 }
 
 #[test]
+#[ignore]
 fn revert_block_with_partial_update() {
     run_test(|store| -> Result<(), ()> {
         let entity_key = EntityKey {

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -9,7 +9,6 @@ extern crate hex;
 use diesel::pg::PgConnection;
 use diesel::*;
 use std::fmt::Debug;
-use std::panic;
 use std::str::FromStr;
 use std::sync::Mutex;
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -985,6 +985,7 @@ fn find_int_not_in() {
     )
 }
 
+// Disabled due to issue #565
 #[test]
 #[ignore]
 fn find_bool_equal() {
@@ -1004,6 +1005,7 @@ fn find_bool_equal() {
     )
 }
 
+// Disabled due to issue #565
 #[test]
 #[ignore]
 fn find_bool_not_equal() {
@@ -1041,6 +1043,7 @@ fn find_bool_in() {
     )
 }
 
+// Disabled due to issue #565
 #[test]
 #[ignore]
 fn find_bool_not_in() {
@@ -1228,6 +1231,7 @@ fn revert_block_with_partial_update() {
     })
 }
 
+// Disabled due to issue #332
 #[test]
 #[ignore]
 fn entity_changes_are_fired_and_forwarded_to_subscriptions() {

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1079,7 +1079,6 @@ fn find_bytes_equal() {
 }
 
 #[test]
-#[ignore]
 fn revert_block() {
     run_test(|store| -> Result<(), ()> {
         let this_query = EntityQuery {
@@ -1120,7 +1119,6 @@ fn revert_block() {
 }
 
 #[test]
-#[ignore]
 fn revert_block_with_delete() {
     run_test(|store| -> Result<(), ()> {
         let this_query = EntityQuery {
@@ -1178,7 +1176,6 @@ fn revert_block_with_delete() {
 }
 
 #[test]
-#[ignore]
 fn revert_block_with_partial_update() {
     run_test(|store| -> Result<(), ()> {
         let entity_key = EntityKey {


### PR DESCRIPTION
Also fixes all (?) compiler warnings except for the internal Diesel warnings, renames a few types and field names for clarity (StoreKey -> EntityKey, StoreOrder -> EntityOrder, etc), and removes a bunch of dead code.

A few tests have been rewritten but are marked `#[ignore]`. Those tests are broken because of known bugs.

Resolves #434 
Resolves #401 