### PR TITLE
Add arguments to n-arity relationship fields and limit collection results to 100 entities

### DIFF
--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -126,8 +126,16 @@ impl fmt::Display for QueryExecutionError {
             SubgraphDeploymentIdError(s) => {
                 write!(f, "Failed to get subgraph ID from type: {}", s)
             }
-            RangeArgumentsError(s) => {
-                write!(f, "Range arguments must be properly formed integer: {:}", s.join(", "))
+            RangeArgumentsError(args) => {
+                let msg = args.iter().map(|arg| {
+                    match arg.as_str() {
+                        "first" => format!("Value of \"first\" must be between 1 and 100"),
+                        "last" => format!("Value of \"last\" must be between 1 and 100"),
+                        "skip" => format!("Value of \"skip\" must be greater than 0"),
+                        _ => format!("Value of \"{}\" is must be an integer", arg),
+                    }
+                }).collect::<Vec<_>>().join(", ");
+                write!(f, "{}", msg)
             }
             InvalidFilterError => write!(f, "Filter must by an object"),
             EntityFieldError(e, a) => {

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -20,9 +20,11 @@ pub enum APISchemaError {
 /// with all its fields and their input arguments, based on the existing
 /// types.
 pub fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
+    // Refactor: Take `input_schema` by value.
     let object_types = ast::get_object_type_definitions(input_schema);
     let interface_types = ast::get_interface_type_definitions(input_schema);
 
+    // Refactor: Don't clone the schema.
     let mut schema = input_schema.clone();
     add_builtin_scalar_types(&mut schema)?;
     add_order_direction_enum(&mut schema);
@@ -421,6 +423,9 @@ fn add_field_arguments(
     schema: &mut Document,
     input_schema: &Document,
 ) -> Result<(), APISchemaError> {
+    // Refactor: Remove the `input_schema` argument and do a mutable iteration
+    // over the definitions in `schema`. Also the duplication between this and
+    // the loop for interfaces below.
     for input_object_type in ast::get_object_type_definitions(input_schema) {
         for input_field in &input_object_type.fields {
             if let Some(input_reference_type) =

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -342,11 +342,6 @@ pub fn is_input_type(schema: &Document, t: &Type) -> bool {
     }
 }
 
-/// Returns true if the given field is an entity relationship field.
-pub fn is_entity_relationship_field(schema: &Document, field: &Field) -> bool {
-    is_entity_type(schema, &field.field_type)
-}
-
 pub fn is_entity_type(schema: &Document, t: &Type) -> bool {
     use self::Type::*;
 

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -522,12 +522,15 @@ mod tests {
     }
 
     #[test]
-    fn build_query_yields_no_range_if_none_is_present() {
+    fn build_query_yields_default_range_if_none_is_present() {
         assert_eq!(
             build_query(&default_object(), &HashMap::new())
                 .unwrap()
                 .range,
-            None,
+            Some(EntityRange {
+                first: 100,
+                skip: 0
+            }),
         );
     }
 

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -67,7 +67,10 @@ fn build_range(
     }
 
     Ok(match (first.unwrap(), skip.unwrap()) {
-        (None, None) => None,
+        (None, None) => Some(EntityRange {
+            first: 100,
+            skip: 0,
+        }),
         (Some(first), None) => Some(EntityRange { first, skip: 0 }),
         (Some(first), Some(skip)) => Some(EntityRange { first, skip }),
         (None, Some(skip)) => Some(EntityRange { first: 100, skip }),

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -28,15 +28,15 @@ fn build_range(
         .map_or(Ok(None), |value| {
             if let q::Value::Int(n) = value {
                 match n.as_i64() {
-                    Some(n) => Ok(Some(n)),
-                    None => Err("first".to_string()),
+                    Some(n) if n > 0 && n <= 100 => Ok(Some(n)),
+                    _ => Err("first".to_string()),
                 }
             } else {
                 Err("first".to_string())
             }
         })
         .map(|n| match n {
-            Some(n) if n >= 0 => Some(n as usize),
+            Some(n) => Some(n as usize),
             _ => None,
         });
 
@@ -45,15 +45,15 @@ fn build_range(
         .map_or(Ok(None), |value| {
             if let q::Value::Int(n) = value {
                 match n.as_i64() {
-                    Some(n) => Ok(Some(n)),
-                    None => Err("first".to_string()),
+                    Some(n) if n > 0 => Ok(Some(n)),
+                    _ => Err("skip".to_string()),
                 }
             } else {
                 Err("skip".to_string())
             }
         })
         .map(|n| match n {
-            Some(n) if n >= 0 => Some(n as usize),
+            Some(n) => Some(n as usize),
             _ => None,
         });
 


### PR DESCRIPTION
This adds `first`, `skip`, `where`, `orderBy` etc. arguments to plural relationship fields.

We also now force `first` and `skip` to be `1 <= first <= 100` and `skip >= 0`.