### PR TITLE
Allow manual creation of pg_trgm extension in Postgres database

### DIFF
--- a/store/postgres/migrations/2018-12-21-003727_create_attribute_indexing_procedure/up.sql
+++ b/store/postgres/migrations/2018-12-21-003727_create_attribute_indexing_procedure/up.sql
@@ -1,5 +1,5 @@
 -- Installs the pg_trgm extension for trigram indexing
-CREATE EXTENSION pg_trgm;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 -- Build a partial index for each entity-attribute
 CREATE OR REPLACE FUNCTION build_attribute_index(subgraph_id Text,index_name Text,index_type Text,index_operator Text,


### PR DESCRIPTION
The Graph node may be connecting to Postgres with a user that has limited permissions, so it is unable to create extensions.
This small PR updates the `create_attribute_indexing_procedure` migration to allow a superuser to add the extension manually before starting the node and running the migration.

