### PR TITLE
Reduce logging volume by removing unnecessary logs

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -532,11 +532,13 @@ where
             return Err(CancelableError::Cancel);
         }
 
-        info!(
-            logger4,
-            "Applying {} entity operation(s)",
-            block_state.entity_operations.len()
-        );
+        if !block_state.entity_operations.is_empty() {
+            info!(
+                logger4,
+                "Applying {} entity operation(s)",
+                block_state.entity_operations.len()
+            );
+        }
 
         // Transact entity operations into the store and update the
         // subgraph's block stream pointer

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -417,11 +417,9 @@ where
         .cloned()
         .collect();
 
-    if logs.len() == 0 {
-        debug!(logger, "No events found in this block for this subgraph");
-    } else if logs.len() == 1 {
+    if logs.len() == 1 {
         info!(logger, "1 event found in this block for this subgraph");
-    } else {
+    } else if logs.len() > 1 {
         info!(
             logger,
             "{} events found in this block for this subgraph",
@@ -478,17 +476,12 @@ where
                 .collect()
         };
 
-        if logs.len() == 0 {
-            debug!(
-                logger,
-                "No events found in this block for the new data sources"
-            );
-        } else if logs.len() == 1 {
+        if logs.len() == 1 {
             info!(
                 logger,
                 "1 event found in this block for the new data sources"
             );
-        } else {
+        } else if logs.len() > 1 {
             info!(
                 logger,
                 "{} events found in this block for the new data sources",
@@ -718,11 +711,13 @@ where
     S: ChainStore + Store,
     T: RuntimeHostBuilder,
 {
-    debug!(
-        logger,
-        "Creating {} dynamic data source(s)",
-        data_sources.len()
-    );
+    if !data_sources.is_empty() {
+        debug!(
+            logger,
+            "Creating {} dynamic data source(s)",
+            data_sources.len()
+        );
+    }
 
     // If there are any new dynamic data sources, we'll have to restart
     // the subgraph after this block

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -216,8 +216,6 @@ where
         let ctx = self.clone();
         let reorg_threshold = ctx.reorg_threshold;
 
-        debug!(ctx.logger, "Identify next step");
-
         // Get pointers from database for comparison
         let head_ptr_opt = ctx.chain_store.chain_head_ptr().unwrap();
         let subgraph_ptr = ctx
@@ -234,12 +232,12 @@ where
 
         let head_ptr = head_ptr_opt.unwrap();
 
-        debug!(
+        trace!(
             ctx.logger, "Chain head pointer";
             "hash" => format!("{:?}", head_ptr.hash),
             "number" => &head_ptr.number
         );
-        debug!(
+        trace!(
             ctx.logger, "Subgraph pointer";
             "hash" => format!("{:?}", subgraph_ptr.hash),
             "number" => &subgraph_ptr.number


### PR DESCRIPTION
A significant portion of the log volume has been taken up by messaging that is not strictly necessary for monitoring progress of the specific subgraph or tracking down errors.  
Many log lines were simply noting inaction such as: "0 events found in this block for this subgraph" or "Creating 0 dynamic data sources".

Removing these logs serves to cut down on the noise, making the logs easier to parse. Also, the overall volume reduction makes it more efficient to send the logs to a storage engine such as Elasticsearch. 