### PR TITLE
Incorporate `cargo fmt` changes for Rust 1.32.0

### DIFF
--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -186,7 +186,7 @@ impl Value {
                 return Err(QueryExecutionError::AttributeTypeError(
                     value.to_string(),
                     ty.to_string(),
-                ))
+                ));
             }
         })
     }

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -301,7 +301,7 @@ impl RuntimeHostTrait for RuntimeHost {
                     event_handler.event,
                     self.data_source_contract_abi.name,
                     self.data_source_name
-                )))
+                )));
             }
         };
 
@@ -316,7 +316,7 @@ impl RuntimeHostTrait for RuntimeHost {
                     "Failed to parse parameters of event: {}: {}",
                     event_handler.event,
                     e
-                )))
+                )));
             }
         };
 

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -109,7 +109,7 @@ where
                     "Value of {} attribute 'id' conflicts with ID passed to `store.set()`: \
                      {} != {}",
                     entity_type, v, entity_id,
-                )))
+                )));
             }
             _ => (),
         }

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -680,7 +680,7 @@ impl ModuleImportResolver for ModuleResolver {
                 return Err(Error::Instantiation(format!(
                     "Export '{}' not found",
                     field_name
-                )))
+                )));
             }
         })
     }

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -180,13 +180,13 @@ where
             Err(e) => {
                 return Box::new(future::err(GraphQLServerError::InternalError(
                     e.to_string(),
-                )))
+                )));
             }
             Ok(false) => {
                 return Box::new(future::err(GraphQLServerError::ClientError(format!(
                     "No data found for subgraph {}",
                     id
-                ))))
+                ))));
             }
             Ok(true) => (),
         }

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -251,7 +251,7 @@ where
                                         &msg_sink,
                                         id.clone(),
                                         format!("Invalid variables provided: {}", e),
-                                    )
+                                    );
                                 }
                             }
                         }
@@ -260,7 +260,7 @@ where
                                 &msg_sink,
                                 id.clone(),
                                 format!("Invalid variables provided (must be an object)"),
-                            )
+                            );
                         }
                     };
 

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -176,7 +176,7 @@ fn build_filter(filter: EntityFilter) -> Result<FilterExpression, UnsupportedFil
                     return Err(UnsupportedFilter {
                         filter: if contains { "contains" } else { "not_contains" }.to_owned(),
                         value,
-                    })
+                    });
                 }
             }
         }
@@ -227,7 +227,7 @@ fn build_filter(filter: EntityFilter) -> Result<FilterExpression, UnsupportedFil
                     return Err(UnsupportedFilter {
                         filter: op.to_owned(),
                         value,
-                    })
+                    });
                 }
             }
         }
@@ -263,7 +263,7 @@ fn build_filter(filter: EntityFilter) -> Result<FilterExpression, UnsupportedFil
                     return Err(UnsupportedFilter {
                         filter: "in".to_owned(),
                         value: Value::List(values),
-                    })
+                    });
                 }
             }
         }
@@ -303,7 +303,7 @@ fn build_filter(filter: EntityFilter) -> Result<FilterExpression, UnsupportedFil
                         }
                         .to_owned(),
                         value,
-                    })
+                    });
                 }
             }
         }
@@ -332,7 +332,7 @@ fn build_filter(filter: EntityFilter) -> Result<FilterExpression, UnsupportedFil
                         }
                         .to_owned(),
                         value,
-                    })
+                    });
                 }
             }
         }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -900,7 +900,7 @@ impl SubgraphDeploymentStore for Store {
             _ => {
                 return Err(format_err!(
                     "Subgraph entity has wrong type in `currentVersion`"
-                ))
+                ));
             }
         };
 
@@ -964,7 +964,7 @@ impl SubgraphDeploymentStore for Store {
                     return Err(format_err!(
                         "Schema not present or has wrong type, subgraph: {}",
                         subgraph_id
-                    ))
+                    ));
                 }
             }
         };


### PR DESCRIPTION
Rust 1.32.0 was released this morning, and `cargo fmt` has a few different
ideas on how things should be formatted. Since Travis pulls in the latest
stable automatically, we need to make sure that `cargo fmt` doesn't find
any changes on master.

