### PR TITLE
Allow creating data sources in `ipfs_map` and fix dynamic data sources missing events

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -2,7 +2,6 @@ use futures::future::{loop_fn, Loop};
 use futures::sync::mpsc::{channel, Receiver, Sender};
 use std::collections::HashMap;
 use std::ops::Deref;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::RwLock;
 use uuid::Uuid;
 
@@ -278,7 +277,6 @@ where
     let id_for_err = ctx.inputs.deployment_id.clone();
     let store_for_err = ctx.inputs.store.clone();
     let logger_for_err = logger.clone();
-    let logger_for_restart_check = logger.clone();
     let logger_for_block_stream_errors = logger.clone();
 
     let block_stream_canceler = CancelGuard::new();
@@ -307,28 +305,14 @@ where
 
     debug!(logger, "Starting block stream");
 
-    // Flag that indicates when the subgraph needs to be
-    // restarted due to new dynamic data sources being added
-    let needs_restart_set = Arc::new(AtomicBool::new(false));
-
-    // Handle to the flag for checking it before every block
-    let needs_restart_check = needs_restart_set.clone();
+    // The processing stream may be end due to an error or for restarting to
+    // account for new data sources.
+    enum StreamEnd<B: BlockStreamBuilder, S: Store + ChainStore, T: RuntimeHostBuilder> {
+        Error(CancelableError<Error>),
+        NeedsRestart(IndexingContext<B, S, T>),
+    }
 
     block_stream
-        // Take blocks from the stream as long as no dynamic data sources
-        // have been created. Once that has happened, we need to restart
-        // the stream to include blocks for these data sources as well.
-        .take_while(move |_| {
-            if needs_restart_check.load(Ordering::SeqCst) {
-                debug!(
-                    logger_for_restart_check,
-                    "New data sources added, restart the subgraph",
-                );
-                Ok(false)
-            } else {
-                Ok(true)
-            }
-        })
         // Log and drop the errors from the block_stream
         // The block stream will continue attempting to produce blocks
         .then(move |result| match result {
@@ -345,49 +329,46 @@ where
         .filter_map(|block_opt| block_opt)
         // Process blocks from the stream as long as no restart is needed
         .fold(ctx, move |ctx, block| {
-            let needs_restart_set = needs_restart_set.clone();
-
             process_block(
                 logger.clone(),
                 ctx,
                 block_stream_cancel_handle.clone(),
                 block,
             )
-            .map(move |(ctx, needs_restart)| {
-                // If new data sources were detected in this block, set the
-                // needs restart flag. This will cause `take_while` to stop
-                // emitting blocks and finish this `fold` loop as well
-                if needs_restart {
-                    needs_restart_set.store(true, Ordering::SeqCst);
-                }
-                ctx
+            .map_err(|e| StreamEnd::Error(e))
+            .and_then(|(ctx, needs_restart)| match needs_restart {
+                false => Ok(ctx),
+                true => Err(StreamEnd::NeedsRestart(ctx)),
             })
         })
-        // A restart is needed
-        .and_then(move |mut ctx| {
-            // Increase the restart counter
-            ctx.state.restarts += 1;
+        .then(move |res| match res {
+            Ok(_) => unreachable!("block stream finished without error"),
+            Err(StreamEnd::NeedsRestart(mut ctx)) => {
+                // Increase the restart counter
+                ctx.state.restarts += 1;
 
-            // Cancel the stream for real
-            ctx.state
-                .instances
-                .write()
-                .unwrap()
-                .remove(&ctx.inputs.deployment_id);
+                // Cancel the stream for real
+                ctx.state
+                    .instances
+                    .write()
+                    .unwrap()
+                    .remove(&ctx.inputs.deployment_id);
 
-            // And restart the subgraph
-            Ok(Loop::Continue(ctx))
-        })
-        // Handle unexpected stream errors by marking the subgraph as failed
-        .map_err(move |e| match e {
-            CancelableError::Cancel => {
+                // And restart the subgraph
+                Ok(Loop::Continue(ctx))
+            }
+
+            Err(StreamEnd::Error(CancelableError::Cancel)) => {
                 debug!(
                     logger_for_err,
                     "Subgraph block stream shut down cleanly";
                     "id" => id_for_err.to_string(),
                 );
+                Err(())
             }
-            CancelableError::Error(e) => {
+
+            // Handle unexpected stream errors by marking the subgraph as failed.
+            Err(StreamEnd::Error(CancelableError::Error(e))) => {
                 error!(
                     logger_for_err,
                     "Subgraph instance failed to run: {}", e;
@@ -406,6 +387,7 @@ where
                         "code" => LogCode::SubgraphSyncingFailureNotRecorded
                     );
                 }
+                Err(())
             }
         })
 }

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -377,7 +377,7 @@ where
         callback: &str,
         user_data: store::Value,
         flags: Vec<String>,
-    ) -> Result<Vec<EntityOperation>, HostExportError<impl ExportError>> {
+    ) -> Result<Vec<BlockState>, HostExportError<impl ExportError>> {
         const JSON_FLAG: &str = "json";
         if !flags.contains(&JSON_FLAG.to_string()) {
             return Err(HostExportError(format!("Flags must contain 'json'")));
@@ -395,7 +395,7 @@ where
         let start = Instant::now();
         let mut last_log = Instant::now();
         let logger = ctx.logger.new(o!("ipfs_map" => link.clone()));
-        let operations = self.block_on(
+        self.block_on(
             self.link_resolver
                 .json_stream(&Link { link })
                 .and_then(move |stream| {
@@ -422,9 +422,7 @@ where
                         .collect()
                 })
                 .map_err(move |e| HostExportError(format!("{}: {}", errmsg, e.to_string()))),
-        )?;
-        // Collect all results into one Vec
-        Ok(operations.into_iter().flatten().collect())
+        )
     }
 
     /// Expects a decimal string.

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -362,14 +362,13 @@ where
         )
     }
 
-    // Read the IPFS file `link`, split it into JSON objects, and invoke
-    // the exported function `callback` on each JSON object. The successful
-    // return value contains all entity operations that were produced by the
-    // callback invocations. Each invocation of `callback` happens in its own
-    // instance of a WASM module, which is identical to `module` when it was
-    // first started. The signature of the callback must be
-    // `callback(JSONValue, Value)`, and the `userData` parameter is passed
-    // to the callback without any changes
+    // Read the IPFS file `link`, split it into JSON objects, and invoke the
+    // exported function `callback` on each JSON object. The successful return
+    // value contains the block state produced by each callback invocation. Each
+    // invocation of `callback` happens in its own instance of a WASM module,
+    // which is identical to `module` when it was first started. The signature
+    // of the callback must be `callback(JSONValue, Value)`, and the `userData`
+    // parameter is passed to the callback without any changes
     pub(crate) fn ipfs_map(
         &self,
         module: &WasmiModule<E, L, S, U>,

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -636,24 +636,24 @@ where
                 .host_exports()
                 .ipfs_map(&self, link.clone(), &*callback, user_data, flags)
             {
-                Ok(ops) => {
+                Ok(output_states) => {
                     debug!(
                         self.logger,
                         "Successfully processed file with ipfs.map";
                         "link" => &link,
                         "callback" => &*callback,
-                        "entity_operations" => ops.len(),
+                        "n_calls" => output_states.len(),
                         "time" => format!("{}ms", start_time.elapsed().as_millis())
                     );
-                    for op in ops {
+                    for output_state in output_states {
                         self.ctx
                             .state
                             .entity_operations
-                            .extend(op.entity_operations);
+                            .extend(output_state.entity_operations);
                         self.ctx
                             .state
                             .created_data_sources
-                            .extend(op.created_data_sources);
+                            .extend(output_state.created_data_sources);
                     }
                     Ok(None)
                 }


### PR DESCRIPTION
The first commit fixes data sources created in `ipfs_map` being ignored, which was a straightforward fix.

The second fixes a more subtle and more general issue, that we'd only restart the block stream to pick up new data sources when receiving the _next_ block in the original data source. This could cause missed events or even the stream to never be restarted because there was only one event in the original data source.

Fixes #1067. Fixes #1035.