### PR TITLE
Enable trace logs in release, don't send them to ElasticSearch

### DIFF
--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -34,7 +34,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 serde_yaml = "0.7"
-slog = { version = "2.2.3", features = ["release_max_level_debug", "max_level_trace"] }
+slog = { version = "2.2.3", features = ["release_max_level_trace", "max_level_trace"] }
 slog-async = "2.3.0"
 slog-envlogger = "2.1.0"
 slog-term = "2.4.0"

--- a/graph/src/log/elastic.rs
+++ b/graph/src/log/elastic.rs
@@ -282,6 +282,10 @@ impl Drain for ElasticDrain {
     type Err = ();
 
     fn log(&self, record: &Record, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+        // Don't sent `trace` logs to ElasticSearch.
+        if record.level() == Level::Trace {
+            return Ok(());
+        }
         let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true);
         let id = format!("{}-{}", self.config.custom_id_value, timestamp);
 


### PR DESCRIPTION
You still need to set `GRAPH_NODE=trace` for the logs to be printed.