### PR TITLE
Serialize warnings to Elasticsearch as 'warning', not 'warn'

### DIFF
--- a/core/src/log/elastic.rs
+++ b/core/src/log/elastic.rs
@@ -34,7 +34,7 @@ where
     serializer.serialize_str(match level {
         Level::Critical => "critical",
         Level::Error => "error",
-        Level::Warning => "warn",
+        Level::Warning => "warning",
         Level::Info => "info",
         Level::Debug => "debug",
         Level::Trace => "trace",


### PR DESCRIPTION
Other software we have written expects this. It's also generally a little odd to have `warning` be cut off but all other levels being written out.