### PR TITLE
Move the subgraph task to the blocking thread pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,7 @@ dependencies = [
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-store 0.1.0",
+ "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.7"
 uuid = { version = "0.7.2", features = ["v4"] }
+tokio-threadpool = "0.1.14"
 
 [dev-dependencies]
 # We're using the latest ipfs-api for the HTTPS support that was merged in


### PR DESCRIPTION
This is probably the busiest task in indexing nodes and it blocks on the DB on many of its steps. Locally I could not reliably measure whether it reduced contention, but still seems worth seeing what happens on the hosted service. Even if we can't see a change, in principle this is a correct thing to do.

Part of #937 
