### PR TITLE
Add ETHEREUM_FAST_SCAN_END environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,6 +751,7 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.5.0",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/datasource/ethereum/Cargo.toml
+++ b/datasource/ethereum/Cargo.toml
@@ -7,3 +7,4 @@ failure = "0.1.2"
 futures = "0.1.21"
 jsonrpc-core = "8.0.1"
 graph = { path = "../../graph" }
+lazy_static = "1.2.0"

--- a/datasource/ethereum/src/lib.rs
+++ b/datasource/ethereum/src/lib.rs
@@ -2,6 +2,7 @@ extern crate failure;
 extern crate futures;
 extern crate graph;
 extern crate jsonrpc_core;
+extern crate lazy_static;
 
 mod block_ingestor;
 mod block_stream;


### PR DESCRIPTION
The graph-node uses `eth_getLogs` to locate blocks with events for a particular subgraph. Most subgraphs do not have events in the first few million blocks, so graph-node optimizes for that case by using `eth_getLogs` on a larger range.

This PR makes customizable the threshold at which the graph-node stops calling eth_getLogs with 100,000-block ranges and begins requesting only 10,000-block ranges instead. It leaves the default at the previous value of 4,000,000.