### PR TITLE
Switch  to /subgraphs/{id,name}/... URLs for accessing subgraphs

### DIFF
--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -65,8 +65,10 @@ where
                                 subgraph_name_mappings.pop().unwrap();
 
                             if let Some(_) = subgraph_id_opt {
-                                return service
-                                    .handle_temp_redirect(&format!("/name/{}", subgraph_name));
+                                return service.handle_temp_redirect(&format!(
+                                    "/subgraphs/name/{}",
+                                    subgraph_name
+                                ));
                             }
                         }
 
@@ -241,21 +243,27 @@ where
                 self.serve_file(include_str!("../assets/graphiql.min.js"))
             }
 
-            (Method::GET, &["id", subgraph_id]) => {
+            (Method::GET, &["subgraphs", "id", subgraph_id]) => {
                 self.handle_graphiql_by_id(subgraph_id.to_owned())
             }
-            (Method::POST, &["id", subgraph_id, "graphql"]) => {
+            (Method::POST, &["subgraphs", "id", subgraph_id, "graphql"]) => {
                 self.handle_graphql_query_by_id(subgraph_id.to_owned(), req)
             }
-            (Method::OPTIONS, ["id", _, "graphql"]) => self.handle_graphql_options(req),
+            (Method::OPTIONS, ["subgraphs", "id", _, "graphql"]) => {
+                self.handle_graphql_options(req)
+            }
 
-            (Method::GET, ["name", subgraph_name]) => self.handle_graphiql_by_name(subgraph_name),
-            (Method::POST, ["name", subgraph_name, "graphql"]) => {
+            (Method::GET, ["subgraphs", "name", subgraph_name]) => {
+                self.handle_graphiql_by_name(subgraph_name)
+            }
+            (Method::POST, ["subgraphs", "name", subgraph_name, "graphql"]) => {
                 self.handle_graphql_query_by_name(subgraph_name, req)
             }
-            (Method::OPTIONS, ["name", _, "graphql"]) => self.handle_graphql_options(req),
+            (Method::OPTIONS, ["subgraphs", "name", _, "graphql"]) => {
+                self.handle_graphql_options(req)
+            }
 
-            // `/subgraphs` acts as an alias to `/id/SUBGRAPHS_ID`
+            // `/subgraphs` acts as an alias to `/subgraphs/id/SUBGRAPHS_ID`
             (Method::GET, &["subgraphs"]) => self.handle_graphiql_by_id(SUBGRAPHS_ID.to_owned()),
             (Method::POST, &["subgraphs", "graphql"]) => {
                 self.handle_graphql_query_by_id(SUBGRAPHS_ID.to_owned(), req)
@@ -326,7 +334,7 @@ mod tests {
 
         let request = Request::builder()
             .method(Method::POST)
-            .uri(format!("http://localhost:8000/id/{}/graphql", id))
+            .uri(format!("http://localhost:8000/subgraphs/id/{}/graphql", id))
             .body(Body::from("{}"))
             .unwrap();
 
@@ -373,7 +381,7 @@ mod tests {
 
                     let request = Request::builder()
                         .method(Method::POST)
-                        .uri(format!("http://localhost:8000/id/{}/graphql", id))
+                        .uri(format!("http://localhost:8000/subgraphs/id/{}/graphql", id))
                         .body(Body::from("{\"query\": \"{ name }\"}"))
                         .unwrap();
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -66,7 +66,7 @@ where
 
                             if let Some(_) = subgraph_id_opt {
                                 return service
-                                    .handle_temp_redirect(&format!("/by-name/{}", subgraph_name));
+                                    .handle_temp_redirect(&format!("/name/{}", subgraph_name));
                             }
                         }
 
@@ -241,23 +241,21 @@ where
                 self.serve_file(include_str!("../assets/graphiql.min.js"))
             }
 
-            (Method::GET, &["by-id", subgraph_id]) => {
+            (Method::GET, &["id", subgraph_id]) => {
                 self.handle_graphiql_by_id(subgraph_id.to_owned())
             }
-            (Method::POST, &["by-id", subgraph_id, "graphql"]) => {
+            (Method::POST, &["id", subgraph_id, "graphql"]) => {
                 self.handle_graphql_query_by_id(subgraph_id.to_owned(), req)
             }
-            (Method::OPTIONS, ["by-id", _, "graphql"]) => self.handle_graphql_options(req),
+            (Method::OPTIONS, ["id", _, "graphql"]) => self.handle_graphql_options(req),
 
-            (Method::GET, ["by-name", subgraph_name]) => {
-                self.handle_graphiql_by_name(subgraph_name)
-            }
-            (Method::POST, ["by-name", subgraph_name, "graphql"]) => {
+            (Method::GET, ["name", subgraph_name]) => self.handle_graphiql_by_name(subgraph_name),
+            (Method::POST, ["name", subgraph_name, "graphql"]) => {
                 self.handle_graphql_query_by_name(subgraph_name, req)
             }
-            (Method::OPTIONS, ["by-name", _, "graphql"]) => self.handle_graphql_options(req),
+            (Method::OPTIONS, ["name", _, "graphql"]) => self.handle_graphql_options(req),
 
-            // `/subgraphs` acts as an alias to `/by-id/SUBGRAPHS_ID`
+            // `/subgraphs` acts as an alias to `/id/SUBGRAPHS_ID`
             (Method::GET, &["subgraphs"]) => self.handle_graphiql_by_id(SUBGRAPHS_ID.to_owned()),
             (Method::POST, &["subgraphs", "graphql"]) => {
                 self.handle_graphql_query_by_id(SUBGRAPHS_ID.to_owned(), req)
@@ -328,7 +326,7 @@ mod tests {
 
         let request = Request::builder()
             .method(Method::POST)
-            .uri(format!("http://localhost:8000/by-id/{}/graphql", id))
+            .uri(format!("http://localhost:8000/id/{}/graphql", id))
             .body(Body::from("{}"))
             .unwrap();
 
@@ -375,7 +373,7 @@ mod tests {
 
                     let request = Request::builder()
                         .method(Method::POST)
-                        .uri(format!("http://localhost:8000/by-id/{}/graphql", id))
+                        .uri(format!("http://localhost:8000/id/{}/graphql", id))
                         .body(Body::from("{\"query\": \"{ name }\"}"))
                         .unwrap();
 

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -77,7 +77,7 @@ mod test {
 
                 // Send an empty JSON POST request
                 let client = Client::new();
-                let request = Request::post(format!("http://localhost:8001/by-id/{}/graphql", id))
+                let request = Request::post(format!("http://localhost:8001/id/{}/graphql", id))
                     .body(Body::from("{}"))
                     .unwrap();
 
@@ -126,7 +126,7 @@ mod test {
 
                 // Send an broken query request
                 let client = Client::new();
-                let request = Request::post(format!("http://localhost:8002/by-id/{}/graphql", id))
+                let request = Request::post(format!("http://localhost:8002/id/{}/graphql", id))
                     .body(Body::from("{\"query\": \"<L<G<>M>\"}"))
                     .unwrap();
 
@@ -209,7 +209,7 @@ mod test {
 
                 // Send a valid example query
                 let client = Client::new();
-                let request = Request::post(format!("http://localhost:8003/by-id/{}/graphql", id))
+                let request = Request::post(format!("http://localhost:8003/id/{}/graphql", id))
                     .body(Body::from("{\"query\": \"{ name }\"}"))
                     .unwrap();
 

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -77,9 +77,10 @@ mod test {
 
                 // Send an empty JSON POST request
                 let client = Client::new();
-                let request = Request::post(format!("http://localhost:8001/id/{}/graphql", id))
-                    .body(Body::from("{}"))
-                    .unwrap();
+                let request =
+                    Request::post(format!("http://localhost:8001/subgraphs/id/{}/graphql", id))
+                        .body(Body::from("{}"))
+                        .unwrap();
 
                 // The response must be a query error
                 client.request(request).and_then(|response| {
@@ -126,9 +127,10 @@ mod test {
 
                 // Send an broken query request
                 let client = Client::new();
-                let request = Request::post(format!("http://localhost:8002/id/{}/graphql", id))
-                    .body(Body::from("{\"query\": \"<L<G<>M>\"}"))
-                    .unwrap();
+                let request =
+                    Request::post(format!("http://localhost:8002/subgraphs/id/{}/graphql", id))
+                        .body(Body::from("{\"query\": \"<L<G<>M>\"}"))
+                        .unwrap();
 
                 // The response must be a query error
                 client.request(request).and_then(|response| {
@@ -209,9 +211,10 @@ mod test {
 
                 // Send a valid example query
                 let client = Client::new();
-                let request = Request::post(format!("http://localhost:8003/id/{}/graphql", id))
-                    .body(Body::from("{\"query\": \"{ name }\"}"))
-                    .unwrap();
+                let request =
+                    Request::post(format!("http://localhost:8003/subgraphs/id/{}/graphql", id))
+                        .body(Body::from("{\"query\": \"{ name }\"}"))
+                        .unwrap();
 
                 // The response must be a 200
                 client.request(request).and_then(|response| {

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -360,11 +360,8 @@ pub fn parse_response(response: Value) -> Result<(), jsonrpc_core::Error> {
 
 fn subgraph_routes(name: &str, http_port: u16, ws_port: u16) -> Value {
     let mut map = BTreeMap::new();
-    map.insert("playground", format!(":{}/by-name/{}", http_port, name));
-    map.insert(
-        "queries",
-        format!(":{}/by-name/{}/graphql", http_port, name),
-    );
-    map.insert("subscriptions", format!(":{}/by-name/{}", ws_port, name));
+    map.insert("playground", format!(":{}/name/{}", http_port, name));
+    map.insert("queries", format!(":{}/name/{}/graphql", http_port, name));
+    map.insert("subscriptions", format!(":{}/name/{}", ws_port, name));
     jsonrpc_core::to_value(map).unwrap()
 }

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -108,11 +108,11 @@ where
 
         match parts.next().and_then(|s| s.to_str()) {
             Some("subgraphs") => Ok(SUBGRAPHS_ID.to_owned()),
-            Some("by-id") => parts
+            Some("id") => parts
                 .next()
                 .and_then(|id| id.to_owned().into_string().ok())
                 .ok_or(()),
-            Some("by-name") => {
+            Some("name") => {
                 let name = parts
                     .next()
                     .and_then(|name| name.to_owned().into_string().ok())


### PR DESCRIPTION
As discussed among the team, `by-name` and `by-id` is replaced by `/name/<subgraph-name>` and `/id/<subgraph-id>`.