### PR TITLE
core: Subgraph reassignment handles deployments with multiple versions

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -842,12 +842,14 @@ fn reassign_subgraph(
     ops.extend(read_summaries_abort_ops);
 
     ops.push(EntityOperation::AbortUnless {
-        description: "Provided name-deploymentId pair must match an existing subgraph version"
-            .to_owned(),
+        description:
+            "Provided name-deploymentId pair must match an existing, current subgraph version"
+                .to_owned(),
         query: SubgraphEntity::query()
             .filter(EntityFilter::new_in("name", vec![name.clone().to_string()])),
         entity_ids: version_summaries
             .iter()
+            .filter(|version| version.current)
             .map(move |summary| summary.clone().subgraph_id)
             .collect(),
     });


### PR DESCRIPTION
This PR updates the `subgraph_reassign` JSON RPC method to handle a subgraph deployment (IPFS hash) that has multiple versions.  We now use only versions marked as current to verify the request is valid before performing the reassignment. 