### PR TITLE
Improve how we record and handle entity_history

### DIFF
--- a/store/postgres/migrations/2019-03-07-171355_update_history_storage/down.sql
+++ b/store/postgres/migrations/2019-03-07-171355_update_history_storage/down.sql
@@ -1,0 +1,126 @@
+CREATE OR REPLACE FUNCTION revert_entity_event(entity_history_id INTEGER, operation_id INTEGER)
+    RETURNS VOID AS
+$$
+DECLARE
+    target_entity_id VARCHAR;
+    target_subgraph VARCHAR;
+    target_entity VARCHAR;
+    target_data_before JSONB;
+    reversion_identifier VARCHAR;
+BEGIN
+    -- Get entity history event information and save into the declared variables
+    SELECT
+        entity_id,
+        subgraph,
+        entity,
+        data_before
+    INTO
+        target_entity_id,
+        target_subgraph,
+        target_entity,
+        target_data_before
+    FROM entity_history
+    WHERE entity_history.id = entity_history_id;
+
+    reversion_identifier := 'REVERSION';
+
+    CASE
+        -- INSERT case
+        WHEN operation_id = 0 THEN
+            -- Delete inserted row
+            BEGIN
+                PERFORM set_config('vars.current_event_source', 'REVERSION', FALSE);
+                EXECUTE
+                    'DELETE FROM entities WHERE (
+                        subgraph = $1 AND
+                        entity = $2 AND
+                        id = $3)'
+                USING target_subgraph, target_entity, target_entity_id;
+
+                -- Row was already updated
+                EXCEPTION
+                    WHEN no_data_found THEN
+                        NULL;
+            END;
+
+        -- UPDATE or DELETE case
+        WHEN operation_id IN (1,2) THEN
+            -- Insert deleted row if not exists
+            -- If row exists perform update
+            BEGIN
+                EXECUTE
+                    'INSERT INTO entities (id, subgraph, entity, data, event_source)
+                        VALUES ($1, $2, $3, $4, $5)
+                        ON CONFLICT (id, subgraph, entity) DO UPDATE
+                        SET data = $4, event_source = $5'
+                USING
+                    target_entity_id,
+                    target_subgraph,
+                    target_entity,
+                    target_data_before,
+                    reversion_identifier;
+            END;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION revert_transaction(event_id_to_revert INTEGER)
+    RETURNS VOID AS
+$$
+DECLARE
+    entity_history_row RECORD;
+BEGIN
+    -- Loop through each record change event
+    FOR entity_history_row IN
+        -- Get all entity changes driven by given event
+        SELECT
+            id,
+            op_id
+        FROM entity_history
+        WHERE (
+            subgraph <> 'subgraphs' AND
+            event_id = event_id_to_revert)
+        ORDER BY id DESC
+    -- Iterate over entity changes and revert each
+    LOOP
+        PERFORM revert_entity_event(entity_history_row.id, entity_history_row.op_id);
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION revert_block(block_to_revert_hash VARCHAR, block_to_revert_number BIGINT, target_block_hash VARCHAR, subgraph_id VARCHAR)
+    RETURNS VOID AS
+$$
+DECLARE
+    event_row RECORD;
+    entity_row RECORD;
+BEGIN
+    -- Revert all relevant events
+    FOR event_row IN
+        -- Get all events associated with the given block
+        SELECT
+            entity_history.event_id AS event_id
+        FROM entity_history
+        JOIN event_meta_data ON
+            entity_history.event_id = event_meta_data.id
+        WHERE event_meta_data.source = block_to_revert_hash AND
+            entity_history.subgraph = subgraph_id
+        GROUP BY
+            entity_history.event_id
+        ORDER BY entity_history.event_id DESC
+    LOOP
+        PERFORM revert_transaction(event_row.event_id::integer);
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP VIEW entity_history_with_source;
+
+DROP TRIGGER IF EXISTS entity_change_insert_trigger ON entities;
+DROP TRIGGER IF EXISTS entity_change_update_trigger ON entities;
+DROP TRIGGER IF EXISTS entity_change_delete_trigger ON entities;
+CREATE TRIGGER after_entity_change_trigger
+  AFTER INSERT OR UPDATE OR DELETE
+  ON entities
+  FOR EACH ROW
+  EXECUTE PROCEDURE log_entity_event();

--- a/store/postgres/migrations/2019-03-07-171355_update_history_storage/up.sql
+++ b/store/postgres/migrations/2019-03-07-171355_update_history_storage/up.sql
@@ -1,0 +1,107 @@
+-- Change log_entity_event such that we do not record history entries for
+-- the 'subgraphs' subgraph and for operations that don't actually change
+-- the data of an entity
+drop trigger if exists after_entity_change_trigger on entities;
+
+create trigger entity_change_insert_trigger
+  after insert on entities
+  for each row
+  when (new.subgraph != 'subgraphs')
+  execute procedure log_entity_event();
+
+create trigger entity_change_update_trigger
+  after update on entities
+  for each row
+  when (old.subgraph != 'subgraphs' and old.data != new.data)
+  execute procedure log_entity_event();
+
+create trigger entity_change_delete_trigger
+  after delete on entities
+  for each row
+  when (old.subgraph != 'subgraphs')
+  execute procedure log_entity_event();
+
+-- Create a view to get entity_history by source ordered by event_id desc
+-- We use this both in revert_block and in the Rust code in
+-- store_events.get_revert_event
+create or replace view entity_history_with_source as
+select
+  h.subgraph,
+  h.entity,
+  h.entity_id,
+  h.data_before,
+  h.op_id,
+  m.source
+from entity_history h, event_meta_data m
+where h.event_id = m.id
+order by h.event_id desc;
+
+-- Rewrite revert_block to be selfcontained and to get all the information
+-- needed for reversion in one query
+create or replace function
+  revert_block(block_to_revert_hash VARCHAR,
+               subgraph_id VARCHAR)
+    returns void as
+$$
+declare
+    history record;
+begin
+    -- Revert all relevant events
+    for history in
+        -- Get all history entries associated with the given block. Note
+        -- that the view imposes the correct order
+    select
+        h.entity,
+        h.entity_id,
+        h.data_before,
+        h.op_id
+    from entity_history_with_source h
+    where h.source = block_to_revert_hash
+      and h.subgraph = subgraph_id
+    loop
+        case
+            -- insert case
+            when history.op_id = 0 then
+                -- Delete inserted row
+            begin
+                perform set_config('vars.current_event_source',
+                                   'REVERSION', false);
+                delete from entities
+                 where subgraph = subgraph_id
+                   and entity = history.entity
+                   and id = history.entity_id;
+                -- Row was already updated
+            exception when no_data_found then
+              -- do nothing, the entity was gone already
+            end;
+            -- update or delete case
+            when history.op_id IN (1,2) then
+                -- Insert deleted row if not exists
+                -- If row exists perform update
+                begin
+                     insert into entities
+                                 (id, subgraph, entity, data, event_source)
+                     values (history.entity_id,
+                             subgraph_id,
+                             history.entity,
+                             history.data_before,
+                             'REVERSION')
+                     on conflict (id, subgraph, entity)
+                     do update
+                           set data = history.data_before,
+                               event_source = 'REVERSION';
+            end;
+        end case;
+    end loop;
+end;
+$$ language plpgsql;
+
+-- remove unused stored procs
+drop function if exists revert_transaction;
+drop function if exists revert_entity_event;
+
+-- remove some old, never used procs while we are at it
+drop function if exists revert_block_group;
+drop function if exists revert_transaction_group;
+drop function if exists rerun_entity;
+drop function if exists rerun_entity_history_event;

--- a/store/postgres/src/functions.rs
+++ b/store/postgres/src/functions.rs
@@ -4,7 +4,7 @@ use diesel::sql_types::*;
 sql_function! {
     revert_block,
     RevertBlock,
-    (block_to_revert_hash: Text, block_to_revert_number: BigInt, target_block_hash: Text, subgraph_id: Text)
+    (block_to_revert_hash: Text, subgraph_id: Text)
 }
 sql_function! {
     current_setting,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -870,14 +870,13 @@ impl StoreTrait for Store {
                 block_ptr_from,
                 block_ptr_to,
             );
+            self.emit_store_events(&conn, &ops)?;
             self.apply_entity_operations_with_conn(&conn, ops, EventSource::None)?;
 
             self.emit_revert_event(&conn, &subgraph_id, &block_ptr_from, block_ptr_to)?;
 
             select(revert_block(
                 &block_ptr_from.hash_hex(),
-                block_ptr_from.number as i64,
-                &block_ptr_to.hash_hex(),
                 subgraph_id.to_string(),
             ))
             .execute(&*conn)

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -110,13 +110,6 @@ pub fn get_revert_event(
     // and the outer query returns the data we need to construct EntityChanges
     // for those history events
     let query = "
-WITH
-  events_for_block_and_subgraph AS
-    (SELECT distinct h.event_id
-       FROM entity_history h, event_meta_data m
-      WHERE h.event_id = m.id
-        AND m.source = $1
-        AND h.subgraph = $2)
 SELECT
   h.subgraph,
   h.entity,
@@ -125,9 +118,9 @@ SELECT
      WHEN h.op_id = 0 THEN 'removed'
      WHEN h.op_id in (1,2) THEN 'set'
    END) as change
-FROM entity_history h
-WHERE h.event_id in (select event_id from events_for_block_and_subgraph)
-ORDER BY h.event_id desc";
+FROM entity_history_with_source h
+WHERE h.source = $1
+  AND h.subgraph = $2";
     let query = diesel::sql_query(query)
         .bind::<Text, _>(block_ptr_from.hash_hex())
         .bind::<Text, _>(subgraph_id.to_string());


### PR DESCRIPTION
The main focus of this change is to stop recording entity_history for the
'subgraphs' subgraph, and to avoid recording history for changes that
actually do not change the entity. The history we recorded for these made
up about 75% of the storage needed in the hosted offering, and we never
need the data thus recorded.

This change also simplifies how the revert_block stored procedure works by
basing it off a single history query, and removes unused input parameters
for it.

The change also gets rid of a few stored procedures that were previously
used, but are not any longer.

More background on these changes can be found at
https://github.com/graphprotocol/graph-node/issues/807

