### PR TITLE
node, core: Remove use of `wait` in main

### DIFF
--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -209,12 +209,11 @@ fn subgraph_provider_events() {
     );
     let provider_events = provider.take_event_stream().unwrap();
     let schema_events = provider.take_event_stream().unwrap();
-    let named_provider = runtime
-        .block_on(graph_core::SubgraphProviderWithNames::init(
-            logger.clone(),
-            Arc::new(provider),
-            Arc::new(MockStore::new()),
-        )).unwrap();
+    let named_provider = graph_core::SubgraphProviderWithNames::new(
+        logger.clone(),
+        Arc::new(provider),
+        Arc::new(MockStore::new()),
+    );
 
     let (subgraph1_link, subgraph2_link) = runtime
         .block_on(future::lazy(|| {


### PR DESCRIPTION
This may or may not be the fix to the hanging on startup we've seen lately, but at least I wasn't able to reproduce it in a few attempts after this change.

