### PR TITLE
Make maximum value for `first` configurable (#1044)

### DIFF
--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -36,7 +36,7 @@ pub enum QueryExecutionError {
     EmptyQuery,
     MultipleSubscriptionFields,
     SubgraphDeploymentIdError(String),
-    RangeArgumentsError(Vec<&'static str>),
+    RangeArgumentsError(Vec<&'static str>, u64),
     InvalidFilterError,
     EntityFieldError(String, String),
     ListTypesError(String, Vec<String>),
@@ -131,10 +131,10 @@ impl fmt::Display for QueryExecutionError {
             SubgraphDeploymentIdError(s) => {
                 write!(f, "Failed to get subgraph ID from type: `{}`", s)
             }
-            RangeArgumentsError(args) => {
+            RangeArgumentsError(args, first_limit) => {
                 let msg = args.into_iter().map(|arg| {
                     match *arg {
-                        "first" => format!("Value of \"first\" must be between 1 and 100"),
+                        "first" => format!("Value of \"first\" must be between 1 and {}", first_limit),
                         "skip" => format!("Value of \"skip\" must be greater than 0"),
                         _ => format!("Value of \"{}\" is must be an integer", arg),
                     }


### PR DESCRIPTION
Resolves #1044.

This adds a `GRAPHQL_MAX_FIRST` environment that allows to set the maximum value that is allowed for `first`. The default `first` value remains at `100` to not accidentally push existing queries past the complexity limit.

The error message for when `first` is too high now includes the configured limit, e.g.

> Value of "first" must be between 1 and 1000

