### PR TITLE
store/postgres: Log errors when reading db notifications

### DIFF
--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -78,8 +78,10 @@ impl NotificationListener {
         Arc<AtomicBool>,
         Arc<Barrier>,
     ) {
-        let logger = logger.new(o!("component" => "NotificationListener",
-                    "channel" => channel_name.0.clone()));
+        let logger = logger.new(o!(
+            "component" => "NotificationListener",
+            "channel" => channel_name.0.clone()
+        ));
 
         // Create two ends of a boolean variable for signalling when the worker
         // thread should be terminated
@@ -115,8 +117,11 @@ impl NotificationListener {
                     .filter_map(|item| match item {
                         Ok(msg) => Some(msg),
                         Err(e) => {
-                            warn!(logger, "Error receiving message";
-                                          "error" => format!("{}", e));
+                            warn!(
+                                logger,
+                                "Error receiving message";
+                                "error" => format!("{}", e)
+                            );
                             None
                         }
                     })


### PR DESCRIPTION
We used to silently ignore errors when reading notifications from the
database. We now log them to make it easier to tell if anything is going
wrong there, e.g., to at least get a message if the connection gets dropped
for whatever reason.

