### PR TITLE
Return subgraph ID from `subgraph_create`

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use graph::data::subgraph::schema::*;
 use graph::prelude::{
-    SubgraphDeploymentProvider as SubgraphDeploymentProviderTrait,
+    CreateSubgraphResult, SubgraphDeploymentProvider as SubgraphDeploymentProviderTrait,
     SubgraphRegistrar as SubgraphRegistrarTrait, *,
 };
 
@@ -201,7 +201,8 @@ where
     fn create_subgraph(
         &self,
         name: SubgraphName,
-    ) -> Box<Future<Item = String, Error = SubgraphRegistrarError> + Send + 'static> {
+    ) -> Box<Future<Item = CreateSubgraphResult, Error = SubgraphRegistrarError> + Send + 'static>
+    {
         Box::new(future::result(create_subgraph(
             &self.logger,
             self.store.clone(),
@@ -325,7 +326,7 @@ fn create_subgraph(
     logger: &Logger,
     store: Arc<impl Store>,
     name: SubgraphName,
-) -> Result<String, SubgraphRegistrarError> {
+) -> Result<CreateSubgraphResult, SubgraphRegistrarError> {
     let mut ops = vec![];
 
     // Check if this subgraph already exists
@@ -363,7 +364,7 @@ fn create_subgraph(
 
     debug!(logger, "Created subgraph"; "subgraph_name" => name.to_string());
 
-    Ok(entity_id)
+    Ok(CreateSubgraphResult { id: entity_id })
 }
 
 fn create_subgraph_version(

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -201,7 +201,7 @@ where
     fn create_subgraph(
         &self,
         name: SubgraphName,
-    ) -> Box<Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static> {
+    ) -> Box<Future<Item = String, Error = SubgraphRegistrarError> + Send + 'static> {
         Box::new(future::result(create_subgraph(
             &self.logger,
             self.store.clone(),
@@ -325,7 +325,7 @@ fn create_subgraph(
     logger: &Logger,
     store: Arc<impl Store>,
     name: SubgraphName,
-) -> Result<(), SubgraphRegistrarError> {
+) -> Result<String, SubgraphRegistrarError> {
     let mut ops = vec![];
 
     // Check if this subgraph already exists
@@ -363,7 +363,7 @@ fn create_subgraph(
 
     debug!(logger, "Created subgraph"; "subgraph_name" => name.to_string());
 
-    Ok(())
+    Ok(entity_id)
 }
 
 fn create_subgraph_version(

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -222,7 +222,7 @@ fn subgraph_provider_events() {
             );
             registrar
                 .start()
-                .and_then(move |()| {
+                .and_then(move |_| {
                     add_subgraph_to_ipfs(resolver.clone(), "two-datasources")
                         .join(add_subgraph_to_ipfs(resolver, "dummy"))
                 })
@@ -266,7 +266,7 @@ fn subgraph_provider_events() {
                             // Create subgraph
                             registrar_clone1.create_subgraph(subgraph_name_clone1.clone())
                         })
-                        .and_then(move |()| {
+                        .and_then(move |_| {
                             // Deploy
                             registrar_clone2.create_subgraph_version(
                                 subgraph_name_clone2.clone(),
@@ -393,8 +393,8 @@ fn subgraph_list() {
                         .and_then(move |()| {
                             registrar_clone1.create_subgraph(subgraph1_name_clone1.clone())
                         })
-                        .and_then(move |()| registrar_clone2.create_subgraph(subgraph2_name_clone1))
-                        .and_then(move |()| registrar_clone3.list_subgraphs())
+                        .and_then(move |_| registrar_clone2.create_subgraph(subgraph2_name_clone1))
+                        .and_then(move |_| registrar_clone3.list_subgraphs())
                         .and_then(move |subgraphs| {
                             assert_eq!(
                                 subgraphs.into_iter().collect::<HashSet<_>>(),

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -5,7 +5,7 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
     fn create_subgraph(
         &self,
         name: SubgraphName,
-    ) -> Box<Future<Item = String, Error = SubgraphRegistrarError> + Send + 'static>;
+    ) -> Box<Future<Item = CreateSubgraphResult, Error = SubgraphRegistrarError> + Send + 'static>;
 
     fn create_subgraph_version(
         &self,

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -5,7 +5,7 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
     fn create_subgraph(
         &self,
         name: SubgraphName,
-    ) -> Box<Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
+    ) -> Box<Future<Item = String, Error = SubgraphRegistrarError> + Send + 'static>;
 
     fn create_subgraph_version(
         &self,

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -147,6 +147,13 @@ impl<'de> de::Deserialize<'de> for SubgraphName {
     }
 }
 
+/// Result of a creating a subgraph in the registar.
+#[derive(Serialize)]
+pub struct CreateSubgraphResult {
+    /// The ID of the subgraph that was created.
+    pub id: String,
+}
+
 #[derive(Fail, Debug)]
 pub enum SubgraphRegistrarError {
     #[fail(display = "subgraph resolve error: {}", _0)]

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -86,9 +86,9 @@ pub mod prelude {
     };
     pub use data::subgraph::schema::TypedEntity;
     pub use data::subgraph::{
-        DataSource, Link, MappingABI, MappingEventHandler, SubgraphDeploymentProviderError,
-        SubgraphDeploymentProviderEvent, SubgraphId, SubgraphManifest,
-        SubgraphManifestResolveError, SubgraphName, SubgraphRegistrarError,
+        CreateSubgraphResult, DataSource, Link, MappingABI, MappingEventHandler,
+        SubgraphDeploymentProviderError, SubgraphDeploymentProviderEvent, SubgraphId,
+        SubgraphManifest, SubgraphManifestResolveError, SubgraphName, SubgraphRegistrarError,
     };
     pub use data::subscription::{
         QueryResultStream, Subscription, SubscriptionError, SubscriptionResult,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -496,7 +496,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                 .then(
                     |result| Ok(result.expect("Failed to create subgraph from `--subgraph` flag")),
                 )
-                .and_then(move |()| {
+                .and_then(move |_| {
                     subgraph_registrar.create_subgraph_version(name, subgraph_id, node_id)
                 })
                 .then(|result| {

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -67,7 +67,7 @@ where
                         json_rpc_error(JSON_RPC_CREATE_ERROR, e.to_string())
                     }
                 })
-                .map(move |_| Value::Null),
+                .map(move |id| Value::String(id)),
         )
     }
 

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -67,7 +67,9 @@ where
                         json_rpc_error(JSON_RPC_CREATE_ERROR, e.to_string())
                     }
                 })
-                .map(move |id| Value::String(id)),
+                .map(move |result| {
+                    serde_json::to_value(result).expect("invalid subgraph creation result")
+                }),
         )
     }
 


### PR DESCRIPTION
This is so users of `subgraph_create` can then use the new ID (e.g. store them somewhere).