### PR TITLE
graphql: Remove unsupported query parameters

### DIFF
--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -133,7 +133,6 @@ impl fmt::Display for QueryExecutionError {
                 let msg = args.iter().map(|arg| {
                     match arg.as_str() {
                         "first" => format!("Value of \"first\" must be between 1 and 100"),
-                        "last" => format!("Value of \"last\" must be between 1 and 100"),
                         "skip" => format!("Value of \"skip\" must be greater than 0"),
                         _ => format!("Value of \"{}\" is must be an integer", arg),
                     }

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -411,9 +411,6 @@ fn collection_arguments_for_named_type(
     let mut args = vec![
         input_value(&"skip".to_string(), "", Type::NamedType("Int".to_string())),
         input_value(&"first".to_string(), "", Type::NamedType("Int".to_string())),
-        input_value(&"last".to_string(), "", Type::NamedType("Int".to_string())),
-        input_value(&"after".to_string(), "", Type::NamedType("ID".to_string())),
-        input_value(&"before".to_string(), "", Type::NamedType("ID".to_string())),
         input_value(
             &"orderBy".to_string(),
             "",
@@ -693,19 +690,10 @@ mod tests {
                 .iter()
                 .map(|input_value| input_value.name.to_owned())
                 .collect::<Vec<String>>(),
-            [
-                "skip",
-                "first",
-                "last",
-                "after",
-                "before",
-                "orderBy",
-                "orderDirection",
-                "where",
-            ]
-            .into_iter()
-            .map(|name| name.to_string())
-            .collect::<Vec<String>>()
+            ["skip", "first", "orderBy", "orderDirection", "where",]
+                .into_iter()
+                .map(|name| name.to_string())
+                .collect::<Vec<String>>()
         );
 
         let user_profile_singular_field = match query_type {
@@ -786,19 +774,10 @@ mod tests {
                 .iter()
                 .map(|input_value| input_value.name.to_owned())
                 .collect::<Vec<String>>(),
-            [
-                "skip",
-                "first",
-                "last",
-                "after",
-                "before",
-                "orderBy",
-                "orderDirection",
-                "where",
-            ]
-            .into_iter()
-            .map(|name| name.to_string())
-            .collect::<Vec<String>>()
+            ["skip", "first", "orderBy", "orderDirection", "where",]
+                .into_iter()
+                .map(|name| name.to_string())
+                .collect::<Vec<String>>()
         );
     }
 }


### PR DESCRIPTION
`last`, `after` and `before` were never supported.

