### PR TITLE
Fix orderBy for all types of attribute values

### DIFF
--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -646,9 +646,13 @@ impl StoreTrait for Store {
                 ValueType::String => "",
             };
             diesel_query = diesel_query.order(
-                sql::<Text>("(data ->>")
+                sql::<Text>("(data ->")
                     .bind::<Text, _>(order_attribute)
-                    .sql(&format!("){} {} NULLS LAST", cast_type, direction)),
+                    .sql("->> 'data')")
+                    .sql(cast_type)
+                    .sql(" ")
+                    .sql(direction)
+                    .sql(" NULLS LAST"),
             );
         }
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1077,6 +1077,110 @@ fn find_bytes_equal() {
 }
 
 #[test]
+fn find_order_by_float() {
+    test_find(
+        vec!["3", "2", "1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: None,
+            order_by: Some(("weight".to_owned(), ValueType::Float)),
+            order_direction: Some(EntityOrder::Ascending),
+            range: None,
+        },
+    );
+    test_find(
+        vec!["1", "2", "3"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: None,
+            order_by: Some(("weight".to_owned(), ValueType::Float)),
+            order_direction: Some(EntityOrder::Descending),
+            range: None,
+        },
+    );
+}
+
+#[test]
+fn find_order_by_id() {
+    test_find(
+        vec!["1", "2", "3"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: None,
+            order_by: Some(("id".to_owned(), ValueType::ID)),
+            order_direction: Some(EntityOrder::Ascending),
+            range: None,
+        },
+    );
+    test_find(
+        vec!["3", "2", "1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: None,
+            order_by: Some(("id".to_owned(), ValueType::ID)),
+            order_direction: Some(EntityOrder::Descending),
+            range: None,
+        },
+    );
+}
+
+#[test]
+fn find_order_by_int() {
+    test_find(
+        vec!["3", "2", "1"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: None,
+            order_by: Some(("age".to_owned(), ValueType::Int)),
+            order_direction: Some(EntityOrder::Ascending),
+            range: None,
+        },
+    );
+    test_find(
+        vec!["1", "2", "3"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: None,
+            order_by: Some(("age".to_owned(), ValueType::Int)),
+            order_direction: Some(EntityOrder::Descending),
+            range: None,
+        },
+    );
+}
+
+#[test]
+fn find_order_by_string() {
+    test_find(
+        vec!["2", "1", "3"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: None,
+            order_by: Some(("name".to_owned(), ValueType::String)),
+            order_direction: Some(EntityOrder::Ascending),
+            range: None,
+        },
+    );
+    test_find(
+        vec!["3", "1", "2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: None,
+            order_by: Some(("name".to_owned(), ValueType::String)),
+            order_direction: Some(EntityOrder::Descending),
+            range: None,
+        },
+    );
+}
+
+#[test]
 fn revert_block() {
     run_test(|store| -> Result<(), ()> {
         let this_query = EntityQuery {


### PR DESCRIPTION
Changing the way we store entities (serializing them as tagged values) broke `orderBy`. This PR fixes it by adding the missing `->> 'data'` traversal before converting the attribute value for comparisons with e.g. `::numeric`.