### PR TITLE
store/postgres: Make subgraph creation not block writers

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -682,7 +682,7 @@ fn create_subgraph_version(
     if deployment_exists {
         store.apply_entity_operations(ops, None)?
     } else {
-        store.create_subgraph_deployment(&manifest.id, ops)?;
+        store.create_subgraph_deployment(logger, &manifest.id, ops)?;
     }
 
     debug!(

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -24,9 +24,13 @@ fn insert_and_query(
         data_sources: vec![],
     };
 
+    let logger = Logger::root(slog::Discard, o!());
+
     let ops = SubgraphDeploymentEntity::new(&manifest, false, false, Default::default(), 1)
         .create_operations_replace(&subgraph_id);
-    STORE.create_subgraph_deployment(&subgraph_id, ops).unwrap();
+    STORE
+        .create_subgraph_deployment(&logger, &subgraph_id, ops)
+        .unwrap();
 
     let insert_ops = entities
         .into_iter()
@@ -41,7 +45,6 @@ fn insert_and_query(
 
     STORE.apply_entity_operations(insert_ops.collect(), None)?;
 
-    let logger = Logger::root(slog::Discard, o!());
     let resolver = StoreResolver::new(&logger, STORE.clone());
 
     let options = QueryExecutionOptions {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1008,6 +1008,7 @@ pub trait Store: Send + Sync + 'static {
     /// version
     fn create_subgraph_deployment(
         &self,
+        subgraph_logger: &Logger,
         subgraph_id: &SubgraphDeploymentId,
         ops: Vec<EntityOperation>,
     ) -> Result<(), StoreError>;

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -13,7 +13,8 @@ lazy_static! {
     static ref TEST_SUBGRAPH_ID: SubgraphDeploymentId = {
         // Also populate the store when the ID is first accessed.
         let id = SubgraphDeploymentId::new("graphqlTestsQuery").unwrap();
-        STORE.create_subgraph_deployment(&id, vec![]).unwrap();
+        let logger = Logger::root(slog::Discard, o!());
+        STORE.create_subgraph_deployment(&logger, &id, vec![]).unwrap();
         insert_test_entities(&**STORE, id.clone());
         id
     };

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -331,6 +331,7 @@ impl Store for MockStore {
 
     fn create_subgraph_deployment(
         &self,
+        _logger: &Logger,
         _subgraph_id: &SubgraphDeploymentId,
         ops: Vec<EntityOperation>,
     ) -> Result<(), StoreError> {
@@ -492,6 +493,7 @@ impl Store for FakeStore {
 
     fn create_subgraph_deployment(
         &self,
+        _logger: &Logger,
         _subgraph_id: &SubgraphDeploymentId,
         _ops: Vec<EntityOperation>,
     ) -> Result<(), StoreError> {

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1023,6 +1023,7 @@ impl StoreTrait for Store {
 
     fn create_subgraph_deployment(
         &self,
+        subgraph_logger: &Logger,
         subgraph_id: &SubgraphDeploymentId,
         ops: Vec<EntityOperation>,
     ) -> Result<(), StoreError> {
@@ -1075,9 +1076,8 @@ impl StoreTrait for Store {
                 // it was because we timed out on the lock and try again.
                 if start.elapsed() >= Duration::from_secs(LOCK_TIMEOUT) {
                     debug!(
-                        self.logger,
-                        "could not acquire lock for creation of subgraph {}, trying again in {}s",
-                        &subgraph_id,
+                        subgraph_logger,
+                        "Could not acquire lock for subgraph creation, trying again in {}s",
                         delay.as_secs()
                     );
                     std::thread::sleep(delay);

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1026,13 +1026,69 @@ impl StoreTrait for Store {
         subgraph_id: &SubgraphDeploymentId,
         ops: Vec<EntityOperation>,
     ) -> Result<(), StoreError> {
+        // Various timing parameters, all in seconds
+        const INITIAL_DELAY: u64 = 2;
+        const MAX_DELAY: u64 = 64;
+        const LOCK_TIMEOUT: u64 = 2;
+
         let conn = self.get_conn().map_err(Error::from)?;
         let econn = e::Connection::new(&conn);
+        let mut delay = Duration::from_secs(INITIAL_DELAY);
 
-        conn.transaction(|| {
-            self.apply_entity_operations_with_conn(&econn, ops, None)?;
-            crate::entities::create_schema(&conn, subgraph_id)
-        })
+        // Creating a subgraph creates a table that references
+        // `event_meta_data`.  To validate that reference, Postgres takes a
+        // `share update exclusive` lock; for this lock, Postgres has to
+        // wait for all write activity that started before the lock was
+        // requested to finish, and it also has to hold all write activity
+        // that starts after the lock request. Usually, this is not a
+        // problem as the lock is only held for a very short amount of
+        // time.
+        //
+        // If there is other activity, like an autovacuum, happening
+        // already when the lock is requested though, we have to wait until
+        // that activity finishes, which in the case of an autovacuum can
+        // be an hour or longer. The autovacuum by itself is not a problem,
+        // as it still allows writes to happen, but once the lock request
+        // from this code gets into the lock queue, write activity also has
+        // to wait for the autovacuum to finish, effectively blocking all
+        // subgraph indexing until the autovacuum has finished.
+        //
+        // To avoid this, we set a lock timeout of 2s, which should be long
+        // enough to get the lock under normal conditions, but not so long
+        // that it materially impedes indexing in the above situation. If
+        // we can not get the lock within 2s, the subgraph creation fails,
+        // and we sleep an increasing amount of time (up to about a minute)
+        // and then retry the subgraph creation.
+        loop {
+            let start = Instant::now();
+            let result = conn.transaction(|| -> Result<(), StoreError> {
+                self.apply_entity_operations_with_conn(&econn, ops.clone(), None)?;
+                conn.batch_execute(&format!("set local lock_timeout to '{}s'", LOCK_TIMEOUT))?;
+                crate::entities::create_schema(&conn, subgraph_id)
+            });
+            if let Err(StoreError::Unknown(_)) = &result {
+                // There is no robust way to actually find out that we timed
+                // out on the lock from the error message; diesel shields us
+                // from these details too much. Rather than grep the error
+                // message, which would be very fragile, we assume that if a
+                // failure occurred after more than LOCK_TIMEOUT seconds that
+                // it was because we timed out on the lock and try again.
+                if start.elapsed() >= Duration::from_secs(LOCK_TIMEOUT) {
+                    debug!(
+                        self.logger,
+                        "could not acquire lock for creation of subgraph {}, trying again in {}s",
+                        &subgraph_id,
+                        delay.as_secs()
+                    );
+                    std::thread::sleep(delay);
+                    if delay.as_secs() < MAX_DELAY {
+                        delay *= 2;
+                    }
+                    continue;
+                }
+            }
+            break result;
+        }
     }
 
     fn start_subgraph_deployment(

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -117,7 +117,7 @@ fn insert_test_data(store: Arc<DieselStore>) {
     let ops = SubgraphDeploymentEntity::new(&manifest, false, false, *TEST_BLOCK_0_PTR, 1)
         .create_operations(&*TEST_SUBGRAPH_ID);
     store
-        .create_subgraph_deployment(&TEST_SUBGRAPH_ID, ops)
+        .create_subgraph_deployment(&*LOGGER, &TEST_SUBGRAPH_ID, ops)
         .unwrap();
 
     let test_entity_1 = create_test_entity(
@@ -1868,7 +1868,9 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
         // Create SubgraphDeploymentEntity
         let ops = SubgraphDeploymentEntity::new(&manifest, false, false, *TEST_BLOCK_0_PTR, 1)
             .create_operations(&subgraph_id);
-        store.create_subgraph_deployment(&subgraph_id, ops).unwrap();
+        store
+            .create_subgraph_deployment(&*LOGGER, &subgraph_id, ops)
+            .unwrap();
 
         // Create store subscriptions
         let meta_subscription =
@@ -2186,7 +2188,7 @@ fn create_subgraph_deployment_tolerates_locks() {
         barrier.wait();
         let start = std::time::Instant::now();
         store
-            .create_subgraph_deployment(&subgraph_id, vec![])
+            .create_subgraph_deployment(&*LOGGER, &subgraph_id, vec![])
             .expect("Subgraph creation failed");
         assert!(start.elapsed() >= Duration::from_secs(BLOCK_TIME));
         Ok(())


### PR DESCRIPTION
Creating a subgraph can block all other subgraph writers if the creation
itself has to wait for its lock, e.g., because of an ongoing autovacuum of
event_meta_data. That wait can be long (an hour or more in the case of
autovacuum)

We now do subgraph creation in such a way that we wait for a lock only a
short time (2s) and then sleep for a bit so that other write activity can
proceed.

