### PR TITLE
docker-compose: Update default Ethereum network name to "mainnet"

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -29,7 +29,7 @@ docker run -it \
 ## Docker Compose
 
 The Docker Compose setup requires an Ethereum network name and node
-to connect to. By default, it will use `dev:http://host.docker.internal:8545`
+to connect to. By default, it will use `mainnet:http://host.docker.internal:8545`
 in order to connect to an Ethereum node running on your host machine.
 You can replace this with anything else in `docker-compose.yaml`.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       postgres_pass: let-me-in
       postgres_db: graph-node
       ipfs: 'ipfs:5001'
-      ethereum: 'dev:http://host.docker.internal:8545'
+      ethereum: 'mainnet:http://host.docker.internal:8545'
       RUST_LOG: info
   ipfs:
     image: ipfs/go-ipfs


### PR DESCRIPTION
Setting the default Ethereum network name to "mainnet" allows many subgraphs to be deployed to the node without modifications to their manifests; the network name must match the Ethereum network defined in the subgraph manifest.

Note: existing users relying on the docker-compose setup may already be using the `dev` network name for local testing, so this change could lead to issues deploying their subgraphs.


