### PR TITLE
Add status and block counts to subgraph entity

### DIFF
--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -81,7 +81,9 @@ where
                         .duration_since(UNIX_EPOCH)
                         .unwrap()
                         .as_secs();
-                    let entity_ops = SubgraphEntity::new(&subgraph, created_at).write_operations();
+                    let entity_ops =
+                        SubgraphEntity::new(&subgraph, SubgraphStatus::Syncing, 0, 0, created_at)
+                            .write_operations();
                     self_clone
                         .store
                         .apply_entity_operations(entity_ops, EventSource::None)

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -85,7 +85,7 @@ pub mod prelude {
     };
     pub use data::subgraph::{
         DataSource, Link, MappingABI, MappingEventHandler, SubgraphId, SubgraphManifest,
-        SubgraphManifestResolveError, SubgraphProviderError,
+        SubgraphManifestResolveError, SubgraphProviderError, SubgraphStatus,
     };
     pub use data::subscription::{
         QueryResultStream, Subscription, SubscriptionError, SubscriptionResult,

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -3,6 +3,16 @@ type Subgraph @entity {
     manifest: SubgraphManifest!
     entityCount: BigInt! # Computed field, not stored.
     createdAt: BigInt!
+    status: SubgraphStatus!
+    processedEthereumBlocksCount: BigInt!
+    totalEthereumBlocksCount: BigInt!
+}
+
+enum SubgraphStatus {
+    SYNCING
+    SYNCED
+    FAILED
+    PAUSED
 }
 
 type SubgraphManifest @entity {
@@ -13,7 +23,6 @@ type SubgraphManifest @entity {
     schema: String!
     dataSources: [EthereumContractDataSource!]!
 }
-
 
 type EthereumContractDataSource @entity {
     id: ID!


### PR DESCRIPTION
Add status and progress fields to subgraph of subgraphs, and update them during block stream processing.

Resolves #584 