### PR TITLE
docker: Pin parity version

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
   parity:
-    image: parity/parity
+    image: parity/parity:v2.1.1
     ports:
       - "8545:8545"
       - "8546:8546"


### PR DESCRIPTION
Newer versions aren't able to read the config file

