### PR TITLE
Fix stray compiler warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "graph"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -710,14 +710,14 @@ dependencies = [
 
 [[package]]
 name = "graph-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.1",
- "graph-graphql 0.4.1",
- "graph-mock 0.4.1",
- "graph-runtime-wasm 0.4.1",
+ "graph 0.5.0",
+ "graph-graphql 0.5.0",
+ "graph-mock 0.5.0",
+ "graph-runtime-wasm 0.5.0",
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -729,24 +729,24 @@ dependencies = [
 
 [[package]]
 name = "graph-datasource-ethereum"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.1",
+ "graph 0.5.0",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "graph-graphql"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "Inflector 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.1",
- "graph-core 0.4.1",
- "graph-mock 0.4.1",
+ "graph 0.5.0",
+ "graph-core 0.5.0",
+ "graph-mock 0.5.0",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -755,32 +755,32 @@ dependencies = [
 
 [[package]]
 name = "graph-mock"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.1",
- "graph-graphql 0.4.1",
+ "graph 0.5.0",
+ "graph-graphql 0.5.0",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "graph-node"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.1",
- "graph-core 0.4.1",
- "graph-datasource-ethereum 0.4.1",
- "graph-mock 0.4.1",
- "graph-runtime-wasm 0.4.1",
- "graph-server-http 0.4.1",
- "graph-server-json-rpc 0.4.1",
- "graph-server-websocket 0.4.1",
- "graph-store-postgres 0.4.1",
+ "graph 0.5.0",
+ "graph-core 0.5.0",
+ "graph-datasource-ethereum 0.5.0",
+ "graph-mock 0.5.0",
+ "graph-runtime-wasm 0.5.0",
+ "graph-server-http 0.5.0",
+ "graph-server-json-rpc 0.5.0",
+ "graph-server-websocket 0.5.0",
+ "graph-store-postgres 0.5.0",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -791,12 +791,12 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-wasm"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "ethabi 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.1",
- "graph-mock 0.4.1",
+ "graph 0.5.0",
+ "graph-mock 0.5.0",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -807,12 +807,12 @@ dependencies = [
 
 [[package]]
 name = "graph-server-http"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.1",
- "graph-graphql 0.4.1",
- "graph-mock 0.4.1",
+ "graph 0.5.0",
+ "graph-graphql 0.5.0",
+ "graph-mock 0.5.0",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -822,20 +822,20 @@ dependencies = [
 
 [[package]]
 name = "graph-server-json-rpc"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
- "graph 0.4.1",
+ "graph 0.5.0",
  "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "graph-server-websocket"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.1",
- "graph-graphql 0.4.1",
+ "graph 0.5.0",
+ "graph-graphql 0.5.0",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "graph-store-postgres"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bigdecimal 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -854,7 +854,7 @@ dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph 0.4.1",
+ "graph 0.5.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/log/elastic.rs
+++ b/core/src/log/elastic.rs
@@ -272,10 +272,10 @@ impl Drain for ElasticDrain {
 
         let mut text = format!("{}", record.msg());
         if n_logger_kvs > 0 {
-            write!(text, ", {}", logger_kvs);
+            write!(text, ", {}", logger_kvs).unwrap();
         }
         if n_value_kvs > 0 {
-            write!(text, ", {}", value_kvs);
+            write!(text, ", {}", value_kvs).unwrap();
         }
 
         // Prepare log document

--- a/datasource/ethereum/src/lib.rs
+++ b/datasource/ethereum/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate failure;
 extern crate futures;
 extern crate graph;

--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -3,7 +3,7 @@ use failure;
 use ipfs_api;
 use tokio::prelude::*;
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// Resolves links to subgraph manifests and resources referenced by them.
 pub trait LinkResolver: Send + Sync + 'static {
@@ -21,7 +21,7 @@ impl LinkResolver for ipfs_api::IpfsClient {
             self.cat(path)
                 .concat2()
                 // Guard against IPFS unresponsiveness.
-                .deadline(Instant::now() + Duration::from_secs(10))
+                .timeout(Duration::from_secs(10))
                 .map(|x| x.to_vec())
                 .map_err(|e| failure::err_msg(e.to_string())),
         )

--- a/server/websocket/src/lib.rs
+++ b/server/websocket/src/lib.rs
@@ -3,7 +3,6 @@ extern crate graph;
 extern crate graph_graphql;
 extern crate graphql_parser;
 extern crate hyper;
-#[macro_use]
 extern crate serde_derive;
 extern crate tokio_tungstenite;
 extern crate uuid;


### PR DESCRIPTION
- Bump graph-node versions in Cargo.lock (autogenerated changes from cargo)
- Remove a few `#[macro_use]` attributes, no longer needed in the latest version of Rust
- Add `.unwrap()` to a couple of unchecked errors
- A tokio update deprecated `.deadline()` in favour of `.timeout()`, which has a near identical API. Swap the former for the latter.

