### PR TITLE
Fix passing positive BigInt starting with `0x80` to AS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.2.1 (git+http://github.com/leodasvacas/num-bigint?branch=fix-to-signed-bytes)",
+ "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1495,8 +1495,8 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.2.1"
-source = "git+http://github.com/leodasvacas/num-bigint?branch=fix-to-signed-bytes#79933434012636e588da6652bdd18fa358b51a31"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3323,7 +3323,7 @@ dependencies = [
 "checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
-"checksum num-bigint 0.2.1 (git+http://github.com/leodasvacas/num-bigint?branch=fix-to-signed-bytes)" = "<none>"
+"checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.1 (git+http://github.com/leodasvacas/num-bigint?branch=fix-to-signed-bytes)",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "num-bigint"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+http://github.com/leodasvacas/num-bigint?branch=fix-to-signed-bytes#79933434012636e588da6652bdd18fa358b51a31"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3323,7 +3323,7 @@ dependencies = [
 "checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
-"checksum num-bigint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "10b8423ea72ec64751198856a853e07b37087cfc9b53a87ecb19bff67b6d1320"
+"checksum num-bigint 0.2.1 (git+http://github.com/leodasvacas/num-bigint?branch=fix-to-signed-bytes)" = "<none>"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -12,9 +12,7 @@ ipfs-api = "0.5.0-alpha2"
 parity-wasm = "0.31"
 failure = "0.1.2"
 lazy_static = "1.2.0"
-
-# Go back to upstream as soon as https://github.com/rust-num/num-bigint/pull/72 is merged.
-num-bigint = { git = "http://github.com/leodasvacas/num-bigint", branch = "fix-to-signed-bytes", features = ["serde"] }
+num-bigint = { version = "^0.2.2", features = ["serde"] }
 serde = "1.0"
 serde_derive = "1.0"
 

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -12,7 +12,9 @@ ipfs-api = "0.5.0-alpha2"
 parity-wasm = "0.31"
 failure = "0.1.2"
 lazy_static = "1.2.0"
-num-bigint = { version = "0.2.0", features = ["serde"] }
+
+# Go back to upstream as soon as https://github.com/rust-num/num-bigint/pull/72 is merged.
+num-bigint = { git = "http://github.com/leodasvacas/num-bigint", branch = "fix-to-signed-bytes", features = ["serde"] }
 serde = "1.0"
 serde_derive = "1.0"
 

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -396,6 +396,25 @@ fn big_int_arithmetic() {
     let result: BigInt = module.heap.asc_get(result_ptr);
     assert_eq!(result, BigInt::from(1));
 
+    // 127 + 1 = 128
+    let zero = BigInt::from(127);
+    let zero: AscPtr<AscBigInt> = module.heap.asc_new(&zero);
+    let one = BigInt::from(1);
+    let one: AscPtr<AscBigInt> = module.heap.asc_new(&one);
+    let result_ptr: AscPtr<AscBigInt> = module
+        .module
+        .invoke_export(
+            "plus",
+            &[RuntimeValue::from(zero), RuntimeValue::from(one)],
+            &mut module.externals,
+        )
+        .expect("call failed")
+        .expect("call returned nothing")
+        .try_into()
+        .expect("call did not return pointer");
+    let result: BigInt = module.heap.asc_get(result_ptr);
+    assert_eq!(result, BigInt::from(128));
+
     // 5 - 10 = -5
     let five = BigInt::from(5);
     let five: AscPtr<AscBigInt> = module.heap.asc_new(&five);


### PR DESCRIPTION
Turns out it was an upstream bug with `to_signed_bytes_le`, it flips the sign of specific numbers such as `128`. Nice catch and investigation @davekaj!

Fixes #626.