### PR TITLE
store/postgres: fix syntax error with Postgres 9.6

### DIFF
--- a/store/postgres/migrations/2019-03-07-171355_update_history_storage/up.sql
+++ b/store/postgres/migrations/2019-03-07-171355_update_history_storage/up.sql
@@ -97,11 +97,11 @@ end;
 $$ language plpgsql;
 
 -- remove unused stored procs
-drop function if exists revert_transaction;
-drop function if exists revert_entity_event;
+drop function if exists revert_transaction();
+drop function if exists revert_entity_event();
 
 -- remove some old, never used procs while we are at it
-drop function if exists revert_block_group;
-drop function if exists revert_transaction_group;
-drop function if exists rerun_entity;
-drop function if exists rerun_entity_history_event;
+drop function if exists revert_block_group();
+drop function if exists revert_transaction_group();
+drop function if exists rerun_entity();
+drop function if exists rerun_entity_history_event();


### PR DESCRIPTION
Postgres 9.6 requires '()' after the name of a function when dropping it.

