### PR TITLE
Add an `ETHEREUM_START_BLOCK` environment variable

### DIFF
--- a/datasource/ethereum/tests/adapter.rs
+++ b/datasource/ethereum/tests/adapter.rs
@@ -145,7 +145,7 @@ fn contract_call() {
     )));
 
     let logger = Logger::root(slog::Discard, o!());
-    let adapter = EthereumAdapter::new(transport);
+    let adapter = EthereumAdapter::new(transport, 0u64);
     let balance_of = Function {
         name: "balanceOf".to_owned(),
         inputs: vec![Param {

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,61 +1,74 @@
 # Environment Variables
 
-**Warning**: the names of some of these environment variables will be changed
-at some point in the near future.
+**Warning**: the names of some of these environment variables will be changed at
+some point in the near future.
 
-This page lists the environment variables used by `graph-node` and what
-effect they have. Some environment variables can be used instead of command
-line flags. Those are not listed here, please consult `graph-node --help`
-for details on those.
+This page lists the environment variables used by `graph-node` and what effect
+they have. Some environment variables can be used instead of command line flags.
+Those are not listed here, please consult `graph-node --help` for details on
+those.
 
 ## Getting blocks from Ethereum
 
-* `ETHEREUM_POLLING_INTERVAL`: how often to poll Ethereum for new blocks
-(in ms, defaults to 500ms)
-* `ETHEREUM_RPC_MAX_PARALLEL_REQUESTS`: how many RPC connections to start
-in parallel for block retrieval (defaults to 64)
-* `ETHEREUM_FAST_SCAN_END`: `graph-node` locates
-  blocks with events for a particular subgraph. Most subgraphs do not have
-  events in the first few million blocks, so `graph-node` optimizes for that
-  case by inquiring about a large range. The value of this variable
-  is the block number at which we switch from probing large ranges to
-  ranges of size `ETHEREUM_BLOCK_RANGE_SIZE` (defaults to 4000000).
-* `ETHEREUM_TRACE_STREAM_STEP_SIZE`: `graph-node` queries traces for a given block
-  range when a subgraph defines call handlers or block handlers with a call filter.
-  The value of this variable controls the number of blocks to scan in a single RPC request for traces
-  from the Ethereum node.
+* `ETHEREUM_POLLING_INTERVAL`: how often to poll Ethereum for new blocks (in ms,
+  defaults to 500ms)
+* `ETHEREUM_RPC_MAX_PARALLEL_REQUESTS`: how many RPC connections to start in
+  parallel for block retrieval (defaults to 64)
+* `ETHEREUM_FAST_SCAN_END`: `graph-node` locates blocks with events for a
+  particular subgraph. Most subgraphs do not have events in the first few
+  million blocks, so `graph-node` optimizes for that case by inquiring about a
+  large range. The value of this variable is the block number at which we switch
+  from probing large ranges to ranges of size `ETHEREUM_BLOCK_RANGE_SIZE`
+  (defaults to 4000000).
+* `ETHEREUM_TRACE_STREAM_STEP_SIZE`: `graph-node` queries traces for a given
+  block range when a subgraph defines call handlers or block handlers with a
+  call filter. The value of this variable controls the number of blocks to scan
+  in a single RPC request for traces from the Ethereum node.
 * `DISABLE_BLOCK_INGESTOR`: set to `true` to disable block ingestion. Leave
   unset or set to `false` to leave block ingestion enabled.
-* `ETHEREUM_BLOCK_BATCH_SIZE`: number of Ethereum blocks to request in
-  parallel (defaults to 50)
-* `ETHEREUM_BLOCK_RANGE_SIZE` - number of blocks to scan for events in
-  each request (defaults to 10000).
-* `ETHEREUM_PARALLEL_BLOCK_RANGES` - Maximum number of parallel `eth_getLogs` calls to make when scanning logs for a subgraph. Defaults to 100.
+* `ETHEREUM_BLOCK_BATCH_SIZE`: number of Ethereum blocks to request in parallel
+  (defaults to 50)
+* `ETHEREUM_BLOCK_RANGE_SIZE`: number of blocks to scan for events in each
+  request (defaults to 10000).
+* `ETHEREUM_PARALLEL_BLOCK_RANGES` - Maximum number of parallel `eth_getLogs`
+  calls to make when scanning logs for a subgraph. Defaults to 100.
+* `ETHEREUM_START_BLOCK`: the block number at which subgraphs should start
+  indexing (defaults to the genesis block). Can save some time while debugging
+  subgraphs locally. _Warning:_ Do not use this in production, as it may
+  cause subgraphs to be only indexed partially.
 
 ## Running mapping handlers
-* `GRAPH_EVENT_HANDLER_TIMEOUT`: amount of time an event handler is allowed
-  to take (in seconds, default is unlimited)
-* `GRAPH_IPFS_TIMEOUT`: timeout for ipfs requests. In seconds, default is 30 seconds.
-* `GRAPH_MAX_IPFS_FILE_BYTES`: maximum size for a file that can be
-  retrieved with `ipfs.cat` (in bytes, default is unlimited)
-* `GRAPH_MAX_IPFS_MAP_FILE_SIZE`: maximum size of files that can be
-  processed with `ipfs.map`. When a file is processed through `ipfs.map`,
-  the entities generated from that are kept in memory until the entire file
-  is done processing. This setting therefore limits how much memory a call
-  to `ipfs.map` may use. (in bytes, defaults to 256MB)
+
+* `GRAPH_EVENT_HANDLER_TIMEOUT`: amount of time an event handler is allowed to
+  take (in seconds, default is unlimited)
+* `GRAPH_IPFS_TIMEOUT`: timeout for ipfs requests. In seconds, default is 30
+  seconds.
+* `GRAPH_MAX_IPFS_FILE_BYTES`: maximum size for a file that can be retrieved
+  with `ipfs.cat` (in bytes, default is unlimited)
+* `GRAPH_MAX_IPFS_MAP_FILE_SIZE`: maximum size of files that can be processed
+  with `ipfs.map`. When a file is processed through `ipfs.map`, the entities
+  generated from that are kept in memory until the entire file is done
+  processing. This setting therefore limits how much memory a call to `ipfs.map`
+  may use. (in bytes, defaults to 256MB)
 
 ## GraphQL
-* `GRAPH_GRAPHQL_QUERY_TIMEOUT`: maximum execution time for a graphql query, in seconds. Default is unlimited.
-* `SUBSCRIPTION_THROTTLE_INTERVAL`: while a subgraph is syncing,
-  subscriptions to that subgraph get updated at most this often, in
-  ms. Default is 1000ms.
-* `GRAPH_GRAPHQL_MAX_COMPLEXITY`: maximum complexity for a graphql query. See [here](https://developer.github.com/v4/guides/resource-limitations) for what that means. Default is unlimited. Typical introspection queries have a complexity of just over 1 million, so setting a value below that may interfere with introspection done by graphql clients.
-* `GRAPH_GRAPHQL_MAX_DEPTH`: maximum depth of a graphql query. Default (and maximum) is 255.
+
+* `GRAPH_GRAPHQL_QUERY_TIMEOUT`: maximum execution time for a graphql query, in
+  seconds. Default is unlimited.
+* `SUBSCRIPTION_THROTTLE_INTERVAL`: while a subgraph is syncing, subscriptions
+  to that subgraph get updated at most this often, in ms. Default is 1000ms.
+* `GRAPH_GRAPHQL_MAX_COMPLEXITY`: maximum complexity for a graphql query. See
+  [here](https://developer.github.com/v4/guides/resource-limitations) for what
+  that means. Default is unlimited. Typical introspection queries have a
+  complexity of just over 1 million, so setting a value below that may interfere
+  with introspection done by graphql clients.
+* `GRAPH_GRAPHQL_MAX_DEPTH`: maximum depth of a graphql query. Default (and
+  maximum) is 255.
 
 ## Miscellaneous
-* `GRAPH_LOG`: control log levels, the same way that `RUST_LOG` is
-described [here](https://docs.rs/env_logger/0.6.0/env_logger/)
+
+* `GRAPH_LOG`: control log levels, the same way that `RUST_LOG` is described
+[here](https://docs.rs/env_logger/0.6.0/env_logger/)
 * `THEGRAPH_SENTRY_URL`:
 * `THEGRAPH_STORE_POSTGRES_DIESEL_URL`: postgres instance used when running
-   tests. Set to
-   `postgresql://<DBUSER>:<DBPASSWORD>@<DBHOST>:<DBPORT>/<DBNAME>`
+   tests. Set to `postgresql://<DBUSER>:<DBPASSWORD>@<DBHOST>:<DBPORT>/<DBNAME>`

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -406,6 +406,16 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     // For now it's fine to just leak it.
     std::mem::forget(transport_event_loop);
 
+    // Warn if the start block is != genesis
+    if *ETHEREUM_START_BLOCK > 0 {
+        warn!(
+            logger,
+            "Using {} as the block to start indexing at. \
+             This may cause subgraphs to be only indexed partially",
+            *ETHEREUM_START_BLOCK,
+        );
+    }
+
     // Create Ethereum adapter
     let eth_adapter = Arc::new(graph_datasource_ethereum::EthereumAdapter::new(
         transport,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -101,6 +101,7 @@ fn initiate_schema(logger: &Logger, conn: &PgConnection, blocking_conn: &PgConne
 pub struct StoreConfig {
     pub postgres_url: String,
     pub network_name: String,
+    pub start_block: u64,
 }
 
 /// A Store based on Diesel and Postgres.
@@ -166,7 +167,7 @@ impl Store {
                 config.network_name.clone(),
             ),
             network_name: config.network_name.clone(),
-            genesis_block_ptr: (net_identifiers.genesis_block_hash, 0u64).into(),
+            genesis_block_ptr: (net_identifiers.genesis_block_hash, config.start_block).into(),
             conn: pool,
             schema_cache: Mutex::new(LruCache::with_capacity(100)),
         };

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -40,6 +40,7 @@ lazy_static! {
                 StoreConfig {
                     postgres_url,
                     network_name,
+                    start_block: 0u64,
                 },
                 &logger,
                 net_identifiers,


### PR DESCRIPTION
Consider this a proposal. We've discussed https://github.com/graphprotocol/graph-cli/issues/218 as an alternative to this, but especially with the new block and call handlers, it can take a long time for a subgraph to reach a certain block.

I'm coming around to @davekaj's point that being able to start indexing at a specific block number when developing or debugging a subgraph locally. I've used this environment variable twice already.