### PR TITLE
Adaptive log range

### DIFF
--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -114,6 +114,44 @@ where
             })
     }
 
+    fn logs_with_sigs(
+        &self,
+        logger: &Logger,
+        from: u64,
+        to: u64,
+        addresses: Vec<H160>,
+        event_signatures: Vec<H256>,
+        too_many_logs_fingerprint: &'static str,
+    ) -> impl Future<Item = Vec<Log>, Error = graph::tokio_timer::timeout::Error<web3::error::Error>>
+    {
+        let eth_adapter = self.clone();
+        let logger = logger.to_owned();
+
+        retry("eth_getLogs RPC call", &logger)
+            .when(move |res: &Result<_, web3::error::Error>| match res {
+                Ok(_) => false,
+                Err(e) => !e.to_string().contains(too_many_logs_fingerprint),
+            })
+            .no_limit()
+            .timeout_secs(60)
+            .run(move || {
+                // Create a log filter
+                let log_filter: Filter = FilterBuilder::default()
+                    .from_block(from.into())
+                    .to_block(to.into())
+                    .address(addresses.clone())
+                    .topics(Some(event_signatures.clone()), None, None, None)
+                    .build();
+
+                // Request logs from client
+                let logger = logger.clone();
+                eth_adapter.web3.eth().logs(log_filter).map(move |logs| {
+                    debug!(logger, "Received logs for blocks [{}, {}]", from, to);
+                    logs
+                })
+            })
+    }
+
     fn trace_stream(
         self,
         logger: &Logger,
@@ -158,36 +196,6 @@ where
         // Code returned by Infura if a requests returns too many logs.
         // web3 doesn't seem to offer a better way of checking the error code.
         const TOO_MANY_LOGS_FINGERPRINT: &str = "ServerError(-32005)";
-        let eth_get_logs = move |eth_adapter: Self,
-                                 logger,
-                                 from: u64,
-                                 to: u64,
-                                 addresses: Vec<H160>,
-                                 event_signatures: Vec<H256>| {
-            retry("eth_getLogs RPC call", &logger)
-                .when(|res: &Result<_, web3::error::Error>| match res {
-                    Ok(_) => false,
-                    Err(e) => !e.to_string().contains(TOO_MANY_LOGS_FINGERPRINT),
-                })
-                .no_limit()
-                .timeout_secs(60)
-                .run(move || {
-                    // Create a log filter
-                    let log_filter: Filter = FilterBuilder::default()
-                        .from_block(from.into())
-                        .to_block(to.into())
-                        .address(addresses.clone())
-                        .topics(Some(event_signatures.clone()), None, None, None)
-                        .build();
-
-                    // Request logs from client
-                    let logger = logger.clone();
-                    eth_adapter.web3.eth().logs(log_filter).map(move |logs| {
-                        debug!(logger, "Received logs for blocks [{}, {}]", from, to);
-                        logs
-                    })
-                })
-        };
 
         if from > to {
             panic!(
@@ -252,32 +260,35 @@ where
             let logger = logger.clone();
             let log_filter = log_filter.clone();
             Some(
-                eth_get_logs(
-                    eth.clone(),
-                    logger.clone(),
+                eth.logs_with_sigs(
+                    &logger,
                     start,
                     end,
                     addresses.clone(),
                     event_sigs.clone(),
+                    TOO_MANY_LOGS_FINGERPRINT,
                 )
                 .map(move |logs| {
                     logs.into_iter()
                         .filter(move |log| log_filter.matches(log))
                         .collect::<Vec<Log>>()
                 })
-                .then(move |res| match res {
-                    Err(e) => {
-                        let string_err = e.to_string();
-                        if string_err.contains(TOO_MANY_LOGS_FINGERPRINT) {
-                            let new_step = (step / 10).max(1);
-                            debug!(logger, "Reducing log step"; "new_step" => new_step);
-                            Ok((vec![], (start, new_step)))
-                        } else {
-                            warn!(logger, "Unexpected RPC error"; "error" => &string_err);
-                            Err(err_msg(string_err))
+                .then(move |res| {
+                    match res {
+                        Err(e) => {
+                            let string_err = e.to_string();
+                            // web3 doesn't seem to offer a better way of inspecting the error code.
+                            if string_err.contains(TOO_MANY_LOGS_FINGERPRINT) {
+                                let new_step = (step / 10).max(1);
+                                debug!(logger, "Reducing log step"; "new_step" => new_step);
+                                Ok((vec![], (start, new_step)))
+                            } else {
+                                warn!(logger, "Unexpected RPC error"; "error" => &string_err);
+                                Err(err_msg(string_err))
+                            }
                         }
+                        Ok(logs) => Ok((logs, (end + 1, step))),
                     }
-                    Ok(logs) => Ok((logs, (end + 1, step))),
                 }),
             )
         })

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -193,7 +193,7 @@ where
         to: u64,
         log_filter: EthereumLogFilter,
     ) -> impl Future<Item = Vec<Log>, Error = Error> {
-        // Code returned by Infura if a requests returns too many logs.
+        // Code returned by Infura if a request returns too many logs.
         // web3 doesn't seem to offer a better way of checking the error code.
         const TOO_MANY_LOGS_FINGERPRINT: &str = "ServerError(-32005)";
 
@@ -273,22 +273,20 @@ where
                         .filter(move |log| log_filter.matches(log))
                         .collect::<Vec<Log>>()
                 })
-                .then(move |res| {
-                    match res {
-                        Err(e) => {
-                            let string_err = e.to_string();
-                            // web3 doesn't seem to offer a better way of inspecting the error code.
-                            if string_err.contains(TOO_MANY_LOGS_FINGERPRINT) {
-                                let new_step = (step / 10).max(1);
-                                debug!(logger, "Reducing log step"; "new_step" => new_step);
-                                Ok((vec![], (start, new_step)))
-                            } else {
-                                warn!(logger, "Unexpected RPC error"; "error" => &string_err);
-                                Err(err_msg(string_err))
-                            }
+                .then(move |res| match res {
+                    Err(e) => {
+                        let string_err = e.to_string();
+                        if string_err.contains(TOO_MANY_LOGS_FINGERPRINT) {
+                            let new_step = step / 10;
+                            debug!(logger, "Reducing block range size to scan for events";
+                                               "new_size" => new_step + 1);
+                            Ok((vec![], (start, new_step)))
+                        } else {
+                            warn!(logger, "Unexpected RPC error"; "error" => &string_err);
+                            Err(err_msg(string_err))
                         }
-                        Ok(logs) => Ok((logs, (end + 1, step))),
                     }
+                    Ok(logs) => Ok((logs, (end + 1, step))),
                 }),
             )
         })

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -19,7 +19,7 @@ in parallel for block retrieval (defaults to 64)
   events in the first few million blocks, so `graph-node` optimizes for that
   case by inquiring about a large range. The value of this variable
   is the block number at which we switch from probing large ranges to
-  smaller ranges (defaults to 4000000)
+  ranges of size `ETHEREUM_BLOCK_RANGE_SIZE` (defaults to 4000000).
 * `ETHEREUM_TRACE_STREAM_STEP_SIZE`: `graph-node` queries traces for a given block
   range when a subgraph defines call handlers or block handlers with a call filter.
   The value of this variable controls the number of blocks to scan in a single RPC request for traces


### PR DESCRIPTION
Resolves #776. If we start getting this error even when requesting logs for a single block, we should re-evaluate in a new issue.

The first thing this does is have `ETHEREUM_FAST_SCAN_END` affect the block stream as a whole, we now multiply `ETHEREUM_BLOCK_RANGE_SIZE` by 10 if doing a fast scan. The one-size-fits-all nature of these values can be an issue, I also added a special case to go one block at a time if there are unconditional block triggers. We should at some point change the way we control the amount of triggers processed at a time.

The adaptive logic for log ranges first tries requesting the entire given range, if that doesn't work the step is reduced on each failure until we no longer get the 1000 logs error.

And then there are some refactors along the way.