### PR TITLE
Start subgraphs in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,6 +898,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "web3 0.6.0 (git+https://github.com/graphprotocol/rust-web3?branch=trace-struct-pre-ethereum-types)",
@@ -921,7 +922,6 @@ dependencies = [
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-store 0.1.0",
- "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,6 @@ serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.7"
 uuid = { version = "0.7.2", features = ["v4"] }
-tokio-threadpool = "0.1.14"
 
 [dev-dependencies]
 # We're using the latest ipfs-api for the HTTPS support that was merged in

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -234,17 +234,11 @@ impl SubgraphInstanceManager {
         // creates dynamic data sources. This allows us to recreate the
         // block stream and include events for the new data sources going
         // forward; this is easier than updating the existing block stream.
-        let mut subgraph_task = loop_fn(ctx, |ctx| run_subgraph(ctx));
-
+        //
         // This task has many calls to the store, so mark it as `blocking`.
-        tokio::spawn(future::poll_fn(move || {
-            match tokio_threadpool::blocking(|| subgraph_task.poll()) {
-                Ok(Async::NotReady) | Ok(Async::Ready(Ok(Async::NotReady))) => Ok(Async::NotReady),
-                Ok(Async::Ready(Ok(Async::Ready(())))) => Ok(Async::Ready(())),
-                Ok(Async::Ready(Err(()))) => Err(()),
-                Err(_) => panic!("not inside a tokio thread pool"),
-            }
-        }));
+        tokio::spawn(graph::util::futures::blocking(loop_fn(ctx, |ctx| {
+            run_subgraph(ctx)
+        })));
 
         Ok(())
     }

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -43,5 +43,6 @@ tokio = "0.1.20"
 tokio-executor = "0.1.5"
 tokio-retry = "0.2"
 tokio-timer = "0.2.7"
+tokio-threadpool = "0.1.14"
 url = "1.7.2"
 web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "trace-struct-pre-ethereum-types" }


### PR DESCRIPTION
Inside the blocking thread pool, and being careful to start them all in a single future. This means subgraphs no longer have to wait for others to start before they can be started.