### PR TITLE
store/postgres: Fix `_contains` filter for String/Bytes (#973)

### DIFF
--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -185,8 +185,8 @@ where
             };
 
             match value {
-                Value::String(s) => Ok(s.into_filter(attribute, op)),
-                Value::Bytes(b) => Ok(b.to_string().into_filter(attribute, op)),
+                Value::String(s) => Ok(format!("%{}%", s).into_filter(attribute, op)),
+                Value::Bytes(b) => Ok(format!("%{}%", b.to_string()).into_filter(attribute, op)),
                 Value::List(lst) => {
                     let s = serde_json::to_string(&lst).expect("failed to serialize list value");
                     let predicate = sql("data -> ")

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -185,7 +185,13 @@ where
             };
 
             match value {
-                Value::String(s) => Ok(format!("%{}%", s).into_filter(attribute, op)),
+                Value::String(s) => {
+                    if s.starts_with('%') || s.ends_with('%') {
+                        Ok(s.into_filter(attribute, op))
+                    } else {
+                        Ok(format!("%{}%", s).into_filter(attribute, op))
+                    }
+                }
                 Value::Bytes(b) => Ok(format!("%{}%", b.to_string()).into_filter(attribute, op)),
                 Value::List(lst) => {
                     let s = serde_json::to_string(&lst).expect("failed to serialize list value");

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -538,7 +538,7 @@ fn find_string_contains() {
             entity_types: vec!["user".to_owned()],
             filter: Some(EntityFilter::And(vec![EntityFilter::Contains(
                 "name".into(),
-                "%ind%".into(),
+                "ind".into(),
             )])),
             order_by: None,
             order_direction: None,


### PR DESCRIPTION
The bug was that `LIKE` in Postgres requires `%...%` around the search value.