### PR TITLE
Fix boolean queries

### DIFF
--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -159,7 +159,7 @@ fn store_filter_by_mode(
                     filter_mode,
                     sql("(data -> ")
                         .bind::<Text, _>(attribute)
-                        .sql("-> 'data')")
+                        .sql("->> 'data')")
                         .sql("::boolean")
                         .sql(op)
                         .bind::<Bool, _>(query_value),

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -985,9 +985,7 @@ fn find_int_not_in() {
     )
 }
 
-// Disabled due to issue #565
 #[test]
-#[ignore]
 fn find_bool_equal() {
     test_find(
         vec!["2"],
@@ -1005,9 +1003,7 @@ fn find_bool_equal() {
     )
 }
 
-// Disabled due to issue #565
 #[test]
-#[ignore]
 fn find_bool_not_equal() {
     test_find(
         vec!["1", "3"],
@@ -1043,9 +1039,7 @@ fn find_bool_in() {
     )
 }
 
-// Disabled due to issue #565
 #[test]
-#[ignore]
 fn find_bool_not_in() {
     test_find(
         vec!["3", "1"],


### PR DESCRIPTION
Queries involving a Not, NotIn, or Equal filter on a boolean value were causing database errors. It seems that Postgres doesn't allow boolean jsonb values to be cast to actual booleans. Converting the jsonb value to a string before casting to boolean fixes the problem.