### PR TITLE
Fix GraphiQL subscription URL and use the configured WS port

### DIFF
--- a/graph/src/components/server/query.rs
+++ b/graph/src/components/server/query.rs
@@ -90,5 +90,6 @@ pub trait GraphQLServer: EventConsumer<SchemaEvent> {
     fn serve(
         &mut self,
         port: u16,
+        ws_port: u16,
     ) -> Result<Box<Future<Item = (), Error = ()> + Send>, Self::ServeError>;
 }

--- a/mock/src/server.rs
+++ b/mock/src/server.rs
@@ -94,6 +94,7 @@ where
     fn serve(
         &mut self,
         _port: u16,
+        _ws_port: u16,
     ) -> Result<Box<Future<Item = (), Error = ()> + Send>, Self::ServeError> {
         let schema = self.schema.clone();
         let query_runner = self.query_runner.clone();

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -441,7 +441,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     // Serve GraphQL queries over HTTP. We will listen on port 8000.
     tokio::spawn(
         graphql_server
-            .serve(http_port)
+            .serve(http_port, ws_port)
             .expect("Failed to start GraphQL query server"),
     );
 

--- a/server/http/assets/index.html
+++ b/server/http/assets/index.html
@@ -135,9 +135,8 @@
 
          let wsUrl = 'ws://'
                    + window.location.hostname
-                   + ':8001'
-                   + window.location.pathname
-                   + "/subscriptions";
+                   + ':__WS_PORT__'
+                   + window.location.pathname;
          var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(
              wsUrl, { reconnect: true }
          );

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -122,6 +122,7 @@ where
     fn serve(
         &mut self,
         port: u16,
+        ws_port: u16,
     ) -> Result<Box<Future<Item = (), Error = ()> + Send>, Self::ServeError> {
         let logger = self.logger.clone();
 
@@ -138,8 +139,12 @@ where
         let schemas = self.schemas.clone();
         let store = self.store.clone();
         let new_service = move || {
-            let service =
-                GraphQLService::new(schemas.clone(), graphql_runner.clone(), store.clone());
+            let service = GraphQLService::new(
+                schemas.clone(),
+                graphql_runner.clone(),
+                store.clone(),
+                ws_port,
+            );
             future::ok::<GraphQLService<Q, S>, hyper::Error>(service)
         };
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -21,11 +21,13 @@ pub struct GraphQLService<Q, S> {
     schemas: Arc<RwLock<BTreeMap<SubgraphId, Schema>>>,
     graphql_runner: Arc<Q>,
     store: Arc<S>,
+    ws_port: u16,
 }
 
 impl<Q, S> Clone for GraphQLService<Q, S> {
     fn clone(&self) -> Self {
         Self {
+            ws_port: self.ws_port,
             schemas: self.schemas.clone(),
             graphql_runner: self.graphql_runner.clone(),
             store: self.store.clone(),
@@ -43,8 +45,10 @@ where
         schemas: Arc<RwLock<BTreeMap<SubgraphId, Schema>>>,
         graphql_runner: Arc<Q>,
         store: Arc<S>,
+        ws_port: u16,
     ) -> Self {
         GraphQLService {
+            ws_port,
             schemas,
             graphql_runner,
             store,

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -351,7 +351,7 @@ mod tests {
         )))));
         let graphql_runner = Arc::new(TestGraphQlRunner);
         let store = Arc::new(MockStore::new());
-        let mut service = GraphQLService::new(schema, graphql_runner, store);
+        let mut service = GraphQLService::new(schema, graphql_runner, store, 8001);
 
         let request = Request::builder()
             .method(Method::POST)
@@ -398,7 +398,7 @@ mod tests {
                         },
                     )))));
 
-                    let mut service = GraphQLService::new(schema, graphql_runner, store);
+                    let mut service = GraphQLService::new(schema, graphql_runner, store, 8001);
 
                     let request = Request::builder()
                         .method(Method::POST)

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -60,7 +60,9 @@ mod test {
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = Arc::new(MockStore::new());
                 let mut server = HyperGraphQLServer::new(&logger, query_runner, store);
-                let http_server = server.serve(8001).expect("Failed to start GraphQL server");
+                let http_server = server
+                    .serve(8001, 8002)
+                    .expect("Failed to start GraphQL server");
 
                 // Create a simple schema and send it to the server
                 let schema = test_schema();
@@ -110,7 +112,9 @@ mod test {
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = Arc::new(MockStore::new());
                 let mut server = HyperGraphQLServer::new(&logger, query_runner, store);
-                let http_server = server.serve(8002).expect("Failed to start GraphQL server");
+                let http_server = server
+                    .serve(8002, 8003)
+                    .expect("Failed to start GraphQL server");
 
                 // Launch the server to handle a single request
                 tokio::spawn(http_server.fuse());
@@ -194,7 +198,9 @@ mod test {
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = Arc::new(MockStore::new());
                 let mut server = HyperGraphQLServer::new(&logger, query_runner, store);
-                let http_server = server.serve(8003).expect("Failed to start GraphQL server");
+                let http_server = server
+                    .serve(8003, 8004)
+                    .expect("Failed to start GraphQL server");
 
                 // Launch the server to handle a single request
                 tokio::spawn(http_server.fuse());


### PR DESCRIPTION
This may well fix #332. Without this fix, GraphiQL isn't even able to establish the WebSocket connection because it's using the wrong URL.