### PR TITLE
Reduce the number of db operations for updating a subgraph's block pointer

### DIFF
--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -102,40 +102,28 @@ impl SubgraphEntity {
         id: &str,
         version_id_opt: Option<String>,
     ) -> Vec<EntityOperation> {
-        let mut ops = vec![];
-
-        ops.push(EntityOperation::AbortUnless {
-            description: "Subgraph entity must still exist to be updated".to_owned(),
-            query: Self::query().filter(EntityFilter::new_equal("id", id)),
-            entity_ids: vec![id.to_owned()],
-        });
-
         let mut entity = Entity::new();
-        entity.set("id", id);
         entity.set("currentVersion", version_id_opt);
-        ops.push(set_entity_operation(Self::TYPENAME, id, entity));
 
-        ops
+        vec![EntityOperation::Update {
+            key: Self::key(id.to_owned()),
+            data: entity,
+            guard: None,
+        }]
     }
 
     pub fn update_pending_version_operations(
         id: &str,
         version_id_opt: Option<String>,
     ) -> Vec<EntityOperation> {
-        let mut ops = vec![];
-
-        ops.push(EntityOperation::AbortUnless {
-            description: "Subgraph entity must still exist to be updated".to_owned(),
-            query: Self::query().filter(EntityFilter::new_equal("id", id)),
-            entity_ids: vec![id.to_owned()],
-        });
-
         let mut entity = Entity::new();
-        entity.set("id", id);
         entity.set("pendingVersion", version_id_opt);
-        ops.push(set_entity_operation(Self::TYPENAME, id, entity));
 
-        ops
+        vec![EntityOperation::Update {
+            key: Self::key(id.to_owned()),
+            data: entity,
+            guard: None,
+        }]
     }
 }
 
@@ -253,94 +241,61 @@ impl SubgraphDeploymentEntity {
         block_ptr_from: EthereumBlockPointer,
         block_ptr_to: EthereumBlockPointer,
     ) -> Vec<EntityOperation> {
-        let mut ops = vec![];
-
-        ops.push(EntityOperation::AbortUnless {
-            description: "Subgraph's Ethereum block pointer must match block_ptr_from".to_owned(),
-            query: Self::query().filter(EntityFilter::And(vec![
-                EntityFilter::new_equal("id", id.to_string()),
-                EntityFilter::new_equal("latestEthereumBlockHash", block_ptr_from.hash_hex()),
-                EntityFilter::new_equal("latestEthereumBlockNumber", block_ptr_from.number),
-            ])),
-            entity_ids: vec![id.to_string()],
-        });
-
         let mut entity = Entity::new();
-        entity.set("id", id.to_string());
         entity.set("latestEthereumBlockHash", block_ptr_to.hash_hex());
         entity.set("latestEthereumBlockNumber", block_ptr_to.number);
-        ops.push(set_entity_operation(Self::TYPENAME, id.to_string(), entity));
 
-        ops
+        let guard = EntityFilter::And(vec![
+            EntityFilter::new_equal("latestEthereumBlockHash", block_ptr_from.hash_hex()),
+            EntityFilter::new_equal("latestEthereumBlockNumber", block_ptr_from.number),
+        ]);
+        vec![EntityOperation::Update {
+            key: Self::key(id.clone()),
+            data: entity,
+            guard: Some(guard),
+        }]
     }
 
     pub fn update_ethereum_blocks_count_operations(
         id: &SubgraphDeploymentId,
         total_blocks_count: u64,
     ) -> Vec<EntityOperation> {
-        let mut ops = vec![];
-
-        ops.push(EntityOperation::AbortUnless {
-            description: "Subgraph deployment entity must exist to be updated".to_owned(),
-            query: Self::query().filter(EntityFilter::And(vec![EntityFilter::new_equal(
-                "id",
-                id.to_string(),
-            )])),
-            entity_ids: vec![id.to_string()],
-        });
-
         let mut entity = Entity::new();
-        entity.set("id", id.to_string());
         entity.set("totalEthereumBlocksCount", total_blocks_count);
-        ops.push(set_entity_operation(Self::TYPENAME, id.to_string(), entity));
 
-        ops
+        vec![EntityOperation::Update {
+            key: Self::key(id.clone()),
+            data: entity,
+            guard: None,
+        }]
     }
 
     pub fn update_failed_operations(
         id: &SubgraphDeploymentId,
         failed: bool,
     ) -> Vec<EntityOperation> {
-        let mut ops = vec![];
-
-        ops.push(EntityOperation::AbortUnless {
-            description: "Subgraph deployment entity must exist to be updated".to_owned(),
-            query: Self::query().filter(EntityFilter::And(vec![EntityFilter::new_equal(
-                "id",
-                id.to_string(),
-            )])),
-            entity_ids: vec![id.to_string()],
-        });
-
         let mut entity = Entity::new();
-        entity.set("id", id.to_string());
         entity.set("failed", failed);
-        ops.push(set_entity_operation(Self::TYPENAME, id.to_string(), entity));
 
-        ops
+        vec![EntityOperation::Update {
+            key: Self::key(id.clone()),
+            data: entity,
+            guard: None,
+        }]
     }
 
     pub fn update_synced_operations(
         id: &SubgraphDeploymentId,
         synced: bool,
     ) -> Vec<EntityOperation> {
-        let mut ops = vec![];
-
-        ops.push(EntityOperation::AbortUnless {
-            description: "Subgraph deployment entity must exist to be updated".to_owned(),
-            query: Self::query().filter(EntityFilter::And(vec![EntityFilter::new_equal(
-                "id",
-                id.to_string(),
-            )])),
-            entity_ids: vec![id.to_string()],
-        });
-
         let mut entity = Entity::new();
-        entity.set("id", id.to_string());
         entity.set("synced", synced);
-        ops.push(set_entity_operation(Self::TYPENAME, id.to_string(), entity));
 
-        ops
+        vec![EntityOperation::Update {
+            key: Self::key(id.clone()),
+            data: entity,
+            guard: None,
+        }]
     }
 }
 

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -128,7 +128,7 @@ pub(crate) fn store_filter<T>(
     Ok(query.filter(build_filter(filter)?))
 }
 
-fn build_filter(filter: EntityFilter) -> Result<FilterExpression, UnsupportedFilter> {
+pub(crate) fn build_filter(filter: EntityFilter) -> Result<FilterExpression, UnsupportedFilter> {
     use self::EntityFilter::*;
 
     let false_expr = Box::new(false.into_sql::<Bool>()) as FilterExpression;

--- a/store/postgres/src/jsonb.rs
+++ b/store/postgres/src/jsonb.rs
@@ -1,0 +1,23 @@
+use diesel::expression::helper_types::AsExprOf;
+use diesel::expression::{AsExpression, Expression};
+use diesel::sql_types::Jsonb;
+
+mod operators {
+    use diesel::sql_types::Jsonb;
+
+    // restrict to backend: Pg
+    diesel_infix_operator!(JsonbMerge, " || ", Jsonb, backend: diesel::pg::Pg);
+}
+
+pub type JsonbMerge<Lhs, Rhs> = operators::JsonbMerge<Lhs, AsExprOf<Rhs, Jsonb>>;
+
+pub trait PgJsonbExpressionMethods: Expression<SqlType = Jsonb> + Sized {
+    fn merge<T: AsExpression<Jsonb>>(self, other: T) -> JsonbMerge<Self, T::Expression> {
+        JsonbMerge::<Self, T::Expression>::new(self, other.as_expression())
+    }
+}
+
+impl<T: Expression<SqlType = Jsonb>> PgJsonbExpressionMethods for T where
+    T: Expression<SqlType = Jsonb>
+{
+}

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -20,6 +20,7 @@ mod chain_head_listener;
 pub mod db_schema;
 mod filter;
 pub mod functions;
+pub mod jsonb;
 pub mod models;
 mod notification_listener;
 pub mod store;


### PR DESCRIPTION
This reduces the db traffic caused by certain subgraph metadata updates from 3 (or more) to 1.