### PR TITLE
Make event matching as backwards-compatible as possible

### DIFF
--- a/graph/src/util/ethereum.rs
+++ b/graph/src/util/ethereum.rs
@@ -46,6 +46,20 @@ fn event_param_type_signature(kind: &ParamType) -> String {
     }
 }
 
+/// Returns an `Event(uint256,address)` signature for an event, without `indexed` hints.
+fn ambiguous_event_signature(event: &Event) -> String {
+    format!(
+        "{}({})",
+        event.name,
+        event
+            .inputs
+            .iter()
+            .map(|input| format!("{}", event_param_type_signature(&input.kind)))
+            .collect::<Vec<_>>()
+            .join(",")
+    )
+}
+
 /// Returns an `Event(indexed uint256,address)` type signature for an event.
 fn event_signature(event: &Event) -> String {
     format!(
@@ -72,6 +86,36 @@ pub fn contract_event_with_signature<'a>(
     contract
         .events()
         .find(|event| event_signature(event) == signature)
+        .or_else(|| {
+            // Fallback for subgraphs that don't use `indexed` in event signatures yet:
+            //
+            // If there is only one event variant with this name and if its signature
+            // without `indexed` matches the event signature from the manifest, we
+            // can safely assume that the event is a match, we don't need to force
+            // the subgraph to add `indexed`.
+
+            // Extract the event name; if there is no '(' in the signature,
+            // `event_name` will be empty and not match any events, so that's ok
+            let parens = signature.find("(").unwrap_or(0);
+            let event_name = &signature[0..parens];
+
+            let matching_events = contract
+                .events()
+                .filter(|event| event.name == event_name)
+                .collect::<Vec<_>>();
+
+            // Only match the event signature without `indexed` if there is
+            // only a single event variant
+            if matching_events.len() == 1
+                && ambiguous_event_signature(matching_events[0]) == signature
+            {
+                Some(matching_events[0])
+            } else {
+                // More than one event variant or the signature
+                // still doesn't match, even if we ignore `indexed` hints
+                None
+            }
+        })
 }
 
 pub fn contract_function_with_signature<'a>(


### PR DESCRIPTION
The recent changes we made to be able to distinguish between event variants with `indexed` and non-`indexed` parameters (#960) are breaking existing subgraphs. This PR provides a fallback for subgraphs that haven't migrated to `indexed` in event signatures yet:

If there is only one event variant with the same name as in the manifest, consider it a match to the signature from the manifest even if the `indexed` hints are missing in the manifest.