### PR TITLE
Make `first` optional again (defaulting to 100)

### DIFF
--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -411,13 +411,16 @@ fn collection_arguments_for_named_type(
     let mut skip = input_value(&"skip".to_string(), "", Type::NamedType("Int".to_string()));
     skip.default_value = Some(Value::Int(0.into()));
 
+    let mut first = input_value(
+        &"first".to_string(),
+        "",
+        Type::NonNullType(Box::new(Type::NamedType("Int".to_string()))),
+    );
+    first.default_value = Some(Value::Int(100.into()));
+
     let mut args = vec![
         skip,
-        input_value(
-            &"first".to_string(),
-            "",
-            Type::NonNullType(Box::new(Type::NamedType("Int".to_string()))),
-        ),
+        first,
         input_value(
             &"orderBy".to_string(),
             "",

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -277,7 +277,7 @@ fn can_query_one_to_one_relationship() {
         graphql_parser::parse_query(
             "
             query {
-                musicians(first: 100) {
+                musicians {
                     name
                     mainBand {
                         name


### PR DESCRIPTION
Making it required was a breaking change and should've prepared better.