### PR TITLE
PSQL version compatibility: use entire function signature in drop function statements

### DIFF
--- a/store/postgres/migrations/2019-02-04-114900_remove_entity_change_triggers/up.sql
+++ b/store/postgres/migrations/2019-02-04-114900_remove_entity_change_triggers/up.sql
@@ -10,6 +10,6 @@ DROP TRIGGER IF EXISTS entity_removed ON entities;
  * DROP FUNCTIONS
  **************************************************************/
 
-DROP FUNCTION IF EXISTS notify_entity_added;
-DROP FUNCTION IF EXISTS notify_entity_updated;
-DROP FUNCTION IF EXISTS notify_entity_removed;
+DROP FUNCTION IF EXISTS notify_entity_added();
+DROP FUNCTION IF EXISTS notify_entity_updated();
+DROP FUNCTION IF EXISTS notify_entity_removed();


### PR DESCRIPTION
When dropping functions without inputs the `()` is optional for Postgres version 10 onwards. 
 
In order to maintain compatibility with older versions of Postgres the drop function statements in the `remove_entity_change_triggers` have been updated. 