### PR TITLE
graph, store, graphql: Add `entityCount` field to subgraph entities

### DIFF
--- a/core/src/subgraph/subgraphs.graphql
+++ b/core/src/subgraph/subgraphs.graphql
@@ -1,7 +1,7 @@
 type Subgraph @entity {
     id: ID!
     manifest: SubgraphManifest!
-#   numberEntities: Int!    Need to figure out how to keep track of this.
+    entityCount: BigInt! # Computed field, not stored.
     createdAt: BigInt!
 }
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -331,6 +331,9 @@ pub trait Store: Send + Sync + 'static {
     ///
     /// Returns a stream of entity changes that match the input arguments.
     fn subscribe(&self, entities: Vec<SubgraphEntityPair>) -> EntityChangeStream;
+
+    /// Counts the total number of entities in a subgraph.
+    fn count_entities(&self, subgraph: SubgraphId) -> Result<u64, Error>;
 }
 
 /// Common trait for blockchain store implementations.

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -1,3 +1,4 @@
+use failure;
 use graphql_parser::{query as q, Pos};
 use hex::FromHexError;
 use num_bigint;
@@ -37,6 +38,7 @@ pub enum QueryExecutionError {
     ValueParseError(String, String),
     AttributeTypeError(String, String),
     EntityParseError(String),
+    StoreError(failure::Error),
 }
 
 impl Error for QueryExecutionError {
@@ -129,6 +131,9 @@ impl fmt::Display for QueryExecutionError {
             }
             QueryExecutionError::EntityParseError(s) => {
                 write!(f, "Broken entity found in store: {}", s)
+            }
+            QueryExecutionError::StoreError(e) => {
+                write!(f, "Store error: {}", e)
             }
         }
     }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -8,6 +8,10 @@ use std::collections::HashMap;
 
 /// ID of the subgraph of subgraphs.
 pub const SUBGRAPHS_ID: &str = "subgraphs";
+
+/// Type name of the root entity in the subgraph of subgraphs.
+pub const SUBGRAPH_ENTITY_TYPENAME: &str = "Subgraph";
+
 const EVENT_SOURCE: &str = "subgraph-added";
 
 #[derive(Debug)]
@@ -40,7 +44,7 @@ impl SubgraphEntity {
             EntityOperation::Set {
                 key: EntityKey {
                     subgraph_id: SUBGRAPHS_ID.to_owned(),
-                    entity_type: "Subgraph".to_owned(),
+                    entity_type: SUBGRAPH_ENTITY_TYPENAME.to_owned(),
                     entity_id: self.id,
                 },
                 data: entity.into(),

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -201,6 +201,10 @@ impl Store for TestStore {
         unimplemented!()
     }
 
+    fn count_entities(&self, _: SubgraphId) -> Result<u64, Error> {
+        Ok(1)
+    }
+
     fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError> {
         self.entities
             .iter()

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -153,6 +153,10 @@ impl Store for MockStore {
     fn subscribe(&self, _: Vec<SubgraphEntityPair>) -> EntityChangeStream {
         unimplemented!();
     }
+
+    fn count_entities(&self, _: SubgraphId) -> Result<u64, Error> {
+        unimplemented!();
+    }
 }
 
 impl ChainStore for MockStore {
@@ -275,6 +279,10 @@ impl Store for FakeStore {
     }
 
     fn subscribe(&self, _: Vec<SubgraphEntityPair>) -> EntityChangeStream {
+        unimplemented!();
+    }
+
+    fn count_entities(&self, _: SubgraphId) -> Result<u64, Error> {
         unimplemented!();
     }
 }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -763,6 +763,16 @@ impl StoreTrait for Store {
         // Return the subscription ID and entity change stream
         Box::new(receiver)
     }
+
+    fn count_entities(&self, subgraph_id: SubgraphId) -> Result<u64, Error> {
+        use db_schema::entities::dsl::*;
+
+        let count: i64 = entities
+            .filter(subgraph.eq(subgraph_id))
+            .count()
+            .get_result(&*self.conn.lock().unwrap())?;
+        Ok(count as u64)
+    }
 }
 
 impl ChainStore for Store {


### PR DESCRIPTION
Resolves #583 (the url should be tracked in a different issue).

This adds the `entityCount` field. Instead of storing it with the data and incrementing on every entity insert, which would be error-prone, this introduces the concept of a "calculated field", which is a field of an entity that is not in the store but rather calculated on the fly. We can probably also use this for `__typename`.