### PR TITLE
Gracefully handle event data ABI mismatches by trying all potential event handlers

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -479,7 +479,8 @@ pub struct MappingEventHandler {
 
 impl MappingEventHandler {
     pub fn topic0(&self) -> H256 {
-        self.topic0.unwrap_or_else(|| string_to_h256(&self.event))
+        self.topic0
+            .unwrap_or_else(|| string_to_h256(&self.event.replace("indexed ", "")))
     }
 }
 

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -708,8 +708,8 @@ impl RuntimeHostTrait for RuntimeHost {
             }
         };
 
-        // Filter out handlers whose signatures don't exist in the contract ABI;
-        // map handlers to (handler, event ABI) pairs
+        // Map event handlers to (event handler, event ABI) pairs; fail if there are
+        // handlers that don't exist in the contract ABI
         let valid_handlers =
             potential_handlers
                 .into_iter()


### PR DESCRIPTION
Resolves #913, together with https://github.com/graphprotocol/graph-cli/pull/281.

This changes the event processing in subgraphs to try all potential event handlers for an event in turn. The problem is that events that match a signature may have parameter data that was encoded in different ways, e.g. using indexed vs. non-indexed event parameters.

By trying all matching handlers, we can handle this situation gracefully and allow any event handler that can decode the event data to process the event. For those that cannot, we'll log a warning just in case.