### PR TITLE
Log query times and use a query-specific logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,7 @@ dependencies = [
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-store 0.1.0",
+ "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -12,6 +12,7 @@ indexmap = "1.0"
 Inflector = "0.11.3"
 serde = "1.0"
 lazy_static = "1.2.0"
+uuid = { version = "0.7.2", features = ["v4"] }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -31,7 +31,10 @@ where
     R: Resolver,
 {
     let query_id = Uuid::new_v4().to_string();
-    let query_logger = options.logger.new(o!("query_id" => query_id));
+    let query_logger = options.logger.new(o!(
+        "subgraph_id" => (*query.schema.id).clone(),
+        "query_id" => query_id
+    ));
     let start_time = Instant::now();
 
     info!(


### PR DESCRIPTION
This logs queries and the time it takes to execute them:
```
component: GraphQlRunner
 query_id: 9cec8008-3cdf-474e-960b-92a167d8aea6
  Mar 29 17:25:24.448 INFO Execute query, query: { subgraphs { id name currentVersion { id createdAt deployment { id failed synced entityCount latestEthereumBlockNumber totalEthereumBlocksCount manifest { repository description schema dataSources(first: 100) { network } } } } pendingVersion { id createdAt deployment { id failed synced entityCount latestEthereumBlockNumber totalEthereumBlocksCount manifest { repository description schema dataSources(first: 100) { network } } } } } }
  Mar 29 17:25:24.477 DEBG Finished query, time: 29ms
```

Each query gets its own `query_id` so the logs inside the query are grouped.