### PR TITLE
Use crossbeam channel for tokio contention check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,7 @@ version = "0.10.0"
 dependencies = [
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "git-testament 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,6 +10,7 @@ futures = "0.1.21"
 git-testament = "0.1"
 graphql-parser = "0.2.1"
 http = "0.1"
+
 # We're using the latest ipfs-api for the HTTPS support that was merged in
 # https://github.com/ferristseng/rust-ipfs-api/commit/55902e98d868dcce047863859caf596a629d10ec
 # but has not been released yet.
@@ -18,6 +19,7 @@ itertools = "0.7"
 lazy_static = "1.2.0"
 sentry = "0.15.1"
 url = "1.7.1"
+crossbeam-channel = "0.3.8"
 graph = { path = "../graph" }
 graph-core = { path = "../core" }
 graph-datasource-ethereum = { path = "../datasource/ethereum" }


### PR DESCRIPTION
I observed a panic in `recv_timeout` due to a bug in std https://github.com/rust-lang/rust/issues/39364, switching to crossbeam fixes that and improves performance, which reduces the effect of the channel in the timings.

