### PR TITLE
store/postgres: Make sure missing notification does not panic listener

### DIFF
--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -245,8 +245,20 @@ impl JsonNotification {
                         "SELECT payload FROM large_notifications WHERE id = $1",
                         &[&(payload_id as i32)],
                     )
-                    .map_err(|_| format_err!("No payload found for notification {}", payload_id))?;
+                    .map_err(|e| {
+                        format_err!(
+                            "Error retrieving payload for notification {}: {}",
+                            payload_id,
+                            e
+                        )
+                    })?;
 
+                if payload_rows.is_empty() || payload_rows.get(0).is_empty() {
+                    return Err(format_err!(
+                        "No payload found for notification {}",
+                        payload_id
+                    ))?;
+                }
                 let payload: String = payload_rows.get(0).get(0);
 
                 Ok(JsonNotification {


### PR DESCRIPTION
When the payload for a large notification was cleaned up too early and went
missing, the notification listener would panic because we
postgres::row::Rows::get panics when we try to access the nonexistent row
in the result.

We now check that the result is not empty before accessing values to avoid
that panic.

This partly addresses https://github.com/graphprotocol/graph-node/issues/1043

