### PR TITLE
Improve block cache robustness

### DIFF
--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -892,11 +892,11 @@ where
 
         // Search for the block in the store first then use the ethereum adapter as a backup
         let block = future::result(ctx.chain_store.block(block_hash))
-            .and_then(
+            .then(
                 move |local_block_opt| -> Box<Future<Item = _, Error = _> + Send> {
                     match local_block_opt {
-                        Some(block) => Box::new(future::ok(block)),
-                        None => {
+                        Ok(Some(block)) => Box::new(future::ok(block)),
+                        Ok(None) | Err(_) => {
                             let logger = ctx.logger.clone();
                             let ctx_1 = ctx.clone();
                             let ctx_2 = ctx_1.clone();


### PR DESCRIPTION
If we error when fetching a block from the cache, try to get it from the ethereum node.

This is important right now because #1089 lost this patch https://github.com/graphprotocol/rust-web3/pull/1 to our web3 fork, causing errors with graph nodes that have blocks cached from old versions of the ethereum node. This is a way to fix this without reviving the patch.