### PR TITLE
travis: increase timeout for cahce pushes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,9 @@ matrix:
           - mv target/release/graph-node target/release/graph-node-$TRAVIS_OS_NAME
 
 # Cache dependencies
-cache: cargo
+cache:
+  cargo: true
+  timeout: 1000
 
 env:
   global:


### PR DESCRIPTION
We run into timeouts when the builder tries to update the build cache from
the current build.

