### PR TITLE
Optimize `blocks_with_calls` memory usage

### DIFF
--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -449,7 +449,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         from: u64,
         to: u64,
         call_filter: EthereumCallFilter,
-    ) -> Box<Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send>;
+    ) -> Box<Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send>;
 
     fn blocks(
         &self,

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -292,7 +292,7 @@ impl Clone for EthereumCallData {
 /// A block hash and block number from a specific Ethereum block.
 ///
 /// Maximum block number supported: 2^63 - 1
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct EthereumBlockPointer {
     pub hash: H256,
     pub number: u64,

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -4,6 +4,7 @@ extern crate ipfs_api;
 use ethabi::Token;
 use futures::sync::mpsc::{channel, Sender};
 use hex;
+use std::collections::HashSet;
 use std::env;
 use std::io::Cursor;
 use std::str::FromStr;
@@ -120,7 +121,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: u64,
         _: u64,
         _: EthereumCallFilter,
-    ) -> Box<Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send> {
         unimplemented!();
     }
 


### PR DESCRIPTION
This could previously collect a vector sized in GBs, by filtering and extracting the block pointer
before collecting, we can optimize the memory usage by at least 10x.

@olibearo could you please double check this code is still correct and I didn't take out anything important?

