### PR TITLE
ethereum, store: Replace chain head listener channels with `tokio::watch`

### DIFF
--- a/graph/src/components/ethereum/listener.rs
+++ b/graph/src/components/ethereum/listener.rs
@@ -21,7 +21,9 @@ pub struct ChainHeadUpdate {
     pub head_block_number: u64,
 }
 
-pub type ChainHeadUpdateStream = Box<Stream<Item = ChainHeadUpdate, Error = ()> + Send>;
+/// The updates have no payload, receivers should call `Store::chain_head_ptr`
+/// to check what the latest block is.
+pub type ChainHeadUpdateStream = Box<Stream<Item = (), Error = ()> + Send>;
 
 pub trait ChainHeadUpdateListener {
     // Subscribe to chain head updates.

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -3,9 +3,7 @@ use futures::Stream;
 
 use crate::prelude::*;
 
-pub trait BlockStream:
-    Stream<Item = EthereumBlockWithTriggers, Error = Error> + EventConsumer<ChainHeadUpdate>
-{
+pub trait BlockStream: Stream<Item = EthereumBlockWithTriggers, Error = Error> {
     fn parse_triggers(
         log_filter_opt: Option<EthereumLogFilter>,
         call_filter_opt: Option<EthereumCallFilter>,

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -1,25 +1,18 @@
-use futures::sync::mpsc::{channel, Sender};
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
-use uuid::Uuid;
+use tokio::sync::watch;
 
 use graph::prelude::{ChainHeadUpdateListener as ChainHeadUpdateListenerTrait, *};
 use graph::serde_json;
 
 use crate::notification_listener::{NotificationListener, SafeChannelName};
 
-type ChainHeadUpdateSubscribers = Arc<RwLock<HashMap<String, Sender<ChainHeadUpdate>>>>;
-
 pub struct ChainHeadUpdateListener {
-    logger: Logger,
-    subscribers: ChainHeadUpdateSubscribers,
+    update_receiver: watch::Receiver<()>,
     _listener: NotificationListener,
 }
 
 impl ChainHeadUpdateListener {
     pub fn new(logger: &Logger, postgres_url: String, network_name: String) -> Self {
         let logger = logger.new(o!("component" => "ChainHeadUpdateListener"));
-        let subscribers = Arc::new(RwLock::new(HashMap::new()));
 
         // Create a Postgres notification listener for chain head updates
         let mut listener = NotificationListener::new(
@@ -28,11 +21,11 @@ impl ChainHeadUpdateListener {
             SafeChannelName::i_promise_this_is_safe("chain_head_updates"),
         );
 
-        Self::listen(&logger, &mut listener, network_name, subscribers.clone());
+        let (update_sender, update_receiver) = watch::channel(());
+        Self::listen(logger, &mut listener, network_name, update_sender);
 
         ChainHeadUpdateListener {
-            logger,
-            subscribers,
+            update_receiver,
 
             // We keep the listener around to tie its stream's lifetime to
             // that of the chain head update listener and prevent it from
@@ -42,10 +35,10 @@ impl ChainHeadUpdateListener {
     }
 
     fn listen(
-        logger: &Logger,
+        logger: Logger,
         listener: &mut NotificationListener,
         network_name: String,
-        subscribers: ChainHeadUpdateSubscribers,
+        mut update_sender: watch::Sender<()>,
     ) {
         let logger = logger.clone();
 
@@ -72,64 +65,25 @@ impl ChainHeadUpdateListener {
                     }
                 })
                 .for_each(move |update| {
-                    let logger = logger.clone();
-                    let senders = subscribers.read().unwrap().clone();
-                    let subscribers = subscribers.clone();
-
                     debug!(
-                        logger,
+                        logger.clone(),
                         "Received chain head update";
                         "network" => &update.network_name,
                         "head_block_hash" => format!("{}", update.head_block_hash),
                         "head_block_number" => &update.head_block_number,
                     );
 
-                    // Forward update to all susbcribers
-                    stream::iter_ok::<_, ()>(senders).for_each(move |(id, mut sender)| {
-                        let logger = logger.clone();
-                        let subscribers = subscribers.clone();
-
-                        // A subgraph that's syncing will let chain head updates
-                        // pile up in the channel. So we don't wait for room in
-                        // the channel and instead skip it, it will have the
-                        // opportunity to grab future updates.
-                        match sender.try_send(update.clone()) {
-                            // Move on to the next subscriber
-                            Ok(()) => (),
-                            Err(ref e) if e.is_full() => {
-                                // Temporary log, feel free to remove if noisy.
-                                debug!(logger, "Full chain head update channel"; "id" => &id);
-                            }
-                            Err(ref e) if e.is_disconnected() => {
-                                // Remove disconnected subscribers.
-                                debug!(logger, "Unsubscribe"; "id" => &id);
-                                subscribers.write().unwrap().remove(&id);
-                            }
-                            Err(e) => warn!(logger, "Unexpected send error"; "e" => e.to_string()),
-                        }
-                        Ok(())
-                    })
+                    update_sender.broadcast(()).map_err(|_| ())
                 }),
         );
 
-        // We're ready, start listening to chain head updaates
+        // We're ready, start listening to chain head updates
         listener.start();
     }
 }
 
 impl ChainHeadUpdateListenerTrait for ChainHeadUpdateListener {
     fn subscribe(&self) -> ChainHeadUpdateStream {
-        // Generate a new (unique) UUID; we're looping just to be sure we avoid collisions
-        let mut id = Uuid::new_v4().to_string();
-        while self.subscribers.read().unwrap().contains_key(&id) {
-            id = Uuid::new_v4().to_string();
-        }
-
-        debug!(self.logger, "Subscribe"; "id" => &id);
-
-        // Create a subscriber and return the receiving end
-        let (sender, receiver) = channel(100);
-        self.subscribers.write().unwrap().insert(id, sender);
-        Box::new(receiver)
+        Box::new(self.update_receiver.clone().map_err(|_| ()))
     }
 }


### PR DESCRIPTION
Simplifies and improves performance of the communication between the listener and block streams. Resolves #930.

