### PR TITLE
Add TOKIO_THREAD_COUNT env var

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -10,69 +10,73 @@ those.
 
 ## Getting blocks from Ethereum
 
-* `ETHEREUM_POLLING_INTERVAL`: how often to poll Ethereum for new blocks (in ms,
+- `ETHEREUM_POLLING_INTERVAL`: how often to poll Ethereum for new blocks (in ms,
   defaults to 500ms)
-* `ETHEREUM_RPC_MAX_PARALLEL_REQUESTS`: how many RPC connections to start in
+- `ETHEREUM_RPC_MAX_PARALLEL_REQUESTS`: how many RPC connections to start in
   parallel for block retrieval (defaults to 64)
-* `ETHEREUM_FAST_SCAN_END`: `graph-node` locates blocks with events for a
+- `ETHEREUM_FAST_SCAN_END`: `graph-node` locates blocks with events for a
   particular subgraph. Most subgraphs do not have events in the first few
   million blocks, so `graph-node` optimizes for that case by inquiring about a
   large range. The value of this variable is the block number at which we switch
   from probing large ranges to ranges of size `ETHEREUM_BLOCK_RANGE_SIZE`
   (defaults to 4000000).
-* `ETHEREUM_TRACE_STREAM_STEP_SIZE`: `graph-node` queries traces for a given
+- `ETHEREUM_TRACE_STREAM_STEP_SIZE`: `graph-node` queries traces for a given
   block range when a subgraph defines call handlers or block handlers with a
   call filter. The value of this variable controls the number of blocks to scan
   in a single RPC request for traces from the Ethereum node.
-* `DISABLE_BLOCK_INGESTOR`: set to `true` to disable block ingestion. Leave
+- `DISABLE_BLOCK_INGESTOR`: set to `true` to disable block ingestion. Leave
   unset or set to `false` to leave block ingestion enabled.
-* `ETHEREUM_BLOCK_BATCH_SIZE`: number of Ethereum blocks to request in parallel
+- `ETHEREUM_BLOCK_BATCH_SIZE`: number of Ethereum blocks to request in parallel
   (defaults to 50)
-* `ETHEREUM_BLOCK_RANGE_SIZE`: number of blocks to scan for events in each
+- `ETHEREUM_BLOCK_RANGE_SIZE`: number of blocks to scan for events in each
   request (defaults to 10000).
-* `ETHEREUM_PARALLEL_BLOCK_RANGES` - Maximum number of parallel `eth_getLogs`
+- `ETHEREUM_PARALLEL_BLOCK_RANGES` - Maximum number of parallel `eth_getLogs`
   calls to make when scanning logs for a subgraph. Defaults to 100.
-* `ETHEREUM_START_BLOCK`: the block number at which subgraphs should start
+- `ETHEREUM_START_BLOCK`: the block number at which subgraphs should start
   indexing (defaults to the genesis block). Can save some time while debugging
   subgraphs locally. _Warning:_ Do not use this in production, as it may
   cause subgraphs to be only indexed partially.
 
 ## Running mapping handlers
 
-* `GRAPH_EVENT_HANDLER_TIMEOUT`: amount of time an event handler is allowed to
+- `GRAPH_EVENT_HANDLER_TIMEOUT`: amount of time an event handler is allowed to
   take (in seconds, default is unlimited)
-* `GRAPH_IPFS_TIMEOUT`: timeout for ipfs requests. In seconds, default is 60.
+- `GRAPH_IPFS_TIMEOUT`: timeout for ipfs requests. In seconds, default is 60.
   seconds.
-* `GRAPH_MAX_IPFS_FILE_BYTES`: maximum size for a file that can be retrieved
+- `GRAPH_MAX_IPFS_FILE_BYTES`: maximum size for a file that can be retrieved
   with `ipfs.cat` (in bytes, default is unlimited)
-* `GRAPH_MAX_IPFS_MAP_FILE_SIZE`: maximum size of files that can be processed
+- `GRAPH_MAX_IPFS_MAP_FILE_SIZE`: maximum size of files that can be processed
   with `ipfs.map`. When a file is processed through `ipfs.map`, the entities
   generated from that are kept in memory until the entire file is done
   processing. This setting therefore limits how much memory a call to `ipfs.map`
   may use. (in bytes, defaults to 256MB)
-* `GRAPH_MAX_IPFS_CACHE_SIZE`: maximum number of files cached in the the
+- `GRAPH_MAX_IPFS_CACHE_SIZE`: maximum number of files cached in the the
   `ipfs.cat` cache (defaults to 50).
-* `GRAPH_MAX_IPFS_CACHE_FILE_SIZE`: maximum size of files that are cached in the
+- `GRAPH_MAX_IPFS_CACHE_FILE_SIZE`: maximum size of files that are cached in the
   `ipfs.cat` cache (defaults to 1MiB)
 
 ## GraphQL
 
-* `GRAPH_GRAPHQL_QUERY_TIMEOUT`: maximum execution time for a graphql query, in
+- `GRAPH_GRAPHQL_QUERY_TIMEOUT`: maximum execution time for a graphql query, in
   seconds. Default is unlimited.
-* `SUBSCRIPTION_THROTTLE_INTERVAL`: while a subgraph is syncing, subscriptions
+- `SUBSCRIPTION_THROTTLE_INTERVAL`: while a subgraph is syncing, subscriptions
   to that subgraph get updated at most this often, in ms. Default is 1000ms.
-* `GRAPH_GRAPHQL_MAX_COMPLEXITY`: maximum complexity for a graphql query. See
+- `GRAPH_GRAPHQL_MAX_COMPLEXITY`: maximum complexity for a graphql query. See
   [here](https://developer.github.com/v4/guides/resource-limitations) for what
   that means. Default is unlimited. Typical introspection queries have a
   complexity of just over 1 million, so setting a value below that may interfere
   with introspection done by graphql clients.
-* `GRAPH_GRAPHQL_MAX_DEPTH`: maximum depth of a graphql query. Default (and
+- `GRAPH_GRAPHQL_MAX_DEPTH`: maximum depth of a graphql query. Default (and
   maximum) is 255.
+
+## Tokio
+
+- `GRAPH_TOKIO_THREAD_COUNT`: controls the number of threads allotted to the Tokio runtime. Default is 100.
 
 ## Miscellaneous
 
-* `GRAPH_LOG`: control log levels, the same way that `RUST_LOG` is described
-[here](https://docs.rs/env_logger/0.6.0/env_logger/)
-* `THEGRAPH_SENTRY_URL`:
-* `THEGRAPH_STORE_POSTGRES_DIESEL_URL`: postgres instance used when running
-   tests. Set to `postgresql://<DBUSER>:<DBPASSWORD>@<DBHOST>:<DBPORT>/<DBNAME>`
+- `GRAPH_LOG`: control log levels, the same way that `RUST_LOG` is described
+  [here](https://docs.rs/env_logger/0.6.0/env_logger/)
+- `THEGRAPH_SENTRY_URL`:
+- `THEGRAPH_STORE_POSTGRES_DIESEL_URL`: postgres instance used when running
+  tests. Set to `postgresql://<DBUSER>:<DBPASSWORD>@<DBHOST>:<DBPORT>/<DBNAME>`

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -65,10 +65,10 @@ lazy_static! {
              .unwrap_or_else(|_| panic!("failed to parse env var ETHEREUM_START_BLOCK")))
         .unwrap_or(0);
 
-    static ref TOKIO_THREAD_COUNT: usize = env::var("TOKIO_THREAD_COUNT")
+    static ref TOKIO_THREAD_COUNT: usize = env::var("GRAPH_TOKIO_THREAD_COUNT")
         .ok()
         .map(|s| usize::from_str(&s)
-             .unwrap_or_else(|_| panic!("failed to parse env var TOKIO_THREAD_COUNT")))
+             .unwrap_or_else(|_| panic!("failed to parse env var GRAPH_TOKIO_THREAD_COUNT")))
         .unwrap_or(100);
 }
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -64,6 +64,12 @@ lazy_static! {
         .map(|s| u64::from_str(&s)
              .unwrap_or_else(|_| panic!("failed to parse env var ETHEREUM_START_BLOCK")))
         .unwrap_or(0);
+
+    static ref TOKIO_THREAD_COUNT: usize = env::var("TOKIO_THREAD_COUNT")
+        .ok()
+        .map(|s| usize::from_str(&s)
+             .unwrap_or_else(|_| panic!("failed to parse env var TOKIO_THREAD_COUNT")))
+        .unwrap_or(100);
 }
 
 git_testament!(TESTAMENT);
@@ -87,7 +93,7 @@ fn main() {
     let handler_runtime = runtime.clone();
     *runtime.lock().unwrap() = Some(
         runtime::Builder::new()
-            .core_threads(100)
+            .core_threads(*TOKIO_THREAD_COUNT)
             .panic_handler(move |_| {
                 let runtime = handler_runtime.clone();
                 std::thread::spawn(move || {


### PR DESCRIPTION
It is useful to tune the Tokio thread pool count down to avoid opening too many file descriptors.