### PR TITLE
Fix issues with filters for List field types

### DIFF
--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -483,7 +483,7 @@ mod tests {
 
     #[test]
     fn api_schema_contains_object_type_filter_enum() {
-        let input_schema = parse_schema("type User { id: ID!, name: String!}")
+        let input_schema = parse_schema("type User { id: ID!, name: String!, pets: [String!]}")
             .expect("Failed to parse input schema");
         let schema = api_schema(&input_schema).expect("Failed to derived API schema");
 
@@ -524,7 +524,11 @@ mod tests {
                 "name_starts_with",
                 "name_not_starts_with",
                 "name_ends_with",
-                "name_not_ends_with"
+                "name_not_ends_with",
+                "pets",
+                "pets_not",
+                "pets_contains",
+                "pets_not_contains"
             ]
             .iter()
             .map(|name| name.to_string())

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -161,6 +161,15 @@ pub fn get_field_value_type(field_type: &Type) -> Result<ValueType, Error> {
     }
 }
 
+/// Returns the value type for a GraphQL field type.
+pub fn get_field_name(field_type: &Type) -> Name {
+    match field_type {
+        Type::NamedType(name) => name.to_string(),
+        Type::NonNullType(inner) => get_field_name(&inner),
+        Type::ListType(inner) => get_field_name(&inner),
+    }
+}
+
 /// Returns the type with the given name.
 pub fn get_named_type<'a>(schema: &'a Document, name: &Name) -> Option<&'a TypeDefinition> {
     schema

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -160,7 +160,8 @@ fn build_filter(filter: EntityFilter) -> Result<FilterExpression, UnsupportedFil
                     let predicate = sql("data -> ")
                         .bind::<Text, _>(attribute)
                         .sql("-> 'data' @> ")
-                        .bind::<Text, _>(s);
+                        .bind::<Text, _>(s)
+                        .sql("::jsonb");
                     if contains {
                         Ok(Box::new(predicate) as FilterExpression)
                     } else {


### PR DESCRIPTION
Resolves #684 and #678 

This PR fixes the following issues with filters for List field types:
  -  Filters were not showing up for List field types in the GraphiQL docs. 
  -  Generated PostgreSQL filters were incorrect and causing errors because a jsonb operator was being used with text data.