### PR TITLE
store/postgres: enable the pg_stat_statements extension

### DIFF
--- a/store/postgres/migrations/2019-02-25-182843_add_pg_stat_statements/down.sql
+++ b/store/postgres/migrations/2019-02-25-182843_add_pg_stat_statements/down.sql
@@ -1,0 +1,1 @@
+DROP EXTENSION IF EXISTS pg_stat_statements;

--- a/store/postgres/migrations/2019-02-25-182843_add_pg_stat_statements/up.sql
+++ b/store/postgres/migrations/2019-02-25-182843_add_pg_stat_statements/up.sql
@@ -1,0 +1,5 @@
+-- The extension requires that the pg_stat_statements DSO is loaded
+-- via shared_preload_libraries. Luckily, this is only needed when
+-- trying to read from the pg_stat_statements view. Extension
+-- creation will succeed either way
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;


### PR DESCRIPTION
One small wrinkle with this is that creating the extension requires that the pg user is a superuser; people would have hit this problem with the migration that adds the `pg_trgm` extension, but it's worth pointing out.