### PR TITLE
Add env var to make large notification cleanup interval configurable

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -355,15 +355,23 @@ fn start_subgraph<P: SubgraphAssignmentProviderTrait>(
     provider: &P,
     logger: Logger,
 ) -> impl Future<Item = (), Error = ()> + 'static {
-    trace!(logger, "SubgraphRegistrar::start_subgraph";
-                   "subgraph_id" => subgraph_id.to_string());
+    trace!(
+        logger,
+        "Start subgraph";
+        "subgraph_id" => subgraph_id.to_string()
+    );
+
     let start_time = Instant::now();
     provider
         .start(subgraph_id.clone())
         .then(move |result| -> Result<(), _> {
-            debug!(logger, "subgraph started";
-                  "subgraph_id" => subgraph_id.to_string(),
-                  "start_ms" => start_time.elapsed().as_millis());
+            debug!(
+                logger,
+                "Subgraph started";
+                "subgraph_id" => subgraph_id.to_string(),
+                "start_ms" => start_time.elapsed().as_millis()
+            );
+
             match result {
                 Ok(()) => Ok(()),
                 Err(SubgraphAssignmentProviderError::AlreadyRunning(_)) => Ok(()),

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -16,6 +16,7 @@ futures = "0.1.21"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
 Inflector = "0.11.3"
+lazy_static = "1.1"
 lru_time_cache = "0.8"
 postgres = "0.15.2"
 serde = "1.0"
@@ -24,6 +25,5 @@ uuid = { version = "0.7.2", features = ["v4"] }
 [dev-dependencies]
 graphql-parser = "0.2.0"
 hex = "0.3.2"
-lazy_static = "1.1"
 parity-wasm = "0.31"
 test-store = { path = "../test-store" }

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -11,6 +11,7 @@ extern crate futures;
 extern crate graph;
 extern crate graph_graphql;
 extern crate inflector;
+extern crate lazy_static;
 extern crate lru_time_cache;
 extern crate postgres;
 extern crate serde;


### PR DESCRIPTION
This adds a `LARGE_NOTIFICATIONS_CLEANUP_INTERVAL` environment variable that defaults to `300` (seconds). This is what we had hard-coded before. Through the env var, this value can now be tweaked to increase or decrease the interval at which old large notifications are roughly cleaned up.