### PR TITLE
store/postgres: Index DynamicEthereumContractDataSource.deployment

### DIFF
--- a/store/postgres/migrations/2019-06-26-164405_index_dynamic_ethereum_contract_data_source_deployment/down.sql
+++ b/store/postgres/migrations/2019-06-26-164405_index_dynamic_ethereum_contract_data_source_deployment/down.sql
@@ -1,0 +1,2 @@
+drop index if exists
+  subgraphs.manual_dynamic_ethereum_contract_data_source_deployment;

--- a/store/postgres/migrations/2019-06-26-164405_index_dynamic_ethereum_contract_data_source_deployment/up.sql
+++ b/store/postgres/migrations/2019-06-26-164405_index_dynamic_ethereum_contract_data_source_deployment/up.sql
@@ -1,0 +1,4 @@
+create index if not exists
+  manual_dynamic_ethereum_contract_data_source_deployment
+    on subgraphs.entities(((data->'deployment'->>'data')))
+    where entity='DynamicEthereumContractDataSource';


### PR DESCRIPTION
Our internal query to look up dynamic data sources repeatedly looks up a
DynamicEthereumContractDataSource by its deployment. Without this index,
this results in a full table scan of subgraphs.entities, which by now is
pretty sizeable (roughly 1M rows)

This index allows Postgres to use a more direct and much more efficient
query plan for these queries.

Fixes https://github.com/graphprotocol/graph-node/issues/999

