### PR TITLE
Fix subscriptions by ensuring API schema types have a @subgraphId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,7 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.5.0",
  "graph-graphql 0.5.0",
+ "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru_time_cache 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -18,6 +18,7 @@ serde = "1.0"
 uuid = { version = "0.7.2", features = ["v4"] }
 
 [dev-dependencies]
+graphql-parser = "0.2.0"
 test-store = { path = "../test-store" }
 lazy_static = "1.1"
 hex = "0.3.2"

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1029,8 +1029,15 @@ impl SubgraphDeploymentStore for Store {
                 }
             }
         };
+
+        // Parse the schema and add @subgraphId directives
         let mut schema = Schema::parse(&raw_schema, subgraph_id.clone())?;
+
+        // Generate an API schema for the subgraph and make sure all types in the
+        // API schema have a @subgraphId directive as well
         schema.document = api_schema(&schema.document)?;
+        schema.add_subgraph_id_directives(subgraph_id.clone());
+
         let schema = Arc::new(schema);
 
         // Insert the schema into the cache.


### PR DESCRIPTION
Fixes #843.

Turns out that the API schema types were lacking a `@subgraphId` directive and that caused subscriptions to fail to link the `Subscription` type to a subgraph ID. This PR fixes that by ensuring that the Postgres store's `subgraph_schema()` method adds missing `@subgraphId` directives after creating an API schema for the subgraph.

Test steps:

1. Start a local Graph node.
2. Open the browser and open the network tab in the developer tools.
3. In the browser, go to `http://localhost:8000/subgraphs/graphql`
3. Submit `subscriptions { subgraphs { id } }` via GraphiQL
4. Check the WebSocket connection with the Graph node for a
   ```
   {"id":"1","type":"start","payload":{"query":"subscription {\n  subgraphs {\n    id\n  }\n}","variables":null}}
   ```
   message. Previously, you'd see an error message there instead.