### PR TITLE
Add missing CORS headers and use wss:// if GraphiQL is served via HTTPS

### DIFF
--- a/server/http/assets/index.html
+++ b/server/http/assets/index.html
@@ -133,10 +133,10 @@
              });
          }
 
-         let wsUrl = 'ws://'
-                   + window.location.hostname
-                   + ':__WS_PORT__'
-                   + window.location.pathname;
+         let wsProtocl = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+         let wsHostname = window.lcoation.hostname
+         let wsPath = window.location.pathname.replace(/^\//, '')
+         let wsUrl = `${wsProtocol}//${wsHostname}:__WS__PORT__/${wsPath}`
          var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(
              wsUrl, { reconnect: true }
          );

--- a/server/http/assets/index.html
+++ b/server/http/assets/index.html
@@ -133,10 +133,10 @@
              });
          }
 
-         let wsProtocl = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-         let wsHostname = window.lcoation.hostname
+         let wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+         let wsHostname = window.location.hostname
          let wsPath = window.location.pathname.replace(/^\//, '')
-         let wsUrl = `${wsProtocol}//${wsHostname}:__WS__PORT__/${wsPath}`
+         let wsUrl = `${wsProtocol}//${wsHostname}:__WS_PORT__/${wsPath}`
          var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(
              wsUrl, { reconnect: true }
          );

--- a/server/http/src/response.rs
+++ b/server/http/src/response.rs
@@ -65,6 +65,7 @@ impl Future for GraphQLResponse {
             .status(status_code)
             .header("Access-Control-Allow-Origin", "*")
             .header("Access-Control-Allow-Headers", "Content-Type")
+            .header("Access-Control-Allow-Methods", "GET, OPTIONS, POST")
             .body(Body::from(json))
             .unwrap();
         Ok(Async::Ready(response))

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -219,6 +219,7 @@ where
                 .status(200)
                 .header("Access-Control-Allow-Origin", "*")
                 .header("Access-Control-Allow-Headers", "Content-Type")
+                .header("Access-Control-Allow-Methods", "GET, OPTIONS, POST")
                 .body(Body::from(""))
                 .unwrap(),
         ))


### PR DESCRIPTION
This fixes #633, as reported by @adamsoffer.