### PR TITLE
Fix writing and loading of dynamically created data sources

### DIFF
--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -754,7 +754,7 @@ impl TryFromValue for EthereumContractMappingEntity {
             abis: map.get_required("abis")?,
             event_handlers: map.get_optional("eventHandlers")?,
             call_handlers: map.get_optional("callHandlers")?,
-            block_handlers: map.get_optional("blockHandlersr")?,
+            block_handlers: map.get_optional("blockHandlers")?,
         })
     }
 }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -703,6 +703,9 @@ impl EthereumContractMappingEntity {
         event_handler_ids.map(|event_handler_ids| entity.set("eventHandlers", event_handler_ids));
         call_handler_ids.map(|call_handler_ids| entity.set("callHandlers", call_handler_ids));
         block_handler_ids.map(|block_handler_ids| entity.set("blockHandlers", block_handler_ids));
+
+        ops.push(set_entity_operation(Self::TYPENAME, id, entity));
+
         ops
     }
 }


### PR DESCRIPTION
This fixes two problems:

1. When writing dynamic data sources entities to the store, the mapping entity was missing. This caused dynamic data sources loading on restarts to fail.

2. There was a typo in the code that parses a mapping entity back from a GraphQL value. This would also cause dynamic data sources to not load correctly.