### PR TITLE
Make HTTP/WS ports configurable with --http-port and --ws-port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,6 @@ name = "graph-server-json-rpc"
 version = "0.4.1"
 dependencies = [
  "graph 0.4.1",
- "graph-graphql 0.4.1",
  "jsonrpc-http-server 8.0.1 (git+https://github.com/paritytech/jsonrpc)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/graph/src/components/server/admin.rs
+++ b/graph/src/components/server/admin.rs
@@ -9,6 +9,8 @@ pub trait JsonRpcServer<P, S> {
 
     fn serve(
         port: u16,
+        http_port: u16,
+        ws_port: u16,
         provider: Arc<P>,
         store: Arc<S>,
         logger: Logger,

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -7,9 +7,6 @@ extern crate serde;
 #[macro_use]
 extern crate failure;
 
-pub const GRAPHQL_HTTP_PORT: u16 = 8000;
-pub const GRAPHQL_WS_PORT: u16 = 8001;
-
 /// Utilities for working with GraphQL schemas.
 pub mod schema;
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -121,11 +121,11 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                 .long("debug")
                 .help("Enable debug logging"),
         ).arg(
-            Arg::with_name("elasticsearch-endpoint")
-                .long("elasticsearch-endpoint")
+            Arg::with_name("elasticsearch-url")
+                .long("elasticsearch-url")
                 .value_name("URL")
-                .env("ELASTICSEARCH_ENDPOINT")
-                .help("Elasticsearch endpoint to write subgraph logs to"),
+                .env("ELASTICSEARCH_URL")
+                .help("Elasticsearch service to write subgraph logs to"),
         ).arg(
             Arg::with_name("elasticsearch-user")
                 .long("elasticsearch-user")
@@ -328,7 +328,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     // Optionally, identify the Elasticsearch logging configuration
     let elastic_config =
         matches
-            .value_of("elasticsearch-endpoint")
+            .value_of("elasticsearch-url")
             .map(|endpoint| ElasticLoggingConfig {
                 endpoint: endpoint.into(),
                 username: matches.value_of("elasticsearch-user").map(|s| s.into()),

--- a/server/http/src/lib.rs
+++ b/server/http/src/lib.rs
@@ -18,6 +18,5 @@ pub use self::request::GraphQLRequest;
 pub use self::response::GraphQLResponse;
 pub use self::server::GraphQLServer;
 pub use self::service::{GraphQLService, GraphQLServiceResponse};
-pub use graph_graphql::GRAPHQL_HTTP_PORT;
 
 pub mod test_utils;

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -125,6 +125,11 @@ where
     ) -> Result<Box<Future<Item = (), Error = ()> + Send>, Self::ServeError> {
         let logger = self.logger.clone();
 
+        info!(
+            logger,
+            "Starting GraphQL HTTP server at: http://localhost:{}", port
+        );
+
         let addr = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), port);
 
         // On every incoming request, launch a new GraphQL service that writes

--- a/server/json-rpc/Cargo.toml
+++ b/server/json-rpc/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.4.1"
 
 [dependencies]
 graph = { path = "../../graph" }
-graph-graphql = { path = "../../graphql" }
 jsonrpc-http-server = { git = "https://github.com/paritytech/jsonrpc" }
 serde = "1.0"
 serde_derive = "1.0"

--- a/server/websocket/src/lib.rs
+++ b/server/websocket/src/lib.rs
@@ -12,4 +12,3 @@ mod connection;
 mod server;
 
 pub use self::server::SubscriptionServer;
-pub use graph_graphql::GRAPHQL_WS_PORT;

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -144,6 +144,11 @@ where
         let error_logger = self.logger.clone();
         let subgraphs = self.subgraphs.clone();
 
+        info!(
+            logger,
+            "Starting GraphQL WebSocket server at: ws://localhost:{}", port
+        );
+
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
         let graphql_runner = self.graphql_runner.clone();
         let store = self.store.clone();


### PR DESCRIPTION
Resolves #590.

This adds new `--http-port` and `--ws-port` flags (and corresponding `HTTP_PORT` and `WS_PORT` environment variables) to configure the ports the GraphQL HTTP and WebSocket servers are serving at.

Log messages are added to confirm the configuration in the logs. Note: I didn't just print the `SockAddr`s because that results in URLs like `0.0.0.0:8020`, which isn't great user experience. 