### PR TITLE
Fetch dynamic data sources _after_ the manifest

### DIFF
--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -268,8 +268,11 @@ where
                     })
             })
             .map(move |state| {
-                trace!(timing_logger, "loaded dynamic data sources";
-                                      "ms" => start_time.elapsed().as_millis());
+                trace!(
+                    timing_logger,
+                    "Loaded dynamic data sources";
+                    "ms" => start_time.elapsed().as_millis()
+                );
                 state.data_sources
             }),
         )

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -92,17 +92,24 @@ where
         let logger = self.logger_factory.subgraph_logger(&id);
         let logger_for_resolve = logger.clone();
         let logger_for_err = logger.clone();
+        let logger_for_data_sources = logger.clone();
 
         info!(logger, "Resolve subgraph files using IPFS");
 
         Box::new(
             SubgraphManifest::resolve(Link { link }, self.resolver.clone(), logger_for_resolve)
                 .map_err(SubgraphAssignmentProviderError::ResolveError)
-                .join(
-                    loader
-                        .load_dynamic_data_sources(&subgraph_id_for_data_sources, logger.clone())
-                        .map_err(SubgraphAssignmentProviderError::DynamicDataSourcesError),
-                )
+                .and_then(move |manifest| {
+                    (
+                        future::ok(manifest),
+                        loader
+                            .load_dynamic_data_sources(
+                                &subgraph_id_for_data_sources,
+                                logger_for_data_sources,
+                            )
+                            .map_err(SubgraphAssignmentProviderError::DynamicDataSourcesError),
+                    )
+                })
                 .and_then(
                     move |(mut subgraph, data_sources)| -> Box<Future<Item = _, Error = _> + Send> {
                         info!(logger, "Successfully resolved subgraph files using IPFS");


### PR DESCRIPTION
So we don't block the IPFS network call on the graphql query, which may cause timeouts. Also time the query to confirm this theory.