### PR TITLE
Replace unsafe transmutes with safe equivalents

### DIFF
--- a/runtime/wasm/src/asc_abi/asc_ptr.rs
+++ b/runtime/wasm/src/asc_abi/asc_ptr.rs
@@ -1,7 +1,7 @@
 use super::{class::EnumPayload, AscHeap, AscType};
 use std::fmt;
 use std::marker::PhantomData;
-use std::mem::{self, size_of};
+use std::mem::size_of;
 use wasmi::{FromRuntimeValue, RuntimeValue};
 
 /// A pointer to an object in the Asc heap.
@@ -49,9 +49,7 @@ impl<C: AscType> AscPtr<C> {
         let raw_bytes = heap.get(self.0, size_of::<u32>() as u32).unwrap();
         let mut u32_bytes: [u8; size_of::<u32>()] = [0; size_of::<u32>()];
         u32_bytes.copy_from_slice(&raw_bytes);
-
-        // Get the u32 from the bytes. This is just `u32::from_bytes` which is unstable.
-        unsafe { mem::transmute(u32_bytes) }
+        u32::from_le_bytes(u32_bytes)
     }
 
     /// Conversion to `u64` for use with `AscEnum`.

--- a/runtime/wasm/src/asc_abi/class.rs
+++ b/runtime/wasm/src/asc_abi/class.rs
@@ -67,7 +67,6 @@ impl<T> AscType for ArrayBuffer<T> {
     fn to_asc_bytes(&self) -> Vec<u8> {
         let mut asc_layout: Vec<u8> = Vec::new();
 
-        // This is just `self.byte_length.to_bytes()` which is unstable.
         let byte_length: [u8; 4] = self.byte_length.to_le_bytes();
         asc_layout.extend(&byte_length);
         asc_layout.extend(&self.padding);

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -9,7 +9,6 @@ use graph::serde_json;
 use graph::web3::types::H160;
 use std::collections::HashMap;
 use std::fmt;
-use std::mem;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
@@ -303,7 +302,7 @@ where
             let n_bytes = n.to_signed_bytes_le();
             let mut i_bytes: [u8; 4] = if n < 0.into() { [255; 4] } else { [0; 4] };
             i_bytes[..n_bytes.len()].copy_from_slice(&n_bytes);
-            let i: i32 = unsafe { mem::transmute(i_bytes) };
+            let i = i32::from_le_bytes(i_bytes);
             Ok(i)
         } else {
             Err(HostExportError(format!(

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -143,7 +143,6 @@ impl FromAscObj<AscEnum<StoreValueKind>> for store::Value {
                 let ptr: AscPtr<AscString> = AscPtr::from(payload);
                 Value::String(heap.asc_get(ptr))
             }
-            // This is just `i32::from_bytes` which is unstable.
             StoreValueKind::Int => Value::Int(i32::from(payload)),
             StoreValueKind::Float => Value::Float(f32::from(payload)),
             StoreValueKind::Bool => Value::Bool(bool::from(payload)),


### PR DESCRIPTION
We can use these now that they've been stabilized in Rust v1.32.0