### PR TITLE
Add subgraph logging before/after/during manifest resolution

### DIFF
--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -90,16 +90,17 @@ where
         let link = format!("/ipfs/{}", id);
 
         let logger = self.logger_factory.subgraph_logger(&id);
+        let logger_for_resolve = logger.clone();
         let logger_for_err = logger.clone();
 
         info!(logger, "Resolve subgraph files using IPFS");
 
         Box::new(
-            SubgraphManifest::resolve(Link { link }, self.resolver.clone())
+            SubgraphManifest::resolve(Link { link }, self.resolver.clone(), logger_for_resolve)
                 .map_err(SubgraphAssignmentProviderError::ResolveError)
                 .join(
                     loader
-                        .load_dynamic_data_sources(&subgraph_id_for_data_sources)
+                        .load_dynamic_data_sources(&subgraph_id_for_data_sources, logger.clone())
                         .map_err(SubgraphAssignmentProviderError::DynamicDataSourcesError),
                 )
                 .and_then(

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -254,7 +254,7 @@ where
         let logger = self.logger_factory.subgraph_logger(&hash);
 
         Box::new(
-            SubgraphManifest::resolve(hash.to_ipfs_link(), self.resolver.clone())
+            SubgraphManifest::resolve(hash.to_ipfs_link(), self.resolver.clone(), logger.clone())
                 .map_err(SubgraphRegistrarError::ResolveError)
                 .and_then(validation::validate_manifest)
                 .and_then(move |manifest| {

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -235,11 +235,12 @@ fn subgraph_provider_events() {
     runtime
         .block_on(future::lazy(|| {
             let logger = Logger::root(slog::Discard, o!());
+            let logger_factory = LoggerFactory::new(logger.clone(), None);
             let resolver = Arc::new(IpfsClient::default());
             let store = Arc::new(MockStore::new(vec![]));
             let graphql_runner = Arc::new(graph_core::GraphQlRunner::new(&logger, store.clone()));
             let mut provider = graph_core::SubgraphAssignmentProvider::new(
-                logger.clone(),
+                &logger_factory,
                 resolver.clone(),
                 store.clone(),
                 graphql_runner.clone(),

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -179,6 +179,7 @@ fn multiple_data_sources_per_subgraph() {
                     link: subgraph_link,
                 },
                 resolver,
+                logger,
             )
             .map_err(|e| panic!("subgraph resolve error {:?}", e))
             .and_then(move |subgraph| {

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -162,15 +162,15 @@ fn multiple_data_sources_per_subgraph() {
         .block_on(future::lazy(|| {
             let resolver = Arc::new(IpfsClient::default());
             let logger = Logger::root(slog::Discard, o!());
+            let logger_factory = LoggerFactory::new(logger.clone(), None);
             let store = Arc::new(FakeStore);
             let host_builder = MockRuntimeHostBuilder::new();
             let block_stream_builder = MockBlockStreamBuilder::new();
             let manager = SubgraphInstanceManager::new(
-                &logger,
+                &logger_factory,
                 store,
                 host_builder.clone(),
                 block_stream_builder,
-                None,
             );
 
             // Load a subgraph with two data sources

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -249,7 +249,7 @@ fn subgraph_provider_events() {
             let node_id = NodeId::new("test").unwrap();
 
             let registrar = graph_core::SubgraphRegistrar::new(
-                logger.clone(),
+                &logger_factory,
                 resolver.clone(),
                 Arc::new(provider),
                 store.clone(),

--- a/graph/src/components/subgraph/loader.rs
+++ b/graph/src/components/subgraph/loader.rs
@@ -4,5 +4,6 @@ pub trait DataSourceLoader {
     fn load_dynamic_data_sources(
         self: Arc<Self>,
         id: &SubgraphDeploymentId,
+        logger: Logger,
     ) -> Box<Future<Item = Vec<DataSource>, Error = Error> + Send>;
 }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -121,6 +121,9 @@ pub mod prelude {
     };
     pub use crate::log::codes::LogCode;
     pub use crate::log::elastic::{elastic_logger, ElasticDrainConfig, ElasticLoggingConfig};
+    pub use crate::log::factory::{
+        ComponentLoggerConfig, ElasticComponentLoggerConfig, LoggerFactory,
+    };
     pub use crate::log::split::split_logger;
     pub use crate::util::futures::retry;
 }

--- a/graph/src/log/factory.rs
+++ b/graph/src/log/factory.rs
@@ -1,0 +1,104 @@
+use std::time::Duration;
+
+use crate::data::subgraph::SubgraphDeploymentId;
+use crate::log::elastic::*;
+use crate::log::split::*;
+use crate::slog::*;
+
+/// Configuration for component-specific logging to Elasticsearch.
+pub struct ElasticComponentLoggerConfig {
+    pub index: String,
+}
+
+/// Configuration for component-specific logging.
+pub struct ComponentLoggerConfig {
+    pub elastic: Option<ElasticComponentLoggerConfig>,
+}
+
+/// Factory for creating component and subgraph loggers.
+#[derive(Clone)]
+pub struct LoggerFactory {
+    parent: Logger,
+    elastic_config: Option<ElasticLoggingConfig>,
+}
+
+impl LoggerFactory {
+    /// Creates a new factory using a parent logger and optional Elasticsearch configuration.
+    pub fn new(logger: Logger, elastic_config: Option<ElasticLoggingConfig>) -> Self {
+        Self {
+            parent: logger,
+            elastic_config,
+        }
+    }
+
+    /// Creates a new factory with a new parent logger.
+    pub fn with_parent(&self, parent: Logger) -> Self {
+        Self {
+            parent,
+            elastic_config: self.elastic_config.clone(),
+        }
+    }
+
+    /// Creates a component-specific logger with optional Elasticsearch support.
+    pub fn component_logger(
+        &self,
+        component: &str,
+        config: Option<ComponentLoggerConfig>,
+    ) -> Logger {
+        let term_logger = self.parent.new(o!("component" => component.to_string()));
+
+        match config {
+            None => term_logger,
+            Some(config) => match config.elastic {
+                None => term_logger,
+                Some(config) => self
+                    .elastic_config
+                    .clone()
+                    .map(|elastic_config| {
+                        split_logger(
+                            term_logger.clone(),
+                            elastic_logger(
+                                ElasticDrainConfig {
+                                    general: elastic_config,
+                                    index: config.index,
+                                    document_type: String::from("log"),
+                                    custom_id_key: String::from("componentId"),
+                                    custom_id_value: component.to_string(),
+                                    flush_interval: Duration::from_secs(5),
+                                },
+                                term_logger.clone(),
+                            ),
+                        )
+                    })
+                    .unwrap_or(term_logger),
+            },
+        }
+    }
+
+    /// Creates a subgraph logger with Elasticsearch support.
+    pub fn subgraph_logger(&self, subgraph_id: &SubgraphDeploymentId) -> Logger {
+        let term_logger = self
+            .parent
+            .new(o!("subgraph_id" => subgraph_id.to_string()));
+
+        self.elastic_config
+            .clone()
+            .map(|elastic_config| {
+                split_logger(
+                    term_logger.clone(),
+                    elastic_logger(
+                        ElasticDrainConfig {
+                            general: elastic_config,
+                            index: String::from("subgraph-logs"),
+                            document_type: String::from("log"),
+                            custom_id_key: String::from("subgraphId"),
+                            custom_id_value: subgraph_id.to_string(),
+                            flush_interval: Duration::from_secs(5),
+                        },
+                        term_logger.clone(),
+                    ),
+                )
+            })
+            .unwrap_or(term_logger)
+    }
+}

--- a/graph/src/log/mod.rs
+++ b/graph/src/log/mod.rs
@@ -6,6 +6,7 @@ use std::env;
 
 pub mod codes;
 pub mod elastic;
+pub mod factory;
 pub mod split;
 
 pub fn logger(show_debug: bool) -> Logger {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -533,7 +533,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
 
     // Create named subgraph provider for resolving subgraph name->ID mappings
     let subgraph_registrar = Arc::new(IpfsSubgraphRegistrar::new(
-        logger.clone(),
+        &logger_factory,
         ipfs_client,
         Arc::new(subgraph_provider),
         store.clone(),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -514,7 +514,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
 
     // Create IPFS-based subgraph provider
     let mut subgraph_provider = IpfsSubgraphAssignmentProvider::new(
-        logger.clone(),
+        &logger_factory,
         ipfs_client.clone(),
         store.clone(),
         graphql_runner.clone(),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -340,6 +340,9 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                 password: matches.value_of("elasticsearch-password").map(|s| s.into()),
             });
 
+    // Create a component and subgraph logger factory
+    let logger_factory = LoggerFactory::new(logger.clone(), elastic_config);
+
     info!(
         logger,
         "Trying IPFS node at: {}",
@@ -460,11 +463,10 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     ));
     let graphql_runner = Arc::new(graph_core::GraphQlRunner::new(&logger, store.clone()));
     let mut graphql_server = GraphQLQueryServer::new(
-        &logger,
+        &logger_factory,
         graphql_runner.clone(),
         store.clone(),
         node_id.clone(),
-        elastic_config.clone(),
     );
     let mut subscription_server =
         GraphQLSubscriptionServer::new(&logger, graphql_runner.clone(), store.clone());

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -506,11 +506,10 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     let runtime_host_builder =
         WASMRuntimeHostBuilder::new(eth_adapter.clone(), ipfs_client.clone(), store.clone());
     let subgraph_instance_manager = SubgraphInstanceManager::new(
-        &logger,
+        &logger_factory,
         store.clone(),
         runtime_host_builder,
         block_stream_builder,
-        elastic_config.clone(),
     );
 
     // Create IPFS-based subgraph provider

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -484,9 +484,8 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
             eth_adapter.clone(),
             *ANCESTOR_COUNT,
             ethereum_network_name.to_string(),
-            logger.clone(),
+            &logger_factory,
             block_polling_interval,
-            elastic_config.clone(),
         )
         .expect("failed to create Ethereum block ingestor");
 

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -114,11 +114,12 @@ mod test {
         runtime
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
+                let logger_factory = LoggerFactory::new(logger, None);
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server = HyperGraphQLServer::new(&logger, query_runner, store, node_id, None);
+                let mut server = HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
                 let http_server = server
                     .serve(8001, 8002)
                     .expect("Failed to start GraphQL server");
@@ -163,12 +164,13 @@ mod test {
         runtime
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
+                let logger_factory = LoggerFactory::new(logger, None);
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
                 let mut server =
-                    HyperGraphQLServer::new(&logger, query_runner, store, node_id, None);
+                    HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
                 let http_server = server
                     .serve(8002, 8003)
                     .expect("Failed to start GraphQL server");
@@ -247,12 +249,13 @@ mod test {
         runtime
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
+                let logger_factory = LoggerFactory::new(logger, None);
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
                 let mut server =
-                    HyperGraphQLServer::new(&logger, query_runner, store, node_id, None);
+                    HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
                 let http_server = server
                     .serve(8003, 8004)
                     .expect("Failed to start GraphQL server");
@@ -296,13 +299,14 @@ mod test {
         runtime
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
+                let logger_factory = LoggerFactory::new(logger, None);
 
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
                 let mut server =
-                    HyperGraphQLServer::new(&logger, query_runner, store, node_id, None);
+                    HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
                 let http_server = server
                     .serve(8005, 8006)
                     .expect("Failed to start GraphQL server");


### PR DESCRIPTION
This introduces a new component called `LoggerFactory`. It's a simple, cloneable component to create component-specific loggers (with and without Elasticsearch support) and subgraph loggers.

This makes it easy to create subgraph loggers in different places that will write out to Elasticsearch; it hides all the split logger stuff.

Subgraph loggers are now created/used in various places inside `SubgraphAssignmentProvider`, `SubgraphRegistrar` and also in the `SubgraphManifest` resolution to better track what is happening during subgraph startup, and also for this information to be sent to the logs on https://thegraph.com/explorer/.

@olibearo One breaking change introduced here is the `componentId` field in component loggers that write to Elasticsearch. The `componentId`s now match the component names 1:1.

Resolves #978.