### PR TITLE
Add optional environment variables EXTERNAL_{HTTP,WS}_BASE_URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,7 @@ version = "0.5.0"
 dependencies = [
  "graph 0.5.0",
  "jsonrpc-http-server 9.0.0 (git+https://github.com/paritytech/jsonrpc)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/server/json-rpc/Cargo.toml
+++ b/server/json-rpc/Cargo.toml
@@ -5,4 +5,5 @@ version = "0.5.0"
 [dependencies]
 graph = { path = "../../graph" }
 jsonrpc-http-server = { git = "https://github.com/paritytech/jsonrpc" }
+lazy_static = "1.2.0"
 serde = "1.0"


### PR DESCRIPTION
Adds two optional environment variables to tell graph-node to send back full URLs in response to `subgraph_deploy` requests.

See also: https://github.com/graphprotocol/graph-cli/pull/202