### PR TITLE
Framework for per-subgraph db migrations and migrate existing subgraphs into their own entities tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel-derive-enum"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "diesel-dynamic-schema"
 version = "1.0.0"
 source = "git+https://github.com/diesel-rs/diesel-dynamic-schema?rev=a8ec4fb1#a8ec4fb11de6242488ba3698d74406f4b5073dc4"
@@ -1055,6 +1065,7 @@ version = "0.12.0"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel-dynamic-schema 1.0.0 (git+https://github.com/diesel-rs/diesel-dynamic-schema?rev=a8ec4fb1)",
  "diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1105,6 +1116,14 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3019,6 +3038,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,6 +3342,7 @@ dependencies = [
 "checksum debugid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "088c9627adec1e494ff9dea77377f1e69893023d631254a0ec68b16ee20be3e9"
 "checksum derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fbe9f11be34f800b3ecaaed0ec9ec2e015d1d0ba0c8644c1310f73d6e8994615"
 "checksum diesel 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a2469cbcf1dfb9446e491cac4c493c2554133f87f7d041e892ac82e5cd36e863"
+"checksum diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "adbaf5e1344edeedc4d1cead2dc3ce6fc4115bb26b3704c533b92717940f2fb5"
 "checksum diesel-dynamic-schema 1.0.0 (git+https://github.com/diesel-rs/diesel-dynamic-schema?rev=a8ec4fb1)" = "<none>"
 "checksum diesel_derives 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62a27666098617d52c487a41f70de23d44a1dc1f3aa5877ceba2790fb1f1cab4"
 "checksum diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3cde8413353dc7f5d72fa8ce0b99a560a359d2c5ef1e5817ca731cd9008f4c"
@@ -3359,6 +3384,7 @@ dependencies = [
 "checksum graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "070cef3f91429889a1ed86e5f5824d6e8b3ebcb9870d7c7050f9bfcc9e4ae235"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
@@ -3564,6 +3590,7 @@ dependencies = [
 "checksum unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
+"checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -187,7 +187,7 @@ impl SubgraphInstanceManager {
         // If we can't even clear the 'failed' flag, don't try to start
         // the subgraph.
         let status_ops = SubgraphDeploymentEntity::update_failed_operations(&manifest.id, false);
-        store.apply_entity_operations(status_ops, None)?;
+        store.start_subgraph_deployment(&manifest.id, status_ops)?;
 
         // Create copies of the data source templates; this creates a vector of
         // the form

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -583,7 +583,16 @@ where
                 block_ptr_after,
                 block_state.entity_operations,
             )
-            .map(|_| (ctx, needs_restart))
+            .map(|should_migrate| {
+                if should_migrate {
+                    ctx.inputs.store.migrate_subgraph_deployment(
+                        &logger4,
+                        &ctx.inputs.deployment_id,
+                        &block_ptr_after,
+                    );
+                }
+                (ctx, needs_restart)
+            })
             .map_err(|e| {
                 format_err!("Error while processing block stream for a subgraph: {}", e).into()
             })

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -24,13 +24,9 @@ fn insert_and_query(
         data_sources: vec![],
     };
 
-    STORE
-        .apply_entity_operations(
-            SubgraphDeploymentEntity::new(&manifest, false, false, Default::default(), 1)
-                .create_operations_replace(&subgraph_id),
-            None,
-        )
-        .unwrap();
+    let ops = SubgraphDeploymentEntity::new(&manifest, false, false, Default::default(), 1)
+        .create_operations_replace(&subgraph_id);
+    STORE.create_subgraph_deployment(&subgraph_id, ops).unwrap();
 
     let insert_ops = entities
         .into_iter()

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1005,6 +1005,16 @@ pub trait Store: Send + Sync + 'static {
         subgraph_id: &SubgraphDeploymentId,
         ops: Vec<EntityOperation>,
     ) -> Result<(), StoreError>;
+
+    /// Start an existing subgraph deployment. This will reset the state of
+    /// the subgraph to a known good state. `ops` needs to contain all the
+    /// operations on the subgraph of subgraphs to reset the metadata of the
+    /// subgraph
+    fn start_subgraph_deployment(
+        &self,
+        subgraph_id: &SubgraphDeploymentId,
+        ops: Vec<EntityOperation>,
+    ) -> Result<(), StoreError>;
 }
 
 pub trait SubgraphDeploymentStore: Send + Sync + 'static {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -668,12 +668,15 @@ pub trait Store: Send + Sync + 'static {
     /// changes are needed to go from `block_ptr_from` to `block_ptr_to`.
     ///
     /// `block_ptr_from` must match the current value of the subgraph block pointer.
+    ///
+    /// Return `true` if the subgraph mentioned in `history_event` should have
+    /// its schema migrated at `block_ptr_to`
     fn set_block_ptr_with_no_changes(
         &self,
         subgraph_id: SubgraphDeploymentId,
         block_ptr_from: EthereumBlockPointer,
         block_ptr_to: EthereumBlockPointer,
-    ) -> Result<(), StoreError>;
+    ) -> Result<bool, StoreError>;
 
     /// Transact the entity changes from a single block atomically into the store, and update the
     /// subgraph block pointer from `block_ptr_from` to `block_ptr_to`.

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -13,6 +13,7 @@ lazy_static! {
     static ref TEST_SUBGRAPH_ID: SubgraphDeploymentId = {
         // Also populate the store when the ID is first accessed.
         let id = SubgraphDeploymentId::new("graphqlTestsQuery").unwrap();
+        STORE.create_subgraph_deployment(&id, vec![]).unwrap();
         insert_test_entities(&**STORE, id.clone());
         id
     };

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -336,6 +336,14 @@ impl Store for MockStore {
     ) -> Result<(), StoreError> {
         self.apply_entity_operations(ops, None)
     }
+
+    fn start_subgraph_deployment(
+        &self,
+        _subgraph_id: &SubgraphDeploymentId,
+        ops: Vec<EntityOperation>,
+    ) -> Result<(), StoreError> {
+        self.apply_entity_operations(ops, None)
+    }
 }
 
 impl SubgraphDeploymentStore for MockStore {
@@ -475,6 +483,14 @@ impl Store for FakeStore {
     }
 
     fn create_subgraph_deployment(
+        &self,
+        _subgraph_id: &SubgraphDeploymentId,
+        _ops: Vec<EntityOperation>,
+    ) -> Result<(), StoreError> {
+        unimplemented!()
+    }
+
+    fn start_subgraph_deployment(
         &self,
         _subgraph_id: &SubgraphDeploymentId,
         _ops: Vec<EntityOperation>,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -162,7 +162,7 @@ impl Store for MockStore {
         _: EthereumBlockPointer,
         _: EthereumBlockPointer,
         _: Vec<EntityOperation>,
-    ) -> Result<(), StoreError> {
+    ) -> Result<bool, StoreError> {
         unimplemented!();
     }
 
@@ -344,6 +344,14 @@ impl Store for MockStore {
     ) -> Result<(), StoreError> {
         self.apply_entity_operations(ops, None)
     }
+
+    fn migrate_subgraph_deployment(
+        &self,
+        _: &Logger,
+        _: &SubgraphDeploymentId,
+        _: &EthereumBlockPointer,
+    ) {
+    }
 }
 
 impl SubgraphDeploymentStore for MockStore {
@@ -450,7 +458,7 @@ impl Store for FakeStore {
         _: EthereumBlockPointer,
         _: EthereumBlockPointer,
         _: Vec<EntityOperation>,
-    ) -> Result<(), StoreError> {
+    ) -> Result<bool, StoreError> {
         unimplemented!();
     }
 
@@ -495,6 +503,15 @@ impl Store for FakeStore {
         _subgraph_id: &SubgraphDeploymentId,
         _ops: Vec<EntityOperation>,
     ) -> Result<(), StoreError> {
+        unimplemented!()
+    }
+
+    fn migrate_subgraph_deployment(
+        &self,
+        _: &Logger,
+        _: &SubgraphDeploymentId,
+        _: &EthereumBlockPointer,
+    ) {
         unimplemented!()
     }
 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -152,7 +152,7 @@ impl Store for MockStore {
         _: SubgraphDeploymentId,
         _: EthereumBlockPointer,
         _: EthereumBlockPointer,
-    ) -> Result<(), StoreError> {
+    ) -> Result<bool, StoreError> {
         unimplemented!();
     }
 
@@ -448,7 +448,7 @@ impl Store for FakeStore {
         _: SubgraphDeploymentId,
         _: EthereumBlockPointer,
         _: EthereumBlockPointer,
-    ) -> Result<(), StoreError> {
+    ) -> Result<bool, StoreError> {
         unimplemented!();
     }
 

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -8,6 +8,7 @@ diesel = { version = "1.3.2", features = ["postgres", "serde_json", "numeric", "
 # We use diesel-dynamic-schema straight from git as the project has not
 # made a release as a crate yet
 diesel-dynamic-schema = { git = "https://github.com/diesel-rs/diesel-dynamic-schema", rev="a8ec4fb1" }
+diesel-derive-enum = { version = "0.4", features = ["postgres"] }
 diesel_migrations = "1.3.0"
 failure = "0.1.2"
 fallible-iterator = "0.1.4"

--- a/store/postgres/migrations/2019-05-15-215022_migrate_entities/down.sql
+++ b/store/postgres/migrations/2019-05-15-215022_migrate_entities/down.sql
@@ -1,0 +1,17 @@
+delete from deployment_schemas
+ where version='public';
+
+drop function migrate_entities_tables(varchar,
+                                      deployment_schema_version,
+                                      varchar);
+drop function migrate_entities_data(varchar,
+                                    deployment_schema_version,
+                                    varchar);
+
+alter table deployment_schemas
+  drop column version,
+  drop column migrating,
+  drop column state;
+
+drop type deployment_schema_version;
+drop type deployment_schema_state;

--- a/store/postgres/migrations/2019-05-15-215022_migrate_entities/up.sql
+++ b/store/postgres/migrations/2019-05-15-215022_migrate_entities/up.sql
@@ -1,0 +1,186 @@
+-- The different storage schemes/versions we support for subgraphs.
+-- Over time, we will add more as our storage scheme for individual
+-- subgraphs evolves
+create type deployment_schema_version as enum ('public', 'split');
+-- How far a currently running migration has gotten. See
+-- store/postgres/src/entities.rs for more details
+create type deployment_schema_state as enum ('ready', 'tables');
+
+-- Modify deployment_schemas to track the progress of any needed migrations
+alter table deployment_schemas
+  add column version   deployment_schema_version,
+  add column migrating bool not null default false,
+  add column state     deployment_schema_state not null default 'ready';
+
+-- Existing subgraphs (subgraph of subgraphs and subgraphs that have been
+-- deployed since commit d2248402) are stored in their own split-out
+-- database schema
+update deployment_schemas
+   set version='split';
+
+alter table deployment_schemas
+  alter column version set not null;
+
+-- Legacy subgraphs (those deployed before commit d2248402) are stored in
+-- the big public.entities table. With the migration machinery we are
+-- putting in place, we need an entry in deployment_schemas for every
+-- deployed subgraph
+insert into deployment_schemas(subgraph, version)
+select id, 'public'::deployment_schema_version
+  from subgraphs.entities e
+ where entity='SubgraphDeployment'
+   and not exists (select 1 from deployment_schemas d
+                           where d.subgraph=e.id);
+
+-- Migrate the entities for one subgraph into their own schema. The
+-- deployment_schemas table must already contain an entry for that
+-- subgraph
+create or replace function migrate_entities_tables(
+  schema_name varchar,
+  schema_version deployment_schema_version,
+  subgraph_id varchar
+) returns void
+language plpgsql
+as $function$
+declare
+  index_row  record;
+begin
+  if schema_version <> 'public' then
+    raise 'Schema for %(%) has version %, but should have version ''public''',
+          schema_name, subgraph_id, schema_version;
+  end if;
+
+  execute format('create schema %I', schema_name);
+
+  -- Dirty trick: modify the search path; unqualified table references
+  -- will be looked up in schema_name first
+  perform set_config('search_path', format('%I, public', schema_name), true);
+
+  -- Create the entities table and all its trimmings
+  create table entities(
+      entity       varchar not null,
+      id           varchar not null,
+      data         jsonb,
+      event_source varchar not null,
+      primary key(entity, id)
+  );
+
+  create table entity_history (
+      id           serial primary key,
+      event_id     integer references event_meta_data(id)
+                             on update cascade on delete cascade,
+      entity       varchar not null,
+      entity_id    varchar not null,
+      data_before  jsonb,
+      reversion    bool not null default false,
+      op_id        int2 NOT NULL
+  );
+
+  create index entity_history_event_id_btree_idx
+      on entity_history(event_id);
+
+  -- Set the search path back to the default so that we do not
+  -- influence other database work
+  perform set_config('search_path', '"$user", public', true);
+end;
+$function$;
+
+create or replace function migrate_entities_data(
+  schema_name varchar,
+  schema_version deployment_schema_version,
+  subgraph_id varchar
+) returns integer
+language plpgsql
+as $function$
+declare
+  entities_count integer;
+  index_row  record;
+  has_rows bool;
+begin
+  if schema_version <> 'public' then
+    raise 'Schema for %(%) has version %, but should have version ''public''',
+          subgraph_id, schema_name, schema_version;
+  end if;
+
+  execute format('select exists (select 1 from %I.entities)', schema_name)
+     into has_rows;
+  if has_rows then
+    raise 'Expected table %.entities to be empty', schema_name;
+  end if;
+
+  execute format('select exists (select 1 from %I.entity_history)', schema_name)
+     into has_rows;
+  if has_rows then
+    raise 'Expected table %.entity_history to be empty', schema_name;
+  end if;
+
+  -- It is possible that a previous attempt to do the migration copied a
+  -- lot of data and then was abandoned (for example, because the
+  -- graph-node instance running it crashed) That leaves the entities and
+  -- entity_history tables empty, but all the data that was copied before
+  -- still exists as dead tuples. Truncate the tables to get rid of those
+  -- dead tuples
+  execute format('truncate %I.entities', schema_name);
+  execute format('truncate %I.entity_history', schema_name);
+
+  -- Migrate data out of the public schema
+  execute format('
+      insert into %I.entities
+      select entity, id, data, event_source
+        from public.entities p
+        where p.subgraph=$1', schema_name)
+  using subgraph_id;
+  GET DIAGNOSTICS entities_count = ROW_COUNT;
+
+  delete from public.entities
+   where subgraph=subgraph_id;
+
+  execute format('
+      insert into
+        %I.entity_history(event_id, entity, entity_id,
+                          data_before, reversion, op_id)
+      select event_id, entity, entity_id,
+             data_before, reversion, op_id
+        from public.entity_history
+       where subgraph=$1', schema_name)
+  using subgraph_id;
+
+  delete from public.entity_history
+   where subgraph=subgraph_id;
+
+  -- Create change triggers after migrating the data
+  -- Otherwise we wind up with duplicate history
+
+  -- Need to set the search_path again so the trigges go on the right table
+  perform set_config('search_path', format('%I, public', schema_name), true);
+  create trigger entity_change_insert_trigger
+      after insert on entities
+      for each row
+      execute procedure subgraph_log_entity_event();
+
+  create trigger entity_change_update_trigger
+      after update on entities
+      for each row
+      when (old.data != new.data)
+      execute procedure subgraph_log_entity_event();
+
+  create trigger entity_change_delete_trigger
+      after delete on entities
+      for each row
+      execute procedure subgraph_log_entity_event();
+
+  perform set_config('search_path', '"$user", public', true);
+
+  -- We should drop attribute indexes for subgraph_id from public.entities
+  -- at this point, but that requires an access exclusive lock on that
+  -- table, which can lead to concurrently running migrations to deadlock.
+  -- We therefore leave the indexes in place, and they will need to be
+  -- cleaned up separately.
+
+  -- Update statistics for our new tables
+  execute format('analyze %I.entities', schema_name);
+  execute format('analyze %I.entity_history', schema_name);
+
+  return entities_count;
+end;
+$function$;

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -1390,10 +1390,10 @@ pub(crate) fn create_schema(
            event_id     integer references event_meta_data(id)
                           on update cascade on delete cascade,
            entity       varchar not null,
-	         entity_id    varchar not null,
-	         data_before  jsonb,
-	         reversion    bool not null default false,
-	         op_id        int2 NOT NULL
+           entity_id    varchar not null,
+           data_before  jsonb,
+           reversion    bool not null default false,
+           op_id        int2 NOT NULL
          )",
         schema_name
     );

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -288,7 +288,7 @@ pub(crate) enum Table {
 /// entity storage, such as migrating a subgraph from the monolithic
 /// entities table to a split entities table
 pub(crate) struct Connection<'a> {
-    conn: &'a PgConnection,
+    pub conn: &'a PgConnection,
     tables: RefCell<HashMap<SubgraphDeploymentId, Table>>,
 }
 

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -314,6 +314,18 @@ impl<'a> Connection<'a> {
         }
     }
 
+    /// Do any cleanup to bring the subgraph into a known good state
+    pub(crate) fn start_subgraph(&self, subgraph: &SubgraphDeploymentId) -> Result<(), StoreError> {
+        use public::deployment_schemas as dsl;
+
+        Ok(
+            diesel::update(dsl::table.filter(dsl::subgraph.eq(subgraph.to_string())))
+                .set(dsl::migrating.eq(false))
+                .execute(self.conn)
+                .map(|_| ())?,
+        )
+    }
+
     pub(crate) fn find(
         &self,
         subgraph: &SubgraphDeploymentId,

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -482,12 +482,12 @@ impl<'a> Connection<'a> {
         self,
         logger: &Logger,
         subgraph: &SubgraphDeploymentId,
-        block_ptr: EthereumBlockPointer,
+        block_ptr: &EthereumBlockPointer,
     ) -> Result<bool, Error> {
         // How many simultaneous subgraph migrations we allow
         const MIGRATION_LIMIT: i32 = 2;
 
-        if !self.should_migrate(subgraph, &block_ptr)? {
+        if !self.should_migrate(subgraph, block_ptr)? {
             return Ok(false);
         }
 

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -3,6 +3,8 @@ extern crate diesel;
 extern crate diesel_dynamic_schema;
 #[macro_use]
 extern crate diesel_migrations;
+#[macro_use]
+extern crate diesel_derive_enum;
 extern crate failure;
 extern crate fallible_iterator;
 extern crate futures;

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -17,13 +17,13 @@ extern crate serde;
 extern crate uuid;
 
 mod chain_head_listener;
-pub mod db_schema;
+mod db_schema;
 mod entities;
 mod filter;
-pub mod functions;
-pub mod jsonb;
+mod functions;
+mod jsonb;
 mod notification_listener;
-pub mod sql_value;
+mod sql_value;
 pub mod store;
 mod store_events;
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1021,6 +1021,21 @@ impl StoreTrait for Store {
             crate::entities::create_schema(&conn, subgraph_id)
         })
     }
+
+    fn start_subgraph_deployment(
+        &self,
+        subgraph_id: &SubgraphDeploymentId,
+        ops: Vec<EntityOperation>,
+    ) -> Result<(), StoreError> {
+        let conn = self.get_conn().map_err(Error::from)?;
+        let econn = e::Connection::new(&conn);
+
+        conn.transaction(|| {
+            self.emit_store_events(&conn, &ops)?;
+            self.apply_entity_operations_with_conn(&econn, ops, None)?;
+            econn.start_subgraph(subgraph_id)
+        })
+    }
 }
 
 impl SubgraphDeploymentStore for Store {

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -108,7 +108,7 @@ pub struct StoreConfig {
 pub struct Store {
     logger: Logger,
     subscriptions: Arc<RwLock<HashMap<String, Sender<StoreEvent>>>>,
-    // listen to StoreEvents emitted by emit_store_events
+    // listen to StoreEvents generated when applying entity operations
     listener: StoreEventListener,
     chain_head_update_listener: ChainHeadUpdateListener,
     network_name: String,
@@ -669,7 +669,21 @@ impl Store {
         let mut count = 0;
         let mut subgraph = None;
 
-        self.emit_store_events(econn.conn, &operations)?;
+        // Emit a store event for the changes we are about to make
+        let changes: Vec<_> = operations
+            .iter()
+            .filter_map(|op| EntityChange::from_entity_operation(op.clone()))
+            .collect();
+        let event = StoreEvent::new(changes);
+
+        trace!(self.logger, "Emit store event";
+                "tag" => event.tag,
+                "changes" => event.changes.len());
+
+        let v = serde_json::to_value(event)?;
+        JsonNotification::send("store_events", &v, econn.conn)?;
+
+        // Actually apply the operations
         for operation in operations.into_iter() {
             if subgraph.is_none() {
                 subgraph = operation
@@ -727,25 +741,6 @@ impl Store {
             self.build_entity_attribute_index_with_conn(conn, index)?;
         }
         Ok(())
-    }
-
-    fn emit_store_events(
-        &self,
-        conn: &PgConnection,
-        operations: &[EntityOperation],
-    ) -> Result<(), StoreError> {
-        let changes: Vec<_> = operations
-            .iter()
-            .filter_map(|op| EntityChange::from_entity_operation(op.clone()))
-            .collect();
-        let event = StoreEvent::new(changes);
-
-        trace!(self.logger, "Emit store event";
-                "tag" => event.tag,
-                "changes" => event.changes.len());
-
-        let v = serde_json::to_value(event)?;
-        JsonNotification::send("store_events", &v, conn)
     }
 
     fn get_conn(&self) -> Result<PooledConnection<ConnectionManager<PgConnection>>, Error> {
@@ -909,7 +904,6 @@ impl StoreTrait for Store {
             let history_event = econn.create_history_event(subgraph_id.clone(), event_source)?;
 
             // Apply the entity operations with the new block as the event source
-            self.emit_store_events(&conn, &operations)?;
             self.apply_entity_operations_with_conn(&econn, operations, Some(&history_event))?;
 
             // Update the subgraph block pointer, without an event source; this way
@@ -919,7 +913,6 @@ impl StoreTrait for Store {
                 block_ptr_from,
                 block_ptr_to,
             );
-            self.emit_store_events(&conn, &block_ptr_ops)?;
             self.apply_entity_operations_with_conn(&econn, block_ptr_ops, None)
         })?;
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -920,7 +920,11 @@ impl StoreTrait for Store {
             );
             self.emit_store_events(&conn, &block_ptr_ops)?;
             self.apply_entity_operations_with_conn(&econn, block_ptr_ops, None)
-        })
+        })?;
+
+        Ok(econn
+            .migrate(&self.logger, &subgraph_id, block_ptr_to)
+            .map(|_| ())?)
     }
 
     fn apply_entity_operations(

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -139,6 +139,13 @@ impl Store {
         let conn_manager = ConnectionManager::new(config.postgres_url.as_str());
         let pool = Pool::builder()
             .error_handler(error_handler)
+            // Set the time we wait for a connection to 6h. The default is 30s
+            // which can be too little if database connections are highly
+            // contended; if we don't get a connection within the timeout,
+            // ultimately subgraphs get marked as failed. This effectively
+            // turns off this timeout and makes it possible that work needing
+            // a database connection blocks for a very long time
+            .connection_timeout(Duration::from_secs(6 * 60 * 60))
             .build(conn_manager)
             .unwrap();
         info!(

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -114,12 +114,10 @@ fn insert_test_data(store: Arc<DieselStore>) {
     };
 
     // Create SubgraphDeploymentEntity
+    let ops = SubgraphDeploymentEntity::new(&manifest, false, false, *TEST_BLOCK_0_PTR, 1)
+        .create_operations(&*TEST_SUBGRAPH_ID);
     store
-        .apply_entity_operations(
-            SubgraphDeploymentEntity::new(&manifest, false, false, *TEST_BLOCK_0_PTR, 1)
-                .create_operations(&*TEST_SUBGRAPH_ID),
-            None,
-        )
+        .create_subgraph_deployment(&TEST_SUBGRAPH_ID, ops)
         .unwrap();
 
     let test_entity_1 = create_test_entity(
@@ -1868,13 +1866,9 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
         };
 
         // Create SubgraphDeploymentEntity
-        store
-            .apply_entity_operations(
-                SubgraphDeploymentEntity::new(&manifest, false, false, *TEST_BLOCK_0_PTR, 1)
-                    .create_operations(&subgraph_id),
-                None,
-            )
-            .unwrap();
+        let ops = SubgraphDeploymentEntity::new(&manifest, false, false, *TEST_BLOCK_0_PTR, 1)
+            .create_operations(&subgraph_id);
+        store.create_subgraph_deployment(&subgraph_id, ops).unwrap();
 
         // Create store subscriptions
         let meta_subscription =


### PR DESCRIPTION
This PR puts a framework in place to perform store migrations for subgraphs one at a time, and uses that to migrate existing subgraphs out of the `public.entities` table into dedicated tables for each subgraph.

I tested this by running it against a dump of the production database, and assigning the subgraphs for one of the mainnet indexing nodes to my graph-node instance. When a subgraph is picked for migration, indexing for that subgraph pauses and its data is successfully transferred into the new tables.

It is still possible for indexing of non-migrating subgraphs to stall; in my testing, these stalls didn't last very long, and block ingestion never fell farther than about 15 blocks behind.

Eventually, all assigned and non-failed subgraphs will be migrated. Subgraphs that are not assigned to a node, and subgraphs that fail during their processing will not be migrated by this mechanism.