### PR TITLE
Don't include __typename in schema introspection

### DIFF
--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -234,6 +234,7 @@ fn field_objects(
     q::Value::List(
         fields
             .into_iter()
+            .filter(|field| field.name != String::from("__typename"))
             .map(|field| field_object(schema, type_objects, field))
             .collect(),
     )


### PR DESCRIPTION
I was considering to drop generating the __typename field at all but that has other implications (like query execution not returning values for the field at all because it wouldn't exist on the types).

Fixes #431 (or rather, the bug caused by the initial implementation of `__typename`).

