### PR TITLE
GraphQL interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,12 +782,16 @@ name = "graph-core"
 version = "0.5.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.5.0",
  "graph-graphql 0.5.0",
  "graph-mock 0.5.0",
  "graph-runtime-wasm 0.5.0",
  "ipfs-api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "graph-store-postgres 0.5.0",
+ "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,16 +782,16 @@ name = "graph-core"
 version = "0.5.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.5.0",
  "graph-graphql 0.5.0",
  "graph-mock 0.5.0",
  "graph-runtime-wasm 0.5.0",
- "ipfs-api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph-store-postgres 0.5.0",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipfs-api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,3 +19,8 @@ serde_yaml = "0.7"
 ipfs-api = "0.5.0-alpha2"
 graph-mock = { path = "../mock" }
 walkdir = "2.2.5"
+diesel = { version = "1.3.2", features = ["postgres", "serde_json", "numeric", "r2d2"] }
+graph-store-postgres = { path = "../store/postgres" }
+lazy_static = "1.2.0"
+hex = "0.3.2"
+graphql-parser = "0.2.1"

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -114,7 +114,26 @@ fn one_interface_one_entity() {
     assert!(res.errors.is_none());
     assert_eq!(
         format!("{:?}", res.data.unwrap()),
-        "Object({\"animals\": List([Object({\"legs\": Int(Number(3))})])})"
+        "Object({\"leggeds\": List([Object({\"legs\": Int(Number(3))})])})"
+    )
+}
+
+#[test]
+fn one_interface_one_entity_typename() {
+    let subgraph_id = "oneInterfaceOneEntityTypename";
+    let schema = "interface Legged { legs: Int }
+                  type Animal implements Legged @entity { id: ID!, legs: Int }";
+
+    let entity = Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]);
+
+    let query = "query { leggeds { __typename } }";
+
+    let res = insert_and_query(subgraph_id, schema, vec![entity], query);
+    dbg!(&res);
+    assert!(res.errors.is_none());
+    assert_eq!(
+        format!("{:?}", res.data.unwrap()),
+        "Object({\"leggeds\": List([Object({\"__typename\": String(\"Animal\")})])})"
     )
 }
 

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -265,10 +265,7 @@ fn derived_interface_relationship() {
 
     let forest = (Entity::from(vec![("id", Value::from("1"))]), "Forest");
     let animal = (
-        Entity::from(vec![
-            ("id", Value::from("1")),
-            ("forest", Value::from("1")),
-        ]),
+        Entity::from(vec![("id", Value::from("1")), ("forest", Value::from("1"))]),
         "Animal",
     );
 

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -1,0 +1,141 @@
+// Tests for graphql interfaces.
+
+extern crate diesel;
+extern crate graph;
+extern crate graph_core;
+#[macro_use]
+extern crate lazy_static;
+extern crate graph_graphql;
+extern crate graph_store_postgres;
+extern crate graphql_parser;
+extern crate hex;
+
+use tokio::runtime::Runtime;
+
+use graph::prelude::{Store as StoreTrait, *};
+use graph::web3::types::H256;
+use graph_graphql::prelude::{api_schema, execute_query, QueryExecutionOptions, StoreResolver};
+use graph_store_postgres::{Store, StoreConfig};
+
+/// Helper function to ensure and obtain the Postgres URL to use for testing.
+fn postgres_test_url() -> String {
+    std::env::var_os("THEGRAPH_STORE_POSTGRES_DIESEL_URL")
+        .expect("The THEGRAPH_STORE_POSTGRES_DIESEL_URL environment variable is not set")
+        .into_string()
+        .unwrap()
+}
+
+lazy_static! {
+    // Create Store instance once for use with each of the tests
+    static ref STORE: Arc<Store> = {
+            let mut runtime = Runtime::new().unwrap();
+            let store = runtime.block_on(future::lazy(|| -> Result<_, ()> {
+                let logger = Logger::root(slog::Discard, o!());
+                let postgres_url = postgres_test_url();
+                let net_identifiers = EthereumNetworkIdentifier {
+                    net_version: "graph test suite".to_owned(),
+                    genesis_block_hash: H256::from("0xbd34884280958002c51d3f7b5f853e6febeba33de0f40d15b0363006533c924f"),
+                };
+                let network_name = "fake_network".to_owned();
+
+                Ok(Arc::new(Store::new(
+                    StoreConfig {
+                        postgres_url,
+                        network_name,
+                    },
+                    &logger,
+                    net_identifiers,
+                )))
+                })).unwrap();
+            store
+    };
+}
+
+fn insert_and_query(
+    subgraph_id: &str,
+    schema: &str,
+    entities: Vec<Entity>,
+    query: &str,
+) -> QueryResult {
+    let subgraph_id = SubgraphDeploymentId::new(subgraph_id).unwrap();
+    let mut schema = Schema::parse(schema, subgraph_id.clone()).unwrap();
+    schema.document = api_schema(&schema.document).unwrap();
+
+    let insert_ops = entities.into_iter().map(|data| EntityOperation::Set {
+        key: EntityKey {
+            subgraph_id: subgraph_id.clone(),
+            entity_type: "Animal".to_owned(),
+            entity_id: "1".to_owned(),
+        },
+        data,
+    });
+    STORE
+        .apply_entity_operations(insert_ops.collect(), EventSource::None)
+        .unwrap();
+
+    let logger = Logger::root(slog::Discard, o!());
+    let resolver = StoreResolver::new(&logger, STORE.clone());
+
+    let options = QueryExecutionOptions { logger, resolver };
+    let document = graphql_parser::parse_query(query).unwrap();
+    let query = Query {
+        schema,
+        document,
+        variables: None,
+    };
+    execute_query(&query, options)
+}
+
+/*
+#[test]
+fn one_interface_zero_entities() {
+    let subgraph_id = "oneInterfaceOneEntity";
+    let schema = "interface Legged { legs: Int }
+                  type Animal implements HasLegs @entity { id: ID!, legs: Int }";
+
+    let query = "query { animals { legs } }";
+
+    let res = insert_and_query(subgraph_id, schema, vec![entity], query);
+    assert!(res.data.is_none() && res.errors.is_empty());
+}*/
+
+#[test]
+fn one_interface_one_entity() {
+    let subgraph_id = "oneInterfaceOneEntity";
+    let schema = "interface Legged { legs: Int }
+                  type Animal implements Legged @entity { id: ID!, legs: Int }";
+
+    let entity = Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]);
+
+    let query = "query { leggeds { legs } }";
+
+    let res = insert_and_query(subgraph_id, schema, vec![entity], query);
+    dbg!(&res);
+    assert!(res.errors.is_none());
+    assert_eq!(
+        format!("{:?}", res.data.unwrap()),
+        "Object({\"animals\": List([Object({\"legs\": Int(Number(3))})])})"
+    )
+}
+
+/*
+#[test]
+fn one_interface_multiple_entities() {
+    let subgraph_id = "oneInterfaceOneEntity";
+    let schema = "interface Legged { legs: Int }
+                  type Animal implements HasLegs @entity { id: ID!, legs: Int }
+                  type Furniture implements HasLegs @entity { id: ID!, legs: Int }
+                  ";
+
+    let entity = Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]);
+
+    let query = "query { animals { legs } }";
+
+    let res = insert_and_query(subgraph_id, schema, vec![entity], query);
+    assert!(res.errors.is_empty());
+    assert_eq!(
+        format!("{:?}", res.data.unwrap()),
+        "Object({\"animals\": List([Object({\"legs\": Int(Number(3))})])})"
+    )
+}
+*/

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -82,7 +82,7 @@ fn insert_and_query(
     let options = QueryExecutionOptions { logger, resolver };
     let document = graphql_parser::parse_query(query).unwrap();
     let query = Query {
-        schema,
+        schema: Arc::new(schema),
         document,
         variables: None,
     };

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -117,15 +117,23 @@ fn one_interface_one_entity() {
         "Animal",
     );
 
+    // Collection query.
     let query = "query { leggeds { legs } }";
-
     let res = insert_and_query(subgraph_id, schema, vec![entity], query);
-
     assert!(res.errors.is_none());
     assert_eq!(
         format!("{:?}", res.data.unwrap()),
         "Object({\"leggeds\": List([Object({\"legs\": Int(Number(3))})])})"
-    )
+    );
+
+    // Query by ID.
+    let query = "query { legged(id: \"1\") { legs } }";
+    let res = insert_and_query(subgraph_id, schema, vec![], query);
+    assert!(res.errors.is_none());
+    assert_eq!(
+        format!("{:?}", res.data.unwrap()),
+        "Object({\"legged\": Object({\"legs\": Int(Number(3))})})",
+    );
 }
 
 #[test]

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -74,7 +74,7 @@ fn insert_and_query(
     STORE
         .apply_entity_operations(
             SubgraphDeploymentEntity::new(&manifest, false, false, Default::default(), 1)
-                .create_operations_force(&subgraph_id),
+                .create_operations_replace(&subgraph_id),
             EventSource::None,
         )
         .unwrap();
@@ -250,7 +250,7 @@ fn conflicting_implementors_id() {
     let res = insert_and_query(subgraph_id, schema, vec![animal, furniture], query);
     assert_eq!(
         res.unwrap_err().to_string(),
-        "tried to set entity of type `Furniture` with ID `1` but an entity of type `Animal`, \
+        "tried to set entity of type `Furniture` with ID \"1\" but an entity of type `Animal`, \
          which has an interface in common with `Furniture`, exists with the same ID"
     );
 }
@@ -307,12 +307,12 @@ fn two_interfaces() {
         "AB",
     );
 
-    let query = "query { ibars { bar } ifoos { foo } }";
+    let query = "query { ibars(orderBy: bar) { bar } ifoos(orderBy: foo) { foo } }";
     let res = insert_and_query(subgraph_id, schema, vec![a, b, ab], query).unwrap();
     assert!(res.errors.is_none());
     assert_eq!(
         format!("{:?}", res.data.unwrap()),
-        "Object({\"ibars\": List([Object({\"bar\": Int(Number(200))}), Object({\"bar\": Int(Number(100))})]), \
+        "Object({\"ibars\": List([Object({\"bar\": Int(Number(100))}), Object({\"bar\": Int(Number(200))})]), \
                  \"ifoos\": List([Object({\"foo\": String(\"bla\")}), Object({\"foo\": String(\"ble\")})])})"
     );
 }

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -254,3 +254,29 @@ fn conflicting_implementors_id() {
          which has an interface in common with `Furniture`, exists with the same ID"
     );
 }
+
+#[test]
+fn derived_interface_relationship() {
+    let subgraph_id = "DerivedInterfaceRelationship";
+    let schema = "interface ForestDweller { id: ID!, forest: Forest }
+                  type Animal implements ForestDweller @entity { id: ID!, forest: Forest }
+                  type Forest @entity { id: ID!, dwellers: [ForestDweller]! @derivedFrom(field: \"forest\") }
+                  ";
+
+    let forest = (Entity::from(vec![("id", Value::from("1"))]), "Forest");
+    let animal = (
+        Entity::from(vec![
+            ("id", Value::from("1")),
+            ("forest", Value::from("1")),
+        ]),
+        "Animal",
+    );
+
+    let query = "query { forests { dwellers { id } } }";
+
+    let res = insert_and_query(subgraph_id, schema, vec![forest, animal], query);
+    assert_eq!(
+        res.unwrap().data.unwrap().to_string(),
+        "{forests: [{dwellers: [{id: \"1\"}]}]}"
+    );
+}

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -81,7 +81,7 @@ fn multiple_data_sources_per_subgraph() {
             _: Arc<Log>,
             _: Vec<EntityOperation>,
         ) -> Box<Future<Item = Vec<EntityOperation>, Error = Error> + Send> {
-            unimplemented!();
+            unreachable!();
         }
     }
 

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -168,7 +168,6 @@ fn multiple_data_sources_per_subgraph() {
                         .iter()
                         .map(|data_source| data_source.name.as_str())
                         .collect::<HashSet<&str>>();
-                    use std::iter::FromIterator;
                     let expected_data_source_names =
                         HashSet::from_iter(vec!["ExampleDataSource", "ExampleDataSource2"]);
 

--- a/datasource/ethereum/tests/adapter.rs
+++ b/datasource/ethereum/tests/adapter.rs
@@ -66,13 +66,10 @@ impl Transport for TestTransport {
         (self.requests.lock().unwrap().len(), request)
     }
 
-    fn send(&self, id: RequestId, request: jsonrpc_core::Call) -> Result<jsonrpc_core::Value> {
+    fn send(&self, _: RequestId, _: jsonrpc_core::Call) -> Result<jsonrpc_core::Value> {
         match self.response.lock().unwrap().pop_front() {
             Some(response) => Box::new(finished(response)),
-            None => {
-                println!("Unexpected request (id: {:?}): {:?}", id, request);
-                Box::new(failed(ErrorKind::Unreachable.into()))
-            }
+            None => Box::new(failed(ErrorKind::Unreachable.into())),
         }
     }
 }

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -147,7 +147,7 @@ impl Clone for EthereumEventData {
 /// A block hash and block number from a specific Ethereum block.
 ///
 /// Maximum block number supported: 2^63 - 1
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EthereumBlockPointer {
     pub hash: H256,
     pub number: u64,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -779,7 +779,7 @@ pub trait Store: Send + Sync + 'static {
 }
 
 pub trait SubgraphDeploymentStore: Send + Sync + 'static {
-    fn subgraph_schema(&self, subgraph_id: SubgraphDeploymentId) -> Result<Schema, Error>;
+    fn subgraph_schema(&self, subgraph_id: SubgraphDeploymentId) -> Result<Arc<Schema>, Error>;
 }
 
 /// Common trait for blockchain store implementations.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -385,6 +385,12 @@ pub enum StoreError {
     Aborted(TransactionAbortError),
     #[fail(display = "store error: {}", _0)]
     Unknown(Error),
+    #[fail(
+        display = "tried to set entity of type `{}` with ID `{}` but an entity of type `{}`, \
+                   which has an interface in common with `{}`, exists with the same ID",
+        _0, _1, _2, _0
+    )]
+    ConflictingId(String, String, String), // (entity, id, conflicting_entity)
 }
 
 impl From<TransactionAbortError> for StoreError {
@@ -411,7 +417,7 @@ impl From<serde_json::Error> for StoreError {
     }
 }
 
-#[derive(Fail, Debug)]
+#[derive(Fail, PartialEq, Eq, Debug)]
 pub enum TransactionAbortError {
     #[fail(
         display = "AbortUnless triggered abort, expected {:?} but got {:?}: {}",
@@ -779,7 +785,7 @@ pub trait Store: Send + Sync + 'static {
 }
 
 pub trait SubgraphDeploymentStore: Send + Sync + 'static {
-    fn subgraph_schema(&self, subgraph_id: SubgraphDeploymentId) -> Result<Arc<Schema>, Error>;
+    fn subgraph_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error>;
 }
 
 /// Common trait for blockchain store implementations.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -86,8 +86,8 @@ pub struct EntityQuery {
     /// ID of the subgraph.
     pub subgraph_id: SubgraphDeploymentId,
 
-    /// The name of the entity type.
-    pub entity_type: String,
+    /// The name of the entity types being queried.
+    pub entity_types: Vec<String>,
 
     /// Filter to filter entities by.
     pub filter: Option<EntityFilter>,
@@ -103,10 +103,10 @@ pub struct EntityQuery {
 }
 
 impl EntityQuery {
-    pub fn new(subgraph_id: SubgraphDeploymentId, entity_type: impl Into<String>) -> Self {
+    pub fn new(subgraph_id: SubgraphDeploymentId, entity_types: Vec<String>) -> Self {
         EntityQuery {
             subgraph_id,
-            entity_type: entity_type.into(),
+            entity_types,
             filter: None,
             order_by: None,
             order_direction: None,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -386,7 +386,7 @@ pub enum StoreError {
     #[fail(display = "store error: {}", _0)]
     Unknown(Error),
     #[fail(
-        display = "tried to set entity of type `{}` with ID `{}` but an entity of type `{}`, \
+        display = "tried to set entity of type `{}` with ID \"{}\" but an entity of type `{}`, \
                    which has an interface in common with `{}`, exists with the same ID",
         _0, _1, _2, _0
     )]

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -86,7 +86,8 @@ pub struct EntityQuery {
     /// ID of the subgraph.
     pub subgraph_id: SubgraphDeploymentId,
 
-    /// The name of the entity types being queried.
+    /// The names of the entity types being queried. The result is the union
+    /// (with repetition) of the query for each entity.
     pub entity_types: Vec<String>,
 
     /// Filter to filter entities by.

--- a/graph/src/data/graphql/serialization.rs
+++ b/graph/src/data/graphql/serialization.rs
@@ -30,7 +30,7 @@ impl<'a> Serialize for SerializableValue<'a> {
                 }
                 map.end()
             }
-            _ => unimplemented!(),
+            Value::Variable(_) => unreachable!("output cannot contain variables"),
         }
     }
 }

--- a/graph/src/data/graphql/validation.rs
+++ b/graph/src/data/graphql/validation.rs
@@ -20,11 +20,11 @@ pub enum SchemaValidationError {
     EntityDirectivesMissing(Strings),
 
     #[fail(
-        display = "Type `{}` cannot implement `{}` because it is missing \
-                   the required fields {:?}",
+        display = "Entity type `{}` cannot implement `{}` because it is missing \
+                   the required fields: {}",
         _0, _1, _2
     )]
-    CannotImplement(String, String, Vec<String>), // (type, interface, missing_fields)
+    CannotImplement(String, String, Strings), // (type, interface, missing_fields)
 }
 
 /// Validates whether a GraphQL schema is compatible with The Graph.
@@ -72,7 +72,7 @@ pub(crate) fn validate_interface_implementation(
         Err(SchemaValidationError::CannotImplement(
             object.name.clone(),
             interface.name.clone(),
-            missing_fields,
+            Strings(missing_fields),
         ))
     } else {
         Ok(())

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -47,6 +47,7 @@ pub enum QueryExecutionError {
     StoreError(failure::Error),
     Timeout,
     EmptySelectionSet(String),
+    Unimplemented(String),
 }
 
 impl Error for QueryExecutionError {
@@ -168,6 +169,9 @@ impl fmt::Display for QueryExecutionError {
             Timeout => write!(f, "Query timed out"),
             EmptySelectionSet(entity_type) => {
                 write!(f, "Selection set for type {} is empty", entity_type)
+            }
+            Unimplemented(feature) => {
+                write!(f, "Feature `{}` is not yet implemented", feature)
             }
         }
     }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -46,6 +46,7 @@ pub enum QueryExecutionError {
     EntityParseError(String),
     StoreError(failure::Error),
     Timeout,
+    EmptySelectionSet(String),
 }
 
 impl Error for QueryExecutionError {
@@ -165,6 +166,9 @@ impl fmt::Display for QueryExecutionError {
                 write!(f, "Store error: {}", e)
             }
             Timeout => write!(f, "Query timed out"),
+            EmptySelectionSet(entity_type) => {
+                write!(f, "Selection set for type {} is empty", entity_type)
+            }
         }
     }
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -67,7 +67,7 @@ impl fmt::Display for QueryExecutionError {
         match self {
             OperationNameRequired => write!(f, "Operation name required"),
             OperationNotFound(s) => {
-                write!(f, "Operation name not found: {}", s)
+                write!(f, "Operation name not found `{}`", s)
             }
             NotSupported(s) => write!(f, "Not supported: {}", s),
             NoRootQueryObjectType => {
@@ -77,49 +77,49 @@ impl fmt::Display for QueryExecutionError {
                 write!(f, "No root Subscription type defined in the schema")
             }
             NonNullError(_, s) => {
-                write!(f, "Null value resolved for non-null field: {}", s)
+                write!(f, "Null value resolved for non-null field `{}`", s)
             }
             ListValueError(_, s) => {
-                write!(f, "Non-list value resolved for list field: {}", s)
+                write!(f, "Non-list value resolved for list field `{}`", s)
             }
             NamedTypeError(s) => {
-                write!(f, "Failed to resolve named type: {}", s)
+                write!(f, "Failed to resolve named type `{}`", s)
             }
             AbstractTypeError(s) => {
-                write!(f, "Failed to resolve abstract type: {}", s)
+                write!(f, "Failed to resolve abstract type `{}`", s)
             }
             InvalidArgumentError(_, s, v) => {
-                write!(f, "Invalid value provided for argument \"{}\": {:?}", s, v)
+                write!(f, "Invalid value provided for argument `{}`: {:?}", s, v)
             }
             MissingArgumentError(_, s) => {
-                write!(f, "No value provided for required argument: {}", s)
+                write!(f, "No value provided for required argument: `{}`", s)
             }
             InvalidVariableTypeError(_, s) => {
-                write!(f, "Variable \"{}\" must have an input type", s)
+                write!(f, "Variable `{}` must have an input type", s)
             }
             InvalidVariableError(_, s, v) => {
-                write!(f, "Invalid value provided for variable \"{}\": {:?}", s, v)
+                write!(f, "Invalid value provided for variable `{}`: {:?}", s, v)
             }
             MissingVariableError(_, s) => {
-                write!(f, "No value provided for required variable: {}", s)
+                write!(f, "No value provided for required variable `{}`", s)
             }
             ResolveEntityError(_, entity, id, e) => {
-                write!(f, "Failed to get {} entity with ID \"{}\" from store: {}", entity, id, e)
+                write!(f, "Failed to get `{}` entity with ID `{}` from store: {}", entity, id, e)
             }
             ResolveEntitiesError(e) => {
                 write!(f, "Failed to get entities from store: {}", e)
             }
             OrderByNotSupportedError(entity, field) => {
-                write!(f, "Ordering by \"{}\" is not supported for type \"{}\"", field, entity)
+                write!(f, "Ordering by `{}` is not supported for type `{}`", field, entity)
             }
             OrderByNotSupportedForType(field_type) => {
-                write!(f, "Ordering by \"{}\" fields is not supported", field_type)
+                write!(f, "Ordering by `{}` fields is not supported", field_type)
             }
             FilterNotSupportedError(value, filter) => {
-                write!(f, "Filter not supported by value {} : {}", value, filter)
+                write!(f, "Filter not supported by value `{}`: `{}`", value, filter)
             }
             UnknownField(_, t, s) => {
-                write!(f, "Type \"{}\" has no field \"{}\"", t, s)
+                write!(f, "Type `{}` has no field `{}`", t, s)
             }
             EmptyQuery => write!(f, "The query is empty"),
             MultipleSubscriptionFields => write!(
@@ -127,7 +127,7 @@ impl fmt::Display for QueryExecutionError {
                 "Only a single top-level field is allowed in subscriptions"
             ),
             SubgraphDeploymentIdError(s) => {
-                write!(f, "Failed to get subgraph ID from type: {}", s)
+                write!(f, "Failed to get subgraph ID from type: `{}`", s)
             }
             RangeArgumentsError(args) => {
                 let msg = args.iter().map(|arg| {
@@ -142,23 +142,23 @@ impl fmt::Display for QueryExecutionError {
             }
             InvalidFilterError => write!(f, "Filter must by an object"),
             EntityFieldError(e, a) => {
-                write!(f, "Entity {} has no attribute {}", e, a)
+                write!(f, "Entity `{}` has no attribute `{}`", e, a)
             }
 
             ListTypesError(s, v) => write!(
                 f,
-                "Values passed to filter {} must be of the same type but are of different types: {}",
+                "Values passed to filter `{}` must be of the same type but are of different types: {}",
                 s,
                 v.join(", ")
             ),
             ListFilterError(s) => {
-                write!(f, "Non-list value passed to {} filter", s)
+                write!(f, "Non-list value passed to `{}` filter", s)
             }
             ValueParseError(t, e) => {
-                write!(f, "Failed to decode {} value: {}", t, e)
+                write!(f, "Failed to decode `{}` value: `{}`", t, e)
             }
             AttributeTypeError(value, ty) => {
-                write!(f, "Query contains value with invalid type {} : {}", ty, value)
+                write!(f, "Query contains value with invalid type `{}`: `{}`", ty, value)
             }
             EntityParseError(s) => {
                 write!(f, "Broken entity found in store: {}", s)
@@ -168,7 +168,7 @@ impl fmt::Display for QueryExecutionError {
             }
             Timeout => write!(f, "Query timed out"),
             EmptySelectionSet(entity_type) => {
-                write!(f, "Selection set for type {} is empty", entity_type)
+                write!(f, "Selection set for type `{}` is empty", entity_type)
             }
             Unimplemented(feature) => {
                 write!(f, "Feature `{}` is not yet implemented", feature)

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -2,6 +2,7 @@ use graphql_parser::query as q;
 use serde::de::{Deserialize, Deserializer};
 use std::collections::{BTreeMap, HashMap};
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 
 use data::schema::Schema;
 
@@ -88,7 +89,7 @@ impl DerefMut for QueryVariables {
 /// A GraphQL query as submitted by a client, either directly or through a subscription.
 #[derive(Clone, Debug)]
 pub struct Query {
-    pub schema: Schema,
+    pub schema: Arc<Schema>,
     pub document: q::Document,
     pub variables: Option<QueryVariables>,
 }

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -156,7 +156,7 @@ fn invalid_interface_implementation() {
     let res = Schema::parse(schema, SubgraphDeploymentId::new("dummy").unwrap());
     assert_eq!(
         res.unwrap_err().to_string(),
-        "Type `Bar` cannot implement `Foo` because it is missing the \
-         required fields [\"x: Int\", \"y: Int\"]"
+        "Entity type `Bar` cannot implement `Foo` because it is missing the \
+         required fields: x: Int, y: Int"
     );
 }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -199,6 +199,12 @@ impl SubgraphDeploymentEntity {
         }
     }
 
+    // Overwrite entity if it exists. Only in debug builds so it's not used outside tests.
+    #[cfg(debug_assertions)]
+    pub fn create_operations_force(self, id: &SubgraphDeploymentId) -> Vec<EntityOperation> {
+        self.private_create_operations(id)
+    }
+
     pub fn create_operations(self, id: &SubgraphDeploymentId) -> Vec<EntityOperation> {
         let mut ops = vec![];
 
@@ -208,6 +214,13 @@ impl SubgraphDeploymentEntity {
             query: Self::query().filter(EntityFilter::new_equal("id", id.to_string())),
             entity_ids: vec![],
         });
+
+        ops.extend(self.private_create_operations(id));
+        ops
+    }
+
+    fn private_create_operations(self, id: &SubgraphDeploymentId) -> Vec<EntityOperation> {
+        let mut ops = vec![];
 
         let manifest_id = SubgraphManifestEntity::id(&id);
         ops.extend(self.manifest.write_operations(&manifest_id));

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -39,7 +39,7 @@ pub trait TypedEntity {
     type IdType: ToString;
 
     fn query() -> EntityQuery {
-        EntityQuery::new(SUBGRAPHS_ID.clone(), Self::TYPENAME)
+        EntityQuery::new(SUBGRAPHS_ID.clone(), vec![Self::TYPENAME.to_owned()])
     }
 
     fn subgraph_entity_pair() -> SubgraphEntityPair {

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -201,7 +201,7 @@ impl SubgraphDeploymentEntity {
 
     // Overwrite entity if it exists. Only in debug builds so it's not used outside tests.
     #[cfg(debug_assertions)]
-    pub fn create_operations_force(self, id: &SubgraphDeploymentId) -> Vec<EntityOperation> {
+    pub fn create_operations_replace(self, id: &SubgraphDeploymentId) -> Vec<EntityOperation> {
         self.private_create_operations(id)
     }
 

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -87,7 +87,7 @@ pub mod prelude {
         AssignmentEvent, Attribute, Entity, NodeId, SubgraphEntityPair, SubgraphVersionSummary,
         Value, ValueType,
     };
-    pub use data::subgraph::schema::TypedEntity;
+    pub use data::subgraph::schema::{SubgraphDeploymentEntity, TypedEntity};
     pub use data::subgraph::{
         CreateSubgraphResult, DataSource, Link, MappingABI, MappingEventHandler,
         SubgraphAssignmentProviderError, SubgraphAssignmentProviderEvent, SubgraphDeploymentId,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -52,6 +52,7 @@ pub mod prelude {
     pub use serde_derive::{Deserialize, Serialize};
     pub use slog::{self, crit, debug, error, info, o, trace, warn, Logger};
     pub use std::fmt::Debug;
+    pub use std::iter::FromIterator;
     pub use std::sync::Arc;
     pub use tokio;
     pub use tokio::prelude::*;

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -391,10 +391,16 @@ where
                     &field.name,
                     t.into(),
                     argument_values,
+                    &BTreeMap::new(), // The introspection schema has no interfaces.
                 )
             } else {
-                ctx.resolver
-                    .resolve_object(object_value, &field.name, t.into(), argument_values)
+                ctx.resolver.resolve_object(
+                    object_value,
+                    &field.name,
+                    t.into(),
+                    argument_values,
+                    ctx.schema.types_for_interface(),
+                )
             }
         }
 
@@ -428,7 +434,6 @@ where
             _ => Ok(q::Value::Null),
         },
 
-        // We will implement these later
         s::TypeDefinition::Interface(i) => {
             if ctx.introspecting {
                 ctx.introspection_resolver.resolve_object(
@@ -436,12 +441,19 @@ where
                     &field.name,
                     i.into(),
                     argument_values,
+                    &BTreeMap::new(), // The introspection schema has no interfaces.
                 )
             } else {
-                ctx.resolver
-                    .resolve_object(object_value, &field.name, i.into(), argument_values)
+                ctx.resolver.resolve_object(
+                    object_value,
+                    &field.name,
+                    i.into(),
+                    argument_values,
+                    ctx.schema.types_for_interface(),
+                )
             }
         }
+
         s::TypeDefinition::Union(_) => unimplemented!(),
 
         _ => unimplemented!(),

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -142,6 +142,11 @@ where
     if errors.is_empty() && !result_map.is_empty() {
         Ok(q::Value::Object(result_map))
     } else {
+        if errors.is_empty() {
+            errors.push(QueryExecutionError::EmptySelectionSet(
+                object_type.name.clone(),
+            ));
+        }
         Err(errors)
     }
 }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -393,12 +393,12 @@ where
                 ctx.introspection_resolver.resolve_object(
                     object_value,
                     &field.name,
-                    t,
+                    t.into(),
                     argument_values,
                 )
             } else {
                 ctx.resolver
-                    .resolve_object(object_value, &field.name, t, argument_values)
+                    .resolve_object(object_value, &field.name, t.into(), argument_values)
             }
         }
 
@@ -490,7 +490,7 @@ where
                         object_value,
                         &field.name,
                         field_definition,
-                        t,
+                        t.into(),
                         argument_values,
                         &BTreeMap::new(), // The introspection schema has no interfaces.
                     )
@@ -499,7 +499,7 @@ where
                         object_value,
                         &field.name,
                         field_definition,
-                        t,
+                        t.into(),
                         argument_values,
                         ctx.schema.types_for_interface(),
                     )

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -104,15 +104,6 @@ where
 
     // Process all field groups in order
     for (response_key, fields) in grouped_field_set {
-        // `__typename` is not in the schema but can be queried in all types.
-        if fields[0].name == "__typename" {
-            result_map.insert(
-                response_key.to_owned(),
-                q::Value::String(object_type.name.to_owned().into()),
-            );
-            continue;
-        }
-
         match ctx.deadline {
             Some(deadline) if deadline < Instant::now() => {
                 errors.push(QueryExecutionError::Timeout);

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -492,6 +492,7 @@ where
                         field_definition,
                         t,
                         argument_values,
+                        &BTreeMap::new(), // The introspection schema has no interfaces.
                     )
                 } else {
                     ctx.resolver.resolve_objects(
@@ -500,6 +501,7 @@ where
                         field_definition,
                         t,
                         argument_values,
+                        ctx.schema.types_for_interface(),
                     )
                 }
                 .map_err(|e| vec![e]),

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -490,7 +490,7 @@ where
                         object_value,
                         &field.name,
                         field_definition,
-                        &t,
+                        t,
                         argument_values,
                     )
                 } else {
@@ -498,7 +498,7 @@ where
                         object_value,
                         &field.name,
                         field_definition,
-                        &t,
+                        t,
                         argument_values,
                     )
                 }

--- a/graphql/src/execution/mod.rs
+++ b/graphql/src/execution/mod.rs
@@ -5,4 +5,4 @@ mod execution;
 mod resolver;
 
 pub use self::execution::*;
-pub use self::resolver::Resolver;
+pub use self::resolver::{ObjectOrInterface, Resolver};

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -67,6 +67,7 @@ pub trait Resolver: Clone + Send + Sync {
         field: &q::Name,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
+        types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an enum value for a given enum type.

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -49,22 +49,22 @@ impl<'a> ObjectOrInterface<'a> {
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
 pub trait Resolver: Clone + Send + Sync {
     /// Resolves entities referenced by a parent object.
-    fn resolve_objects<'a>(
+    fn resolve_objects(
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
         field_definition: &s::Field,
-        object_type: impl Into<ObjectOrInterface<'a>>,
+        object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an entity referenced by a parent object.
-    fn resolve_object<'a>(
+    fn resolve_object(
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
-        object_type: impl Into<ObjectOrInterface<'a>>,
+        object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError>;
 

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -5,24 +5,65 @@ use std::collections::HashMap;
 use graph::prelude::{QueryExecutionError, StoreEvent};
 use prelude::*;
 
+#[derive(Copy, Clone)]
+pub enum ObjectOrInterface<'a> {
+    Object(&'a s::ObjectType),
+    Interface(&'a s::InterfaceType),
+}
+
+impl<'a> From<&'a s::ObjectType> for ObjectOrInterface<'a> {
+    fn from(object: &'a s::ObjectType) -> Self {
+        ObjectOrInterface::Object(object)
+    }
+}
+
+impl<'a> From<&'a s::InterfaceType> for ObjectOrInterface<'a> {
+    fn from(interface: &'a s::InterfaceType) -> Self {
+        ObjectOrInterface::Interface(interface)
+    }
+}
+
+impl<'a> ObjectOrInterface<'a> {
+    pub fn name(self) -> &'a str {
+        match self {
+            ObjectOrInterface::Object(object) => &object.name,
+            ObjectOrInterface::Interface(interface) => &interface.name,
+        }
+    }
+
+    pub fn directives(self) -> &'a Vec<s::Directive> {
+        match self {
+            ObjectOrInterface::Object(object) => &object.directives,
+            ObjectOrInterface::Interface(interface) => &interface.directives,
+        }
+    }
+
+    pub fn fields(self) -> &'a Vec<s::Field> {
+        match self {
+            ObjectOrInterface::Object(object) => &object.fields,
+            ObjectOrInterface::Interface(interface) => &interface.fields,
+        }
+    }
+}
+
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
 pub trait Resolver: Clone + Send + Sync {
     /// Resolves entities referenced by a parent object.
-    fn resolve_objects(
+    fn resolve_objects<'a>(
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
         field_definition: &s::Field,
-        object_type: &s::ObjectType,
+        object_type: impl Into<ObjectOrInterface<'a>>,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an entity referenced by a parent object.
-    fn resolve_object(
+    fn resolve_object<'a>(
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
-        object_type: &s::ObjectType,
+        object_type: impl Into<ObjectOrInterface<'a>>,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError>;
 

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use graph::prelude::{QueryExecutionError, StoreEvent};
 use prelude::*;
+use schema::ast::get_named_type;
 
 #[derive(Copy, Clone)]
 pub enum ObjectOrInterface<'a> {
@@ -137,11 +138,24 @@ pub trait Resolver: Clone + Send + Sync {
     // Resolves an abstract type into the specific type of an object.
     fn resolve_abstract_type<'a>(
         &self,
-        _schema: &'a s::Document,
+        schema: &'a s::Document,
         _abstract_type: &s::TypeDefinition,
-        _object_value: &q::Value,
+        object_value: &q::Value,
     ) -> Option<&'a s::ObjectType> {
-        None
+        let concrete_type_name = match object_value {
+            // All objects contain `__typename`
+            q::Value::Object(data) => match &data["__typename"] {
+                q::Value::String(name) => name.clone(),
+                _ => unreachable!("__typename must be a string"),
+            },
+            _ => unreachable!("abstract type value must be an object"),
+        };
+
+        // A name returned in a `__typename` must exist in the schema.
+        match get_named_type(schema, &concrete_type_name).unwrap() {
+            s::TypeDefinition::Object(object) => Some(object),
+            _ => unreachable!("only objects may implement interfaces"),
+        }
     }
 
     // Resolves a change stream for a given field.

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,6 +1,6 @@
 use futures::Stream;
 use graphql_parser::{query as q, schema as s};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use graph::prelude::{QueryExecutionError, StoreEvent};
 use prelude::*;
@@ -56,6 +56,7 @@ pub trait Resolver: Clone + Send + Sync {
         field_definition: &s::Field,
         object_type: impl Into<ObjectOrInterface<'a>>,
         arguments: &HashMap<&q::Name, q::Value>,
+        types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an entity referenced by a parent object.

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -141,18 +141,7 @@ fn input_object_type_object(
                 .as_ref()
                 .map_or(q::Value::Null, |s| q::Value::String(s.to_owned())),
         ),
-        // The JS graphql library that graphiql uses does not like an empty
-        // "inputFields" and will refuse to load the schema if it finds one. So make
-        // sure to please it by using `null` if empty. graphql could be more
-        // flexible here, looks like an upstream bug.
-        (
-            "inputFields",
-            if input_values.is_empty() {
-                q::Value::Null
-            } else {
-                q::Value::List(input_values)
-            },
-        ),
+        ("inputFields", q::Value::List(input_values)),
     ])
 }
 

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -169,15 +169,10 @@ fn interface_type_object(
         (
             "possibleTypes",
             q::Value::List(
-                schema
-                    .types_for_interface(&interface_type.name)
-                    .map(|types| {
-                        types
-                            .iter()
-                            .map(|object_type| q::Value::String(object_type.name.to_owned()))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
+                schema.types_for_interface()[&interface_type.name]
+                    .iter()
+                    .map(|object_type| q::Value::String(object_type.name.to_owned()))
+                    .collect(),
             ),
         ),
     ])
@@ -466,6 +461,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         _field_definition: &s::Field,
         _object_type: impl Into<ObjectOrInterface<'b>>,
         _arguments: &HashMap<&q::Name, q::Value>,
+        _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError> {
         match field.as_str() {
             "possibleTypes" => {

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -454,12 +454,12 @@ impl<'a> IntrospectionResolver<'a> {
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
 impl<'a> Resolver for IntrospectionResolver<'a> {
-    fn resolve_objects<'b>(
+    fn resolve_objects(
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
         _field_definition: &s::Field,
-        _object_type: impl Into<ObjectOrInterface<'b>>,
+        _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError> {
@@ -492,11 +492,11 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         }
     }
 
-    fn resolve_object<'b>(
+    fn resolve_object(
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
-        _object_type: impl Into<ObjectOrInterface<'b>>,
+        _object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         let object = match field.as_str() {

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -459,12 +459,12 @@ impl<'a> IntrospectionResolver<'a> {
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
 impl<'a> Resolver for IntrospectionResolver<'a> {
-    fn resolve_objects(
+    fn resolve_objects<'b>(
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
         _field_definition: &s::Field,
-        _object_type: &s::ObjectType,
+        _object_type: impl Into<ObjectOrInterface<'b>>,
         _arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         match field.as_str() {
@@ -496,11 +496,11 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         }
     }
 
-    fn resolve_object(
+    fn resolve_object<'b>(
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
-        _object_type: &s::ObjectType,
+        _object_type: impl Into<ObjectOrInterface<'b>>,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         let object = match field.as_str() {

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -508,6 +508,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         field: &q::Name,
         _object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
+        _: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError> {
         let object = match field.as_str() {
             "__schema" => self.schema_object(),

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -39,5 +39,8 @@ pub mod prelude {
     pub use super::subscription::{execute_subscription, SubscriptionExecutionOptions};
     pub use super::values::{object_value, MaybeCoercible};
 
-    pub use super::graphql_parser::schema;
+    pub use super::graphql_parser::{
+        query::Name,
+        schema::{self, ObjectType},
+    };
 }

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -31,7 +31,7 @@ mod store;
 
 /// Prelude that exports the most important traits and types.
 pub mod prelude {
-    pub use super::execution::{ExecutionContext, Resolver};
+    pub use super::execution::{ExecutionContext, ObjectOrInterface, Resolver};
     pub use super::introspection::{introspection_schema, IntrospectionResolver};
     pub use super::query::{execute_query, QueryExecutionOptions};
     pub use super::schema::{api_schema, APISchemaError};

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -421,11 +421,16 @@ pub fn get_referenced_entity_type<'a>(
     schema: &'a Document,
     field: &Field,
 ) -> Option<&'a TypeDefinition> {
-    unpack_type(schema, &field.field_type).and_then(|type_def| {
-        if is_entity_type_definition(type_def) {
-            Some(type_def)
-        } else {
-            None
-        }
-    })
+    unpack_type(schema, &field.field_type).filter(|ty| is_entity_type_definition(ty))
+}
+
+pub fn get_input_object_definitions(schema: &Document) -> Vec<InputObjectType> {
+    schema
+        .definitions
+        .iter()
+        .filter_map(|d| match d {
+            Definition::TypeDefinition(TypeDefinition::InputObject(t)) => Some(t.clone()),
+            _ => None,
+        })
+        .collect()
 }

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -5,6 +5,7 @@ use lazy_static::lazy_static;
 use std::ops::Deref;
 use std::str::FromStr;
 
+use execution::ObjectOrInterface;
 use graph::prelude::ValueType;
 
 pub(crate) enum FilterOp {
@@ -162,8 +163,15 @@ pub fn get_interface_type_mut<'a>(
 }
 
 /// Returns the type of a field of an object type.
-pub fn get_field_type<'a>(object_type: &'a ObjectType, name: &Name) -> Option<&'a Field> {
-    object_type.fields.iter().find(|field| &field.name == name)
+pub fn get_field_type<'a>(
+    object_type: impl Into<ObjectOrInterface<'a>>,
+    name: &Name,
+) -> Option<&'a Field> {
+    object_type
+        .into()
+        .fields()
+        .iter()
+        .find(|field| &field.name == name)
 }
 
 /// Returns the type of a field of an interface type.

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -167,11 +167,26 @@ pub fn get_field_type<'a>(
     object_type: impl Into<ObjectOrInterface<'a>>,
     name: &Name,
 ) -> Option<&'a Field> {
-    object_type
-        .into()
-        .fields()
-        .iter()
-        .find(|field| &field.name == name)
+    lazy_static! {
+        pub static ref TYPENAME_FIELD: Field = Field {
+            position: Pos::default(),
+            description: None,
+            name: "__typename".to_owned(),
+            field_type: Type::NonNullType(Box::new(Type::NamedType("String".to_owned()))),
+            arguments: vec![],
+            directives: vec![],
+        };
+    }
+
+    if name == &TYPENAME_FIELD.name {
+        Some(&TYPENAME_FIELD)
+    } else {
+        object_type
+            .into()
+            .fields()
+            .iter()
+            .find(|field| &field.name == name)
+    }
 }
 
 /// Returns the type of a field of an interface type.

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -296,7 +296,6 @@ mod tests {
         Pos,
     };
     use std::collections::{BTreeMap, HashMap};
-    use std::iter::FromIterator;
 
     use graph::prelude::*;
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -1,5 +1,5 @@
 use graphql_parser::{query as q, schema as s};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::ops::Deref;
 use std::result;
 use std::sync::Arc;
@@ -232,9 +232,10 @@ where
         field_definition: &s::Field,
         object_type: impl Into<ObjectOrInterface<'a>>,
         arguments: &HashMap<&q::Name, q::Value>,
+        types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError> {
         let object_type = object_type.into();
-        let mut query = build_query(object_type, arguments)?;
+        let mut query = build_query(object_type, arguments, types_for_interface)?;
 
         // Add matching filter for derived fields
         let is_derived =

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -114,13 +114,11 @@ where
             // Add the `Contains`/`Equal` filter to the top-level `And` filter, creating one
             // if necessary
             let top_level_filter = query.filter.get_or_insert(EntityFilter::And(vec![]));
-            *top_level_filter = match top_level_filter {
+            match top_level_filter {
                 EntityFilter::And(ref mut filters) => {
-                    let mut filters = filters.clone();
                     filters.push(filter);
-                    EntityFilter::And(filters)
                 }
-                _ => top_level_filter.clone(),
+                _ => unreachable!("top level filter is always `And`"),
             };
 
             true
@@ -157,8 +155,8 @@ where
                     _ => None,
                 })
                 .unwrap_or_else(|| {
-                    // Unreachable, caught by `UnknownField` error.
-                    panic!(
+                    // Caught by `UnknownField` error.
+                    unreachable!(
                         "Field \"{}\" missing in parent object",
                         field_definition.name
                     )
@@ -166,13 +164,11 @@ where
 
             // Add the `Or` filter to the top-level `And` filter, creating one if necessary
             let top_level_filter = query.filter.get_or_insert(EntityFilter::And(vec![]));
-            *top_level_filter = match top_level_filter {
+            match top_level_filter {
                 EntityFilter::And(ref mut filters) => {
-                    let mut filters = filters.clone();
                     filters.push(filter);
-                    EntityFilter::And(filters)
                 }
-                _ => top_level_filter.clone(),
+                _ => unreachable!("top level filter is always `And`"),
             };
         }
     }

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -225,12 +225,12 @@ impl<S> Resolver for StoreResolver<S>
 where
     S: Store,
 {
-    fn resolve_objects<'a>(
+    fn resolve_objects(
         &self,
         parent: &Option<q::Value>,
         _field: &q::Name,
         field_definition: &s::Field,
-        object_type: impl Into<ObjectOrInterface<'a>>,
+        object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError> {
@@ -263,14 +263,13 @@ where
         Ok(q::Value::List(entity_values))
     }
 
-    fn resolve_object<'a>(
+    fn resolve_object(
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
-        object_type: impl Into<ObjectOrInterface<'a>>,
+        object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
-        let object_type = object_type.into();
         let id = arguments.get(&"id".to_string()).and_then(|id| match id {
             q::Value::String(s) => Some(s),
             _ => None,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -16,22 +16,22 @@ use graph_graphql::prelude::*;
 pub struct MockResolver;
 
 impl Resolver for MockResolver {
-    fn resolve_objects(
+    fn resolve_objects<'a>(
         &self,
         _parent: &Option<q::Value>,
         _field: &q::Name,
         _field_definition: &s::Field,
-        _object_type: &s::ObjectType,
+        _object_type: impl Into<ObjectOrInterface<'a>>,
         _arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }
 
-    fn resolve_object(
+    fn resolve_object<'a>(
         &self,
         _parent: &Option<q::Value>,
         _field: &q::Name,
-        _object_type: &s::ObjectType,
+        _object_type: impl Into<ObjectOrInterface<'a>>,
         _arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -480,7 +480,7 @@ fn expected_mock_schema_introspection() -> q::Value {
 fn introspection_query(schema: Schema, query: &str) -> QueryResult {
     // Create the query
     let query = Query {
-        schema: schema,
+        schema: Arc::new(schema),
         document: graphql_parser::parse_query(query).unwrap(),
         variables: None,
     };

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -34,6 +34,7 @@ impl Resolver for MockResolver {
         _field: &q::Name,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
+        _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -6,7 +6,7 @@ extern crate graph_graphql;
 extern crate graphql_parser;
 
 use graphql_parser::{query as q, schema as s};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use graph::prelude::*;
 use graph_graphql::prelude::*;
@@ -23,6 +23,7 @@ impl Resolver for MockResolver {
         _field_definition: &s::Field,
         _object_type: impl Into<ObjectOrInterface<'a>>,
         _arguments: &HashMap<&q::Name, q::Value>,
+        _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -21,18 +21,18 @@ impl Resolver for MockResolver {
         _parent: &Option<q::Value>,
         _field: &q::Name,
         _field_definition: &s::Field,
-        _object_type: impl Into<ObjectOrInterface<'a>>,
+        _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }
 
-    fn resolve_object<'a>(
+    fn resolve_object(
         &self,
         _parent: &Option<q::Value>,
         _field: &q::Name,
-        _object_type: impl Into<ObjectOrInterface<'a>>,
+        _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -200,7 +200,7 @@ impl Store for TestStore {
     }
 
     fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
-        let entity_name = Value::String(query.entity_type.clone());
+        let entity_name = Value::String(query.entity_types[0].clone());
 
         let entities = self
             .entities

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -13,9 +13,6 @@ use graphql_parser::query as q;
 use std::collections::HashMap;
 use std::time::Instant;
 
-use graph::prelude::*;
-use graph_graphql::prelude::*;
-
 fn test_schema() -> Schema {
     let mut schema = Schema::parse(
         "
@@ -698,7 +695,7 @@ fn include_directive_works_with_query_variables() {
 #[test]
 fn instant_timeout() {
     let query = Query {
-        schema: test_schema(),
+        schema: Arc::new(test_schema()),
         document: graphql_parser::parse_query("query { musicians { name } }").unwrap(),
         variables: None,
     };

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -254,7 +254,7 @@ fn execute_query_document_with_variables(
     variables: Option<QueryVariables>,
 ) -> QueryResult {
     let query = Query {
-        schema: test_schema(),
+        schema: Arc::new(test_schema()),
         document: query,
         variables,
     };

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -11,8 +11,10 @@ use graph::prelude::*;
 use graph_graphql::prelude::*;
 use graphql_parser::query as q;
 use std::collections::HashMap;
-use std::iter::FromIterator;
 use std::time::Instant;
+
+use graph::prelude::*;
+use graph_graphql::prelude::*;
 
 fn test_schema() -> Schema {
     let mut schema = Schema::parse(

--- a/mock/src/server.rs
+++ b/mock/src/server.rs
@@ -62,7 +62,7 @@ where
             .map(|_| {
                 let schema = schema.lock().unwrap();
                 Query {
-                    schema: schema.clone().unwrap(),
+                    schema: Arc::new(schema.clone().unwrap()),
                     document: graphql_parser::parse_query("{ allUsers { name }}").unwrap(),
                     variables: None,
                 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -72,7 +72,7 @@ impl MockStore {
 
         let EntityQuery {
             subgraph_id,
-            entity_type,
+            entity_types,
             filter,
             order_by,
             order_direction,
@@ -85,7 +85,7 @@ impl MockStore {
         let entities_of_type = entities
             .get(&subgraph_id)
             .unwrap_or(&empty1)
-            .get(&entity_type)
+            .get(&entity_types[0]) // This does not support querying interfaces.
             .unwrap_or(&empty2)
             .values();
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -303,8 +303,8 @@ impl Store for MockStore {
 }
 
 impl SubgraphDeploymentStore for MockStore {
-    fn subgraph_schema(&self, subgraph_id: SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
-        Ok(Arc::new(self.schemas.get(&subgraph_id).unwrap().clone()))
+    fn subgraph_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
+        Ok(Arc::new(self.schemas.get(subgraph_id).unwrap().clone()))
     }
 }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -303,8 +303,8 @@ impl Store for MockStore {
 }
 
 impl SubgraphDeploymentStore for MockStore {
-    fn subgraph_schema(&self, subgraph_id: SubgraphDeploymentId) -> Result<Schema, Error> {
-        Ok(self.schemas.get(&subgraph_id).unwrap().clone())
+    fn subgraph_schema(&self, subgraph_id: SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
+        Ok(Arc::new(self.schemas.get(&subgraph_id).unwrap().clone()))
     }
 }
 

--- a/server/http/src/request.rs
+++ b/server/http/src/request.rs
@@ -78,7 +78,6 @@ mod tests {
     use graphql_parser::query as q;
     use hyper;
     use std::collections::{BTreeMap, HashMap};
-    use std::iter::FromIterator;
 
     use graph::prelude::*;
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -414,7 +414,7 @@ mod tests {
         }
 
         fn run_subscription(&self, _subscription: Subscription) -> SubscriptionResultFuture {
-            unimplemented!();
+            unreachable!();
         }
     }
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -162,7 +162,7 @@ where
                     ))
                 })
                 .and_then(move |subgraph_id| {
-                    service.handle_graphql_query(subgraph_id, request.into_body())
+                    service.handle_graphql_query(&subgraph_id, request.into_body())
                 }),
         )
     }
@@ -174,18 +174,18 @@ where
     ) -> GraphQLServiceResponse {
         match SubgraphDeploymentId::new(id) {
             Err(()) => self.handle_not_found(),
-            Ok(id) => self.handle_graphql_query(id, request.into_body()),
+            Ok(id) => self.handle_graphql_query(&id, request.into_body()),
         }
     }
 
     fn handle_graphql_query(
         &self,
-        id: SubgraphDeploymentId,
+        id: &SubgraphDeploymentId,
         request_body: Body,
     ) -> GraphQLServiceResponse {
         let service = self.clone();
 
-        match self.store.is_deployed(&id) {
+        match self.store.is_deployed(id) {
             Err(e) => {
                 return Box::new(future::err(GraphQLServerError::InternalError(
                     e.to_string(),
@@ -389,7 +389,6 @@ mod tests {
     use hyper::service::Service;
     use hyper::{Body, Method, Request};
     use std::collections::BTreeMap;
-    use std::iter::FromIterator;
 
     use graph::data::subgraph::schema::*;
     use graph::prelude::*;

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -11,7 +11,6 @@ use graphql_parser::query as q;
 use http::StatusCode;
 use hyper::{Body, Client, Request};
 use std::collections::BTreeMap;
-use std::iter::FromIterator;
 use std::time::{Duration, Instant};
 
 use graph::prelude::*;

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -64,7 +64,6 @@ impl GraphQlRunner for TestGraphQlRunner {
 #[cfg(test)]
 mod test {
     use super::*;
-    use graph::data::subgraph::schema::*;
     use graph::web3::types::H256;
     use graph_mock::MockStore;
 

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -58,7 +58,7 @@ impl GraphQlRunner for TestGraphQlRunner {
     }
 
     fn run_subscription(&self, _subscription: Subscription) -> SubscriptionResultFuture {
-        unimplemented!();
+        unreachable!();
     }
 }
 

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -151,7 +151,7 @@ pub struct GraphQlConnection<Q, S> {
     logger: Logger,
     graphql_runner: Arc<Q>,
     stream: WebSocketStream<S>,
-    schema: Schema,
+    schema: Arc<Schema>,
 }
 
 impl<Q, S> GraphQlConnection<Q, S>
@@ -162,7 +162,7 @@ where
     /// Creates a new GraphQL subscription service.
     pub(crate) fn new(
         logger: &Logger,
-        schema: Schema,
+        schema: Arc<Schema>,
         stream: WebSocketStream<S>,
         graphql_runner: Arc<Q>,
     ) -> Self {
@@ -180,7 +180,7 @@ where
         mut msg_sink: mpsc::UnboundedSender<WsMessage>,
         logger: Logger,
         connection_id: String,
-        schema: Schema,
+        schema: Arc<Schema>,
         graphql_runner: Arc<Q>,
     ) -> impl Future<Item = (), Error = WsError> {
         let mut operations = Operations::new(msg_sink.clone());

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -3,7 +3,6 @@ use futures::stream::SplitStream;
 use futures::sync::mpsc;
 use graphql_parser::parse_query;
 use std::collections::HashMap;
-use std::iter::FromIterator;
 use tokio_tungstenite::tungstenite::{Error as WsError, Message as WsMessage};
 use tokio_tungstenite::WebSocketStream;
 use uuid::Uuid;

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -165,7 +165,7 @@ where
                             let subgraph_id = subgraph_id.lock().unwrap().clone().unwrap();
 
                             // Get the subgraph schema
-                            let schema = match store2.subgraph_schema(subgraph_id.clone()) {
+                            let schema = match store2.subgraph_schema(&subgraph_id) {
                                 Ok(schema) => schema,
                                 Err(e) => {
                                     error!(logger2, "Failed to establish WS connection, could not find schema";

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -4,7 +4,7 @@ use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::query_builder::BoxedSelectStatement;
 use diesel::serialize::ToSql;
-use diesel::sql_types::{Array, Bool, Double, HasSqlType, Integer, Jsonb, Numeric, Text};
+use diesel::sql_types::{Array, Bool, Double, HasSqlType, Integer, Numeric, Text};
 use std::str::FromStr;
 
 use graph::components::store::EntityFilter;
@@ -120,11 +120,11 @@ impl IntoArrayFilter<SqlValue> for Vec<SqlValue> {
     }
 }
 
-/// Adds `filter` to a `SELECT data FROM entities` statement.
-pub(crate) fn store_filter(
-    query: BoxedSelectStatement<Jsonb, entities::table, Pg>,
+/// Adds `filter` to a SELECT statement.
+pub(crate) fn store_filter<T>(
+    query: BoxedSelectStatement<T, entities::table, Pg>,
     filter: EntityFilter,
-) -> Result<BoxedSelectStatement<Jsonb, entities::table, Pg>, UnsupportedFilter> {
+) -> Result<BoxedSelectStatement<T, entities::table, Pg>, UnsupportedFilter> {
     Ok(query.filter(build_filter(filter)?))
 }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1,5 +1,5 @@
 use diesel::debug_query;
-use diesel::dsl::sql;
+use diesel::dsl::{any, sql};
 use diesel::pg::Pg;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
@@ -321,7 +321,7 @@ impl Store {
         // Create base boxed query; this will be added to based on the
         // query parameters provided
         let mut diesel_query = entities
-            .filter(entity.eq(query.entity_type))
+            .filter(entity.eq(any(query.entity_types)))
             .filter(subgraph.eq(query.subgraph_id.to_string()))
             .select(data)
             .into_boxed::<Pg>();

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -72,7 +72,7 @@ pub struct Store {
     network_name: String,
     genesis_block_ptr: EthereumBlockPointer,
     conn: Pool<ConnectionManager<PgConnection>>,
-    schema_cache: Mutex<LruCache<SubgraphDeploymentId, Schema>>,
+    schema_cache: Mutex<LruCache<SubgraphDeploymentId, Arc<Schema>>>,
 }
 
 impl Store {
@@ -902,7 +902,7 @@ impl StoreTrait for Store {
 }
 
 impl SubgraphDeploymentStore for Store {
-    fn subgraph_schema(&self, subgraph_id: SubgraphDeploymentId) -> Result<Schema, Error> {
+    fn subgraph_schema(&self, subgraph_id: SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
         if let Some(schema) = self.schema_cache.lock().unwrap().get(&subgraph_id) {
             trace!(self.logger, "schema cache hit"; "id" => subgraph_id.to_string());
             return Ok(schema.clone());
@@ -933,13 +933,13 @@ impl SubgraphDeploymentStore for Store {
         };
         let mut schema = Schema::parse(&raw_schema, subgraph_id.clone())?;
         schema.document = api_schema(&schema.document)?;
+        let schema = Arc::new(schema);
 
-        if !self.schema_cache.lock().unwrap().contains_key(&subgraph_id) {
-            self.schema_cache
-                .lock()
-                .unwrap()
-                .insert(subgraph_id, schema.clone());
-        }
+        // Insert the schema into the cache.
+        self.schema_cache
+            .lock()
+            .unwrap()
+            .insert(subgraph_id, schema.clone());
 
         Ok(schema)
     }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -412,7 +412,45 @@ impl Store {
         data: Entity,
         event_source: EventSource,
     ) -> Result<(), StoreError> {
-        use db_schema::entities;
+        use db_schema::entities::{self, dsl};
+
+        // Collect all types that share an interface implementation with this
+        // entity type, and make sure there are no conflicting IDs.
+        //
+        // To understand why this is necessary, suppose that `Dog` and `Cat` are
+        // types and both implement an interface `Pet`, and both have instances
+        // with `id: "Fred"`. If a type `PetOwner` has a field `pets: [Pet]`
+        // then with the value `pets: ["Fred"]`, there's no way to disambiguate
+        // if that's Fred the Dog, Fred the Cat or both.
+        let schema = self.subgraph_schema(&key.subgraph_id)?;
+        let types_for_interface = schema.types_for_interface();
+        let types_with_shared_interface = Vec::from_iter(
+            schema
+                .interfaces_for_type(&key.entity_type)
+                .into_iter()
+                .flatten()
+                .map(|interface| &types_for_interface[&interface.name])
+                .flatten()
+                .map(|object_type| &object_type.name)
+                .filter(|type_name| **type_name != key.entity_type),
+        );
+
+        if !types_with_shared_interface.is_empty() {
+            if let Some(conflicting_entity) = dsl::entities
+                .select(entities::entity)
+                .filter(entities::subgraph.eq(key.subgraph_id.to_string()))
+                .filter(entities::entity.eq(any(types_with_shared_interface)))
+                .filter(entities::id.eq(&key.entity_id))
+                .first(conn)
+                .optional()?
+            {
+                return Err(StoreError::ConflictingId(
+                    key.entity_type,
+                    key.entity_id,
+                    conflicting_entity,
+                ));
+            }
+        }
 
         // Load the entity if exists
         let existing_entity = self
@@ -902,14 +940,14 @@ impl StoreTrait for Store {
 }
 
 impl SubgraphDeploymentStore for Store {
-    fn subgraph_schema(&self, subgraph_id: SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
+    fn subgraph_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
         if let Some(schema) = self.schema_cache.lock().unwrap().get(&subgraph_id) {
             trace!(self.logger, "schema cache hit"; "id" => subgraph_id.to_string());
             return Ok(schema.clone());
         }
         trace!(self.logger, "schema cache miss"; "id" => subgraph_id.to_string());
 
-        let raw_schema = if subgraph_id == *SUBGRAPHS_ID {
+        let raw_schema = if *subgraph_id == *SUBGRAPHS_ID {
             // The subgraph of subgraphs schema is built-in.
             include_str!("subgraphs.graphql").to_owned()
         } else {
@@ -939,7 +977,7 @@ impl SubgraphDeploymentStore for Store {
         self.schema_cache
             .lock()
             .unwrap()
-            .insert(subgraph_id, schema.clone());
+            .insert(subgraph_id.clone(), schema.clone());
 
         Ok(schema)
     }

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -9,7 +9,6 @@ extern crate hex;
 use diesel::pg::PgConnection;
 use diesel::*;
 use std::env;
-use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::Mutex;
 use std::time::Duration;

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -326,6 +326,7 @@ fn get_entity_1() {
 
         let mut expected_entity = Entity::new();
 
+        expected_entity.insert("__typename".to_owned(), "user".into());
         expected_entity.insert("id".to_owned(), "1".into());
         expected_entity.insert("name".to_owned(), "Johnton".into());
         expected_entity.insert(
@@ -358,6 +359,7 @@ fn get_entity_3() {
 
         let mut expected_entity = Entity::new();
 
+        expected_entity.insert("__typename".to_owned(), "user".into());
         expected_entity.insert("id".to_owned(), "3".into());
         expected_entity.insert("name".to_owned(), "Shaqueeena".into());
         expected_entity.insert(
@@ -453,6 +455,8 @@ fn update_existing() {
             Some(Value::Bytes(bytes)) => bytes.clone(),
             _ => unreachable!(),
         };
+
+        new_data.insert("__typename".to_owned(), "user".into());
         new_data.insert("bin_name".to_owned(), Value::Bytes(bin_name));
         assert_eq!(store.get(entity_key).unwrap(), Some(new_data));
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -541,7 +541,7 @@ fn find_string_contains() {
         vec!["2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Contains(
                 "name".into(),
                 "%ind%".into(),
@@ -559,7 +559,7 @@ fn find_string_equal() {
         vec!["2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
                 "name".to_owned(),
                 "Cindini".into(),
@@ -577,7 +577,7 @@ fn find_string_not_equal() {
         vec!["1", "3"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Not(
                 "name".to_owned(),
                 "Cindini".into(),
@@ -595,7 +595,7 @@ fn find_string_greater_than() {
         vec!["3"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
                 "name".to_owned(),
                 "Kundi".into(),
@@ -613,7 +613,7 @@ fn find_string_less_than_order_by_asc() {
         vec!["2", "1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
                 "name".to_owned(),
                 "Kundi".into(),
@@ -631,7 +631,7 @@ fn find_string_less_than_order_by_desc() {
         vec!["1", "2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
                 "name".to_owned(),
                 "Kundi".into(),
@@ -649,7 +649,7 @@ fn find_string_less_than_range() {
         vec!["1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
                 "name".to_owned(),
                 "ZZZ".into(),
@@ -667,7 +667,7 @@ fn find_string_multiple_and() {
         vec!["2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![
                 EntityFilter::LessThan("name".to_owned(), "Cz".into()),
                 EntityFilter::Equal("name".to_owned(), "Cindini".into()),
@@ -685,7 +685,7 @@ fn find_string_ends_with() {
         vec!["2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::EndsWith(
                 "name".to_owned(),
                 "ini".into(),
@@ -703,7 +703,7 @@ fn find_string_not_ends_with() {
         vec!["3", "1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::NotEndsWith(
                 "name".to_owned(),
                 "ini".into(),
@@ -721,7 +721,7 @@ fn find_string_in() {
         vec!["1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::In(
                 "name".to_owned(),
                 vec!["Johnton".into()],
@@ -739,7 +739,7 @@ fn find_string_not_in() {
         vec!["1", "2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
                 "name".to_owned(),
                 vec!["Shaqueeena".into()],
@@ -757,7 +757,7 @@ fn find_float_equal() {
         vec!["1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
                 "weight".to_owned(),
                 Value::Float(184.4),
@@ -775,7 +775,7 @@ fn find_float_not_equal() {
         vec!["3", "2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Not(
                 "weight".to_owned(),
                 Value::Float(184.4),
@@ -793,7 +793,7 @@ fn find_float_greater_than() {
         vec!["1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
                 "weight".to_owned(),
                 Value::Float(160.0),
@@ -811,7 +811,7 @@ fn find_float_less_than() {
         vec!["2", "3"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::Float(160.0),
@@ -829,7 +829,7 @@ fn find_float_less_than_order_by_desc() {
         vec!["3", "2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::Float(160.0),
@@ -847,7 +847,7 @@ fn find_float_less_than_range() {
         vec!["2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::Float(161.0),
@@ -865,7 +865,7 @@ fn find_float_in() {
         vec!["3", "1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::In(
                 "weight".to_owned(),
                 vec![Value::Float(184.4), Value::Float(111.7)],
@@ -883,7 +883,7 @@ fn find_float_not_in() {
         vec!["2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
                 "weight".to_owned(),
                 vec![Value::Float(184.4), Value::Float(111.7)],
@@ -901,7 +901,7 @@ fn find_int_equal() {
         vec!["1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
                 "age".to_owned(),
                 Value::Int(67 as i32),
@@ -919,7 +919,7 @@ fn find_int_not_equal() {
         vec!["3", "2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Not(
                 "age".to_owned(),
                 Value::Int(67 as i32),
@@ -937,7 +937,7 @@ fn find_int_greater_than() {
         vec!["1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
                 "age".to_owned(),
                 Value::Int(43 as i32),
@@ -955,7 +955,7 @@ fn find_int_greater_or_equal() {
         vec!["2", "1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::GreaterOrEqual(
                 "age".to_owned(),
                 Value::Int(43 as i32),
@@ -973,7 +973,7 @@ fn find_int_less_than() {
         vec!["2", "3"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(50 as i32),
@@ -991,7 +991,7 @@ fn find_int_less_or_equal() {
         vec!["2", "3"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::LessOrEqual(
                 "age".to_owned(),
                 Value::Int(43 as i32),
@@ -1009,7 +1009,7 @@ fn find_int_less_than_order_by_desc() {
         vec!["3", "2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(50 as i32),
@@ -1027,7 +1027,7 @@ fn find_int_less_than_range() {
         vec!["2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(67 as i32),
@@ -1045,7 +1045,7 @@ fn find_int_in() {
         vec!["1", "2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::In(
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
@@ -1063,7 +1063,7 @@ fn find_int_not_in() {
         vec!["3"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
@@ -1081,7 +1081,7 @@ fn find_bool_equal() {
         vec!["2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
                 "coffee".to_owned(),
                 Value::Bool(true),
@@ -1099,7 +1099,7 @@ fn find_bool_not_equal() {
         vec!["1", "3"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Not(
                 "coffee".to_owned(),
                 Value::Bool(true),
@@ -1117,7 +1117,7 @@ fn find_bool_in() {
         vec!["2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::In(
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
@@ -1135,7 +1135,7 @@ fn find_bool_not_in() {
         vec!["3", "1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
@@ -1153,7 +1153,7 @@ fn find_bytes_equal() {
         vec!["1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
                 "bin_name".to_owned(),
                 Value::Bytes("Johnton".as_bytes().into()),
@@ -1171,7 +1171,7 @@ fn find_null_equal() {
         vec!["3", "1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::Equal(
                 "favorite_color".to_owned(),
                 Value::Null,
@@ -1189,7 +1189,7 @@ fn find_null_not_equal() {
         vec!["2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::Not("favorite_color".to_owned(), Value::Null)),
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
@@ -1204,7 +1204,7 @@ fn find_null_not_in() {
         vec!["2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::NotIn(
                 "favorite_color".to_owned(),
                 vec![Value::Null],
@@ -1222,7 +1222,7 @@ fn find_order_by_float() {
         vec!["3", "2", "1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: None,
             order_by: Some(("weight".to_owned(), ValueType::Float)),
             order_direction: Some(EntityOrder::Ascending),
@@ -1233,7 +1233,7 @@ fn find_order_by_float() {
         vec!["1", "2", "3"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: None,
             order_by: Some(("weight".to_owned(), ValueType::Float)),
             order_direction: Some(EntityOrder::Descending),
@@ -1248,7 +1248,7 @@ fn find_order_by_id() {
         vec!["1", "2", "3"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: None,
             order_by: Some(("id".to_owned(), ValueType::ID)),
             order_direction: Some(EntityOrder::Ascending),
@@ -1259,7 +1259,7 @@ fn find_order_by_id() {
         vec!["3", "2", "1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: None,
             order_by: Some(("id".to_owned(), ValueType::ID)),
             order_direction: Some(EntityOrder::Descending),
@@ -1274,7 +1274,7 @@ fn find_order_by_int() {
         vec!["3", "2", "1"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: None,
             order_by: Some(("age".to_owned(), ValueType::Int)),
             order_direction: Some(EntityOrder::Ascending),
@@ -1285,7 +1285,7 @@ fn find_order_by_int() {
         vec!["1", "2", "3"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: None,
             order_by: Some(("age".to_owned(), ValueType::Int)),
             order_direction: Some(EntityOrder::Descending),
@@ -1300,7 +1300,7 @@ fn find_order_by_string() {
         vec!["2", "1", "3"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: None,
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
@@ -1311,7 +1311,7 @@ fn find_order_by_string() {
         vec!["3", "1", "2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: None,
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
@@ -1326,7 +1326,7 @@ fn find_where_nested_and_or() {
         vec!["1", "2"],
         EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Or(vec![
                 EntityFilter::Equal("id".to_owned(), Value::from("1")),
                 EntityFilter::Equal("id".to_owned(), Value::from("2")),
@@ -1427,7 +1427,7 @@ fn revert_block_basic() {
     run_test(|store| {
         let this_query = EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
                 "name".to_owned(),
                 Value::String("Shaqueeena".to_owned()),
@@ -1480,7 +1480,7 @@ fn revert_block_with_delete() {
     run_test(|store| {
         let this_query = EntityQuery {
             subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_type: "user".to_owned(),
+            entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
                 "name".to_owned(),
                 Value::String("Cindini".to_owned()),


### PR DESCRIPTION
Basic support for GraphQL interfaces. Still missing fragments, which are tracked in #771, so we can claim full interface support.

We keep a map from interface to implementing types, and when resolving an interface we query all implementing types. Apart from that resolving interfaces isn't all that different from resolving an object, so they are merged in the `ObjectOrInterface` enum. To correctly execute objects fetched through an interface we must know the concrete type, to get this information `__typename` is inserted into entities after they are retrieved from the DB. This PR also validates that types actually implement the interfaces they claim to implement.

Resolves #154.