### PR TITLE
Use entities.id rather than entities.data->'id'->>'data' in queries

### DIFF
--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -627,7 +627,11 @@ pub fn attribute_index_definitions(
     for (entity_number, schema_type) in document.definitions.clone().into_iter().enumerate() {
         if let Definition::TypeDefinition(definition) = schema_type {
             if let TypeDefinition::Object(schema_object) = definition {
-                for (attribute_number, entity_field) in schema_object.fields.into_iter().enumerate()
+                for (attribute_number, entity_field) in schema_object
+                    .fields
+                    .into_iter()
+                    .filter(|f| f.name != "id")
+                    .enumerate()
                 {
                     indexing_ops.push(AttributeIndexDefinition {
                         subgraph_id: subgraph_id.clone(),

--- a/store/postgres/migrations/2019-03-28-004319_drop_entities_id_indexes/down.sql
+++ b/store/postgres/migrations/2019-03-28-004319_drop_entities_id_indexes/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/store/postgres/migrations/2019-03-28-004319_drop_entities_id_indexes/up.sql
+++ b/store/postgres/migrations/2019-03-28-004319_drop_entities_id_indexes/up.sql
@@ -1,0 +1,26 @@
+-- Remove indexes on entities for data->'id'->>'data'
+create or replace function remove_entities_id_indexes()
+    returns void as
+$$
+declare
+    index_to_drop record;
+    counter int := 0;
+begin
+    for index_to_drop in
+        select
+          indexname as name
+        from pg_indexes
+       where tablename = 'entities'
+         and indexname like 'qm%'
+         and indexdef like '%ON public.entities USING btree ((((data -> ''id''::text) ->> ''data''::text))) WHERE%'
+    loop
+        execute 'drop index ' || index_to_drop.name;
+        counter := counter + 1;
+    end loop;
+    raise notice 'Successfully dropped % indexes', counter;
+end;
+$$ language plpgsql;
+
+select remove_entities_id_indexes();
+
+drop function remove_entities_id_indexes();

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -28,13 +28,16 @@ trait IntoFilter {
 
 impl IntoFilter for String {
     fn into_filter(self, attribute: String, op: &str) -> FilterExpression {
-        Box::new(
-            sql("data -> ")
-                .bind::<Text, _>(attribute)
-                .sql("->> 'data'")
-                .sql(op)
-                .bind::<Text, _>(self),
-        ) as FilterExpression
+        Box::new(match &*attribute {
+            "id" => Box::new(sql("id").sql(op).bind::<Text, _>(self)) as FilterExpression,
+            _ => Box::new(
+                sql("data -> ")
+                    .bind::<Text, _>(attribute)
+                    .sql("->> 'data'")
+                    .sql(op)
+                    .bind::<Text, _>(self),
+            ) as FilterExpression,
+        })
     }
 }
 


### PR DESCRIPTION
This PR makes sure we do not query `entities.id` via the `data` column, and instead always use `entities.id`. That allows us to get rid of ~ 260 attribute indexes in production, which the migration in this PR does.