### PR TITLE
runtime, graph: Allow panics in mapping runtime threads

### DIFF
--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -161,7 +161,13 @@ impl RuntimeHost {
             })?
             .clone();
 
-        thread::spawn(move || {
+        let conf = thread::Builder::new().name(format!(
+            "{}-{}-{}",
+            util::log::MAPPING_THREAD_PREFIX,
+            config.subgraph_id,
+            data_source_name
+        ));
+        conf.spawn(move || {
             debug!(module_logger, "Start WASM runtime");
 
             // Load the mapping of the data source as a WASM module
@@ -215,7 +221,8 @@ impl RuntimeHost {
                 })
                 .wait()
                 .ok();
-        });
+        })
+        .expect("failed to spawn runtime thread");
 
         Ok(RuntimeHost {
             data_source_name,


### PR DESCRIPTION
Threads are already a point where panics are naturaly catched. But by design we exit the process on
panics, so give the mapping threads special names which the handler checks for and then doesn't exit the process.

The subgraph will go into failed status as soon as it needs calls the mapping and finds that the channel was dropped.

Resolves #663.