### PR TITLE
Improve error handling in server/{http,websocket}

### DIFF
--- a/graph/src/components/server/query.rs
+++ b/graph/src/components/server/query.rs
@@ -41,10 +41,18 @@ impl From<String> for GraphQLServerError {
 impl fmt::Display for GraphQLServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            GraphQLServerError::Canceled(_) => write!(f, "Query was canceled"),
-            GraphQLServerError::ClientError(ref s) => write!(f, "{}", s),
-            GraphQLServerError::QueryError(ref e) => write!(f, "{}", e),
-            GraphQLServerError::InternalError(ref s) => write!(f, "{}", s),
+            GraphQLServerError::Canceled(_) => {
+                write!(f, "GraphQL server error (query was canceled)")
+            }
+            GraphQLServerError::ClientError(ref s) => {
+                write!(f, "GraphQL server error (client error): {}", s)
+            }
+            GraphQLServerError::QueryError(ref e) => {
+                write!(f, "GraphQL server error (query error): {}", e)
+            }
+            GraphQLServerError::InternalError(ref s) => {
+                write!(f, "GraphQL server error (internal error): {}", s)
+            }
         }
     }
 }

--- a/server/http/src/response.rs
+++ b/server/http/src/response.rs
@@ -143,7 +143,7 @@ mod tests {
             .as_str()
             .expect("Error message is not a string");
 
-        assert_eq!(message, "Query was canceled");
+        assert_eq!(message, "GraphQL server error (query was canceled)");
     }
 
     #[test]
@@ -162,7 +162,10 @@ mod tests {
             .as_str()
             .expect("Error message is not a string");
 
-        assert_eq!(message, "Something went wrong");
+        assert_eq!(
+            message,
+            "GraphQL server error (client error): Something went wrong"
+        );
     }
 
     #[test]
@@ -236,6 +239,9 @@ mod tests {
             .as_str()
             .expect("Error message is not a string");
 
-        assert_eq!(message, "Something went wrong");
+        assert_eq!(
+            message,
+            "GraphQL server error (internal error): Something went wrong"
+        );
     }
 }

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -81,11 +81,13 @@ where
 
         // On every incoming request, launch a new GraphQL service that writes
         // incoming queries to the query sink.
+        let logger_for_service = self.logger.clone();
         let graphql_runner = self.graphql_runner.clone();
         let store = self.store.clone();
         let node_id = self.node_id.clone();
         let new_service = move || {
             let service = GraphQLService::new(
+                logger_for_service.clone(),
                 graphql_runner.clone(),
                 store.clone(),
                 ws_port,

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -144,7 +144,7 @@ mod test {
                             .expect("Error contains no message")
                             .as_str()
                             .expect("Error message is not a string");
-                        assert_eq!(message, "The \"query\" field missing in request data");
+                        assert_eq!(message, "GraphQL server error (client error): The \"query\" field missing in request data");
                         Ok(())
                     })
             }))


### PR DESCRIPTION
Return HTTP error responses to server requests that error instead of terminating the connection abruptly or panicking

Resolves #659 