### PR TITLE
Bump edition to 2018

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "graph-core"
 version = "0.5.0"
+edition = "2018"
 
 [dependencies]
 chrono = "0.4"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,7 +17,7 @@ mod graphql;
 mod log;
 mod subgraph;
 
-pub use graphql::GraphQlRunner;
-pub use log::elastic::{elastic_logger, ElasticDrainConfig, ElasticLoggingConfig};
-pub use log::split::split_logger;
-pub use subgraph::{SubgraphAssignmentProvider, SubgraphInstanceManager, SubgraphRegistrar};
+pub use crate::graphql::GraphQlRunner;
+pub use crate::log::elastic::{elastic_logger, ElasticDrainConfig, ElasticLoggingConfig};
+pub use crate::log::split::split_logger;
+pub use crate::subgraph::{SubgraphAssignmentProvider, SubgraphInstanceManager, SubgraphRegistrar};

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -6,10 +6,10 @@ use std::sync::RwLock;
 use std::time::Duration;
 
 use super::SubgraphInstance;
-use elastic_logger;
-use split_logger;
-use ElasticDrainConfig;
-use ElasticLoggingConfig;
+use crate::elastic_logger;
+use crate::split_logger;
+use crate::ElasticDrainConfig;
+use crate::ElasticLoggingConfig;
 
 type InstanceShutdownMap = Arc<RwLock<HashMap<SubgraphDeploymentId, CancelGuard>>>;
 

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -10,7 +10,7 @@ extern crate graph_store_postgres;
 extern crate graphql_parser;
 extern crate hex;
 
-use tokio::runtime::Runtime;
+use crate::tokio::runtime::Runtime;
 
 use graph::prelude::{Store as StoreTrait, *};
 use graph::web3::types::H256;

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -8,6 +8,7 @@ extern crate walkdir;
 use ipfs_api::IpfsClient;
 use walkdir::WalkDir;
 
+use crate::tokio::timer::Delay;
 use graph::components::ethereum::*;
 use graph::prelude::*;
 use graph::web3::types::*;
@@ -19,7 +20,6 @@ use std::io::Cursor;
 use std::sync::Mutex;
 use std::time::Duration;
 use std::time::Instant;
-use tokio::timer::Delay;
 
 /// Adds subgraph located in `test/subgraphs/`, replacing "link to" placeholders
 /// in the subgraph manifest with links to files just added into a local IPFS

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "graph"
 version = "0.5.0"
+edition = "2018"
 
 [dependencies]
 backtrace = "0.3.9"

--- a/graph/src/components/ethereum/listener.rs
+++ b/graph/src/components/ethereum/listener.rs
@@ -2,7 +2,7 @@ use serde::de::{Deserialize, Deserializer, Error as DeserializerError};
 use std::str::FromStr;
 use web3::types::H256;
 
-use components::EventProducer;
+use crate::components::EventProducer;
 
 /// Deserialize an H256 hash (with or without '0x' prefix).
 fn deserialize_h256<'de, D>(deserializer: D) -> Result<H256, D::Error>

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -1,7 +1,7 @@
 use failure::Error;
 use futures::Stream;
 
-use prelude::*;
+use crate::prelude::*;
 
 pub trait BlockStream:
     Stream<Item = EthereumBlock, Error = Error> + EventConsumer<ChainHeadUpdate>

--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -1,7 +1,7 @@
 use futures::prelude::*;
 
-use data::query::{Query, QueryError, QueryResult};
-use data::subscription::{Subscription, SubscriptionError, SubscriptionResult};
+use crate::data::query::{Query, QueryError, QueryResult};
+use crate::data::subscription::{Subscription, SubscriptionError, SubscriptionResult};
 
 /// Future for query results.
 pub type QueryResultFuture = Box<Future<Item = QueryResult, Error = QueryError> + Send>;

--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -1,4 +1,4 @@
-use data::subgraph::Link;
+use crate::data::subgraph::Link;
 use failure;
 use ipfs_api;
 use std::env;

--- a/graph/src/components/server/admin.rs
+++ b/graph/src/components/server/admin.rs
@@ -1,8 +1,8 @@
 use std::io;
 use std::sync::Arc;
 
-use prelude::Logger;
-use prelude::NodeId;
+use crate::prelude::Logger;
+use crate::prelude::NodeId;
 
 /// Common trait for JSON-RPC admin server implementations.
 pub trait JsonRpcServer<P> {

--- a/graph/src/components/server/query.rs
+++ b/graph/src/components/server/query.rs
@@ -1,4 +1,4 @@
-use data::query::QueryError;
+use crate::data::query::QueryError;
 use futures::prelude::*;
 use futures::sync::oneshot::Canceled;
 use serde::ser::*;

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -11,9 +11,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use web3::types::H256;
 
-use data::store::*;
-use data::subgraph::schema::*;
-use prelude::*;
+use crate::data::store::*;
+use crate::data::subgraph::schema::*;
+use crate::prelude::*;
 
 lazy_static! {
     pub static ref SUBSCRIPTION_THROTTLE_INTERVAL: Duration =

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -2,7 +2,7 @@ use failure::Error;
 use futures::prelude::*;
 use std::sync::Arc;
 
-use prelude::*;
+use crate::prelude::*;
 use web3::types::{Log, Transaction};
 
 /// Common trait for runtime host implementations.

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -1,4 +1,4 @@
-use prelude::*;
+use crate::prelude::*;
 use web3::types::{Log, Transaction};
 
 /// Represents a loaded instance of a subgraph.

--- a/graph/src/components/subgraph/instance_manager.rs
+++ b/graph/src/components/subgraph/instance_manager.rs
@@ -1,4 +1,4 @@
-use components::EventConsumer;
+use crate::components::EventConsumer;
 
 use crate::data::subgraph::SubgraphAssignmentProviderEvent;
 

--- a/graph/src/components/subgraph/mod.rs
+++ b/graph/src/components/subgraph/mod.rs
@@ -4,7 +4,7 @@ mod instance_manager;
 mod provider;
 mod registrar;
 
-pub use prelude::Entity;
+pub use crate::prelude::Entity;
 
 pub use self::host::{RuntimeHost, RuntimeHostBuilder};
 pub use self::instance::SubgraphInstance;

--- a/graph/src/components/subgraph/provider.rs
+++ b/graph/src/components/subgraph/provider.rs
@@ -1,4 +1,4 @@
-use prelude::*;
+use crate::prelude::*;
 
 /// Common trait for subgraph providers.
 pub trait SubgraphAssignmentProvider:

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -1,4 +1,4 @@
-use prelude::*;
+use crate::prelude::*;
 
 #[derive(Clone, Copy, Debug)]
 pub enum SubgraphVersionSwitchingMode {

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -1,4 +1,4 @@
-use data::subgraph::*;
+use crate::data::subgraph::*;
 use graphql_parser::{query as q, Pos};
 
 use failure;

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -259,7 +259,7 @@ impl Serialize for QueryError {
             // graphql_parser team makes improvements to their error reporting
             QueryError::ParseError(_) => {
                 // Split the inner message into (first line, rest)
-                let mut msg = format!("{}", self);
+                let msg = format!("{}", self);
                 let inner_msg = msg.replace("query parse error:", "");
                 let inner_msg = inner_msg.trim();
                 let parts: Vec<&str> = inner_msg.splitn(2, '\n').collect();

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
-use data::schema::Schema;
+use crate::data::schema::Schema;
 
 fn deserialize_number<'de, D>(deserializer: D) -> Result<q::Number, D::Error>
 where

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -2,7 +2,7 @@ use graphql_parser::query as q;
 use serde::ser::*;
 
 use super::error::{QueryError, QueryExecutionError};
-use data::graphql::SerializableValue;
+use crate::data::graphql::SerializableValue;
 
 fn serialize_data<S>(data: &Option<q::Value>, serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -1,8 +1,8 @@
-use data::graphql::validation::{
+use crate::data::graphql::validation::{
     get_object_type_definitions, validate_interface_implementation, validate_schema,
     SchemaValidationError,
 };
-use data::subgraph::SubgraphDeploymentId;
+use crate::data::subgraph::SubgraphDeploymentId;
 use failure::Error;
 use graphql_parser;
 use graphql_parser::{

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -7,10 +7,10 @@ use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
-use data::subgraph::SubgraphDeploymentId;
+use crate::data::subgraph::SubgraphDeploymentId;
+use crate::prelude::QueryExecutionError;
 use graphql_parser::query;
 use graphql_parser::schema;
-use prelude::QueryExecutionError;
 
 /// Custom scalars in GraphQL.
 pub mod scalar;

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -13,10 +13,10 @@ use std::sync::Arc;
 use tokio::prelude::*;
 use web3::types::Address;
 
-use components::link_resolver::LinkResolver;
-use components::store::StoreError;
-use data::query::QueryExecutionError;
-use data::schema::Schema;
+use crate::components::link_resolver::LinkResolver;
+use crate::components::store::StoreError;
+use crate::data::query::QueryExecutionError;
+use crate::data::schema::Schema;
 
 /// Rust representation of the GraphQL schema for a `SubgraphManifest`.
 pub mod schema;

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -20,12 +20,12 @@ use std::str::FromStr;
 use web3::types::*;
 
 use super::SubgraphDeploymentId;
-use components::ethereum::EthereumBlockPointer;
-use components::store::{
+use crate::components::ethereum::EthereumBlockPointer;
+use crate::components::store::{
     AttributeIndexDefinition, EntityFilter, EntityKey, EntityOperation, EntityQuery, EntityRange,
 };
-use data::store::{Entity, NodeId, SubgraphEntityPair, Value, ValueType};
-use data::subgraph::{SubgraphManifest, SubgraphName};
+use crate::data::store::{Entity, NodeId, SubgraphEntityPair, Value, ValueType};
+use crate::data::subgraph::{SubgraphManifest, SubgraphName};
 
 /// ID of the subgraph of subgraphs.
 lazy_static! {

--- a/graph/src/data/subscription/error.rs
+++ b/graph/src/data/subscription/error.rs
@@ -1,6 +1,6 @@
 use serde::ser::*;
 
-use prelude::QueryExecutionError;
+use crate::prelude::QueryExecutionError;
 
 /// Error caused while processing a [Subscription](struct.Subscription.html) request.
 #[derive(Debug, Fail)]

--- a/graph/src/data/subscription/result.rs
+++ b/graph/src/data/subscription/result.rs
@@ -1,6 +1,6 @@
 use futures::prelude::*;
 
-use prelude::QueryResult;
+use crate::prelude::QueryResult;
 
 /// A stream of query results for a subscription.
 pub type QueryResultStream = Box<Stream<Item = QueryResult, Error = ()> + Send>;

--- a/graph/src/data/subscription/subscription.rs
+++ b/graph/src/data/subscription/subscription.rs
@@ -1,4 +1,4 @@
-use prelude::Query;
+use crate::prelude::Query;
 
 /// A GraphQL subscription made by a client.
 ///

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -57,48 +57,52 @@ pub mod prelude {
     pub use tokio;
     pub use tokio::prelude::*;
 
-    pub use components::ethereum::{
+    pub use crate::components::ethereum::{
         BlockStream, BlockStreamBuilder, ChainHeadUpdate, ChainHeadUpdateListener, EthereumAdapter,
         EthereumAdapterError, EthereumBlock, EthereumBlockData, EthereumBlockPointer,
         EthereumEventData, EthereumLogFilter, EthereumNetworkIdentifier, EthereumTransactionData,
     };
-    pub use components::graphql::{GraphQlRunner, QueryResultFuture, SubscriptionResultFuture};
-    pub use components::link_resolver::LinkResolver;
-    pub use components::server::admin::JsonRpcServer;
-    pub use components::server::query::GraphQLServer;
-    pub use components::server::subscription::SubscriptionServer;
-    pub use components::store::{
+    pub use crate::components::graphql::{
+        GraphQlRunner, QueryResultFuture, SubscriptionResultFuture,
+    };
+    pub use crate::components::link_resolver::LinkResolver;
+    pub use crate::components::server::admin::JsonRpcServer;
+    pub use crate::components::server::query::GraphQLServer;
+    pub use crate::components::server::subscription::SubscriptionServer;
+    pub use crate::components::store::{
         AttributeIndexDefinition, ChainStore, EntityChange, EntityChangeOperation, EntityFilter,
         EntityKey, EntityOperation, EntityOrder, EntityQuery, EntityRange, EventSource, Store,
         StoreError, StoreEvent, StoreEventStream, StoreEventStreamBox, SubgraphDeploymentStore,
         TransactionAbortError, SUBSCRIPTION_THROTTLE_INTERVAL,
     };
-    pub use components::subgraph::{
+    pub use crate::components::subgraph::{
         RuntimeHost, RuntimeHostBuilder, SubgraphAssignmentProvider, SubgraphInstance,
         SubgraphInstanceManager, SubgraphRegistrar, SubgraphVersionSwitchingMode,
     };
-    pub use components::{EventConsumer, EventProducer};
+    pub use crate::components::{EventConsumer, EventProducer};
 
-    pub use data::graphql::SerializableValue;
-    pub use data::query::{Query, QueryError, QueryExecutionError, QueryResult, QueryVariables};
-    pub use data::schema::Schema;
-    pub use data::store::scalar::{BigInt, BigIntSign};
-    pub use data::store::{
+    pub use crate::data::graphql::SerializableValue;
+    pub use crate::data::query::{
+        Query, QueryError, QueryExecutionError, QueryResult, QueryVariables,
+    };
+    pub use crate::data::schema::Schema;
+    pub use crate::data::store::scalar::{BigInt, BigIntSign};
+    pub use crate::data::store::{
         AssignmentEvent, Attribute, Entity, NodeId, SubgraphEntityPair, SubgraphVersionSummary,
         Value, ValueType,
     };
-    pub use data::subgraph::schema::{SubgraphDeploymentEntity, TypedEntity};
-    pub use data::subgraph::{
+    pub use crate::data::subgraph::schema::{SubgraphDeploymentEntity, TypedEntity};
+    pub use crate::data::subgraph::{
         CreateSubgraphResult, DataSource, Link, MappingABI, MappingEventHandler,
         SubgraphAssignmentProviderError, SubgraphAssignmentProviderEvent, SubgraphDeploymentId,
         SubgraphManifest, SubgraphManifestResolveError, SubgraphName, SubgraphRegistrarError,
     };
-    pub use data::subscription::{
+    pub use crate::data::subscription::{
         QueryResultStream, Subscription, SubscriptionError, SubscriptionResult,
     };
-    pub use ext::futures::{
+    pub use crate::ext::futures::{
         CancelGuard, CancelHandle, CancelableError, FutureExtension, SharedCancelGuard,
         StreamExtension,
     };
-    pub use util::futures::retry;
+    pub use crate::util::futures::retry;
 }

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "graph-graphql"
 version = "0.5.0"
+edition = "2018"
 
 [dependencies]
 failure = "0.1"

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -8,9 +8,9 @@ use std::time::Instant;
 
 use graph::prelude::*;
 
-use prelude::*;
-use query::ast as qast;
-use schema::ast as sast;
+use crate::prelude::*;
+use crate::query::ast as qast;
+use crate::schema::ast as sast;
 
 /// Contextual information passed around during query execution.
 #[derive(Clone)]
@@ -844,8 +844,8 @@ where
     R1: Resolver,
     R2: Resolver,
 {
+    use crate::values::coercion::coerce_value;
     use graphql_parser::schema::Name;
-    use values::coercion::coerce_value;
 
     let resolver = |name: &Name| {
         sast::get_named_type(
@@ -961,8 +961,8 @@ fn coerce_variable_value(
     variable_def: &q::VariableDefinition,
     value: &q::Value,
 ) -> Result<q::Value, Vec<QueryExecutionError>> {
+    use crate::values::coercion::coerce_value;
     use graphql_parser::schema::Name;
-    use values::coercion::coerce_value;
 
     let resolver = |name: &Name| sast::get_named_type(&schema.document, name);
 

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,9 +1,9 @@
 use graphql_parser::{query as q, schema as s};
 use std::collections::{BTreeMap, HashMap};
 
+use crate::prelude::*;
+use crate::schema::ast::get_named_type;
 use graph::prelude::{QueryExecutionError, StoreEventStreamBox};
-use prelude::*;
-use schema::ast::get_named_type;
 
 #[derive(Copy, Clone)]
 pub enum ObjectOrInterface<'a> {

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -3,8 +3,8 @@ use std::collections::{BTreeMap, HashMap};
 
 use graph::prelude::*;
 
-use prelude::*;
-use schema::ast as sast;
+use crate::prelude::*;
+use crate::schema::ast as sast;
 
 type TypeObjectsMap = BTreeMap<String, q::Value>;
 

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -2,9 +2,9 @@ use graph::prelude::*;
 use graphql_parser::query as q;
 use std::time::Instant;
 
-use execution::*;
-use prelude::*;
-use query::ast as qast;
+use crate::execution::*;
+use crate::prelude::*;
+use crate::query::ast as qast;
 
 /// Utilities for working with GraphQL query ASTs.
 pub mod ast;

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -3,7 +3,7 @@ use graphql_parser::Pos;
 use inflector::Inflector;
 use std::iter::IntoIterator;
 
-use schema::ast;
+use crate::schema::ast;
 
 #[derive(Fail, Debug)]
 pub enum APISchemaError {
@@ -459,7 +459,7 @@ fn add_field_arguments(
             {
                 if ast::is_list_or_non_null_list_field(&input_field) {
                     // Get corresponding object type and field in the output schema
-                    let mut object_type = ast::get_object_type_mut(schema, &input_object_type.name)
+                    let object_type = ast::get_object_type_mut(schema, &input_object_type.name)
                         .expect("object type from input schema is missing in API schema");
                     let mut field = object_type
                         .fields
@@ -492,7 +492,7 @@ fn add_field_arguments(
             {
                 if ast::is_list_or_non_null_list_field(&input_field) {
                     // Get corresponding interface type and field in the output schema
-                    let mut interface_type =
+                    let interface_type =
                         ast::get_interface_type_mut(schema, &input_interface_type.name)
                             .expect("interface type from input schema is missing in API schema");
                     let mut field = interface_type
@@ -527,7 +527,7 @@ mod tests {
     use graphql_parser::schema::*;
 
     use super::api_schema;
-    use schema::ast;
+    use crate::schema::ast;
 
     #[test]
     fn api_schema_contains_built_in_scalar_types() {

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -5,7 +5,7 @@ use lazy_static::lazy_static;
 use std::ops::Deref;
 use std::str::FromStr;
 
-use execution::ObjectOrInterface;
+use crate::execution::ObjectOrInterface;
 use graph::prelude::ValueType;
 
 pub(crate) enum FilterOp {

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -1,7 +1,7 @@
-use execution::ObjectOrInterface;
+use crate::execution::ObjectOrInterface;
+use crate::schema::ast as sast;
 use graph::prelude::*;
 use graphql_parser::{query as q, query::Name, schema as s, schema::ObjectType};
-use schema::ast as sast;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::mem::discriminant;
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -8,10 +8,10 @@ use graph::components::store::*;
 use graph::data::subgraph::schema::SubgraphDeploymentEntity;
 use graph::prelude::*;
 
-use prelude::*;
-use query::ast as qast;
-use schema::ast as sast;
-use store::query::{collect_entities_from_query_field, parse_subgraph_id};
+use crate::prelude::*;
+use crate::query::ast as qast;
+use crate::schema::ast as sast;
+use crate::store::query::{collect_entities_from_query_field, parse_subgraph_id};
 
 /// A resolver that fetches entities from a `Store`.
 pub struct StoreResolver<S> {
@@ -287,7 +287,7 @@ where
                         .map(|o| o.name.clone())
                         .collect();
                     let range = EntityRange::first(1);
-                    let mut query = EntityQuery::new(subgraph_id, entity_types, range);
+                    let query = EntityQuery::new(subgraph_id, entity_types, range);
                     self.store.find(query)?.into_iter().next()
                 }
             }

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -5,10 +5,10 @@ use std::time::{Duration, Instant};
 
 use graph::prelude::*;
 
-use execution::*;
-use prelude::*;
-use query::ast as qast;
-use schema::ast as sast;
+use crate::execution::*;
+use crate::prelude::*;
+use crate::query::ast as qast;
+use crate::schema::ast as sast;
 
 /// Options available for subscription execution.
 pub struct SubscriptionExecutionOptions<R>

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "graph-mock"
 version = "0.5.0"
+edition = "2018"
 
 [dependencies]
 failure = "0.1.2"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "graph-node"
 version = "0.5.0"
+edition = "2018"
 
 [dependencies]
 clap = "2.31.2"

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "graph-runtime-wasm"
 version = "0.5.0"
+edition = "2018"
 
 [dependencies]
 # We would like to switch to upstream master once https://github.com/paritytech/ethabi/pull/145

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -15,7 +15,7 @@ use graph::util;
 use graph::web3::types::{Log, Transaction};
 
 use super::EventHandlerContext;
-use module::{ValidModule, WasmiModule, WasmiModuleConfig};
+use crate::module::{ValidModule, WasmiModule, WasmiModuleConfig};
 
 pub struct RuntimeHostConfig {
     subgraph_id: SubgraphDeploymentId,

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -1,3 +1,5 @@
+use crate::EventHandlerContext;
+use crate::UnresolvedContractCall;
 use ethabi::Token;
 use futures::sync::oneshot;
 use graph::components::ethereum::*;
@@ -11,8 +13,6 @@ use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
-use crate::EventHandlerContext;
-use crate::UnresolvedContractCall;
 
 pub(crate) const TIMEOUT_ENV_VAR: &str = "GRAPH_EVENT_HANDLER_TIMEOUT";
 

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -11,8 +11,8 @@ use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
-use EventHandlerContext;
-use UnresolvedContractCall;
+use crate::EventHandlerContext;
+use crate::UnresolvedContractCall;
 
 pub(crate) const TIMEOUT_ENV_VAR: &str = "GRAPH_EVENT_HANDLER_TIMEOUT";
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -13,12 +13,12 @@ use graph::data::subgraph::DataSource;
 use graph::ethabi::LogParam;
 use graph::prelude::{Error as FailureError, *};
 use graph::web3::types::{Log, U256};
-use host_exports::{self, HostExportError, HostExports};
-use EventHandlerContext;
+use crate::host_exports::{self, HostExportError, HostExports};
+use crate::EventHandlerContext;
 
-use asc_abi::asc_ptr::*;
-use asc_abi::class::*;
-use asc_abi::*;
+use crate::asc_abi::asc_ptr::*;
+use crate::asc_abi::class::*;
+use crate::asc_abi::*;
 
 #[cfg(test)]
 mod test;

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -8,13 +8,13 @@ use wasmi::{
     Signature, Trap,
 };
 
+use crate::host_exports::{self, HostExportError, HostExports};
+use crate::EventHandlerContext;
 use graph::components::ethereum::*;
 use graph::data::subgraph::DataSource;
 use graph::ethabi::LogParam;
 use graph::prelude::{Error as FailureError, *};
 use graph::web3::types::{Log, U256};
-use crate::host_exports::{self, HostExportError, HostExports};
-use crate::EventHandlerContext;
 
 use crate::asc_abi::asc_ptr::*;
 use crate::asc_abi::class::*;

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -2,8 +2,8 @@ extern crate graph_mock;
 extern crate ipfs_api;
 
 use self::graph_mock::FakeStore;
-use ethabi::Token;
 use crate::failure::Error;
+use ethabi::Token;
 use futures::sync::mpsc::{channel, Sender};
 use graph::components::ethereum::*;
 use graph::components::store::*;

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -3,7 +3,7 @@ extern crate ipfs_api;
 
 use self::graph_mock::FakeStore;
 use ethabi::Token;
-use failure::Error;
+use crate::failure::Error;
 use futures::sync::mpsc::{channel, Sender};
 use graph::components::ethereum::*;
 use graph::components::store::*;

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -7,10 +7,10 @@ use graph::prelude::BigInt;
 use graph::serde_json;
 use graph::web3::types as web3;
 
-use asc_abi::class::*;
-use asc_abi::{AscHeap, AscPtr, FromAscObj, ToAscObj};
+use crate::asc_abi::class::*;
+use crate::asc_abi::{AscHeap, AscPtr, FromAscObj, ToAscObj};
 
-use UnresolvedContractCall;
+use crate::UnresolvedContractCall;
 
 impl ToAscObj<Uint8Array> for web3::H160 {
     fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Uint8Array {

--- a/runtime/wasm/src/to_from/mod.rs
+++ b/runtime/wasm/src/to_from/mod.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::FromIterator;
 
-use asc_abi::class::*;
-use asc_abi::{AscHeap, AscPtr, AscType, AscValue, FromAscObj, ToAscObj};
+use crate::asc_abi::class::*;
+use crate::asc_abi::{AscHeap, AscPtr, AscType, AscValue, FromAscObj, ToAscObj};
 
 ///! Implementations of `ToAscObj` and `FromAscObj` for Rust types.
 ///! Standard Rust types go in `mod.rs` and external types in `external.rs`.

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "graph-server-http"
 version = "0.5.0"
+edition = "2018"
 
 [dependencies]
 futures = "0.1.21"

--- a/server/http/src/response.rs
+++ b/server/http/src/response.rs
@@ -78,7 +78,7 @@ mod tests {
     use http::status::StatusCode;
     use std::collections::BTreeMap;
 
-    use test_utils;
+    use crate::test_utils;
 
     #[test]
     fn generates_500_for_internal_errors() {

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -5,8 +5,8 @@ use std::error::Error;
 use std::fmt;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
-use graph::prelude::{GraphQLServer as GraphQLServerTrait, *};
 use crate::service::GraphQLService;
+use graph::prelude::{GraphQLServer as GraphQLServerTrait, *};
 
 /// Errors that may occur when starting the server.
 #[derive(Debug)]

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
 use graph::prelude::{GraphQLServer as GraphQLServerTrait, *};
-use service::GraphQLService;
+use crate::service::GraphQLService;
 
 /// Errors that may occur when starting the server.
 #[derive(Debug)]

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -5,8 +5,8 @@ use http::header;
 use hyper::service::Service;
 use hyper::{Body, Method, Request, Response, StatusCode};
 
-use request::GraphQLRequest;
-use response::GraphQLResponse;
+use crate::request::GraphQLRequest;
+use crate::response::GraphQLResponse;
 
 /// An asynchronous response to a GraphQL request.
 pub type GraphQLServiceResponse =
@@ -392,7 +392,7 @@ mod tests {
     use graph::prelude::*;
 
     use super::GraphQLService;
-    use test_utils;
+    use crate::test_utils;
 
     /// A simple stupid query runner for testing.
     pub struct TestGraphQlRunner;

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -18,7 +18,7 @@ use graph::prelude::*;
 use graph_server_http::test_utils;
 use graph_server_http::GraphQLServer as HyperGraphQLServer;
 
-use tokio::timer::Delay;
+use crate::tokio::timer::Delay;
 
 /// A simple stupid query runner for testing.
 pub struct TestGraphQlRunner;

--- a/server/json-rpc/Cargo.toml
+++ b/server/json-rpc/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "graph-server-json-rpc"
 version = "0.5.0"
+edition = "2018"
 
 [dependencies]
 graph = { path = "../../graph" }

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "graph-server-websocket"
 version = "0.5.0"
+edition = "2018"
 
 [dependencies]
 futures = "0.1.23"

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 use tokio_tungstenite::accept_hdr_async;
 use tokio_tungstenite::tungstenite::{handshake::server::Request, Error as WsError};
 
-use connection::GraphQlConnection;
+use crate::connection::GraphQlConnection;
 
 /// A GraphQL subscription server based on Hyper / Websockets.
 pub struct SubscriptionServer<Q, S> {

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -1,6 +1,6 @@
 use graph::prelude::{ChainHeadUpdateListener as ChainHeadUpdateListenerTrait, *};
 use graph::serde_json;
-use notification_listener::{NotificationListener, SafeChannelName};
+use crate::notification_listener::{NotificationListener, SafeChannelName};
 
 pub struct ChainHeadUpdateListener {
     notification_listener: NotificationListener,

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -1,6 +1,6 @@
+use crate::notification_listener::{NotificationListener, SafeChannelName};
 use graph::prelude::{ChainHeadUpdateListener as ChainHeadUpdateListenerTrait, *};
 use graph::serde_json;
-use crate::notification_listener::{NotificationListener, SafeChannelName};
 
 pub struct ChainHeadUpdateListener {
     notification_listener: NotificationListener,

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -12,8 +12,8 @@ use graph::data::store::*;
 use graph::prelude::BigInt;
 use graph::serde_json;
 
-use db_schema::entities;
-use models::SqlValue;
+use crate::db_schema::entities;
+use crate::models::SqlValue;
 
 pub(crate) struct UnsupportedFilter {
     pub filter: String,

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -1,7 +1,7 @@
+use crate::functions::pg_notify;
 use diesel::pg::PgConnection;
 use diesel::select;
 use fallible_iterator::FallibleIterator;
-use crate::functions::pg_notify;
 use postgres::notification::Notification;
 use postgres::{Connection, TlsMode};
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -1,7 +1,7 @@
 use diesel::pg::PgConnection;
 use diesel::select;
 use fallible_iterator::FallibleIterator;
-use functions::pg_notify;
+use crate::functions::pg_notify;
 use postgres::notification::Notification;
 use postgres::{Connection, TlsMode};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -235,7 +235,7 @@ impl JsonNotification {
         data: &serde_json::Value,
         conn: &PgConnection,
     ) -> Result<(), StoreError> {
-        use db_schema::large_notifications::dsl::*;
+        use crate::db_schema::large_notifications::dsl::*;
         use diesel::ExpressionMethods;
         use diesel::RunQueryDsl;
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1,3 +1,4 @@
+use crate::filter::store_filter;
 use diesel::debug_query;
 use diesel::dsl::{any, sql};
 use diesel::pg::Pg;
@@ -6,7 +7,6 @@ use diesel::prelude::*;
 use diesel::r2d2::{self, ConnectionManager, Pool};
 use diesel::sql_types::Text;
 use diesel::{delete, insert_into, select, update};
-use crate::filter::store_filter;
 use futures::sync::mpsc::{channel, Sender};
 use lru_time_cache::LruCache;
 use std::collections::HashMap;
@@ -14,6 +14,7 @@ use std::sync::{Mutex, RwLock};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
+use crate::notification_listener::JsonNotification;
 use graph::components::store::Store as StoreTrait;
 use graph::data::subgraph::schema::*;
 use graph::prelude::*;
@@ -21,7 +22,6 @@ use graph::serde_json;
 use graph::web3::types::H256;
 use graph::{tokio, tokio::timer::Interval};
 use graph_graphql::prelude::api_schema;
-use crate::notification_listener::JsonNotification;
 
 use crate::chain_head_listener::ChainHeadUpdateListener;
 use crate::functions::{

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -1,3 +1,4 @@
+use crate::notification_listener::{NotificationListener, SafeChannelName};
 use diesel::deserialize::QueryableByName;
 use diesel::pg::Pg;
 use diesel::pg::PgConnection;
@@ -5,7 +6,6 @@ use diesel::sql_types::Text;
 use diesel::RunQueryDsl;
 use graph::prelude::*;
 use graph::serde_json;
-use crate::notification_listener::{NotificationListener, SafeChannelName};
 
 pub struct StoreEventListener {
     notification_listener: NotificationListener,

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -5,7 +5,7 @@ use diesel::sql_types::Text;
 use diesel::RunQueryDsl;
 use graph::prelude::*;
 use graph::serde_json;
-use notification_listener::{NotificationListener, SafeChannelName};
+use crate::notification_listener::{NotificationListener, SafeChannelName};
 
 pub struct StoreEventListener {
     notification_listener: NotificationListener,

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -6,13 +6,13 @@ extern crate graph;
 extern crate graph_store_postgres;
 extern crate hex;
 
+use crate::tokio::runtime::Runtime;
 use diesel::pg::PgConnection;
 use diesel::*;
 use std::env;
 use std::str::FromStr;
 use std::sync::Mutex;
 use std::time::Duration;
-use crate::tokio::runtime::Runtime;
 
 use graph::components::store::{EntityFilter, EntityKey, EntityOrder, EntityQuery, EntityRange};
 use graph::data::store::scalar;

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -12,7 +12,7 @@ use std::env;
 use std::str::FromStr;
 use std::sync::Mutex;
 use std::time::Duration;
-use tokio::runtime::Runtime;
+use crate::tokio::runtime::Runtime;
 
 use graph::components::store::{EntityFilter, EntityKey, EntityOrder, EntityQuery, EntityRange};
 use graph::data::store::scalar;
@@ -268,7 +268,7 @@ fn create_test_entity(
 
 /// Removes test data from the database behind the store.
 fn remove_test_data() {
-    use db_schema::{entities, entity_history, event_meta_data};
+    use crate::db_schema::{entities, entity_history, event_meta_data};
 
     let url = postgres_test_url();
     let conn = PgConnection::establish(url.as_str()).expect("Failed to connect to Postgres");


### PR DESCRIPTION
Run `cargo fix --edition` and add `"edition = 2018"` to all our `Cargo.toml`s to make sure we keep up with the latest and greatest Rust features.