### PR TITLE
Move all web3 calls to EthereumAdapter

### DIFF
--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -4,9 +4,9 @@ mod stream;
 mod types;
 
 pub use self::adapter::{
-    EthereumAdapter, EthereumContractCall, EthereumContractCallError, EthereumContractState,
-    EthereumContractStateError, EthereumContractStateRequest, EthereumError, EthereumLogFilter,
-    EthereumNetworkIdentifier,
+    EthereumAdapter, EthereumAdapterError, EthereumContractCall, EthereumContractCallError,
+    EthereumContractState, EthereumContractStateError, EthereumContractStateRequest,
+    EthereumLogFilter, EthereumNetworkIdentifier,
 };
 pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener};
 pub use self::stream::{BlockStream, BlockStreamBuilder};

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -58,8 +58,8 @@ pub mod prelude {
 
     pub use components::ethereum::{
         BlockStream, BlockStreamBuilder, ChainHeadUpdate, ChainHeadUpdateListener, EthereumAdapter,
-        EthereumBlock, EthereumBlockData, EthereumBlockPointer, EthereumEventData,
-        EthereumLogFilter, EthereumNetworkIdentifier, EthereumTransactionData,
+        EthereumAdapterError, EthereumBlock, EthereumBlockData, EthereumBlockPointer,
+        EthereumEventData, EthereumLogFilter, EthereumNetworkIdentifier, EthereumTransactionData,
     };
     pub use components::graphql::{GraphQlRunner, QueryResultFuture, SubscriptionResultFuture};
     pub use components::link_resolver::LinkResolver;

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -9,7 +9,7 @@ use graph::components::ethereum::*;
 use graph::components::store::*;
 use graph::data::store::scalar;
 use graph::data::subgraph::*;
-use graph::web3::types::{Address, H160, H256};
+use graph::web3::types::{Address, Block, Transaction, H160, H256};
 use hex;
 use std::io::Cursor;
 use std::str::FromStr;
@@ -32,11 +32,26 @@ impl EthereumAdapter for MockEthereumAdapter {
         unimplemented!();
     }
 
+    fn latest_block(
+        &self,
+        _: &Logger,
+    ) -> Box<Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send> {
+        unimplemented!();
+    }
+
     fn block_by_hash(
         &self,
         _: &Logger,
         _: H256,
-    ) -> Box<Future<Item = Option<EthereumBlock>, Error = Error> + Send> {
+    ) -> Box<Future<Item = Option<Block<Transaction>>, Error = Error> + Send> {
+        unimplemented!();
+    }
+
+    fn load_full_block(
+        &self,
+        _: &Logger,
+        _: Block<Transaction>,
+    ) -> Box<Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send> {
         unimplemented!();
     }
 


### PR DESCRIPTION
I found this little refactor on an old branch and thought I'd get it in. This adds methods to the EthereumAdapter so that the BlockIngestor can use the EthereumAdapter instead of using the web3 transport directly. That's nice because it allows for some more code reuse (in particular: loading blocks and tx receipts), which is why this PR deletes more lines than it adds.

Additionally, this does some more batching of web3 requests, which speeds up the initial load time when starting from an empty database.

Details:
- New method `EthereumAdapter::latest_block` returns a `Block<Transaction>`.
- New method `EthereumAdapter::load_full_block` takes a `Block<Transaction>` and returns a `EthereumBlock` (containing the full tx receipts).
- `EthereumAdapter::block_by_hash` used to return an `EthereumBlock`. To be more flexible, it now just returns a `Block<Transaction>`, and then you can call `EthereumAdapter::load_full_block` to get full info if needed.
- `BlockIngestorError` is gone, replaced with `EthereumAdapterError`, since the "block unavailable" error case (where a receipt is unavailable due to its block being uncled) now occurs in the Ethereum adapter. I also removed `EthereumError`, which was left over from before and not referenced anywhere.