### PR TITLE
Make reorg threshold and ancestor count configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,7 @@ dependencies = [
  "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,6 +10,7 @@ graphql-parser = "0.2.1"
 http = "0.1"
 ipfs-api = "0.5.0-alpha2"
 itertools = "0.7"
+lazy_static = "1.2.0"
 sentry = "0.3.1"
 url = "1.7.1"
 graph = { path = "../graph" }


### PR DESCRIPTION
This is a prerequisite for adjusting the reorg threshold without having to recompile Graph Node.