### PR TITLE
Parallel get logs

### DIFF
--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -311,7 +311,7 @@ where
                                 Err(err_msg(string_err))
                             }
                         }
-                        Ok(logs) => Ok((logs, (low + 1, step))),
+                        Ok(logs) => Ok((logs, (low, step))),
                     }),
             )
         })

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -131,7 +131,6 @@ where
     ) -> impl Future<Item = Vec<Log>, Error = graph::tokio_timer::timeout::Error<web3::error::Error>>
     {
         let eth_adapter = self.clone();
-        let logger = logger.to_owned();
 
         retry("eth_getLogs RPC call", &logger)
             .when(move |res: &Result<_, web3::error::Error>| match res {
@@ -150,11 +149,7 @@ where
                     .build();
 
                 // Request logs from client
-                let logger = logger.clone();
-                eth_adapter.web3.eth().logs(log_filter).map(move |logs| {
-                    debug!(logger, "Received logs for blocks [{}, {}]", from, to);
-                    logs
-                })
+                eth_adapter.web3.eth().logs(log_filter)
             })
     }
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -30,6 +30,7 @@ in parallel for block retrieval (defaults to 64)
   parallel (defaults to 50)
 * `ETHEREUM_BLOCK_RANGE_SIZE` - number of blocks to scan for events in
   each request (defaults to 10000).
+* `ETHEREUM_PARALLEL_BLOCK_RANGES` - Maximum number of parallel `eth_getLogs` calls to make when scanning logs for a subgraph. Defaults to 100.
 
 ## Running mapping handlers
 * `GRAPH_EVENT_HANDLER_TIMEOUT`: amount of time an event handler is allowed


### PR DESCRIPTION
Part #912, specifically item 1.

When the log range is shortened due to hitting the Infura limit, we start making parallel requests in order to retain performance. The env var `ETHEREUM_PARALLEL_BLOCK_RANGES` limits the amount of parallelism possible, defaulted to 100 (is that a reasonable default?).

Regarding the rest of #912, I think this should be enough to regain the performance of log scanning. At the default values of a block range of 10000 and 100 parallel requests, even when the step drops to 10 we're still simultaneously requesting a total range of 1000, which is what we hard coded before, no performance is lost. So I'd say that trying to proactively re-widen the log range is low-prority, we can leave it as an idea if we still have performance issues after this.

This could be applied to traces if we get a specific response when the limit is hit as we do for logs.