### PR TITLE
Handle block stream errors gracefully in SubgraphInstanceManager

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -353,9 +353,10 @@ where
         .then(move |result| match result {
             Ok(block) => Ok(Some(block)),
             Err(e) => {
-                error!(
+                debug!(
                     logger_for_block_stream_errors,
-                    "Block stream produced a non fatal error = {}", e,
+                    "Block stream produced a non-fatal error";
+                    "error" => format!("{}", e),
                 );
                 Ok(None)
             }

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -1096,22 +1096,11 @@ where
                         Err(e) => {
                             self.consecutive_err_count += 1;
 
-                            // If too many errors without progress, give up
-                            if self.consecutive_err_count >= 100 {
-                                return Err(e);
-                            }
-
-                            warn!(
-                                self.ctx.logger,
-                                "Trying again after error in block stream reconcile: {}", e
-                            );
-
                             // Try again by restarting reconciliation
                             let next_blocks_future = self.ctx.next_blocks();
                             state = BlockStreamState::Reconciliation(next_blocks_future);
 
-                            // Poll the next_blocks() future
-                            continue;
+                            return Err(e);
                         }
                     }
                 }
@@ -1147,22 +1136,11 @@ where
                         Err(e) => {
                             self.consecutive_err_count += 1;
 
-                            // If too many errors without progress, give up
-                            if self.consecutive_err_count >= 100 {
-                                return Err(e);
-                            }
-
-                            warn!(
-                                self.ctx.logger,
-                                "Trying again after error yielding blocks to block stream: {}", e
-                            );
-
                             // Try again by restarting reconciliation
                             let next_blocks_future = self.ctx.next_blocks();
                             state = BlockStreamState::Reconciliation(next_blocks_future);
 
-                            // Poll the next_blocks() future
-                            continue;
+                            return Err(e);
                         }
                     }
                 }

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -1106,7 +1106,7 @@ where
                             self.consecutive_err_count += 1;
 
                             // Pause before trying again
-                            let secs = (5 * self.consecutive_err_count).min(120) as u64;
+                            let secs = (5 * self.consecutive_err_count).max(120) as u64;
                             let instant = Instant::now() + Duration::from_secs(secs);
                             state = BlockStreamState::Paused(Box::new(
                                 Delay::new(instant).map_err(|err| {
@@ -1150,7 +1150,7 @@ where
                             self.consecutive_err_count += 1;
 
                             // Pause before trying again
-                            let secs = (5 * self.consecutive_err_count).min(120) as u64;
+                            let secs = (5 * self.consecutive_err_count).max(120) as u64;
                             let instant = Instant::now() + Duration::from_secs(secs);
                             state = BlockStreamState::Paused(Box::new(
                                 Delay::new(instant).map_err(|err| {

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -1110,7 +1110,7 @@ where
                             let instant = Instant::now() + Duration::from_secs(secs);
                             state = BlockStreamState::RetryAfterDelay(Box::new(
                                 Delay::new(instant).map_err(|err| {
-                                    format_err!("Paused state's delay future failed = {}", err)
+                                    format_err!("RetryAfterDelay future failed = {}", err)
                                 }),
                             ));
                             break Err(e);
@@ -1154,7 +1154,7 @@ where
                             let instant = Instant::now() + Duration::from_secs(secs);
                             state = BlockStreamState::RetryAfterDelay(Box::new(
                                 Delay::new(instant).map_err(|err| {
-                                    format_err!("RetryAfterDelays future failed: {}", err)
+                                    format_err!("RetryAfterDelay future failed: {}", err)
                                 }),
                             ));
                             break Err(e);

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -1152,11 +1152,10 @@ where
                             // Pause before trying again
                             let secs = (5 * self.consecutive_err_count).max(120) as u64;
                             let instant = Instant::now() + Duration::from_secs(secs);
-                            state = BlockStreamState::Paused(Box::new(
-                                Delay::new(instant).map_err(|err| {
-                                    format_err!("Paused state's delay future failed = {}", err)
-                                }),
-                            ));
+                            state =
+                                BlockStreamState::Paused(Box::new(Delay::new(instant).map_err(
+                                    |err| format_err!("RetryAfterDelays future failed: {}", err),
+                                )));
                             break Err(e);
                         }
                     }


### PR DESCRIPTION
The blockstream should faithfully attempt to produce blocks for a subgraph.

An error in the blockstream is non fatal and temporary, so the `SubgraphInstanceManager` should not fail the subgraph when these errors occur.