### PR TITLE
Top level templates

### DIFF
--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -35,6 +35,7 @@ where
     ) -> Result<Self, Error> {
         let manifest_id = manifest.id.clone();
         let network_name = manifest.network_name()?;
+        let templates = manifest.templates.unwrap_or_default();
 
         // Create a new runtime host for each data source in the subgraph manifest;
         // we use the same order here as in the subgraph manifest to make the
@@ -42,7 +43,15 @@ where
         let (hosts, errors): (_, Vec<_>) = manifest
             .data_sources
             .into_iter()
-            .map(|d| host_builder.build(&logger, network_name.clone(), manifest_id.clone(), d))
+            .map(|d| {
+                host_builder.build(
+                    &logger,
+                    network_name.clone(),
+                    manifest_id.clone(),
+                    d,
+                    templates.clone(),
+                )
+            })
             .partition(|res| res.is_ok());
 
         if !errors.is_empty() {

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -507,7 +507,8 @@ where
                     true => Err(err_msg(
                         "A dynamic data source, in the same block that it was created,
                         attempted to create another dynamic data source.
-                        Let us know in graph-node issue #1105 that you hit this.",
+                        To let us know that you are affected by this bug, please comment in
+                        https://github.com/graphprotocol/graph-node/issues/1105",
                     )
                     .into()),
                 }

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -22,6 +22,7 @@ fn insert_and_query(
         repository: None,
         schema: schema.clone(),
         data_sources: vec![],
+        templates: None,
     };
 
     let logger = Logger::root(slog::Discard, o!());

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -147,6 +147,7 @@ fn multiple_data_sources_per_subgraph() {
             _: String,
             _: SubgraphDeploymentId,
             data_source: DataSource,
+            _: Vec<DataSourceTemplate>,
         ) -> Result<Self::Host, Error> {
             self.data_sources_received.lock().unwrap().push(data_source);
 

--- a/docs/subgraph-manifest.md
+++ b/docs/subgraph-manifest.md
@@ -18,6 +18,7 @@ Any data format that has a well-defined 1:1 mapping with the [IPLD Canonical For
 | **description**   | *String* | An optional description of the subgraph's purpose. |
 | **repository**   | *String* | An optional link to where the subgraph lives. |
 | **dataSources**| [*Data Source Spec*](#15-data-source)| Each data source spec defines the data that will be ingested as well as the transformation logic to derive the state of the subgraph's entities based on the source data.|
+| **templates** | [*Data Source Templates Spec*](#17-data-source-templates) | Each data source template defines a data source that can be created dynamically from the mappings. |
 
 ## 1.4 Schema
 
@@ -34,7 +35,6 @@ Any data format that has a well-defined 1:1 mapping with the [IPLD Canonical For
 | **network** | *String* | For blockchains, this describes which network the subgraph targets. For Ethereum, this could be, for example, "mainnet" or "rinkeby". |
 | **source** | [*EthereumContractSource*](#151-ethereumcontractsource) | The source data on a blockchain such as Ethereum. |
 | **mapping** | [*Mapping*](#152-mapping) | The transformation logic applied to the data prior to being indexed. |
-| **templates** | [*Data Source Templates Spec*](#17-data-source-templates) | Each data source template defines a data source that can be created dynamically from the mappings. |
 
 ### 1.5.1 EthereumContractSource
 
@@ -80,27 +80,23 @@ When using the Graph-CLI, local paths may be used during development, and then, 
 A data source template has all of the fields of a normal data source, except it does not include a contract address under `source`. The address is a parameter that can later be provided when creating a dynamic data source from the template.
 ```yml
 # ...
-dataSources:
-  - kind: ethereum/contract
-    name: Factory
-    # ...
-    templates:
-      - name: Exchange
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: Exchange
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.1
-          language: wasm/assemblyscript
-          file: ./src/mappings/exchange.ts
-          entities:
-            - Exchange
-          abis:
-            - name: Exchange
-              file: ./abis/exchange.json
-          eventHandlers:
-            - event: TokenPurchase(address,uint256,uint256)
-              handler: handleTokenPurchase
+templates:
+  - name: Exchange
+    kind: ethereum/contract
+    network: mainnet
+    source:
+      abi: Exchange
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.1
+      language: wasm/assemblyscript
+      file: ./src/mappings/exchange.ts
+      entities:
+        - Exchange
+      abis:
+        - name: Exchange
+          file: ./abis/exchange.json
+      eventHandlers:
+        - event: TokenPurchase(address,uint256,uint256)
+          handler: handleTokenPurchase
 ```

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -56,5 +56,6 @@ pub trait RuntimeHostBuilder: Clone + Send + Sync + 'static {
         network_name: String,
         subgraph_id: SubgraphDeploymentId,
         data_source: DataSource,
+        top_level_templates: Vec<DataSourceTemplate>,
     ) -> Result<Self::Host, Error>;
 }

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -1,10 +1,10 @@
 use crate::prelude::*;
 use web3::types::Log;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct DataSourceTemplateInfo {
     pub data_source: String,
-    pub template: String,
+    pub template: DataSourceTemplate,
     pub params: Vec<String>,
 }
 

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -908,14 +908,13 @@ impl UnresolvedSubgraphManifest {
             _ => {
                 return Box::new(future::err(format_err!(
                     "This Graph Node only supports manifest spec versions <= 0.0.2,
-                but subgraph `{}` uses `{}`",
+                    but subgraph `{}` uses `{}`",
                     id,
                     spec_version
                 ))) as Box<dyn Future<Item = _, Error = _> + Send>;
             }
         }
 
-        // resolve each data set
         Box::new(
             schema
                 .resolve(id.clone(), resolver, logger.clone())
@@ -923,7 +922,7 @@ impl UnresolvedSubgraphManifest {
                     stream::futures_ordered(
                         data_sources
                             .into_iter()
-                            .map(|data_set| data_set.resolve(resolver, logger.clone())),
+                            .map(|ds| ds.resolve(resolver, logger.clone())),
                     )
                     .collect(),
                 )

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -147,7 +147,7 @@ impl SubgraphName {
                 return Err(());
             }
 
-            // Part should not start or end with a special character or start with a number.
+            // Part should not start or end with a special character.
             let first_char = part.chars().next().unwrap();
             let last_char = part.chars().last().unwrap();
             if !first_char.is_ascii_alphanumeric()

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -666,7 +666,7 @@ impl UnresolvedDataSource {
 
 impl DataSource {
     pub fn try_from_template(
-        template: &DataSourceTemplate,
+        template: DataSourceTemplate,
         params: &Vec<String>,
     ) -> Result<Self, failure::Error> {
         // Obtain the address from the parameters
@@ -689,14 +689,14 @@ impl DataSource {
         })?;
 
         Ok(DataSource {
-            kind: template.kind.clone(),
-            network: template.network.clone(),
-            name: template.name.clone(),
+            kind: template.kind,
+            network: template.network,
+            name: template.name,
             source: Source {
                 address: Some(address),
-                abi: template.source.abi.clone(),
+                abi: template.source.abi,
             },
-            mapping: template.mapping.clone(),
+            mapping: template.mapping,
             templates: None,
         })
     }

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -74,6 +74,7 @@ fn insert_test_entities(store: &impl Store, id: SubgraphDeploymentId) {
         repository: None,
         schema: test_schema(id.clone()),
         data_sources: vec![],
+        templates: None,
     };
 
     store

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -14,10 +14,10 @@ pwasm-utils = "0.6.1"
 bs58 = "0.2.2"
 graph-runtime-derive = { path = "../derive" }
 semver = "0.9.0"
+parity-wasm = "0.31"
 
 [dev-dependencies]
 graphql-parser = "0.2.0"
-parity-wasm = "0.31"
 graph-core = { path = "../../core" }
 graph-mock = { path = "../../mock" }
 # We're using the latest ipfs-api for the HTTPS support that was merged in

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -225,7 +225,11 @@ impl RuntimeHost {
             debug!(module_logger, "Start WASM runtime");
             let wasmi_config = WasmiModuleConfig {
                 subgraph_id: config.subgraph_id,
-                data_source: config.data_source,
+                api_version: Version::parse(&config.data_source.mapping.api_version).unwrap(),
+                parsed_module: config.data_source.mapping.runtime,
+                abis: config.data_source.mapping.abis,
+                data_source_name: config.data_source.name,
+                templates: config.data_source.templates.unwrap_or_default(),
                 ethereum_adapter: ethereum_adapter.clone(),
                 link_resolver: link_resolver.clone(),
                 store: store.clone(),

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -81,6 +81,7 @@ where
         network_name: String,
         subgraph_id: SubgraphDeploymentId,
         data_source: DataSource,
+        top_level_templates: Vec<DataSourceTemplate>,
     ) -> Result<Self::Host, Error> {
         let store = self.stores.get(&network_name).ok_or_else(|| {
             format_err!(
@@ -96,6 +97,13 @@ where
             )
         })?;
 
+        // Detect whether the subgraph uses templates in data sources, which are
+        // deprecated, or the top-level templates field.
+        let templates = match top_level_templates.is_empty() {
+            false => top_level_templates,
+            true => data_source.templates.unwrap_or_default(),
+        };
+
         RuntimeHost::new(
             logger,
             ethereum_adapter.clone(),
@@ -106,7 +114,7 @@ where
                 mapping: data_source.mapping,
                 data_source_name: data_source.name,
                 contract: data_source.source,
-                templates: data_source.templates.unwrap_or_default(),
+                templates,
             },
         )
     }

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -599,7 +599,8 @@ where
         );
 
         // Resolve the name into the right template
-        self.templates
+        let template = self
+            .templates
             .iter()
             .find(|template| template.name == name)
             .ok_or_else(|| {
@@ -615,12 +616,13 @@ where
                         .collect::<Vec<_>>()
                         .join(", ")
                 ))
-            })?;
+            })?
+            .clone();
 
         // Remember that we need to create this data source
         ctx.state.created_data_sources.push(DataSourceTemplateInfo {
             data_source: self.data_source_name.clone(),
-            template: name,
+            template,
             params,
         });
 

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -164,7 +164,11 @@ fn test_valid_module(
             &logger,
             WasmiModuleConfig {
                 subgraph_id: SubgraphDeploymentId::new("wasmModuleTest").unwrap(),
-                data_source,
+                api_version: Version::parse(&data_source.mapping.api_version).unwrap(),
+                parsed_module: data_source.mapping.runtime,
+                abis: data_source.mapping.abis,
+                data_source_name: data_source.name,
+                templates: data_source.templates.unwrap_or_default(),
                 ethereum_adapter: mock_ethereum_adapter,
                 link_resolver: Arc::new(ipfs_api::IpfsClient::default().into()),
                 store: Arc::new(FakeStore),

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -780,15 +780,11 @@ fn data_source_create() {
     let data_source = String::from("example data source");
     let template = String::from("example template");
     let params = vec![String::from("0xc0a47dFe034B400B47bDaD5FecDa2621de6c4d95")];
-    let result = run_data_source_create(template.clone(), params.clone());
-    assert_eq!(
-        result.expect("unexpected error returned from dataSourceCreate"),
-        vec![DataSourceTemplateInfo {
-            data_source: data_source.clone(),
-            template: template.clone(),
-            params: params.clone()
-        }]
-    );
+    let result = run_data_source_create(template.clone(), params.clone())
+        .expect("unexpected error returned from dataSourceCreate");
+    assert_eq!(result[0].data_source, data_source);
+    assert_eq!(result[0].params, params.clone());
+    assert_eq!(result[0].template.name, template);
 
     // Test with a template that doesn't exist
     let template = String::from("nonexistent template");

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -469,6 +469,7 @@ mod tests {
             repository: None,
             schema: schema.clone(),
             data_sources: vec![],
+            templates: None,
         };
 
         let graphql_runner = Arc::new(TestGraphQlRunner);
@@ -539,6 +540,7 @@ mod tests {
             repository: None,
             schema: schema.clone(),
             data_sources: vec![],
+            templates: None,
         };
         let graphql_runner = Arc::new(TestGraphQlRunner);
         let store = Arc::new(MockStore::new(vec![(id.clone(), schema)]));

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -85,6 +85,7 @@ mod test {
             repository: None,
             schema: schema.clone(),
             data_sources: vec![],
+            templates: None,
         };
 
         let store = Arc::new(MockStore::new(vec![(id, schema)]));

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -39,6 +39,7 @@ type SubgraphManifest @entity {
     repository: String
     schema: String!
     dataSources: [EthereumContractDataSource!]!
+    templates: [EthereumContractDataSourceTemplate!]
 }
 
 type EthereumContractDataSource @entity {

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -121,6 +121,7 @@ fn insert_test_data(store: Arc<DieselStore>) {
         repository: None,
         schema: Schema::parse("scalar Foo", TEST_SUBGRAPH_ID.clone()).unwrap(),
         data_sources: vec![],
+        templates: None,
     };
 
     // Create SubgraphDeploymentEntity
@@ -1875,6 +1876,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             repository: None,
             schema: Schema::parse("scalar Foo", subgraph_id.clone()).unwrap(),
             data_sources: vec![],
+            templates: None,
         };
 
         // Create SubgraphDeploymentEntity


### PR DESCRIPTION
See https://github.com/graphprotocol/graph-node/issues/1023. Both formats are supported, but not a mix of both in the same subgraph. If a subgraph tries to mix both, only the top-level templates are considered. The `RuntimeHostBuilder` is given the data and the logic to make the decision of which template format is in use. See commits for more details.

A current limitation is that a data source cannot spawn another in the same block that it was created, for now just detect and error in this case, but this should be fixed in a follow up. See https://github.com/graphprotocol/graph-node/issues/1105.

graph-cli PR https://github.com/graphprotocol/graph-cli/pull/319