### PR TITLE
Create subgraph deployment reassignment RPC endpoint

### DIFF
--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -34,4 +34,11 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
         &self,
         name: SubgraphName,
     ) -> Box<Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
+
+    fn reassign_subgraph(
+        &self,
+        name: SubgraphName,
+        hash: SubgraphDeploymentId,
+        node_id: NodeId,
+    ) -> Box<Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
 }


### PR DESCRIPTION
Resolves #939 

This PR creates a JSON-RPC method for reassigning a subgraph to a different node.  The node that receives the JSON request will update the assignment entity and propagate the assignment removals and additions to all subscribing `graph-nodes`.  If the provided target `node_id` does not match any of the nodes in the system the subgraph will effectively be paused.

Example request: 
```
curl -H "content-type: application/json" --data '{"jsonrpc": "2.0", "method": "subgraph_reassign", "params": { "name": "username/SubgraphName", "ipfs_hash":"QmXxiWNWHtzap2hX8A5L6yJzKx23ypt6i4UVRqZmVR2jnO", "node_id":"default"}, "id": "1"}'
``` 

In the past, subgraph deployment reassignments could only be made by manually updating the now deprecated `subgraph_deployments` table which was subscribed to by all connected `graph-nodes`. 


