### PR TITLE
Add support for GraphQL variables

### DIFF
--- a/graph/src/data/query/mod.rs
+++ b/graph/src/data/query/mod.rs
@@ -3,5 +3,5 @@ mod query;
 mod result;
 
 pub use self::error::{QueryError, QueryExecutionError};
-pub use self::query::{Query, QueryVariableValue, QueryVariables};
+pub use self::query::{Query, QueryVariables};
 pub use self::result::QueryResult;

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -61,7 +61,7 @@ where
 }
 
 /// Variable values for a GraphQL query.
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
 pub struct QueryVariables(
     #[serde(deserialize_with = "deserialize_variables")] HashMap<String, q::Value>,
 );
@@ -71,6 +71,12 @@ impl Deref for QueryVariables {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl DerefMut for QueryVariables {
+    fn deref_mut(&mut self) -> &mut HashMap<String, q::Value> {
+        &mut self.0
     }
 }
 

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -1,6 +1,5 @@
 use graphql_parser::query as q;
-use serde::de::{Deserialize, Deserializer, Error as DeserializerError};
-use std::cmp::PartialEq;
+use serde::de::{Deserialize, Deserializer};
 use std::collections::{BTreeMap, HashMap};
 use std::ops::{Deref, DerefMut};
 
@@ -65,6 +64,12 @@ where
 pub struct QueryVariables(
     #[serde(deserialize_with = "deserialize_variables")] HashMap<String, q::Value>,
 );
+
+impl QueryVariables {
+    pub fn new(variables: HashMap<String, q::Value>) -> Self {
+        QueryVariables(variables)
+    }
+}
 
 impl Deref for QueryVariables {
     type Target = HashMap<String, q::Value>;

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -219,6 +219,7 @@ impl Value {
                     .ok_or_else(|| QueryExecutionError::NamedTypeError("Int".to_string()))?
                     as i32,
             ),
+            (query::Value::Variable(var), _) => Value::String(var.to_owned()),
             (query::Value::Float(f), _) => Value::Float(f.to_owned() as f32),
             (query::Value::Boolean(b), _) => Value::Bool(b.to_owned()),
             (query::Value::Null, _) => Value::Null,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -74,9 +74,7 @@ pub mod prelude {
     pub use components::{EventConsumer, EventProducer};
 
     pub use data::graphql::SerializableValue;
-    pub use data::query::{
-        Query, QueryError, QueryExecutionError, QueryResult, QueryVariables,
-    };
+    pub use data::query::{Query, QueryError, QueryExecutionError, QueryResult, QueryVariables};
     pub use data::schema::Schema;
     pub use data::store::scalar::{BigInt, BigIntSign};
     pub use data::store::{

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -75,7 +75,7 @@ pub mod prelude {
 
     pub use data::graphql::SerializableValue;
     pub use data::query::{
-        Query, QueryError, QueryExecutionError, QueryResult, QueryVariableValue, QueryVariables,
+        Query, QueryError, QueryExecutionError, QueryResult, QueryVariables,
     };
     pub use data::schema::Schema;
     pub use data::store::scalar::{BigInt, BigIntSign};

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -148,7 +148,7 @@ where
         .items
         .iter()
         .filter(|selection| !qast::skip_selection(selection, ctx.variable_values.deref()))
-        .filter(|selection| qast::include_selection(selection))
+        .filter(|selection| qast::include_selection(selection, ctx.variable_values.deref()))
         .collect();
 
     for selection in selections {

--- a/graphql/src/query/ast.rs
+++ b/graphql/src/query/ast.rs
@@ -71,11 +71,13 @@ pub fn skip_selection(selection: &Selection, variables: &HashMap<Name, Value>) -
             Some(val) => match val {
                 // Skip if @skip(if: true)
                 Value::Boolean(skip_if) => *skip_if,
+
                 // Also skip if @skip(if: $variable) where $variable is true
                 Value::Variable(name) => variables.get(name).map_or(false, |var| match var {
                     Value::Boolean(v) => v.to_owned(),
                     _ => false,
                 }),
+
                 _ => false,
             },
             None => true,
@@ -85,11 +87,19 @@ pub fn skip_selection(selection: &Selection, variables: &HashMap<Name, Value>) -
 }
 
 /// Returns true if a selection should be included (as per the `@include` directive).
-pub fn include_selection(selection: &Selection) -> bool {
+pub fn include_selection(selection: &Selection, variables: &HashMap<Name, Value>) -> bool {
     match get_directive(selection, "include".to_string()) {
-        Some(directive) => match get_argument_value(&directive.arguments, &"include".to_string()) {
+        Some(directive) => match get_argument_value(&directive.arguments, &"if".to_string()) {
             Some(val) => match val {
+                // Include if @include(if: true)
                 Value::Boolean(include) => *include,
+
+                // Also include if @include(if: $variable) where $variable is true
+                Value::Variable(name) => variables.get(name).map_or(false, |var| match var {
+                    Value::Boolean(v) => v.to_owned(),
+                    _ => false,
+                }),
+
                 _ => false,
             },
             None => true,

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -33,6 +33,13 @@ where
         Err(e) => return QueryResult::from(e),
     };
 
+    // Parse variable values
+    let coerced_variable_values =
+        match coerce_variable_values(&query.schema, operation, &query.variables) {
+            Ok(values) => values,
+            Err(errors) => return QueryResult::from(errors),
+        };
+
     // Create an introspection type store and resolver
     let introspection_schema = introspection_schema();
     let introspection_resolver = IntrospectionResolver::new(&options.logger, &query.schema);
@@ -47,6 +54,7 @@ where
         introspecting: false,
         document: &query.document,
         fields: vec![],
+        variable_values: Arc::new(coerced_variable_values),
     };
 
     let result = match *operation {

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -237,3 +237,31 @@ pub fn get_object_type_directive(object_type: &ObjectType, name: Name) -> Option
         .iter()
         .find(|directive| directive.name == name)
 }
+
+// Returns true if the given type is a non-null type.
+pub fn is_non_null_type(t: &Type) -> bool {
+    match t {
+        Type::NonNullType(_) => true,
+        _ => false,
+    }
+}
+
+/// Returns true if the given type is an input type.
+///
+/// Uses the algorithm outlined on
+/// https://facebook.github.io/graphql/draft/#IsInputType().
+pub fn is_input_type(schema: &Document, t: &Type) -> bool {
+    use self::TypeDefinition::*;
+
+    match t {
+        Type::NamedType(name) => {
+            let named_type = get_named_type(schema, name);
+            named_type.map_or(false, |type_def| match type_def {
+                Scalar(_) | Enum(_) | InputObject(_) => true,
+                _ => false,
+            })
+        }
+        Type::ListType(inner) => is_input_type(schema, inner),
+        Type::NonNullType(inner) => is_input_type(schema, inner),
+    }
+}

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -545,3 +545,145 @@ fn query_variables_are_used() {
         )]))
     );
 }
+
+#[test]
+fn skip_directive_works_with_query_variables() {
+    let query = graphql_parser::parse_query(
+        "
+        query musicians($skip: Boolean!) {
+          musicians {
+            id @skip(if: $skip)
+            name
+          }
+        }
+    ",
+    )
+    .expect("invalid test query");
+
+    // Set variable $skip to true
+    let result = execute_query_document_with_variables(
+        query.clone(),
+        Some(QueryVariables::new(HashMap::from_iter(
+            vec![(String::from("skip"), q::Value::Boolean(true))].into_iter(),
+        ))),
+    );
+
+    // Assert that only names are returned
+    assert_eq!(
+        result.data,
+        Some(object_value(vec![(
+            "musicians",
+            q::Value::List(vec![
+                object_value(vec![("name", q::Value::String(String::from("John")))]),
+                object_value(vec![("name", q::Value::String(String::from("Lisa")))]),
+                object_value(vec![("name", q::Value::String(String::from("Tom")))]),
+                object_value(vec![("name", q::Value::String(String::from("Valerie")))]),
+            ],)
+        )]))
+    );
+
+    // Set variable $skip to false
+    let result = execute_query_document_with_variables(
+        query,
+        Some(QueryVariables::new(HashMap::from_iter(
+            vec![(String::from("skip"), q::Value::Boolean(false))].into_iter(),
+        ))),
+    );
+
+    // Assert that IDs and names are returned
+    assert_eq!(
+        result.data,
+        Some(object_value(vec![(
+            "musicians",
+            q::Value::List(vec![
+                object_value(vec![
+                    ("id", q::Value::String(String::from("m1"))),
+                    ("name", q::Value::String(String::from("John")))
+                ]),
+                object_value(vec![
+                    ("id", q::Value::String(String::from("m2"))),
+                    ("name", q::Value::String(String::from("Lisa")))
+                ]),
+                object_value(vec![
+                    ("id", q::Value::String(String::from("m3"))),
+                    ("name", q::Value::String(String::from("Tom")))
+                ]),
+                object_value(vec![
+                    ("id", q::Value::String(String::from("m4"))),
+                    ("name", q::Value::String(String::from("Valerie")))
+                ]),
+            ],)
+        )]))
+    );
+}
+
+#[test]
+fn include_directive_works_with_query_variables() {
+    let query = graphql_parser::parse_query(
+        "
+        query musicians($include: Boolean!) {
+          musicians {
+            id @include(if: $include)
+            name
+          }
+        }
+    ",
+    )
+    .expect("invalid test query");
+
+    // Set variable $include to true
+    let result = execute_query_document_with_variables(
+        query.clone(),
+        Some(QueryVariables::new(HashMap::from_iter(
+            vec![(String::from("include"), q::Value::Boolean(true))].into_iter(),
+        ))),
+    );
+
+    // Assert that IDs and names are returned
+    assert_eq!(
+        result.data,
+        Some(object_value(vec![(
+            "musicians",
+            q::Value::List(vec![
+                object_value(vec![
+                    ("id", q::Value::String(String::from("m1"))),
+                    ("name", q::Value::String(String::from("John")))
+                ]),
+                object_value(vec![
+                    ("id", q::Value::String(String::from("m2"))),
+                    ("name", q::Value::String(String::from("Lisa")))
+                ]),
+                object_value(vec![
+                    ("id", q::Value::String(String::from("m3"))),
+                    ("name", q::Value::String(String::from("Tom")))
+                ]),
+                object_value(vec![
+                    ("id", q::Value::String(String::from("m4"))),
+                    ("name", q::Value::String(String::from("Valerie")))
+                ]),
+            ],)
+        )]))
+    );
+
+    // Set variable $include to false
+    let result = execute_query_document_with_variables(
+        query,
+        Some(QueryVariables::new(HashMap::from_iter(
+            vec![(String::from("include"), q::Value::Boolean(false))].into_iter(),
+        ))),
+    );
+
+    // Assert that only names are returned
+    assert_eq!(
+        result.data,
+        Some(object_value(vec![(
+            "musicians",
+            q::Value::List(vec![
+                object_value(vec![("name", q::Value::String(String::from("John")))]),
+                object_value(vec![("name", q::Value::String(String::from("Lisa")))]),
+                object_value(vec![("name", q::Value::String(String::from("Tom")))]),
+                object_value(vec![("name", q::Value::String(String::from("Valerie")))]),
+            ],)
+        )]))
+    );
+}

--- a/server/http/src/request.rs
+++ b/server/http/src/request.rs
@@ -75,7 +75,9 @@ impl Future for GraphQLRequest {
 #[cfg(test)]
 mod tests {
     use graphql_parser;
+    use graphql_parser::query as q;
     use hyper;
+    use std::ops::DerefMut;
 
     use graph::prelude::*;
 
@@ -205,8 +207,10 @@ mod tests {
         let query = request.wait().expect("Should accept valid queries");
 
         let expected_query = graphql_parser::parse_query("{ user { name } }").unwrap();
-        let mut expected_variables = QueryVariables::new();
-        expected_variables.insert("foo".to_string(), QueryVariableValue::from("bar"));
+        let mut expected_variables: QueryVariables = Default::default();
+        expected_variables
+            .deref_mut()
+            .insert(String::from("foo"), q::Value::String(String::from("bar")));
 
         assert_eq!(query.document, expected_query);
         assert_eq!(query.variables, Some(expected_variables));

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -268,8 +268,9 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
 
+                let id = SubgraphId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
-                let store = Arc::new(MockStore::new());
+                let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
                 let mut server = HyperGraphQLServer::new(&logger, query_runner, store, node_id);
                 let http_server = server
@@ -282,16 +283,6 @@ mod test {
                 Delay::new(Instant::now() + Duration::from_secs(2))
                     .map_err(|e| panic!("failed to start server: {:?}", e))
                     .and_then(move |()| {
-                        // Create a simple schema and send it to the server
-                        let schema = test_schema();
-                        let id = schema.id.clone();
-
-                        server
-                            .event_sink()
-                            .send(SchemaEvent::SchemaAdded(schema))
-                            .wait()
-                            .expect("Failed to send schema to server");
-
                         // Send a valid example query
                         let client = Client::new();
                         let request = Request::post(format!(


### PR DESCRIPTION
Resolves #432 by supporting GraphQL variables a la
```graphql
query subgraph($id: ID!) {
  subgraph(id: $id) {
    id
    entityCount
  }
}
```
Clients can provide values for these variables by submitting a query request payload like this one:
```json
{
  "query": "query subgraph($id: ID!) { subgraph(id: $id) { id entityCount } }",
  "variables": {
    "id": "QmQ4i9cTazP1ZC8JrHEP1BhZdvbSxXt1mEeoQCMnQMnFH5"
  }
}
```