### PR TITLE
Support multi-node deployments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,6 @@ dependencies = [
  "http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/core/src/log/elastic.rs
+++ b/core/src/log/elastic.rs
@@ -54,7 +54,7 @@ struct ElasticLogMeta {
 #[serde(rename_all = "camelCase")]
 struct ElasticLog {
     id: String,
-    subgraph_id: String,
+    subgraph_id: SubgraphId,
     timestamp: String,
     text: String,
     #[serde(serialize_with = "serialize_log_level")]
@@ -101,7 +101,7 @@ pub struct ElasticDrainConfig {
     /// The Elasticsearch type to use for logs.
     pub document_type: String,
     /// The subgraph ID that the drain is for.
-    pub subgraph_id: String,
+    pub subgraph_id: SubgraphId,
     /// The batching interval.
     pub flush_interval: Duration,
 }

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -244,17 +244,17 @@ impl SubgraphInstanceManager {
                 }).map_err(move |e| match e {
                     CancelableError::Cancel => {
                         info!(
-                                error_logger,
-                                "Subgraph block stream shut down cleanly";
-                                "id" => id_for_err.to_string()
-                            );
+                            error_logger,
+                            "Subgraph block stream shut down cleanly";
+                            "id" => id_for_err.to_string()
+                        );
                     }
                     CancelableError::Error(e) => {
                         error!(
-                                error_logger,
-                                "Subgraph instance failed to run: {}", e;
-                                "id" => id_for_err.to_string()
-                            );
+                            error_logger,
+                            "Subgraph instance failed to run: {}", e;
+                            "id" => id_for_err.to_string()
+                        );
                     }
                 }),
         );

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -36,7 +36,10 @@ where
             store,
         };
 
-        provider.send_builtin_schema(&include_str!("subgraphs.graphql"), SUBGRAPHS_ID.to_owned());
+        provider.send_builtin_schema(
+            &include_str!("subgraphs.graphql"),
+            SubgraphId::new(SUBGRAPHS_ID).unwrap(),
+        );
 
         provider
     }
@@ -73,7 +76,7 @@ where
 
     fn send_remove_events(
         &self,
-        id: String,
+        id: SubgraphId,
     ) -> impl Future<Item = (), Error = SubgraphProviderError> + Send + 'static {
         let schema_removal = self
             .schema_event_sink
@@ -136,6 +139,7 @@ where
                         )));
                     }
 
+                    // Place subgraph info into store
                     SubgraphEntity::new(
                         &subgraph,
                         SystemTime::now()

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -93,7 +93,7 @@ struct BlockStreamContext<S, C, E> {
     subgraph_store: Arc<S>,
     chain_store: Arc<C>,
     eth_adapter: Arc<E>,
-    subgraph_id: String,
+    subgraph_id: SubgraphId,
     logger: Logger,
 }
 
@@ -128,7 +128,7 @@ where
         subgraph_store: Arc<S>,
         chain_store: Arc<C>,
         eth_adapter: Arc<E>,
-        subgraph_id: String,
+        subgraph_id: SubgraphId,
         log_filter: EthereumLogFilter,
         logger: Logger,
     ) -> Self {

--- a/graph/src/components/server/admin.rs
+++ b/graph/src/components/server/admin.rs
@@ -2,9 +2,10 @@ use std::io;
 use std::sync::Arc;
 
 use prelude::Logger;
+use prelude::NodeId;
 
 /// Common trait for JSON-RPC admin server implementations.
-pub trait JsonRpcServer<P, S> {
+pub trait JsonRpcServer<P> {
     type Server;
 
     fn serve(
@@ -12,7 +13,7 @@ pub trait JsonRpcServer<P, S> {
         http_port: u16,
         ws_port: u16,
         provider: Arc<P>,
-        store: Arc<S>,
+        node_id: NodeId,
         logger: Logger,
     ) -> Result<Self::Server, io::Error>;
 }

--- a/graph/src/components/subgraph/provider.rs
+++ b/graph/src/components/subgraph/provider.rs
@@ -1,7 +1,7 @@
 use prelude::*;
 
 /// Events emitted by [SubgraphProvider](trait.SubgraphProvider.html) implementations.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum SubgraphProviderEvent {
     /// A subgraph with the given manifest should start processing.
     SubgraphStart(SubgraphManifest),
@@ -37,12 +37,15 @@ pub trait SubgraphProvider:
 pub trait SubgraphProviderWithNames: Send + Sync + 'static {
     fn deploy(
         &self,
-        name: String,
+        name: SubgraphDeploymentName,
         id: SubgraphId,
+        node_id: NodeId,
     ) -> Box<Future<Item = (), Error = SubgraphProviderError> + Send + 'static>;
 
     fn remove(
         &self,
-        name: String,
+        name: SubgraphDeploymentName,
     ) -> Box<Future<Item = (), Error = SubgraphProviderError> + Send + 'static>;
+
+    fn list(&self) -> Result<Vec<(SubgraphDeploymentName, SubgraphId)>, Error>;
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -1,5 +1,7 @@
-use failure;
+use data::subgraph::*;
 use graphql_parser::{query as q, Pos};
+
+use failure;
 use hex::FromHexError;
 use num_bigint;
 use serde::ser::*;
@@ -22,14 +24,14 @@ pub enum QueryExecutionError {
     AbstractTypeError(String),
     InvalidArgumentError(Pos, String, q::Value),
     MissingArgumentError(Pos, String),
-    ResolveEntityError(String, String, String, String),
+    ResolveEntityError(SubgraphId, String, String, String),
     ResolveEntitiesError(String),
     OrderByNotSupportedError(String, String),
     FilterNotSupportedError(String, String),
     UnknownField(Pos, String, String),
     EmptyQuery,
     MultipleSubscriptionFields,
-    SupgraphIdError(String),
+    SubgraphIdError(String),
     RangeArgumentsError(Vec<String>),
     InvalidFilterError,
     EntityFieldError(String, String),
@@ -103,7 +105,7 @@ impl fmt::Display for QueryExecutionError {
                 f,
                 "Only a single top-level field is allowed in subscriptions"
             ),
-            QueryExecutionError::SupgraphIdError(s) => {
+            QueryExecutionError::SubgraphIdError(s) => {
                 write!(f, "Failed to get subgraph ID from type: {}", s)
             }
             QueryExecutionError::RangeArgumentsError(s) => {

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -26,8 +26,10 @@ impl Schema {
     // Adds a @subgraphId(id: ...) directive to object/interface/enum types in the schema.
     fn add_subgraph_id_directives(&mut self, id: SubgraphId) {
         for definition in self.document.definitions.iter_mut() {
-            let subgraph_id_argument =
-                (schema::Name::from("id"), schema::Value::String(id.clone()));
+            let subgraph_id_argument = (
+                schema::Name::from("id"),
+                schema::Value::String(id.to_string()),
+            );
 
             let subgraph_id_directive = schema::Directive {
                 name: "subgraphId".to_string(),

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -53,25 +53,9 @@ impl<'de> de::Deserialize<'de> for SubgraphDeploymentName {
     where
         D: de::Deserializer<'de>,
     {
-        struct SubgraphDeploymentNameVisitor;
-
-        impl<'de> de::Visitor<'de> for SubgraphDeploymentNameVisitor {
-            type Value = SubgraphDeploymentName;
-
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("a string containing a subgraph name")
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<SubgraphDeploymentName, E>
-            where
-                E: de::Error,
-            {
-                SubgraphDeploymentName::new(v.to_owned())
-                    .map_err(|()| E::invalid_value(de::Unexpected::Str(v), &"valid subgraph name"))
-            }
-        }
-
-        deserializer.deserialize_str(SubgraphDeploymentNameVisitor)
+        let s: String = de::Deserialize::deserialize(deserializer)?;
+        SubgraphDeploymentName::new(s.clone())
+            .map_err(|()| de::Error::invalid_value(de::Unexpected::Str(&s), &"valid subgraph name"))
     }
 }
 
@@ -110,25 +94,9 @@ impl<'de> de::Deserialize<'de> for NodeId {
     where
         D: de::Deserializer<'de>,
     {
-        struct NodeIdVisitor;
-
-        impl<'de> de::Visitor<'de> for NodeIdVisitor {
-            type Value = NodeId;
-
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("a string containing a node ID")
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<NodeId, E>
-            where
-                E: de::Error,
-            {
-                NodeId::new(v.to_owned())
-                    .map_err(|()| E::invalid_value(de::Unexpected::Str(v), &"valid node ID"))
-            }
-        }
-
-        deserializer.deserialize_str(NodeIdVisitor)
+        let s: String = de::Deserialize::deserialize(deserializer)?;
+        NodeId::new(s.clone())
+            .map_err(|()| de::Error::invalid_value(de::Unexpected::Str(&s), &"valid node ID"))
     }
 }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -72,10 +72,8 @@ impl NodeId {
         }
 
         // Check that the ID contains only allowed characters.
-        if !s
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-        {
+        // Note: these restrictions are relied upon to prevent SQL injection
+        if !s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
             return Err(());
         }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -115,6 +115,15 @@ pub enum DeploymentEvent {
     },
 }
 
+impl DeploymentEvent {
+    pub fn node_id(&self) -> &NodeId {
+        match self {
+            DeploymentEvent::Add { node_id, .. } => node_id,
+            DeploymentEvent::Remove { node_id, .. } => node_id,
+        }
+    }
+}
+
 /// An entity attribute name is represented as a string.
 pub type Attribute = String;
 

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -71,25 +71,9 @@ impl<'de> de::Deserialize<'de> for SubgraphId {
     where
         D: de::Deserializer<'de>,
     {
-        struct SubgraphIdVisitor;
-
-        impl<'de> de::Visitor<'de> for SubgraphIdVisitor {
-            type Value = SubgraphId;
-
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("a string containing a subgraph ID")
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<SubgraphId, E>
-            where
-                E: de::Error,
-            {
-                SubgraphId::new(v.to_owned())
-                    .map_err(|()| E::invalid_value(de::Unexpected::Str(v), &"valid subgraph name"))
-            }
-        }
-
-        deserializer.deserialize_str(SubgraphIdVisitor)
+        let s: String = de::Deserialize::deserialize(deserializer)?;
+        SubgraphId::new(s.clone())
+            .map_err(|()| de::Error::invalid_value(de::Unexpected::Str(&s), &"valid subgraph name"))
     }
 }
 

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -32,7 +32,7 @@ impl SubgraphEntity {
 
     pub fn write_to_store(self, store: &impl Store) -> Result<(), Error> {
         let mut entity = HashMap::new();
-        entity.insert("id".to_owned(), self.id.clone().into());
+        entity.insert("id".to_owned(), self.id.to_string().into());
         let manifest_id = format!("{}-manifest", self.id);
         entity.insert(
             "manifest".to_owned(),
@@ -43,9 +43,9 @@ impl SubgraphEntity {
         store.apply_set_operation(
             EntityOperation::Set {
                 key: EntityKey {
-                    subgraph_id: SUBGRAPHS_ID.to_owned(),
+                    subgraph_id: SubgraphId::new(SUBGRAPHS_ID).unwrap(),
                     entity_type: SUBGRAPH_ENTITY_TYPENAME.to_owned(),
-                    entity_id: self.id,
+                    entity_id: self.id.to_string(),
                 },
                 data: entity.into(),
             },
@@ -84,7 +84,7 @@ impl SubgraphManifest {
         store.apply_set_operation(
             EntityOperation::Set {
                 key: EntityKey {
-                    subgraph_id: SUBGRAPHS_ID.to_owned(),
+                    subgraph_id: SubgraphId::new(SUBGRAPHS_ID).unwrap(),
                     entity_type: "SubgraphManifest".to_owned(),
                     entity_id: id.clone(),
                 },
@@ -141,7 +141,7 @@ impl EthereumContractDataSource {
         store.apply_set_operation(
             EntityOperation::Set {
                 key: EntityKey {
-                    subgraph_id: SUBGRAPHS_ID.to_owned(),
+                    subgraph_id: SubgraphId::new(SUBGRAPHS_ID).unwrap(),
                     entity_type: "EthereumContractDataSource".to_owned(),
                     entity_id: id.clone(),
                 },
@@ -182,7 +182,7 @@ impl EthereumContractSource {
         store.apply_set_operation(
             EntityOperation::Set {
                 key: EntityKey {
-                    subgraph_id: SUBGRAPHS_ID.to_owned(),
+                    subgraph_id: SubgraphId::new(SUBGRAPHS_ID).unwrap(),
                     entity_type: "EthereumContractSource".to_owned(),
                     entity_id: id.clone(),
                 },
@@ -244,7 +244,7 @@ impl EthereumContractMapping {
         store.apply_set_operation(
             EntityOperation::Set {
                 key: EntityKey {
-                    subgraph_id: SUBGRAPHS_ID.to_owned(),
+                    subgraph_id: SubgraphId::new(SUBGRAPHS_ID).unwrap(),
                     entity_type: "EthereumContractMapping".to_owned(),
                     entity_id: id.clone(),
                 },
@@ -292,7 +292,7 @@ impl EthereumContractAbi {
         store.apply_set_operation(
             EntityOperation::Set {
                 key: EntityKey {
-                    subgraph_id: SUBGRAPHS_ID.to_owned(),
+                    subgraph_id: SubgraphId::new(SUBGRAPHS_ID).unwrap(),
                     entity_type: "EthereumContractAbi".to_owned(),
                     entity_id: id.clone(),
                 },
@@ -330,7 +330,7 @@ impl EthereumContractEventHandler {
         store.apply_set_operation(
             EntityOperation::Set {
                 key: EntityKey {
-                    subgraph_id: SUBGRAPHS_ID.to_owned(),
+                    subgraph_id: SubgraphId::new(SUBGRAPHS_ID).unwrap(),
                     entity_type: "EthereumContractEventHandler".to_owned(),
                     entity_id: id.clone(),
                 },

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -69,7 +69,7 @@ pub mod prelude {
     pub use components::store::{
         ChainStore, EntityChange, EntityChangeOperation, EntityChangeStream, EntityFilter,
         EntityKey, EntityOperation, EntityOrder, EntityQuery, EntityRange, Store,
-        SubgraphEntityPair,
+        SubgraphDeploymentStore,
     };
     pub use components::subgraph::{
         RuntimeHost, RuntimeHostBuilder, SchemaEvent, SubgraphInstance, SubgraphInstanceManager,
@@ -83,7 +83,10 @@ pub mod prelude {
     };
     pub use data::schema::Schema;
     pub use data::store::scalar::{BigInt, BigIntSign};
-    pub use data::store::{Attribute, Entity, Value, ValueType};
+    pub use data::store::{
+        Attribute, DeploymentEvent, Entity, NodeId, SubgraphDeploymentName, SubgraphEntityPair,
+        Value, ValueType,
+    };
     pub use data::subgraph::{
         DataSource, Link, MappingABI, MappingEventHandler, SubgraphId, SubgraphManifest,
         SubgraphManifestResolveError, SubgraphProviderError,

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -192,7 +192,7 @@ fn build_order_direction(
 }
 
 /// Parses the subgraph ID from the ObjectType directives.
-pub fn parse_subgraph_id(entity: &s::ObjectType) -> Result<String, QueryExecutionError> {
+pub fn parse_subgraph_id(entity: &s::ObjectType) -> Result<SubgraphId, QueryExecutionError> {
     let entity_name = entity.name.clone();
     entity
         .directives
@@ -206,7 +206,9 @@ pub fn parse_subgraph_id(entity: &s::ObjectType) -> Result<String, QueryExecutio
         }).and_then(|(_, value)| match value {
             s::Value::String(id) => Some(id.clone()),
             _ => None,
-        }).ok_or_else(|| QueryExecutionError::SupgraphIdError(entity_name))
+        }).ok_or(())
+        .and_then(|id| SubgraphId::new(id))
+        .map_err(|()| QueryExecutionError::SubgraphIdError(entity_name))
 }
 
 /// Recursively collects entities involved in a query field as `(subgraph ID, name)` tuples.
@@ -214,7 +216,7 @@ pub fn collect_entities_from_query_field(
     schema: &s::Document,
     object_type: &s::ObjectType,
     field: &q::Field,
-) -> Vec<(String, String)> {
+) -> Vec<(SubgraphId, String)> {
     // Output entities
     let mut entities = HashSet::new();
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -190,11 +190,11 @@ where
         mut entity: Entity,
         object_type: &s::ObjectType,
     ) -> Result<Entity, QueryExecutionError> {
-        if parse_subgraph_id(object_type)? == SUBGRAPHS_ID
+        if parse_subgraph_id(object_type)? == SubgraphId::new(SUBGRAPHS_ID).unwrap()
             && object_type.name == SUBGRAPH_ENTITY_TYPENAME
         {
             let id = match entity["id"].clone() {
-                Value::String(id) => id,
+                Value::String(id) => SubgraphId::new(id).expect("invalid subgraph ID in database"),
                 _ => panic!("no id field"),
             };
             entity.insert(

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -43,7 +43,7 @@ impl Resolver for MockResolver {
 /// enums, interfaces, input objects, object types and field arguments.
 fn mock_schema() -> Schema {
     Schema {
-        id: "mock-schema".to_string(),
+        id: SubgraphId::new("mockschema").unwrap(),
         document: graphql_parser::parse_schema(
             "
              scalar String
@@ -1041,7 +1041,7 @@ type Parameter {
     let api_document = api_schema(&document).unwrap();
 
     let schema = Schema {
-        id: String::from("complex-schema"),
+        id: SubgraphId::new("complexschema").unwrap(),
         document: api_document,
     };
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -35,7 +35,7 @@ fn test_schema() -> Schema {
                 writtenBy: Musician!
             }
             ",
-        String::from("test-schema"),
+        SubgraphId::new("testschema").unwrap(),
     ).expect("Test schema invalid");
 
     let api_document =
@@ -129,34 +129,6 @@ impl TestStore {
 }
 
 impl Store for TestStore {
-    fn authorize_subgraph_name(&self, _: String, _: String) -> Result<(), Error> {
-        unimplemented!()
-    }
-
-    fn check_subgraph_name_access_token(&self, _: String, _: String) -> Result<bool, Error> {
-        unimplemented!()
-    }
-
-    fn read_all_subgraph_names(&self) -> Result<Vec<(String, Option<SubgraphId>)>, Error> {
-        unimplemented!()
-    }
-
-    fn read_subgraph_name(&self, _: String) -> Result<Option<Option<SubgraphId>>, Error> {
-        unimplemented!()
-    }
-
-    fn write_subgraph_name(&self, _: String, _: Option<SubgraphId>) -> Result<(), Error> {
-        unimplemented!()
-    }
-
-    fn find_subgraph_names_by_id(&self, _: SubgraphId) -> Result<Vec<String>, Error> {
-        unimplemented!()
-    }
-
-    fn delete_subgraph_name(&self, _: String) -> Result<(), Error> {
-        unimplemented!()
-    }
-
     fn add_subgraph_if_missing(&self, _: SubgraphId, _: EthereumBlockPointer) -> Result<(), Error> {
         unimplemented!()
     }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -1,5 +1,5 @@
 use failure::*;
-use std::collections::HashMap;
+use futures::sync::mpsc::{channel, Sender};
 use std::sync::Mutex;
 
 use graph::components::store::*;
@@ -21,10 +21,10 @@ impl EventProducer<ChainHeadUpdate> for MockChainHeadUpdateListener {
     }
 }
 
-/// A mock `Store`.
 pub struct MockStore {
     entities: Vec<Entity>,
-    subgraph_names: Mutex<HashMap<String, Option<SubgraphId>>>,
+    subgraph_deployments: Mutex<Vec<(SubgraphDeploymentName, SubgraphId, NodeId)>>,
+    subgraph_deployment_event_senders: Mutex<Vec<Sender<DeploymentEvent>>>,
 }
 
 impl MockStore {
@@ -41,7 +41,26 @@ impl MockStore {
 
         MockStore {
             entities,
-            subgraph_names: Mutex::new(HashMap::new()),
+            subgraph_deployments: Default::default(),
+            subgraph_deployment_event_senders: Default::default(),
+        }
+    }
+
+    fn emit_deployment_event(&self, event: DeploymentEvent) {
+        for sender in self
+            .subgraph_deployment_event_senders
+            .lock()
+            .unwrap()
+            .iter()
+        {
+            let sender = sender.clone();
+            let event = event.clone();
+            tokio::spawn(future::lazy(move || {
+                sender
+                    .send(event)
+                    .map(|_| ())
+                    .map_err(|e| panic!("sender error: {}", e))
+            }));
         }
     }
 }
@@ -66,48 +85,6 @@ impl Store for MockStore {
 
     fn find(&self, _query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
         Ok(self.entities.clone())
-    }
-
-    fn authorize_subgraph_name(&self, _: String, _: String) -> Result<(), Error> {
-        unimplemented!();
-    }
-
-    fn check_subgraph_name_access_token(&self, _: String, _: String) -> Result<bool, Error> {
-        unimplemented!();
-    }
-
-    fn read_all_subgraph_names(&self) -> Result<Vec<(String, Option<SubgraphId>)>, Error> {
-        let subgraph_names = self.subgraph_names.lock().unwrap();
-        Ok(subgraph_names
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect())
-    }
-
-    fn read_subgraph_name(&self, name: String) -> Result<Option<Option<SubgraphId>>, Error> {
-        let subgraph_names = self.subgraph_names.lock().unwrap();
-        Ok(subgraph_names.get(&name).map(|opt| opt.to_owned()))
-    }
-
-    fn write_subgraph_name(&self, name: String, id_opt: Option<SubgraphId>) -> Result<(), Error> {
-        let mut subgraph_names = self.subgraph_names.lock().unwrap();
-        subgraph_names.insert(name, id_opt);
-        Ok(())
-    }
-
-    fn find_subgraph_names_by_id(&self, subgraph_id: SubgraphId) -> Result<Vec<String>, Error> {
-        let subgraph_names = self.subgraph_names.lock().unwrap();
-        Ok(subgraph_names
-            .iter()
-            .filter(|(_, id_opt)| id_opt.as_ref() == Some(&subgraph_id))
-            .map(|(name, _)| name.to_owned())
-            .collect())
-    }
-
-    fn delete_subgraph_name(&self, name: String) -> Result<(), Error> {
-        let mut subgraph_names = self.subgraph_names.lock().unwrap();
-        subgraph_names.remove(&name);
-        Ok(())
     }
 
     fn add_subgraph_if_missing(&self, _: SubgraphId, _: EthereumBlockPointer) -> Result<(), Error> {
@@ -159,6 +136,125 @@ impl Store for MockStore {
     }
 }
 
+impl SubgraphDeploymentStore for MockStore {
+    fn read_by_node_id(
+        &self,
+        by_node_id: NodeId,
+    ) -> Result<Vec<(SubgraphDeploymentName, SubgraphId)>, Error> {
+        Ok(self
+            .subgraph_deployments
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|(name, subgraph_id, node_id)| {
+                if *node_id == by_node_id {
+                    Some((name.to_owned(), subgraph_id.to_owned()))
+                } else {
+                    None
+                }
+            }).collect())
+    }
+
+    fn write(
+        &self,
+        name: SubgraphDeploymentName,
+        new_subgraph_id: SubgraphId,
+        new_node_id: NodeId,
+    ) -> Result<(), Error> {
+        let mut deployments = self.subgraph_deployments.lock().unwrap();
+
+        // Find first deployment with matching name
+        for deployment in deployments.iter_mut() {
+            if deployment.0 == name {
+                // Keep old values for event
+                let old_subgraph_id = deployment.1.to_owned();
+                let old_node_id = deployment.2.to_owned();
+
+                // Update deployment
+                deployment.1 = new_subgraph_id.clone();
+                deployment.2 = new_node_id.clone();
+
+                // Send events
+                self.emit_deployment_event(DeploymentEvent::Remove {
+                    deployment_name: name.clone(),
+                    subgraph_id: old_subgraph_id.clone(),
+                    node_id: old_node_id.clone(),
+                });
+                self.emit_deployment_event(DeploymentEvent::Add {
+                    deployment_name: name.clone(),
+                    subgraph_id: new_subgraph_id.clone(),
+                    node_id: new_node_id.clone(),
+                });
+
+                return Ok(());
+            }
+        }
+
+        // Add deployment
+        deployments.push((name.clone(), new_subgraph_id.clone(), new_node_id.clone()));
+
+        // Send event
+        self.emit_deployment_event(DeploymentEvent::Add {
+            deployment_name: name.clone(),
+            subgraph_id: new_subgraph_id.clone(),
+            node_id: new_node_id.clone(),
+        });
+        Ok(())
+    }
+
+    fn read(&self, by_name: SubgraphDeploymentName) -> Result<Option<(SubgraphId, NodeId)>, Error> {
+        Ok(self
+            .subgraph_deployments
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(name, _, _)| *name == by_name)
+            .map(|(_, subgraph_id, node_id)| (subgraph_id.to_owned(), node_id.to_owned())))
+    }
+
+    fn remove(&self, by_name: SubgraphDeploymentName) -> Result<bool, Error> {
+        let mut deployments = self.subgraph_deployments.lock().unwrap();
+
+        // Find deployment by name
+        let pos_opt = deployments.iter().position(|(name, _, _)| *name == by_name);
+
+        // If found
+        if let Some(pos) = pos_opt {
+            // Remove the deployment
+            let (deployment_name, subgraph_id, node_id) = deployments.swap_remove(pos);
+
+            // Send event
+            self.emit_deployment_event(DeploymentEvent::Remove {
+                deployment_name,
+                subgraph_id,
+                node_id,
+            });
+
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn deployment_events(
+        &self,
+        by_node_id: NodeId,
+    ) -> Box<Stream<Item = DeploymentEvent, Error = Error> + Send> {
+        let (sender, receiver) = channel(100);
+        self.subgraph_deployment_event_senders
+            .lock()
+            .unwrap()
+            .push(sender);
+        Box::new(
+            receiver
+                .filter(move |event| match event {
+                    DeploymentEvent::Add { node_id, .. } => *node_id == by_node_id,
+                    DeploymentEvent::Remove { node_id, .. } => *node_id == by_node_id,
+                }).map_err(|()| format_err!("receiver error")),
+        )
+    }
+}
+
 impl ChainStore for MockStore {
     type ChainHeadUpdateListener = MockChainHeadUpdateListener;
 
@@ -207,34 +303,6 @@ impl Store for FakeStore {
     }
 
     fn find(&self, _: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
-        unimplemented!();
-    }
-
-    fn authorize_subgraph_name(&self, _: String, _: String) -> Result<(), Error> {
-        unimplemented!();
-    }
-
-    fn check_subgraph_name_access_token(&self, _: String, _: String) -> Result<bool, Error> {
-        unimplemented!();
-    }
-
-    fn read_all_subgraph_names(&self) -> Result<Vec<(String, Option<SubgraphId>)>, Error> {
-        unimplemented!();
-    }
-
-    fn read_subgraph_name(&self, _: String) -> Result<Option<Option<SubgraphId>>, Error> {
-        unimplemented!();
-    }
-
-    fn write_subgraph_name(&self, _: String, _: Option<SubgraphId>) -> Result<(), Error> {
-        unimplemented!();
-    }
-
-    fn find_subgraph_names_by_id(&self, _: SubgraphId) -> Result<Vec<String>, Error> {
-        unimplemented!();
-    }
-
-    fn delete_subgraph_name(&self, _: String) -> Result<(), Error> {
         unimplemented!();
     }
 

--- a/mock/src/subgraph.rs
+++ b/mock/src/subgraph.rs
@@ -21,7 +21,7 @@ impl MockSubgraphProvider {
 
         let (schema_event_sink, schema_event_stream) = channel(100);
 
-        let id = "176dbd4fdeb8407b899be5d456ababc0".to_string();
+        let id = SubgraphId::new("176dbd4fdeb8407b899be5d456ababc0").unwrap();
         MockSubgraphProvider {
             logger: logger.new(o!("component" => "MockSubgraphProvider")),
             event_sink,
@@ -45,13 +45,13 @@ impl MockSubgraphProvider {
         info!(self.logger, "Generate mock events");
 
         let mock_subgraph = SubgraphManifest {
-            id: String::from("mock subgraph"),
+            id: SubgraphId::new("mocksubgraph").unwrap(),
             location: String::from("/tmp/example-data-source.yaml"),
             spec_version: String::from("0.1"),
             description: None,
             repository: None,
             schema: Schema {
-                id: String::from("exampled id"),
+                id: SubgraphId::new("exampleid").unwrap(),
                 document: Document {
                     definitions: vec![],
                 },

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -11,7 +11,6 @@ graphql-parser = "0.2.1"
 http = "0.1"
 ipfs-api = "0.5.0-alpha2"
 itertools = "0.7"
-reqwest = "0.8.7"
 sentry = "0.3.1"
 url = "1.7.1"
 graph = { path = "../graph" }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -171,7 +171,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     let postgres_url = matches.value_of("postgres-url").unwrap().to_string();
 
     let node_id = NodeId::new(matches.value_of("node-id").unwrap())
-        .expect("node ID contains invalid characters");
+        .expect("Node ID must contain only a-z, A-Z, 0-9, and '_'");
 
     // Obtain subgraph related command-line arguments
     let subgraph = matches.value_of("subgraph").map(|s| s.to_owned());
@@ -432,9 +432,9 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                 };
 
                 let name = SubgraphDeploymentName::new(name)
-                    .expect("Subgraph name command line arg contains invalid characters");
-                let subgraph_id = SubgraphId::new(hash)
-                    .expect("Subgraph hash command line arg contains invalid characters");
+                    .expect("Subgraph name must contain only a-z, A-Z, 0-9, '-' and '_'");
+                let subgraph_id =
+                    SubgraphId::new(hash).expect("Subgraph hash must be a valid IPFS hash");
 
                 Box::new(
                     named_subgraph_provider

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -404,68 +404,62 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
         store.clone(),
         node_id.clone(),
     ));
-    named_subgraph_provider
-        .start()
-        .then(
-            move |start_result| -> Box<Future<Item = _, Error = _> + Send> {
-                start_result.expect("failed to initialize subgraph provider");
+    tokio::spawn(
+        named_subgraph_provider
+            .start()
+            .then(|start_result| Ok(start_result.expect("failed to initialize subgraph provider"))),
+    );
 
-                // Start admin JSON-RPC server.
-                let json_rpc_server = JsonRpcServer::serve(
-                    json_rpc_port,
-                    http_port,
-                    ws_port,
-                    named_subgraph_provider.clone(),
-                    node_id.clone(),
-                    logger.clone(),
-                ).expect("failed to start JSON-RPC admin server");
+    // Start admin JSON-RPC server.
+    let json_rpc_server = JsonRpcServer::serve(
+        json_rpc_port,
+        http_port,
+        ws_port,
+        named_subgraph_provider.clone(),
+        node_id.clone(),
+        logger.clone(),
+    ).expect("failed to start JSON-RPC admin server");
 
-                // Let the server run forever.
-                std::mem::forget(json_rpc_server);
+    // Let the server run forever.
+    std::mem::forget(json_rpc_server);
 
-                // Add the CLI subgraph with a REST request to the admin server.
-                if let Some(subgraph) = subgraph {
-                    let (name, hash) = if subgraph.contains(':') {
-                        let mut split = subgraph.split(':');
-                        (split.next().unwrap(), split.next().unwrap().to_owned())
-                    } else {
-                        ("cli", subgraph)
-                    };
+    // Add the CLI subgraph with a REST request to the admin server.
+    if let Some(subgraph) = subgraph {
+        let (name, hash) = if subgraph.contains(':') {
+            let mut split = subgraph.split(':');
+            (split.next().unwrap(), split.next().unwrap().to_owned())
+        } else {
+            ("cli", subgraph)
+        };
 
-                    let name = SubgraphDeploymentName::new(name)
-                        .expect("Subgraph name must contain only a-z, A-Z, 0-9, '-' and '_'");
-                    let subgraph_id =
-                        SubgraphId::new(hash).expect("Subgraph hash must be a valid IPFS hash");
+        let name = SubgraphDeploymentName::new(name)
+            .expect("Subgraph name must contain only a-z, A-Z, 0-9, '-' and '_'");
+        let subgraph_id = SubgraphId::new(hash).expect("Subgraph hash must be a valid IPFS hash");
 
-                    Box::new(
-                        named_subgraph_provider
-                            .deploy(name, subgraph_id, node_id.clone())
-                            .then(|deploy_result| {
-                                Ok(deploy_result
-                                    .expect("Failed to deploy subgraph from `--subgraph` flag"))
-                            }),
-                    )
-                } else {
-                    Box::new(future::ok(()))
-                }
-            },
-        ).and_then(move |()| {
-            // Serve GraphQL queries over HTTP
-            tokio::spawn(
-                graphql_server
-                    .serve(http_port, ws_port)
-                    .expect("Failed to start GraphQL query server"),
-            );
+        tokio::spawn(
+            named_subgraph_provider
+                .deploy(name, subgraph_id, node_id.clone())
+                .then(|deploy_result| {
+                    Ok(deploy_result.expect("Failed to deploy subgraph from `--subgraph` flag"))
+                }),
+        );
+    }
 
-            // Serve GraphQL subscriptions over WebSockets
-            tokio::spawn(
-                subscription_server
-                    .serve(ws_port)
-                    .expect("Failed to start GraphQL subscription server"),
-            );
+    // Serve GraphQL queries over HTTP
+    tokio::spawn(
+        graphql_server
+            .serve(http_port, ws_port)
+            .expect("Failed to start GraphQL query server"),
+    );
 
-            Ok(())
-        })
+    // Serve GraphQL subscriptions over WebSockets
+    tokio::spawn(
+        subscription_server
+            .serve(ws_port)
+            .expect("Failed to start GraphQL subscription server"),
+    );
+
+    future::ok(())
 }
 
 /// Parses an Ethereum connection string and returns the network name and Ethereum node.

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -4,7 +4,6 @@ extern crate env_logger;
 extern crate failure;
 extern crate futures;
 extern crate itertools;
-extern crate reqwest;
 #[macro_use]
 extern crate sentry;
 extern crate graph;

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -131,7 +131,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                 .default_value("default")
                 .long("node-id")
                 .value_name("NODE_ID")
-                .help("an identifier for this Graph node"),
+                .help("a unique identifier for this node"),
         ).arg(
             Arg::with_name("debug")
                 .long("debug")

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -93,7 +93,7 @@ fn test_module(
     WasmiModule::new(
         &logger,
         WasmiModuleConfig {
-            subgraph_id: "test_subgraph".to_owned(),
+            subgraph_id: SubgraphId::new("testsubgraph").unwrap(),
             data_source,
             ethereum_adapter: mock_ethereum_adapter,
             link_resolver: Arc::new(ipfs_api::IpfsClient::default()),
@@ -268,7 +268,7 @@ fn call_event_handler_and_receive_store_event() {
         result.unwrap(),
         vec![EntityOperation::Set {
             key: EntityKey {
-                subgraph_id: "test_subgraph".to_owned(),
+                subgraph_id: SubgraphId::new("testsubgraph").unwrap(),
                 entity_type: "ExampleEntity".to_owned(),
                 entity_id: "example id".to_owned(),
             },

--- a/server/http/src/request.rs
+++ b/server/http/src/request.rs
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn rejects_invalid_json() {
         let schema = Schema {
-            id: "test".to_string(),
+            id: SubgraphId::new("test").unwrap(),
             document: graphql_parser::parse_schema(EXAMPLE_SCHEMA).unwrap(),
         };
         let request = GraphQLRequest::new(hyper::Chunk::from("!@#)%"), schema);
@@ -96,7 +96,7 @@ mod tests {
     #[test]
     fn rejects_json_without_query_field() {
         let schema = Schema {
-            id: "test".to_string(),
+            id: SubgraphId::new("test").unwrap(),
             document: graphql_parser::parse_schema(EXAMPLE_SCHEMA).unwrap(),
         };
         let request = GraphQLRequest::new(hyper::Chunk::from("{}"), schema);
@@ -108,7 +108,7 @@ mod tests {
     #[test]
     fn rejects_json_with_non_string_query_field() {
         let schema = Schema {
-            id: "test".to_string(),
+            id: SubgraphId::new("test").unwrap(),
             document: graphql_parser::parse_schema(EXAMPLE_SCHEMA).unwrap(),
         };
         let request = GraphQLRequest::new(hyper::Chunk::from("{\"query\": 5}"), schema);
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn rejects_broken_queries() {
         let schema = Schema {
-            id: "test".to_string(),
+            id: SubgraphId::new("test").unwrap(),
             document: graphql_parser::parse_schema(EXAMPLE_SCHEMA).unwrap(),
         };
         let request = GraphQLRequest::new(hyper::Chunk::from("{\"query\": \"foo\"}"), schema);
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn accepts_valid_queries() {
         let schema = Schema {
-            id: "test".to_string(),
+            id: SubgraphId::new("test").unwrap(),
             document: graphql_parser::parse_schema(EXAMPLE_SCHEMA).unwrap(),
         };
         let request = GraphQLRequest::new(
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     fn accepts_null_variables() {
         let schema = Schema {
-            id: "test".to_string(),
+            id: SubgraphId::new("test").unwrap(),
             document: graphql_parser::parse_schema(EXAMPLE_SCHEMA).unwrap(),
         };
         let request = GraphQLRequest::new(
@@ -170,7 +170,7 @@ mod tests {
     #[test]
     fn rejects_non_map_variables() {
         let schema = Schema {
-            id: "test".to_string(),
+            id: SubgraphId::new("test").unwrap(),
             document: graphql_parser::parse_schema(EXAMPLE_SCHEMA).unwrap(),
         };
         let request = GraphQLRequest::new(
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn parses_variables() {
         let schema = Schema {
-            id: "test".to_string(),
+            id: SubgraphId::new("test").unwrap(),
             document: graphql_parser::parse_schema(EXAMPLE_SCHEMA).unwrap(),
         };
         let request = GraphQLRequest::new(

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -417,7 +417,8 @@ mod tests {
                         },
                     )))));
                     let node_id = NodeId::new("test").unwrap();
-                    let mut service = GraphQLService::new(schema, graphql_runner, store, 8001, node_id);
+                    let mut service =
+                        GraphQLService::new(schema, graphql_runner, store, 8001, node_id);
 
                     let request = Request::builder()
                         .method(Method::POST)

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -45,7 +45,7 @@ mod test {
 
     fn test_schema() -> Schema {
         Schema {
-            id: "test-schema".to_string(),
+            id: SubgraphId::new("testschema").unwrap(),
             document: Default::default(),
         }
     }
@@ -59,7 +59,8 @@ mod test {
 
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = Arc::new(MockStore::new());
-                let mut server = HyperGraphQLServer::new(&logger, query_runner, store);
+                let node_id = NodeId::new("test").unwrap();
+                let mut server = HyperGraphQLServer::new(&logger, query_runner, store, node_id);
                 let http_server = server
                     .serve(8001, 8002)
                     .expect("Failed to start GraphQL server");
@@ -111,7 +112,8 @@ mod test {
 
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = Arc::new(MockStore::new());
-                let mut server = HyperGraphQLServer::new(&logger, query_runner, store);
+                let node_id = NodeId::new("test").unwrap();
+                let mut server = HyperGraphQLServer::new(&logger, query_runner, store, node_id);
                 let http_server = server
                     .serve(8002, 8003)
                     .expect("Failed to start GraphQL server");
@@ -197,7 +199,8 @@ mod test {
 
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = Arc::new(MockStore::new());
-                let mut server = HyperGraphQLServer::new(&logger, query_runner, store);
+                let node_id = NodeId::new("test").unwrap();
+                let mut server = HyperGraphQLServer::new(&logger, query_runner, store, node_id);
                 let http_server = server
                     .serve(8003, 8004)
                     .expect("Failed to start GraphQL server");

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -39,7 +39,7 @@ pub struct SubscriptionServer<Q, S> {
 impl<Q, S> SubscriptionServer<Q, S>
 where
     Q: GraphQlRunner + 'static,
-    S: Store,
+    S: SubgraphDeploymentStore,
 {
     pub fn new(logger: &Logger, graphql_runner: Arc<Q>, store: Arc<S>) -> Self {
         let logger = logger.new(o!("component" => "SubscriptionServer"));
@@ -68,7 +68,7 @@ where
         tokio::spawn(stream.for_each(move |event| {
             match event {
                 SchemaEvent::SchemaAdded(new_schema) => {
-                    debug!(logger, "Received SchemaAdded event"; "id" => &new_schema.id);
+                    debug!(logger, "Received SchemaAdded event"; "id" => new_schema.id.to_string());
 
                     let derived_schema = match api_schema(&new_schema.document) {
                         Ok(document) => Schema {
@@ -88,7 +88,7 @@ where
                     );
                 }
                 SchemaEvent::SchemaRemoved(id) => {
-                    debug!(logger, "Received SchemaRemoved event"; "id" => &id);
+                    debug!(logger, "Received SchemaRemoved event"; "id" => id.to_string());
 
                     // On removal, the `GuardedSchema` will be dropped and all
                     // connections to it will be terminated.
@@ -100,7 +100,7 @@ where
         }));
     }
 
-    fn subgraph_id_from_url_path(store: Arc<S>, path: &Path) -> Result<String, ()> {
+    fn subgraph_id_from_url_path(store: Arc<S>, path: &Path) -> Result<SubgraphId, ()> {
         let path_segments = {
             let mut segments = path.iter();
 
@@ -111,13 +111,15 @@ where
         };
 
         match path_segments.as_slice() {
-            &["subgraphs"] => Ok(SUBGRAPHS_ID.to_owned()),
-            &["subgraphs", "id", subgraph_id] => Ok(subgraph_id.to_string()),
-            &["subgraphs", "name", subgraph_name] => store
-                .read_subgraph_name(subgraph_name.to_string())
-                .expect("error reading subgraph name from store")
-                .ok_or(())
-                .and_then(|id_opt| id_opt.ok_or(())),
+            &["subgraphs"] => Ok(SubgraphId::new(SUBGRAPHS_ID).unwrap()),
+            &["subgraphs", "id", subgraph_id] => SubgraphId::new(subgraph_id),
+            &["subgraphs", "name", subgraph_name] => SubgraphDeploymentName::new(subgraph_name)
+                .map(|subgraph_name| {
+                    store
+                        .read(subgraph_name)
+                        .expect("error reading subgraph name from store")
+                }).and_then(|deployment_opt| deployment_opt.ok_or(()))
+                .map(|(subgraph_id, _node_id)| subgraph_id),
             _ => return Err(()),
         }
     }
@@ -126,7 +128,7 @@ where
 impl<Q, S> SubscriptionServerTrait for SubscriptionServer<Q, S>
 where
     Q: GraphQlRunner + 'static,
-    S: Store,
+    S: SubgraphDeploymentStore,
 {
     type ServeError = ();
 
@@ -198,9 +200,10 @@ where
                             let cancel_subgraph = subgraph_id.clone();
                             let connection = service.into_future().cancelable(&guard, move || {
                                 debug!(
-                                        logger,
-                                        "Canceling subscriptions"; "subgraph" => &cancel_subgraph
-                                    )
+                                    logger,
+                                    "Canceling subscriptions";
+                                    "subgraph" => cancel_subgraph.to_string()
+                                )
                             });
                             subgraphs.mutate(&subgraph_id, |subgraph| {
                                 subgraph.connection_guards.push(guard)
@@ -225,7 +228,7 @@ where
 impl<Q, S> EventConsumer<SchemaEvent> for SubscriptionServer<Q, S>
 where
     Q: GraphQlRunner + 'static,
-    S: Store,
+    S: SubgraphDeploymentStore,
 {
     fn event_sink(&self) -> Box<Sink<SinkItem = SchemaEvent, SinkError = ()> + Send> {
         let logger = self.logger.clone();

--- a/store/postgres/migrations/2018-08-22-140000_create_chain_head_update_procedure/up.sql
+++ b/store/postgres/migrations/2018-08-22-140000_create_chain_head_update_procedure/up.sql
@@ -75,7 +75,7 @@ BEGIN
     WHERE name = net_name;
 
     -- Fire chain head block update event
-    PERFORM pg_notify('chain_head_update', json_build_object(
+    PERFORM pg_notify('chain_head_updates', json_build_object(
         'network_name', net_name,
         'head_block_hash', new_head_hash,
         'head_block_number', new_head_number

--- a/store/postgres/migrations/2018-08-29-120000_create_subgraphs_table/down.sql
+++ b/store/postgres/migrations/2018-08-29-120000_create_subgraphs_table/down.sql
@@ -1,5 +1,10 @@
-/**************************************************************
-* DROP TABLES
-**************************************************************/
+DROP TRIGGER after_deployment_insert ON subgraph_deployments;
+DROP TRIGGER after_deployment_update ON subgraph_deployments;
+DROP TRIGGER after_deployment_delete ON subgraph_deployments;
+
+DROP FUNCTION deployment_insert();
+DROP FUNCTION deployment_update();
+DROP FUNCTION deployment_delete();
+
+DROP TABLE subgraph_deployments;
 DROP TABLE subgraphs;
-DROP TABLE subgraph_names;

--- a/store/postgres/migrations/2018-08-29-120000_create_subgraphs_table/up.sql
+++ b/store/postgres/migrations/2018-08-29-120000_create_subgraphs_table/up.sql
@@ -20,7 +20,7 @@ CREATE OR REPLACE FUNCTION deployment_insert()
     RETURNS trigger AS
 $$
 BEGIN
-    PERFORM pg_notify(CONCAT('subgraph_deployment_', NEW.node_id), json_build_object(
+    PERFORM pg_notify(CONCAT('subgraph_deployments_', NEW.node_id), json_build_object(
         'type', 'Add',
         'deployment_name', NEW.deployment_name,
         'subgraph_id', NEW.subgraph_id,
@@ -34,13 +34,13 @@ CREATE OR REPLACE FUNCTION deployment_update()
     RETURNS trigger AS
 $$
 BEGIN
-    PERFORM pg_notify(CONCAT('subgraph_deployment_', OLD.node_id), json_build_object(
+    PERFORM pg_notify(CONCAT('subgraph_deployments_', OLD.node_id), json_build_object(
         'type', 'Remove',
         'deployment_name', OLD.deployment_name,
         'subgraph_id', OLD.subgraph_id,
         'node_id', OLD.node_id
     )::text);
-    PERFORM pg_notify(CONCAT('subgraph_deployment_', NEW.node_id), json_build_object(
+    PERFORM pg_notify(CONCAT('subgraph_deployments_', NEW.node_id), json_build_object(
         'type', 'Add',
         'deployment_name', NEW.deployment_name,
         'subgraph_id', NEW.subgraph_id,
@@ -54,7 +54,7 @@ CREATE OR REPLACE FUNCTION deployment_delete()
     RETURNS trigger AS
 $$
 BEGIN
-    PERFORM pg_notify(CONCAT('subgraph_deployment_', OLD.node_id), json_build_object(
+    PERFORM pg_notify(CONCAT('subgraph_deployments_', OLD.node_id), json_build_object(
         'type', 'Remove',
         'deployment_name', OLD.deployment_name,
         'subgraph_id', OLD.subgraph_id,

--- a/store/postgres/migrations/2018-08-29-120000_create_subgraphs_table/up.sql
+++ b/store/postgres/migrations/2018-08-29-120000_create_subgraphs_table/up.sql
@@ -9,9 +9,69 @@ CREATE TABLE IF NOT EXISTS subgraphs (
     latest_block_number BIGINT NOT NULL
 );
 
--- Maps subgraph names to immutable subgraph versions (IDs).
-CREATE TABLE IF NOT EXISTS subgraph_names (
-    subgraph_name VARCHAR PRIMARY KEY,
-    subgraph_id VARCHAR,
-    access_token VARCHAR
+-- Maps names to immutable subgraph versions (IDs) and node IDs.
+CREATE TABLE IF NOT EXISTS subgraph_deployments (
+    deployment_name VARCHAR PRIMARY KEY,
+    subgraph_id VARCHAR UNIQUE NOT NULL,
+    node_id VARCHAR NOT NULL
 );
+
+CREATE OR REPLACE FUNCTION deployment_insert()
+    RETURNS trigger AS
+$$
+BEGIN
+    PERFORM pg_notify(CONCAT('subgraph_deployment_', NEW.node_id), json_build_object(
+        'type', 'Add',
+        'deployment_name', NEW.deployment_name,
+        'subgraph_id', NEW.subgraph_id,
+        'node_id', NEW.node_id
+    )::text);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION deployment_update()
+    RETURNS trigger AS
+$$
+BEGIN
+    PERFORM pg_notify(CONCAT('subgraph_deployment_', OLD.node_id), json_build_object(
+        'type', 'Remove',
+        'deployment_name', OLD.deployment_name,
+        'subgraph_id', OLD.subgraph_id,
+        'node_id', OLD.node_id
+    )::text);
+    PERFORM pg_notify(CONCAT('subgraph_deployment_', NEW.node_id), json_build_object(
+        'type', 'Add',
+        'deployment_name', NEW.deployment_name,
+        'subgraph_id', NEW.subgraph_id,
+        'node_id', NEW.node_id
+    )::text);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION deployment_delete()
+    RETURNS trigger AS
+$$
+BEGIN
+    PERFORM pg_notify(CONCAT('subgraph_deployment_', OLD.node_id), json_build_object(
+        'type', 'Remove',
+        'deployment_name', OLD.deployment_name,
+        'subgraph_id', OLD.subgraph_id,
+        'node_id', OLD.node_id
+    )::text);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER after_deployment_insert
+    AFTER INSERT ON subgraph_deployments
+    FOR EACH ROW EXECUTE PROCEDURE deployment_insert();
+
+CREATE TRIGGER after_deployment_update
+    AFTER UPDATE ON subgraph_deployments
+    FOR EACH ROW EXECUTE PROCEDURE deployment_update();
+
+CREATE TRIGGER after_deployment_delete
+    AFTER DELETE ON subgraph_deployments
+    FOR EACH ROW EXECUTE PROCEDURE deployment_delete();

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -12,7 +12,7 @@ impl ChainHeadUpdateListener {
         ChainHeadUpdateListener {
             notification_listener: NotificationListener::new(
                 postgres_url,
-                SafeChannelName::i_promise_this_is_safe("chain_head_update"),
+                SafeChannelName::i_promise_this_is_safe("chain_head_updates"),
             ),
             network_name,
         }

--- a/store/postgres/src/db_schema.rs
+++ b/store/postgres/src/db_schema.rs
@@ -40,9 +40,9 @@ allow_tables_to_appear_in_same_query!(entities, subgraphs);
 joinable!(entities -> subgraphs (subgraph));
 
 table! {
-    subgraph_names (subgraph_name) {
-        subgraph_name -> Varchar,
-        subgraph_id -> Nullable<Varchar>,
-        access_token -> Nullable<Varchar>,
+    subgraph_deployments (deployment_name) {
+        deployment_name -> Varchar,
+        subgraph_id -> Varchar,
+        node_id -> Varchar,
     }
 }

--- a/store/postgres/src/entity_changes.rs
+++ b/store/postgres/src/entity_changes.rs
@@ -1,134 +1,44 @@
-use fallible_iterator::FallibleIterator;
-use postgres::{Connection, TlsMode};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Barrier};
-use std::thread;
-use std::time::Duration;
-
-use futures::sync::mpsc::{channel, Receiver};
 use graph::prelude::*;
 use graph::serde_json;
+use notification_listener::{NotificationListener, SafeChannelName};
 
 pub struct EntityChangeListener {
-    output: Option<Receiver<EntityChange>>,
-    worker_handle: Option<thread::JoinHandle<()>>,
-    terminate_worker: Arc<AtomicBool>,
-    worker_barrier: Arc<Barrier>,
-    started: bool,
+    notification_listener: NotificationListener,
 }
 
 impl EntityChangeListener {
-    pub fn new(url: String) -> Self {
-        // Listen to Postgres notifications in a worker thread
-        let (receiver, worker_handle, terminate_worker, worker_barrier) = Self::listen(url);
-
+    pub fn new(postgres_url: String) -> Self {
         EntityChangeListener {
-            output: Some(receiver),
-            worker_handle: Some(worker_handle),
-            terminate_worker,
-            worker_barrier,
-            started: false,
+            notification_listener: NotificationListener::new(
+                postgres_url,
+                SafeChannelName::i_promise_this_is_safe("entity_changes"),
+            ),
         }
     }
 
-    /// Begins processing notifications coming in from Postgres.
     pub fn start(&mut self) {
-        if !self.started {
-            self.worker_barrier.wait();
-            self.started = true;
-        }
-    }
-
-    fn listen(
-        url: String,
-    ) -> (
-        Receiver<EntityChange>,
-        thread::JoinHandle<()>,
-        Arc<AtomicBool>,
-        Arc<Barrier>,
-    ) {
-        // Create two ends of a boolean variable for signalling when the worker
-        // thread should be terminated
-        let terminate = Arc::new(AtomicBool::new(false));
-        let terminate_worker = terminate.clone();
-        let barrier = Arc::new(Barrier::new(2));
-        let worker_barrier = barrier.clone();
-
-        // Create a channel for entity changes
-        let (sender, receiver) = channel(100);
-
-        let worker_handle = thread::spawn(move || {
-            // Connect to Postgres
-            let conn = Connection::connect(url, TlsMode::None)
-                .expect("failed to connect entity change listener to Postgres");
-
-            // Subscribe to the "entity_changes" notification channel in Postgres
-            conn.execute("LISTEN entity_changes", &[])
-                .expect("failed to listen to entity changes in Postgres");
-
-            // Wait until the listener has been started
-            barrier.wait();
-
-            // Read notifications until the thread is to be terminated
-            while !terminate.load(Ordering::SeqCst) {
-                // Obtain a notifications iterator from Postgres
-                let notifications = conn.notifications();
-
-                // Read notifications until there hasn't been one for 500ms
-                for notification in notifications
-                    .timeout_iter(Duration::from_millis(500))
-                    .iterator()
-                    .filter_map(Result::ok)
-                    .filter(|notification| notification.channel == "entity_changes")
-                {
-                    // Terminate the thread if desired
-                    if terminate.load(Ordering::SeqCst) {
-                        break;
-                    }
-
-                    // Parse payload into an entity change
-                    let value: serde_json::Value =
-                        serde_json::from_str(notification.payload.as_str())
-                            .expect("Invalid JSON entity change data received from database");
-                    let change: EntityChange = serde_json::from_value(value.clone())
-                        .unwrap_or_else(|_| {
-                            panic!(
-                                "Invalid entity change received from the database: {:?}",
-                                value
-                            )
-                        });
-
-                    // We'll assume here that if sending fails, this means that the
-                    // entity change listener has already been dropped, the receiving
-                    // is gone and we should terminate the listener loop
-                    if sender.clone().send(change).wait().is_err() {
-                        break;
-                    }
-                }
-            }
-        });
-
-        (receiver, worker_handle, terminate_worker, worker_barrier)
-    }
-}
-
-impl Drop for EntityChangeListener {
-    fn drop(&mut self) {
-        // When dropping the change listener, also make sure we signal termination
-        // to the worker and wait for it to shut down
-        self.terminate_worker.store(true, Ordering::SeqCst);
-        self.worker_handle
-            .take()
-            .unwrap()
-            .join()
-            .expect("failed to terminate EntityChangeListener thread");
+        self.notification_listener.start()
     }
 }
 
 impl EventProducer<EntityChange> for EntityChangeListener {
     fn take_event_stream(&mut self) -> Option<Box<Stream<Item = EntityChange, Error = ()> + Send>> {
-        self.output
-            .take()
-            .map(|s| Box::new(s) as Box<Stream<Item = EntityChange, Error = ()> + Send>)
+        self.notification_listener.take_event_stream().map(
+            |stream| -> Box<Stream<Item = _, Error = _> + Send> {
+                Box::new(stream.map(|notification| {
+                    // Parse notification as JSON
+                    let value: serde_json::Value = serde_json::from_str(&notification.payload)
+                        .expect("invalid JSON entity change received from database");
+
+                    // Create EntityChange from JSON
+                    let change: EntityChange = serde_json::from_value(value.clone())
+                        .unwrap_or_else(|_| {
+                            panic!("invalid entity change received from database: {:?}", value)
+                        });
+
+                    change
+                }))
+            },
+        )
     }
 }

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -18,6 +18,7 @@ mod entity_changes;
 mod filter;
 pub mod functions;
 pub mod models;
+mod notification_listener;
 pub mod store;
 
 pub use self::chain_head_listener::ChainHeadUpdateListener;

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -1,0 +1,148 @@
+use fallible_iterator::FallibleIterator;
+use postgres::notification::Notification;
+use postgres::{Connection, TlsMode};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::Duration;
+
+use futures::sync::mpsc::{channel, Receiver};
+use graph::prelude::*;
+
+/// This newtype exists to make it hard to misuse the `NotificationListener` API in a way that
+/// could impact security.
+pub struct SafeChannelName(String);
+
+impl SafeChannelName {
+    /// Channel names must be valid Postgres SQL identifiers.
+    /// If a channel name is provided that is not a valid identifier,
+    /// then there is a security risk due to SQL injection.
+    /// Unfortunately, it is difficult to properly validate a channel name.
+    /// (A blacklist would have to include SQL keywords, for example)
+    ///
+    /// The caller of this method is promising that the supplied channel name
+    /// is a valid Postgres identifier and cannot be supplied (even partially)
+    /// by an attacker.
+    pub fn i_promise_this_is_safe(channel_name: impl Into<String>) -> Self {
+        SafeChannelName(channel_name.into())
+    }
+}
+
+pub struct NotificationListener {
+    output: Option<Receiver<Notification>>,
+    worker_handle: Option<thread::JoinHandle<()>>,
+    terminate_worker: Arc<AtomicBool>,
+    worker_barrier: Arc<Barrier>,
+    started: bool,
+}
+
+impl NotificationListener {
+    /// Connect to the specified database and listen for Postgres notifications on the specified
+    /// channel.
+    ///
+    /// Must call `.start()` to begin receiving notifications.
+    pub fn new(postgres_url: String, channel_name: SafeChannelName) -> Self {
+        // Listen to Postgres notifications in a worker thread
+        let (receiver, worker_handle, terminate_worker, worker_barrier) =
+            Self::listen(postgres_url, channel_name);
+
+        NotificationListener {
+            output: Some(receiver),
+            worker_handle: Some(worker_handle),
+            terminate_worker,
+            worker_barrier,
+            started: false,
+        }
+    }
+
+    /// Start accepting notifications.
+    /// Must be called for any notifications to be received.
+    pub fn start(&mut self) {
+        if !self.started {
+            self.worker_barrier.wait();
+            self.started = true;
+        }
+    }
+
+    fn listen(
+        postgres_url: String,
+        channel_name: SafeChannelName,
+    ) -> (
+        Receiver<Notification>,
+        thread::JoinHandle<()>,
+        Arc<AtomicBool>,
+        Arc<Barrier>,
+    ) {
+        // Create two ends of a boolean variable for signalling when the worker
+        // thread should be terminated
+        let terminate = Arc::new(AtomicBool::new(false));
+        let terminate_worker = terminate.clone();
+        let barrier = Arc::new(Barrier::new(2));
+        let worker_barrier = barrier.clone();
+
+        // Create a channel for notifications
+        let (sender, receiver) = channel(1024);
+
+        let worker_handle = thread::spawn(move || {
+            // Connect to Postgres
+            let conn = Connection::connect(postgres_url, TlsMode::None)
+                .expect("failed to connect notification listener to Postgres");
+
+            // Subscribe to the notification channel in Postgres
+            conn.execute(&format!("LISTEN {}", channel_name.0), &[])
+                .expect("failed to listen to Postgres notifications");
+
+            // Wait until the listener has been started
+            barrier.wait();
+
+            // Read notifications until the thread is to be terminated
+            while !terminate.load(Ordering::SeqCst) {
+                // Obtain a notifications iterator from Postgres
+                let notifications = conn.notifications();
+
+                // Read notifications until there hasn't been one for 500ms
+                for notification in notifications
+                    .timeout_iter(Duration::from_millis(500))
+                    .iterator()
+                    .filter_map(Result::ok)
+                    .filter(|notification| notification.channel == channel_name.0)
+                {
+                    // Terminate the thread if desired
+                    if terminate.load(Ordering::SeqCst) {
+                        break;
+                    }
+
+                    // We'll assume here that if sending fails, this means that the
+                    // listener has already been dropped, the receiving
+                    // end is gone and we should terminate the listener loop
+                    if sender.clone().send(notification).wait().is_err() {
+                        break;
+                    }
+                }
+            }
+        });
+
+        (receiver, worker_handle, terminate_worker, worker_barrier)
+    }
+}
+
+impl Drop for NotificationListener {
+    fn drop(&mut self) {
+        // When dropping the listener, also make sure we signal termination
+        // to the worker and wait for it to shut down
+        self.terminate_worker.store(true, Ordering::SeqCst);
+        self.worker_handle
+            .take()
+            .unwrap()
+            .join()
+            .expect("failed to terminate NotificationListener thread");
+    }
+}
+
+impl EventProducer<Notification> for NotificationListener {
+    fn take_event_stream(&mut self) -> Option<Box<Stream<Item = Notification, Error = ()> + Send>> {
+        self.output
+            .take()
+            .map(|s| Box::new(s) as Box<Stream<Item = Notification, Error = ()> + Send>)
+    }
+}

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -767,7 +767,7 @@ impl SubgraphDeploymentStore for Store {
     ) -> Box<Stream<Item = DeploymentEvent, Error = Error> + Send> {
         // Create postgres listener
         let channel_name =
-            SafeChannelName::i_promise_this_is_safe(format!("subgraph_deployment_{}", node_id));
+            SafeChannelName::i_promise_this_is_safe(format!("subgraph_deployments_{}", node_id));
         let mut listener = NotificationListener::new(self.postgres_url.clone(), channel_name);
 
         // Start receiving notifications

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -766,8 +766,11 @@ impl SubgraphDeploymentStore for Store {
         node_id: NodeId,
     ) -> Box<Stream<Item = DeploymentEvent, Error = Error> + Send> {
         // Create postgres listener
-        let channel_name =
-            SafeChannelName::i_promise_this_is_safe(format!("subgraph_deployments_{}", node_id));
+        // This way of choosing a channel name is only safe because NodeId is restricted to
+        // alphanumeric and underscores, and because we forcibly prefix the node ID (which prevents
+        // the channel name from being a keyword).
+        let raw_channel_name = format!("subgraph_deployments_{}", node_id);
+        let channel_name = SafeChannelName::i_promise_this_is_safe(raw_channel_name);
         let mut listener = NotificationListener::new(self.postgres_url.clone(), channel_name);
 
         // Start receiving notifications

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -751,8 +751,7 @@ impl SubgraphDeploymentStore for Store {
     fn remove(&self, name: SubgraphDeploymentName) -> Result<bool, Error> {
         use db_schema::subgraph_deployments;
 
-        delete(subgraph_deployments::table)
-            .filter(subgraph_deployments::deployment_name.eq(name.to_string()))
+        delete(subgraph_deployments::table.find(name.to_string()))
             .execute(&*self.conn.lock().unwrap())
             .map(|row_count| match row_count {
                 0 => false,


### PR DESCRIPTION
This PR changes how subgraphs are started/stopped and persisted in order to enable multi-node deployments.

- `subgraph_names` table is gone (previously used for subgraph persistence), and the corresponding Store methods are gone
- `subgraph_deployments` table is new, and is accessible using a SubgraphDeploymentStore
- `subgraph_deployments` table has postgres triggers that produce an Add event for each INSERT, a Remove event + an Add event for each UPDATE, and a Remove event for each DELETE
- `SubgraphDeploymentStore::deployment_events` returns a stream that can be used to listen for Add/Remove events
- SubgraphProviderWithNames (should this be renamed to `SubgraphDeploymentProvider`?) `deploy` and `remove` methods now just write to the SubgraphDeploymentStore, which implicitly triggers a DeploymentEvent.
- SubgraphProviderWithNames listens for DeploymentEvents on startup and calls the appropriate SubgraphProvider start/stop methods as needed in response to Add/Remove events.
- node/src/main has a new optional CLI flag `--node-id`, which enables SubgraphProviderWithNames to ignore subgraphs deployed to other nodes. If the flag is not specified, the node ID is set to `"default"`.
- server/json-rpc is backwards compatible with the existing graph-cli, but adds a new optional `node_id` field to subgraph_deploy. This field will be used to specify what node a subgraph is to be deployed to.
- server/json-rpc token-based authentication is removed
- subgraph name/subgraph ID/node ID validation is now done via wrapper types (SubgraphDeploymentName, SubgraphId, NodeId) so that a function parameter's type indicates whether it has been validated yet
- ChainHeadUpdateListener and EntityChangeListener are now simple wrappers around a generic Postgres NotificationListener, which is now also used to receive DeploymentEvents
- core/tests/tests has been rewritten to be more async and to use the new API
- MockStore fully implements SubgraphDeploymentStore and mocks deployment events

Resolves #553 