### PR TITLE
runtime: Improve error message for division by zero

### DIFF
--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -479,8 +479,18 @@ where
         x * y
     }
 
-    pub(crate) fn big_int_divided_by(&self, x: BigInt, y: BigInt) -> BigInt {
-        x / y
+    pub(crate) fn big_int_divided_by(
+        &self,
+        x: BigInt,
+        y: BigInt,
+    ) -> Result<BigInt, HostExportError<impl ExportError>> {
+        if y == 0.into() {
+            return Err(HostExportError(format!(
+                "attempted to divide BigInt `{}` by zero",
+                x
+            )));
+        }
+        Ok(x / y)
     }
 
     pub(crate) fn big_int_mod(&self, x: BigInt, y: BigInt) -> BigInt {

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -748,7 +748,7 @@ where
     ) -> Result<Option<RuntimeValue>, Trap> {
         let result = self
             .host_exports()
-            .big_int_divided_by(self.asc_get(x_ptr), self.asc_get(y_ptr));
+            .big_int_divided_by(self.asc_get(x_ptr), self.asc_get(y_ptr))?;
         let result_ptr: AscPtr<AscBigInt> = self.asc_new(&result);
         Ok(Some(RuntimeValue::from(result_ptr)))
     }


### PR DESCRIPTION
Previously this would panic with a generic error message.