### PR TITLE
Cleanup indexes: remove subgraph entity indexes for unassigned subgraphs

### DIFF
--- a/store/postgres/migrations/2019-02-26-182914_remove_unassigned_deployment_indexes_procedure/down.sql
+++ b/store/postgres/migrations/2019-02-26-182914_remove_unassigned_deployment_indexes_procedure/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION remove_unassigned_deployment_indexes();

--- a/store/postgres/migrations/2019-02-26-182914_remove_unassigned_deployment_indexes_procedure/up.sql
+++ b/store/postgres/migrations/2019-02-26-182914_remove_unassigned_deployment_indexes_procedure/up.sql
@@ -1,0 +1,43 @@
+-- Find all subgraphs without deployment assignments and remove their indexes
+CREATE OR REPLACE FUNCTION remove_unassigned_deployment_indexes()
+    RETURNS VOID AS
+$$
+DECLARE
+    index_to_drop RECORD;
+    counter INT := 0;
+BEGIN
+    -- Loop through each index
+    FOR index_to_drop IN
+        -- Get all indexes on subgraphs without deployment assignments
+        SELECT
+          indexname as name
+        from pg_indexes
+        where
+          -- Extract the subgraph hash from the index name (subgraph hashes are 46 characters long)
+          left(indexname,46) IN
+          (
+            -- Format the subgraph id for comparison with the index names
+            select left(lower(deployments.id),46)
+            from entities as deployments
+            left join
+              (
+                select
+                  id, entity
+                from entities
+                where
+                  subgraph='subgraphs' and
+                  entity='SubgraphDeploymentAssignment'
+              ) assigments
+            on deployments.id=assigments.id
+            where
+              deployments.subgraph='subgraphs' and
+              deployments.entity='SubgraphDeployment' and
+              assigments.id is null)
+    -- Iterate over indexes and drop each
+    LOOP
+        DROP INDEX index_to_drop.name;
+        counter := counter + 1;
+    END LOOP;
+    RAISE NOTICE 'Successfully dropped % indexes', counter;
+END;
+$$ LANGUAGE plpgsql;

--- a/store/postgres/migrations/2019-02-26-183156_cleanup_unassigned_deployment_indexes/down.sql
+++ b/store/postgres/migrations/2019-02-26-183156_cleanup_unassigned_deployment_indexes/down.sql
@@ -1,0 +1,1 @@
+-- To rebuild a set of indexes simply redeploy the subgraph

--- a/store/postgres/migrations/2019-02-26-183156_cleanup_unassigned_deployment_indexes/up.sql
+++ b/store/postgres/migrations/2019-02-26-183156_cleanup_unassigned_deployment_indexes/up.sql
@@ -1,0 +1,2 @@
+-- Remove subgraph attribute indexes for subgraphs without a deployment assignment
+SELECT remove_unassigned_deployment_indexes();


### PR DESCRIPTION
Many of the subgraphs stored in the database are not the current version of the deployment, so their subgraph entity indexes are an unnecessary load on the `entities` table.  The shear number of indexes has lead to shared memory issues during select statements that create a lock for each index on the `entities` table.  

This PR creates and uses a subgraph indexes cleanup function that:
  - finds all subgraph deployments in the database without an assignment, 
  - gets a list of their subgraph attribute indexes on the entities table, 
  - and drops each of the indexes.   