### PR TITLE
Re-instantiate module on each handler call

### DIFF
--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -15,8 +15,38 @@ impl EthereumBlock {
     }
 }
 
+// Remove this and derive after a new web3 is released is released.
+impl Default for EthereumBlock {
+    fn default() -> Self {
+        Self {
+            block: Block {
+                hash: Some(H256::default()),
+                parent_hash: H256::default(),
+                uncles_hash: H256::default(),
+                author: H160::default(),
+                state_root: H256::default(),
+                transactions_root: H256::default(),
+                receipts_root: H256::default(),
+                number: None,
+                gas_used: U256::default(),
+                gas_limit: U256::default(),
+                extra_data: Bytes(vec![]),
+                logs_bloom: H2048::default(),
+                timestamp: U256::default(),
+                difficulty: U256::default(),
+                total_difficulty: U256::default(),
+                seal_fields: vec![],
+                uncles: vec![],
+                transactions: vec![],
+                size: None,
+            },
+            transaction_receipts: vec![],
+        }
+    }
+}
+
 /// Ethereum block data.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct EthereumBlockData {
     pub hash: H256,
     pub parent_hash: H256,

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -15,7 +15,7 @@ impl EthereumBlock {
     }
 }
 
-// Remove this and derive after a new web3 is released is released.
+// Remove this and derive after a new web3 is released.
 impl Default for EthereumBlock {
     fn default() -> Self {
         Self {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -241,7 +241,7 @@ impl EntityOperation {
     /// `ops` must not contain any `AbortUnless` operations.
     pub fn apply_all(
         entity: Option<Entity>,
-        ops: &Vec<EntityOperation>,
+        ops: &[&EntityOperation],
     ) -> Result<Option<Entity>, Error> {
         use self::EntityOperation::*;
 

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -161,6 +161,11 @@ impl RuntimeHost {
             })?
             .clone();
 
+        // Spawn a dedicated thread for the runtime.
+        //
+        // In case of failure, this thread may panic or simply terminate,
+        // dropping the `handle_event_receiver` which ultimately causes the
+        // subgraph to fail the next time it tries to handle an event.
         let conf = thread::Builder::new().name(format!(
             "{}-{}-{}",
             util::log::MAPPING_THREAD_PREFIX,

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -22,7 +22,7 @@ impl<E> ExportError for E where E: fmt::Debug + fmt::Display + Send + Sync + 'st
 
 /// Error raised in host functions.
 #[derive(Debug)]
-pub(crate) struct HostExportError<E>(E);
+pub(crate) struct HostExportError<E>(pub(crate) E);
 
 impl<E: fmt::Display> fmt::Display for HostExportError<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -59,7 +59,7 @@ pub struct WasmiModuleConfig<T, L, S> {
     pub store: Arc<S>,
 }
 
-/// A WASM module based on wasmi that powers a subgraph runtime.
+/// A pre-processed and valid WASM module, ready to be started as a WasmiModule.
 pub(crate) struct ValidModule<T, L, S, U> {
     pub logger: Logger,
     pub module: Module,

--- a/runtime/wasm/src/module/test/abi.rs
+++ b/runtime/wasm/src/module/test/abi.rs
@@ -4,7 +4,9 @@ use super::*;
 fn unbounded_loop() {
     // Set handler timeout to 3 seconds.
     env::set_var(host_exports::TIMEOUT_ENV_VAR, "3");
-    let mut module = test_module(mock_data_source("wasm_test/non_terminating.wasm"));
+    let valid_module = test_valid_module(mock_data_source("wasm_test/non_terminating.wasm"));
+    let mut module =
+        WasmiModule::from_valid_module_with_ctx(&valid_module, mock_context()).unwrap();
     module.start_time = Instant::now();
     let err = module
         .module
@@ -19,7 +21,9 @@ fn unbounded_loop() {
 
 #[test]
 fn unbounded_recursion() {
-    let mut module = test_module(mock_data_source("wasm_test/non_terminating.wasm"));
+    let valid_module = test_valid_module(mock_data_source("wasm_test/non_terminating.wasm"));
+    let mut module =
+        WasmiModule::from_valid_module_with_ctx(&valid_module, mock_context()).unwrap();
     let err = module
         .module
         .clone()
@@ -30,7 +34,9 @@ fn unbounded_recursion() {
 
 #[test]
 fn abi_array() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let mut module =
+        WasmiModule::from_valid_module_with_ctx(&valid_module, mock_context()).unwrap();
 
     let vec = vec![
         "1".to_owned(),
@@ -58,7 +64,9 @@ fn abi_array() {
 
 #[test]
 fn abi_subarray() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let mut module =
+        WasmiModule::from_valid_module_with_ctx(&valid_module, mock_context()).unwrap();
 
     let vec: Vec<u8> = vec![1, 2, 3, 4];
     let vec_obj: AscPtr<TypedArray<u8>> = module.asc_new(&*vec);
@@ -72,7 +80,9 @@ fn abi_subarray() {
 
 #[test]
 fn abi_bytes_and_fixed_bytes() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let mut module =
+        WasmiModule::from_valid_module_with_ctx(&valid_module, mock_context()).unwrap();
     let bytes1: Vec<u8> = vec![42, 45, 7, 245, 45];
     let bytes2: Vec<u8> = vec![3, 12, 0, 1, 255];
 
@@ -93,7 +103,9 @@ fn abi_bytes_and_fixed_bytes() {
 /// and assert the final token is the same as the starting one.
 #[test]
 fn abi_ethabi_token_identity() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_token.wasm"));
+    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_token.wasm"));
+    let mut module =
+        WasmiModule::from_valid_module_with_ctx(&valid_module, mock_context()).unwrap();
 
     // Token::Address
     let address = H160([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
@@ -198,7 +210,9 @@ fn abi_ethabi_token_identity() {
 fn abi_store_value() {
     use graph::data::store::Value;
 
-    let mut module = test_module(mock_data_source("wasm_test/abi_store_value.wasm"));
+    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_store_value.wasm"));
+    let mut module =
+        WasmiModule::from_valid_module_with_ctx(&valid_module, mock_context()).unwrap();
 
     // Value::Null
     let null_value_ptr: AscPtr<AscEnum<StoreValueKind>> = module
@@ -295,7 +309,9 @@ fn abi_store_value() {
 
 #[test]
 fn abi_h160() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let mut module =
+        WasmiModule::from_valid_module_with_ctx(&valid_module, mock_context()).unwrap();
     let address = H160::zero();
 
     // As an `Uint8Array`
@@ -314,7 +330,9 @@ fn abi_h160() {
 
 #[test]
 fn string() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let mut module =
+        WasmiModule::from_valid_module_with_ctx(&valid_module, mock_context()).unwrap();
     let string = "    漢字Double_Me🇧🇷  ";
     let trimmed_string_ptr = module.asc_new(string);
     let trimmed_string_obj: AscPtr<AscString> =
@@ -325,7 +343,9 @@ fn string() {
 
 #[test]
 fn abi_big_int() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let mut module =
+        WasmiModule::from_valid_module_with_ctx(&valid_module, mock_context()).unwrap();
 
     // Test passing in 0 and increment it by 1
     let old_uint = U256::zero();


### PR DESCRIPTION
This resets memory and global state between calls. This has worse performance than trying to do a soft reset of the module, but since I didn't succeed in trying that, we decided to go with this and I'll open an issue to track the idea of a soft reset. Issue opened: #716.

Module initialization is split between constructing a `ValidModule`, which contains all pre-processing that can be re-used, and the `WasmiModule` which finishes the module initialization and is then used to handle a single call.

The `EventHandlerContext` is moved up from `HostExternals` to `WasmiModule` and then passed down as an argument. It's no longer in an `Option` which is nice.

The second commit takes care of a possible backwards incompatibility. We now call the WASM module's start function before running each handler, but in the future if we go for soft reset we might call it only once. So we prevent start from modifying the store.

Resolves #438.