### PR TITLE
store/postgres: make store_entity_count migration more robust

### DIFF
--- a/store/postgres/migrations/2019-05-03-164052_store_entity_count/up.sql
+++ b/store/postgres/migrations/2019-05-03-164052_store_entity_count/up.sql
@@ -26,8 +26,12 @@ begin
 
   -- Handle split entities tables
   for deployment in
-    select * from deployment_schemas
+    -- Join with pg_namespace to make sure we do not, under any
+    -- circumstances, try to access a schema that was dropped for
+    -- whatever reason
+    select s.* from deployment_schemas s, pg_namespace n
             where subgraph != 'subgraphs'
+              and s.name = n.nspname
   loop
     execute format('select count(*) from %I.entities', deployment.name)
        into entity_count;


### PR DESCRIPTION
In staging, we had an entry in `deployment_schemas` where the underlying
Postgres schema did not exist, causing the migration to fail. To make this
more robust, we will skip these entries. The issue was most likely caused
by manual changes in staging.

