### PR TITLE
Reduce noisiness of tokio contention check

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -636,17 +636,17 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     );
     let contention_logger = logger.clone();
     std::thread::spawn(move || loop {
-        std::thread::sleep(Duration::from_millis(100));
+        std::thread::sleep(Duration::from_secs(1));
         let (pong_send, pong_receive) = crossbeam_channel::bounded(1);
         if ping_send.clone().send(pong_send).wait().is_err() {
             debug!(contention_logger, "Shutting down contention checker thread");
             break;
         }
-        let mut timeout = Duration::from_millis(1);
+        let mut timeout = Duration::from_millis(10);
         while pong_receive.recv_timeout(timeout)
             == Err(crossbeam_channel::RecvTimeoutError::Timeout)
         {
-            warn!(contention_logger, "Possible contention in tokio threadpool";
+            debug!(contention_logger, "Possible contention in tokio threadpool";
                                      "timeout_ms" => timeout.as_millis(),
                                      "code" => LogCode::TokioContention);
             if timeout < Duration::from_secs(10) {


### PR DESCRIPTION
Reduce frequency of check to every second and downgrade log level to debug.

Also increase the wait time to 10ms. In a production environment 1ms wait time does signal an issue, but at that point we're measuring contention in the OS scheduler, and there are more suitable tools to measure that than this log.

