### PR TITLE
Replace current version with new version if current is not fully synced yet

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -686,9 +686,8 @@ pub trait Store: Send + Sync + 'static {
 
     /// Return true if the deployment with the given id is fully synced,
     /// and return false otherwise. Errors from the store are passed back up
-    fn is_deployment_synced(&self, id: &SubgraphDeploymentId) -> Result<bool, Error> {
-        let filter = EntityFilter::new_equal("id", id.to_string());
-        let entity = self.find_one(SubgraphDeploymentEntity::query().filter(filter))?;
+    fn is_deployment_synced(&self, id: SubgraphDeploymentId) -> Result<bool, Error> {
+        let entity = self.get(SubgraphDeploymentEntity::key(id))?;
         entity
             .map(|entity| match entity.get("synced") {
                 Some(Value::Bool(true)) => Ok(true),

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -683,6 +683,19 @@ pub trait Store: Send + Sync + 'static {
             .map_err(|e| format_err!("Failed to query SubgraphDeployment entities: {}", e))
             .map(|entity_opt| entity_opt.is_some())
     }
+
+    /// Return true if the deployment with the given id is fully synced,
+    /// and return false otherwise. Errors from the store are passed back up
+    fn is_deployment_synced(&self, id: &SubgraphDeploymentId) -> Result<bool, Error> {
+        let filter = EntityFilter::new_equal("id", id.to_string());
+        let entity = self.find_one(SubgraphDeploymentEntity::query().filter(filter))?;
+        entity
+            .map(|entity| match entity.get("synced") {
+                Some(Value::Bool(true)) => Ok(true),
+                _ => Ok(false),
+            })
+            .unwrap_or(Ok(false))
+    }
 }
 
 pub trait SubgraphDeploymentStore: Send + Sync + 'static {


### PR DESCRIPTION
I believe this does what it should do. The policy for replacing current or pending with a new version now is: if there is no current version, or the current version is not synced, replace it with the new version. Otherwise, replace the pending version. I think the code could be simplified a little if it expressed these rules more clearly.

In particular, I'd subsume the logic around `current_version_id_opt.is_some()` and `current_is_synced` into a variable `replace_current` and structure the code according to that. But it might be better to do that as a separate change as it will be a bit more invasive than this PR.