### PR TITLE
Configurable timeout for graphql queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ dependencies = [
  "graph-runtime-wasm 0.5.0",
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,7 @@ graph = { path = "../graph" }
 graph-graphql = { path = "../graphql" }
 graph-runtime-wasm = { path = "../runtime/wasm" }
 itertools = "0.7"
+lazy_static = "1.2.0"
 reqwest = "0.9"
 serde = "1.0"
 serde_json = "1.0"

--- a/core/src/graphql/runner.rs
+++ b/core/src/graphql/runner.rs
@@ -6,10 +6,21 @@ use std::time::{Duration, Instant};
 use graph::prelude::{GraphQlRunner as GraphQlRunnerTrait, *};
 use graph_graphql::prelude::*;
 
+use lazy_static::lazy_static;
+
 /// GraphQL runner implementation for The Graph.
 pub struct GraphQlRunner<S> {
     logger: Logger,
     store: Arc<S>,
+}
+
+lazy_static! {
+    static ref GRAPHQL_QUERY_TIMEOUT: Option<Duration> = env::var("GRAPH_GRAPHQL_QUERY_TIMEOUT")
+        .ok()
+        .map(|s| Duration::from_secs(
+            u64::from_str(&s)
+                .unwrap_or_else(|_| panic!("failed to parse env var GRAPH_GRAPHQL_QUERY_TIMEOUT"))
+        ));
 }
 
 impl<S> GraphQlRunner<S>
@@ -30,17 +41,12 @@ where
     S: Store,
 {
     fn run_query(&self, query: Query) -> QueryResultFuture {
-        let timeout = env::var("GRAPH_GRAPHQL_QUERY_TIMEOUT").ok().map(|s| {
-            u64::from_str(&s)
-                .unwrap_or_else(|_| panic!("failed to parse env var GRAPH_GRAPHQL_QUERY_TIMEOUT"))
-        });
-
         let result = execute_query(
             &query,
             QueryExecutionOptions {
                 logger: self.logger.clone(),
                 resolver: StoreResolver::new(&self.logger, self.store.clone()),
-                deadline: timeout.map(|t| Instant::now() + Duration::from_secs(t)),
+                deadline: GRAPHQL_QUERY_TIMEOUT.map(|t| Instant::now() + t),
             },
         );
         Box::new(future::ok(result))
@@ -52,6 +58,7 @@ where
             SubscriptionExecutionOptions {
                 logger: self.logger.clone(),
                 resolver: StoreResolver::new(&self.logger, self.store.clone()),
+                timeout: GRAPHQL_QUERY_TIMEOUT.clone(),
             },
         );
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,6 +10,7 @@ extern crate reqwest;
 extern crate serde;
 #[macro_use]
 extern crate serde_json;
+extern crate lazy_static;
 extern crate serde_yaml;
 
 mod graphql;

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -37,3 +37,4 @@ described [here](https://docs.rs/env_logger/0.6.0/env_logger/)
 * `THEGRAPH_STORE_POSTGRES_DIESEL_URL`: postgres instance used when running
    tests. Set to
    `postgresql://<DBUSER>:<DBPASSWORD>@<DBHOST>:<DBPORT>/<DBNAME>`
+* `GRAPH_GRAPHQL_QUERY_TIMEOUT`: maximum execution time for a graphql query, in seconds. Default is unlimited.

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -45,6 +45,7 @@ pub enum QueryExecutionError {
     AttributeTypeError(String, String),
     EntityParseError(String),
     StoreError(failure::Error),
+    Timeout,
 }
 
 impl Error for QueryExecutionError {
@@ -163,6 +164,7 @@ impl fmt::Display for QueryExecutionError {
             StoreError(e) => {
                 write!(f, "Store error: {}", e)
             }
+            Timeout => write!(f, "Query timed out"),
         }
     }
 }

--- a/graph/src/util/log.rs
+++ b/graph/src/util/log.rs
@@ -1,6 +1,6 @@
 use backtrace::Backtrace;
 use futures::sync::oneshot;
-use slog::{crit, debug, info, o, Drain, FilterLevel, Logger};
+use slog::{crit, debug, o, Drain, FilterLevel, Logger};
 use slog_async;
 use slog_envlogger;
 use slog_term;

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,6 +1,6 @@
-use graphql_parser::query as q;
-
 use graph::prelude::*;
+use graphql_parser::query as q;
+use std::time::Instant;
 
 use execution::*;
 use prelude::*;
@@ -16,8 +16,12 @@ where
 {
     /// The logger to use during query execution.
     pub logger: Logger,
+
     /// The resolver to use.
     pub resolver: R,
+
+    /// Time at which the query times out.
+    pub deadline: Option<Instant>,
 }
 
 /// Executes a query and returns a result.
@@ -55,6 +59,7 @@ where
         document: &query.document,
         fields: vec![],
         variable_values: Arc::new(coerced_variable_values),
+        deadline: options.deadline,
     };
 
     let result = match *operation {

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -59,6 +59,7 @@ where
         document: &subscription.query.document,
         fields: vec![],
         variable_values: Arc::new(coerced_variable_values),
+        deadline: None,
     };
 
     match *operation {
@@ -182,6 +183,7 @@ where
         document: &document,
         fields: vec![],
         variable_values,
+        deadline: None,
     };
 
     // We have established that this exists earlier in the subscription execution

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -489,6 +489,7 @@ fn introspection_query(schema: Schema, query: &str) -> QueryResult {
         QueryExecutionOptions {
             logger: Logger::root(slog::Discard, o!()),
             resolver: MockResolver,
+            deadline: None,
         },
     )
 }

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -712,6 +712,6 @@ fn instant_timeout() {
 
     match execute_query(&query, options).errors.unwrap()[0] {
         QueryError::ExecutionError(QueryExecutionError::Timeout) => (), // Expected
-        _ => panic!("did not timeout"),
+        _ => panic!("did not time out"),
     };
 }


### PR DESCRIPTION
Timeout is checked when a new field is executed. I'll open an issue for returning partial results in case of an error, it's not difficult but lets land this first. Resolves #742.