### PR TITLE
Make contract addresses in data sources optional

### DIFF
--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -118,9 +118,15 @@ where
 
         // Collect all contract addresses; if we have a data source without a contract
         // address, we can't add addresses to the filter because it would only match
-        // the contracts for which we _have_ addresses; therefor if we have a data source
+        // the contracts for which we _have_ addresses; therefore if we have a data source
         // without a contract address, we perform a broader logs scan and filter out
-        // irrelevant events ourselves
+        // irrelevant events ourselves.
+        //
+        // Our own filtering is performed later when the events are passed to
+        // subgraphs and runtime hosts for processing:
+        // - At the top level in `SubgraphInstanceManager::start_subgraph`
+        // - At the subgraph level in `SubgraphInstance::matches_log`
+        // - At the data source level in `RuntimeHost::matches_log`
         let addresses = if log_filter
             .contract_address_and_event_sig_pairs
             .iter()

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -112,13 +112,19 @@ impl EthereumLogFilter {
         // First topic should be event sig
         match log.topics.first() {
             None => false,
-            Some(sig) => {
-                self.contract_address_and_event_sig_pairs
-                    .contains(&(Some(log.address), *sig))
-                    || self
-                        .contract_address_and_event_sig_pairs
-                        .contains(&(None, *sig))
-            }
+            Some(sig) => self
+                .contract_address_and_event_sig_pairs
+                .iter()
+                .any(|pair| match pair {
+                    // The `Log` matches the filter either if the filter contains
+                    // a (contract address, event signature) pair that matches the
+                    // `Log`...
+                    (Some(addr), s) => addr == &log.address && s == sig,
+
+                    // ...or if the filter contains a pair with no contract address
+                    // but an event signature that matches the event
+                    (None, s) => s == sig,
+                }),
         }
     }
 }

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -95,7 +95,7 @@ impl From<Error> for EthereumAdapterError {
 
 #[derive(Clone, Debug)]
 pub struct EthereumLogFilter {
-    pub contract_address_and_event_sig_pairs: HashSet<(Address, H256)>,
+    pub contract_address_and_event_sig_pairs: HashSet<(Option<Address>, H256)>,
 }
 
 impl EthereumLogFilter {
@@ -112,17 +112,21 @@ impl EthereumLogFilter {
         // First topic should be event sig
         match log.topics.first() {
             None => false,
-            Some(sig) => self
-                .contract_address_and_event_sig_pairs
-                .contains(&(log.address, *sig)),
+            Some(sig) => {
+                self.contract_address_and_event_sig_pairs
+                    .contains(&(Some(log.address), *sig))
+                    || self
+                        .contract_address_and_event_sig_pairs
+                        .contains(&(None, *sig))
+            }
         }
     }
 }
 
-impl FromIterator<(Address, H256)> for EthereumLogFilter {
+impl FromIterator<(Option<Address>, H256)> for EthereumLogFilter {
     fn from_iter<I>(iter: I) -> Self
     where
-        I: IntoIterator<Item = (Address, H256)>,
+        I: IntoIterator<Item = (Option<Address>, H256)>,
     {
         EthereumLogFilter {
             contract_address_and_event_sig_pairs: iter.into_iter().collect(),

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -23,7 +23,7 @@ use crate::data::schema::Schema;
 pub mod schema;
 
 /// Deserialize an Address (with or without '0x' prefix).
-fn deserialize_address<'de, D>(deserializer: D) -> Result<Address, D::Error>
+fn deserialize_address<'de, D>(deserializer: D) -> Result<Option<Address>, D::Error>
 where
     D: de::Deserializer<'de>,
 {
@@ -31,7 +31,9 @@ where
 
     let s: String = de::Deserialize::deserialize(deserializer)?;
     let address = s.trim_start_matches("0x");
-    Address::from_str(address).map_err(D::Error::custom)
+    Address::from_str(address)
+        .map_err(D::Error::custom)
+        .map(|addr| Some(addr))
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -324,8 +326,8 @@ impl SchemaData {
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Deserialize)]
 pub struct Source {
-    #[serde(deserialize_with = "deserialize_address")]
-    pub address: Address,
+    #[serde(default, deserialize_with = "deserialize_address")]
+    pub address: Option<Address>,
     pub abi: String,
 }
 

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -429,7 +429,7 @@ impl<'a> From<&'a super::DataSource> for EthereumContractDataSourceEntity {
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 struct EthereumContractSourceEntity {
-    address: super::Address,
+    address: Option<super::Address>,
     abi: String,
 }
 

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -245,8 +245,12 @@ impl RuntimeHost {
     }
 
     fn matches_log_address(&self, log: &Log) -> bool {
-        self.data_source_contract.address.is_none()
-            || self.data_source_contract.address.unwrap() == log.address
+        // The runtime host matches the contract address of the `Log`
+        // if the data source contains the same contract address or
+        // if the data source doesn't have a contract address at all
+        self.data_source_contract
+            .address
+            .map_or(true, |addr| addr == log.address)
     }
 
     fn matches_log_signature(&self, log: &Log) -> bool {

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -245,7 +245,8 @@ impl RuntimeHost {
     }
 
     fn matches_log_address(&self, log: &Log) -> bool {
-        self.data_source_contract.address == log.address
+        self.data_source_contract.address.is_none()
+            || self.data_source_contract.address.unwrap() == log.address
     }
 
     fn matches_log_signature(&self, log: &Log) -> bool {

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -126,7 +126,7 @@ fn mock_data_source(path: &str) -> DataSource {
         name: String::from("example data source"),
         network: Some(String::from("mainnet")),
         source: Source {
-            address: Address::from_str("0123123123012312312301231231230123123123").unwrap(),
+            address: Some(Address::from_str("0123123123012312312301231231230123123123").unwrap()),
             abi: String::from("123123"),
         },
         mapping: Mapping {


### PR DESCRIPTION
Resolves #616 (together with https://github.com/graphprotocol/graph-cli/pull/240).

To not leave out data sources without contract addresses in our `eth_getLogs` requests, we need to exclude contract addresses from the logs filter if there is even a single data source without an address. That makes the scan broader and thus less efficient but doesn't break our processing. We still have `matches_log_address()` checks in place to direct events to the right data sources and filter out false positives from the bloom filter.

