### PR TITLE
Return 200 on presence of graphql errors

### DIFF
--- a/server/http/src/response.rs
+++ b/server/http/src/response.rs
@@ -21,17 +21,13 @@ impl GraphQLResponse {
 
     fn status_code_from_result(&self) -> StatusCode {
         match self.result {
-            Ok(ref result) => {
-                if result.errors.is_some() {
-                    StatusCode::BAD_REQUEST
-                } else {
-                    StatusCode::OK
-                }
-            }
+            Ok(_) => StatusCode::OK,
             Err(GraphQLServerError::ClientError(_)) | Err(GraphQLServerError::QueryError(_)) => {
                 StatusCode::BAD_REQUEST
             }
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
+            Err(GraphQLServerError::Canceled(_)) | Err(GraphQLServerError::InternalError(_)) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
         }
     }
 }


### PR DESCRIPTION
The convention here isn't clear, but at least Apollo seems to only look at the graphql response if the response code is 200. This doesn't fix all cases where we don't return 200 but covers most of them. @michaelhly this should fix the issues you observed.