### PR TITLE
Add network name to block ingestor logs

### DIFF
--- a/datasource/ethereum/src/block_ingestor.rs
+++ b/datasource/ethereum/src/block_ingestor.rs
@@ -12,6 +12,7 @@ where
     chain_store: Arc<S>,
     eth_adapter: Arc<E>,
     ancestor_count: u64,
+    network_name: String,
     logger: Logger,
     polling_interval: Duration,
 }
@@ -25,6 +26,7 @@ where
         chain_store: Arc<S>,
         eth_adapter: Arc<E>,
         ancestor_count: u64,
+        network_name: String,
         logger: Logger,
         polling_interval: Duration,
         elastic_config: Option<ElasticLoggingConfig>,
@@ -53,6 +55,7 @@ where
             chain_store,
             eth_adapter,
             ancestor_count,
+            network_name,
             logger,
             polling_interval,
         })
@@ -97,6 +100,7 @@ where
 
     fn do_poll<'a>(&'a self) -> impl Future<Item = (), Error = EthereumAdapterError> + 'a {
         trace!(self.logger, "BlockIngestor::do_poll");
+        let network_name = self.network_name.clone();
 
         // Get chain head ptr from store
         future::result(self.chain_store.chain_head_ptr())
@@ -128,6 +132,7 @@ where
                                         "latest_block_head" => latest_number,
                                         "blocks_behind" => distance,
                                         "blocks_needed" => blocks_needed,
+                                        "network_name" => network_name,
                                         "code" => LogCode::BlockIngestionStatus,
                                     );
                                 }

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -698,7 +698,7 @@ where
                 // If there are no traces something has gone wrong.
                 if traces.is_empty() {
                     return future::err(format_err!(
-                        "Trace stream return no traces for block: number = `{}`, hash = `{}`",
+                        "Trace stream returned no traces for block: number = `{}`, hash = `{}`",
                         block_number,
                         block_hash,
                     ));

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -452,6 +452,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
             store.clone(),
             eth_adapter.clone(),
             *ANCESTOR_COUNT,
+            ethereum_network_name.to_string(),
             logger.clone(),
             block_polling_interval,
             elastic_config.clone(),


### PR DESCRIPTION
This data is needed to filter out logs in the Grafana panels