### PR TITLE
Insert `__typename` at query time

### DIFF
--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -89,6 +89,15 @@ where
 
     // Process all field groups in order
     for (response_key, fields) in grouped_field_set {
+        // `__typename` is not in the schema but can be queried in all types.
+        if fields[0].name == "__typename" {
+            result_map.insert(
+                response_key.to_owned(),
+                q::Value::String(object_type.name.to_owned().into()),
+            );
+            continue;
+        }
+
         // If the field exists on the object, execute it and add its result to the result map
         if let Some((ref field, introspecting)) =
             get_field_type(ctx.clone(), object_type, &fields[0].name)

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -111,17 +111,6 @@ where
             _ => (),
         }
 
-        // Automatically add a "__typename" value
-        match data.insert("__typename".to_string(), Value::String(entity_type.clone())) {
-            Some(ref v) if v != &Value::String(entity_type.clone()) => {
-                return Err(HostExportError(format!(
-                    "Conflicting '__typename' value set by mapping for {} entity: {} != {}",
-                    entity_type, v, entity_type
-                )))
-            }
-            _ => (),
-        }
-
         self.ctx
             .as_mut()
             .map(|ctx| &mut ctx.entity_operations)

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -274,7 +274,6 @@ fn call_event_handler_and_receive_store_event() {
             data: Entity::from(HashMap::from_iter(
                 vec![
                     ("id".to_owned(), "example id".into()),
-                    ("__typename".to_owned(), "ExampleEntity".into()),
                     ("exampleAttribute".to_owned(), "some data".into()),
                 ].into_iter()
             )),


### PR DESCRIPTION
This makes it so we no longer add `__typename` to the schema (which does not conform to the spec) neither store it in the store (which is inefficient) but instead insert it at query time.

Fixes #431 for good. Alternative to #624.