### PR TITLE
Fix deprecation warnings for Rust 1.33

### DIFF
--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -233,10 +233,10 @@ fn subgraph_provider_events() {
                 .and_then(move |(subgraph1_link, subgraph2_link)| {
                     let registrar = Arc::new(registrar);
                     let subgraph1_id =
-                        SubgraphDeploymentId::new(subgraph1_link.trim_left_matches("/ipfs/"))
+                        SubgraphDeploymentId::new(subgraph1_link.trim_start_matches("/ipfs/"))
                             .unwrap();
                     let subgraph2_id =
-                        SubgraphDeploymentId::new(subgraph2_link.trim_left_matches("/ipfs/"))
+                        SubgraphDeploymentId::new(subgraph2_link.trim_start_matches("/ipfs/"))
                             .unwrap();
                     let subgraph_name = SubgraphName::new("subgraph").unwrap();
 

--- a/graph/src/components/ethereum/listener.rs
+++ b/graph/src/components/ethereum/listener.rs
@@ -10,7 +10,7 @@ where
     D: Deserializer<'de>,
 {
     let s: String = Deserialize::deserialize(deserializer)?;
-    let block_hash = s.trim_left_matches("0x");
+    let block_hash = s.trim_start_matches("0x");
     H256::from_str(block_hash).map_err(D::Error::custom)
 }
 

--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -29,7 +29,7 @@ impl LinkResolver for ipfs_api::IpfsClient {
         });
 
         // Discard the `/ipfs/` prefix (if present) to get the hash.
-        let path = link.link.trim_left_matches("/ipfs/").to_owned();
+        let path = link.link.trim_start_matches("/ipfs/").to_owned();
 
         let ipfs_timeout = Duration::from_secs(ipfs_timeout.unwrap_or(30));
         let cat = self

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -213,7 +213,7 @@ impl FromStr for Bytes {
     type Err = hex::FromHexError;
 
     fn from_str(s: &str) -> Result<Bytes, Self::Err> {
-        hex::decode(s.trim_left_matches("0x")).map(|x| Bytes(x.into()))
+        hex::decode(s.trim_start_matches("0x")).map(|x| Bytes(x.into()))
     }
 }
 

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -29,7 +29,7 @@ where
     use serde::de::Error;
 
     let s: String = de::Deserialize::deserialize(deserializer)?;
-    let address = s.trim_left_matches("0x");
+    let address = s.trim_start_matches("0x");
     Address::from_str(address).map_err(D::Error::custom)
 }
 
@@ -499,7 +499,7 @@ impl SubgraphManifest {
                     // into the definition.
                     raw_mapping.insert(
                         serde_yaml::Value::from("id"),
-                        serde_yaml::Value::from(link.link.trim_left_matches("/ipfs/")),
+                        serde_yaml::Value::from(link.link.trim_start_matches("/ipfs/")),
                     );
 
                     // Inject the IPFS link as the location of the data

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -44,7 +44,7 @@ pub(crate) fn parse_field_as_filter(key: &Name) -> (Name, FilterOp) {
     };
 
     // Strip the operator suffix to get the attribute.
-    (key.trim_right_matches(suffix).to_owned(), op)
+    (key.trim_end_matches(suffix).to_owned(), op)
 }
 
 /// Returns the root query type (if there is one).

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -250,7 +250,7 @@ where
         // The string may have been encoded in a fixed length
         // buffer and padded with null characters, so trim
         // trailing nulls.
-        Ok(s.trim_right_matches('\u{0000}').to_string())
+        Ok(s.trim_end_matches('\u{0000}').to_string())
     }
 
     /// Converts bytes to a hex string.
@@ -278,7 +278,7 @@ where
         }
 
         let bytes = n.to_bytes_be().1;
-        format!("0x{}", ::hex::encode(bytes).trim_left_matches('0'))
+        format!("0x{}", ::hex::encode(bytes).trim_start_matches('0'))
     }
 
     pub(crate) fn big_int_to_i32(
@@ -418,7 +418,7 @@ where
 
 pub(crate) fn string_to_h160(string: &str) -> Result<H160, HostExportError<impl ExportError>> {
     // `H160::from_str` takes a hex string with no leading `0x`.
-    let string = string.trim_left_matches("0x");
+    let string = string.trim_start_matches("0x");
     H160::from_str(string)
         .map_err(|e| HostExportError(format!("Failed to convert string to Address/H160: {}", e)))
 }


### PR DESCRIPTION
The warnings are all caused by the renaming of
String.trim_{left,right}_matches to String.trim{start,end}_matches.

