### PR TITLE
Implement @derivedFrom for non-list fields

### DIFF
--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -147,7 +147,7 @@ fn one_interface_multiple_entities() {
         "Furniture",
     );
 
-    let query = "query { leggeds(first: 100) { legs } }";
+    let query = "query { leggeds(first: 100, orderBy: legs) { legs } }";
 
     let res = insert_and_query(subgraph_id, schema, vec![animal, furniture], query).unwrap();
     assert!(res.errors.is_none());

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -170,7 +170,7 @@ impl fmt::Display for QueryExecutionError {
             }
             AmbiguousDerivedFromResult(_, field, target_type, target_field) => {
                 write!(f, "Ambiguous result for derived field `{}`: \
-                           More than one `{}` entity has the same `{}` value",
+                           Multiple `{}` entities refer back via `{}`",
                        field, target_type, target_field)
             }
             Unimplemented(feature) => {

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -46,6 +46,7 @@ pub enum QueryExecutionError {
     StoreError(failure::Error),
     Timeout,
     EmptySelectionSet(String),
+    AmbiguousDerivedFromResult(Pos, String, String, String),
     Unimplemented(String),
     EnumCoercionError(Pos, String, q::Value, String, Vec<String>),
     ScalarCoercionError(Pos, String, q::Value, String),
@@ -166,6 +167,11 @@ impl fmt::Display for QueryExecutionError {
             Timeout => write!(f, "Query timed out"),
             EmptySelectionSet(entity_type) => {
                 write!(f, "Selection set for type `{}` is empty", entity_type)
+            }
+            AmbiguousDerivedFromResult(_, field, target_type, target_field) => {
+                write!(f, "Ambiguous result for derived field `{}`: \
+                           More than one `{}` entity has the same `{}` value",
+                       field, target_type, target_field)
             }
             Unimplemented(feature) => {
                 write!(f, "Feature `{}` is not yet implemented", feature)
@@ -301,6 +307,7 @@ impl Serialize for QueryError {
             | QueryError::ExecutionError(MissingArgumentError(pos, _))
             | QueryError::ExecutionError(InvalidVariableTypeError(pos, _))
             | QueryError::ExecutionError(MissingVariableError(pos, _))
+            | QueryError::ExecutionError(AmbiguousDerivedFromResult(pos, _, _, _))
             | QueryError::ExecutionError(EnumCoercionError(pos, _, _, _, _))
             | QueryError::ExecutionError(ScalarCoercionError(pos, _, _, _)) => {
                 let mut location = HashMap::new();

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -350,6 +350,7 @@ where
             object_type,
             object_value,
             field,
+            field_definition,
             name,
             argument_values,
         ),
@@ -372,6 +373,7 @@ fn resolve_field_value_for_named_type<'a, R1, R2>(
     object_type: &s::ObjectType,
     object_value: &Option<q::Value>,
     field: &q::Field,
+    field_definition: &s::Field,
     type_name: &s::Name,
     argument_values: &HashMap<&q::Name, q::Value>,
 ) -> Result<q::Value, Vec<QueryExecutionError>>
@@ -398,6 +400,7 @@ where
                 ctx.introspection_resolver.resolve_object(
                     object_value,
                     &field.name,
+                    field_definition,
                     t.into(),
                     argument_values,
                     &BTreeMap::new(), // The introspection schema has no interfaces.
@@ -406,6 +409,7 @@ where
                 ctx.resolver.resolve_object(
                     object_value,
                     &field.name,
+                    field_definition,
                     t.into(),
                     argument_values,
                     ctx.schema.types_for_interface(),
@@ -453,6 +457,7 @@ where
                 ctx.introspection_resolver.resolve_object(
                     object_value,
                     &field.name,
+                    field_definition,
                     i.into(),
                     argument_values,
                     &BTreeMap::new(), // The introspection schema has no interfaces.
@@ -461,6 +466,7 @@ where
                 ctx.resolver.resolve_object(
                     object_value,
                     &field.name,
+                    field_definition,
                     i.into(),
                     argument_values,
                     ctx.schema.types_for_interface(),

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -399,7 +399,7 @@ where
             if ctx.introspecting {
                 ctx.introspection_resolver.resolve_object(
                     object_value,
-                    &field.name,
+                    field,
                     field_definition,
                     t.into(),
                     argument_values,
@@ -408,7 +408,7 @@ where
             } else {
                 ctx.resolver.resolve_object(
                     object_value,
-                    &field.name,
+                    field,
                     field_definition,
                     t.into(),
                     argument_values,
@@ -456,7 +456,7 @@ where
             if ctx.introspecting {
                 ctx.introspection_resolver.resolve_object(
                     object_value,
-                    &field.name,
+                    field,
                     field_definition,
                     i.into(),
                     argument_values,
@@ -465,7 +465,7 @@ where
             } else {
                 ctx.resolver.resolve_object(
                     object_value,
-                    &field.name,
+                    field,
                     field_definition,
                     i.into(),
                     argument_values,

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -63,7 +63,7 @@ pub trait Resolver: Clone + Send + Sync {
     fn resolve_object(
         &self,
         parent: &Option<q::Value>,
-        field: &q::Name,
+        field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -64,6 +64,7 @@ pub trait Resolver: Clone + Send + Sync {
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
+        field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -497,6 +497,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
+        _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         _: &BTreeMap<Name, Vec<ObjectType>>,

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -496,13 +496,13 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
     fn resolve_object(
         &self,
         parent: &Option<q::Value>,
-        field: &q::Name,
+        field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         _: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError> {
-        let object = match field.as_str() {
+        let object = match field.name.as_str() {
             "__schema" => self.schema_object(),
             "__type" => {
                 let name = arguments.get(&String::from("name")).ok_or_else(|| {
@@ -525,7 +525,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
                     _ => Some(value.clone()),
                 })
                 .unwrap_or(q::Value::Null),
-            _ => object_field(parent, field.as_str())
+            _ => object_field(parent, field.name.as_str())
                 .cloned()
                 .unwrap_or(q::Value::Null),
         };

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -300,6 +300,7 @@ where
         &self,
         parent: &Option<q::Value>,
         field: &q::Name,
+        _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -8,7 +8,6 @@ use graph::components::store::*;
 use graph::prelude::*;
 
 use crate::prelude::*;
-use crate::query::ast as qast;
 use crate::schema::ast as sast;
 use crate::store::query::{collect_entities_from_query_field, parse_subgraph_id};
 
@@ -41,15 +40,6 @@ where
         }
     }
 
-    /// If the field has a `@derivedFrom(field: "foo")` directive, obtain the
-    /// name of the field (e.g. `"foo"`)
-    fn get_derived_from_directive(field_definition: &s::Field) -> Option<&s::Directive> {
-        field_definition
-            .directives
-            .iter()
-            .find(|directive| directive.name == s::Name::from("derivedFrom"))
-    }
-
     /// Adds a filter for matching entities that correspond to a derived field.
     ///
     /// Returns true if the field is a derived field (i.e., if it is defined with
@@ -57,77 +47,58 @@ where
     fn add_filter_for_derived_field(
         query: &mut EntityQuery,
         parent: &Option<q::Value>,
-        field_definition: &s::Field,
-        object_type: ObjectOrInterface,
-    ) -> bool {
-        let derived_from_field = Self::get_derived_from_directive(field_definition)
-            .and_then(|directive| {
-                qast::get_argument_value(&directive.arguments, &q::Name::from("field"))
-            })
+        derived_from_field: &s::Field,
+    ) {
+        // This field is derived from a field in the object type that we're trying
+        // to resolve values for; e.g. a `bandMembers` field maybe be derived from
+        // a `bands` or `band` field in a `Musician` type.
+        //
+        // Our goal here is to identify the ID of the parent entity (e.g. the ID of
+        // a band) and add a `Contains("bands", [<id>])` or `Equal("band", <id>)`
+        // filter to the arguments.
+
+        let field_name = derived_from_field.name.clone();
+
+        // To achieve this, we first identify the parent ID
+        let parent_id = parent
+            .as_ref()
             .and_then(|value| match value {
-                q::Value::String(s) => Some(s),
+                q::Value::Object(o) => Some(o),
                 _ => None,
             })
-            .and_then(|derived_from_field_name| {
-                sast::get_field_type(object_type, derived_from_field_name)
-            });
+            .and_then(|object| object.get(&q::Name::from("id")))
+            .and_then(|value| match value {
+                q::Value::String(s) => Some(Value::from(s)),
+                _ => None,
+            })
+            .expect("Parent object is missing an \"id\"")
+            .clone();
 
-        if let Some(derived_from_field) = derived_from_field {
-            // This field is derived from a field in the object type that we're trying
-            // to resolve values for; e.g. a `bandMembers` field maybe be derived from
-            // a `bands` or `band` field in a `Musician` type.
-            //
-            // Our goal here is to identify the ID of the parent entity (e.g. the ID of
-            // a band) and add a `Contains("bands", [<id>])` or `Equal("band", <id>)`
-            // filter to the arguments.
-
-            let field_name = derived_from_field.name.clone();
-
-            // To achieve this, we first identify the parent ID
-            let parent_id = parent
-                .as_ref()
-                .and_then(|value| match value {
-                    q::Value::Object(o) => Some(o),
-                    _ => None,
-                })
-                .and_then(|object| object.get(&q::Name::from("id")))
-                .and_then(|value| match value {
-                    q::Value::String(s) => Some(Value::from(s)),
-                    _ => None,
-                })
-                .expect("Parent object is missing an \"id\"")
-                .clone();
-
-            // Depending on whether the field we're deriving from has a list or a
-            // single value type, we either create a `Contains` or `Equal`
-            // filter argument
-            let filter = match derived_from_field.field_type {
+        // Depending on whether the field we're deriving from has a list or a
+        // single value type, we either create a `Contains` or `Equal`
+        // filter argument
+        let filter = match derived_from_field.field_type {
+            s::Type::ListType(_) => {
+                EntityFilter::Contains(field_name, Value::List(vec![parent_id]))
+            }
+            s::Type::NonNullType(ref inner) => match inner.deref() {
                 s::Type::ListType(_) => {
                     EntityFilter::Contains(field_name, Value::List(vec![parent_id]))
                 }
-                s::Type::NonNullType(ref inner) => match inner.deref() {
-                    s::Type::ListType(_) => {
-                        EntityFilter::Contains(field_name, Value::List(vec![parent_id]))
-                    }
-                    _ => EntityFilter::Equal(field_name, parent_id),
-                },
                 _ => EntityFilter::Equal(field_name, parent_id),
-            };
+            },
+            _ => EntityFilter::Equal(field_name, parent_id),
+        };
 
-            // Add the `Contains`/`Equal` filter to the top-level `And` filter, creating one
-            // if necessary
-            let top_level_filter = query.filter.get_or_insert(EntityFilter::And(vec![]));
-            match top_level_filter {
-                EntityFilter::And(ref mut filters) => {
-                    filters.push(filter);
-                }
-                _ => unreachable!("top level filter is always `And`"),
-            };
-
-            true
-        } else {
-            false
-        }
+        // Add the `Contains`/`Equal` filter to the top-level `And` filter, creating one
+        // if necessary
+        let top_level_filter = query.filter.get_or_insert(EntityFilter::And(vec![]));
+        match top_level_filter {
+            EntityFilter::And(ref mut filters) => {
+                filters.push(filter);
+            }
+            _ => unreachable!("top level filter is always `And`"),
+        };
     }
 
     /// Adds a filter for matching entities that are referenced by the given field.
@@ -271,8 +242,11 @@ where
         let mut query = build_query(object_type, arguments, types_for_interface)?;
 
         // Add matching filter for derived fields
-        let is_derived =
-            Self::add_filter_for_derived_field(&mut query, parent, field_definition, object_type);
+        let derived_from_field = sast::get_derived_from_field(object_type, field_definition);
+        let is_derived = derived_from_field.is_some();
+        if let Some(derived_from_field) = derived_from_field {
+            Self::add_filter_for_derived_field(&mut query, parent, derived_from_field);
+        }
 
         // Return an empty list if we're dealing with a non-derived field that
         // holds an empty list of references; there's no point in querying the store
@@ -330,16 +304,33 @@ where
                 }
             }
         } else {
-            match parent {
-                Some(q::Value::Object(parent_object)) => match parent_object.get(field) {
-                    Some(q::Value::String(id)) => self.store.get(EntityKey {
-                        subgraph_id,
-                        entity_type: object_type.name().to_owned(),
-                        entity_id: id.to_owned(),
-                    })?,
-                    _ => None,
-                },
-                _ => panic!("top level queries must either take an `id` or return a list"),
+            // Identify whether the field is derived with @derivedFrom
+            let derived_from_field = sast::get_derived_from_field(object_type, field_definition);
+            if let Some(derived_from_field) = derived_from_field {
+                // The field is derived -> build a query for the entity that might be
+                // referencing the parent object
+                let mut arguments = arguments.clone();
+                let first_arg_name = q::Name::from("first");
+                let skip_arg_name = q::Name::from("skip");
+                arguments.insert(&first_arg_name, q::Value::Int(q::Number::from(1)));
+                arguments.insert(&skip_arg_name, q::Value::Int(q::Number::from(0)));
+                let mut query = build_query(object_type, &arguments, types_for_interface)?;
+                Self::add_filter_for_derived_field(&mut query, parent, derived_from_field);
+
+                // Find the entity that references the parent entity, if there is one
+                self.store.find(query)?.into_iter().next()
+            } else {
+                match parent {
+                    Some(q::Value::Object(parent_object)) => match parent_object.get(field) {
+                        Some(q::Value::String(id)) => self.store.get(EntityKey {
+                            subgraph_id,
+                            entity_type: object_type.name().to_owned(),
+                            entity_id: id.to_owned(),
+                        })?,
+                        _ => None,
+                    },
+                    _ => panic!("top level queries must either take an `id` or return a list"),
+                }
             }
         };
 

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -31,7 +31,7 @@ impl Resolver for MockResolver {
     fn resolve_object(
         &self,
         _parent: &Option<q::Value>,
-        _field: &q::Name,
+        _field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -32,6 +32,7 @@ impl Resolver for MockResolver {
         &self,
         _parent: &Option<q::Value>,
         _field: &q::Name,
+        _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,


### PR DESCRIPTION
This allows to define types like
```graphql
type Domain @entity {
  id: ID!
  ...
}

type DomainAuction @entity {
  id: ID!
  domain: Domain @derivedFrom(field: "id")
  ...
}
```
and resolve them in queries by virtue of the two sides sharing the same ID.