### PR TITLE
subgraph registrar: Panic on cancel

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -101,7 +101,7 @@ where
                         handle_assignment_event(assignment_event, provider.clone(), &logger_clone1)
                     })
                     .map_err(move |e| match e {
-                        CancelableError::Cancel => {}
+                        CancelableError::Cancel => panic!("assignment event stream canceled"),
                         CancelableError::Error(e) => {
                             error!(logger_clone2, "Assignment event stream failed: {}", e);
                             panic!("assignment event stream failed: {}", e);


### PR DESCRIPTION
A subgraph on the hosted service became stuck on deploy, apparently because the node that should receive the `AssignmentEvent::Add` was not listening. This code path that could cause a node to silently stop listening for assignment events. I don't how this stream would ever be canceled, but I'd like to confirm or rule this out as a cause. If it's confirmed, then imo we should just make this not cancelable.