### PR TITLE
Print version information on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-testament"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "git-testament-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "git-testament-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +931,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-testament 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.9.0",
  "graph-core 0.9.0",
  "graph-datasource-ethereum 0.9.0",
@@ -3289,6 +3309,8 @@ dependencies = [
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+"checksum git-testament 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0b00f56c9844ed5d927a5cfccfe5d4a32fffa3b8a56f14c0634e70c613dc584b"
+"checksum git-testament-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4abfb23d91a9da7cec4796bc94b3009fe87812d909035faea726681d2f3e3b5e"
 "checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
 "checksum graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "070cef3f91429889a1ed86e5f5824d6e8b3ebcb9870d7c7050f9bfcc9e4ae235"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 clap = "2.31.2"
 env_logger = "0.5.10"
 futures = "0.1.21"
+git-testament = "0.1"
 graphql-parser = "0.2.1"
 http = "0.1"
 # We're using the latest ipfs-api for the HTTPS support that was merged in

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -19,6 +19,7 @@ extern crate url;
 
 use clap::{App, Arg};
 use futures::sync::oneshot;
+use git_testament::{git_testament, render_testament};
 use ipfs_api::IpfsClient;
 use lazy_static::lazy_static;
 use std::env;
@@ -58,6 +59,8 @@ lazy_static! {
              .unwrap_or_else(|_| panic!("failed to parse env var ETHEREUM_ANCESTOR_COUNT")))
         .unwrap_or(50);
 }
+
+git_testament!(TESTAMENT);
 
 fn main() {
     let (shutdown_sender, shutdown_receiver) = oneshot::channel();
@@ -235,6 +238,13 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
 
     // Set up logger
     let logger = logger(matches.is_present("debug"));
+
+    // Log version information
+    info!(
+        logger,
+        "Graph Node version: {}",
+        render_testament!(TESTAMENT)
+    );
 
     // Safe to unwrap because a value is required by CLI
     let postgres_url = matches.value_of("postgres-url").unwrap().to_string();


### PR DESCRIPTION
Resolves #591. Thanks to my friend @kinnison who wrote git-testament!

Prints a message like this at startup:
```
Apr 25 01:14:44.973 INFO Graph Node version: v0.9.0+109 (6ec315781 2019-04-24) dirty 4 modifications
```