### PR TITLE
store/postgres: Add an index on event_meta_data(source)

### DIFF
--- a/store/postgres/migrations/2019-05-14-200255_event_meta_data_source_index/down.sql
+++ b/store/postgres/migrations/2019-05-14-200255_event_meta_data_source_index/down.sql
@@ -1,0 +1,1 @@
+drop index event_meta_data_source;

--- a/store/postgres/migrations/2019-05-14-200255_event_meta_data_source_index/up.sql
+++ b/store/postgres/migrations/2019-05-14-200255_event_meta_data_source_index/up.sql
@@ -1,0 +1,1 @@
+create index if not exists event_meta_data_source on event_meta_data(source);


### PR DESCRIPTION
We find event_meta_data during block reversions by the source attribute,
and not having an index on it slows down those queries, and therefore block
reversion, dramatically. In one case, query time for a block reversion goes
from 18s to 5ms after adding the index.

