### PR TITLE
Fix 'Invalid subgraph hash in assignment entity' error on initial deployments

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -716,8 +716,8 @@ pub trait Store: Send + Sync + 'static {
             debug!(
                 logger,
                 "Adding subgraph node assignments for {} subgraph deployment ID(s) ({})",
-                removed_assignments.len(),
-                removed_assignments
+                added_assignments.len(),
+                added_assignments
                     .iter()
                     .map(ToString::to_string)
                     .collect::<Vec<_>>()


### PR DESCRIPTION
This was caused by handling all entity changes in the store events emitted for the `SubgraphDeploymentAssignment` subscription. Prior to store events, this subscription would only include changes to `SubgraphDeploymentAssignment` entities. Store events however may contain entity changes for multiple entities of different types, not just the ones subscribed to.

In order to handle assignment changes correctly, we need to filter changes to match `SubgraphDeploymentAssignment` entities.

Without this fix, the first deployment for any subgraph fails with the following kind of error:
```rust
 Feb 23 22:05:15.555 CRIT Assignment event stream failed: subgraph provider error: Invalid subgraph hash in assignment entity: EntityChange {
    subgraph_id: SubgraphDeploymentId(
        "subgraphs"
    ),
    entity_type: "EthereumContractSource",
    entity_id: "QmZwDxfPKJQsFTtXBiDmdjqbX4i4moB9xV92o9je1canvf-manifest-data-source-0-source",
    operation: Set
}
```