### PR TITLE
travis: reduce the amount of build data we cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ matrix:
 cache:
   cargo: true
   timeout: 1000
+before_cache:
+  - $TRAVIS_BUILD_DIR/.travis/before_cache.sh
 
 env:
   global:

--- a/.travis/before_cache.sh
+++ b/.travis/before_cache.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+# Remove test binaries and the artifacts for graph-node itself since
+# they are pretty big and of no use in the cache. This is a game of
+# whack-a-mole since there's no convenient way to have cargo tell us
+# what corresponds to our subcrates directly, and what are dependencies
+# of those
+
+set -ev
+
+cd $TRAVIS_BUILD_DIR/target/debug
+
+du -hs .
+
+find . -maxdepth 1 -type f -executable -printf '%f\n' \
+    | xargs -iF rm -f F deps/F
+
+rm -rf deps/*graph[_-]* .fingerprint/graph-* incremental/* ../.rustc_info.json
+
+du -hs .


### PR DESCRIPTION
The target/debug/ directory is roughly 3.3G big; by removing the build
artifacts for graph-node itself, and especially the test binaries, we can
reduce the size of the cache to 1.6G, and therefore speed up how long
downloading and updating the build cache takes.

