### PR TITLE
store/postgres: Index string attributes as btrees

### DIFF
--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -1450,8 +1450,8 @@ impl Table {
             | ValueType::Bytes
             | ValueType::BigDecimal
             | ValueType::ID
-            | ValueType::Int => (String::from("btree"), String::from(""), "->>"),
-            ValueType::String => (String::from("gin"), String::from("gin_trgm_ops"), "->>"),
+            | ValueType::Int
+            | ValueType::String => (String::from("btree"), String::from(""), "->>"),
             ValueType::List => (String::from("gin"), String::from("jsonb_path_ops"), "->"),
         };
         // Cast between the type we store in JSONB for the field and the type


### PR DESCRIPTION
We used to create indexes on string attributes as GIN indexes; with the way
we translate filters into SQL, these indexes do not get used. Since they
are only on individual attributes, there's no downside to using a standard
BTree index, which makes them usable for our filters.

