### PR TITLE
Delete unneeded entity_history and event_meta_data

### DIFF
--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -102,40 +102,28 @@ impl SubgraphEntity {
         id: &str,
         version_id_opt: Option<String>,
     ) -> Vec<EntityOperation> {
-        let mut ops = vec![];
-
-        ops.push(EntityOperation::AbortUnless {
-            description: "Subgraph entity must still exist to be updated".to_owned(),
-            query: Self::query().filter(EntityFilter::new_equal("id", id)),
-            entity_ids: vec![id.to_owned()],
-        });
-
         let mut entity = Entity::new();
-        entity.set("id", id);
         entity.set("currentVersion", version_id_opt);
-        ops.push(set_entity_operation(Self::TYPENAME, id, entity));
 
-        ops
+        vec![EntityOperation::Update {
+            key: Self::key(id.to_owned()),
+            data: entity,
+            guard: None,
+        }]
     }
 
     pub fn update_pending_version_operations(
         id: &str,
         version_id_opt: Option<String>,
     ) -> Vec<EntityOperation> {
-        let mut ops = vec![];
-
-        ops.push(EntityOperation::AbortUnless {
-            description: "Subgraph entity must still exist to be updated".to_owned(),
-            query: Self::query().filter(EntityFilter::new_equal("id", id)),
-            entity_ids: vec![id.to_owned()],
-        });
-
         let mut entity = Entity::new();
-        entity.set("id", id);
         entity.set("pendingVersion", version_id_opt);
-        ops.push(set_entity_operation(Self::TYPENAME, id, entity));
 
-        ops
+        vec![EntityOperation::Update {
+            key: Self::key(id.to_owned()),
+            data: entity,
+            guard: None,
+        }]
     }
 }
 
@@ -253,94 +241,61 @@ impl SubgraphDeploymentEntity {
         block_ptr_from: EthereumBlockPointer,
         block_ptr_to: EthereumBlockPointer,
     ) -> Vec<EntityOperation> {
-        let mut ops = vec![];
-
-        ops.push(EntityOperation::AbortUnless {
-            description: "Subgraph's Ethereum block pointer must match block_ptr_from".to_owned(),
-            query: Self::query().filter(EntityFilter::And(vec![
-                EntityFilter::new_equal("id", id.to_string()),
-                EntityFilter::new_equal("latestEthereumBlockHash", block_ptr_from.hash_hex()),
-                EntityFilter::new_equal("latestEthereumBlockNumber", block_ptr_from.number),
-            ])),
-            entity_ids: vec![id.to_string()],
-        });
-
         let mut entity = Entity::new();
-        entity.set("id", id.to_string());
         entity.set("latestEthereumBlockHash", block_ptr_to.hash_hex());
         entity.set("latestEthereumBlockNumber", block_ptr_to.number);
-        ops.push(set_entity_operation(Self::TYPENAME, id.to_string(), entity));
 
-        ops
+        let guard = EntityFilter::And(vec![
+            EntityFilter::new_equal("latestEthereumBlockHash", block_ptr_from.hash_hex()),
+            EntityFilter::new_equal("latestEthereumBlockNumber", block_ptr_from.number),
+        ]);
+        vec![EntityOperation::Update {
+            key: Self::key(id.clone()),
+            data: entity,
+            guard: Some(guard),
+        }]
     }
 
     pub fn update_ethereum_blocks_count_operations(
         id: &SubgraphDeploymentId,
         total_blocks_count: u64,
     ) -> Vec<EntityOperation> {
-        let mut ops = vec![];
-
-        ops.push(EntityOperation::AbortUnless {
-            description: "Subgraph deployment entity must exist to be updated".to_owned(),
-            query: Self::query().filter(EntityFilter::And(vec![EntityFilter::new_equal(
-                "id",
-                id.to_string(),
-            )])),
-            entity_ids: vec![id.to_string()],
-        });
-
         let mut entity = Entity::new();
-        entity.set("id", id.to_string());
         entity.set("totalEthereumBlocksCount", total_blocks_count);
-        ops.push(set_entity_operation(Self::TYPENAME, id.to_string(), entity));
 
-        ops
+        vec![EntityOperation::Update {
+            key: Self::key(id.clone()),
+            data: entity,
+            guard: None,
+        }]
     }
 
     pub fn update_failed_operations(
         id: &SubgraphDeploymentId,
         failed: bool,
     ) -> Vec<EntityOperation> {
-        let mut ops = vec![];
-
-        ops.push(EntityOperation::AbortUnless {
-            description: "Subgraph deployment entity must exist to be updated".to_owned(),
-            query: Self::query().filter(EntityFilter::And(vec![EntityFilter::new_equal(
-                "id",
-                id.to_string(),
-            )])),
-            entity_ids: vec![id.to_string()],
-        });
-
         let mut entity = Entity::new();
-        entity.set("id", id.to_string());
         entity.set("failed", failed);
-        ops.push(set_entity_operation(Self::TYPENAME, id.to_string(), entity));
 
-        ops
+        vec![EntityOperation::Update {
+            key: Self::key(id.clone()),
+            data: entity,
+            guard: None,
+        }]
     }
 
     pub fn update_synced_operations(
         id: &SubgraphDeploymentId,
         synced: bool,
     ) -> Vec<EntityOperation> {
-        let mut ops = vec![];
-
-        ops.push(EntityOperation::AbortUnless {
-            description: "Subgraph deployment entity must exist to be updated".to_owned(),
-            query: Self::query().filter(EntityFilter::And(vec![EntityFilter::new_equal(
-                "id",
-                id.to_string(),
-            )])),
-            entity_ids: vec![id.to_string()],
-        });
-
         let mut entity = Entity::new();
-        entity.set("id", id.to_string());
         entity.set("synced", synced);
-        ops.push(set_entity_operation(Self::TYPENAME, id.to_string(), entity));
 
-        ops
+        vec![EntityOperation::Update {
+            key: Self::key(id.clone()),
+            data: entity,
+            guard: None,
+        }]
     }
 }
 

--- a/store/postgres/migrations/2019-03-11-221621_delete_unneeded_entity_history/down.sql
+++ b/store/postgres/migrations/2019-03-11-221621_delete_unneeded_entity_history/down.sql
@@ -1,0 +1,77 @@
+-- We put the schema back, but there is no getting the data that we deleted
+-- back and it is therefore much better to undo this migration by restoring
+-- from a backup.
+ALTER TABLE entity_history
+  ADD COLUMN data_after jsonb;
+
+CREATE OR REPLACE FUNCTION log_entity_event()
+    RETURNS trigger AS
+$$
+DECLARE
+    event_id INTEGER;
+    new_event_id INTEGER;
+    is_reversion BOOLEAN := FALSE;
+    operation_type INTEGER := 10;
+    event_source  VARCHAR;
+    subgraph VARCHAR;
+    entity VARCHAR;
+    entity_id VARCHAR;
+    data_before JSONB;
+    data_after JSONB;
+BEGIN
+    -- Get operation type and source
+    IF (TG_OP = 'INSERT') THEN
+        operation_type := 0;
+        event_source := NEW.event_source;
+        subgraph := NEW.subgraph;
+        entity := NEW.entity;
+        entity_id := NEW.id;
+        data_before := NULL;
+        data_after := NEW.data;
+    ELSIF (TG_OP = 'UPDATE') THEN
+        operation_type := 1;
+        event_source := NEW.event_source;
+        subgraph := OLD.subgraph;
+        entity := OLD.entity;
+        entity_id := OLD.id;
+        data_before := OLD.data;
+        data_after := NEW.data;
+    ELSIF (TG_OP = 'DELETE') THEN
+        operation_type := 2;
+        event_source := current_setting('vars.current_event_source', TRUE);
+        subgraph := OLD.subgraph;
+        entity := OLD.entity;
+        entity_id := OLD.id;
+        data_before := OLD.data;
+        data_after := NULL;
+    ELSE
+        RAISE EXCEPTION 'unexpected entity row operation type, %', TG_OP;
+    END IF;
+
+    IF event_source = 'REVERSION' THEN
+        is_reversion := TRUE;
+    END IF;
+
+    SELECT id INTO event_id
+    FROM event_meta_data
+    WHERE db_transaction_id = txid_current();
+
+    new_event_id := null;
+
+    IF event_id IS NULL THEN
+        -- Log information on the postgres transaction for later use in revert operations
+        INSERT INTO event_meta_data
+            (db_transaction_id, db_transaction_time, source)
+        VALUES
+            (txid_current(), statement_timestamp(), event_source)
+        RETURNING event_meta_data.id INTO new_event_id;
+    END IF;
+
+    -- Log row metadata and changes, specify whether event was an original ethereum event or a reversion
+    INSERT INTO entity_history
+        (event_id, entity_id, subgraph, entity, data_before, data_after, reversion, op_id)
+    VALUES
+        (COALESCE(new_event_id, event_id), entity_id, subgraph, entity, data_before, data_after, is_reversion, operation_type);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;

--- a/store/postgres/migrations/2019-03-11-221621_delete_unneeded_entity_history/up.sql
+++ b/store/postgres/migrations/2019-03-11-221621_delete_unneeded_entity_history/up.sql
@@ -1,0 +1,190 @@
+-- Remove mention of data_after from the log_entity_event function
+CREATE OR REPLACE FUNCTION log_entity_event()
+    RETURNS trigger AS
+$$
+DECLARE
+    event_id INTEGER;
+    new_event_id INTEGER;
+    is_reversion BOOLEAN := FALSE;
+    operation_type INTEGER := 10;
+    event_source  VARCHAR;
+    subgraph VARCHAR;
+    entity VARCHAR;
+    entity_id VARCHAR;
+    data_before JSONB;
+BEGIN
+    -- Get operation type and source
+    IF (TG_OP = 'INSERT') THEN
+        operation_type := 0;
+        event_source := NEW.event_source;
+        subgraph := NEW.subgraph;
+        entity := NEW.entity;
+        entity_id := NEW.id;
+        data_before := NULL;
+    ELSIF (TG_OP = 'UPDATE') THEN
+        operation_type := 1;
+        event_source := NEW.event_source;
+        subgraph := OLD.subgraph;
+        entity := OLD.entity;
+        entity_id := OLD.id;
+        data_before := OLD.data;
+    ELSIF (TG_OP = 'DELETE') THEN
+        operation_type := 2;
+        event_source := current_setting('vars.current_event_source', TRUE);
+        subgraph := OLD.subgraph;
+        entity := OLD.entity;
+        entity_id := OLD.id;
+        data_before := OLD.data;
+    ELSE
+        RAISE EXCEPTION 'unexpected entity row operation type, %', TG_OP;
+    END IF;
+
+    IF event_source = 'REVERSION' THEN
+        is_reversion := TRUE;
+    END IF;
+
+    SELECT id INTO event_id
+    FROM event_meta_data
+    WHERE db_transaction_id = txid_current();
+
+    new_event_id := null;
+
+    IF event_id IS NULL THEN
+        -- Log information on the postgres transaction for later use in revert operations
+        INSERT INTO event_meta_data
+            (db_transaction_id, db_transaction_time, source)
+        VALUES
+            (txid_current(), statement_timestamp(), event_source)
+        RETURNING event_meta_data.id INTO new_event_id;
+    END IF;
+
+    -- Log row metadata and changes, specify whether event was an original ethereum event or a reversion
+    INSERT INTO entity_history
+        (event_id, entity_id, subgraph, entity, data_before, reversion, op_id)
+    VALUES
+        (COALESCE(new_event_id, event_id), entity_id, subgraph, entity, data_before, is_reversion, operation_type);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Remove unneeded entity_history data, and event_meta_data that becomes
+-- unnecessary because of that, too. Since we need to get rid of most of
+-- the data, it is faster to copy the 'good' data into a new table and swap
+-- tables around
+
+-- Create a new table that clones the entity_history table. For now,
+-- we only clone the schema. We create indexes and constraints after
+-- we are done copying, for speed.
+create table eh(like entity_history
+                     including defaults
+                     including comments
+                     including storage);
+-- eh and entity_history both use entity_history_id_seq now. Remove its
+-- use from entity_history, so we don't get a conflict later when we
+-- drop that table
+alter table entity_history
+      alter column id drop default;
+alter sequence entity_history_id_seq
+      owned by eh.id;
+alter table eh drop column data_after;
+
+-- Lock any writes to entity_history and event_meta_data. We can not
+-- afford to have any changes happen while we copy, as we would lose
+-- them because we are copying
+lock table entity_history in exclusive mode;
+lock table event_meta_data in exclusive mode;
+
+-- Copy the good data. Do not log to avoid stress on the WAL. Note that
+-- either data_before or data_after can be null, and we need to make sure
+-- we include rows with a null in either column, but that 'anything !=
+-- null' will always be false. We lift SQL NULL to JSON null, since JSON
+-- uses normal, not three-state logic for comparisons with null
+alter table eh set unlogged;
+insert into eh
+  select id, event_id, entity_id, subgraph, entity, data_before,
+         reversion, op_id from entity_history
+  where subgraph != 'subgraphs'
+    and coalesce(data_before, 'null'::jsonb)
+        != coalesce(data_after, 'null'::jsonb);
+alter table eh set logged;
+
+-- Swap old and new tables
+alter table entity_history rename to eh_old;
+alter table eh rename to entity_history;
+
+-- Create indexes
+alter index entity_history_pkey rename to eh_old_pkey;
+alter table entity_history
+  add constraint entity_history_pkey primary key(id);
+
+alter index entity_history_event_id_btree_idx
+  rename to eh_old_event_id_btree_idx;
+create index entity_history_event_id_btree_idx
+  on entity_history(event_id);
+
+--
+-- Deal with event_meta_data
+--
+
+-- Remove uneeded event_meta_data entries following the same pattern
+create table emd(like event_meta_data
+                     including defaults
+                     including comments
+                     including storage);
+alter table event_meta_data
+      alter column id drop default;
+alter sequence event_meta_data_id_seq
+      owned by emd.id;
+
+-- Copy the good event_meta_data
+alter table emd set unlogged;
+insert into emd
+  select * from event_meta_data d
+  where exists (select 1 from entity_history h where d.id = h.event_id);
+alter table emd set logged;
+
+alter table event_meta_data rename to emd_old;
+alter table emd rename to event_meta_data;
+
+-- Create indexes
+alter index event_meta_data_pkey rename to emd_old_pkey;
+alter table event_meta_data
+  add constraint event_meta_data_pkey primary key(id);
+
+alter index event_meta_data_db_transaction_id_key
+  rename to emd_old_db_transaction_id_key;
+alter table event_meta_data
+  add constraint event_meta_data_db_transaction_id_key
+                 unique(db_transaction_id);
+
+-- Make sure the fk constraint on entity_history points to the new
+-- event_meta_data table
+alter table eh_old
+  drop constraint entity_history_event_id_fkey;
+
+alter table entity_history
+  add constraint entity_history_event_id_fkey
+  foreign key (event_id) references event_meta_data(id)
+  match full on update cascade on delete cascade;
+
+-- Recreate the entity_history_with_source view so that
+-- it points to the right version of these tables
+drop view entity_history_with_source;
+create view entity_history_with_source as
+  select
+    h.subgraph,
+    h.entity,
+    h.entity_id,
+    h.data_before,
+    h.op_id,
+    m.source
+  from entity_history h, event_meta_data m
+  where h.event_id = m.id
+  order by h.event_id desc;
+
+-- Clean up
+drop table eh_old;
+drop table emd_old;
+
+analyze entity_history;
+analyze event_meta_data;

--- a/store/postgres/src/db_schema.rs
+++ b/store/postgres/src/db_schema.rs
@@ -16,7 +16,6 @@ table! {
         subgraph -> Varchar,
         entity -> Varchar,
         data_before -> Nullable<Jsonb>,
-        data_after -> Nullable<Jsonb>,
         reversion -> Bool,
     }
 }

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -128,7 +128,7 @@ pub(crate) fn store_filter<T>(
     Ok(query.filter(build_filter(filter)?))
 }
 
-fn build_filter(filter: EntityFilter) -> Result<FilterExpression, UnsupportedFilter> {
+pub(crate) fn build_filter(filter: EntityFilter) -> Result<FilterExpression, UnsupportedFilter> {
     use self::EntityFilter::*;
 
     let false_expr = Box::new(false.into_sql::<Bool>()) as FilterExpression;

--- a/store/postgres/src/jsonb.rs
+++ b/store/postgres/src/jsonb.rs
@@ -1,0 +1,23 @@
+use diesel::expression::helper_types::AsExprOf;
+use diesel::expression::{AsExpression, Expression};
+use diesel::sql_types::Jsonb;
+
+mod operators {
+    use diesel::sql_types::Jsonb;
+
+    // restrict to backend: Pg
+    diesel_infix_operator!(JsonbMerge, " || ", Jsonb, backend: diesel::pg::Pg);
+}
+
+pub type JsonbMerge<Lhs, Rhs> = operators::JsonbMerge<Lhs, AsExprOf<Rhs, Jsonb>>;
+
+pub trait PgJsonbExpressionMethods: Expression<SqlType = Jsonb> + Sized {
+    fn merge<T: AsExpression<Jsonb>>(self, other: T) -> JsonbMerge<Self, T::Expression> {
+        JsonbMerge::<Self, T::Expression>::new(self, other.as_expression())
+    }
+}
+
+impl<T: Expression<SqlType = Jsonb>> PgJsonbExpressionMethods for T where
+    T: Expression<SqlType = Jsonb>
+{
+}

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -20,6 +20,7 @@ mod chain_head_listener;
 pub mod db_schema;
 mod filter;
 pub mod functions;
+pub mod jsonb;
 pub mod models;
 mod notification_listener;
 pub mod store;


### PR DESCRIPTION
Get rid of the following in entity_history:

- all history for the 'subgraphs' subgraph
- all history where data_before = data_after
- the data_after column in entity_history
- any event_meta_data event that is not used by an entry in entity_history

The migration is a little more complicated than one might think because we
are trying to do this as fast as possible: instead of deleting from
entity_history and event_meta_data, we copy the 'good' data to a new
table. We also defer creating constraints and indexes until after the data
has been copied since bulk creation is faster than doing it on every row.

Fixes https://github.com/graphprotocol/graph-node/issues/807

