### PR TITLE
Don't block updates on a full channel

### DIFF
--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -89,7 +89,7 @@ impl ChainHeadUpdateListener {
                         let logger = logger.clone();
                         let subscribers = subscribers.clone();
 
-                        sender.send(update.clone()).then(move |result| {
+                        tokio::spawn(sender.send(update.clone()).then(move |result| {
                             if result.is_err() {
                                 // If sending to a subscriber fails, we'll assume that
                                 // the receiving end has been dropped. In this case we
@@ -100,7 +100,7 @@ impl ChainHeadUpdateListener {
 
                             // Move on to the next subscriber
                             Ok(())
-                        })
+                        }))
                     })
                 }),
         );

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -89,6 +89,10 @@ impl ChainHeadUpdateListener {
                         let logger = logger.clone();
                         let subscribers = subscribers.clone();
 
+                        // A subgraph that's syncing will not regularly pull
+                        // chain head updates from the channel, to prevent a
+                        // full channel from stopping all updates each update is
+                        // sent in its own task. 
                         tokio::spawn(sender.send(update.clone()).then(move |result| {
                             if result.is_err() {
                                 // If sending to a subscriber fails, we'll assume that


### PR DESCRIPTION
Previously a syncing subgraph with a full buffer of chain head updates could prevent other subgraph from getting updates. I have not reproduced and tested the fix, but the hypothesis seems solid.