### PR TITLE
Only use terminal colors if stdout is a tty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,7 @@ dependencies = [
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.1 (git+https://github.com/ferristseng/rust-ipfs-api)",
+ "isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -8,6 +8,7 @@ backtrace = "0.3.9"
 bigdecimal = { version = "0.0.14", features = ["serde"] }
 diesel = { version = "1.3.2", features = ["postgres", "serde_json", "numeric", "r2d2"] }
 chrono = "0.4"
+isatty = "0.1"
 itertools = "0.7"
 reqwest = "0.9"
 # We would like to switch to upstream master once https://github.com/paritytech/ethabi/pull/145


### PR DESCRIPTION
Avoids writing `[36m` type term color strings to non-TTY terminals.

This is not 100% ideal, as the output may be to stderr instead of stdout, but we have no way of knowing where the `TermDecorator` is writing to.

