### PR TITLE
Build subgraph indexes cleanup function: build drop index statements using string concatenation

### DIFF
--- a/store/postgres/migrations/2019-02-26-182914_remove_unassigned_deployment_indexes_procedure/up.sql
+++ b/store/postgres/migrations/2019-02-26-182914_remove_unassigned_deployment_indexes_procedure/up.sql
@@ -35,7 +35,7 @@ BEGIN
               assigments.id is null)
     -- Iterate over indexes and drop each
     LOOP
-        DROP INDEX index_to_drop.name;
+        EXECUTE 'DROP INDEX ' || index_to_drop.name;
         counter := counter + 1;
     END LOOP;
     RAISE NOTICE 'Successfully dropped % indexes', counter;


### PR DESCRIPTION
This PR fixes an issue with the index cleanup function incorrectly building drop index statements.  
In order to build the drop index statements correctly using the `record` type variable consumed in the for loop, the statements are built using string concatenation and executed otherwise the drop index function expects a table reference.