### PR TITLE
Update subgraph reassignment conditional to allow all deployment version types

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -846,14 +846,13 @@ fn reassign_subgraph(
     ops.extend(read_summaries_abort_ops);
 
     ops.push(EntityOperation::AbortUnless {
-        description:
-            "Provided name-deploymentId pair must match an existing, current subgraph version"
-                .to_owned(),
+        description: "Provided name-deploymentId pair must match an existing subgraph version"
+            .to_owned(),
         query: SubgraphEntity::query()
             .filter(EntityFilter::new_in("name", vec![name.clone().to_string()])),
         entity_ids: version_summaries
             .iter()
-            .filter(|version| version.current)
+            .filter(|version| version.deployment_id == hash)
             .map(move |summary| summary.clone().subgraph_id)
             .collect(),
     });

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -284,13 +284,11 @@ where
 
     fn reassign_subgraph(
         &self,
-        name: SubgraphName,
         hash: SubgraphDeploymentId,
         node_id: NodeId,
     ) -> Box<Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static> {
         Box::new(future::result(reassign_subgraph(
             self.store.clone(),
-            name,
             hash,
             node_id,
         )))
@@ -834,36 +832,34 @@ fn remove_subgraph_versions(
 /// subgraph syncing process.
 fn reassign_subgraph(
     store: Arc<impl Store>,
-    name: SubgraphName,
     hash: SubgraphDeploymentId,
     node_id: NodeId,
 ) -> Result<(), SubgraphRegistrarError> {
     let mut ops = vec![];
 
-    // Find all subgraph version entities that point to this hash.
-    let (version_summaries, read_summaries_abort_ops) =
-        store.read_subgraph_version_summaries(vec![hash.clone()])?;
-    ops.extend(read_summaries_abort_ops);
+    let current_deployment = store.find(
+        SubgraphDeploymentAssignmentEntity::query()
+            .filter(EntityFilter::new_equal("id", hash.clone().to_string())),
+    )?;
+
+    let current_node_id = current_deployment
+        .first()
+        .and_then(|d| d.get("nodeId"))
+        .ok_or_else(|| SubgraphRegistrarError::DeploymentNotFound(hash.clone().to_string()))?;
+
+    if current_node_id.to_string() == node_id.to_string() {
+        return Err(SubgraphRegistrarError::DeploymentAssignmentUnchanged(
+            hash.clone().to_string(),
+        ));
+    }
 
     ops.push(EntityOperation::AbortUnless {
-        description: "Provided name-deploymentId pair must match an existing subgraph version"
-            .to_owned(),
-        query: SubgraphEntity::query()
-            .filter(EntityFilter::new_in("name", vec![name.clone().to_string()])),
-        entity_ids: version_summaries
-            .iter()
-            .filter(|version| version.deployment_id == hash)
-            .map(move |summary| summary.clone().subgraph_id)
-            .collect(),
-    });
-
-    ops.push(EntityOperation::AbortUnless {
-        description: "Target node must be different from the currently assigned one".to_owned(),
+        description: "Deployment assignment is unchanged".to_owned(),
         query: SubgraphDeploymentAssignmentEntity::query().filter(EntityFilter::And(vec![
-            EntityFilter::new_equal("nodeId", node_id.to_string()),
+            EntityFilter::new_equal("nodeId", current_node_id.to_string()),
             EntityFilter::new_equal("id", hash.clone().to_string()),
         ])),
-        entity_ids: vec![],
+        entity_ids: vec![hash.clone().to_string()],
     });
 
     // Create the assignment update operations.

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -37,7 +37,6 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
 
     fn reassign_subgraph(
         &self,
-        name: SubgraphName,
         hash: SubgraphDeploymentId,
         node_id: NodeId,
     ) -> Box<Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -228,6 +228,10 @@ pub enum SubgraphRegistrarError {
     NameExists(String),
     #[fail(display = "subgraph name not found: {}", _0)]
     NameNotFound(String),
+    #[fail(display = "deployment not found: {}", _0)]
+    DeploymentNotFound(String),
+    #[fail(display = "deployment assignment unchanged: {}", _0)]
+    DeploymentAssignmentUnchanged(String),
     #[fail(display = "subgraph registrar internal query error: {}", _0)]
     QueryExecutionError(QueryExecutionError),
     #[fail(display = "subgraph registrar error with store: {}", _0)]

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -47,7 +47,6 @@ struct SubgraphRemoveParams {
 
 #[derive(Debug, Deserialize)]
 struct SubgraphReassignParams {
-    name: SubgraphName,
     ipfs_hash: SubgraphDeploymentId,
     node_id: NodeId,
 }
@@ -153,7 +152,7 @@ where
 
         Box::new(
             self.registrar
-                .reassign_subgraph(params.name, params.ipfs_hash, params.node_id)
+                .reassign_subgraph(params.ipfs_hash, params.node_id)
                 .map_err(move |e| {
                     if let SubgraphRegistrarError::Unknown(e) = e {
                         error!(logger, "subgraph_reassignment failed: {}", e);


### PR DESCRIPTION
The `AbortUnless` conditional operation being generated by the `subgraph_reassign` RPC method was only allowing deployments that are the current version to be reassigned. 

This PR updates the conditional simply to simply check if any existing deployment version matches the subgraph name and deployment id provided.