### PR TITLE
Improve data parsing errors in runtime hosted parsing functions

### DIFF
--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -248,9 +248,9 @@ where
     ) -> Result<String, HostExportError<impl ExportError>> {
         let s = String::from_utf8(bytes).map_err(|e| {
             HostExportError(format!(
-                "Failed to parse Byte array using `toString()`. This may be caused by attempting \
+                "Failed to parse byte array using `toString()`. This may be caused by attempting \
                  to convert a value such as an address that cannot be parsed to a unicode string. \
-                 Try 'toHexString()' instead. error: {error},  bytes:`{bytes:?}`",
+                 Try 'toHexString()' instead. Bytes: `{bytes:?}`. Error: {error}",
                 error = e.utf8_error(),
                 bytes = e.into_bytes(),
             ))
@@ -313,9 +313,9 @@ where
     ) -> Result<serde_json::Value, HostExportError<impl ExportError>> {
         serde_json::from_reader(&*bytes).map_err(|e| {
             HostExportError(format!(
-                "Failed to parse byte array to JSON. error: {error}, bytes: `{bytes:?}`",
-                error = e,
+                "Failed to parse JSON from byte array. Bytes: `{bytes:?}`. Error: {error}",
                 bytes = bytes,
+                error = e,
             ))
         })
     }

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -246,7 +246,15 @@ where
         &self,
         bytes: Vec<u8>,
     ) -> Result<String, HostExportError<impl ExportError>> {
-        let s = String::from_utf8(bytes).map_err(HostExportError)?;
+        let s = String::from_utf8(bytes).map_err(|e| {
+            HostExportError(format!(
+                "Failed to parse Byte array using `toString()`. This may be caused by attempting \
+                 to convert a value such as an address that cannot be parsed to a unicode string. \
+                 Try 'toHexString()' instead. error: {error},  bytes:`{bytes:?}`",
+                error = e.utf8_error(),
+                bytes = e.into_bytes(),
+            ))
+        })?;
         // The string may have been encoded in a fixed length
         // buffer and padded with null characters, so trim
         // trailing nulls.

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -311,7 +311,13 @@ where
         &self,
         bytes: Vec<u8>,
     ) -> Result<serde_json::Value, HostExportError<impl ExportError>> {
-        serde_json::from_reader(&*bytes).map_err(HostExportError)
+        serde_json::from_reader(&*bytes).map_err(|e| {
+            HostExportError(format!(
+                "Failed to parse byte array to JSON. error: {error}, bytes: `{bytes:?}`",
+                error = e,
+                bytes = bytes,
+            ))
+        })
     }
 
     pub(crate) fn ipfs_cat(


### PR DESCRIPTION
The hosted function exports `bytes_to_string()` and `json_from_bytes()` have been updated to return helpful error messages.  Since these parsing functions are called from  a subgraph mapping, context on the `graph-ts` function used can be essential for efficient debugging. 

Related to the `graph-ts` issue to [make toHex() more discoverable](https://github.com/graphprotocol/graph-ts/issues/41). 

