### PR TITLE
Add undeployed hint to `currentVersion` error

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -712,10 +712,14 @@ pub trait Store: Send + Sync + 'static {
         }?;
 
         // Get current active subgraph version ID
-        let current_version_id = match subgraph_entity
-            .get("currentVersion")
-            .ok_or_else(|| format_err!("Subgraph entity without `currentVersion`"))?
-        {
+        let current_version_id = match subgraph_entity.get("currentVersion").ok_or_else(|| {
+            format_err!(
+                "Subgraph entity has no `currentVersion`. \
+                 The subgraph may have been created but not deployed yet. Make sure \
+                 to run `graph deploy` to deploy the subgraph and have it start \
+                 indexing."
+            )
+        })? {
             Value::String(s) => s.to_owned(),
             Value::Null => return Ok(None),
             _ => {


### PR DESCRIPTION
This makes the error more useful and increases the changes of
developers being able to unblock themselves in situations where they
have forgotten to deploy a subgraph and are wondering why the GraphQL
endpoints don't work.

