### PR TITLE
Bump IPFS default timeout to 60 seconds

### DIFF
--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -36,7 +36,7 @@ fn ipfs_timeout() -> Duration {
     let timeout = env::var("GRAPH_IPFS_TIMEOUT").ok().map(|s| {
         u64::from_str(&s).unwrap_or_else(|_| panic!("failed to parse env var GRAPH_IPFS_TIMEOUT"))
     });
-    Duration::from_secs(timeout.unwrap_or(30))
+    Duration::from_secs(timeout.unwrap_or(60))
 }
 
 fn read_u64_from_env(name: &str) -> Option<u64> {

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -41,7 +41,7 @@ those.
 
 * `GRAPH_EVENT_HANDLER_TIMEOUT`: amount of time an event handler is allowed to
   take (in seconds, default is unlimited)
-* `GRAPH_IPFS_TIMEOUT`: timeout for ipfs requests. In seconds, default is 30
+* `GRAPH_IPFS_TIMEOUT`: timeout for ipfs requests. In seconds, default is 60.
   seconds.
 * `GRAPH_MAX_IPFS_FILE_BYTES`: maximum size for a file that can be retrieved
   with `ipfs.cat` (in bytes, default is unlimited)


### PR DESCRIPTION
On a docker setup I hit 30 seconds even for a local file. We already use a higher value on the hosted service.

