### PR TITLE
Clear entity history between test runs

### DIFF
--- a/store/postgres/src/db_schema.rs
+++ b/store/postgres/src/db_schema.rs
@@ -9,6 +9,29 @@ table! {
 }
 
 table! {
+    entity_history (id) {
+        id -> Integer,
+        event_id -> BigInt,
+        entity_id -> Varchar,
+        subgraph -> Varchar,
+        entity -> Varchar,
+        data_before -> Nullable<Jsonb>,
+        data_after -> Nullable<Jsonb>,
+        reversion -> Bool,
+    }
+}
+
+table! {
+    event_meta_data (id) {
+        id -> Integer,
+        db_transaction_id -> BigInt,
+        db_transaction_time -> Timestamp,
+        op_id -> SmallInt,
+        source -> Nullable<Varchar>,
+    }
+}
+
+table! {
     ethereum_networks (name) {
         name -> Varchar,
         head_block_hash -> Nullable<Varchar>,

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -252,13 +252,19 @@ fn create_test_entity(
 
 /// Removes test data from the database behind the store.
 fn remove_test_data() {
-    use db_schema::entities;
+    use db_schema::{entities, entity_history, event_meta_data};
 
     let url = postgres_test_url();
     let conn = PgConnection::establish(url.as_str()).expect("Failed to connect to Postgres");
     delete(entities::table)
         .execute(&conn)
         .expect("Failed to remove entity test data");
+    delete(entity_history::table)
+        .execute(&conn)
+        .expect("Failed to remove entity history test data");
+    delete(event_meta_data::table)
+        .execute(&conn)
+        .expect("Failed to remove entity change event test data");
 }
 
 #[test]


### PR DESCRIPTION
Not clearing the history would cause confusing test failures occasionally

Bonus: I reworked `run_test` to reuse the Store instance so that the Postgres connection can be reused, which speeds up the store tests significantly

Resolves #709 
