### PR TITLE
Make info logs less verbose: only show logs related to relevant blocks

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -169,8 +169,6 @@ impl SubgraphInstanceManager {
                         "block_hash" => format!("{:?}", block.block.hash.unwrap())
                     ));
 
-                    info!(logger, "Processing events from block");
-
                     // Extract logs relevant to the subgraph
                     let logs: Vec<_> = block
                         .transaction_receipts
@@ -182,7 +180,7 @@ impl SubgraphInstanceManager {
                         .collect();
 
                     if logs.len() == 0 {
-                        info!(logger, "No events found in this block for this subgraph");
+                        debug!(logger, "No events found in this block for this subgraph");
                     } else if logs.len() == 1 {
                         info!(logger, "1 event found in this block for this subgraph");
                     } else {

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -994,7 +994,7 @@ where
         let logger = self.ctx.logger.clone();
 
         Box::new(self.chain_head_update_sink.clone().sink_map_err(move |_| {
-            info!(logger, "Terminating chain head updates");
+            debug!(logger, "Terminating chain head updates");
         }))
     }
 }

--- a/graph/src/util/log.rs
+++ b/graph/src/util/log.rs
@@ -1,6 +1,6 @@
 use backtrace::Backtrace;
 use futures::sync::oneshot;
-use slog::{crit, info, o, Drain, FilterLevel, Logger};
+use slog::{crit, debug, info, o, Drain, FilterLevel, Logger};
 use slog_async;
 use slog_envlogger;
 use slog_term;
@@ -97,7 +97,7 @@ pub fn register_panic_hook(panic_logger: Logger, shutdown_sender: oneshot::Sende
                     ()
                 })
                 .unwrap_or(()),
-            None => info!(panic_logger, "Shutdown signal already sent"),
+            None => debug!(panic_logger, "Shutdown signal already sent"),
         }
         thread::sleep(Duration::from_millis(3000));
         process::exit(1);

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -362,7 +362,7 @@ impl RuntimeHostTrait for RuntimeHost {
                     })
                 })
                 .and_then(move |result| {
-                    debug!(
+                    info!(
                         logger, "Done processing Ethereum event";
                         "signature" => &event_handler.event,
                         "handler" => &event_handler.handler,


### PR DESCRIPTION
Resolves #743 

Make `INFO` logs less verbose by only showing logs relevant to the subgraph such as: 
  - `block with relevant events found`, 
  - `event handlers being called to process the events`,
  - `entity operations being applied.` 

Logs concerning a block which do not necessarily contain a relevant event have been changed to `DEBUG`.  