### PR TITLE
Fix panics related to invalid schemas

### DIFF
--- a/graph/src/data/graphql/validation.rs
+++ b/graph/src/data/graphql/validation.rs
@@ -1,7 +1,7 @@
 use graphql_parser::schema::*;
 use std::fmt;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Strings(Vec<String>);
 
 impl fmt::Display for Strings {
@@ -11,8 +11,11 @@ impl fmt::Display for Strings {
     }
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Fail, PartialEq, Eq)]
 pub enum SchemaValidationError {
+    #[fail(display = "Interface {} not defined", _0)]
+    UndefinedInterface(String),
+
     #[fail(display = "@entity directive missing on the following types: {}", _0)]
     EntityDirectivesMissing(Strings),
 }

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -1,10 +1,12 @@
-use data::graphql::validation::{get_object_type_definitions, validate_schema};
+use data::graphql::validation::{
+    get_object_type_definitions, validate_schema, SchemaValidationError,
+};
 use data::subgraph::SubgraphDeploymentId;
 use failure::Error;
 use graphql_parser;
 use graphql_parser::{
-    query,
-    schema::{self, ObjectType},
+    query::Name,
+    schema::{self, InterfaceType, ObjectType, TypeDefinition},
     Pos,
 };
 use std::collections::BTreeMap;
@@ -14,8 +16,12 @@ use std::collections::BTreeMap;
 pub struct Schema {
     pub id: SubgraphDeploymentId,
     pub document: schema::Document,
+
+    // Maps type name to implemented interfaces.
+    interfaces_for_type: BTreeMap<Name, Vec<InterfaceType>>,
+
     // Maps an interface name to the list of entities that implement it.
-    types_for_interface: BTreeMap<query::Name, Vec<ObjectType>>,
+    types_for_interface: BTreeMap<Name, Vec<ObjectType>>,
 }
 
 impl Schema {
@@ -23,19 +29,40 @@ impl Schema {
         let document = graphql_parser::parse_schema(&raw)?;
         validate_schema(&document)?;
 
+        let mut interfaces_for_type = BTreeMap::<_, Vec<_>>::new();
         let mut types_for_interface = BTreeMap::<_, Vec<_>>::new();
         for object_type in get_object_type_definitions(&document) {
             for implemented_interface in object_type.implements_interfaces.clone() {
+                let interface_type = document
+                    .definitions
+                    .iter()
+                    .find_map(|def| match def {
+                        schema::Definition::TypeDefinition(TypeDefinition::Interface(i))
+                            if i.name == implemented_interface =>
+                        {
+                            Some(i.clone())
+                        }
+                        _ => None,
+                    })
+                    .ok_or_else(|| {
+                        SchemaValidationError::UndefinedInterface(implemented_interface.clone())
+                    })?;
+
+                interfaces_for_type
+                    .entry(object_type.name.clone())
+                    .or_default()
+                    .push(interface_type);
                 types_for_interface
                     .entry(implemented_interface)
-                    .and_modify(|vec| vec.push(object_type.clone()))
-                    .or_insert(vec![object_type.clone()]);
+                    .or_default()
+                    .push(object_type.clone());
             }
         }
 
         let mut schema = Schema {
             id: id.clone(),
             document,
+            interfaces_for_type,
             types_for_interface,
         };
         schema.add_subgraph_id_directives(id);
@@ -43,8 +70,12 @@ impl Schema {
         Ok(schema)
     }
 
-    pub fn type_for_interface(&self, interface_name: &query::Name) -> Option<&Vec<ObjectType>> {
+    pub fn types_for_interface(&self, interface_name: &Name) -> Option<&Vec<ObjectType>> {
         self.types_for_interface.get(interface_name)
+    }
+
+    pub fn interfaces_for_type(&self, type_name: &Name) -> Option<&Vec<InterfaceType>> {
+        self.interfaces_for_type.get(type_name)
     }
 
     // Adds a @subgraphId(id: ...) directive to object/interface/enum types in the schema.
@@ -63,20 +94,34 @@ impl Schema {
 
             if let schema::Definition::TypeDefinition(ref mut type_definition) = definition {
                 match type_definition {
-                    schema::TypeDefinition::Object(ref mut object_type) => {
+                    TypeDefinition::Object(ref mut object_type) => {
                         object_type.directives.push(subgraph_id_directive);
                     }
-                    schema::TypeDefinition::Interface(ref mut interface_type) => {
+                    TypeDefinition::Interface(ref mut interface_type) => {
                         interface_type.directives.push(subgraph_id_directive);
                     }
-                    schema::TypeDefinition::Enum(ref mut enum_type) => {
+                    TypeDefinition::Enum(ref mut enum_type) => {
                         enum_type.directives.push(subgraph_id_directive);
                     }
-                    schema::TypeDefinition::Scalar(_scalar_type) => (),
-                    schema::TypeDefinition::InputObject(_input_object_type) => (),
-                    schema::TypeDefinition::Union(_union_type) => (),
+                    TypeDefinition::Scalar(_scalar_type) => (),
+                    TypeDefinition::InputObject(_input_object_type) => (),
+                    TypeDefinition::Union(_union_type) => (),
                 }
             };
         }
     }
+}
+
+#[test]
+fn non_existing_interface() {
+    let schema = "type Foo implements Bar @entity { foo: Int }";
+    let res = Schema::parse(schema, SubgraphDeploymentId::new("dummy").unwrap());
+    let error = res
+        .unwrap_err()
+        .downcast::<SchemaValidationError>()
+        .unwrap();
+    assert_eq!(
+        error,
+        SchemaValidationError::UndefinedInterface("Bar".to_owned())
+    );
 }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -460,7 +460,7 @@ where
                 },
                 type_name,
             )
-            .expect("Failed to resolve named type inside list type");
+            .ok_or_else(|| QueryExecutionError::NamedTypeError(type_name.to_string()))?;
 
             match named_type {
                 // Let the resolver decide how the list field (with the given item object type)

--- a/graphql/src/query/ast.rs
+++ b/graphql/src/query/ast.rs
@@ -29,12 +29,10 @@ pub fn get_operations(document: &Document) -> Vec<&OperationDefinition> {
     document
         .definitions
         .iter()
-        .map(|d| match d {
+        .filter_map(|d| match d {
             Definition::Operation(op) => Some(op),
             _ => None,
         })
-        .filter(|op| op.is_some())
-        .map(|op| op.unwrap())
         .collect()
 }
 

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -233,9 +233,7 @@ pub fn collect_entities_from_query_field(
     let mut queue = VecDeque::new();
     queue.push_back((object_type, field));
 
-    while !queue.is_empty() {
-        let (object_type, field) = queue.pop_front().unwrap();
-
+    while let Some((object_type, field)) = queue.pop_front() {
         // Check if the field exists on the object type
         if let Some(field_type) = sast::get_field_type(object_type, &field.name) {
             // Check if the field type corresponds to a type definition (in a valid schema,

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -157,6 +157,7 @@ where
                     _ => None,
                 })
                 .unwrap_or_else(|| {
+                    // Unreachable, caught by `UnknownField` error.
                     panic!(
                         "Field \"{}\" missing in parent object",
                         field_definition.name


### PR DESCRIPTION
Part of #664, though I'm not sure if these are what that issue refers to. I grepped for panics, fixed two which could really cause a crash on an invalid schema: One when an undefined interface was implemented, another when an undefined type appeared inside a list. I also refactored away some unwraps.