### PR TITLE
Change GraphQL query execution to decide whether introspection is needed upfront

### DIFF
--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -27,6 +27,18 @@ pub struct Schema {
 }
 
 impl Schema {
+    /// Create a new schema. The document must already have been
+    /// validated. This function is only useful for creating an introspection
+    /// schema, and should not be used otherwise
+    pub fn new(id: SubgraphDeploymentId, document: schema::Document) -> Self {
+        Schema {
+            id,
+            document,
+            interfaces_for_type: BTreeMap::new(),
+            types_for_interface: BTreeMap::new(),
+        }
+    }
+
     pub fn parse(raw: &str, id: SubgraphDeploymentId) -> Result<Self, Error> {
         let document = graphql_parser::parse_schema(&raw)?;
         validate_schema(&document)?;

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -249,7 +249,7 @@ where
     if data_set.items.is_empty() {
         // Only introspection
         ctx.introspecting = true;
-        execute_selection_set(ctx, &intro_set, query_type, initial_value)
+        execute_selection_set(ctx, &intro_set, introspection_query_type, initial_value)
     } else if intro_set.items.is_empty() {
         // Only data
         ctx.introspecting = false;
@@ -263,7 +263,7 @@ where
         values.extend(execute_selection_set_to_map(
             ctx,
             &intro_set,
-            query_type,
+            introspection_query_type,
             initial_value,
         )?);
         Ok(q::Value::Object(values))
@@ -318,7 +318,7 @@ where
         }
 
         // If the field exists on the object, execute it and add its result to the result map
-        if let Some(ref field) = get_field_type(ctx.clone(), object_type, &fields[0].name) {
+        if let Some(ref field) = sast::get_field_type(object_type, &fields[0].name) {
             // Push the new field onto the context's field stack
             let ctx = ctx.for_field(&fields[0]);
 
@@ -909,25 +909,6 @@ where
     } else {
         Err(errors)
     }
-}
-
-fn get_field_type<'a, R1, R2>(
-    ctx: ExecutionContext<'a, R1, R2>,
-    object_type: &'a s::ObjectType,
-    name: &'a s::Name,
-) -> Option<&'a s::Field>
-where
-    R1: Resolver,
-    R2: Resolver,
-{
-    // Resolve __schema and __Type using the introspection schema
-    let introspection_query_type =
-        sast::get_root_query_type(&ctx.introspection_schema.document).unwrap();
-    if let Some(ty) = sast::get_field_type(introspection_query_type, name) {
-        return Some(ty);
-    }
-
-    sast::get_field_type(object_type, name)
 }
 
 /// Coerces variable values for an operation.

--- a/graphql/src/introspection/schema.rs
+++ b/graphql/src/introspection/schema.rs
@@ -1,5 +1,7 @@
 use graphql_parser;
-use graphql_parser::schema as s;
+
+use graph::data::schema::Schema;
+use graph::data::subgraph::SubgraphDeploymentId;
 
 const INTROSPECTION_SCHEMA: &str = "
 scalar Boolean
@@ -107,6 +109,9 @@ enum __DirectiveLocation {
   INPUT_FIELD_DEFINITION
 }";
 
-pub fn introspection_schema() -> s::Document {
-    graphql_parser::parse_schema(INTROSPECTION_SCHEMA).unwrap()
+pub fn introspection_schema(id: SubgraphDeploymentId) -> Schema {
+    Schema::new(
+        id,
+        graphql_parser::parse_schema(INTROSPECTION_SCHEMA).unwrap(),
+    )
 }

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -57,7 +57,7 @@ where
         };
 
     // Create an introspection type store and resolver
-    let introspection_schema = introspection_schema();
+    let introspection_schema = introspection_schema(query.schema.id.clone());
     let introspection_resolver = IntrospectionResolver::new(&query_logger, &query.schema);
 
     // Create a fresh execution context

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -48,7 +48,7 @@ where
     };
 
     // Create an introspection type store and resolver
-    let introspection_schema = introspection_schema();
+    let introspection_schema = introspection_schema(subscription.query.schema.id.clone());
     let introspection_resolver =
         IntrospectionResolver::new(&options.logger, &subscription.query.schema);
 
@@ -177,7 +177,7 @@ where
     debug!(logger, "Execute subscription event"; "event" => format!("{:?}", event));
 
     // Create an introspection type store and resolver
-    let introspection_schema = introspection_schema();
+    let introspection_schema = introspection_schema(schema.id.clone());
     let introspection_resolver = IntrospectionResolver::new(&logger, &schema);
 
     // Create a fresh execution context with deadline.


### PR DESCRIPTION
With this PR, the decision which fields in a selection set require introspection and which ones require 'normal' data lookup is made based just on the root fields. That simplifies `ExecutionContext` as we can now just pass different contexts into query execution rather than have the context decide when to use an introspection schema and when to use the subgraph schema.