### PR TITLE
Add `description`, `repository` and `network` to manifest

### DIFF
--- a/core/src/subgraph/subgraphs.graphql
+++ b/core/src/subgraph/subgraphs.graphql
@@ -8,10 +8,10 @@ type Subgraph @entity {
 type SubgraphManifest @entity {
     id: ID!
     specVersion: String!
-    description: String!
+    description: String
+    repository: String
     schema: String!
     dataSources: [EthereumContractDataSource!]!
-    repository: String
 }
 
 
@@ -19,6 +19,7 @@ type EthereumContractDataSource @entity {
     id: ID!
     kind: String!
     name: String!
+    network: String
     source: EthereumContractSource!
     mapping: EthereumContractMapping!
 }

--- a/docs/subgraph-manifest.md
+++ b/docs/subgraph-manifest.md
@@ -31,7 +31,7 @@ Any data format which has a well-defined 1:1 mapping with [IPLD Canonical Format
 | --- | --- | --- |
 | **kind** | *String | The type of data source. Possible values: *ethereum/contract*|
 | **name** | *String* | The name of the source data. Will be used to generate APIs in mapping, and also for self-documentation purposes |
-| **network** | *String* | For blockhains this describes which network the subgraph targets. For Ethereum this could be, for example, "mainnet" or "rinkeby". |
+| **network** | *String* | For blockchains this describes which network the subgraph targets. For Ethereum this could be, for example, "mainnet" or "rinkeby". |
 | **source** | [*EthereumContractSource*](#151-ethereumcontractsource) | The source data on a blockchain such as Ethereum |
 | **mapping** | [*Mapping*](#152-mapping) | The transformation logic applied to the data prior to being indexed |
 

--- a/docs/subgraph-manifest.md
+++ b/docs/subgraph-manifest.md
@@ -15,6 +15,8 @@ Any data format which has a well-defined 1:1 mapping with [IPLD Canonical Format
 | --- | --- | --- |
 | **specVersion** | *String*   | A semver version indicating which version of this API is being used.|
 | **schema**   | [*Schema*](#14-schema) | The GraphQL schema of this subgraph|
+| **description**   | *String* | An optional description of the subgraph's purpose. |
+| **repository**   | *String* | An optional link to where the subgraph lives. |
 | **dataSources**| [*Data Source Spec*](#15-data-source)| Each Data Source spec defines data which will be ingested, and transformation logic to derive the state of the subgraph's entities based on the source data.|
 
 ## 1.4 Schema
@@ -29,6 +31,7 @@ Any data format which has a well-defined 1:1 mapping with [IPLD Canonical Format
 | --- | --- | --- |
 | **kind** | *String | The type of data source. Possible values: *ethereum/contract*|
 | **name** | *String* | The name of the source data. Will be used to generate APIs in mapping, and also for self-documentation purposes |
+| **network** | *String* | For blockhains this describes which network the subgraph targets. For Ethereum this could be, for example, "mainnet" or "rinkeby". |
 | **source** | [*EthereumContractSource*](#151-ethereumcontractsource) | The source data on a blockchain such as Ethereum |
 | **mapping** | [*Mapping*](#152-mapping) | The transformation logic applied to the data prior to being indexed |
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -203,6 +203,18 @@ impl From<Address> for Value {
     }
 }
 
+impl<T> From<Option<T>> for Value
+where
+    Value: From<T>,
+{
+    fn from(x: Option<T>) -> Value {
+        match x {
+            Some(x) => x.into(),
+            None => Value::Null,
+        }
+    }
+}
+
 /// An entity is represented as a map of attribute names to values.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Entity(HashMap<Attribute, Value>);

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -209,6 +209,7 @@ impl UnresolvedMapping {
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct BaseDataSource<M> {
     pub kind: String,
+    pub network: Option<String>,
     pub name: String,
     pub source: Source,
     pub mapping: M,
@@ -224,12 +225,14 @@ impl UnresolvedDataSource {
     ) -> impl Future<Item = DataSource, Error = failure::Error> {
         let UnresolvedDataSource {
             kind,
+            network,
             name,
             source,
             mapping,
         } = self;
         mapping.resolve(resolver).map(|mapping| DataSource {
             kind,
+            network,
             name,
             source,
             mapping,
@@ -243,6 +246,8 @@ pub struct BaseSubgraphManifest<S, D> {
     pub id: SubgraphId,
     pub location: String,
     pub spec_version: String,
+    pub description: Option<String>,
+    pub repository: Option<String>,
     pub schema: S,
     pub data_sources: Vec<D>,
 }
@@ -311,6 +316,8 @@ impl UnresolvedSubgraphManifest {
             id,
             location,
             spec_version,
+            description,
+            repository,
             schema,
             data_sources,
         } = self;
@@ -326,6 +333,8 @@ impl UnresolvedSubgraphManifest {
             id,
             location,
             spec_version,
+            description,
+            repository,
             schema,
             data_sources,
         })

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -66,10 +66,8 @@ impl SubgraphManifest {
         let mut entity = HashMap::new();
         entity.insert("id".to_owned(), id.clone().into());
         entity.insert("specVersion".to_owned(), self.spec_version.into());
-        let description = self.description.unwrap_or_default();
-        entity.insert("description".to_owned(), description.into());
-        let repository = self.repository.unwrap_or_default();
-        entity.insert("repository".to_owned(), repository.into());
+        entity.insert("description".to_owned(), self.description.into());
+        entity.insert("repository".to_owned(), self.repository.into());
         entity.insert("schema".to_owned(), self.schema.into());
 
         let mut data_sources: Vec<Value> = Vec::new();
@@ -121,8 +119,7 @@ impl EthereumContractDataSource {
         let mut entity = HashMap::new();
         entity.insert("id".to_owned(), id.clone().into());
         entity.insert("kind".to_owned(), self.kind.into());
-        let network = self.network.unwrap_or_default();
-        entity.insert("network".to_owned(), network.into());
+        entity.insert("network".to_owned(), self.network.into());
         entity.insert("name".to_owned(), self.name.into());
         entity.insert(
             "source".to_owned(),

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -54,10 +54,10 @@ impl SubgraphEntity {
 #[derive(Debug)]
 struct SubgraphManifest {
     spec_version: String,
-    description: String,
+    description: Option<String>,
+    repository: Option<String>,
     schema: String,
     data_sources: Vec<EthereumContractDataSource>,
-    repository: String,
 }
 
 impl SubgraphManifest {
@@ -66,7 +66,10 @@ impl SubgraphManifest {
         let mut entity = HashMap::new();
         entity.insert("id".to_owned(), id.clone().into());
         entity.insert("specVersion".to_owned(), self.spec_version.into());
-        entity.insert("description".to_owned(), self.description.into());
+        let description = self.description.unwrap_or_default();
+        entity.insert("description".to_owned(), description.into());
+        let repository = self.repository.unwrap_or_default();
+        entity.insert("repository".to_owned(), repository.into());
         entity.insert("schema".to_owned(), self.schema.into());
 
         let mut data_sources: Vec<Value> = Vec::new();
@@ -95,10 +98,10 @@ impl<'a> From<&'a super::SubgraphManifest> for SubgraphManifest {
     fn from(manifest: &'a super::SubgraphManifest) -> Self {
         Self {
             spec_version: manifest.spec_version.clone(),
-            description: String::new(),
+            description: manifest.description.clone(),
+            repository: manifest.repository.clone(),
             schema: manifest.schema.document.clone().to_string(),
             data_sources: manifest.data_sources.iter().map(Into::into).collect(),
-            repository: String::new(),
         }
     }
 }
@@ -106,6 +109,7 @@ impl<'a> From<&'a super::SubgraphManifest> for SubgraphManifest {
 #[derive(Debug)]
 struct EthereumContractDataSource {
     kind: String,
+    network: Option<String>,
     name: String,
     source: EthereumContractSource,
     mapping: EthereumContractMapping,
@@ -117,6 +121,8 @@ impl EthereumContractDataSource {
         let mut entity = HashMap::new();
         entity.insert("id".to_owned(), id.clone().into());
         entity.insert("kind".to_owned(), self.kind.into());
+        let network = self.network.unwrap_or_default();
+        entity.insert("network".to_owned(), network.into());
         entity.insert("name".to_owned(), self.name.into());
         entity.insert(
             "source".to_owned(),
@@ -151,6 +157,7 @@ impl<'a> From<&'a super::DataSource> for EthereumContractDataSource {
         Self {
             kind: data_source.kind.clone(),
             name: data_source.name.clone(),
+            network: data_source.network.clone(),
             source: data_source.source.clone().into(),
             mapping: EthereumContractMapping::from(&data_source.mapping),
         }

--- a/mock/src/subgraph.rs
+++ b/mock/src/subgraph.rs
@@ -48,6 +48,8 @@ impl MockSubgraphProvider {
             id: String::from("mock subgraph"),
             location: String::from("/tmp/example-data-source.yaml"),
             spec_version: String::from("0.1"),
+            description: None,
+            repository: None,
             schema: Schema {
                 id: String::from("exampled id"),
                 document: Document {

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -109,6 +109,7 @@ fn mock_data_source(path: &str) -> DataSource {
     DataSource {
         kind: String::from("ethereum/contract"),
         name: String::from("example data source"),
+        network: Some(String::from("mainnet")),
         source: Source {
             address: Address::from_str("0123123123012312312301231231230123123123").unwrap(),
             abi: String::from("123123"),


### PR DESCRIPTION
All as optional strings, and add them to the schema for the subgraph of subgraphs. Part of #583 (will do `numberOfEntites` separately). Example query to test this:
```
query {
 subgraphs {
    id
    createdAt
    manifest {
      id    
  	description
  	repository
      dataSources {
         id
        kind
        name
        network
      }
    }
  }
}
```
Requires https://github.com/graphprotocol/graph-cli/pull/176 for the `network` field to validate on the cli.