### PR TITLE
Support connecting to multiple Ethereum networks on a single graph-node

### DIFF
--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -34,6 +34,7 @@ where
         host_builder: &T,
     ) -> Result<Self, Error> {
         let manifest_id = manifest.id.clone();
+        let network_name = manifest.network_name()?;
 
         // Create a new runtime host for each data source in the subgraph manifest;
         // we use the same order here as in the subgraph manifest to make the
@@ -41,7 +42,7 @@ where
         let (hosts, errors): (_, Vec<_>) = manifest
             .data_sources
             .into_iter()
-            .map(|d| host_builder.build(&logger, manifest_id.clone(), d))
+            .map(|d| host_builder.build(&logger, network_name.clone(), manifest_id.clone(), d))
             .partition(|res| res.is_ok());
 
         if !errors.is_empty() {

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -272,17 +272,18 @@ where
             SubgraphManifest::resolve(hash.to_ipfs_link(), self.resolver.clone(), logger.clone())
                 .map_err(SubgraphRegistrarError::ResolveError)
                 .and_then(validation::validate_manifest)
-                .and_then(move |(network_name, manifest)| {
+                .and_then(move |manifest| {
+                    let network_name = manifest.network_name()?;
                     let chain_store = chain_stores.get(&network_name).expect(&format!(
-                        "subgraph deploy error: the ethereum network, {}, is not supported.",
-                        "mainnet"
+                        "Subgraph deployment failed: Ethereum network {}, is not supported.",
+                        &network_name
                     ));
                     create_subgraph_version(
                         &logger,
                         store,
                         chain_store.clone(),
                         name,
-                        manifest.clone(),
+                        manifest,
                         node_id,
                         version_switching_mode,
                     )

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -274,10 +274,9 @@ where
                 .and_then(validation::validate_manifest)
                 .and_then(move |manifest| {
                     let network_name = manifest.network_name()?;
-                    let chain_store = chain_stores.get(&network_name).expect(&format!(
-                        "Subgraph deployment failed: Ethereum network {}, is not supported.",
-                        &network_name
-                    ));
+                    let chain_store = chain_stores
+                        .get(&network_name)
+                        .ok_or(SubgraphRegistrarError::NetworkNotSupported(network_name))?;
                     create_subgraph_version(
                         &logger,
                         store,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::iter;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -15,7 +15,7 @@ pub struct SubgraphRegistrar<L, P, S, CS> {
     resolver: Arc<L>,
     provider: Arc<P>,
     store: Arc<S>,
-    chain_store: Arc<CS>,
+    chain_stores: HashMap<String, Arc<CS>>,
     node_id: NodeId,
     version_switching_mode: SubgraphVersionSwitchingMode,
     assignment_event_stream_cancel_guard: CancelGuard, // cancels on drop
@@ -33,7 +33,7 @@ where
         resolver: Arc<L>,
         provider: Arc<P>,
         store: Arc<S>,
-        chain_store: Arc<CS>,
+        chain_stores: HashMap<String, Arc<CS>>,
         node_id: NodeId,
         version_switching_mode: SubgraphVersionSwitchingMode,
     ) -> Self {
@@ -46,7 +46,7 @@ where
             resolver,
             provider,
             store,
-            chain_store,
+            chain_stores,
             node_id,
             version_switching_mode,
             assignment_event_stream_cancel_guard: CancelGuard::new(),
@@ -263,8 +263,8 @@ where
         node_id: NodeId,
     ) -> Box<Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static> {
         let store = self.store.clone();
+        let chain_stores = self.chain_stores.clone();
         let version_switching_mode = self.version_switching_mode;
-        let chain_store = self.chain_store.clone();
 
         let logger = self.logger_factory.subgraph_logger(&hash);
 
@@ -272,13 +272,17 @@ where
             SubgraphManifest::resolve(hash.to_ipfs_link(), self.resolver.clone(), logger.clone())
                 .map_err(SubgraphRegistrarError::ResolveError)
                 .and_then(validation::validate_manifest)
-                .and_then(move |manifest| {
+                .and_then(move |(network_name, manifest)| {
+                    let chain_store = chain_stores.get(&network_name).expect(&format!(
+                        "subgraph deploy error: the ethereum network, {}, is not supported.",
+                        "mainnet"
+                    ));
                     create_subgraph_version(
                         &logger,
                         store,
-                        chain_store,
+                        chain_store.clone(),
                         name,
-                        manifest,
+                        manifest.clone(),
                         node_id,
                         version_switching_mode,
                     )
@@ -687,7 +691,7 @@ fn create_subgraph_version(
         logger,
         "Wrote new subgraph version to store";
         "subgraph_name" => name.to_string(),
-        "subgraph_hash" => manifest_id
+        "subgraph_hash" => manifest_id,
     );
 
     Ok(())

--- a/core/src/subgraph/validation.rs
+++ b/core/src/subgraph/validation.rs
@@ -2,7 +2,7 @@ use graph::prelude::*;
 
 pub fn validate_manifest(
     manifest: SubgraphManifest,
-) -> Result<SubgraphManifest, SubgraphRegistrarError> {
+) -> Result<(String, SubgraphManifest), SubgraphRegistrarError> {
     let mut errors: Vec<SubgraphManifestValidationError> = Vec::new();
 
     // Validate that the manifest has a `source` address in each data source
@@ -57,8 +57,14 @@ pub fn validate_manifest(
         errors.push(SubgraphManifestValidationError::DataSourceBlockHandlerLimitExceeded)
     }
 
+    let mut network_name = String::from("none");
+    match manifest.network_name() {
+        Ok(n) => network_name = n,
+        Err(e) => errors.push(e),
+    };
+
     if errors.is_empty() {
-        return Ok(manifest);
+        return Ok((network_name, manifest));
     }
 
     return Err(SubgraphRegistrarError::ManifestValidationError(errors));

--- a/core/src/subgraph/validation.rs
+++ b/core/src/subgraph/validation.rs
@@ -2,7 +2,7 @@ use graph::prelude::*;
 
 pub fn validate_manifest(
     manifest: SubgraphManifest,
-) -> Result<(String, SubgraphManifest), SubgraphRegistrarError> {
+) -> Result<SubgraphManifest, SubgraphRegistrarError> {
     let mut errors: Vec<SubgraphManifestValidationError> = Vec::new();
 
     // Validate that the manifest has a `source` address in each data source
@@ -57,14 +57,8 @@ pub fn validate_manifest(
         errors.push(SubgraphManifestValidationError::DataSourceBlockHandlerLimitExceeded)
     }
 
-    let mut network_name = String::from("none");
-    match manifest.network_name() {
-        Ok(n) => network_name = n,
-        Err(e) => errors.push(e),
-    };
-
     if errors.is_empty() {
-        return Ok((network_name, manifest));
+        return Ok(manifest);
     }
 
     return Err(SubgraphRegistrarError::ManifestValidationError(errors));

--- a/core/tests/subgraphs/dummy/dummy.yaml
+++ b/core/tests/subgraphs/dummy/dummy.yaml
@@ -4,6 +4,7 @@ schema:
     /: 'link to schema.graphql'
 dataSources:
 - kind: ethereum/contract
+  network: mainnet
   name: ExampleDataSource
   source:
     address: "22843e74c59580b3eaf6c233fa67d8b7c561a835"

--- a/core/tests/subgraphs/two-datasources/two-datasources.yaml
+++ b/core/tests/subgraphs/two-datasources/two-datasources.yaml
@@ -4,6 +4,7 @@ schema:
     /: 'link to schema.graphql'
 dataSources:
 - kind: ethereum/contract
+  network: mainnet
   name: ExampleDataSource
   source:
     address: "22843e74c59580b3eaf6c233fa67d8b7c561a835"
@@ -23,6 +24,7 @@ dataSources:
     file:
       /: 'link to empty.wasm'
 - kind: ethereum/contract
+  network: mainnet
   name: ExampleDataSource2
   source:
     address: "22222e74c59580b3eaf6c233fa67d8b7c561a835"

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -144,6 +144,7 @@ fn multiple_data_sources_per_subgraph() {
         fn build(
             &self,
             _: &Logger,
+            _: String,
             _: SubgraphDeploymentId,
             data_source: DataSource,
         ) -> Result<Self::Host, Error> {
@@ -169,16 +170,13 @@ fn multiple_data_sources_per_subgraph() {
             let mut stores = HashMap::new();
             stores.insert("mainnet".to_string(), Arc::new(FakeStore));
             let host_builder = MockRuntimeHostBuilder::new();
-            let mut runtime_host_builders = HashMap::new();
-            runtime_host_builders.insert("mainnet".to_string(), host_builder.clone());
             let block_stream_builder = MockBlockStreamBuilder::new();
-            let mut block_stream_builders = HashMap::new();
-            block_stream_builders.insert("mainnet".to_string(), block_stream_builder);
+
             let manager = SubgraphInstanceManager::new(
                 &logger_factory,
                 stores,
-                runtime_host_builders,
-                block_stream_builders,
+                host_builder.clone(),
+                block_stream_builder.clone(),
             );
 
             // Load a subgraph with two data sources

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -20,6 +20,7 @@ pub trait BlockStreamBuilder: Clone + Send + Sync {
         &self,
         logger: Logger,
         deployment_id: SubgraphDeploymentId,
+        network_name: String,
         log_filter: Option<EthereumLogFilter>,
         call_filter: Option<EthereumCallFilter>,
         block_filter: Option<EthereumBlockFilter>,

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -53,6 +53,7 @@ pub trait RuntimeHostBuilder: Clone + Send + Sync + 'static {
     fn build(
         &self,
         logger: &Logger,
+        network_name: String,
         subgraph_id: SubgraphDeploymentId,
         data_source: DataSource,
     ) -> Result<Self::Host, Error>;

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -264,6 +264,12 @@ impl From<Error> for SubgraphRegistrarError {
     }
 }
 
+impl From<SubgraphManifestValidationError> for SubgraphRegistrarError {
+    fn from(e: SubgraphManifestValidationError) -> Self {
+        SubgraphRegistrarError::ManifestValidationError(vec![e])
+    }
+}
+
 #[derive(Fail, Debug)]
 pub enum SubgraphAssignmentProviderError {
     #[fail(display = "Subgraph resolve error: {}", _0)]
@@ -312,7 +318,7 @@ pub enum SubgraphAssignmentProviderEvent {
 pub enum SubgraphManifestValidationError {
     #[fail(display = "subgraph source address is required")]
     SourceAddressRequired,
-    #[fail(display = "subgraph cannot index data from multiple different ethereum networks")]
+    #[fail(display = "subgraph cannot index data from different Ethereum networks")]
     MultipleEthereumNetworks,
     #[fail(display = "subgraph must have at least one Ethereum network data source")]
     EthereumNetworkRequired,

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -232,6 +232,8 @@ pub enum SubgraphRegistrarError {
     NameExists(String),
     #[fail(display = "subgraph name not found: {}", _0)]
     NameNotFound(String),
+    #[fail(display = "Ethereum network not supported by registrar: {}", _0)]
+    NetworkNotSupported(String),
     #[fail(display = "deployment not found: {}", _0)]
     DeploymentNotFound(String),
     #[fail(display = "deployment assignment unchanged: {}", _0)]

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -854,9 +854,7 @@ impl SubgraphManifest {
             })
     }
 
-    pub fn network_name(
-        &self,
-    ) -> Result<String, SubgraphManifestValidationError> {
+    pub fn network_name(&self) -> Result<String, SubgraphManifestValidationError> {
         let mut ethereum_networks: Vec<Option<String>> = self
             .data_sources
             .iter()

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -61,6 +61,7 @@ impl BlockStreamBuilder for MockBlockStreamBuilder {
         &self,
         _logger: Logger,
         _deployment_id: SubgraphDeploymentId,
+        _network_name: String,
         _log_filter: Option<EthereumLogFilter>,
         _call_filter: Option<EthereumCallFilter>,
         _block_filter: Option<EthereumBlockFilter>,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -413,12 +413,12 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     .iter()
     .cloned()
     .filter(|(_, values)| values.is_some())
-    .fold(HashMap::new(), |networks, (connection_type, values)| {
+    .fold(HashMap::new(), |adapters, (connection_type, values)| {
         match parse_ethereum_networks_and_nodes(logger.clone(), values.unwrap(), connection_type) {
-            Ok(adapters) => networks.into_iter().chain(adapters).collect(),
+            Ok(adapter) => adapters.into_iter().chain(adapter).collect(),
             Err(e) => {
                 panic!(
-                    "Failed to parse ethereum networks and create ethereum adapters: {}",
+                    "Failed to parse Ethereum networks and create Ethereum adapters: {}",
                     e
                 );
             }
@@ -452,7 +452,8 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
             match eth_adapter.net_identifiers(&logger).wait() {
                 Ok(network_identifier) => {
                     info!(
-                    logger, "Connected to Ethereum";
+                    logger,
+                    "Connected to Ethereum";
                     "network" => &network_name,
                     "network_version" => &network_identifier.net_version,
                     );

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -81,7 +81,7 @@ where
     ) -> Result<Self::Host, Error> {
         let store = self.stores.get(&network_name).ok_or_else(|| {
             format_err!(
-                "No Store found that matches subgraph network: \"{}\"",
+                "No store found that matches subgraph network: \"{}\"",
                 &network_name
             )
         })?;

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -79,27 +79,23 @@ where
         subgraph_id: SubgraphDeploymentId,
         data_source: DataSource,
     ) -> Result<Self::Host, Error> {
-        let store = self
-            .stores
-            .get(&network_name)
-            .expect(&format!(
-                "expected store that matches subgraph network: {}",
+        let store = self.stores.get(&network_name).ok_or_else(|| {
+            format_err!(
+                "No Store found that matches subgraph network: \"{}\"",
                 &network_name
-            ))
-            .clone();
+            )
+        })?;
 
-        let ethereum_adapter = self
-            .ethereum_adapters
-            .get(&network_name)
-            .expect(&format!(
-                "expected Ethereum adapter that matches subgraph network: {}",
+        let ethereum_adapter = self.ethereum_adapters.get(&network_name).ok_or_else(|| {
+            format_err!(
+                "No Ethereum adapter found that matches subgraph network: \"{}\"",
                 &network_name
-            ))
-            .clone();
+            )
+        })?;
 
         RuntimeHost::new(
             logger,
-            ethereum_adapter,
+            ethereum_adapter.clone(),
             self.link_resolver.clone(),
             store.clone(),
             RuntimeHostConfig {


### PR DESCRIPTION
Resolves #1018
Updating the graph-node to handle multiple, different Ethereum networks on a single instance allows for more flexibility in devops because one does not have to run separate nodes to support subgraphs on different Ethereum chains. 

Summary:
The `ethereum-rpc`, `ethereum-ipc`, `ethereum-ws` CLI arguments now accept multiple values each. These supplied Ethereum networks are used to create sets of stores, runtime host builders and block stream builders (containing one item per Ethereum network). The subgraph instance manager and the subgraph registrar now take these sets (implemented as HashMap) as input and when deploying a subgraph version will decide which store, runtime, and block stream to use based on the Ethereum network name defined in the subgraph's manifest.