### PR TITLE
Recursively coerce input objects in GraphQL object coercion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,13 +783,11 @@ name = "graph-core"
 version = "0.5.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.5.0",
  "graph-graphql 0.5.0",
  "graph-mock 0.5.0",
  "graph-runtime-wasm 0.5.0",
- "graph-store-postgres 0.5.0",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -800,6 +798,7 @@ dependencies = [
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "test-store 0.1.0",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -954,6 +953,7 @@ dependencies = [
  "lru_time_cache 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "test-store 0.1.0",
  "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2447,6 +2447,15 @@ dependencies = [
  "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "test-store"
+version = "0.1.0"
+dependencies = [
+ "graph 0.5.0",
+ "graph-store-postgres 0.5.0",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "test-store 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ members = [
     "server/http",
     "server/json-rpc",
     "store/postgres",
+    "store/test-store",
     "graph",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,8 +21,6 @@ serde_yaml = "0.7"
 ipfs-api = "0.5.0-alpha2"
 graph-mock = { path = "../mock" }
 walkdir = "2.2.5"
-diesel = { version = "1.3.2", features = ["postgres", "serde_json", "numeric", "r2d2"] }
-graph-store-postgres = { path = "../store/postgres" }
-lazy_static = "1.2.0"
+test-store = { path = "../store/test-store" }
 hex = "0.3.2"
 graphql-parser = "0.2.1"

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -1,55 +1,8 @@
 // Tests for graphql interfaces.
 
-extern crate diesel;
-extern crate graph;
-extern crate graph_core;
-#[macro_use]
-extern crate lazy_static;
-extern crate graph_graphql;
-extern crate graph_store_postgres;
-extern crate graphql_parser;
-extern crate hex;
-
-use crate::tokio::runtime::Runtime;
-
-use graph::prelude::{Store as StoreTrait, *};
-use graph::web3::types::H256;
+use graph::prelude::*;
 use graph_graphql::prelude::{execute_query, QueryExecutionOptions, StoreResolver};
-use graph_store_postgres::{Store, StoreConfig};
-
-/// Helper function to ensure and obtain the Postgres URL to use for testing.
-fn postgres_test_url() -> String {
-    std::env::var_os("THEGRAPH_STORE_POSTGRES_DIESEL_URL")
-        .expect("The THEGRAPH_STORE_POSTGRES_DIESEL_URL environment variable is not set")
-        .into_string()
-        .unwrap()
-}
-
-lazy_static! {
-    // Create Store instance once for use with each of the tests
-    static ref STORE: Arc<Store> = {
-            let mut runtime = Runtime::new().unwrap();
-            let store = runtime.block_on(future::lazy(|| -> Result<_, ()> {
-                let logger = Logger::root(slog::Discard, o!());
-                let postgres_url = postgres_test_url();
-                let net_identifiers = EthereumNetworkIdentifier {
-                    net_version: "graph test suite".to_owned(),
-                    genesis_block_hash: H256::from("0xbd34884280958002c51d3f7b5f853e6febeba33de0f40d15b0363006533c924f"),
-                };
-                let network_name = "fake_network".to_owned();
-
-                Ok(Arc::new(Store::new(
-                    StoreConfig {
-                        postgres_url,
-                        network_name,
-                    },
-                    &logger,
-                    net_identifiers,
-                )))
-                })).unwrap();
-            store
-    };
-}
+use test_store::*;
 
 // `entities` is `(entity, type)`.
 fn insert_and_query(

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -25,7 +25,6 @@ pub enum QueryExecutionError {
     InvalidArgumentError(Pos, String, q::Value),
     MissingArgumentError(Pos, String),
     InvalidVariableTypeError(Pos, String),
-    InvalidVariableError(Pos, String, q::Value),
     MissingVariableError(Pos, String),
     ResolveEntityError(SubgraphDeploymentId, String, String, String),
     ResolveEntitiesError(String),
@@ -96,9 +95,6 @@ impl fmt::Display for QueryExecutionError {
             }
             InvalidVariableTypeError(_, s) => {
                 write!(f, "Variable `{}` must have an input type", s)
-            }
-            InvalidVariableError(_, s, v) => {
-                write!(f, "Invalid value provided for variable `{}`: {:?}", s, v)
             }
             MissingVariableError(_, s) => {
                 write!(f, "No value provided for required variable `{}`", s)
@@ -296,7 +292,6 @@ impl Serialize for QueryError {
             | QueryError::ExecutionError(InvalidArgumentError(pos, _, _))
             | QueryError::ExecutionError(MissingArgumentError(pos, _))
             | QueryError::ExecutionError(InvalidVariableTypeError(pos, _))
-            | QueryError::ExecutionError(InvalidVariableError(pos, _, _))
             | QueryError::ExecutionError(MissingVariableError(pos, _)) => {
                 let mut location = HashMap::new();
                 location.insert("line", pos.line);

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -17,3 +17,4 @@ lazy_static = "1.2.0"
 pretty_assertions = "0.5.1"
 graph-mock = { path = "../mock" }
 graph-core = { path = "../core" }
+test-store = { path = "../store/test-store" }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -801,13 +801,7 @@ where
         .flatten()
     {
         let value = qast::get_argument_value(&field.arguments, &argument_def.name).cloned();
-        match coercion::coerce_input_value(
-            field.position.clone(),
-            value,
-            &argument_def,
-            &resolver,
-            &ctx.variable_values,
-        ) {
+        match coercion::coerce_input_value(value, &argument_def, &resolver, &ctx.variable_values) {
             Ok(Some(value)) => {
                 coerced_values.insert(&argument_def.name, value);
             }
@@ -906,7 +900,7 @@ fn coerce_variable_value(
 
     let resolver = |name: &Name| sast::get_named_type(&schema.document, name);
 
-    coerce_value(&value, &variable_def.var_type, &resolver).ok_or_else(|| {
+    coerce_value(&value, &variable_def.var_type, &resolver, &HashMap::new()).ok_or_else(|| {
         vec![QueryExecutionError::InvalidArgumentError(
             variable_def.position,
             variable_def.name.to_owned(),

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -39,8 +39,5 @@ pub mod prelude {
     pub use super::subscription::{execute_subscription, SubscriptionExecutionOptions};
     pub use super::values::{object_value, MaybeCoercible};
 
-    pub use super::graphql_parser::{
-        query::Name,
-        schema::{self, ObjectType},
-    };
+    pub use super::graphql_parser::{query::Name, schema::ObjectType};
 }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -83,13 +83,10 @@ fn build_filter(
     arguments: &HashMap<&q::Name, q::Value>,
 ) -> Result<Option<EntityFilter>, QueryExecutionError> {
     match arguments.get(&"where".to_string()) {
-        Some(value) => match value {
-            q::Value::Object(object) => Ok(object),
-            _ => return Err(QueryExecutionError::InvalidFilterError),
-        },
-        None => return Ok(None),
+        Some(q::Value::Object(object)) => build_filter_from_object(entity, object),
+        None | Some(q::Value::Null) => Ok(None),
+        _ => Err(QueryExecutionError::InvalidFilterError),
     }
-    .and_then(|object| build_filter_from_object(entity, &object))
 }
 
 /// Parses a GraphQL input object into a EntityFilter, if present.

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -79,8 +79,8 @@ where
             // a `bands` or `band` field in a `Musician` type.
             //
             // Our goal here is to identify the ID of the parent entity (e.g. the ID of
-            // a band) and add a `Contains("bands", <id>)` or `Equal("band", <id>)` filter
-            // to the arguments
+            // a band) and add a `Contains("bands", [<id>])` or `Equal("band", <id>)`
+            // filter to the arguments.
 
             let field_name = derived_from_field.name.clone();
 
@@ -103,9 +103,13 @@ where
             // single value type, we either create a `Contains` or `Equal`
             // filter argument
             let filter = match derived_from_field.field_type {
-                s::Type::ListType(_) => EntityFilter::Contains(field_name, parent_id),
+                s::Type::ListType(_) => {
+                    EntityFilter::Contains(field_name, Value::List(vec![parent_id]))
+                }
                 s::Type::NonNullType(ref inner) => match inner.deref() {
-                    s::Type::ListType(_) => EntityFilter::Contains(field_name, parent_id),
+                    s::Type::ListType(_) => {
+                        EntityFilter::Contains(field_name, Value::List(vec![parent_id]))
+                    }
                     _ => EntityFilter::Equal(field_name, parent_id),
                 },
                 _ => EntityFilter::Equal(field_name, parent_id),

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -110,7 +110,7 @@ where
 
     let fields = grouped_field_set.get_index(0).unwrap();
     let field = fields.1[0];
-    let argument_values = coerce_argument_values(ctx.clone(), subscription_type, field)?;
+    let argument_values = coerce_argument_values(&ctx, subscription_type, field)?;
 
     resolve_field_stream(ctx, subscription_type, field, argument_values)
 }

--- a/graphql/src/values/coercion.rs
+++ b/graphql/src/values/coercion.rs
@@ -174,12 +174,9 @@ pub(crate) fn coerce_value<'a>(
 #[cfg(test)]
 mod tests {
     use graphql_parser::query::Value;
-    use graphql_parser::schema::{
-        EnumType, EnumValue, InputObjectType, ScalarType, TypeDefinition,
-    };
+    use graphql_parser::schema::{EnumType, EnumValue, ScalarType, TypeDefinition};
     use graphql_parser::Pos;
-    use std::collections::{BTreeMap, HashMap};
-    use std::iter::FromIterator;
+    use std::collections::HashMap;
 
     use super::coerce_to_definition;
 

--- a/graphql/src/values/coercion.rs
+++ b/graphql/src/values/coercion.rs
@@ -524,44 +524,6 @@ mod tests {
         );
     }
 
-    /* #[test]
-    fn coercion_using_input_object_type_definitions_is_correct() {
-        let input_object_type =
-            TypeDefinition::InputObject(InputObjectType::new("InputObject".to_owned()));
-        let resolver = |_: &String| Some(&input_object_type);
-
-        // We can coerce from Value::Object -> TypeDefinition::InputObject
-        let example_object = BTreeMap::from_iter(
-            vec![
-                ("Foo".to_string(), Value::Boolean(false)),
-                ("Bar".to_string(), Value::Float(15.2)),
-            ]
-            .into_iter(),
-        );
-        assert_eq!(
-            Value::Object(example_object.clone()).coerce(&input_object_type),
-            Some(Value::Object(example_object))
-        );
-
-        // We don't support going from Value::String -> TypeDefinition::InputObject
-        assert_eq!(
-            Value::String("foo".to_string()).coerce(&input_object_type),
-            None,
-        );
-        assert_eq!(
-            Value::String("bar".to_string()).coerce(&input_object_type),
-            None,
-        );
-
-        // We don't support going from Value::Boolean -> TypeDefinition::InputObject
-        assert_eq!(Value::Boolean(true).coerce(&input_object_type), None,);
-        assert_eq!(Value::Boolean(false).coerce(&input_object_type), None,);
-
-        // We don't spport going from Value::Float -> TypeDefinition::InputObject
-        assert_eq!(Value::Float(23.7).coerce(&input_object_type), None,);
-        assert_eq!(Value::Float(-5.879).coerce(&input_object_type), None,);
-    }*/
-
     #[test]
     fn coerce_big_int_scalar() {
         let big_int_type = TypeDefinition::Scalar(ScalarType::new("BigInt".to_string()));

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1,20 +1,25 @@
-extern crate failure;
-extern crate futures;
-extern crate graphql_parser;
 #[macro_use]
 extern crate pretty_assertions;
-extern crate graph;
-extern crate graph_core;
-extern crate graph_graphql;
 
 use graph::prelude::*;
 use graph_graphql::prelude::*;
 use graphql_parser::query as q;
+use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::time::Instant;
+use test_store::STORE;
 
-fn test_schema() -> Schema {
-    let mut schema = Schema::parse(
+lazy_static! {
+    static ref TEST_SUBGRAPH_ID: SubgraphDeploymentId = {
+        // Also populate the store when the ID is first accessed.
+        let id = SubgraphDeploymentId::new("graphqlTestsQuery").unwrap();
+        insert_test_entities(&**STORE, id.clone());
+        id
+    };
+}
+
+fn test_schema(id: SubgraphDeploymentId) -> Schema {
+    Schema::parse(
         "
             type Musician @entity {
                 id: ID!
@@ -36,212 +41,120 @@ fn test_schema() -> Schema {
                 writtenBy: Musician!
             }
             ",
-        SubgraphDeploymentId::new("testschema").unwrap(),
+        id,
     )
-    .expect("Test schema invalid");
+    .expect("Test schema invalid")
+}
 
-    schema.document =
-        api_schema(&schema.document).expect("Failed to derive API schema from test schema");
+fn api_test_schema() -> Schema {
+    let mut schema = test_schema(TEST_SUBGRAPH_ID.clone());
+    schema.document = api_schema(&schema.document).expect("Failed to derive API schema");
     schema
 }
 
-#[derive(Clone)]
-struct TestStore {
-    entities: Vec<Entity>,
-}
+fn insert_test_entities(store: &impl Store, id: SubgraphDeploymentId) {
+    // First insert the manifest.
+    let manifest = SubgraphManifest {
+        id: id.clone(),
+        location: String::new(),
+        spec_version: "1".to_owned(),
+        description: None,
+        repository: None,
+        schema: test_schema(id.clone()),
+        data_sources: vec![],
+    };
 
-impl TestStore {
-    pub fn new() -> Self {
-        TestStore {
-            entities: vec![
-                Entity::from(vec![
-                    ("__typename", Value::from("Musician")),
-                    ("id", Value::from("m1")),
-                    ("name", Value::from("John")),
-                    ("mainBand", Value::from("b1")),
-                    (
-                        "bands",
-                        Value::List(vec![Value::from("b1"), Value::from("b2")]),
-                    ),
-                ]),
-                Entity::from(vec![
-                    ("__typename", Value::from("Musician")),
-                    ("id", Value::from("m2")),
-                    ("name", Value::from("Lisa")),
-                    ("mainBand", Value::from("b1")),
-                    ("bands", Value::List(vec![Value::from("b1")])),
-                ]),
-                Entity::from(vec![
-                    ("__typename", Value::from("Musician")),
-                    ("id", Value::from("m3")),
-                    ("name", Value::from("Tom")),
-                    ("mainBand", Value::from("b2")),
-                    (
-                        "bands",
-                        Value::List(vec![Value::from("b1"), Value::from("b2")]),
-                    ),
-                ]),
-                Entity::from(vec![
-                    ("__typename", Value::from("Musician")),
-                    ("id", Value::from("m4")),
-                    ("name", Value::from("Valerie")),
-                    ("bands", Value::List(vec![])),
-                    ("writtenSongs", Value::List(vec![Value::from("s2")])),
-                ]),
-                Entity::from(vec![
-                    ("__typename", Value::from("Band")),
-                    ("id", Value::from("b1")),
-                    ("name", Value::from("The Musicians")),
-                ]),
-                Entity::from(vec![
-                    ("__typename", Value::from("Band")),
-                    ("id", Value::from("b2")),
-                    ("name", Value::from("The Amateurs")),
-                ]),
-                Entity::from(vec![
-                    ("__typename", Value::from("Song")),
-                    ("id", Value::from("s1")),
-                    ("title", Value::from("Cheesy Tune")),
-                    ("writtenBy", Value::from("m1")),
-                ]),
-                Entity::from(vec![
-                    ("__typename", Value::from("Song")),
-                    ("id", Value::from("s2")),
-                    ("title", Value::from("Rock Tune")),
-                    ("writtenBy", Value::from("m2")),
-                ]),
-                Entity::from(vec![
-                    ("__typename", Value::from("Song")),
-                    ("id", Value::from("s3")),
-                    ("title", Value::from("Pop Tune")),
-                    ("writtenBy", Value::from("m1")),
-                ]),
-                Entity::from(vec![
-                    ("__typename", Value::from("Song")),
-                    ("id", Value::from("s4")),
-                    ("title", Value::from("Folk Tune")),
-                    ("writtenBy", Value::from("m3")),
-                ]),
-            ],
-        }
-    }
-}
+    store
+        .apply_entity_operations(
+            SubgraphDeploymentEntity::new(&manifest, false, false, Default::default(), 1)
+                .create_operations_replace(&id),
+            EventSource::None,
+        )
+        .unwrap();
 
-impl Store for TestStore {
-    fn block_ptr(&self, _: SubgraphDeploymentId) -> Result<EthereumBlockPointer, Error> {
-        unimplemented!()
-    }
+    let entities = vec![
+        Entity::from(vec![
+            ("__typename", Value::from("Musician")),
+            ("id", Value::from("m1")),
+            ("name", Value::from("John")),
+            ("mainBand", Value::from("b1")),
+            (
+                "bands",
+                Value::List(vec![Value::from("b1"), Value::from("b2")]),
+            ),
+        ]),
+        Entity::from(vec![
+            ("__typename", Value::from("Musician")),
+            ("id", Value::from("m2")),
+            ("name", Value::from("Lisa")),
+            ("mainBand", Value::from("b1")),
+            ("bands", Value::List(vec![Value::from("b1")])),
+        ]),
+        Entity::from(vec![
+            ("__typename", Value::from("Musician")),
+            ("id", Value::from("m3")),
+            ("name", Value::from("Tom")),
+            ("mainBand", Value::from("b2")),
+            (
+                "bands",
+                Value::List(vec![Value::from("b1"), Value::from("b2")]),
+            ),
+        ]),
+        Entity::from(vec![
+            ("__typename", Value::from("Musician")),
+            ("id", Value::from("m4")),
+            ("name", Value::from("Valerie")),
+            ("bands", Value::List(vec![])),
+            ("writtenSongs", Value::List(vec![Value::from("s2")])),
+        ]),
+        Entity::from(vec![
+            ("__typename", Value::from("Band")),
+            ("id", Value::from("b1")),
+            ("name", Value::from("The Musicians")),
+        ]),
+        Entity::from(vec![
+            ("__typename", Value::from("Band")),
+            ("id", Value::from("b2")),
+            ("name", Value::from("The Amateurs")),
+        ]),
+        Entity::from(vec![
+            ("__typename", Value::from("Song")),
+            ("id", Value::from("s1")),
+            ("title", Value::from("Cheesy Tune")),
+            ("writtenBy", Value::from("m1")),
+        ]),
+        Entity::from(vec![
+            ("__typename", Value::from("Song")),
+            ("id", Value::from("s2")),
+            ("title", Value::from("Rock Tune")),
+            ("writtenBy", Value::from("m2")),
+        ]),
+        Entity::from(vec![
+            ("__typename", Value::from("Song")),
+            ("id", Value::from("s3")),
+            ("title", Value::from("Pop Tune")),
+            ("writtenBy", Value::from("m1")),
+        ]),
+        Entity::from(vec![
+            ("__typename", Value::from("Song")),
+            ("id", Value::from("s4")),
+            ("title", Value::from("Folk Tune")),
+            ("writtenBy", Value::from("m3")),
+        ]),
+    ];
 
-    fn set_block_ptr_with_no_changes(
-        &self,
-        _: SubgraphDeploymentId,
-        _: EthereumBlockPointer,
-        _: EthereumBlockPointer,
-    ) -> Result<(), StoreError> {
-        unimplemented!()
-    }
+    let insert_ops = entities.into_iter().map(|data| EntityOperation::Set {
+        key: EntityKey {
+            subgraph_id: id.clone(),
+            entity_type: data["__typename"].clone().as_string().unwrap(),
+            entity_id: data["id"].clone().as_string().unwrap(),
+        },
+        data,
+    });
 
-    fn apply_entity_operations(
-        &self,
-        _: Vec<EntityOperation>,
-        _: EventSource,
-    ) -> Result<(), StoreError> {
-        unimplemented!()
-    }
-
-    fn build_entity_attribute_indexes(
-        &self,
-        _: Vec<AttributeIndexDefinition>,
-    ) -> Result<(), SubgraphAssignmentProviderError> {
-        unimplemented!()
-    }
-
-    fn transact_block_operations(
-        &self,
-        _: SubgraphDeploymentId,
-        _: EthereumBlockPointer,
-        _: EthereumBlockPointer,
-        _: Vec<EntityOperation>,
-    ) -> Result<(), StoreError> {
-        unimplemented!()
-    }
-
-    fn revert_block_operations(
-        &self,
-        _: SubgraphDeploymentId,
-        _: EthereumBlockPointer,
-        _: EthereumBlockPointer,
-    ) -> Result<(), StoreError> {
-        unimplemented!()
-    }
-
-    fn subscribe(&self, _: Vec<SubgraphEntityPair>) -> StoreEventStreamBox {
-        unimplemented!()
-    }
-
-    fn count_entities(&self, _: SubgraphDeploymentId) -> Result<u64, Error> {
-        Ok(1)
-    }
-
-    fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError> {
-        self.entities
-            .iter()
-            .find(|entity| {
-                entity.get("id") == Some(&Value::String(key.entity_id.clone()))
-                    && entity.get("__typename") == Some(&Value::String(key.entity_type.clone()))
-            })
-            .map_or(
-                Err(QueryExecutionError::ResolveEntitiesError(String::from(
-                    "Mock get query error",
-                ))),
-                |entity| Ok(Some(entity.clone())),
-            )
-    }
-
-    fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
-        let entity_name = Value::String(query.entity_types[0].clone());
-
-        let entities = self
-            .entities
-            .iter()
-            .filter(|entity| entity.get("__typename") == Some(&entity_name))
-            // We're only supporting the following filters here to to test
-            // the filters generated for reference fields and @derivedFrom fields:
-            //
-            // - And(Contains(...))
-            // - And(Equal(...))
-            // - And(Or([Equal(...), ...]))
-            .filter(|entity| {
-                query
-                    .filter
-                    .as_ref()
-                    .and_then(|filter| match filter {
-                        EntityFilter::And(filters) => filters.get(0),
-                        _ => None,
-                    })
-                    .map(|filter| match filter {
-                        EntityFilter::Equal(k, v) => entity.get(k) == Some(&v),
-                        EntityFilter::Contains(k, v) => match entity.get(k) {
-                            Some(Value::List(values)) => values.contains(v),
-                            _ => false,
-                        },
-                        EntityFilter::Or(filters) => filters.iter().any(|filter| match filter {
-                            EntityFilter::Equal(k, v) => entity.get(k) == Some(&v),
-                            _ => unimplemented!(),
-                        }),
-                        _ => unimplemented!(),
-                    })
-                    .unwrap_or(true)
-            })
-            .map(|entity| entity.clone())
-            .collect();
-
-        Ok(entities)
-    }
-
-    fn find_one(&self, query: EntityQuery) -> Result<Option<Entity>, QueryExecutionError> {
-        Ok(self.find(query)?.pop())
-    }
+    store
+        .apply_entity_operations(insert_ops.collect(), EventSource::None)
+        .unwrap();
 }
 
 fn execute_query_document(query: q::Document) -> QueryResult {
@@ -253,14 +166,13 @@ fn execute_query_document_with_variables(
     variables: Option<QueryVariables>,
 ) -> QueryResult {
     let query = Query {
-        schema: Arc::new(test_schema()),
+        schema: Arc::new(api_test_schema()),
         document: query,
         variables,
     };
 
     let logger = Logger::root(slog::Discard, o!());
-    let store = Arc::new(TestStore::new());
-    let store_resolver = StoreResolver::new(&logger, store);
+    let store_resolver = StoreResolver::new(&logger, STORE.clone());
 
     let options = QueryExecutionOptions {
         logger: logger,
@@ -277,7 +189,7 @@ fn can_query_one_to_one_relationship() {
         graphql_parser::parse_query(
             "
             query {
-                musicians {
+                musicians(first: 100) {
                     name
                     mainBand {
                         name
@@ -695,13 +607,12 @@ fn include_directive_works_with_query_variables() {
 #[test]
 fn instant_timeout() {
     let query = Query {
-        schema: Arc::new(test_schema()),
+        schema: Arc::new(api_test_schema()),
         document: graphql_parser::parse_query("query { musicians(first: 100) { name } }").unwrap(),
         variables: None,
     };
     let logger = Logger::root(slog::Discard, o!());
-    let store = Arc::new(TestStore::new());
-    let store_resolver = StoreResolver::new(&logger, store);
+    let store_resolver = StoreResolver::new(&logger, STORE.clone());
 
     let options = QueryExecutionOptions {
         logger: logger,
@@ -713,6 +624,56 @@ fn instant_timeout() {
         QueryError::ExecutionError(QueryExecutionError::Timeout) => (), // Expected
         _ => panic!("did not time out"),
     };
+}
+
+#[test]
+fn variable_defaults() {
+    let query = graphql_parser::parse_query(
+        "
+        query musicians($orderDir: OrderDirection = desc) {
+          bands(first: 2, orderBy: id, orderDirection: $orderDir) {
+            id
+          }
+        }
+    ",
+    )
+    .expect("invalid test query");
+
+    // Assert that missing variables are defaulted.
+    let result =
+        execute_query_document_with_variables(query.clone(), Some(QueryVariables::default()));
+
+    assert!(result.errors.is_none());
+    assert_eq!(
+        result.data,
+        Some(object_value(vec![(
+            "bands",
+            q::Value::List(vec![
+                object_value(vec![("id", q::Value::String(String::from("b2")))]),
+                object_value(vec![("id", q::Value::String(String::from("b1")))])
+            ],)
+        )]))
+    );
+
+    // Assert that null variables are not defaulted.
+    let result = execute_query_document_with_variables(
+        query,
+        Some(QueryVariables::new(HashMap::from_iter(
+            vec![(String::from("orderDir"), q::Value::Null)].into_iter(),
+        ))),
+    );
+
+    assert!(result.errors.is_none());
+    assert_eq!(
+        result.data,
+        Some(object_value(vec![(
+            "bands",
+            q::Value::List(vec![
+                object_value(vec![("id", q::Value::String(String::from("b1")))]),
+                object_value(vec![("id", q::Value::String(String::from("b2")))])
+            ],)
+        )]))
+    );
 }
 
 #[test]

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -107,7 +107,7 @@ fn test_valid_module(
     ValidModule::new(
         &logger,
         WasmiModuleConfig {
-            subgraph_id: SubgraphDeploymentId::new("testsubgraph").unwrap(),
+            subgraph_id: SubgraphDeploymentId::new("wasmModuleTest").unwrap(),
             data_source,
             ethereum_adapter: mock_ethereum_adapter,
             link_resolver: Arc::new(ipfs_api::IpfsClient::default()),

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "graph-store-postgres"
 version = "0.5.0"
+edition = "2018"
 
 [dependencies]
 bigdecimal = "0.0.14"
@@ -17,5 +18,6 @@ serde = "1.0"
 uuid = { version = "0.7.2", features = ["v4"] }
 
 [dev-dependencies]
+test-store = { path = "../test-store" }
 lazy_static = "1.1"
 hex = "0.3.2"

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -28,7 +28,7 @@ use crate::functions::{
     attempt_chain_head_update, build_attribute_index, lookup_ancestor_block, revert_block,
     set_config,
 };
-use crate::jsonb::PgJsonbExpressionMethods;
+use crate::jsonb::PgJsonbExpressionMethods as _;
 use crate::store_events::{get_revert_event, StoreEventListener};
 
 embed_migrations!("./migrations");
@@ -463,7 +463,7 @@ impl Store {
         data: Entity,
         event_source: EventSource,
     ) -> Result<(), StoreError> {
-        use db_schema::entities;
+        use crate::db_schema::entities;
 
         self.check_interface_entity_uniqueness(conn, &key)?;
 
@@ -530,7 +530,7 @@ impl Store {
         guard: Option<EntityFilter>,
         event_source: EventSource,
     ) -> Result<(), StoreError> {
-        use db_schema::entities;
+        use crate::db_schema::entities;
 
         self.check_interface_entity_uniqueness(conn, &key)?;
 

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "test-store"
+version = "0.1.0"
+authors = ["Leonardo Yvens <leoyvens@gmail.com>"]
+edition = "2018"
+description = "Provides static store instance for tests."
+
+[dependencies]
+graph = { path = "../../graph" }
+graph-store-postgres = { path = "../postgres" }
+lazy_static = "1.1"

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -1,0 +1,54 @@
+use crate::tokio::runtime::Runtime;
+#[allow(unused_imports)]
+use graph::prelude::{Store as _, *};
+use graph::util::log;
+use graph::web3::types::H256;
+use graph_store_postgres::{Store, StoreConfig};
+use lazy_static::lazy_static;
+use std::env;
+use std::sync::Mutex;
+
+pub fn postgres_test_url() -> String {
+    std::env::var_os("THEGRAPH_STORE_POSTGRES_DIESEL_URL")
+        .expect("The THEGRAPH_STORE_POSTGRES_DIESEL_URL environment variable is not set")
+        .into_string()
+        .unwrap()
+}
+
+lazy_static! {
+    pub static ref LOGGER:Logger = match env::var_os("GRAPH_LOG") {
+        Some(_) => log::logger(false),
+        None => Logger::root(slog::Discard, o!()),
+    };
+
+    // Use this for tests that need subscriptions from `STORE`.
+    pub static ref STORE_RUNTIME: Mutex<Runtime> = Mutex::new(Runtime::new().unwrap());
+
+    // Create Store instance once for use with each of the tests.
+    pub static ref STORE: Arc<Store> = {
+        STORE_RUNTIME.lock().unwrap().block_on(future::lazy(|| -> Result<_, ()> {
+            // Set up Store
+            let logger = &*LOGGER;
+            let postgres_url = postgres_test_url();
+            let net_identifiers = EthereumNetworkIdentifier {
+                net_version: "graph test suite".to_owned(),
+                genesis_block_hash: GENESIS_PTR.hash,
+            };
+            let network_name = "fake_network".to_owned();
+
+            Ok(Arc::new(Store::new(
+                StoreConfig {
+                    postgres_url,
+                    network_name,
+                },
+                &logger,
+                net_identifiers,
+            )))
+        })).expect("could not create Diesel Store instance for test suite")
+    };
+
+    pub static ref GENESIS_PTR: EthereumBlockPointer = (
+        H256::from("0xbd34884280958002c51d3f7b5f853e6febeba33de0f40d15b0363006533c924f"),
+        0u64
+    ).into();
+}


### PR DESCRIPTION
Fixes #789. That was affecting any variables in `where` because we were not coercing values nested in input objects. The adjusted coercion algorithm departs a bit from what's in the spec, but there are a few reasons for this, such as the spec assuming validation, which we don't have, and also the spec does not have pseudocode for coercing input objects.

This also introduces the `test-store` crate, which provides a static store that can be reused across test in different crates. Tests that had their own static stores were refactored to use it, and the query tests now use instead of the mock store. Testing the real store uncovered a bug with `derivedFrom` which is also fixed.