### PR TITLE
Remove dead code in resolver

### DIFF
--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -332,14 +332,9 @@ where
             argument_values,
         ),
 
-        s::Type::NamedType(ref name) => resolve_field_value_for_named_type(
-            ctx,
-            object_value,
-            field,
-            field_definition,
-            name,
-            argument_values,
-        ),
+        s::Type::NamedType(ref name) => {
+            resolve_field_value_for_named_type(ctx, object_value, field, name, argument_values)
+        }
 
         s::Type::ListType(inner_type) => resolve_field_value_for_list_type(
             ctx,
@@ -358,7 +353,6 @@ fn resolve_field_value_for_named_type<'a, R1, R2>(
     ctx: ExecutionContext<'a, R1, R2>,
     object_value: &Option<q::Value>,
     field: &q::Field,
-    field_definition: &s::Field,
     type_name: &s::Name,
     argument_values: &HashMap<&q::Name, q::Value>,
 ) -> Result<q::Value, Vec<QueryExecutionError>>
@@ -385,18 +379,12 @@ where
                 ctx.introspection_resolver.resolve_object(
                     object_value,
                     &field.name,
-                    field_definition,
                     t,
                     argument_values,
                 )
             } else {
-                ctx.resolver.resolve_object(
-                    object_value,
-                    &field.name,
-                    field_definition,
-                    t,
-                    argument_values,
-                )
+                ctx.resolver
+                    .resolve_object(object_value, &field.name, t, argument_values)
             }
         }
 

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -21,7 +21,6 @@ pub trait Resolver: Clone + Send + Sync {
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
-        field_definition: &s::Field,
         object_type: &s::ObjectType,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError>;

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -509,7 +509,6 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
-        _field_definition: &s::Field,
         _object_type: &s::ObjectType,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -261,7 +261,6 @@ where
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
-        field_definition: &s::Field,
         object_type: &s::ObjectType,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -288,21 +288,7 @@ where
                     })?,
                     _ => None,
                 },
-                _ => {
-                    let mut query = build_query(&object_type, arguments)?;
-
-                    // Add matching filter for derived fields
-                    Self::add_filter_for_derived_field(
-                        &mut query,
-                        parent,
-                        field_definition,
-                        object_type,
-                    );
-
-                    query.range = Some(EntityRange { first: 1, skip: 0 });
-
-                    self.store.find(query)?.into_iter().next()
-                }
+                _ => panic!("top level queries must either take an `id` or return a list"),
             }
         };
 

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -31,7 +31,6 @@ impl Resolver for MockResolver {
         &self,
         _parent: &Option<q::Value>,
         _field: &q::Name,
-        _field_definition: &s::Field,
         _object_type: &s::ObjectType,
         _arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {


### PR DESCRIPTION
Resolving a single object with no parent and no supplied `id` dosen't make much sense when you think about it. Unless it is some sort of unique global object? Which is not something that exists in our graphql API, so I'd rather just remove this confusing code, we can rethink this if we ever get a top level query that returns a single object but doesn't take an `id` parameter.