### PR TITLE
Fix subscription stream termination issue

### DIFF
--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1370,9 +1370,7 @@ fn revert_block_with_partial_update() {
     })
 }
 
-// Disabled due to issue #332
 #[test]
-#[ignore]
 fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
     run_test(|store| {
         let subgraph_id = SubgraphId::new("EntityChangeTestSubgraph").unwrap();
@@ -1410,7 +1408,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
                     .map(|(id, data)| EntityOperation::Set {
                         key: EntityKey {
                             subgraph_id: subgraph_id.clone(),
-                            entity_type: "user".to_owned(),
+                            entity_type: "User".to_owned(),
                             entity_id: id.to_owned(),
                         },
                         data: data.to_owned(),


### PR DESCRIPTION
Resolves #332 

`Store::subscribe` returns a stream of entity changes. This stream is actually a `mpsc` `Receiver`. Each time `Store::subscribe` is invoked, a new `Sender`/`Receiver` pair is created, and the `Sender` is saved into the `Store` instance.

When the `Receiver` is dropped, the corresponding `Sender` will return an error the next time the store tries to send it an entity change, at which point that `Sender` (and information about the subscription it represents) is removed from the `Store`. However, the `Sender` error was not being suppressed properly, so it brought down the store's global entity change stream. As soon as any subscription was removed, all subscriptions would silently stop receiving entity changes.

The bug is really just a case of accidentally using `.and_then(|_| Ok(()))` instead of `.then(|_| Ok(()))`, which would have correctly suppressed the error. (I wonder if a Clippy lint could catch this mistake?)