### PR TITLE
Denormalize `entityCount`

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -695,9 +695,6 @@ pub trait Store: Send + Sync + 'static {
     /// Returns a stream of store events that match the input arguments.
     fn subscribe(&self, entities: Vec<SubgraphEntityPair>) -> StoreEventStreamBox;
 
-    /// Counts the total number of entities in a subgraph.
-    fn count_entities(&self, subgraph: SubgraphDeploymentId) -> Result<u64, Error>;
-
     fn resolve_subgraph_name_to_id(
         &self,
         name: SubgraphName,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -484,6 +484,16 @@ impl EntityOperation {
         }
     }
 
+    /// Return the subgraph that this operation applies to
+    pub fn subgraph(&self) -> Option<&SubgraphDeploymentId> {
+        use self::EntityOperation::*;
+
+        match self {
+            Set { key, .. } | Update { key, .. } | Remove { key } => Some(&key.subgraph_id),
+            AbortUnless { .. } => None,
+        }
+    }
+
     /// Returns true if the operation matches a given store key.
     pub fn matches_entity(&self, key: &EntityKey) -> bool {
         self.entity_key() == key

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -22,7 +22,7 @@ use crate::data::subgraph::schema::{
     EthereumBlockHandlerEntity, EthereumCallHandlerEntity, EthereumContractAbiEntity,
     EthereumContractDataSourceEntity, EthereumContractDataSourceTemplateEntity,
     EthereumContractDataSourceTemplateSourceEntity, EthereumContractEventHandlerEntity,
-    EthereumContractMappingEntity, EthereumContractSourceEntity,
+    EthereumContractMappingEntity, EthereumContractSourceEntity, SUBGRAPHS_ID,
 };
 use crate::util::ethereum::string_to_h256;
 
@@ -67,6 +67,12 @@ impl SubgraphDeploymentId {
         Link {
             link: format!("/ipfs/{}", self),
         }
+    }
+
+    /// Return true if this is the id of the special
+    /// "subgraph of subgraphs" that contains metadata about everything
+    pub fn is_meta(&self) -> bool {
+        self.0 == *SUBGRAPHS_ID.0
     }
 }
 

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -233,6 +233,7 @@ impl SubgraphDeploymentEntity {
             self.latest_ethereum_block_number,
         );
         entity.set("totalEthereumBlocksCount", self.total_ethereum_blocks_count);
+        entity.set("entityCount", 0 as u64);
         ops.push(set_entity_operation(Self::TYPENAME, id.to_string(), entity));
 
         ops

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -325,10 +325,6 @@ impl Store for MockStore {
         StoreEventStream::new(Box::new(receiver))
     }
 
-    fn count_entities(&self, _: SubgraphDeploymentId) -> Result<u64, Error> {
-        unimplemented!();
-    }
-
     fn create_subgraph_deployment(
         &self,
         _subgraph_id: &SubgraphDeploymentId,
@@ -463,10 +459,6 @@ impl Store for FakeStore {
     }
 
     fn subscribe(&self, _: Vec<SubgraphEntityPair>) -> StoreEventStreamBox {
-        unimplemented!();
-    }
-
-    fn count_entities(&self, _: SubgraphDeploymentId) -> Result<u64, Error> {
         unimplemented!();
     }
 

--- a/store/postgres/migrations/2019-05-03-164052_store_entity_count/down.sql
+++ b/store/postgres/migrations/2019-05-03-164052_store_entity_count/down.sql
@@ -1,0 +1,4 @@
+-- Remove entityCount from SubgraphDeployment
+update subgraphs.entities
+   set data = data - 'entityCount'
+ where entity='SubgraphDeployment';

--- a/store/postgres/migrations/2019-05-03-164052_store_entity_count/up.sql
+++ b/store/postgres/migrations/2019-05-03-164052_store_entity_count/up.sql
@@ -1,0 +1,46 @@
+create function store_entity_count()
+returns void
+language plpgsql
+as $function$
+declare
+  deployment   record;
+  entity_count int8;
+begin
+  -- Initialize the entityCount for all subgraphs
+  update subgraphs.entities e
+  set data = data || '{"entityCount": {"data": "0", "type": "BigInt"}}'
+  where e.entity='SubgraphDeployment';
+
+  -- Handle public.entities
+  with entity_counts as (
+    select subgraph, count(*) as count
+      from public.entities
+    group by subgraph)
+  update subgraphs.entities e
+  set data = data ||
+             format('{"entityCount": {"data": "%s", "type": "BigInt"}}',
+                    (select count from entity_counts c
+                                 where c.subgraph=e.id))::jsonb
+  where e.entity='SubgraphDeployment'
+    and e.id in (select subgraph from entity_counts);
+
+  -- Handle split entities tables
+  for deployment in
+    select * from deployment_schemas
+            where subgraph != 'subgraphs'
+  loop
+    execute format('select count(*) from %I.entities', deployment.name)
+       into entity_count;
+    update subgraphs.entities e
+    set data = data ||
+             format('{"entityCount": {"data": "%s", "type": "BigInt"}}',
+                    entity_count)::jsonb
+    where e.entity='SubgraphDeployment'
+      and e.id = deployment.subgraph;
+  end loop;
+end;
+$function$;
+
+select store_entity_count();
+
+drop function store_entity_count();

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -292,6 +292,15 @@ impl<'a> Connection<'a> {
         let table = self.table(subgraph)?;
         table.count_entities(self.conn)
     }
+
+    pub(crate) fn update_entity_count(
+        &self,
+        subgraph: Option<SubgraphDeploymentId>,
+        count: i32,
+    ) -> Result<(), StoreError> {
+        // TODO: still needs to be implemented
+        Ok(())
+    }
 }
 
 // Find the database schema for `subgraph`. If no explicit schema exists,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -866,7 +866,8 @@ impl StoreTrait for Store {
             self.emit_store_events(&conn, &ops)?;
             self.apply_entity_operations_with_conn(&econn, ops, EventSource::None)?;
 
-            let event = econn.revert_block(&subgraph_id, block_ptr_from.hash_hex())?;
+            let (event, count) = econn.revert_block(&subgraph_id, block_ptr_from.hash_hex())?;
+            econn.update_entity_count(Some(subgraph_id), count)?;
 
             trace!(self.logger, "Emit store event for revert";
                 "tag" => event.tag,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -902,13 +902,6 @@ impl StoreTrait for Store {
         StoreEventStream::new(Box::new(receiver)).filter_by_entities(entities)
     }
 
-    fn count_entities(&self, subgraph_id: SubgraphDeploymentId) -> Result<u64, Error> {
-        let conn = &*self.conn.get()?;
-        let conn = e::Connection::new(&conn);
-
-        conn.count_entities(&subgraph_id)
-    }
-
     fn create_subgraph_deployment(
         &self,
         subgraph_id: &SubgraphDeploymentId,

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -22,7 +22,7 @@ type SubgraphDeployment @entity {
     latestEthereumBlockHash: String!
     latestEthereumBlockNumber: BigInt!
     totalEthereumBlocksCount: BigInt!
-    entityCount: BigInt! # Computed field, not stored.
+    entityCount: BigInt!
     dynamicDataSources: [DynamicEthereumContractDataSource!] @derivedFrom(field: "deployment")
 }
 


### PR DESCRIPTION
This PR stores the `entityCount` as an attribute of the `SubgraphDeployment`, and keeps it updated as entities are added and removed from the subgraph.