### PR TITLE
Throttle subscription updates

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -38,3 +38,6 @@ described [here](https://docs.rs/env_logger/0.6.0/env_logger/)
    tests. Set to
    `postgresql://<DBUSER>:<DBPASSWORD>@<DBHOST>:<DBPORT>/<DBNAME>`
 * `GRAPH_GRAPHQL_QUERY_TIMEOUT`: maximum execution time for a graphql query, in seconds. Default is unlimited.
+* `SUBSCRIPTION_THROTTLE_INTERVAL`: while a subgraph is syncing,
+  subscriptions to that subgraph get updated at most this often, in
+  ms. Default is 1000ms.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -4,7 +4,9 @@ use futures::Future;
 use futures::Stream;
 use futures::{Async, Poll};
 use std::collections::HashSet;
+use std::env;
 use std::fmt;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use web3::types::H256;
@@ -12,6 +14,17 @@ use web3::types::H256;
 use data::store::*;
 use data::subgraph::schema::*;
 use prelude::*;
+
+lazy_static! {
+    pub static ref SUBSCRIPTION_THROTTLE_INTERVAL: Duration =
+        env::var("SUBSCRIPTION_THROTTLE_INTERVAL")
+            .ok()
+            .map(|s| u64::from_str(&s).unwrap_or_else(|_| panic!(
+                "failed to parse env var SUBSCRIPTION_THROTTLE_INTERVAL"
+            )))
+            .map(|millis| Duration::from_millis(millis))
+            .unwrap_or(Duration::from_millis(1000));
+}
 
 /// Key by which an individual entity in the store can be accessed.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -149,7 +149,7 @@ impl EntityQuery {
 }
 
 /// Operation types that lead to entity changes.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum EntityChangeOperation {
     /// An entity was added or updated
@@ -159,7 +159,7 @@ pub enum EntityChangeOperation {
 }
 
 /// Entity change events emitted by [Store](trait.Store.html) implementations.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct EntityChange {
     /// ID of the subgraph the changed entity belongs to.
     pub subgraph_id: SubgraphDeploymentId,
@@ -214,7 +214,7 @@ pub struct StoreEvent {
     // The tag is only there to make it easier to track StoreEvents in the
     // logs as they flow through the system
     pub tag: usize,
-    pub changes: Vec<EntityChange>,
+    pub changes: HashSet<EntityChange>,
 }
 
 impl StoreEvent {
@@ -222,6 +222,7 @@ impl StoreEvent {
         static NEXT_TAG: AtomicUsize = AtomicUsize::new(0);
 
         let tag = NEXT_TAG.fetch_add(1, Ordering::Relaxed);
+        let changes = changes.into_iter().collect();
         StoreEvent { tag, changes }
     }
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1,9 +1,12 @@
 use failure::Error;
+use futures::stream::poll_fn;
 use futures::Future;
 use futures::Stream;
+use futures::{Async, Poll};
 use std::collections::HashSet;
 use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 use web3::types::H256;
 
 use data::store::*;
@@ -208,6 +211,17 @@ impl StoreEvent {
         let tag = NEXT_TAG.fetch_add(1, Ordering::Relaxed);
         StoreEvent { tag, changes }
     }
+
+    /// Extend `ev1` with `ev2`. If `ev1` is `None`, just set it to `ev2`
+    fn accumulate(logger: &Logger, ev1: &mut Option<StoreEvent>, ev2: StoreEvent) {
+        if let Some(e) = ev1 {
+            trace!(logger, "Adding changes to event";
+                           "from" => ev2.tag, "to" => e.tag);
+            e.changes.extend(ev2.changes);
+        } else {
+            *ev1 = Some(ev2);
+        }
+    }
 }
 
 impl fmt::Display for StoreEvent {
@@ -228,14 +242,14 @@ impl PartialEq for StoreEvent {
     }
 }
 
-/// A boxed `StoreEventStream`
-pub type StoreEventStreamBox = Box<Stream<Item = StoreEvent, Error = ()> + Send>;
-
 /// A `StoreEventStream` produces the `StoreEvents`. Various filters can be applied
 /// to it to reduce which and how many events are delivered by the stream.
 pub struct StoreEventStream<S> {
     source: S,
 }
+
+/// A boxed `StoreEventStream`
+pub type StoreEventStreamBox = StoreEventStream<Box<Stream<Item = StoreEvent, Error = ()> + Send>>;
 
 impl<S> Stream for StoreEventStream<S>
 where
@@ -251,7 +265,7 @@ where
 
 impl<S> StoreEventStream<S>
 where
-    S: Stream<Item = StoreEvent, Error = ()> + Send,
+    S: Stream<Item = StoreEvent, Error = ()> + Send + 'static,
 {
     // Create a new `StoreEventStream` from another such stream
     pub fn new(source: S) -> Self {
@@ -261,10 +275,7 @@ where
     /// Filter a `StoreEventStream` by subgraph and entity. Only events that have
     /// at least one change to one of the given (subgraph, entity) combinations
     /// will be delivered by the filtered stream.
-    pub fn filter_by_entities(
-        self,
-        entities: Vec<SubgraphEntityPair>,
-    ) -> StoreEventStream<impl Stream<Item = StoreEvent, Error = ()> + Send> {
+    pub fn filter_by_entities(self, entities: Vec<SubgraphEntityPair>) -> StoreEventStreamBox {
         let source = self.source.filter(move |event| {
             event.changes.iter().any({
                 |change| {
@@ -275,7 +286,99 @@ where
             })
         });
 
-        StoreEventStream { source }
+        StoreEventStream::new(Box::new(source))
+    }
+
+    /// Reduce the frequency with which events are generated while a
+    /// subgraph deployment is syncing. While the given `deployment` is not
+    /// synced yet, events from `source` are reported at most every
+    /// `interval`. At the same time, no event is held for longer than
+    /// `interval`. The `StoreEvents` that arrive during an interval appear
+    /// on the returned stream as a single `StoreEvent`; the events are
+    /// combined by using the maximum of all sources and the concatenation
+    /// of the changes of the `StoreEvents` received during the interval.
+    pub fn throttle_while_syncing(
+        self,
+        logger: &Logger,
+        store: Arc<impl Store>,
+        deployment: SubgraphDeploymentId,
+        interval: Duration,
+    ) -> StoreEventStreamBox {
+        // Check whether a deployment is marked as synced in the store. The
+        // special 'subgraphs' subgraph is never considered synced so that
+        // we always throttle it
+        let check_synced = |store: &Store, deployment: &SubgraphDeploymentId| {
+            deployment != &*SUBGRAPHS_ID
+                && store
+                    .is_deployment_synced(deployment.clone())
+                    .unwrap_or(false)
+        };
+        let mut synced = check_synced(&*store, &deployment);
+
+        let mut pending_event: Option<StoreEvent> = None;
+        let mut source = self.source.fuse();
+        let mut had_err = false;
+        let mut delay = tokio_timer::Delay::new(Instant::now() + interval);
+        let logger = logger.clone();
+
+        let source = Box::new(poll_fn(move || -> Poll<Option<StoreEvent>, ()> {
+            if had_err {
+                // We had an error the last time through, but returned the pending
+                // event first. Indicate the error now
+                had_err = false;
+                return Err(());
+            }
+
+            if !synced {
+                synced = check_synced(&*store, &deployment);
+            }
+
+            if synced {
+                return source.poll();
+            }
+
+            // Check if interval has passed since the last time we sent something.
+            // If it has, start a new delay timer
+            let should_send = match delay.poll() {
+                Ok(Async::NotReady) => false,
+                // Timer errors are harmless. Treat them as if the timer had
+                // become ready.
+                Ok(Async::Ready(())) | Err(_) => {
+                    delay = tokio_timer::Delay::new(Instant::now() + interval);
+                    true
+                }
+            };
+
+            // Get as many events as we can off of the source stream
+            loop {
+                match source.poll() {
+                    Ok(Async::NotReady) => {
+                        if should_send && pending_event.is_some() {
+                            return Ok(Async::Ready(pending_event.take()));
+                        } else {
+                            return Ok(Async::NotReady);
+                        }
+                    }
+                    Ok(Async::Ready(None)) => {
+                        return Ok(Async::Ready(pending_event.take()));
+                    }
+                    Ok(Async::Ready(Some(event))) => {
+                        StoreEvent::accumulate(&logger, &mut pending_event, event);
+                    }
+                    Err(()) => {
+                        // Before we report the error, deliver what we have accumulated so far.
+                        // We will report the error the next time poll() is called
+                        if pending_event.is_some() {
+                            had_err = true;
+                            return Ok(Async::Ready(pending_event.take()));
+                        } else {
+                            return Err(());
+                        }
+                    }
+                };
+            }
+        }));
+        StoreEventStream::new(source)
     }
 }
 

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -70,7 +70,7 @@ pub mod prelude {
         AttributeIndexDefinition, ChainStore, EntityChange, EntityChangeOperation, EntityFilter,
         EntityKey, EntityOperation, EntityOrder, EntityQuery, EntityRange, EventSource, Store,
         StoreError, StoreEvent, StoreEventStream, StoreEventStreamBox, SubgraphDeploymentStore,
-        TransactionAbortError,
+        TransactionAbortError, SUBSCRIPTION_THROTTLE_INTERVAL,
     };
     pub use components::subgraph::{
         RuntimeHost, RuntimeHostBuilder, SubgraphAssignmentProvider, SubgraphInstance,

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,8 +1,7 @@
-use futures::Stream;
 use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 
-use graph::prelude::{QueryExecutionError, StoreEvent};
+use graph::prelude::{QueryExecutionError, StoreEventStreamBox};
 use prelude::*;
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
@@ -108,7 +107,7 @@ pub trait Resolver: Clone + Send + Sync {
         _schema: &'a s::Document,
         _object_type: &'a s::ObjectType,
         _field: &'b q::Field,
-    ) -> Result<Box<Stream<Item = StoreEvent, Error = ()> + Send>, QueryExecutionError> {
+    ) -> Result<StoreEventStreamBox, QueryExecutionError> {
         Err(QueryExecutionError::NotSupported(String::from(
             "Resolving field streams is not supported by this resolver",
         )))

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -318,6 +318,12 @@ where
         let entities = collect_entities_from_query_field(schema, object_type, field);
 
         // Subscribe to the store and return the entity change stream
-        Ok(self.store.subscribe(entities))
+        let deployment_id = parse_subgraph_id(object_type)?;
+        Ok(self.store.subscribe(entities).throttle_while_syncing(
+            &self.logger,
+            self.store.clone(),
+            deployment_id,
+            *SUBSCRIPTION_THROTTLE_INTERVAL,
+        ))
     }
 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -291,7 +291,7 @@ impl Store for MockStore {
             .unwrap()
             .push((entity_types.into_iter().collect(), sender));
 
-        Box::new(receiver)
+        StoreEventStream::new(Box::new(receiver))
     }
 
     fn count_entities(&self, _: SubgraphDeploymentId) -> Result<u64, Error> {

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -254,10 +254,7 @@ impl Store for MockStore {
                     let sender = sender.clone();
 
                     tokio::spawn(future::lazy(move || {
-                        let event = StoreEvent {
-                            source: EventSource::None,
-                            changes: vec![entity_change],
-                        };
+                        let event = StoreEvent::new(vec![entity_change]);
                         sender
                             .send(event)
                             .map(|_| ())

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -28,7 +28,7 @@ impl StoreEventListener {
 }
 
 impl EventProducer<StoreEvent> for StoreEventListener {
-    fn take_event_stream(&mut self) -> Option<StoreEventStreamBox> {
+    fn take_event_stream(&mut self) -> Option<Box<Stream<Item = StoreEvent, Error = ()> + Send>> {
         self.notification_listener.take_event_stream().map(
             |stream| -> Box<Stream<Item = _, Error = _> + Send> {
                 Box::new(stream.map(|notification| {

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -133,7 +133,6 @@ ORDER BY h.event_id desc";
         .bind::<Text, _>(subgraph_id.to_string());
     let changes: Vec<EntityChangeQBN> = query.get_results(conn)?;
     let changes = changes.into_iter().map(|qbn| qbn.0).collect();
-    let source = EventSource::EthereumBlock(block_ptr_to);
 
-    Ok(StoreEvent { source, changes })
+    Ok(StoreEvent::new(changes))
 }


### PR DESCRIPTION
This PR throttles subscription updates so that updates are generated at most every 500ms; at the same time, no `StoreEvent` is held for longer than 500ms.

There are two things that need improvement still:

* `throttle_while_syncing` now queries the `synced` status of a deployment every time a `StoreEvent` comes through. One way to avoid that would be to get the current chain head pointer when throttling is started, and compare it to the source for any event coming through. We would only requery the head pointer once we see event sources newer than the head pointer. We would then switch to querying the deployment status once we see the head pointer advancing very little when we requery (say by 100 blocks) and then switch to querying the deployment status.
* the throttle time for subscriptions is hardcoded to 500ms. We could expose that as an env var and make it configurable that way (Which brings up the tough issue of naming that env var)

I'd appreciate comments on these two things (and on the PR in general, of course)