### PR TITLE
Rewrite EntityFilter -> SQL translation to support nested filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "graph"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -691,15 +691,15 @@ dependencies = [
 
 [[package]]
 name = "graph-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.0",
- "graph-graphql 0.4.0",
- "graph-mock 0.4.0",
- "graph-runtime-wasm 0.4.0",
+ "graph 0.4.1",
+ "graph-graphql 0.4.1",
+ "graph-mock 0.4.1",
+ "graph-runtime-wasm 0.4.1",
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -712,24 +712,24 @@ dependencies = [
 
 [[package]]
 name = "graph-datasource-ethereum"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.0",
+ "graph 0.4.1",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "graph-graphql"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "Inflector 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.0",
- "graph-core 0.4.0",
- "graph-mock 0.4.0",
+ "graph 0.4.1",
+ "graph-core 0.4.1",
+ "graph-mock 0.4.1",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -738,33 +738,33 @@ dependencies = [
 
 [[package]]
 name = "graph-mock"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.0",
- "graph-graphql 0.4.0",
+ "graph 0.4.1",
+ "graph-graphql 0.4.1",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "graph-node"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.0",
- "graph-core 0.4.0",
- "graph-datasource-ethereum 0.4.0",
- "graph-mock 0.4.0",
- "graph-runtime-wasm 0.4.0",
- "graph-server-http 0.4.0",
- "graph-server-json-rpc 0.4.0",
- "graph-server-websocket 0.4.0",
- "graph-store-postgres 0.4.0",
+ "graph 0.4.1",
+ "graph-core 0.4.1",
+ "graph-datasource-ethereum 0.4.1",
+ "graph-mock 0.4.1",
+ "graph-runtime-wasm 0.4.1",
+ "graph-server-http 0.4.1",
+ "graph-server-json-rpc 0.4.1",
+ "graph-server-websocket 0.4.1",
+ "graph-store-postgres 0.4.1",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -776,13 +776,13 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-wasm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ethabi 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.0",
- "graph-mock 0.4.0",
+ "graph 0.4.1",
+ "graph-mock 0.4.1",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -795,12 +795,12 @@ dependencies = [
 
 [[package]]
 name = "graph-server-http"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.0",
- "graph-graphql 0.4.0",
- "graph-mock 0.4.0",
+ "graph 0.4.1",
+ "graph-graphql 0.4.1",
+ "graph-mock 0.4.1",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -810,10 +810,10 @@ dependencies = [
 
 [[package]]
 name = "graph-server-json-rpc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
- "graph 0.4.0",
- "graph-graphql 0.4.0",
+ "graph 0.4.1",
+ "graph-graphql 0.4.1",
  "jsonrpc-http-server 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -821,11 +821,11 @@ dependencies = [
 
 [[package]]
 name = "graph-server-websocket"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.0",
- "graph-graphql 0.4.0",
+ "graph 0.4.1",
+ "graph-graphql 0.4.1",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "graph-store-postgres"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bigdecimal 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -845,7 +845,7 @@ dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.0",
+ "graph 0.4.1",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -1,18 +1,18 @@
-use std::str::FromStr;
-
 use bigdecimal::BigDecimal;
-use db_schema::entities;
 use diesel::dsl::{self, sql};
-use diesel::expression::NonAggregate;
 use diesel::pg::Pg;
 use diesel::prelude::*;
-use diesel::query_builder::{BoxedSelectStatement, QueryFragment};
-use diesel::sql_types::{Array, Bool, Float, Integer, Jsonb, Numeric, Text};
-use diesel::AppearsOnTable;
+use diesel::query_builder::BoxedSelectStatement;
+use diesel::serialize::ToSql;
+use diesel::sql_types::{Array, Bool, Float, HasSqlType, Integer, Jsonb, Numeric, Text};
+use std::str::FromStr;
 
 use graph::components::store::EntityFilter;
 use graph::data::store::*;
+use graph::prelude::BigInt;
 use graph::serde_json;
+
+use db_schema::entities;
 use models::SqlValue;
 
 pub(crate) struct UnsupportedFilter {
@@ -20,9 +20,104 @@ pub(crate) struct UnsupportedFilter {
     pub value: Value,
 }
 
-enum FilterMode {
-    And,
-    Or,
+type FilterExpression = Box<BoxableExpression<entities::table, Pg, SqlType = Bool>>;
+
+trait IntoFilter {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression;
+}
+
+impl IntoFilter for String {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression {
+        Box::new(
+            sql("data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data'")
+                .sql(op)
+                .bind::<Text, _>(self),
+        ) as FilterExpression
+    }
+}
+
+impl IntoFilter for f32 {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression {
+        Box::new(
+            sql("(data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data')::float")
+                .sql(op)
+                .bind::<Float, _>(self),
+        ) as FilterExpression
+    }
+}
+
+impl IntoFilter for i32 {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression {
+        Box::new(
+            sql("(data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data')::int")
+                .sql(op)
+                .bind::<Integer, _>(self),
+        ) as FilterExpression
+    }
+}
+
+impl IntoFilter for bool {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression {
+        Box::new(
+            sql("(data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data')::boolean")
+                .sql(op)
+                .bind::<Bool, _>(self),
+        ) as FilterExpression
+    }
+}
+
+impl IntoFilter for BigInt {
+    fn into_filter(self, attribute: String, op: &str) -> FilterExpression {
+        Box::new(
+            sql("(data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data')::numeric")
+                .sql(op)
+                // Using `BigDecimal::new(query_value.0, 0)` results in a
+                // mismatch of `bignum` versions, go through the string
+                // representation to work around that.
+                .bind::<Numeric, _>(BigDecimal::from_str(&self.to_string()).unwrap()),
+        ) as FilterExpression
+    }
+}
+
+trait IntoArrayFilter<T>
+where
+    T: 'static,
+{
+    fn into_array_filter<U>(self, attribute: String, op: &str, coercion: &str) -> FilterExpression
+    where
+        T: ToSql<U, Pg>,
+        U: 'static,
+        Pg: HasSqlType<U>;
+}
+
+impl IntoArrayFilter<SqlValue> for Vec<SqlValue> {
+    fn into_array_filter<U>(self, attribute: String, op: &str, coercion: &str) -> FilterExpression
+    where
+        SqlValue: ToSql<U, Pg>,
+        U: 'static,
+        Pg: HasSqlType<U>,
+    {
+        Box::new(
+            sql("(data -> ")
+                .bind::<Text, _>(attribute)
+                .sql("->> 'data')")
+                .sql(coercion)
+                .sql(op)
+                .sql("(")
+                .bind::<Array<U>, _>(self)
+                .sql(")"),
+        ) as FilterExpression
+    }
 }
 
 /// Adds `filter` to a `SELECT data FROM entities` statement.
@@ -30,77 +125,46 @@ pub(crate) fn store_filter(
     query: BoxedSelectStatement<Jsonb, entities::table, Pg>,
     filter: EntityFilter,
 ) -> Result<BoxedSelectStatement<Jsonb, entities::table, Pg>, UnsupportedFilter> {
-    store_filter_by_mode(query, filter, FilterMode::And)
+    Ok(query.filter(build_filter(filter)?))
 }
 
-fn add_filter<'a, P: 'a>(
-    query: BoxedSelectStatement<'a, Jsonb, entities::table, Pg>,
-    filter_mode: FilterMode,
-    predicate: P,
-) -> BoxedSelectStatement<'a, Jsonb, entities::table, Pg>
-where
-    P: AppearsOnTable<entities::table>
-        + NonAggregate
-        + QueryFragment<Pg>
-        + Expression<SqlType = Bool>,
-{
-    match filter_mode {
-        FilterMode::And => query.filter(predicate),
-        FilterMode::Or => query.or_filter(predicate),
-    }
-}
+fn build_filter(filter: EntityFilter) -> Result<FilterExpression, UnsupportedFilter> {
+    use self::EntityFilter::*;
 
-/// Adds `filter` to a `SELECT data FROM entities` statement.
-fn store_filter_by_mode(
-    query: BoxedSelectStatement<Jsonb, entities::table, Pg>,
-    filter: EntityFilter,
-    filter_mode: FilterMode,
-) -> Result<BoxedSelectStatement<Jsonb, entities::table, Pg>, UnsupportedFilter> {
-    Ok(match filter {
-        EntityFilter::And(filters) => filters
-            .into_iter()
-            .try_fold(query, |q, f| store_filter_by_mode(q, f, FilterMode::And))?,
-        EntityFilter::Or(filters) => filters
-            .into_iter()
-            .try_fold(query, |q, f| store_filter_by_mode(q, f, FilterMode::Or))?,
-        EntityFilter::Contains(..) | EntityFilter::NotContains(..) => {
-            let (attribute, not, value) = match filter {
-                EntityFilter::Contains(attribute, value) => (attribute, false, value),
-                EntityFilter::NotContains(attribute, value) => (attribute, true, value),
+    let false_expr = Box::new(false.into_sql::<Bool>()) as FilterExpression;
+    let true_expr = Box::new(true.into_sql::<Bool>()) as FilterExpression;
+
+    match filter {
+        And(filters) => filters.into_iter().try_fold(true_expr, |p, filter| {
+            build_filter(filter).map(|filter_expr| Box::new(p.and(filter_expr)) as FilterExpression)
+        }),
+
+        Or(filters) => filters.into_iter().try_fold(false_expr, |p, filter| {
+            build_filter(filter).map(|filter_expr| Box::new(p.or(filter_expr)) as FilterExpression)
+        }),
+
+        Contains(..) | NotContains(..) => {
+            let (attribute, contains, op, value) = match filter {
+                EntityFilter::Contains(attribute, value) => (attribute, true, " LIKE ", value),
+                EntityFilter::NotContains(attribute, value) => {
+                    (attribute, false, " NOT LIKE ", value)
+                }
                 _ => unreachable!(),
             };
-            let op = if not { " NOT LIKE " } else { " LIKE " };
+
             match value {
-                Value::String(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data'")
-                        .sql(op)
-                        .bind::<Text, _>(query_value),
-                ),
-                Value::Bytes(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data'")
-                        .sql(op)
-                        .bind::<Text, _>(query_value.to_string()),
-                ),
-                Value::List(query_value) => {
-                    let query_array =
-                        serde_json::to_string(&query_value).expect("Failed to serialize Value");
-                    // Is `query_array` contained in array `data -> attribute -> 'data'`?
+                Value::String(s) => Ok(s.into_filter(attribute, op)),
+                Value::Bytes(b) => Ok(b.to_string().into_filter(attribute, op)),
+                Value::List(lst) => {
+                    let s = serde_json::to_string(&lst).expect("failed to serialize list value");
                     let predicate = sql("data -> ")
                         .bind::<Text, _>(attribute)
                         .sql("->> 'data' @> ")
-                        .bind::<Text, _>(query_array);
-                    if not {
-                        add_filter(query, filter_mode, dsl::not(predicate))
+                        .bind::<Text, _>(s);
+                    if contains {
+                        Ok(Box::new(predicate) as FilterExpression)
                     } else {
-                        add_filter(query, filter_mode, predicate)
+                        Ok(Box::new(dsl::not(predicate)) as FilterExpression)
                     }
                 }
                 Value::Null
@@ -109,167 +173,54 @@ fn store_filter_by_mode(
                 | Value::Bool(_)
                 | Value::BigInt(_) => {
                     return Err(UnsupportedFilter {
-                        filter: if not { "not_contains" } else { "contains" }.to_owned(),
+                        filter: if contains { "contains" } else { "not_contains" }.to_owned(),
                         value,
                     })
                 }
             }
         }
-        EntityFilter::Equal(..) | EntityFilter::Not(..) => {
+
+        Equal(..) | Not(..) => {
             let (attribute, op, value) = match filter {
-                EntityFilter::Equal(attribute, value) => (attribute, " = ", value),
-                EntityFilter::Not(attribute, value) => (attribute, " != ", value),
+                Equal(attribute, value) => (attribute, " = ", value),
+                Not(attribute, value) => (attribute, " != ", value),
                 _ => unreachable!(),
             };
 
             match value {
-                Value::String(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("(")
-                        .sql("data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data')")
-                        .sql(op)
-                        .bind::<Text, _>(query_value),
-                ),
-                Value::Float(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("(")
-                        .sql("data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data')")
-                        .sql("::float")
-                        .sql(op)
-                        .bind::<Float, _>(query_value),
-                ),
-                Value::Int(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("(data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data')")
-                        .sql("::int")
-                        .sql(op)
-                        .bind::<Integer, _>(query_value),
-                ),
-                Value::Bool(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("(data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data')")
-                        .sql("::boolean")
-                        .sql(op)
-                        .bind::<Bool, _>(query_value),
-                ),
-                Value::Null => add_filter(
-                    query,
-                    filter_mode,
+                Value::BigInt(n) => Ok(n.into_filter(attribute, op)),
+                Value::Bool(b) => Ok(b.into_filter(attribute, op)),
+                Value::Bytes(b) => Ok(b.to_string().into_filter(attribute, op)),
+                Value::Float(n) => Ok(n.into_filter(attribute, op)),
+                Value::Int(n) => Ok(n.into_filter(attribute, op)),
+                Value::List(lst) => {
+                    let s = serde_json::to_string(&lst).expect("failed to serialize list value");
+                    Ok(s.into_filter(attribute, op))
+                }
+                Value::Null => Ok(Box::new(
                     sql("data -> ")
                         .bind::<Text, _>(attribute)
                         .sql(" -> 'data' = 'null' "),
-                ),
-                Value::List(query_value) => {
-                    // Note that lists with the same elements but in different order
-                    // are considered not equal.
-                    let query_array =
-                        serde_json::to_string(&query_value).expect("Failed to serialize Value");
-                    add_filter(
-                        query,
-                        filter_mode,
-                        sql("data -> ")
-                            .bind::<Text, _>(attribute)
-                            .sql("->> 'data'")
-                            .sql(op)
-                            .bind::<Text, _>(query_array),
-                    )
-                }
-                Value::Bytes(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data'")
-                        .sql(op)
-                        .bind::<Text, _>(query_value.to_string()),
-                ),
-                Value::BigInt(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("(data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data')")
-                        .sql("::numeric")
-                        .sql(op)
-                        // Using `BigDecimal::new(query_value.0, 0)` results in a
-                        // mismatch of `bignum` versions, go through the string
-                        // representation to work around that.
-                        .bind::<Numeric, _>(
-                            BigDecimal::from_str(&query_value.to_string()).unwrap(),
-                        ),
-                ),
+                ) as FilterExpression),
+                Value::String(s) => Ok(s.into_filter(attribute, op)),
             }
         }
-        EntityFilter::GreaterThan(..)
-        | EntityFilter::LessThan(..)
-        | EntityFilter::GreaterOrEqual(..)
-        | EntityFilter::LessOrEqual(..) => {
+
+        GreaterThan(..) | LessThan(..) | GreaterOrEqual(..) | LessOrEqual(..) => {
             let (attribute, op, value) = match filter {
-                EntityFilter::GreaterThan(attribute, value) => (attribute, " > ", value),
-                EntityFilter::LessThan(attribute, value) => (attribute, " < ", value),
-                EntityFilter::GreaterOrEqual(attribute, value) => (attribute, " >= ", value),
-                EntityFilter::LessOrEqual(attribute, value) => (attribute, " <= ", value),
+                GreaterThan(attribute, value) => (attribute, " > ", value),
+                LessThan(attribute, value) => (attribute, " < ", value),
+                GreaterOrEqual(attribute, value) => (attribute, " >= ", value),
+                LessOrEqual(attribute, value) => (attribute, " <= ", value),
                 _ => unreachable!(),
             };
+
             match value {
-                Value::String(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data'")
-                        .sql(op)
-                        .bind::<Text, _>(query_value),
-                ),
-                Value::Float(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("(data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data'")
-                        .sql(")")
-                        .sql("::float")
-                        .sql(op)
-                        .bind::<Float, _>(query_value as f32),
-                ),
-                Value::Int(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("(data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data')")
-                        .sql("::int")
-                        .sql(op)
-                        .bind::<Integer, _>(query_value),
-                ),
-                Value::BigInt(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("(data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data')")
-                        .sql("::numeric")
-                        .sql(op)
-                        // Using `BigDecimal::new(query_value.0, 0)` results in a
-                        // mismatch of `bignum` versions, go through the string
-                        // representation to work around that.
-                        .bind::<Numeric, _>(
-                            BigDecimal::from_str(&query_value.to_string()).unwrap(),
-                        ),
-                ),
-                Value::Null | Value::Bool(_) | Value::List(_) | Value::Bytes(_) => {
+                Value::BigInt(n) => Ok(n.into_filter(attribute, op)),
+                Value::Float(n) => Ok(n.into_filter(attribute, op)),
+                Value::Int(n) => Ok(n.into_filter(attribute, op)),
+                Value::String(s) => Ok(s.into_filter(attribute, op)),
+                Value::Bool(_) | Value::Bytes(_) | Value::List(_) | Value::Null => {
                     return Err(UnsupportedFilter {
                         filter: op.to_owned(),
                         value,
@@ -277,112 +228,70 @@ fn store_filter_by_mode(
                 }
             }
         }
-        // Is `attribute` equal to some `v` in `query_values`?
-        EntityFilter::In(attribute, query_values) => {
-            let op = " = ANY (";
-            if query_values.is_empty() {
-                return Ok(add_filter(query, filter_mode, sql("false")));
+
+        In(attribute, values) => {
+            if values.is_empty() {
+                return Ok(false_expr);
             }
-            match query_values[0].clone() {
-                Value::Bool(_) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("(data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data')")
-                        .sql("::boolean")
-                        .sql(op)
-                        .bind::<Array<Bool>, _>(SqlValue::new_array(query_values))
-                        .sql(")"),
-                ),
-                Value::BigInt(_) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data')")
-                        .sql("::numeric")
-                        .sql(op)
-                        .bind::<Array<Numeric>, _>(SqlValue::new_array(query_values))
-                        .sql(")"),
-                ),
-                Value::Bytes(_) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data'")
-                        .sql(op)
-                        .bind::<Array<Text>, _>(SqlValue::new_array(query_values))
-                        .sql(")"),
-                ),
-                Value::Float(_) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("(data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data')")
-                        .sql("::float")
-                        .sql(op)
-                        .bind::<Array<Float>, _>(SqlValue::new_array(query_values))
-                        .sql(")"),
-                ),
-                Value::Int(_) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("(data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data')")
-                        .sql("::int")
-                        .sql(op)
-                        .bind::<Array<Integer>, _>(SqlValue::new_array(query_values))
-                        .sql(")"),
-                ),
-                Value::String(_) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data'")
-                        .sql(op)
-                        .bind::<Array<Text>, _>(SqlValue::new_array(query_values))
-                        .sql(")"),
-                ),
-                _ => unimplemented!(),
+            let op = " = ANY ";
+
+            match values[0] {
+                Value::BigInt(_) => Ok(SqlValue::new_array(values).into_array_filter::<Numeric>(
+                    attribute,
+                    op,
+                    "::numeric",
+                )),
+                Value::Bool(_) => Ok(SqlValue::new_array(values).into_array_filter::<Bool>(
+                    attribute,
+                    op,
+                    "::boolean",
+                )),
+                Value::Bytes(_) => {
+                    Ok(SqlValue::new_array(values).into_array_filter::<Text>(attribute, op, ""))
+                }
+                Value::Float(_) => Ok(SqlValue::new_array(values)
+                    .into_array_filter::<Float>(attribute, op, "::float")),
+                Value::Int(_) => Ok(SqlValue::new_array(values)
+                    .into_array_filter::<Integer>(attribute, op, "::int")),
+                Value::String(_) => {
+                    Ok(SqlValue::new_array(values).into_array_filter::<Text>(attribute, op, ""))
+                }
+                Value::List(_) | Value::Null => {
+                    return Err(UnsupportedFilter {
+                        filter: "in".to_owned(),
+                        value: Value::List(values),
+                    })
+                }
             }
         }
-        // Is `attribute` different from all `query_values`?
-        EntityFilter::NotIn(attribute, query_values) => {
-            if query_values.is_empty() {
-                return Ok(add_filter(query, filter_mode, sql("true")));
+
+        NotIn(attribute, values) => {
+            if values.is_empty() {
+                return Ok(true_expr);
             }
-            query_values.into_iter().try_fold(query, |q, v| {
-                store_filter_by_mode(q, EntityFilter::Not(attribute.clone(), v), FilterMode::And)
-            })?
+
+            build_filter(And(values
+                .into_iter()
+                .map(|value| Not(attribute.clone(), value))
+                .collect()))
         }
-        EntityFilter::StartsWith(..) | EntityFilter::NotStartsWith(..) => {
+
+        StartsWith(..) | NotStartsWith(..) => {
             let (attribute, op, value) = match filter {
-                EntityFilter::StartsWith(attribute, value) => (attribute, " LIKE ", value),
-                EntityFilter::NotStartsWith(attribute, value) => (attribute, " NOT LIKE ", value),
+                StartsWith(attribute, value) => (attribute, " LIKE ", value),
+                NotStartsWith(attribute, value) => (attribute, " NOT LIKE ", value),
                 _ => unreachable!(),
             };
+
             match value {
-                Value::String(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data'")
-                        .sql(op)
-                        .bind::<Text, _>(format!("{}%", query_value)),
-                ),
-                Value::List(_)
-                | Value::Null
+                Value::String(s) => Ok(format!("{}%", s).into_filter(attribute, op)),
+                Value::Bool(_)
+                | Value::BigInt(_)
+                | Value::Bytes(_)
                 | Value::Float(_)
                 | Value::Int(_)
-                | Value::Bool(_)
-                | Value::BigInt(_)
-                | Value::Bytes(_) => {
+                | Value::List(_)
+                | Value::Null => {
                     return Err(UnsupportedFilter {
                         filter: if op == " LIKE " {
                             "starts_with"
@@ -395,29 +304,22 @@ fn store_filter_by_mode(
             }
         }
 
-        EntityFilter::EndsWith(..) | EntityFilter::NotEndsWith(..) => {
+        EndsWith(..) | NotEndsWith(..) => {
             let (attribute, op, value) = match filter {
-                EntityFilter::EndsWith(attribute, value) => (attribute, " LIKE ", value),
-                EntityFilter::NotEndsWith(attribute, value) => (attribute, " NOT LIKE ", value),
+                EndsWith(attribute, value) => (attribute, " LIKE ", value),
+                NotEndsWith(attribute, value) => (attribute, " NOT LIKE ", value),
                 _ => unreachable!(),
             };
+
             match value {
-                Value::String(query_value) => add_filter(
-                    query,
-                    filter_mode,
-                    sql("data -> ")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data'")
-                        .sql(op)
-                        .bind::<Text, _>(format!("%{}", query_value)),
-                ),
-                Value::List(_)
-                | Value::Null
+                Value::String(s) => Ok(format!("%{}", s).into_filter(attribute, op)),
+                Value::Bool(_)
+                | Value::BigInt(_)
+                | Value::Bytes(_)
                 | Value::Float(_)
                 | Value::Int(_)
-                | Value::Bool(_)
-                | Value::BigInt(_)
-                | Value::Bytes(_) => {
+                | Value::List(_)
+                | Value::Null => {
                     return Err(UnsupportedFilter {
                         filter: if op == " LIKE " {
                             "ends_with"
@@ -429,5 +331,5 @@ fn store_filter_by_mode(
                 }
             }
         }
-    })
+    }
 }

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1181,6 +1181,24 @@ fn find_order_by_string() {
 }
 
 #[test]
+fn find_where_nested_and_or() {
+    test_find(
+        vec!["1", "2"],
+        EntityQuery {
+            subgraph_id: TEST_SUBGRAPH_ID.clone(),
+            entity_type: "user".to_owned(),
+            filter: Some(EntityFilter::And(vec![EntityFilter::Or(vec![
+                EntityFilter::Equal("id".to_owned(), Value::from("1")),
+                EntityFilter::Equal("id".to_owned(), Value::from("2")),
+            ])])),
+            order_by: Some(("id".to_owned(), ValueType::String)),
+            order_direction: Some(EntityOrder::Ascending),
+            range: None,
+        },
+    )
+}
+
+#[test]
 fn revert_block() {
     run_test(|store| -> Result<(), ()> {
         let this_query = EntityQuery {


### PR DESCRIPTION
This fixes #577 by correctly generating the correct SQL to query just the entities referenced in a list of references.

It also fixes the SQL generated for any other nested `where: { ..., or: { ... }, and: { ... } }` filters.
