### PR TITLE
Use split subgraph table when testing the store

### DIFF
--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -1315,6 +1315,12 @@ pub fn delete_all_entities_for_test_use_only(conn: &PgConnection) -> Result<usiz
     rows = rows + diesel::delete(public::event_meta_data::table).execute(conn)?;
     // Delete subgraphs entities
     rows = rows + diesel::delete(subgraphs::entities::table).execute(conn)?;
+    // Delete all subgraph deployment schemas entries; except for the "subgraphs"
+    // entry that is created by the split entities migration
+    rows = rows
+        + diesel::delete(deployment_schemas::table)
+            .filter(deployment_schemas::subgraph.ne("subgraphs"))
+            .execute(conn)?;
     Ok(rows)
 }
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -115,10 +115,10 @@ fn insert_test_data(store: Arc<DieselStore>) {
 
     // Create SubgraphDeploymentEntity
     store
-        .apply_entity_operations(
+        .create_subgraph_deployment(
+            &*TEST_SUBGRAPH_ID,
             SubgraphDeploymentEntity::new(&manifest, false, false, *TEST_BLOCK_0_PTR, 1)
                 .create_operations(&*TEST_SUBGRAPH_ID),
-            None,
         )
         .unwrap();
 


### PR DESCRIPTION
Ideally, we'd test both the `public` entities table and a subgraph-specific entities table. However, with the tests being defined as `FnOnce` functions, we can't easily clone them and run them twice.

So it's not 100% clear which variant is best to test. This PR switches from `public` to subgraph-specific. @lutter What are your thoughts?