### PR TITLE
Add LRU cache (50 files) to `LinkResolver`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.1 (git+https://github.com/ferristseng/rust-ipfs-api)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru_time_cache 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,6 @@ version = "0.12.0"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigdecimal 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 6.1.0 (git+https://github.com/graphprotocol/ethabi.git?branch=graph-patches)",
@@ -907,6 +906,7 @@ dependencies = [
 name = "graph-core"
 version = "0.12.0"
 dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.12.0",
  "graph-graphql 0.12.0",
@@ -1007,6 +1007,7 @@ dependencies = [
  "ethabi 6.1.0 (git+https://github.com/graphprotocol/ethabi.git?branch=graph-patches)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.12.0",
+ "graph-core 0.12.0",
  "graph-mock 0.12.0",
  "graph-runtime-derive 0.12.0",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ graph-runtime-wasm = { path = "../runtime/wasm" }
 # but has not been released yet.
 ipfs-api = { git = "https://github.com/ferristseng/rust-ipfs-api", branch = "master", features = ["hyper-tls"] }
 lazy_static = "1.2.0"
+lru_time_cache = "0.8"
 semver = "0.9.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,10 +4,15 @@ version = "0.12.0"
 edition = "2018"
 
 [dependencies]
+bytes = "0.4.11"
 futures = "0.1.21"
 graph = { path = "../graph" }
 graph-graphql = { path = "../graphql" }
 graph-runtime-wasm = { path = "../runtime/wasm" }
+# We're using the latest ipfs-api for the HTTPS support that was merged in
+# https://github.com/ferristseng/rust-ipfs-api/commit/55902e98d868dcce047863859caf596a629d10ec
+# but has not been released yet.
+ipfs-api = { git = "https://github.com/ferristseng/rust-ipfs-api", branch = "master", features = ["hyper-tls"] }
 lazy_static = "1.2.0"
 semver = "0.9.0"
 serde = "1.0"
@@ -17,10 +22,6 @@ uuid = { version = "0.7.2", features = ["v4"] }
 tokio-threadpool = "0.1.14"
 
 [dev-dependencies]
-# We're using the latest ipfs-api for the HTTPS support that was merged in
-# https://github.com/ferristseng/rust-ipfs-api/commit/55902e98d868dcce047863859caf596a629d10ec
-# but has not been released yet.
-ipfs-api = { git = "https://github.com/ferristseng/rust-ipfs-api", branch = "master", features = ["hyper-tls"] }
 graph-mock = { path = "../mock" }
 walkdir = "2.2.5"
 test-store = { path = "../store/test-store" }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,9 +12,11 @@ extern crate serde_yaml;
 extern crate uuid;
 
 mod graphql;
+mod link_resolver;
 mod subgraph;
 
 pub use crate::graphql::GraphQlRunner;
+pub use crate::link_resolver::LinkResolver;
 pub use crate::subgraph::{
     DataSourceLoader, SubgraphAssignmentProvider, SubgraphInstanceManager, SubgraphRegistrar,
 };

--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -1,0 +1,250 @@
+use bytes::BytesMut;
+use futures::{stream::poll_fn, try_ready};
+use ipfs_api;
+use std::env;
+use std::str::FromStr;
+use std::time::Duration;
+
+use graph::prelude::{LinkResolver as LinkResolverTrait, *};
+use graph::serde_json::Value;
+
+const MAX_IPFS_FILE_BYTES_ENV_VAR: &str = "GRAPH_MAX_IPFS_FILE_BYTES";
+
+const MAX_IPFS_MAP_FILE_SIZE_ENV_VAR: &str = "GRAPH_MAX_IPFS_MAP_FILE_SIZE";
+
+// Default size limitation for streaming files through ipfs_map is
+// 256MB
+const MAX_IPFS_MAP_FILE_SIZE: u64 = 256 * 1024 * 1024;
+
+// The timeout for IPFS requests in seconds
+fn ipfs_timeout() -> Duration {
+    let timeout = env::var("GRAPH_IPFS_TIMEOUT").ok().map(|s| {
+        u64::from_str(&s).unwrap_or_else(|_| panic!("failed to parse env var GRAPH_IPFS_TIMEOUT"))
+    });
+    Duration::from_secs(timeout.unwrap_or(30))
+}
+
+fn read_u64_from_env(name: &str) -> Option<u64> {
+    env::var(name).ok().map(|s| {
+        u64::from_str(&s).unwrap_or_else(|_| {
+            panic!(
+                "expected env var {} to contain a number (unsigned 64-bit integer), but got '{}'",
+                name, s
+            )
+        })
+    })
+}
+
+/// Wrap the future `fut` into another future that only resolves successfully
+/// if the IPFS file at `path` is no bigger than `max_file_bytes`.
+/// If `max_file_bytes` is `None`, do not restrict the size of the file
+fn restrict_file_size<T>(
+    client: &ipfs_api::IpfsClient,
+    path: String,
+    max_file_bytes: Option<u64>,
+    fut: Box<Future<Item = T, Error = failure::Error> + Send>,
+) -> Box<Future<Item = T, Error = failure::Error> + Send>
+where
+    T: Send + 'static,
+{
+    match max_file_bytes {
+        Some(max_bytes) => Box::new(
+            client
+                .object_stat(&path)
+                .timeout(ipfs_timeout())
+                .map_err(|e| failure::err_msg(e.to_string()))
+                .and_then(move |stat| match stat.cumulative_size > max_bytes {
+                    false => Ok(()),
+                    true => Err(format_err!(
+                        "IPFS file {} is too large. It can be at most {} bytes but is {} bytes",
+                        path,
+                        max_bytes,
+                        stat.cumulative_size
+                    )),
+                })
+                .and_then(|()| fut),
+        ),
+        None => fut,
+    }
+}
+
+pub struct LinkResolver {
+    client: ipfs_api::IpfsClient,
+}
+
+impl From<ipfs_api::IpfsClient> for LinkResolver {
+    fn from(client: ipfs_api::IpfsClient) -> Self {
+        Self { client }
+    }
+}
+
+impl LinkResolverTrait for LinkResolver {
+    /// Supports links of the form `/ipfs/ipfs_hash` or just `ipfs_hash`.
+    fn cat(&self, link: &Link) -> Box<Future<Item = Vec<u8>, Error = failure::Error> + Send> {
+        // Grab env vars.
+        let max_file_bytes = read_u64_from_env(MAX_IPFS_FILE_BYTES_ENV_VAR);
+
+        // Discard the `/ipfs/` prefix (if present) to get the hash.
+        let path = link.link.trim_start_matches("/ipfs/").to_owned();
+
+        let ipfs_timeout = ipfs_timeout();
+        let cat = self
+            .client
+            .cat(&path)
+            .concat2()
+            .timeout(ipfs_timeout)
+            .map(|x| x.to_vec())
+            .map_err(|e| failure::err_msg(e.to_string()));
+
+        restrict_file_size(&self.client, path.clone(), max_file_bytes, Box::new(cat))
+    }
+
+    fn json_stream(
+        &self,
+        link: &Link,
+    ) -> Box<Future<Item = JsonValueStream, Error = failure::Error> + Send + 'static> {
+        // Discard the `/ipfs/` prefix (if present) to get the hash.
+        let path = link.link.trim_start_matches("/ipfs/").to_owned();
+        let mut stream = self.client.cat(&path).fuse();
+        let mut buf = BytesMut::with_capacity(1024);
+        // Count the number of lines we've already successfully deserialized.
+        // We need that to adjust the line number in error messages from serde_json
+        // to translate from line numbers in the snippet we are deserializing
+        // to the line number in the overall file
+        let mut count = 0;
+
+        let stream: JsonValueStream = Box::new(poll_fn(
+            move || -> Poll<Option<JsonStreamValue>, failure::Error> {
+                loop {
+                    if let Some(offset) = buf.iter().position(|b| *b == b'\n') {
+                        let line_bytes = buf.split_to(offset + 1);
+                        count += 1;
+                        if line_bytes.len() > 1 {
+                            let line = std::str::from_utf8(&line_bytes)?;
+                            let res = match serde_json::from_str::<Value>(line) {
+                                Ok(v) => Ok(Async::Ready(Some(JsonStreamValue {
+                                    value: v,
+                                    line: count,
+                                }))),
+                                Err(e) => {
+                                    // Adjust the line number in the serde error. This
+                                    // is fun because we can only get at the full error
+                                    // message, and not the error message without line number
+                                    let msg = e.to_string();
+                                    let msg = msg.split(" at line ").next().unwrap();
+                                    Err(format_err!(
+                                        "{} at line {} column {}: '{}'",
+                                        msg,
+                                        e.line() + count - 1,
+                                        e.column(),
+                                        line
+                                    ))
+                                }
+                            };
+                            return res;
+                        }
+                    } else {
+                        // We only get here if there is no complete line in buf, and
+                        // it is therefore ok to immediately pass an Async::NotReady
+                        // from stream through.
+                        // If we get a None from poll, but still have something in buf,
+                        // that means the input was not terminated with a newline. We
+                        // add that so that the last line gets picked up in the next
+                        // run through the loop.
+                        match try_ready!(stream.poll()) {
+                            Some(b) => buf.extend_from_slice(&b),
+                            None if buf.len() > 0 => buf.extend_from_slice(&[b'\n']),
+                            None => return Ok(Async::Ready(None)),
+                        }
+                    }
+                }
+            },
+        ));
+        // Check the size of the file
+        let max_file_bytes =
+            read_u64_from_env(MAX_IPFS_MAP_FILE_SIZE_ENV_VAR).unwrap_or(MAX_IPFS_MAP_FILE_SIZE);
+
+        restrict_file_size(
+            &self.client,
+            path,
+            Some(max_file_bytes),
+            Box::new(future::ok(stream)),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn max_file_size() {
+        env::set_var(MAX_IPFS_FILE_BYTES_ENV_VAR, "200");
+        let file: &[u8] = &[0u8; 201];
+        let client = ipfs_api::IpfsClient::default();
+
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        let link = runtime.block_on(client.add(file)).unwrap().hash;
+        let err = runtime
+            .block_on(LinkResolver::cat(
+                &client.into(),
+                &Link { link: link.clone() },
+            ))
+            .unwrap_err();
+        env::remove_var(MAX_IPFS_FILE_BYTES_ENV_VAR);
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "IPFS file {} is too large. It can be at most 200 bytes but is 212 bytes",
+                link
+            )
+        );
+    }
+
+    fn json_round_trip(text: &'static str) -> Result<Vec<Value>, failure::Error> {
+        let client = ipfs_api::IpfsClient::default();
+
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        let link = runtime.block_on(client.add(text.as_bytes())).unwrap().hash;
+        runtime.block_on(
+            LinkResolver::json_stream(&client.into(), &Link { link: link.clone() })
+                .and_then(|stream| stream.map(|sv| sv.value).collect()),
+        )
+    }
+
+    #[test]
+    fn read_json_stream() {
+        let values = json_round_trip("\"with newline\"\n");
+        assert_eq!(vec![json!("with newline")], values.unwrap());
+
+        let values = json_round_trip("\"without newline\"");
+        assert_eq!(vec![json!("without newline")], values.unwrap());
+
+        let values = json_round_trip("\"two\" \n \"things\"");
+        assert_eq!(vec![json!("two"), json!("things")], values.unwrap());
+
+        let values = json_round_trip("\"one\"\n  \"two\" \n [\"bad\" \n \"split\"]");
+        assert_eq!(
+            "EOF while parsing a list at line 4 column 0: ' [\"bad\" \n'",
+            values.unwrap_err().to_string()
+        );
+    }
+
+    #[test]
+    fn ipfs_map_file_size() {
+        let file = "\"small test string that trips the size restriction\"";
+        env::set_var(MAX_IPFS_MAP_FILE_SIZE_ENV_VAR, (file.len() - 1).to_string());
+
+        let err = json_round_trip(file).unwrap_err();
+        env::remove_var(MAX_IPFS_MAP_FILE_SIZE_ENV_VAR);
+
+        assert!(err.to_string().contains(" is too large"));
+
+        let values = json_round_trip(file);
+        assert_eq!(
+            vec!["small test string that trips the size restriction"],
+            values.unwrap()
+        );
+    }
+}

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -50,6 +50,10 @@ those.
   generated from that are kept in memory until the entire file is done
   processing. This setting therefore limits how much memory a call to `ipfs.map`
   may use. (in bytes, defaults to 256MB)
+* `GRAPH_MAX_IPFS_CACHE_SIZE`: maximum number of files cached in the the
+  `ipfs.cat` cache (defaults to 50).
+* `GRAPH_MAX_IPFS_CACHE_FILE_SIZE`: maximum size of files that are cached in the
+  `ipfs.cat` cache (defaults to 1MiB)
 
 ## GraphQL
 

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 [dependencies]
 backtrace = "0.3.9"
 bigdecimal = { version = "0.0.14", features = ["serde"] }
-bytes = "0.4.11"
 diesel = { version = "1.3.2", features = ["postgres", "serde_json", "numeric", "r2d2"] }
 chrono = "0.4"
 itertools = "0.7"

--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -1,5 +1,6 @@
 use failure;
 use serde_json::Value;
+use slog::Logger;
 use tokio::prelude::*;
 
 use crate::data::subgraph::Link;
@@ -18,7 +19,11 @@ pub type JsonValueStream =
 /// Resolves links to subgraph manifests and resources referenced by them.
 pub trait LinkResolver: Send + Sync + 'static + Sized {
     /// Fetches the link contents as bytes.
-    fn cat(&self, link: &Link) -> Box<Future<Item = Vec<u8>, Error = failure::Error> + Send>;
+    fn cat(
+        &self,
+        logger: &Logger,
+        link: &Link,
+    ) -> Box<Future<Item = Vec<u8>, Error = failure::Error> + Send>;
 
     /// Read the contents of `link` and deserialize them into a stream of JSON
     /// values. The values must each be on a single line; newlines are significant

--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -1,34 +1,22 @@
-use crate::data::subgraph::Link;
-use bytes::BytesMut;
 use failure;
-use futures::{stream::poll_fn, try_ready};
-use ipfs_api;
 use serde_json::Value;
-use std::env;
-use std::str::FromStr;
-use std::time::Duration;
 use tokio::prelude::*;
 
-const MAX_IPFS_FILE_BYTES_ENV_VAR: &str = "GRAPH_MAX_IPFS_FILE_BYTES";
-
-const MAX_IPFS_MAP_FILE_SIZE_ENV_VAR: &str = "GRAPH_MAX_IPFS_MAP_FILE_SIZE";
-
-// Default size limitation for streaming files through ipfs_map is
-// 256MB
-const MAX_IPFS_MAP_FILE_SIZE: u64 = 256 * 1024 * 1024;
+use crate::data::subgraph::Link;
 
 /// The values that `json_stream` returns. The struct contains the deserialized
 /// JSON value from the input stream, together with the line number from which
 /// the value was read.
-pub struct StreamValue {
+pub struct JsonStreamValue {
     pub value: Value,
     pub line: usize,
 }
 
-type ValueStream = Box<Stream<Item = StreamValue, Error = failure::Error> + Send + 'static>;
+pub type JsonValueStream =
+    Box<Stream<Item = JsonStreamValue, Error = failure::Error> + Send + 'static>;
 
 /// Resolves links to subgraph manifests and resources referenced by them.
-pub trait LinkResolver: Send + Sync + 'static {
+pub trait LinkResolver: Send + Sync + 'static + Sized {
     /// Fetches the link contents as bytes.
     fn cat(&self, link: &Link) -> Box<Future<Item = Vec<u8>, Error = failure::Error> + Send>;
 
@@ -39,224 +27,5 @@ pub trait LinkResolver: Send + Sync + 'static {
     fn json_stream(
         &self,
         link: &Link,
-    ) -> Box<Future<Item = ValueStream, Error = failure::Error> + Send + 'static>;
-}
-
-// The timeout for IPFS requests in seconds
-fn ipfs_timeout() -> Duration {
-    let timeout = env::var("GRAPH_IPFS_TIMEOUT").ok().map(|s| {
-        u64::from_str(&s).unwrap_or_else(|_| panic!("failed to parse env var GRAPH_IPFS_TIMEOUT"))
-    });
-    Duration::from_secs(timeout.unwrap_or(30))
-}
-
-fn read_u64_from_env(name: &str) -> Option<u64> {
-    env::var(name).ok().map(|s| {
-        u64::from_str(&s).unwrap_or_else(|_| {
-            panic!(
-                "expected env var {} to contain a number (unsigned 64-bit integer), but got '{}'",
-                name, s
-            )
-        })
-    })
-}
-
-/// Wrap the future `fut` into another future that only resolves successfully
-/// if the IPFS file at `path` is no bigger than `max_file_bytes`.
-/// If `max_file_bytes` is `None`, do not restrict the size of the file
-fn restrict_file_size<T>(
-    client: &ipfs_api::IpfsClient,
-    path: String,
-    max_file_bytes: Option<u64>,
-    fut: Box<Future<Item = T, Error = failure::Error> + Send>,
-) -> Box<Future<Item = T, Error = failure::Error> + Send>
-where
-    T: Send + 'static,
-{
-    match max_file_bytes {
-        Some(max_bytes) => Box::new(
-            client
-                .object_stat(&path)
-                .timeout(ipfs_timeout())
-                .map_err(|e| failure::err_msg(e.to_string()))
-                .and_then(move |stat| match stat.cumulative_size > max_bytes {
-                    false => Ok(()),
-                    true => Err(format_err!(
-                        "IPFS file {} is too large. It can be at most {} bytes but is {} bytes",
-                        path,
-                        max_bytes,
-                        stat.cumulative_size
-                    )),
-                })
-                .and_then(|()| fut),
-        ),
-        None => fut,
-    }
-}
-
-impl LinkResolver for ipfs_api::IpfsClient {
-    /// Supports links of the form `/ipfs/ipfs_hash` or just `ipfs_hash`.
-    fn cat(&self, link: &Link) -> Box<Future<Item = Vec<u8>, Error = failure::Error> + Send> {
-        // Grab env vars.
-        let max_file_bytes = read_u64_from_env(MAX_IPFS_FILE_BYTES_ENV_VAR);
-
-        // Discard the `/ipfs/` prefix (if present) to get the hash.
-        let path = link.link.trim_start_matches("/ipfs/").to_owned();
-
-        let ipfs_timeout = ipfs_timeout();
-        let cat = self
-            .cat(&path)
-            .concat2()
-            .timeout(ipfs_timeout)
-            .map(|x| x.to_vec())
-            .map_err(|e| failure::err_msg(e.to_string()));
-
-        restrict_file_size(&self, path, max_file_bytes, Box::new(cat))
-    }
-
-    fn json_stream(
-        &self,
-        link: &Link,
-    ) -> Box<Future<Item = ValueStream, Error = failure::Error> + Send + 'static> {
-        // Discard the `/ipfs/` prefix (if present) to get the hash.
-        let path = link.link.trim_start_matches("/ipfs/").to_owned();
-        let mut stream = self.cat(&path).fuse();
-        let mut buf = BytesMut::with_capacity(1024);
-        // Count the number of lines we've already successfully deserialized.
-        // We need that to adjust the line number in error messages from serde_json
-        // to translate from line numbers in the snippet we are deserializing
-        // to the line number in the overall file
-        let mut count = 0;
-
-        let stream: ValueStream = Box::new(poll_fn(
-            move || -> Poll<Option<StreamValue>, failure::Error> {
-                loop {
-                    if let Some(offset) = buf.iter().position(|b| *b == b'\n') {
-                        let line_bytes = buf.split_to(offset + 1);
-                        count += 1;
-                        if line_bytes.len() > 1 {
-                            let line = std::str::from_utf8(&line_bytes)?;
-                            let res = match serde_json::from_str::<Value>(line) {
-                                Ok(v) => Ok(Async::Ready(Some(StreamValue {
-                                    value: v,
-                                    line: count,
-                                }))),
-                                Err(e) => {
-                                    // Adjust the line number in the serde error. This
-                                    // is fun because we can only get at the full error
-                                    // message, and not the error message without line number
-                                    let msg = e.to_string();
-                                    let msg = msg.split(" at line ").next().unwrap();
-                                    Err(format_err!(
-                                        "{} at line {} column {}: '{}'",
-                                        msg,
-                                        e.line() + count - 1,
-                                        e.column(),
-                                        line
-                                    ))
-                                }
-                            };
-                            return res;
-                        }
-                    } else {
-                        // We only get here if there is no complete line in buf, and
-                        // it is therefore ok to immediately pass an Async::NotReady
-                        // from stream through.
-                        // If we get a None from poll, but still have something in buf,
-                        // that means the input was not terminated with a newline. We
-                        // add that so that the last line gets picked up in the next
-                        // run through the loop.
-                        match try_ready!(stream.poll()) {
-                            Some(b) => buf.extend_from_slice(&b),
-                            None if buf.len() > 0 => buf.extend_from_slice(&[b'\n']),
-                            None => return Ok(Async::Ready(None)),
-                        }
-                    }
-                }
-            },
-        ));
-        // Check the size of the file
-        let max_file_bytes =
-            read_u64_from_env(MAX_IPFS_MAP_FILE_SIZE_ENV_VAR).unwrap_or(MAX_IPFS_MAP_FILE_SIZE);
-
-        restrict_file_size(
-            &self,
-            path,
-            Some(max_file_bytes),
-            Box::new(future::ok(stream)),
-        )
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn max_file_size() {
-        env::set_var(MAX_IPFS_FILE_BYTES_ENV_VAR, "200");
-        let file: &[u8] = &[0u8; 201];
-        let client = ipfs_api::IpfsClient::default();
-
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
-        let link = runtime.block_on(client.add(file)).unwrap().hash;
-        let err = runtime
-            .block_on(LinkResolver::cat(&client, &Link { link: link.clone() }))
-            .unwrap_err();
-        env::remove_var(MAX_IPFS_FILE_BYTES_ENV_VAR);
-        assert_eq!(
-            err.to_string(),
-            format!(
-                "IPFS file {} is too large. It can be at most 200 bytes but is 212 bytes",
-                link
-            )
-        );
-    }
-
-    fn json_round_trip(text: &'static str) -> Result<Vec<Value>, failure::Error> {
-        let client = ipfs_api::IpfsClient::default();
-
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
-        let link = runtime.block_on(client.add(text.as_bytes())).unwrap().hash;
-        runtime.block_on(
-            LinkResolver::json_stream(&client, &Link { link: link.clone() })
-                .and_then(|stream| stream.map(|sv| sv.value).collect()),
-        )
-    }
-
-    #[test]
-    fn read_json_stream() {
-        let values = json_round_trip("\"with newline\"\n");
-        assert_eq!(vec![json!("with newline")], values.unwrap());
-
-        let values = json_round_trip("\"without newline\"");
-        assert_eq!(vec![json!("without newline")], values.unwrap());
-
-        let values = json_round_trip("\"two\" \n \"things\"");
-        assert_eq!(vec![json!("two"), json!("things")], values.unwrap());
-
-        let values = json_round_trip("\"one\"\n  \"two\" \n [\"bad\" \n \"split\"]");
-        assert_eq!(
-            "EOF while parsing a list at line 4 column 0: ' [\"bad\" \n'",
-            values.unwrap_err().to_string()
-        );
-    }
-
-    #[test]
-    fn ipfs_map_file_size() {
-        let file = "\"small test string that trips the size restriction\"";
-        env::set_var(MAX_IPFS_MAP_FILE_SIZE_ENV_VAR, (file.len() - 1).to_string());
-
-        let err = json_round_trip(file).unwrap_err();
-        env::remove_var(MAX_IPFS_MAP_FILE_SIZE_ENV_VAR);
-
-        assert!(err.to_string().contains(" is too large"));
-
-        let values = json_round_trip(file);
-        assert_eq!(
-            vec!["small test string that trips the size restriction"],
-            values.unwrap()
-        );
-    }
+    ) -> Box<Future<Item = JsonValueStream, Error = failure::Error> + Send + 'static>;
 }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -77,7 +77,7 @@ pub mod prelude {
     pub use crate::components::graphql::{
         GraphQlRunner, QueryResultFuture, SubscriptionResultFuture,
     };
-    pub use crate::components::link_resolver::LinkResolver;
+    pub use crate::components::link_resolver::{JsonStreamValue, JsonValueStream, LinkResolver};
     pub use crate::components::server::admin::JsonRpcServer;
     pub use crate::components::server::query::GraphQLServer;
     pub use crate::components::server::subscription::SubscriptionServer;

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -23,6 +23,7 @@ semver = "0.9.0"
 [dev-dependencies]
 graphql-parser = "0.2.0"
 parity-wasm = "0.31"
+graph-core = { path = "../../core" }
 graph-mock = { path = "../../mock" }
 # We're using the latest ipfs-api for the HTTPS support that was merged in
 # https://github.com/ferristseng/rust-ipfs-api/commit/55902e98d868dcce047863859caf596a629d10ec

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -352,11 +352,12 @@ where
 
     pub(crate) fn ipfs_cat(
         &self,
+        logger: &Logger,
         link: String,
     ) -> Result<Vec<u8>, HostExportError<impl ExportError>> {
         self.block_on(
             self.link_resolver
-                .cat(&Link { link })
+                .cat(logger, &Link { link })
                 .map_err(HostExportError),
         )
     }

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -597,7 +597,7 @@ where
     /// function ipfs.cat(link: String): Bytes
     fn ipfs_cat(&mut self, link_ptr: AscPtr<AscString>) -> Result<Option<RuntimeValue>, Trap> {
         let link = self.asc_get(link_ptr);
-        let ipfs_res = self.host_exports().ipfs_cat(link);
+        let ipfs_res = self.host_exports().ipfs_cat(&self.ctx.logger, link);
         match ipfs_res {
             Ok(bytes) => {
                 let bytes_obj: AscPtr<Uint8Array> = self.asc_new(&*bytes);

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -1,23 +1,27 @@
 extern crate graph_mock;
 extern crate ipfs_api;
 
-use self::graph_mock::FakeStore;
-use crate::failure::Error;
 use ethabi::Token;
 use futures::sync::mpsc::{channel, Sender};
-use graph::components::ethereum::*;
-use graph::components::store::*;
-use graph::data::store::scalar;
-use graph::data::subgraph::*;
-use graph::web3::types::{Address, Block, Transaction, H160, H256};
 use hex;
+use std::env;
 use std::io::Cursor;
 use std::str::FromStr;
 use wasmi::nan_preserving_float::F64;
 
-use std::env;
+use graph::components::ethereum::*;
+use graph::components::store::*;
+use graph::data::store::scalar;
+use graph::data::subgraph::*;
+use graph::prelude::LinkResolver;
+use graph::web3::types::{Address, Block, Transaction, H160, H256};
+use graph_core;
+
+use crate::failure::Error;
 
 use super::*;
+
+use self::graph_mock::FakeStore;
 
 mod abi;
 
@@ -143,7 +147,7 @@ fn test_valid_module(
 ) -> Arc<
     ValidModule<
         MockEthereumAdapter,
-        ipfs_api::IpfsClient,
+        graph_core::LinkResolver,
         FakeStore,
         Sender<Box<Future<Item = (), Error = ()> + Send>>,
     >,
@@ -161,7 +165,7 @@ fn test_valid_module(
                 subgraph_id: SubgraphDeploymentId::new("wasmModuleTest").unwrap(),
                 data_source,
                 ethereum_adapter: mock_ethereum_adapter,
-                link_resolver: Arc::new(ipfs_api::IpfsClient::default()),
+                link_resolver: Arc::new(ipfs_api::IpfsClient::default().into()),
                 store: Arc::new(FakeStore),
             },
             task_sender,


### PR DESCRIPTION
Resolves #992.

This avoids unnecessary roundtrips to IPFS for files that are requested again and again in quick succession, as is the case with data sources created from the same templates.

To not add a dependency on `lru_time_cache` to the `graph` crate, this PR moves the `LinkResolver` implementation to `graph-core`. This requires wrapping `IpfsClient` instead of implementing `LinkResolver` for it directly.

With this, starting a subgraph first logs cache misses:
```
component: SubgraphAssignmentProvider
 subgraph_id: QmRBpsAmUqazecaZ2XCmiLjrEgXJR3JoGyw2kNky6GdZCF
  Jun 07 16:34:22.057 INFO Resolve schema, link: /ipfs/QmebUhZs6i7kCPcLqyP2m6ZEbW69ouTkPQetWdYx4Am9oJ
  Jun 07 16:34:22.057 TRCE IPFS cache miss, hash: QmebUhZs6i7kCPcLqyP2m6ZEbW69ouTkPQetWdYx4Am9oJ
  Jun 07 16:34:22.058 INFO Resolve data source, name: RegistryDataSource
  Jun 07 16:34:22.058 INFO Resolve mapping, link: /ipfs/QmRpvhz37B2rzYQ42GF2LARaCvZ17CFGs7x2z1cGcQ5edp
  Jun 07 16:34:22.058 INFO Resolve ABI, link: /ipfs/QmU2NJjiHMBNxzzuSrFhis24qjR5eCWKZGQGKnGRNptH3u, name: RegistryContract
  Jun 07 16:34:22.059 TRCE IPFS cache miss, hash: QmU2NJjiHMBNxzzuSrFhis24qjR5eCWKZGQGKnGRNptH3u
  Jun 07 16:34:22.059 TRCE IPFS cache miss, hash: QmRpvhz37B2rzYQ42GF2LARaCvZ17CFGs7x2z1cGcQ5edp
  Jun 07 16:34:22.059 INFO Resolve data source, name: EngineDataSource
  Jun 07 16:34:22.060 INFO Resolve mapping, link: /ipfs/QmSnaZn9vNMYWtnkDUeBxvyEyFkydoSdKQQDGpJi7nayCt
  Jun 07 16:34:22.060 INFO Resolve ABI, link: /ipfs/QmTBn21gAsbzL3yfBEaJQKbjCY7Gd6ZjjXt8muJXob61Ba, name: EngineContract
  Jun 07 16:34:22.060 TRCE IPFS cache miss, hash: QmTBn21gAsbzL3yfBEaJQKbjCY7Gd6ZjjXt8muJXob61Ba
  Jun 07 16:34:22.060 TRCE IPFS cache miss, hash: QmSnaZn9vNMYWtnkDUeBxvyEyFkydoSdKQQDGpJi7nayCt
  Jun 07 16:34:22.060 INFO Resolve data source, name: PriceSourceDataSource
  Jun 07 16:34:22.061 INFO Resolve mapping, link: /ipfs/QmVtzBJBNu22bZvqDCMAPihv27iZEuX2KZCrxkxWA7fqWb
  Jun 07 16:34:22.061 INFO Resolve ABI, link: /ipfs/QmQiETkGht3YFtw1vfuT31F993EsKrZddRPEGoB7zoBNnG, name: PriceSourceContract
  Jun 07 16:34:22.061 TRCE IPFS cache miss, hash: QmQiETkGht3YFtw1vfuT31F993EsKrZddRPEGoB7zoBNnG
```

but when its dynamic data sources are loaded, they all hit the cache:

```
omponent: SubgraphAssignmentProvider
 subgraph_id: QmRBpsAmUqazecaZ2XCmiLjrEgXJR3JoGyw2kNky6GdZCF
  Jun 07 16:34:23.048 INFO Resolve data source, name: PolicyManagerDataSource
  Jun 07 16:34:23.048 INFO Resolve mapping, link: /ipfs/QmYpbn1uMvP6XQEuKJtBty7QKgYY8aT8B59WhbFbPQYXW1
  Jun 07 16:34:23.048 INFO Resolve ABI, link: /ipfs/QmUeHnKj8DQqWdgvvNh5hTi4hgsoCQaJSBy9C3rWed3AkM, name: PolicyManagerContract
  Jun 07 16:34:23.049 TRCE IPFS cache hit, hash: QmUeHnKj8DQqWdgvvNh5hTi4hgsoCQaJSBy9C3rWed3AkM
  Jun 07 16:34:23.049 INFO Resolve ABI, link: /ipfs/QmRQMAWbzTrQjhjP1KP7fLKd95hpDTA6yUyYTHHw7D5pAr, name: PolicyContract
  Jun 07 16:34:23.049 TRCE IPFS cache hit, hash: QmRQMAWbzTrQjhjP1KP7fLKd95hpDTA6yUyYTHHw7D5pAr
  Jun 07 16:34:23.049 TRCE IPFS cache hit, hash: QmYpbn1uMvP6XQEuKJtBty7QKgYY8aT8B59WhbFbPQYXW1
  Jun 07 16:34:23.054 INFO Resolve data source, name: FeeManagerDataSource
  Jun 07 16:34:23.055 INFO Resolve mapping, link: /ipfs/QmRk7Ch7cPLbsGF6vY91ywWtF4BNuMQM7b5b1KLhgb22mt
  Jun 07 16:34:23.055 INFO Resolve ABI, link: /ipfs/QmTgmfrWkBzL6fbTMnRvht79Lv4LYWZU3RkhdPbZ1Azwrf, name: FeeManagerContract
  Jun 07 16:34:23.055 TRCE IPFS cache hit, hash: QmTgmfrWkBzL6fbTMnRvht79Lv4LYWZU3RkhdPbZ1Azwrf
  Jun 07 16:34:23.055 INFO Resolve ABI, link: /ipfs/QmZtu75zpxjhFQUZdAHQ9aWBNEpQ3C5GXymTid2Kabt5GP, name: ManagementFeeContract
  Jun 07 16:34:23.055 TRCE IPFS cache hit, hash: QmZtu75zpxjhFQUZdAHQ9aWBNEpQ3C5GXymTid2Kabt5GP
  Jun 07 16:34:23.056 INFO Resolve ABI, link: /ipfs/QmYRewDG2p5XM1EC6nan1LcutMYYFK31bGba2YBiDXMtPy, name: PerformanceFeeContract
  Jun 07 16:34:23.056 TRCE IPFS cache hit, hash: QmYRewDG2p5XM1EC6nan1LcutMYYFK31bGba2YBiDXMtPy
  Jun 07 16:34:23.056 TRCE IPFS cache hit, hash: QmRk7Ch7cPLbsGF6vY91ywWtF4BNuMQM7b5b1KLhgb22mt
  Jun 07 16:34:23.065 INFO Resolve data source, name: AccountingDataSource
  Jun 07 16:34:23.065 INFO Resolve mapping, link: /ipfs/QmYCPvPangFPhU5qG784zur2Y8gz7cgDStcbVQ4aRddbH6
  Jun 07 16:34:23.065 INFO Resolve ABI, link: /ipfs/QmeWyLGruNRtPVLMX8gEq9ASe1tkQCF6FfvxW45AqLigb5, name: AccountingContract
  Jun 07 16:34:23.066 TRCE IPFS cache hit, hash: QmeWyLGruNRtPVLMX8gEq9ASe1tkQCF6FfvxW45AqLigb5
  Jun 07 16:34:23.066 TRCE IPFS cache hit, hash: QmYCPvPangFPhU5qG784zur2Y8gz7cgDStcbVQ4aRddbH6
  Jun 07 16:34:23.074 INFO Resolve data source, name: FeeManagerDataSource
  Jun 07 16:34:23.074 INFO Resolve mapping, link: /ipfs/QmRk7Ch7cPLbsGF6vY91ywWtF4BNuMQM7b5b1KLhgb22mt
  Jun 07 16:34:23.075 INFO Resolve ABI, link: /ipfs/QmTgmfrWkBzL6fbTMnRvht79Lv4LYWZU3RkhdPbZ1Azwrf, name: FeeManagerContract
  Jun 07 16:34:23.075 TRCE IPFS cache hit, hash: QmTgmfrWkBzL6fbTMnRvht79Lv4LYWZU3RkhdPbZ1Azwrf
  Jun 07 16:34:23.075 INFO Resolve ABI, link: /ipfs/QmZtu75zpxjhFQUZdAHQ9aWBNEpQ3C5GXymTid2Kabt5GP, name: ManagementFeeContract
  Jun 07 16:34:23.075 TRCE IPFS cache hit, hash: QmZtu75zpxjhFQUZdAHQ9aWBNEpQ3C5GXymTid2Kabt5GP
  Jun 07 16:34:23.075 INFO Resolve ABI, link: /ipfs/QmYRewDG2p5XM1EC6nan1LcutMYYFK31bGba2YBiDXMtPy, name: PerformanceFeeContract
  Jun 07 16:34:23.076 TRCE IPFS cache hit, hash: QmYRewDG2p5XM1EC6nan1LcutMYYFK31bGba2YBiDXMtPy
  Jun 07 16:34:23.076 TRCE IPFS cache hit, hash: QmRk7Ch7cPLbsGF6vY91ywWtF4BNuMQM7b5b1KLhgb22mt
  Jun 07 16:34:23.083 INFO Resolve data source, name: SharesDataSource
  Jun 07 16:34:23.083 INFO Resolve mapping, link: /ipfs/QmVpECxecVWXg8dbZeBztX9ECsyhsEM4u3dVEDGHsn5T9D
  Jun 07 16:34:23.083 INFO Resolve ABI, link: /ipfs/QmWmHBCbXagiVxSUXSC7YX3zvf2kU8ppTRA5bd9uQ9hMYG, name: SharesContract
  Jun 07 16:34:23.084 TRCE IPFS cache hit, hash: QmWmHBCbXagiVxSUXSC7YX3zvf2kU8ppTRA5bd9uQ9hMYG
  Jun 07 16:34:23.084 TRCE IPFS cache hit, hash: QmVpECxecVWXg8dbZeBztX9ECsyhsEM4u3dVEDGHsn5T9D
  Jun 07 16:34:23.089 INFO Resolve data source, name: SharesDataSource
  Jun 07 16:34:23.089 INFO Resolve mapping, link: /ipfs/QmVpECxecVWXg8dbZeBztX9ECsyhsEM4u3dVEDGHsn5T9D
  Jun 07 16:34:23.089 INFO Resolve ABI, link: /ipfs/QmWmHBCbXagiVxSUXSC7YX3zvf2kU8ppTRA5bd9uQ9hMYG, name: SharesContract
  Jun 07 16:34:23.090 TRCE IPFS cache hit, hash: QmWmHBCbXagiVxSUXSC7YX3zvf2kU8ppTRA5bd9uQ9hMYG
  Jun 07 16:34:23.090 TRCE IPFS cache hit, hash: QmVpECxecVWXg8dbZeBztX9ECsyhsEM4u3dVEDGHsn5T9D
```