### PR TITLE
Include a "Content-type" header in http query response

### DIFF
--- a/server/http/src/response.rs
+++ b/server/http/src/response.rs
@@ -62,6 +62,7 @@ impl Future for GraphQLResponse {
             .header("Access-Control-Allow-Origin", "*")
             .header("Access-Control-Allow-Headers", "Content-Type")
             .header("Access-Control-Allow-Methods", "GET, OPTIONS, POST")
+            .header("Content-Type", "application/json")
             .body(Body::from(json))
             .unwrap();
         Ok(Async::Ready(response))


### PR DESCRIPTION
Resolves #1032 

GraphQL query responses from subgraph endpoints use the  application/json content type.