### PR TITLE
Pass large Postgres notifications through a dedicated table

### DIFF
--- a/store/postgres/migrations/2019-02-27-035443_create_large_notifications/down.sql
+++ b/store/postgres/migrations/2019-02-27-035443_create_large_notifications/down.sql
@@ -1,0 +1,1 @@
+drop table large_notifications;

--- a/store/postgres/migrations/2019-02-27-035443_create_large_notifications/up.sql
+++ b/store/postgres/migrations/2019-02-27-035443_create_large_notifications/up.sql
@@ -1,0 +1,8 @@
+create unlogged table large_notifications (
+  id serial  primary key,
+  payload    varchar not null,
+  created_at timestamp default current_timestamp not null
+);
+
+comment on table large_notifications is
+'Table for notifications whose payload is too big to send directly';

--- a/store/postgres/src/db_schema.rs
+++ b/store/postgres/src/db_schema.rs
@@ -50,3 +50,11 @@ table! {
         data -> Jsonb,
     }
 }
+
+table! {
+    large_notifications(id) {
+        id -> Integer,
+        payload -> Text,
+        created_at -> Timestamp,
+    }
+}

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -131,9 +131,9 @@ impl NotificationListener {
                         Err(e) => {
                             crit!(
                                 logger,
-                                "Failed to parse database notification: {:?}: {}",
-                                notification,
-                                e
+                                "Failed to parse database notification";
+                                "notification" => format!("{:?}", notification),
+                                "error" => format!("{}", e),
                             );
                             continue;
                         }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -21,11 +21,12 @@ use graph::serde_json;
 use graph::web3::types::H256;
 use graph::{tokio, tokio::timer::Interval};
 use graph_graphql::prelude::api_schema;
+use notification_listener::LargeNotification;
 
 use chain_head_listener::ChainHeadUpdateListener;
 use functions::{
-    attempt_chain_head_update, build_attribute_index, lookup_ancestor_block, pg_notify,
-    revert_block, set_config,
+    attempt_chain_head_update, build_attribute_index, lookup_ancestor_block, revert_block,
+    set_config,
 };
 use store_events::{get_revert_event, StoreEventListener};
 
@@ -659,7 +660,7 @@ impl Store {
                 "changes" => event.changes.len());
 
         let v = serde_json::to_value(event)?;
-        select(pg_notify("store_events", v.to_string())).execute(conn)?;
+        LargeNotification::send_json("store_events", &v.to_string(), conn)?;
         Ok(())
     }
 
@@ -677,7 +678,7 @@ impl Store {
                 "changes" => event.changes.len());
 
         let v = serde_json::to_value(event)?;
-        select(pg_notify("store_events", v.to_string())).execute(conn)?;
+        LargeNotification::send_json("store_events", &v.to_string(), conn)?;
         Ok(())
     }
 }


### PR DESCRIPTION
We create a large_notifications table. Notification payloads on the
store_events channel bigger than 8000 bytes are put into this table, and
the id of the entry in that table is sent instead.

The NotificationListener is responsible for transparently unpacking
payloads that go through this table.

