### PR TITLE
Split entities table into one table per subgraph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,6 +1002,7 @@ dependencies = [
 name = "graph-store-postgres"
 version = "0.9.0"
 dependencies = [
+ "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel-dynamic-schema 1.0.0 (git+https://github.com/diesel-rs/diesel-dynamic-schema?rev=a8ec4fb1)",
  "diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel-dynamic-schema"
+version = "1.0.0"
+source = "git+https://github.com/diesel-rs/diesel-dynamic-schema?rev=a8ec4fb1#a8ec4fb11de6242488ba3698d74406f4b5073dc4"
+dependencies = [
+ "diesel 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "diesel_derives"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1003,7 @@ name = "graph-store-postgres"
 version = "0.9.0"
 dependencies = [
  "diesel 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel-dynamic-schema 1.0.0 (git+https://github.com/diesel-rs/diesel-dynamic-schema?rev=a8ec4fb1)",
  "diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3244,6 +3253,7 @@ dependencies = [
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum debugid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "088c9627adec1e494ff9dea77377f1e69893023d631254a0ec68b16ee20be3e9"
 "checksum diesel 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a2469cbcf1dfb9446e491cac4c493c2554133f87f7d041e892ac82e5cd36e863"
+"checksum diesel-dynamic-schema 1.0.0 (git+https://github.com/diesel-rs/diesel-dynamic-schema?rev=a8ec4fb1)" = "<none>"
 "checksum diesel_derives 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62a27666098617d52c487a41f70de23d44a1dc1f3aa5877ceba2790fb1f1cab4"
 "checksum diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3cde8413353dc7f5d72fa8ce0b99a560a359d2c5ef1e5817ca731cd9008f4c"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -446,6 +446,8 @@ pub enum EntityOperation {
     /// need to be changed, not the entire entity. The update will only happen
     /// if the given entity matches `guard` when the update is made. `Update`
     /// provides a way to atomically do a check-and-set change to an entity.
+    /// This operation can currently only be performed on the subgraph of
+    /// subgraphs
     Update {
         key: EntityKey,
         data: Entity,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -559,7 +559,8 @@ impl fmt::Display for EventSource {
 #[derive(Clone, Debug)]
 pub struct AttributeIndexDefinition {
     pub subgraph_id: SubgraphDeploymentId,
-    pub index_name: String,
+    pub entity_number: usize,
+    pub attribute_number: usize,
     pub field_value_type: ValueType,
     pub attribute_name: String,
     pub entity_name: String,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -966,6 +966,16 @@ pub trait Store: Send + Sync + 'static {
             })
             .unwrap_or(Ok(false))
     }
+
+    /// Create a new subgraph deployment. The deployment must not exist yet. `ops`
+    /// needs to contain all the operations on subgraphs and subgraph deployments to
+    /// create the deployment, including any assignments as a current or pending
+    /// version
+    fn create_subgraph_deployment(
+        &self,
+        subgraph_id: &SubgraphDeploymentId,
+        ops: Vec<EntityOperation>,
+    ) -> Result<(), StoreError>;
 }
 
 pub trait SubgraphDeploymentStore: Send + Sync + 'static {

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -8,6 +8,7 @@ use std::error::Error;
 use std::fmt;
 use std::string::FromUtf8Error;
 
+use crate::components::store::StoreError;
 use crate::data::subgraph::*;
 
 /// Error caused while executing a [Query](struct.Query.html).
@@ -216,6 +217,12 @@ impl From<num_bigint::ParseBigIntError> for QueryExecutionError {
 impl From<bigdecimal::ParseBigDecimalError> for QueryExecutionError {
     fn from(e: bigdecimal::ParseBigDecimalError) -> Self {
         QueryExecutionError::ValueParseError("BigDecimal".to_string(), format!("{}", e))
+    }
+}
+
+impl From<StoreError> for QueryExecutionError {
+    fn from(e: StoreError) -> Self {
+        QueryExecutionError::StoreError(e.into())
     }
 }
 

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -963,12 +963,8 @@ pub fn attribute_index_definitions(
                 {
                     indexing_ops.push(AttributeIndexDefinition {
                         subgraph_id: subgraph_id.clone(),
-                        index_name: format!(
-                            "{}_{}_{}_idx",
-                            subgraph_id.clone(),
-                            entity_number,
-                            attribute_number,
-                        ),
+                        entity_number,
+                        attribute_number,
                         field_value_type: match inner_type_name(&entity_field.field_type) {
                             Ok(value_type) => value_type,
                             Err(_) => continue,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -334,6 +334,14 @@ impl Store for MockStore {
     fn count_entities(&self, _: SubgraphDeploymentId) -> Result<u64, Error> {
         unimplemented!();
     }
+
+    fn create_subgraph_deployment(
+        &self,
+        _subgraph_id: &SubgraphDeploymentId,
+        ops: Vec<EntityOperation>,
+    ) -> Result<(), StoreError> {
+        self.apply_entity_operations(ops, EventSource::None)
+    }
 }
 
 impl SubgraphDeploymentStore for MockStore {
@@ -466,6 +474,14 @@ impl Store for FakeStore {
 
     fn count_entities(&self, _: SubgraphDeploymentId) -> Result<u64, Error> {
         unimplemented!();
+    }
+
+    fn create_subgraph_deployment(
+        &self,
+        _subgraph_id: &SubgraphDeploymentId,
+        _ops: Vec<EntityOperation>,
+    ) -> Result<(), StoreError> {
+        unimplemented!()
     }
 }
 

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2018"
 
 [dependencies]
 diesel = { version = "1.3.2", features = ["postgres", "serde_json", "numeric", "r2d2"] }
+# We use diesel-dynamic-schema straight from git as the project has not
+# made a release as a crate yet
+diesel-dynamic-schema = { git = "https://github.com/diesel-rs/diesel-dynamic-schema", rev="a8ec4fb1" }
 diesel_migrations = "1.3.0"
 failure = "0.1.2"
 fallible-iterator = "0.1.4"

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -14,6 +14,7 @@ fallible-iterator = "0.1.4"
 futures = "0.1.21"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
+Inflector = "0.11.3"
 lru_time_cache = "0.8"
 postgres = "0.15.2"
 serde = "1.0"

--- a/store/postgres/migrations/2019-04-19-171709_split_entities/down.sql
+++ b/store/postgres/migrations/2019-04-19-171709_split_entities/down.sql
@@ -1,0 +1,27 @@
+insert into public.entities(subgraph, entity, id, data, event_source)
+select 'subgraphs', entity, id, data, event_source
+from subgraphs.entities;
+
+
+create or replace function drop_schemas() returns void
+language plpgsql
+as $function$
+declare
+  schema_name varchar;
+begin
+  for schema_name in
+  select name from deployment_schemas
+  loop
+    execute 'drop schema ' || schema_name || ' cascade';
+  end loop;
+end
+$function$;
+
+select drop_schemas();
+
+drop table deployment_schemas;
+
+drop function drop_schemas();
+
+drop function if exists subgraph_log_entity_event();
+drop function if exists subgraph_revert_block(varchar, varchar);

--- a/store/postgres/migrations/2019-04-19-171709_split_entities/up.sql
+++ b/store/postgres/migrations/2019-04-19-171709_split_entities/up.sql
@@ -1,0 +1,106 @@
+-- metadata to track the DB schemas we create for subgraph deployments
+
+-- The name of the DB schema corresponding to a deployment
+create table deployment_schemas(
+  id         serial primary key,
+  subgraph   varchar unique not null,
+  name       varchar not null default 'sgd' || currval('deployment_schemas_id_seq')
+);
+
+insert into deployment_schemas(id, subgraph, name)
+  values(0, 'subgraphs', 'subgraphs');
+
+-- Schema for the subgraph of subgraphs
+-- Note that this schema does not have a entity_history table
+-- because we do not collect history for the subgraph of subgraphs
+create schema subgraphs;
+
+create table subgraphs.entities (
+  entity       varchar not null,
+  id           varchar not null,
+  data         jsonb,
+  event_source varchar not null,
+  primary key(entity, id)
+);
+
+insert into subgraphs.entities
+  select entity, id, data, event_source
+  from public.entities
+  where subgraph='subgraphs';
+
+delete from public.entities
+  where subgraph='subgraphs';
+
+--
+-- Log entity history into sgdN.entities (without a subgraph field)
+--
+CREATE OR REPLACE FUNCTION public.subgraph_log_entity_event()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    event_id INTEGER;
+    new_event_id INTEGER;
+    is_reversion BOOLEAN := FALSE;
+    operation_type INTEGER := 10;
+    event_source  VARCHAR;
+    entity VARCHAR;
+    entity_id VARCHAR;
+    data_before JSONB;
+BEGIN
+    -- Get operation type and source
+    IF (TG_OP = 'INSERT') THEN
+        operation_type := 0;
+        event_source := NEW.event_source;
+        entity := NEW.entity;
+        entity_id := NEW.id;
+        data_before := NULL;
+    ELSIF (TG_OP = 'UPDATE') THEN
+        operation_type := 1;
+        event_source := NEW.event_source;
+        entity := OLD.entity;
+        entity_id := OLD.id;
+        data_before := OLD.data;
+    ELSIF (TG_OP = 'DELETE') THEN
+        operation_type := 2;
+        event_source := current_setting('vars.current_event_source', TRUE);
+        entity := OLD.entity;
+        entity_id := OLD.id;
+        data_before := OLD.data;
+    ELSE
+        RAISE EXCEPTION 'unexpected entity row operation type, %', TG_OP;
+    END IF;
+
+    IF event_source = 'REVERSION' THEN
+        is_reversion := TRUE;
+    END IF;
+
+    SELECT id INTO event_id
+    FROM event_meta_data
+    WHERE db_transaction_id = txid_current();
+
+    new_event_id := null;
+
+    IF event_id IS NULL THEN
+        -- Log information on the postgres transaction for later use in
+        -- revert operations
+        INSERT INTO event_meta_data
+            (db_transaction_id, db_transaction_time, source)
+        VALUES
+            (txid_current(), statement_timestamp(), event_source)
+        RETURNING event_meta_data.id INTO new_event_id;
+    END IF;
+
+    -- Log row metadata and changes, specify whether event was an original
+    -- ethereum event or a reversion
+    EXECUTE format('INSERT INTO %I.entity_history
+        (event_id, entity_id, entity,
+         data_before, reversion, op_id)
+      VALUES
+        ($1, $2, $3, $4, $5, $6)', TG_TABLE_SCHEMA)
+    USING COALESCE(new_event_id, event_id), entity_id, entity,
+          data_before, is_reversion, operation_type;
+    RETURN NULL;
+END;
+$function$
+;

--- a/store/postgres/migrations/2019-04-22-190022_remove_unneeded_stored_procs/down.sql
+++ b/store/postgres/migrations/2019-04-22-190022_remove_unneeded_stored_procs/down.sql
@@ -1,0 +1,88 @@
+CREATE OR REPLACE FUNCTION build_attribute_index(subgraph_id text, index_name text, index_type text, index_operator text, jsonb_index boolean, attribute_name text, entity_name text)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    jsonb_operator TEXT := '->>';
+BEGIN
+    IF jsonb_index THEN
+      jsonb_operator := '->';
+    END IF;
+    EXECUTE 'CREATE INDEX ' || index_name
+      || ' ON entities USING '
+      || index_type
+      || '((data -> '
+      || quote_literal(attribute_name)
+      || ' '
+      || jsonb_operator
+      || '''data'')'
+      || index_operator
+      || ') where subgraph='
+      || quote_literal(subgraph_id)
+      || ' and entity='
+      || quote_literal(entity_name);
+  RETURN ;
+EXCEPTION
+  WHEN duplicate_table THEN
+      -- do nothing if index already exists
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.revert_block(block_to_revert_hash character varying, subgraph_id character varying)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+declare
+    history record;
+begin
+    -- Revert all relevant events
+    for history in
+        -- Get all history entries associated with the given block. Note
+        -- that the view imposes the correct order
+    select
+        h.entity,
+        h.entity_id,
+        h.data_before,
+        h.op_id
+    from entity_history_with_source h
+    where h.source = block_to_revert_hash
+      and h.subgraph = subgraph_id
+    loop
+        case
+            -- insert case
+            when history.op_id = 0 then
+                -- Delete inserted row
+            begin
+                perform set_config('vars.current_event_source',
+                                   'REVERSION', false);
+                delete from entities
+                 where subgraph = subgraph_id
+                   and entity = history.entity
+                   and id = history.entity_id;
+                -- Row was already updated
+            exception when no_data_found then
+              -- do nothing, the entity was gone already
+            end;
+            -- update or delete case
+            when history.op_id IN (1,2) then
+                -- Insert deleted row if not exists
+                -- If row exists perform update
+                begin
+                     insert into entities
+                                 (id, subgraph, entity, data, event_source)
+                     values (history.entity_id,
+                             subgraph_id,
+                             history.entity,
+                             history.data_before,
+                             'REVERSION')
+                     on conflict (id, subgraph, entity)
+                     do update
+                           set data = history.data_before,
+                               event_source = 'REVERSION';
+            end;
+        end case;
+    end loop;
+end;
+$function$
+;

--- a/store/postgres/migrations/2019-04-22-190022_remove_unneeded_stored_procs/up.sql
+++ b/store/postgres/migrations/2019-04-22-190022_remove_unneeded_stored_procs/up.sql
@@ -1,0 +1,22 @@
+drop function if exists
+  build_attribute_index(text, text, text, text, boolean, text, text);
+
+drop function if exists
+  revert_block(varchar, varchar);
+
+-- Functions we meant to get rid of earlier, but used the wrong syntax for
+-- PostgreSQL 9.6
+drop function if exists
+  revert_block(varchar, int8, varchar, varchar);
+
+drop function if exists
+  revert_block(varchar[], varchar);
+
+drop function if exists
+  revert_entity_event(integer, integer);
+
+drop function if exists
+  revert_transaction(integer);
+
+drop function if exists
+  revert_transaction(integer[]);

--- a/store/postgres/src/db_schema.rs
+++ b/store/postgres/src/db_schema.rs
@@ -1,14 +1,4 @@
 table! {
-    entities (id, subgraph, entity) {
-        id -> Varchar,
-        subgraph -> Varchar,
-        entity -> Varchar,
-        data -> Jsonb,
-        event_source -> Varchar,
-    }
-}
-
-table! {
     entity_history (id) {
         id -> Integer,
         event_id -> BigInt,

--- a/store/postgres/src/db_schema.rs
+++ b/store/postgres/src/db_schema.rs
@@ -1,27 +1,4 @@
 table! {
-    entity_history (id) {
-        id -> Integer,
-        event_id -> BigInt,
-        entity_id -> Varchar,
-        subgraph -> Varchar,
-        entity -> Varchar,
-        data_before -> Nullable<Jsonb>,
-        data_after -> Nullable<Jsonb>,
-        reversion -> Bool,
-    }
-}
-
-table! {
-    event_meta_data (id) {
-        id -> Integer,
-        db_transaction_id -> BigInt,
-        db_transaction_time -> Timestamp,
-        op_id -> SmallInt,
-        source -> Nullable<Varchar>,
-    }
-}
-
-table! {
     ethereum_networks (name) {
         name -> Varchar,
         head_block_hash -> Nullable<Varchar>,

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -776,3 +776,107 @@ pub(crate) fn table(
 ) -> Result<Table, StoreError> {
     Table::new(conn, subgraph)
 }
+
+pub(crate) fn create_schema(
+    conn: &PgConnection,
+    subgraph_id: &SubgraphDeploymentId,
+) -> Result<(), StoreError> {
+    // Create a schema for the deployment
+    let schemas: Vec<String> = diesel::insert_into(deployment_schemas::table)
+        .values(deployment_schemas::subgraph.eq(subgraph_id.to_string()))
+        .returning(deployment_schemas::name)
+        .get_results(conn)?;
+    let schema_name = schemas
+        .first()
+        .ok_or_else(|| format_err!("failed to read schema name for {} back", subgraph_id))?;
+
+    // Note that we have to use conn.batch_execute to issue DDL commands; using
+    // diesel::sql_query(..).execute(conn) can lead to cases where the command
+    // is sent to the database, and shows up in the database logs, but has no
+    // effect at all, but also does not result in an error.
+    let query = format!("create schema {}", schema_name);
+    conn.batch_execute(&*query)?;
+
+    // The order of columns in the primary key matters a lot, since
+    // we want the pk index to also support queries that do not have an id,
+    // just an entity (like counting the number of entities of a certain type)
+    let query = format!(
+        "create table {}.entities(
+            entity       varchar not null,
+            id           varchar not null,
+            data         jsonb,
+            event_source varchar not null,
+            primary key(entity, id)
+        )",
+        schema_name
+    );
+    conn.batch_execute(&*query)?;
+
+    let query = format!(
+        "create trigger entity_change_insert_trigger
+            after insert on {schema}.entities
+            for each row
+            execute procedure subgraph_log_entity_event()",
+        schema = schema_name
+    );
+    conn.batch_execute(&*query)?;
+
+    let query = format!(
+        "create trigger entity_change_update_trigger
+            after update on {schema}.entities
+            for each row
+            when (old.data != new.data)
+            execute procedure subgraph_log_entity_event()",
+        schema = schema_name
+    );
+    conn.batch_execute(&*query)?;
+
+    let query = format!(
+        "create trigger entity_change_delete_trigger
+            after delete on {schema}.entities
+            for each row
+            execute procedure subgraph_log_entity_event()",
+        schema = schema_name
+    );
+    conn.batch_execute(&*query)?;
+
+    let query = format!(
+        "create table {}.entity_history (
+            id           serial primary key,
+	        event_id     integer references event_meta_data(id)
+                             on update cascade on delete cascade,
+            entity       varchar not null,
+	        entity_id    varchar not null,
+	        data_before  jsonb,
+	        reversion    bool not null default false,
+	        op_id        int2 NOT NULL)",
+        schema_name
+    );
+    conn.batch_execute(&*query)?;
+
+    let query = format!(
+        "create index entity_history_event_id_btree_idx
+            on {}.entity_history(event_id)",
+        schema_name
+    );
+    conn.batch_execute(&*query)?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub(crate) fn drop_schema(
+    conn: &diesel::pg::PgConnection,
+    subgraph: &SubgraphDeploymentId,
+) -> Result<usize, StoreError> {
+    let info = find_schema(conn, subgraph)?;
+    if let Some(schema) = info {
+        let query = format!("drop schema if exists {} cascade", schema.name);
+        conn.batch_execute(&*query)?;
+        Ok(diesel::delete(deployment_schemas::table)
+            .filter(deployment_schemas::subgraph.eq(schema.subgraph))
+            .execute(conn)?)
+    } else {
+        Ok(0)
+    }
+}

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -1,9 +1,13 @@
+use diesel::deserialize::QueryableByName;
 use diesel::dsl::{any, sql};
 use diesel::pg::{Pg, PgConnection};
-use diesel::sql_types::Text;
+use diesel::sql_types::{Jsonb, Nullable, Text};
+use diesel::BoolExpressionMethods;
 use diesel::ExpressionMethods;
 use diesel::{debug_query, insert_into};
 use diesel::{OptionalExtension, QueryDsl, RunQueryDsl};
+use diesel_dynamic_schema::{schema, Column, Table as DynamicTable};
+use graph::data::subgraph::schema::SUBGRAPHS_ID;
 use graph::prelude::{
     format_err, EntityChange, EntityChangeOperation, EntityFilter, EntityKey, Error, EventSource,
     QueryExecutionError, StoreError, StoreEvent, SubgraphDeploymentId, TransactionAbortError,
@@ -11,7 +15,7 @@ use graph::prelude::{
 use graph::serde_json;
 
 use crate::filter::{build_filter, store_filter};
-use crate::functions::{revert_block, set_config};
+use crate::functions::set_config;
 use crate::jsonb::PgJsonbExpressionMethods as _;
 
 /// Marker trait for tables that store entities
@@ -60,19 +64,234 @@ mod public {
 
     joinable!(entity_history -> event_meta_data (event_id));
     allow_tables_to_appear_in_same_query!(entity_history, event_meta_data);
+
+    table! {
+        deployment_schemas(id) {
+            id -> Integer,
+            subgraph -> Text,
+            name -> Text,
+        }
+    }
+}
+
+// The entities table for the subgraph of subgraphs.
+mod subgraphs {
+    table! {
+        subgraphs.entities (entity, id) {
+            entity -> Varchar,
+            id -> Varchar,
+            data -> Jsonb,
+            event_source -> Varchar,
+        }
+    }
 }
 
 impl EntitySource for self::public::entities::table {}
 
-//impl EntitySource for DynamicTable<String> {}
+impl EntitySource for self::subgraphs::entities::table {}
+
+// This is a bit weak, as any DynamicTable<String> is now an EntitySource
+impl EntitySource for DynamicTable<String> {}
+
+/// Support for the management of the schemas and tables we create in
+/// the database for each deployment. The Postgres schemas for each
+/// deployment/subgraph are tracked in the `deployment_schemas` table.
+///
+/// The functions in this module are very low-level and should only be used
+/// directly by the Postgres store, and nowhere else. At the same time, all
+/// manipulation of entities in the database should go through this module
+/// to make it easier to handle future schema changes
+// We use Diesel's dynamic table support for querying the entities and history
+// tables of a subgraph. Unfortunately, this support is not good enough for
+// modifying data, and we fall back to generating literal SQL queries for that.
+// For the `entities` table of the subgraph of subgraphs, we do map the table
+// statically and use it in some cases to bridge the gap between dynamic and
+// static table support, in particular in the update operation for entities.
+// Diesel deeply embeds the assumption that all schema is known at compile time;
+// for example, the column for a dynamic table can not implement
+// `diesel::query_source::Column` since that must carry the column name as a
+// constant. As a consequence, a lot of Diesel functionality is not available
+// for dynamic tables.
+use public::deployment_schemas;
+
+#[derive(Queryable, QueryableByName, Debug)]
+#[table_name = "deployment_schemas"]
+struct Schema {
+    id: i32,
+    subgraph: String,
+    name: String,
+}
+
+type EntityColumn<ST> = Column<DynamicTable<String>, String, ST>;
+
+/// A table representing a split entities table, i.e. a setup where
+/// a subgraph deployment's entity are split into their own schema rather
+/// than residing in the entities table in the `public` database schema
+#[derive(Debug, Clone)]
+pub(crate) struct SplitTable {
+    /// The name of the database schema
+    schema: String,
+    /// The subgraph id
+    subgraph: SubgraphDeploymentId,
+    table: DynamicTable<String>,
+    id: EntityColumn<diesel::sql_types::Text>,
+    entity: EntityColumn<diesel::sql_types::Text>,
+    data: EntityColumn<diesel::sql_types::Jsonb>,
+    event_source: EntityColumn<diesel::sql_types::Text>,
+}
+
+#[derive(Queryable)]
+struct RawHistory {
+    id: i32,
+    entity: String,
+    entity_id: String,
+    data: Option<serde_json::Value>,
+    // The operation that lead to this history record
+    // 0 = INSERT, 1 = UPDATE, 2 = DELETE
+    op: i16,
+}
+
+impl QueryableByName<Pg> for RawHistory {
+    // Extract one RawHistory entry from the database. The names of the columns
+    // must follow exactly the names used in the queries in revert_block
+    fn build<R: diesel::row::NamedRow<Pg>>(row: &R) -> diesel::deserialize::Result<Self> {
+        Ok(RawHistory {
+            id: row.get("id")?,
+            entity: row.get("entity")?,
+            entity_id: row.get("entity_id")?,
+            data: row.get::<Nullable<Jsonb>, _>("data_before")?,
+            op: row.get("op_id")?,
+        })
+    }
+}
 
 pub(crate) enum Table {
     Public(SubgraphDeploymentId),
+    Split(SplitTable),
+}
+
+// Find the database schema for `subgraph`. If no explicit schema exists,
+// return `None`.
+fn find_schema(
+    conn: &diesel::pg::PgConnection,
+    subgraph: &SubgraphDeploymentId,
+) -> Result<Option<Schema>, StoreError> {
+    Ok(deployment_schemas::table
+        .filter(deployment_schemas::subgraph.eq(subgraph.to_string()))
+        .first::<Schema>(conn)
+        .optional()?)
+}
+
+impl SplitTable {
+    // Update for a split entities table, called from Table.update. It's lengthy,
+    // so we split it into its own helper function
+    fn update(
+        &self,
+        conn: &PgConnection,
+        key: &EntityKey,
+        data: &serde_json::Value,
+        guard: Option<EntityFilter>,
+        event_source: EventSource,
+    ) -> Result<usize, StoreError> {
+        if !guard.is_none() && key.subgraph_id != *SUBGRAPHS_ID {
+            // We can only make adding additional conditions to the update
+            // operation work for a query that is fully generated with
+            // Diesel's DSL. Trying to combine the result of build_filter
+            // with a direct query is too cumbersome because of various type
+            // system gyrations. For now, we also only need update guards for
+            // the subgraph of subgraphs
+            panic!("update guards are only possible for the 'subgraphs' subgraph");
+        }
+        if let Some(filter) = guard {
+            // Update for subgraph of subgraphs with a guard
+            use self::subgraphs::entities;
+
+            let filter = build_filter(filter).map_err(|e| {
+                TransactionAbortError::Other(format!(
+                    "invalid filter '{}' for value '{}'",
+                    e.filter, e.value
+                ))
+            })?;
+
+            let target = entities::table
+                .filter(entities::entity.eq(&key.entity_type))
+                .filter(entities::id.eq(&key.entity_id));
+
+            Ok(diesel::update(target)
+                .set((
+                    entities::data.eq(entities::data.merge(&data)),
+                    entities::event_source.eq(event_source.to_string()),
+                ))
+                .filter(filter)
+                .execute(conn)?)
+        } else {
+            // If there is no guard (which has to include all 'normal' subgraphs),
+            // we need to use a direct query since diesel::update does not like
+            // dynamic tables.
+            let query = format!(
+                "UPDATE {}.entities
+                   SET data = data || $3, event_source = $4
+                   WHERE entity = $1 AND id = $2",
+                self.schema
+            );
+            let query = diesel::sql_query(query)
+                .bind::<Text, _>(&key.entity_type)
+                .bind::<Text, _>(&key.entity_id)
+                .bind::<Jsonb, _>(data)
+                .bind::<Text, _>(event_source.to_string());
+            query.execute(conn).map_err(|e| {
+                format_err!(
+                    "Failed to update entity ({}, {}, {}): {}",
+                    key.subgraph_id,
+                    key.entity_type,
+                    key.entity_id,
+                    e
+                )
+                .into()
+            })
+        }
+    }
 }
 
 impl Table {
-    fn new(subgraph: &SubgraphDeploymentId) -> Self {
-        Table::Public(subgraph.clone())
+    /// Look up the schema for `subgraph` and return its entity table.
+    /// If `subgraph` does not have an entry in `deployment_schemas`, we assume
+    /// it has not been migrated yet, and return the `entities` table
+    /// in the `public` schema
+    fn new(conn: &PgConnection, subgraph: &SubgraphDeploymentId) -> Result<Self, StoreError> {
+        let table = match find_schema(conn, subgraph)? {
+            Some(sc) => {
+                let table = schema(sc.name.clone()).table("entities".to_owned());
+                let id = table.column::<Text, _>("id".to_string());
+                let entity = table.column::<Text, _>("entity".to_string());
+                let data = table.column::<Jsonb, _>("data".to_string());
+                let event_source = table.column::<Text, _>("event_source".to_string());
+
+                Table::Split(SplitTable {
+                    schema: sc.name,
+                    subgraph: subgraph.clone(),
+                    table,
+                    id,
+                    entity,
+                    data,
+                    event_source,
+                })
+            }
+            None => Table::Public(subgraph.clone()),
+        };
+        Ok(table)
+    }
+
+    fn entity_key(&self, entity_type: String, entity_id: String) -> EntityKey {
+        let subgraph_id = match self {
+            Table::Public(subgraph) => subgraph.clone(),
+            Table::Split(entities) => entities.subgraph.clone(),
+        };
+        EntityKey {
+            subgraph_id,
+            entity_type,
+            entity_id,
+        }
     }
 
     pub(crate) fn find(
@@ -87,6 +306,15 @@ impl Table {
                 .select(public::entities::data)
                 .first::<serde_json::Value>(conn)
                 .optional()?),
+            Table::Split(entities) => {
+                let entities = entities.clone();
+                Ok(entities
+                    .table
+                    .filter(entities.entity.eq(entity).and(entities.id.eq(id)))
+                    .select(entities.data)
+                    .first::<serde_json::Value>(conn)
+                    .optional()?)
+            }
         }
     }
 
@@ -154,6 +382,54 @@ impl Table {
                         ))
                     })
             }
+            Table::Split(entities) => {
+                let entities = entities.clone();
+
+                let mut query = entities
+                    .table
+                    .filter((&entities.entity).eq(any(entity_types)))
+                    .select((&entities.data, &entities.entity))
+                    .into_boxed::<Pg>();
+
+                if let Some(filter) = filter {
+                    query = store_filter(query, filter).map_err(|e| {
+                        QueryExecutionError::FilterNotSupportedError(
+                            format!("{}", e.value),
+                            e.filter,
+                        )
+                    })?;
+                }
+
+                if let Some((attribute, cast, direction)) = order {
+                    query = query.order(
+                        sql::<Text>("(data ->")
+                            .bind::<Text, _>(attribute)
+                            .sql("->> 'data')")
+                            .sql(cast)
+                            .sql(" ")
+                            .sql(direction)
+                            .sql(" NULLS LAST"),
+                    );
+                }
+
+                if let Some(first) = first {
+                    query = query.limit(first as i64);
+                }
+                if skip > 0 {
+                    query = query.offset(skip as i64);
+                }
+
+                let query_debug_info = debug_query(&query).to_string();
+
+                query
+                    .load::<(serde_json::Value, String)>(conn)
+                    .map_err(|e| {
+                        QueryExecutionError::ResolveEntitiesError(format!(
+                            "{}, query = {:?}",
+                            e, query_debug_info
+                        ))
+                    })
+            }
         }
     }
 
@@ -184,6 +460,21 @@ impl Table {
                     public::entities::event_source.eq(&event_source.to_string()),
                 ))
                 .execute(conn)?),
+            Table::Split(entities) => {
+                let query = format!(
+                    "INSERT into {}.entities(entity, id, data, event_source)
+                                VALUES($1, $2, $3, $4)
+                                ON CONFLICT(entity, id)
+                                DO UPDATE SET data = $3, event_source = $4",
+                    entities.schema
+                );
+                let query = diesel::sql_query(query)
+                    .bind::<Text, _>(&key.entity_type)
+                    .bind::<Text, _>(&key.entity_id)
+                    .bind::<Jsonb, _>(data)
+                    .bind::<Text, _>(event_source.to_string());
+                Ok(query.execute(conn)?)
+            }
         }
     }
 
@@ -220,6 +511,7 @@ impl Table {
                     None => Ok(query.execute(conn)?),
                 }
             }
+            Table::Split(entities) => entities.update(conn, key, data, guard, event_source),
         }
     }
 
@@ -246,6 +538,17 @@ impl Table {
                     .filter(public::entities::id.eq(&key.entity_id)),
             )
             .execute(conn)?),
+            Table::Split(entities) => {
+                let query = format!(
+                    "DELETE FROM {}.entities
+                    WHERE entity = $1 AND id = $2",
+                    entities.schema
+                );
+                let query = diesel::sql_query(query)
+                    .bind::<Text, _>(&key.entity_type)
+                    .bind::<Text, _>(&key.entity_id);
+                Ok(query.execute(conn)?)
+            }
         }
     }
 
@@ -256,6 +559,11 @@ impl Table {
                     .filter(public::entities::subgraph.eq(subgraph.to_string()))
                     .count()
                     .get_result(conn)?;
+                Ok(count as u64)
+            }
+            Table::Split(entities) => {
+                let table = entities.table.clone();
+                let count: i64 = table.count().get_result(conn)?;
                 Ok(count as u64)
             }
         }
@@ -275,6 +583,16 @@ impl Table {
                 .filter(public::entities::id.eq(entity_id))
                 .first(conn)
                 .optional()?),
+            Table::Split(ents) => {
+                let ents = ents.clone();
+                Ok(ents
+                    .table
+                    .select(ents.entity.clone())
+                    .filter(ents.entity.eq(any(entities)))
+                    .filter(ents.id.eq(entity_id))
+                    .first(conn)
+                    .optional()?)
+            }
         }
     }
 
@@ -286,45 +604,91 @@ impl Table {
         conn: &PgConnection,
         block_ptr: String,
     ) -> Result<StoreEvent, StoreError> {
-        match self {
+        let entries: Vec<RawHistory> = match self {
             Table::Public(subgraph) => {
                 use self::public::entity_history::dsl as h;
                 use self::public::event_meta_data as m;
 
-                let entries: Vec<(String, String, i16)> = h::entity_history
+                h::entity_history
                     .inner_join(m::table)
-                    .select((h::entity, h::entity_id, h::op_id))
-                    .filter(h::subgraph.eq(&subgraph.to_string()))
+                    .select((h::id, h::entity, h::entity_id, h::data_before, h::op_id))
+                    .filter(h::subgraph.eq(subgraph.to_string()))
                     .filter(m::source.eq(&block_ptr))
                     .order(h::event_id.desc())
-                    .load(conn)?;
-
-                let mut changes = Vec::with_capacity(entries.len());
-                for (entity_type, entity_id, op) in entries.into_iter() {
-                    let change = EntityChange {
-                        subgraph_id: subgraph.clone(),
-                        entity_type,
-                        entity_id,
-                        operation: match op {
-                            0 => EntityChangeOperation::Removed,
-                            1 | 2 => EntityChangeOperation::Set,
-                            _ => {
-                                return Err(StoreError::Unknown(format_err!(
-                                    "bad operation {}",
-                                    op
-                                )))
-                            }
-                        },
-                    };
-                    changes.push(change);
-                }
-
-                public::entities::table
-                    .select(revert_block(block_ptr, subgraph.to_string()))
-                    .execute(conn)?;
-                Ok(StoreEvent::new(changes))
+                    .load(conn)?
             }
+            Table::Split(entities) => {
+                // We can't use Diesel's JoinOnDsl here because DynamicTable
+                // does not implement AppearsInFromClause, so we have to run
+                // a raw SQL query
+                let query = format!(
+                    "SELECT h.id, h.entity, h.entity_id, h.data_before, h.op_id
+                    FROM {}.entity_history h, event_meta_data m
+                    WHERE m.id = h.event_id
+                      AND m.source = $1
+                    ORDER BY h.event_id desc",
+                    entities.schema
+                );
+
+                let query = diesel::sql_query(query).bind::<Text, _>(&block_ptr);
+
+                query.get_results(conn)?
+            }
+        };
+
+        let subgraph_id = match self {
+            Table::Public(subgraph) => subgraph.clone(),
+            Table::Split(entities) => entities.subgraph.clone(),
+        };
+
+        let mut changes = Vec::with_capacity(entries.len());
+        for history in entries.into_iter() {
+            // Perform the actual reversion
+            let key = self.entity_key(history.entity.clone(), history.entity_id.clone());
+            match history.op {
+                0 => {
+                    // Reverse an insert
+                    self.delete(conn, &key, EventSource::None)?;
+                }
+                1 | 2 => {
+                    // Reverse an update or delete
+                    if let Some(data) = history.data {
+                        self.upsert(conn, &key, &data, EventSource::None)?;
+                    } else {
+                        return Err(StoreError::Unknown(format_err!(
+                            "History entry for update/delete has NULL data_before. id={}, op={}",
+                            history.id,
+                            history.op
+                        )));
+                    }
+                }
+                _ => {
+                    return Err(StoreError::Unknown(format_err!(
+                        "bad operation {}",
+                        history.op
+                    )))
+                }
+            }
+            // Record the change that was just made
+            let change = EntityChange {
+                subgraph_id: subgraph_id.clone(),
+                entity_type: history.entity,
+                entity_id: history.entity_id,
+                operation: match history.op {
+                    0 => EntityChangeOperation::Removed,
+                    1 | 2 => EntityChangeOperation::Set,
+                    _ => {
+                        return Err(StoreError::Unknown(format_err!(
+                            "bad operation {}",
+                            history.op
+                        )))
+                    }
+                },
+            };
+            changes.push(change);
         }
+
+        Ok(StoreEvent::new(changes))
     }
 }
 
@@ -332,13 +696,19 @@ impl Table {
 /// and should never be called from any other code. Unfortunately, Rust makes
 /// it very hard to export items just for testing
 pub fn delete_all_entities_for_test_use_only(conn: &PgConnection) -> Result<usize, StoreError> {
+    // Delete public entities and related data
     let mut rows = diesel::delete(public::entities::table).execute(conn)?;
     rows = rows + diesel::delete(public::entity_history::table).execute(conn)?;
     rows = rows + diesel::delete(public::event_meta_data::table).execute(conn)?;
+    // Delete subgraphs entities
+    rows = rows + diesel::delete(subgraphs::entities::table).execute(conn)?;
     Ok(rows)
 }
 
 /// Return a table for the subgraph
-pub(crate) fn table(subgraph: &SubgraphDeploymentId) -> Table {
-    Table::new(subgraph)
+pub(crate) fn table(
+    conn: &PgConnection,
+    subgraph: &SubgraphDeploymentId,
+) -> Result<Table, StoreError> {
+    Table::new(conn, subgraph)
 }

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -1,0 +1,262 @@
+use diesel::debug_query;
+use diesel::dsl::{any, sql};
+use diesel::insert_into;
+use diesel::pg::Pg;
+use diesel::pg::PgConnection;
+use diesel::sql_types::Text;
+use diesel::ExpressionMethods;
+use diesel::{OptionalExtension, QueryDsl, RunQueryDsl};
+use graph::prelude::{
+    format_err, EntityFilter, EntityKey, Error, EventSource, QueryExecutionError, StoreError,
+    SubgraphDeploymentId, TransactionAbortError,
+};
+use graph::serde_json;
+
+use crate::filter::{build_filter, store_filter};
+use crate::functions::set_config;
+use crate::jsonb::PgJsonbExpressionMethods as _;
+
+/// Marker trait for tables that store entities
+pub(crate) trait EntitySource {}
+
+// The entities table in the public schema
+mod public {
+    table! {
+        entities (id, subgraph, entity) {
+            id -> Varchar,
+            subgraph -> Varchar,
+            entity -> Varchar,
+            data -> Jsonb,
+            event_source -> Varchar,
+        }
+    }
+}
+
+impl EntitySource for self::public::entities::table {}
+
+//impl EntitySource for DynamicTable<String> {}
+
+pub(crate) enum Table {
+    Public(SubgraphDeploymentId),
+}
+
+impl Table {
+    fn new(subgraph: &SubgraphDeploymentId) -> Self {
+        Table::Public(subgraph.clone())
+    }
+
+    pub(crate) fn find(
+        &self,
+        conn: &PgConnection,
+        entity: &String,
+        id: &String,
+    ) -> Result<Option<serde_json::Value>, StoreError> {
+        match self {
+            Table::Public(subgraph) => Ok(public::entities::table
+                .find((id, subgraph.to_string(), entity))
+                .select(public::entities::data)
+                .first::<serde_json::Value>(conn)
+                .optional()?),
+        }
+    }
+
+    /// order is a tuple (attribute, cast, direction)
+    pub(crate) fn query(
+        &self,
+        conn: &PgConnection,
+        entity_types: Vec<String>,
+        filter: Option<EntityFilter>,
+        order: Option<(String, &str, &str)>,
+        first: Option<u32>,
+        skip: u32,
+    ) -> Result<Vec<(serde_json::Value, String)>, QueryExecutionError> {
+        match self {
+            Table::Public(subgraph) => {
+                // Create base boxed query; this will be added to based on the
+                // query parameters provided
+                let mut query = public::entities::table
+                    .filter(public::entities::entity.eq(any(entity_types)))
+                    .filter(public::entities::subgraph.eq(subgraph.to_string()))
+                    .select((public::entities::data, public::entities::entity))
+                    .into_boxed::<Pg>();
+
+                // Add specified filter to query
+                if let Some(filter) = filter {
+                    query =
+                        store_filter::<public::entities::table, _>(query, filter).map_err(|e| {
+                            QueryExecutionError::FilterNotSupportedError(
+                                format!("{}", e.value),
+                                e.filter,
+                            )
+                        })?;
+                }
+
+                // Add order by filters to query
+                if let Some((attribute, cast, direction)) = order {
+                    query = query.order(
+                        sql::<Text>("(data ->")
+                            .bind::<Text, _>(attribute)
+                            .sql("->> 'data')")
+                            .sql(cast)
+                            .sql(" ")
+                            .sql(direction)
+                            .sql(" NULLS LAST"),
+                    );
+                }
+
+                // Add range filter to query
+                if let Some(first) = first {
+                    query = query.limit(first as i64);
+                }
+                if skip > 0 {
+                    query = query.offset(skip as i64);
+                }
+
+                let query_debug_info = debug_query(&query).to_string();
+
+                // Process results; deserialize JSON data
+                query
+                    .load::<(serde_json::Value, String)>(conn)
+                    .map_err(|e| {
+                        QueryExecutionError::ResolveEntitiesError(format!(
+                            "{}, query = {:?}",
+                            e, query_debug_info
+                        ))
+                    })
+            }
+        }
+    }
+
+    pub(crate) fn upsert(
+        &self,
+        conn: &PgConnection,
+        key: &EntityKey,
+        data: &serde_json::Value,
+        event_source: EventSource,
+    ) -> Result<usize, StoreError> {
+        match self {
+            Table::Public(subgraph) => Ok(insert_into(public::entities::table)
+                .values((
+                    public::entities::id.eq(&key.entity_id),
+                    public::entities::entity.eq(&key.entity_type),
+                    public::entities::subgraph.eq(subgraph.to_string()),
+                    public::entities::data.eq(data),
+                    public::entities::event_source.eq(&event_source.to_string()),
+                ))
+                .on_conflict((
+                    public::entities::id,
+                    public::entities::entity,
+                    public::entities::subgraph,
+                ))
+                .do_update()
+                .set((
+                    public::entities::data.eq(data),
+                    public::entities::event_source.eq(&event_source.to_string()),
+                ))
+                .execute(conn)?),
+        }
+    }
+
+    pub(crate) fn update(
+        &self,
+        conn: &PgConnection,
+        key: &EntityKey,
+        data: &serde_json::Value,
+        guard: Option<EntityFilter>,
+        event_source: EventSource,
+    ) -> Result<usize, StoreError> {
+        match self {
+            Table::Public(subgraph) => {
+                let target = public::entities::table
+                    .filter(public::entities::subgraph.eq(subgraph.to_string()))
+                    .filter(public::entities::entity.eq(&key.entity_type))
+                    .filter(public::entities::id.eq(&key.entity_id));
+
+                let query = diesel::update(target).set((
+                    public::entities::data.eq(public::entities::data.merge(data)),
+                    public::entities::event_source.eq(event_source.to_string()),
+                ));
+
+                match guard {
+                    Some(filter) => {
+                        let filter = build_filter(filter).map_err(|e| {
+                            TransactionAbortError::Other(format!(
+                                "invalid filter '{}' for value '{}'",
+                                e.filter, e.value
+                            ))
+                        })?;
+                        Ok(query.filter(filter).execute(conn)?)
+                    }
+                    None => Ok(query.execute(conn)?),
+                }
+            }
+        }
+    }
+
+    pub(crate) fn delete(
+        &self,
+        conn: &PgConnection,
+        key: &EntityKey,
+        event_source: EventSource,
+    ) -> Result<usize, StoreError> {
+        diesel::select(set_config(
+            "vars.current_event_source",
+            event_source.to_string(),
+            true,
+        ))
+        .execute(conn)
+        .map_err(|e| format_err!("Failed to set event source for remove operation: {}", e))
+        .map(|_| ())?;
+
+        match self {
+            Table::Public(subgraph) => Ok(diesel::delete(
+                public::entities::table
+                    .filter(public::entities::subgraph.eq(subgraph.to_string()))
+                    .filter(public::entities::entity.eq(&key.entity_type))
+                    .filter(public::entities::id.eq(&key.entity_id)),
+            )
+            .execute(conn)?),
+        }
+    }
+
+    pub(crate) fn count_entities(&self, conn: &PgConnection) -> Result<u64, Error> {
+        match self {
+            Table::Public(subgraph) => {
+                let count: i64 = public::entities::table
+                    .filter(public::entities::subgraph.eq(subgraph.to_string()))
+                    .count()
+                    .get_result(conn)?;
+                Ok(count as u64)
+            }
+        }
+    }
+
+    pub(crate) fn conflicting_entity(
+        &self,
+        conn: &PgConnection,
+        entity_id: &String,
+        entities: Vec<&String>,
+    ) -> Result<Option<String>, StoreError> {
+        match self {
+            Table::Public(subgraph) => Ok(public::entities::table
+                .select(public::entities::entity)
+                .filter(public::entities::subgraph.eq(subgraph.to_string()))
+                .filter(public::entities::entity.eq(any(entities)))
+                .filter(public::entities::id.eq(entity_id))
+                .first(conn)
+                .optional()?),
+        }
+    }
+}
+
+/// Delete all entities. This function exists solely for integration tests
+/// and should never be called from any other code. Unfortunately, Rust makes
+/// it very hard to export items just for testing
+pub fn delete_all_entities_for_test_use_only(conn: &PgConnection) -> Result<usize, StoreError> {
+    Ok(diesel::delete(public::entities::table).execute(conn)?)
+}
+
+/// Return a table for the subgraph
+pub(crate) fn table(subgraph: &SubgraphDeploymentId) -> Table {
+    Table::new(subgraph)
+}

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -12,7 +12,7 @@ use graph::prelude::{BigDecimal, BigInt};
 use graph::serde_json;
 
 use crate::db_schema::entities;
-use crate::models::SqlValue;
+use crate::sql_value::SqlValue;
 
 pub(crate) struct UnsupportedFilter {
     pub filter: String,

--- a/store/postgres/src/functions.rs
+++ b/store/postgres/src/functions.rs
@@ -2,11 +2,6 @@ use diesel::sql_types::*;
 
 // Create modules for hosting stored procedures
 sql_function! {
-    revert_block,
-    RevertBlock,
-    (block_to_revert_hash: Text, subgraph_id: Text)
-}
-sql_function! {
     current_setting,
     CurrentSetting,
     (setting_name: Text, missing_ok: Bool)
@@ -25,20 +20,6 @@ sql_function! {
     lookup_ancestor_block,
     LookupAncestorBlock,
     (start_block_hash: Varchar, ancestor_count: BigInt) -> Nullable<Jsonb>
-}
-
-sql_function! {
-    build_attribute_index,
-    BuildAttributeIndex,
-    (
-        subgraph_id: Text,
-        index_name: Text,
-        index_type: Text,
-        index_operator: Text,
-        jsonb_index: Bool,
-        attribute_name: Text,
-        entity_name: Text
-    )
 }
 
 sql_function! {

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate diesel;
+extern crate diesel_dynamic_schema;
 #[macro_use]
 extern crate diesel_migrations;
 extern crate failure;

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -17,8 +17,8 @@ pub mod db_schema;
 mod filter;
 pub mod functions;
 pub mod jsonb;
-pub mod models;
 mod notification_listener;
+pub mod sql_value;
 pub mod store;
 mod store_events;
 

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -14,6 +14,7 @@ extern crate uuid;
 
 mod chain_head_listener;
 pub mod db_schema;
+mod entities;
 mod filter;
 pub mod functions;
 pub mod jsonb;

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -8,6 +8,7 @@ extern crate fallible_iterator;
 extern crate futures;
 extern crate graph;
 extern crate graph_graphql;
+extern crate inflector;
 extern crate lru_time_cache;
 extern crate postgres;
 extern crate serde;

--- a/store/postgres/src/sql_value.rs
+++ b/store/postgres/src/sql_value.rs
@@ -1,26 +1,9 @@
 use diesel::pg::Pg;
 use diesel::serialize::{self, Output, ToSql};
-use diesel::sql_types::{Bool, Integer, Jsonb, Numeric, Text, VarChar};
-use graph::serde_json;
+use diesel::sql_types::{Bool, Integer, Numeric, Text};
 use std::io::Write;
 
 use graph::data::store::Value;
-
-pub type EntityJSON = serde_json::Value;
-
-#[derive(Queryable, QueryableByName, Debug)]
-pub struct EntityTable {
-    #[sql_type = "VarChar"]
-    pub id: String,
-    #[sql_type = "VarChar"]
-    pub subgraph: String,
-    #[sql_type = "VarChar"]
-    pub entity: String,
-    #[sql_type = "Jsonb"]
-    pub data: EntityJSON,
-    #[sql_type = "VarChar"]
-    pub event_source: String,
-}
 
 #[derive(Clone, Debug, PartialEq, AsExpression)]
 pub struct SqlValue(Value);

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -999,6 +999,14 @@ impl StoreTrait for Store {
             .get_result(&*self.conn.get()?)?;
         Ok(count as u64)
     }
+
+    fn create_subgraph_deployment(
+        &self,
+        _subgraph_id: &SubgraphDeploymentId,
+        ops: Vec<EntityOperation>,
+    ) -> Result<(), StoreError> {
+        self.apply_entity_operations(ops, EventSource::None)
+    }
 }
 
 impl SubgraphDeploymentStore for Store {

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -1,9 +1,4 @@
 use crate::notification_listener::{NotificationListener, SafeChannelName};
-use diesel::deserialize::QueryableByName;
-use diesel::pg::Pg;
-use diesel::pg::PgConnection;
-use diesel::sql_types::Text;
-use diesel::RunQueryDsl;
 use graph::prelude::*;
 use graph::serde_json;
 
@@ -46,86 +41,4 @@ impl EventProducer<StoreEvent> for StoreEventListener {
             },
         )
     }
-}
-
-// Querying the entity changes corresponding to the reversion of a certain
-// block for a certain subgraph. We want to keep the deserialization
-// logic (QueryableByName) close to the actual query. That's why we introduce
-// the intermediate EntityChangeQBN struct
-
-struct EntityChangeQBN(EntityChange);
-
-impl QueryableByName<Pg> for EntityChangeQBN {
-    fn build<R: diesel::row::NamedRow<diesel::pg::Pg>>(
-        row: &R,
-    ) -> diesel::deserialize::Result<Self> {
-        let subgraph_id: String = row.get("subgraph")?;
-        let subgraph_id = SubgraphDeploymentId::new(subgraph_id).map_err(|_| {
-            format!(
-                "Illegal subgraph_id {}",
-                row.get("subgraph").unwrap_or("<unknown>".to_string())
-            )
-        })?;
-        let change: String = row.get("change")?;
-        Ok(EntityChangeQBN(EntityChange {
-            subgraph_id,
-            entity_type: row.get("entity")?,
-            entity_id: row.get("entity_id")?,
-            operation: match change.as_str() {
-                "set" => EntityChangeOperation::Set,
-                "removed" => EntityChangeOperation::Removed,
-                _ => return Err(Box::new(format_err!("bad operation {}", change).compat())),
-            },
-        }))
-    }
-}
-
-// Get the store event corresponding to reverting the operations for
-// block block_ptr_from. After reversion, we will be at block_ptr_to, which
-// must be one less than block_ptr_from. The source of the event will be
-// block_ptr_to as we will be at that block after the reversion
-pub fn get_revert_event(
-    conn: &PgConnection,
-    subgraph_id: &SubgraphDeploymentId,
-    block_ptr_from: &EthereumBlockPointer,
-    block_ptr_to: EthereumBlockPointer,
-) -> Result<StoreEvent, StoreError> {
-    // Sanity check on block numbers
-    assert_eq!(
-        block_ptr_from.number,
-        block_ptr_to.number + 1,
-        "get_revert_event must revert a single block only"
-    );
-
-    // The query to find the EntityChanges that need to be emitted for the
-    // reversion follows the logic of the revert_block stored procedure closely.
-    // If that logic ever changes, this query will need to change, too.
-    //
-    // The query takes two parameters:
-    //   - block_ptr_from: the block hash that we want to revert
-    //   - subgraph_id: the subgraph for which we are reverting
-    //
-    // The query is fairly straightforward: the events_for_block_and_subgraph
-    // query finds all events that affect the given subgraph at the given block,
-    // and the outer query returns the data we need to construct EntityChanges
-    // for those history events
-    let query = "
-SELECT
-  h.subgraph,
-  h.entity,
-  h.entity_id,
-  (CASE
-     WHEN h.op_id = 0 THEN 'removed'
-     WHEN h.op_id in (1,2) THEN 'set'
-   END) as change
-FROM entity_history_with_source h
-WHERE h.source = $1
-  AND h.subgraph = $2";
-    let query = diesel::sql_query(query)
-        .bind::<Text, _>(block_ptr_from.hash_hex())
-        .bind::<Text, _>(subgraph_id.to_string());
-    let changes: Vec<EntityChangeQBN> = query.get_results(conn)?;
-    let changes = changes.into_iter().map(|qbn| qbn.0).collect();
-
-    Ok(StoreEvent::new(changes))
 }

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -232,12 +232,11 @@ fn create_test_entity(
 
 /// Removes test data from the database behind the store.
 fn remove_test_data() {
-    use crate::db_schema::{entities, entity_history, event_meta_data};
+    use crate::db_schema::{entity_history, event_meta_data};
 
     let url = postgres_test_url();
     let conn = PgConnection::establish(url.as_str()).expect("Failed to connect to Postgres");
-    delete(entities::table)
-        .execute(&conn)
+    graph_store_postgres::store::delete_all_entities_for_test_use_only(&conn)
         .expect("Failed to remove entity test data");
     delete(entity_history::table)
         .execute(&conn)

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -18,7 +18,7 @@ use graph::data::store::scalar;
 use graph::data::subgraph::schema::SubgraphDeploymentEntity;
 use graph::prelude::*;
 use graph::web3::types::H256;
-use graph_store_postgres::{db_schema, Store as DieselStore};
+use graph_store_postgres::Store as DieselStore;
 
 lazy_static! {
     static ref TEST_SUBGRAPH_ID_STRING: String = String::from("testsubgraph");
@@ -232,18 +232,10 @@ fn create_test_entity(
 
 /// Removes test data from the database behind the store.
 fn remove_test_data() {
-    use crate::db_schema::{entity_history, event_meta_data};
-
     let url = postgres_test_url();
     let conn = PgConnection::establish(url.as_str()).expect("Failed to connect to Postgres");
     graph_store_postgres::store::delete_all_entities_for_test_use_only(&conn)
         .expect("Failed to remove entity test data");
-    delete(entity_history::table)
-        .execute(&conn)
-        .expect("Failed to remove entity history test data");
-    delete(event_meta_data::table)
-        .execute(&conn)
-        .expect("Failed to remove entity change event test data");
 }
 
 #[test]


### PR DESCRIPTION
This PR makes it so that newly deployed subgraphs will be stored in their own `entities` (and `entity_histroy`) table. Deploying a new subgraph will create a schema in Postgres, and store the data for the subgraph in that schema.

The PR does not migrate existing data; instead, queries (and changes) against existing data are still done against the existing `public.entities` table. Migrating data will be the subject of another PR.

(Opening this as draft as I haven't tested this other than running unit tests; will remove draft status once I've done that. The code is ready for review, though)