### PR TITLE
Resolve entityCount only if queried for

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -8,6 +8,7 @@ use serde::de;
 use serde::ser;
 use serde_yaml;
 use std::fmt;
+use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::prelude::*;
@@ -57,6 +58,14 @@ impl SubgraphDeploymentId {
         Link {
             link: format!("/ipfs/{}", self),
         }
+    }
+}
+
+impl Deref for SubgraphDeploymentId {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -427,11 +427,15 @@ where
         s::TypeDefinition::Scalar(t) => match object_value {
             Some(q::Value::Object(o)) => {
                 if ctx.introspecting {
-                    Ok(ctx
-                        .introspection_resolver
-                        .resolve_scalar_value(t, o.get(&field.name)))
+                    ctx.introspection_resolver.resolve_scalar_value(
+                        o,
+                        &field.name,
+                        t,
+                        o.get(&field.name),
+                    )
                 } else {
-                    Ok(ctx.resolver.resolve_scalar_value(t, o.get(&field.name)))
+                    ctx.resolver
+                        .resolve_scalar_value(o, &field.name, t, o.get(&field.name))
                 }
             }
             _ => Ok(q::Value::Null),

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -345,9 +345,14 @@ where
             argument_values,
         ),
 
-        s::Type::NamedType(ref name) => {
-            resolve_field_value_for_named_type(ctx, object_value, field, name, argument_values)
-        }
+        s::Type::NamedType(ref name) => resolve_field_value_for_named_type(
+            ctx,
+            object_type,
+            object_value,
+            field,
+            name,
+            argument_values,
+        ),
 
         s::Type::ListType(inner_type) => resolve_field_value_for_list_type(
             ctx,
@@ -364,6 +369,7 @@ where
 /// Resolves the value of a field that corresponds to a named type.
 fn resolve_field_value_for_named_type<'a, R1, R2>(
     ctx: ExecutionContext<'a, R1, R2>,
+    object_type: &s::ObjectType,
     object_value: &Option<q::Value>,
     field: &q::Field,
     type_name: &s::Name,
@@ -428,14 +434,20 @@ where
             Some(q::Value::Object(o)) => {
                 if ctx.introspecting {
                     ctx.introspection_resolver.resolve_scalar_value(
+                        object_type,
                         o,
                         &field.name,
                         t,
                         o.get(&field.name),
                     )
                 } else {
-                    ctx.resolver
-                        .resolve_scalar_value(o, &field.name, t, o.get(&field.name))
+                    ctx.resolver.resolve_scalar_value(
+                        object_type,
+                        o,
+                        &field.name,
+                        t,
+                        o.get(&field.name),
+                    )
                 }
             }
             _ => Ok(q::Value::Null),

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -418,11 +418,11 @@ where
         s::TypeDefinition::Enum(t) => match object_value {
             Some(q::Value::Object(o)) => {
                 if ctx.introspecting {
-                    Ok(ctx
-                        .introspection_resolver
-                        .resolve_enum_value(t, o.get(&field.name)))
+                    ctx.introspection_resolver
+                        .resolve_enum_value(field, t, o.get(&field.name))
                 } else {
-                    Ok(ctx.resolver.resolve_enum_value(t, o.get(&field.name)))
+                    ctx.resolver
+                        .resolve_enum_value(field, t, o.get(&field.name))
                 }
             }
             _ => Ok(q::Value::Null),
@@ -436,18 +436,13 @@ where
                     ctx.introspection_resolver.resolve_scalar_value(
                         object_type,
                         o,
-                        &field.name,
+                        field,
                         t,
                         o.get(&field.name),
                     )
                 } else {
-                    ctx.resolver.resolve_scalar_value(
-                        object_type,
-                        o,
-                        &field.name,
-                        t,
-                        o.get(&field.name),
-                    )
+                    ctx.resolver
+                        .resolve_scalar_value(object_type, o, field, t, o.get(&field.name))
                 }
             }
             _ => Ok(q::Value::Null),
@@ -477,12 +472,7 @@ where
 
         s::TypeDefinition::InputObject(_) => unreachable!("input objects are never resolved"),
     }
-    .map_err(|e| {
-        vec![
-            e,
-            QueryExecutionError::NamedTypeError(type_name.to_string()),
-        ]
-    })
+    .map_err(|e| vec![e])
 }
 
 /// Resolves the value of a field that corresponds to a list type.
@@ -550,11 +540,14 @@ where
                 s::TypeDefinition::Enum(t) => match object_value {
                     Some(q::Value::Object(o)) => {
                         if ctx.introspecting {
-                            Ok(ctx
-                                .introspection_resolver
-                                .resolve_enum_values(&t, o.get(&field.name)))
+                            ctx.introspection_resolver.resolve_enum_values(
+                                field,
+                                &t,
+                                o.get(&field.name),
+                            )
                         } else {
-                            Ok(ctx.resolver.resolve_enum_values(&t, o.get(&field.name)))
+                            ctx.resolver
+                                .resolve_enum_values(field, &t, o.get(&field.name))
                         }
                     }
                     _ => Ok(q::Value::Null),
@@ -565,11 +558,14 @@ where
                 s::TypeDefinition::Scalar(t) => match object_value {
                     Some(q::Value::Object(o)) => {
                         if ctx.introspecting {
-                            Ok(ctx
-                                .introspection_resolver
-                                .resolve_scalar_values(&t, o.get(&field.name)))
+                            ctx.introspection_resolver.resolve_scalar_values(
+                                field,
+                                &t,
+                                o.get(&field.name),
+                            )
                         } else {
-                            Ok(ctx.resolver.resolve_scalar_values(&t, o.get(&field.name)))
+                            ctx.resolver
+                                .resolve_scalar_values(field, &t, o.get(&field.name))
                         }
                     }
                     _ => Ok(q::Value::Null),

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -79,6 +79,7 @@ pub trait Resolver: Clone + Send + Sync {
     /// Resolves a scalar value for a given scalar type.
     fn resolve_scalar_value(
         &self,
+        _parent_object_type: &s::ObjectType,
         _parent: &BTreeMap<String, q::Value>,
         _field: &q::Name,
         scalar_type: &s::ScalarType,

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -79,12 +79,14 @@ pub trait Resolver: Clone + Send + Sync {
     /// Resolves a scalar value for a given scalar type.
     fn resolve_scalar_value(
         &self,
+        _parent: &BTreeMap<String, q::Value>,
+        _field: &q::Name,
         scalar_type: &s::ScalarType,
         value: Option<&q::Value>,
-    ) -> q::Value {
-        value
+    ) -> Result<q::Value, QueryExecutionError> {
+        Ok(value
             .and_then(|value| value.coerce(scalar_type))
-            .unwrap_or(q::Value::Null)
+            .unwrap_or(q::Value::Null))
     }
 
     /// Resolves a list of enum values for a given enum type.

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -385,7 +385,9 @@ fn input_value(
             input_value
                 .default_value
                 .as_ref()
-                .map_or(q::Value::Null, |value| value.clone()),
+                .map_or(q::Value::Null, |value| {
+                    q::Value::String(format!("{}", value))
+                }),
         ),
     ])
 }

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -200,11 +200,14 @@ where
     /// Resolves a scalar value for a given scalar type.
     fn resolve_scalar_value(
         &self,
+        parent_object_type: &s::ObjectType,
         parent: &BTreeMap<String, q::Value>,
         field: &q::Name,
         scalar_type: &s::ScalarType,
         value: Option<&q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
+        let subgraph_id = parse_subgraph_id(parent_object_type).unwrap();
+
         // Extract __typename from the parent object
         let typename = parent
             .get("__typename")
@@ -214,9 +217,13 @@ where
             })
             .expect("GraphQL object must have `__typename`");
 
-        match (typename.as_str(), field.as_str()) {
+        match (
+            subgraph_id.deref().as_str(),
+            typename.as_str(),
+            field.as_str(),
+        ) {
             // Compute `entityCount` on-demand
-            ("SubgraphDeployment", "entityCount") => {
+            ("subgraphs", "SubgraphDeployment", "entityCount") => {
                 // Extract the entity ID
                 let id = parent
                     .get("id")

--- a/graphql/src/values/coercion.rs
+++ b/graphql/src/values/coercion.rs
@@ -12,6 +12,7 @@ pub trait MaybeCoercible<T> {
 impl MaybeCoercible<EnumType> for Value {
     fn coerce(&self, using_type: &EnumType) -> Option<Value> {
         match self {
+            Value::Null => Some(Value::Null),
             Value::String(name) => using_type
                 .values
                 .iter()
@@ -30,6 +31,7 @@ impl MaybeCoercible<EnumType> for Value {
 impl MaybeCoercible<ScalarType> for Value {
     fn coerce(&self, using_type: &ScalarType) -> Option<Value> {
         match (using_type.name.as_str(), self) {
+            (_, v @ Value::Null) => Some(v.clone()),
             ("Boolean", v @ Value::Boolean(_)) => Some(v.clone()),
             ("Float", v @ Value::Float(_)) => Some(v.clone()),
             ("Int", Value::Int(num)) => {

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -449,7 +449,7 @@ fn expected_mock_schema_introspection() -> q::Value {
             q::Value::List(vec![object_value(vec![
                 ("name", q::Value::String("language".to_string())),
                 ("description", q::Value::Null),
-                ("defaultValue", q::Value::String("English".to_string())),
+                ("defaultValue", q::Value::String("\"English\"".to_string())),
                 (
                     "type",
                     object_value(vec![


### PR DESCRIPTION
<s>This comes with a small limitation: We only check the entity type name
to be `SubgraphDeployment` now, rather than also checking the ID of the
subgraph this entity originates from. We should improve this.</s>

This now limits the lazy `entityCount` "resolver" to the subgraph of subgraphs.