### PR TITLE
core,graph: Get dynamic block and call handlers on node restart

### DIFF
--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -55,6 +55,8 @@ where
                         file
                         entities
                         abis { name file }
+                        blockHandlers { handler filter}
+                        callHandlers {  function handler}
                         eventHandlers { event handler }
                       }
                       templates {
@@ -69,6 +71,8 @@ where
                           file
                           entities
                           abis { name file }
+                          blockHandlers { handler filter}
+                          callHandlers { function handler}
                           eventHandlers { event handler }
                         }
                       }
@@ -163,7 +167,7 @@ where
         }?;
 
         // Parse the raw data sources into typed entities
-        let entities = values.into_iter().try_fold(vec![], |mut entities, value| {
+        let entities = values.iter().try_fold(vec![], |mut entities, value| {
             entities.push(EthereumContractDataSourceEntity::try_from_value(value)?);
             Ok(entities)
         }) as Result<Vec<_>, Error>;

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -17,6 +17,7 @@ use graphql_parser::schema::{Definition, Document, Field, Name, Type, TypeDefini
 use hex;
 use rand::rngs::OsRng;
 use rand::Rng;
+use std::collections::BTreeMap;
 use std::str::FromStr;
 use web3::types::*;
 
@@ -849,7 +850,7 @@ impl From<super::MappingBlockHandler> for EthereumBlockHandlerEntity {
             Some(filter) => match filter {
                 // TODO: Figure out how to use serde to get lowercase spelling here
                 super::BlockHandlerFilter::Call => Some(EthereumBlockHandlerFilterEntity {
-                    kind: "call".to_string(),
+                    kind: Some("call".to_string()),
                 }),
             },
             None => None,
@@ -880,7 +881,7 @@ impl TryFromValue for EthereumBlockHandlerEntity {
 
 #[derive(Debug)]
 pub struct EthereumBlockHandlerFilterEntity {
-    pub kind: String,
+    pub kind: Option<String>,
 }
 
 impl TypedEntity for EthereumBlockHandlerFilterEntity {
@@ -899,8 +900,10 @@ impl EthereumBlockHandlerFilterEntity {
 
 impl TryFromValue for EthereumBlockHandlerFilterEntity {
     fn try_from_value(value: &q::Value) -> Result<Self, Error> {
+        let empty_map = BTreeMap::new();
         let map = match value {
             q::Value::Object(map) => Ok(map),
+            q::Value::Null => Ok(&empty_map),
             _ => Err(format_err!(
                 "Cannot parse value into block handler filter entity: {:?}",
                 value,
@@ -908,7 +911,7 @@ impl TryFromValue for EthereumBlockHandlerFilterEntity {
         }?;
 
         Ok(Self {
-            kind: map.get_required("kind")?,
+            kind: map.get_optional("kind")?,
         })
     }
 }


### PR DESCRIPTION
Resolves #1084 

On node startup all existing deployments assigned to that node are picked up from the db to be redeployed; however, the block and call handlers that had been created with dynamic data sources were not being fetched.  
This PR adds the block and call handlers to the dynamic data sources query and adds handling of  Ethereum block handler filter values from the query results. 



