### PR TITLE
Move coercion to completion

### DIFF
--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -73,25 +73,11 @@ pub trait Resolver: Clone + Send + Sync {
     /// Resolves an enum value for a given enum type.
     fn resolve_enum_value(
         &self,
-        field: &q::Field,
-        enum_type: &s::EnumType,
+        _field: &q::Field,
+        _enum_type: &s::EnumType,
         value: Option<&q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
-        value.map_or(Ok(q::Value::Null), |value| {
-            value.coerce(enum_type).ok_or_else(|| {
-                QueryExecutionError::EnumCoercionError(
-                    field.position.clone(),
-                    field.name.to_owned(),
-                    value.clone(),
-                    enum_type.name.to_owned(),
-                    enum_type
-                        .values
-                        .iter()
-                        .map(|value| value.name.to_owned())
-                        .collect(),
-                )
-            })
-        })
+        Ok(value.cloned().unwrap_or(q::Value::Null))
     }
 
     /// Resolves a scalar value for a given scalar type.
@@ -99,20 +85,11 @@ pub trait Resolver: Clone + Send + Sync {
         &self,
         _parent_object_type: &s::ObjectType,
         _parent: &BTreeMap<String, q::Value>,
-        field: &q::Field,
-        scalar_type: &s::ScalarType,
+        _field: &q::Field,
+        _scalar_type: &s::ScalarType,
         value: Option<&q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
-        value.map_or(Ok(q::Value::Null), |value| {
-            value.coerce(scalar_type).ok_or_else(|| {
-                QueryExecutionError::ScalarCoercionError(
-                    field.position.clone(),
-                    field.name.to_owned(),
-                    value.clone(),
-                    scalar_type.name.to_owned(),
-                )
-            })
-        })
+        Ok(value.cloned().unwrap_or(q::Value::Null))
     }
 
     /// Resolves a list of enum values for a given enum type.

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -95,78 +95,21 @@ pub trait Resolver: Clone + Send + Sync {
     /// Resolves a list of enum values for a given enum type.
     fn resolve_enum_values(
         &self,
-        field: &q::Field,
-        enum_type: &s::EnumType,
+        _field: &q::Field,
+        _enum_type: &s::EnumType,
         value: Option<&q::Value>,
     ) -> Result<q::Value, Vec<QueryExecutionError>> {
-        value
-            .and_then(|value| match value {
-                q::Value::List(values) => Some(values),
-                _ => None,
-            })
-            .map_or(Ok(q::Value::Null), |values| {
-                let mut coerced_values = vec![];
-                let mut errors = vec![];
-
-                for value in values.iter() {
-                    match value.coerce(enum_type) {
-                        Some(value) => coerced_values.push(value),
-                        None => errors.push(QueryExecutionError::EnumCoercionError(
-                            field.position.clone(),
-                            field.name.to_owned(),
-                            value.clone(),
-                            enum_type.name.to_owned(),
-                            enum_type
-                                .values
-                                .iter()
-                                .map(|value| value.name.to_owned())
-                                .collect(),
-                        )),
-                    }
-                }
-
-                if !errors.is_empty() {
-                    return Err(errors);
-                } else {
-                    return Ok(q::Value::List(coerced_values));
-                }
-            })
+        Ok(value.cloned().unwrap_or(q::Value::Null))
     }
 
     /// Resolves a list of scalar values for a given list type.
     fn resolve_scalar_values(
         &self,
-        field: &q::Field,
-        scalar_type: &s::ScalarType,
+        _field: &q::Field,
+        _scalar_type: &s::ScalarType,
         value: Option<&q::Value>,
     ) -> Result<q::Value, Vec<QueryExecutionError>> {
-        value
-            .and_then(|value| match value {
-                q::Value::List(values) => Some(values),
-                _ => None,
-            })
-            .map_or(Ok(q::Value::Null), |values| {
-                let mut coerced_values = vec![];
-                let mut errors = vec![];
-
-                for value in values.iter() {
-                    match value.coerce(scalar_type) {
-                        Some(value) => coerced_values.push(value),
-                        None => errors.push(QueryExecutionError::ScalarCoercionError(
-                            field.position.clone(),
-                            field.name.to_owned(),
-                            value.clone(),
-                            scalar_type.name.to_owned(),
-                        )),
-                    }
-                }
-
-                if !errors.is_empty() {
-                    return Err(errors);
-                } else {
-                    return Ok(q::Value::List(coerced_values));
-                }
-            })
+        Ok(value.cloned().unwrap_or(q::Value::Null))
     }
 
     // Resolves an abstract type into the specific type of an object.


### PR DESCRIPTION
Doing coercion in `complete_value` is more [in line with the spec](https://graphql.github.io/graphql-spec/draft/#CompleteValue()). Right now we only have one real resolver so it doesn't make much difference, but with #957 and #857 we might get more resolvers so this is an important refactoring.