### PR TITLE
Change URL structure and support 2-part names

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -117,6 +117,11 @@ impl SubgraphName {
             return Err(());
         }
 
+        // To keep URLs unambiguous, reserve the token "graphql"
+        if s.split("/").any(|part| part == "graphql") {
+            return Err(());
+        }
+
         Ok(SubgraphName(s))
     }
 }

--- a/server/http/assets/index.html
+++ b/server/http/assets/index.html
@@ -108,13 +108,14 @@
              history.replaceState(null, null, newSearch);
          }
 
+         var graphQLEndpoint = window.location.pathname
+             .substring(0, window.location.pathname.length - "/graphql".length);
+
          // Defines a GraphQL fetcher using the fetch API. You're not required to
          // use fetch, and could instead implement graphQLFetcher however you like,
          // as long as it returns a Promise or Observable.
          function graphQLFetcher(graphQLParams) {
-             // This example expects a GraphQL server at the path /graphql.
-             // Change this to point wherever you host your GraphQL server.
-             return fetch(window.location.pathname + '/graphql', {
+             return fetch(graphQLEndpoint, {
                  method: 'post',
                  headers: {
                      'Accept': 'application/json',
@@ -135,7 +136,7 @@
 
          let wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
          let wsHostname = window.location.hostname
-         let wsPath = window.location.pathname.replace(/^\//, '')
+         let wsPath = graphQLEndpoint.replace(/^\//, '')
          let wsUrl = `${wsProtocol}//${wsHostname}:__WS_PORT__/${wsPath}`
          var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(
              wsUrl, { reconnect: true }

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -95,12 +95,10 @@ mod test {
                     .and_then(move |()| {
                         // Send an empty JSON POST request
                         let client = Client::new();
-                        let request = Request::post(format!(
-                            "http://localhost:8001/subgraphs/id/{}/graphql",
-                            id
-                        ))
-                        .body(Body::from("{}"))
-                        .unwrap();
+                        let request =
+                            Request::post(format!("http://localhost:8001/subgraphs/id/{}", id))
+                                .body(Body::from("{}"))
+                                .unwrap();
 
                         // The response must be a query error
                         client.request(request)
@@ -146,12 +144,10 @@ mod test {
                     .and_then(move |()| {
                         // Send an broken query request
                         let client = Client::new();
-                        let request = Request::post(format!(
-                            "http://localhost:8002/subgraphs/id/{}/graphql",
-                            id
-                        ))
-                        .body(Body::from("{\"query\": \"<L<G<>M>\"}"))
-                        .unwrap();
+                        let request =
+                            Request::post(format!("http://localhost:8002/subgraphs/id/{}", id))
+                                .body(Body::from("{\"query\": \"<L<G<>M>\"}"))
+                                .unwrap();
 
                         // The response must be a query error
                         client.request(request)
@@ -231,12 +227,10 @@ mod test {
                     .and_then(move |()| {
                         // Send a valid example query
                         let client = Client::new();
-                        let request = Request::post(format!(
-                            "http://localhost:8003/subgraphs/id/{}/graphql",
-                            id
-                        ))
-                        .body(Body::from("{\"query\": \"{ name }\"}"))
-                        .unwrap();
+                        let request =
+                            Request::post(format!("http://localhost:8003/subgraphs/id/{}", id))
+                                .body(Body::from("{\"query\": \"{ name }\"}"))
+                                .unwrap();
 
                         // The response must be a 200
                         client.request(request)
@@ -282,12 +276,10 @@ mod test {
                     .and_then(move |()| {
                         // Send a valid example query
                         let client = Client::new();
-                        let request = Request::post(format!(
-                            "http://localhost:8005/subgraphs/id/{}/graphql",
-                            id
-                        ))
-                        .body(Body::from(
-                            "
+                        let request =
+                            Request::post(format!("http://localhost:8005/subgraphs/id/{}", id))
+                                .body(Body::from(
+                                    "
                             {
                               \"query\": \" \
                                 query name($equals: String!) { \
@@ -297,8 +289,8 @@ mod test {
                               \"variables\": { \"equals\": \"John\" }
                             }
                             ",
-                        ))
-                        .unwrap();
+                                ))
+                                .unwrap();
 
                         // The response must be a 200
                         client.request(request)

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -43,13 +43,17 @@ where
         match path_segments.as_slice() {
             &["subgraphs"] => Ok(SUBGRAPHS_ID.clone()),
             &["subgraphs", "id", subgraph_id] => SubgraphId::new(subgraph_id),
-            &["subgraphs", "name", subgraph_name] => SubgraphName::new(subgraph_name)
-                .map(|subgraph_name| {
-                    store
-                        .resolve_subgraph_name_to_id(subgraph_name)
-                        .expect("failed to resolve subgraph name to ID")
-                })
-                .and_then(|deployment_opt| deployment_opt.ok_or(())),
+            &["subgraphs", "name", _] | &["subgraphs", "name", _, _] => {
+                let subgraph_name = path_segments[2..].join("/");
+
+                SubgraphName::new(subgraph_name)
+                    .map(|subgraph_name| {
+                        store
+                            .resolve_subgraph_name_to_id(subgraph_name)
+                            .expect("failed to resolve subgraph name to ID")
+                    })
+                    .and_then(|deployment_opt| deployment_opt.ok_or(()))
+            }
             _ => return Err(()),
         }
     }


### PR DESCRIPTION
Before:
- `GET /subgraphs` returned a GraphiQL interface
- `POST /subgraphs` 404
- `GET /subgraphs/graphql` 404
- `POST /subgraphs/graphql` handled a GraphQL query
- `GET /subgraphs/[name|id]/<some name or id>` returned a GraphiQL interface
- `POST /subgraphs/[name|id]/<some name or id>` 404
- `GET /subgraphs/[name|id]/<some name or id>/graphql` 404
- `POST /subgraphs/[name|id]/<some name or id>/graphql` handled a GraphQL query

After:
- `GET /subgraphs` redirects to `/subgraphs/graphql`
- `POST /subgraphs` handles a GraphQL query
- `GET /subgraphs/graphql` returns a GraphiQL interface
- `POST /subgraphs/graphql` 404
- `GET /subgraphs/[name|id]/<some name or id>` redirects to `/subgraphs/[name|id]/<some name or id>/graphql`
- `POST /subgraphs/[name|id]/<some name or id>` handles a GraphQL query
- `GET /subgraphs/[name|id]/<some name or id>/graphql` returns a GraphiQL interface
- `POST /subgraphs/[name|id]/<some name or id>/graphql` 404

Additionally, this PR allows names to be two URL path segments long, e.g. `/subgraphs/name/tim/decentraland`, and prevents subgraph names from ending in `/graphql`.

Resolves #658 