### PR TITLE
Address warnings emitted by Rust 1.37

### DIFF
--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -57,8 +57,8 @@ fn restrict_file_size<T>(
     client: &ipfs_api::IpfsClient,
     path: String,
     max_file_bytes: Option<u64>,
-    fut: Box<Future<Item = T, Error = failure::Error> + Send>,
-) -> Box<Future<Item = T, Error = failure::Error> + Send>
+    fut: Box<dyn Future<Item = T, Error = failure::Error> + Send>,
+) -> Box<dyn Future<Item = T, Error = failure::Error> + Send>
 where
     T: Send + 'static,
 {
@@ -105,7 +105,7 @@ impl LinkResolverTrait for LinkResolver {
         &self,
         logger: &Logger,
         link: &Link,
-    ) -> Box<Future<Item = Vec<u8>, Error = failure::Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<u8>, Error = failure::Error> + Send> {
         // Discard the `/ipfs/` prefix (if present) to get the hash.
         let path = link.link.trim_start_matches("/ipfs/").to_owned();
 
@@ -148,7 +148,7 @@ impl LinkResolverTrait for LinkResolver {
     fn json_stream(
         &self,
         link: &Link,
-    ) -> Box<Future<Item = JsonValueStream, Error = failure::Error> + Send + 'static> {
+    ) -> Box<dyn Future<Item = JsonValueStream, Error = failure::Error> + Send + 'static> {
         // Discard the `/ipfs/` prefix (if present) to get the hash.
         let path = link.link.trim_start_matches("/ipfs/").to_owned();
         let mut stream = self.client.cat(&path).fuse();

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -87,7 +87,7 @@ where
         block: Arc<EthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
         Self::process_trigger_in_runtime_hosts(
             logger,
             self.hosts.iter().cloned(),
@@ -103,7 +103,7 @@ where
         block: Arc<EthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send>
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>
     where
         I: IntoIterator<Item = Arc<T::Host>>,
     {

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -264,7 +264,7 @@ impl EventConsumer<SubgraphAssignmentProviderEvent> for SubgraphInstanceManager 
     /// Get the wrapped event sink.
     fn event_sink(
         &self,
-    ) -> Box<Sink<SinkItem = SubgraphAssignmentProviderEvent, SinkError = ()> + Send> {
+    ) -> Box<dyn Sink<SinkItem = SubgraphAssignmentProviderEvent, SinkError = ()> + Send> {
         let logger = self.logger.clone();
         Box::new(self.input.clone().sink_map_err(move |e| {
             error!(logger, "Component was dropped: {}", e);

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -219,7 +219,7 @@ where
         self: Arc<Self>,
         deployment_id: &SubgraphDeploymentId,
         logger: Logger,
-    ) -> Box<Future<Item = Vec<DataSource>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<DataSource>, Error = Error> + Send> {
         struct LoopState {
             data_sources: Vec<DataSource>,
             skip: i32,

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -75,7 +75,7 @@ where
     fn start(
         &self,
         id: SubgraphDeploymentId,
-    ) -> Box<Future<Item = (), Error = SubgraphAssignmentProviderError> + Send + 'static> {
+    ) -> Box<dyn Future<Item = (), Error = SubgraphAssignmentProviderError> + Send + 'static> {
         let self_clone = self.clone();
         let store = self.store.clone();
         let subgraph_id = id.clone();
@@ -111,7 +111,7 @@ where
                     )
                 })
                 .and_then(
-                    move |(mut subgraph, data_sources)| -> Box<Future<Item = _, Error = _> + Send> {
+                    move |(mut subgraph, data_sources)| -> Box<dyn Future<Item = _, Error = _> + Send> {
                         info!(logger, "Successfully resolved subgraph files using IPFS");
 
                         // Add dynamic data sources to the subgraph
@@ -180,7 +180,7 @@ where
     fn stop(
         &self,
         id: SubgraphDeploymentId,
-    ) -> Box<Future<Item = (), Error = SubgraphAssignmentProviderError> + Send + 'static> {
+    ) -> Box<dyn Future<Item = (), Error = SubgraphAssignmentProviderError> + Send + 'static> {
         // If subgraph ID was in set
         if self.subgraphs_running.lock().unwrap().remove(&id) {
             // Shut down subgraph processing
@@ -202,9 +202,10 @@ impl<L, Q, S> EventProducer<SubgraphAssignmentProviderEvent>
 {
     fn take_event_stream(
         &mut self,
-    ) -> Option<Box<Stream<Item = SubgraphAssignmentProviderEvent, Error = ()> + Send>> {
+    ) -> Option<Box<dyn Stream<Item = SubgraphAssignmentProviderEvent, Error = ()> + Send>> {
         self.event_stream.take().map(|s| {
-            Box::new(s) as Box<Stream<Item = SubgraphAssignmentProviderEvent, Error = ()> + Send>
+            Box::new(s)
+                as Box<dyn Stream<Item = SubgraphAssignmentProviderEvent, Error = ()> + Send>
         })
     }
 }

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -43,7 +43,7 @@ fn add_subgraph_to_ipfs(
     let dir = format!("tests/subgraphs/{}", subgraph);
     let subgraph_string = std::fs::read_to_string(format!("{}/{}.yaml", dir, subgraph)).unwrap();
     let mut ipfs_upload = Box::new(future::ok(subgraph_string.clone()))
-        as Box<Future<Item = String, Error = Error> + Send>;
+        as Box<dyn Future<Item = String, Error = Error> + Send>;
     // Search for files linked by the subgraph, upload and update the sugraph
     // with their link.
     for file in WalkDir::new(&dir)
@@ -93,7 +93,7 @@ fn multiple_data_sources_per_subgraph() {
             _: Arc<Transaction>,
             _: Arc<Log>,
             _: BlockState,
-        ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
+        ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
             unimplemented!();
         }
 
@@ -104,7 +104,7 @@ fn multiple_data_sources_per_subgraph() {
             _transaction: Arc<Transaction>,
             _call: Arc<EthereumCall>,
             _state: BlockState,
-        ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
+        ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
             unimplemented!();
         }
 
@@ -114,7 +114,7 @@ fn multiple_data_sources_per_subgraph() {
             _block: Arc<EthereumBlock>,
             _trigger_type: EthereumBlockTriggerType,
             _state: BlockState,
-        ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
+        ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
             unimplemented!();
         }
     }

--- a/datasource/ethereum/src/block_ingestor.rs
+++ b/datasource/ethereum/src/block_ingestor.rs
@@ -97,7 +97,7 @@ where
                 // Ask for latest block from Ethereum node
                 self.eth_adapter.latest_block(&self.logger)
                     // Compare latest block with head ptr, alert user if far behind
-                    .and_then(move |latest_block: Block<Transaction>| -> Box<Future<Item=_, Error=_> + Send> {
+                    .and_then(move |latest_block: Block<Transaction>| -> Box<dyn Future<Item=_, Error=_> + Send> {
                         match head_block_ptr_opt {
                             None => {
                                 info!(
@@ -167,7 +167,7 @@ where
                                 // - Therefore, the loop will iterate at most ancestor_count times.
                                 future::loop_fn(
                                     missing_block_hashes,
-                                    move |missing_block_hashes| -> Box<Future<Item = _, Error = _> + Send> {
+                                    move |missing_block_hashes| -> Box<dyn Future<Item = _, Error = _> + Send> {
                                         if missing_block_hashes.is_empty() {
                                             // If no blocks were missing, then the block head pointer was updated
                                             // successfully, and this poll has completed.
@@ -210,7 +210,7 @@ where
     fn get_blocks<'a>(
         &'a self,
         block_hashes: &[H256],
-    ) -> Box<Stream<Item = EthereumBlock, Error = EthereumAdapterError> + Send + 'a> {
+    ) -> Box<dyn Stream<Item = EthereumBlock, Error = EthereumAdapterError> + Send + 'a> {
         let logger = self.logger.clone();
         let eth_adapter = self.eth_adapter.clone();
 

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -400,7 +400,7 @@ where
     fn net_identifiers(
         &self,
         logger: &Logger,
-    ) -> Box<Future<Item = EthereumNetworkIdentifier, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = EthereumNetworkIdentifier, Error = Error> + Send> {
         let logger = logger.clone();
         let start_block = self.start_block;
 
@@ -459,7 +459,7 @@ where
     fn latest_block(
         &self,
         logger: &Logger,
-    ) -> Box<Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send> {
+    ) -> Box<dyn Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send> {
         let web3 = self.web3.clone();
 
         Box::new(
@@ -489,7 +489,7 @@ where
         &self,
         logger: &Logger,
         block_hash: H256,
-    ) -> Box<Future<Item = Option<Block<Transaction>>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Option<Block<Transaction>>, Error = Error> + Send> {
         let web3 = self.web3.clone();
         let logger = logger.clone();
 
@@ -515,7 +515,7 @@ where
         &self,
         logger: &Logger,
         block: Block<Transaction>,
-    ) -> Box<Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send> {
+    ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send> {
         let logger = logger.clone();
         let block_hash = block.hash.expect("block is missing block hash");
 
@@ -637,7 +637,7 @@ where
         &self,
         logger: &Logger,
         descendant_block_hash: H256,
-    ) -> Box<Future<Item = Option<H256>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send> {
         let web3 = self.web3.clone();
 
         Box::new(
@@ -666,7 +666,7 @@ where
         &self,
         logger: &Logger,
         block_number: u64,
-    ) -> Box<Future<Item = Option<H256>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send> {
         let web3 = self.web3.clone();
 
         Box::new(
@@ -695,7 +695,7 @@ where
         &self,
         logger: &Logger,
         block_ptr: EthereumBlockPointer,
-    ) -> Box<Future<Item = bool, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = bool, Error = Error> + Send> {
         Box::new(
             self.block_hash_by_block_number(&logger, block_ptr.number)
                 .and_then(move |block_hash_opt| {
@@ -713,7 +713,7 @@ where
         logger: &Logger,
         block_number: u64,
         block_hash: H256,
-    ) -> Box<Future<Item = Vec<EthereumCall>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<EthereumCall>, Error = Error> + Send> {
         let eth = self.clone();
         let addresses = Vec::new();
         let calls = eth
@@ -761,7 +761,7 @@ where
         log_filter_opt: Option<EthereumLogFilter>,
         call_filter_opt: Option<EthereumCallFilter>,
         block_filter_opt: Option<EthereumBlockFilter>,
-    ) -> Box<Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
         // If no filters are provided, return an empty vector of blocks.
         if log_filter_opt.is_none() && call_filter_opt.is_none() && block_filter_opt.is_none() {
             return Box::new(future::ok(vec![]));
@@ -772,7 +772,7 @@ where
         // while searching for a trigger type, the entire operation fails.
         let eth = self.clone();
         let mut block_futs: futures::stream::FuturesUnordered<
-            Box<Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send>,
+            Box<dyn Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send>,
         > = futures::stream::FuturesUnordered::new();
         if block_filter_opt.is_some() && block_filter_opt.clone().unwrap().trigger_every_block {
             // All blocks in the range contain a trigger
@@ -827,7 +827,7 @@ where
         logger: &Logger,
         from: u64,
         to: u64,
-    ) -> Box<Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
         let eth = self.clone();
         let logger = logger.clone();
 
@@ -870,7 +870,7 @@ where
         from: u64,
         to: u64,
         log_filter: EthereumLogFilter,
-    ) -> Box<Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
         let eth = self.clone();
         Box::new(
             // Get a stream of all relevant logs in range
@@ -903,7 +903,7 @@ where
         from: u64,
         to: u64,
         call_filter: EthereumCallFilter,
-    ) -> Box<Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send> {
         let eth = self.clone();
 
         let addresses: Vec<H160> = call_filter
@@ -937,7 +937,7 @@ where
         &self,
         logger: &Logger,
         call: EthereumContractCall,
-    ) -> Box<Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send> {
+    ) -> Box<dyn Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send> {
         // Emit custom error for type mismatches.
         for (token, kind) in call
             .args

--- a/datasource/ethereum/src/transport.rs
+++ b/datasource/ethereum/src/transport.rs
@@ -47,7 +47,7 @@ impl Transport {
 }
 
 impl web3::Transport for Transport {
-    type Out = Box<Future<Item = Value, Error = web3::error::Error> + Send>;
+    type Out = Box<dyn Future<Item = Value, Error = web3::error::Error> + Send>;
 
     fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {
         match self {
@@ -68,7 +68,8 @@ impl web3::Transport for Transport {
 
 impl web3::BatchTransport for Transport {
     type Batch = Box<
-        Future<Item = Vec<Result<Value, web3::error::Error>>, Error = web3::error::Error> + Send,
+        dyn Future<Item = Vec<Result<Value, web3::error::Error>>, Error = web3::error::Error>
+            + Send,
     >;
 
     fn send_batch<T>(&self, requests: T) -> Self::Batch

--- a/datasource/ethereum/tests/adapter.rs
+++ b/datasource/ethereum/tests/adapter.rs
@@ -15,7 +15,7 @@ use web3::helpers::*;
 use web3::types::*;
 use web3::{BatchTransport, RequestId, Transport};
 
-pub type Result<T> = Box<Future<Item = T, Error = Error> + Send + 'static>;
+pub type Result<T> = Box<dyn Future<Item = T, Error = Error> + Send + 'static>;
 
 fn mock_block() -> Block<U256> {
     Block {

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -345,34 +345,34 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     fn net_identifiers(
         &self,
         logger: &Logger,
-    ) -> Box<Future<Item = EthereumNetworkIdentifier, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = EthereumNetworkIdentifier, Error = Error> + Send>;
 
     /// Find the most recent block.
     fn latest_block(
         &self,
         logger: &Logger,
-    ) -> Box<Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send>;
+    ) -> Box<dyn Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send>;
 
     /// Find a block by its hash.
     fn block_by_hash(
         &self,
         logger: &Logger,
         block_hash: H256,
-    ) -> Box<Future<Item = Option<Block<Transaction>>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Option<Block<Transaction>>, Error = Error> + Send>;
 
     /// Load full information for the specified `block` (in particular, transaction receipts).
     fn load_full_block(
         &self,
         logger: &Logger,
         block: Block<Transaction>,
-    ) -> Box<Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send>;
+    ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send>;
 
     /// Find the hash for the parent block of the provided block hash
     fn block_parent_hash(
         &self,
         logger: &Logger,
         block_hash: H256,
-    ) -> Box<Future<Item = Option<H256>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send>;
 
     /// Find a block by its number.
     ///
@@ -387,7 +387,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         &self,
         logger: &Logger,
         block_number: u64,
-    ) -> Box<Future<Item = Option<H256>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send>;
 
     /// Check if `block_ptr` refers to a block that is on the main chain, according to the Ethereum
     /// node.
@@ -403,14 +403,14 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         &self,
         logger: &Logger,
         block_ptr: EthereumBlockPointer,
-    ) -> Box<Future<Item = bool, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = bool, Error = Error> + Send>;
 
     fn calls_in_block(
         &self,
         logger: &Logger,
         block_number: u64,
         block_hash: H256,
-    ) -> Box<Future<Item = Vec<EthereumCall>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Vec<EthereumCall>, Error = Error> + Send>;
 
     fn blocks_with_triggers(
         &self,
@@ -420,7 +420,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         log_filter: Option<EthereumLogFilter>,
         call_filter: Option<EthereumCallFilter>,
         block_filter: Option<EthereumBlockFilter>,
-    ) -> Box<Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send>;
 
     /// Find the first few blocks in the specified range containing at least one transaction with
     /// at least one log entry matching the specified `log_filter`.
@@ -440,7 +440,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         from: u64,
         to: u64,
         log_filter: EthereumLogFilter,
-    ) -> Box<Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send>;
 
     fn blocks_with_calls(
         &self,
@@ -448,19 +448,19 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         from: u64,
         to: u64,
         call_filter: EthereumCallFilter,
-    ) -> Box<Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send>;
 
     fn blocks(
         &self,
         logger: &Logger,
         from: u64,
         to: u64,
-    ) -> Box<Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send>;
 
     /// Call the function of a smart contract.
     fn contract_call(
         &self,
         logger: &Logger,
         call: EthereumContractCall,
-    ) -> Box<Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send>;
+    ) -> Box<dyn Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send>;
 }

--- a/graph/src/components/ethereum/listener.rs
+++ b/graph/src/components/ethereum/listener.rs
@@ -24,7 +24,7 @@ pub struct ChainHeadUpdate {
 
 /// The updates have no payload, receivers should call `Store::chain_head_ptr`
 /// to check what the latest block is.
-pub type ChainHeadUpdateStream = Box<Stream<Item = (), Error = ()> + Send>;
+pub type ChainHeadUpdateStream = Box<dyn Stream<Item = (), Error = ()> + Send>;
 
 pub trait ChainHeadUpdateListener {
     // Subscribe to chain head updates.

--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -4,11 +4,11 @@ use crate::data::query::{Query, QueryError, QueryResult};
 use crate::data::subscription::{Subscription, SubscriptionError, SubscriptionResult};
 
 /// Future for query results.
-pub type QueryResultFuture = Box<Future<Item = QueryResult, Error = QueryError> + Send>;
+pub type QueryResultFuture = Box<dyn Future<Item = QueryResult, Error = QueryError> + Send>;
 
 /// Future for subscription results.
 pub type SubscriptionResultFuture =
-    Box<Future<Item = SubscriptionResult, Error = SubscriptionError> + Send>;
+    Box<dyn Future<Item = SubscriptionResult, Error = SubscriptionError> + Send>;
 
 /// A component that can run GraphqL queries against a [Store](../store/trait.Store.html).
 pub trait GraphQlRunner: Send + Sync + 'static {

--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -14,7 +14,7 @@ pub struct JsonStreamValue {
 }
 
 pub type JsonValueStream =
-    Box<Stream<Item = JsonStreamValue, Error = failure::Error> + Send + 'static>;
+    Box<dyn Stream<Item = JsonStreamValue, Error = failure::Error> + Send + 'static>;
 
 /// Resolves links to subgraph manifests and resources referenced by them.
 pub trait LinkResolver: Send + Sync + 'static + Sized {
@@ -23,7 +23,7 @@ pub trait LinkResolver: Send + Sync + 'static + Sized {
         &self,
         logger: &Logger,
         link: &Link,
-    ) -> Box<Future<Item = Vec<u8>, Error = failure::Error> + Send>;
+    ) -> Box<dyn Future<Item = Vec<u8>, Error = failure::Error> + Send>;
 
     /// Read the contents of `link` and deserialize them into a stream of JSON
     /// values. The values must each be on a single line; newlines are significant
@@ -32,5 +32,5 @@ pub trait LinkResolver: Send + Sync + 'static + Sized {
     fn json_stream(
         &self,
         link: &Link,
-    ) -> Box<Future<Item = JsonValueStream, Error = failure::Error> + Send + 'static>;
+    ) -> Box<dyn Future<Item = JsonValueStream, Error = failure::Error> + Send + 'static>;
 }

--- a/graph/src/components/mod.rs
+++ b/graph/src/components/mod.rs
@@ -91,7 +91,7 @@ pub trait EventConsumer<E> {
     /// Get the event sink.
     ///
     /// Avoid calling directly, prefer helpers such as `forward`.
-    fn event_sink(&self) -> Box<Sink<SinkItem = E, SinkError = ()> + Send>;
+    fn event_sink(&self) -> Box<dyn Sink<SinkItem = E, SinkError = ()> + Send>;
 }
 
 /// A component that outputs events of type `T`.
@@ -101,5 +101,5 @@ pub trait EventProducer<E> {
     /// return `None`.
     ///
     /// Avoid calling directly, prefer helpers such as `forward`.
-    fn take_event_stream(&mut self) -> Option<Box<Stream<Item = E, Error = ()> + Send>>;
+    fn take_event_stream(&mut self) -> Option<Box<dyn Stream<Item = E, Error = ()> + Send>>;
 }

--- a/graph/src/components/server/query.rs
+++ b/graph/src/components/server/query.rs
@@ -62,7 +62,7 @@ impl Error for GraphQLServerError {
         "Failed to process the GraphQL request"
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             GraphQLServerError::Canceled(ref e) => Some(e),
             GraphQLServerError::ClientError(_) => None,
@@ -97,5 +97,5 @@ pub trait GraphQLServer {
         &mut self,
         port: u16,
         ws_port: u16,
-    ) -> Result<Box<Future<Item = (), Error = ()> + Send>, Self::ServeError>;
+    ) -> Result<Box<dyn Future<Item = (), Error = ()> + Send>, Self::ServeError>;
 }

--- a/graph/src/components/server/subscription.rs
+++ b/graph/src/components/server/subscription.rs
@@ -8,5 +8,5 @@ pub trait SubscriptionServer {
     fn serve(
         &mut self,
         port: u16,
-    ) -> Result<Box<Future<Item = (), Error = ()> + Send>, Self::ServeError>;
+    ) -> Result<Box<dyn Future<Item = (), Error = ()> + Send>, Self::ServeError>;
 }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -288,7 +288,8 @@ pub struct StoreEventStream<S> {
 }
 
 /// A boxed `StoreEventStream`
-pub type StoreEventStreamBox = StoreEventStream<Box<Stream<Item = StoreEvent, Error = ()> + Send>>;
+pub type StoreEventStreamBox =
+    StoreEventStream<Box<dyn Stream<Item = StoreEvent, Error = ()> + Send>>;
 
 impl<S> Stream for StoreEventStream<S>
 where
@@ -353,7 +354,7 @@ where
         // Check whether a deployment is marked as synced in the store. The
         // special 'subgraphs' subgraph is never considered synced so that
         // we always throttle it
-        let check_synced = |store: &Store, deployment: &SubgraphDeploymentId| {
+        let check_synced = |store: &dyn Store, deployment: &SubgraphDeploymentId| {
             deployment != &*SUBGRAPHS_ID
                 && store
                     .is_deployment_synced(deployment.clone())
@@ -1052,7 +1053,10 @@ pub trait ChainStore: Send + Sync + 'static {
     fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error>;
 
     /// Insert blocks into the store (or update if they are already present).
-    fn upsert_blocks<'a, B, E>(&self, blocks: B) -> Box<Future<Item = (), Error = E> + Send + 'a>
+    fn upsert_blocks<'a, B, E>(
+        &self,
+        blocks: B,
+    ) -> Box<dyn Future<Item = (), Error = E> + Send + 'a>
     where
         B: Stream<Item = EthereumBlock, Error = E> + Send + 'a,
         E: From<Error> + Send + 'a;

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -24,7 +24,7 @@ pub trait RuntimeHost: Send + Sync + Debug {
         transaction: Arc<Transaction>,
         log: Arc<Log>,
         state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;
 
     /// Process an Ethereum call and return a vector of entity operations
     fn process_call(
@@ -34,7 +34,7 @@ pub trait RuntimeHost: Send + Sync + Debug {
         transaction: Arc<Transaction>,
         call: Arc<EthereumCall>,
         state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;
 
     /// Process an Ethereum block and return a vector of entity operations
     fn process_block(
@@ -43,7 +43,7 @@ pub trait RuntimeHost: Send + Sync + Debug {
         block: Arc<EthereumBlock>,
         trigger_type: EthereumBlockTriggerType,
         state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;
 }
 
 pub trait RuntimeHostBuilder: Clone + Send + Sync + 'static {

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -36,7 +36,7 @@ where
         block: Arc<EthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;
 
     /// Like `process_trigger` but processes an Ethereum event in a given list of hosts.
     fn process_trigger_in_runtime_hosts<I>(
@@ -45,7 +45,7 @@ where
         block: Arc<EthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send>
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>
     where
         I: IntoIterator<Item = Arc<T::Host>>;
 

--- a/graph/src/components/subgraph/loader.rs
+++ b/graph/src/components/subgraph/loader.rs
@@ -5,5 +5,5 @@ pub trait DataSourceLoader {
         self: Arc<Self>,
         id: &SubgraphDeploymentId,
         logger: Logger,
-    ) -> Box<Future<Item = Vec<DataSource>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Vec<DataSource>, Error = Error> + Send>;
 }

--- a/graph/src/components/subgraph/provider.rs
+++ b/graph/src/components/subgraph/provider.rs
@@ -7,10 +7,10 @@ pub trait SubgraphAssignmentProvider:
     fn start(
         &self,
         id: SubgraphDeploymentId,
-    ) -> Box<Future<Item = (), Error = SubgraphAssignmentProviderError> + Send + 'static>;
+    ) -> Box<dyn Future<Item = (), Error = SubgraphAssignmentProviderError> + Send + 'static>;
 
     fn stop(
         &self,
         id: SubgraphDeploymentId,
-    ) -> Box<Future<Item = (), Error = SubgraphAssignmentProviderError> + Send + 'static>;
+    ) -> Box<dyn Future<Item = (), Error = SubgraphAssignmentProviderError> + Send + 'static>;
 }

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -21,23 +21,23 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
     fn create_subgraph(
         &self,
         name: SubgraphName,
-    ) -> Box<Future<Item = CreateSubgraphResult, Error = SubgraphRegistrarError> + Send + 'static>;
+    ) -> Box<dyn Future<Item = CreateSubgraphResult, Error = SubgraphRegistrarError> + Send + 'static>;
 
     fn create_subgraph_version(
         &self,
         name: SubgraphName,
         hash: SubgraphDeploymentId,
         assignment_node_id: NodeId,
-    ) -> Box<Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
+    ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
 
     fn remove_subgraph(
         &self,
         name: SubgraphName,
-    ) -> Box<Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
+    ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
 
     fn reassign_subgraph(
         &self,
         hash: SubgraphDeploymentId,
         node_id: NodeId,
-    ) -> Box<Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
+    ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -60,7 +60,7 @@ impl Error for QueryExecutionError {
         "Query execution error"
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         None
     }
 }
@@ -257,7 +257,7 @@ impl Error for QueryError {
         "Query error"
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             QueryError::EncodingError(ref e) => Some(e),
             QueryError::ExecutionError(ref e) => Some(e),

--- a/graph/src/data/subscription/result.rs
+++ b/graph/src/data/subscription/result.rs
@@ -3,7 +3,7 @@ use futures::prelude::*;
 use crate::prelude::QueryResult;
 
 /// A stream of query results for a subscription.
-pub type QueryResultStream = Box<Stream<Item = QueryResult, Error = ()> + Send>;
+pub type QueryResultStream = Box<dyn Stream<Item = QueryResult, Error = ()> + Send>;
 
 /// The result of running a subscription, if successful.
 pub type SubscriptionResult = QueryResultStream;

--- a/graph/src/log/codes.rs
+++ b/graph/src/log/codes.rs
@@ -32,7 +32,7 @@ impl slog::Value for LogCode {
         &self,
         _rec: &slog::Record,
         key: slog::Key,
-        serializer: &mut slog::Serializer,
+        serializer: &mut dyn slog::Serializer,
     ) -> slog::Result {
         serializer.emit_str(key, format!("{}", self).as_str())
     }

--- a/graph/src/log/elastic.rs
+++ b/graph/src/log/elastic.rs
@@ -205,7 +205,8 @@ impl ElasticDrain {
 
                     // Do nothing if there are no logs to flush
                     if logs_to_send.is_empty() {
-                        return Box::new(future::ok(())) as Box<Future<Item = _, Error = _> + Send>;
+                        return Box::new(future::ok(()))
+                            as Box<dyn Future<Item = _, Error = _> + Send>;
                     }
 
                     trace!(

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -302,7 +302,7 @@ where
     })
 }
 
-fn retry_strategy(limit_opt: Option<usize>) -> Box<Iterator<Item = Duration> + Send> {
+fn retry_strategy(limit_opt: Option<usize>) -> Box<dyn Iterator<Item = Duration> + Send> {
     // Exponential backoff, but with a maximum
     let max_delay_ms = 30_000;
     let backoff = ExponentialBackoff::from_millis(2)
@@ -322,7 +322,7 @@ fn retry_strategy(limit_opt: Option<usize>) -> Box<Iterator<Item = Duration> + S
 
 enum RetryIf<I, E> {
     Error,
-    Predicate(Box<Fn(&Result<I, E>) -> bool + Send + Sync>),
+    Predicate(Box<dyn Fn(&Result<I, E>) -> bool + Send + Sync>),
 }
 
 impl<I, E> RetryIf<I, E> {

--- a/graph/src/util/security.rs
+++ b/graph/src/util/security.rs
@@ -33,7 +33,7 @@ impl<T: fmt::Display> slog::Value for SafeDisplay<T> {
         &self,
         _rec: &slog::Record,
         key: slog::Key,
-        serializer: &mut slog::Serializer,
+        serializer: &mut dyn slog::Serializer,
     ) -> slog::Result {
         serializer.emit_str(key, format!("{}", self).as_str())
     }

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -28,7 +28,7 @@ impl Stream for MockBlockStream {
 }
 
 impl EventConsumer<ChainHeadUpdate> for MockBlockStream {
-    fn event_sink(&self) -> Box<Sink<SinkItem = ChainHeadUpdate, SinkError = ()> + Send> {
+    fn event_sink(&self) -> Box<dyn Sink<SinkItem = ChainHeadUpdate, SinkError = ()> + Send> {
         Box::new(self.chain_head_update_sink.clone().sink_map_err(|_| ()))
     }
 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -384,7 +384,7 @@ impl ChainStore for MockStore {
         })
     }
 
-    fn upsert_blocks<'a, B, E>(&self, _: B) -> Box<Future<Item = (), Error = E> + Send + 'a>
+    fn upsert_blocks<'a, B, E>(&self, _: B) -> Box<dyn Future<Item = (), Error = E> + Send + 'a>
     where
         B: Stream<Item = EthereumBlock, Error = E> + Send + 'a,
         E: From<Error> + Send + 'a,
@@ -525,7 +525,7 @@ impl ChainStore for FakeStore {
         unimplemented!();
     }
 
-    fn upsert_blocks<'a, B, E>(&self, _: B) -> Box<Future<Item = (), Error = E> + Send + 'a>
+    fn upsert_blocks<'a, B, E>(&self, _: B) -> Box<dyn Future<Item = (), Error = E> + Send + 'a>
     where
         B: Stream<Item = EthereumBlock, Error = E> + Send + 'a,
         E: From<Error> + Send + 'a,

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -525,7 +525,7 @@ impl RuntimeHostTrait for RuntimeHost {
         transaction: Arc<Transaction>,
         call: Arc<EthereumCall>,
         state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
         // Identify the call handler for this call
         let call_handler = match self.handler_for_call(&call) {
             Ok(handler) => handler,
@@ -668,7 +668,7 @@ impl RuntimeHostTrait for RuntimeHost {
         block: Arc<EthereumBlock>,
         trigger_type: EthereumBlockTriggerType,
         state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
         let block_handler = match self.handler_for_block(trigger_type) {
             Ok(handler) => handler,
             Err(e) => return Box::new(future::err(e)),
@@ -725,7 +725,7 @@ impl RuntimeHostTrait for RuntimeHost {
         transaction: Arc<Transaction>,
         log: Arc<Log>,
         state: BlockState,
-    ) -> Box<Future<Item = BlockState, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
         let logger = logger.clone();
         let mapping_request_sender = self.mapping_request_sender.clone();
 

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -56,7 +56,11 @@ where
     E: EthereumAdapter,
     L: LinkResolver,
     S: Store + Send + Sync,
-    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone + Send + Sync + 'static,
+    U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     pub(crate) fn new(
         subgraph_id: SubgraphDeploymentId,

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -101,7 +101,11 @@ where
     T: EthereumAdapter,
     L: LinkResolver,
     S: Store + Send + Sync + 'static,
-    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone + Send + Sync + 'static,
+    U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     /// Pre-process and validate the module.
     pub fn new(
@@ -190,7 +194,11 @@ where
     T: EthereumAdapter,
     L: LinkResolver,
     S: Store + Send + Sync + 'static,
-    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone + Send + Sync + 'static,
+    U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     /// Creates a new wasmi module
     pub fn from_valid_module_with_ctx(
@@ -392,7 +400,11 @@ where
     T: EthereumAdapter,
     L: LinkResolver,
     S: Store + Send + Sync + 'static,
-    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone + Send + Sync + 'static,
+    U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     fn raw_new(&mut self, bytes: &[u8]) -> Result<u32, Error> {
         let address = self
@@ -426,7 +438,11 @@ where
     T: EthereumAdapter,
     L: LinkResolver,
     S: Store + Send + Sync + 'static,
-    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone + Send + Sync + 'static,
+    U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     fn gas(&mut self, _gas_spent: u32) -> Result<Option<RuntimeValue>, Trap> {
         self.host_exports().check_timeout(self.start_time)?;
@@ -948,7 +964,11 @@ where
     T: EthereumAdapter,
     L: LinkResolver,
     S: Store + Send + Sync + 'static,
-    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone + Send + Sync + 'static,
+    U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     fn invoke_index(
         &mut self,

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -33,14 +33,14 @@ impl EthereumAdapter for MockEthereumAdapter {
     fn net_identifiers(
         &self,
         _: &Logger,
-    ) -> Box<Future<Item = EthereumNetworkIdentifier, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = EthereumNetworkIdentifier, Error = Error> + Send> {
         unimplemented!();
     }
 
     fn latest_block(
         &self,
         _: &Logger,
-    ) -> Box<Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send> {
+    ) -> Box<dyn Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send> {
         unimplemented!();
     }
 
@@ -48,7 +48,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         &self,
         _: &Logger,
         _: H256,
-    ) -> Box<Future<Item = Option<Block<Transaction>>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Option<Block<Transaction>>, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -56,7 +56,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         &self,
         _: &Logger,
         _: Block<Transaction>,
-    ) -> Box<Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send> {
+    ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send> {
         unimplemented!();
     }
 
@@ -64,7 +64,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         &self,
         _: &Logger,
         _: H256,
-    ) -> Box<Future<Item = Option<H256>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -72,7 +72,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         &self,
         _: &Logger,
         _: u64,
-    ) -> Box<Future<Item = Option<H256>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -80,7 +80,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         &self,
         _: &Logger,
         _: EthereumBlockPointer,
-    ) -> Box<Future<Item = bool, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = bool, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -89,7 +89,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: &Logger,
         _: u64,
         _: H256,
-    ) -> Box<Future<Item = Vec<EthereumCall>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<EthereumCall>, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -101,7 +101,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: Option<EthereumLogFilter>,
         _: Option<EthereumCallFilter>,
         _: Option<EthereumBlockFilter>,
-    ) -> Box<Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -111,7 +111,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: u64,
         _: u64,
         _: EthereumLogFilter,
-    ) -> Box<Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -121,7 +121,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: u64,
         _: u64,
         _: EthereumCallFilter,
-    ) -> Box<Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -130,7 +130,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: &Logger,
         _: u64,
         _: u64,
-    ) -> Box<Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -138,7 +138,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         &self,
         _: &Logger,
         _: EthereumContractCall,
-    ) -> Box<Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send> {
+    ) -> Box<dyn Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send> {
         unimplemented!();
     }
 }
@@ -150,7 +150,7 @@ fn test_valid_module(
         MockEthereumAdapter,
         graph_core::LinkResolver,
         FakeStore,
-        Sender<Box<Future<Item = (), Error = ()> + Send>>,
+        Sender<Box<dyn Future<Item = (), Error = ()> + Send>>,
     >,
 > {
     let logger = Logger::root(slog::Discard, o!());
@@ -242,7 +242,11 @@ where
     T: EthereumAdapter,
     L: LinkResolver,
     S: Store + Send + Sync + 'static,
-    U: Sink<SinkItem = Box<Future<Item = (), Error = ()> + Send>> + Clone + Send + Sync + 'static,
+    U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     fn takes_val_returns_ptr<P>(&mut self, fn_name: &str, val: RuntimeValue) -> AscPtr<P> {
         self.module

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -19,7 +19,7 @@ impl Error for GraphQLServeError {
         "Failed to start the server"
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         None
     }
 }
@@ -83,7 +83,7 @@ where
         &mut self,
         port: u16,
         ws_port: u16,
-    ) -> Result<Box<Future<Item = (), Error = ()> + Send>, Self::ServeError> {
+    ) -> Result<Box<dyn Future<Item = (), Error = ()> + Send>, Self::ServeError> {
         let logger = self.logger.clone();
 
         info!(

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -13,7 +13,7 @@ use crate::response::GraphQLResponse;
 
 /// An asynchronous response to a GraphQL request.
 pub type GraphQLServiceResponse =
-    Box<Future<Item = Response<Body>, Error = GraphQLServerError> + Send>;
+    Box<dyn Future<Item = Response<Body>, Error = GraphQLServerError> + Send>;
 
 /// A Hyper Service that serves GraphQL over a POST / endpoint.
 #[derive(Debug)]

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -67,7 +67,7 @@ where
     fn create_handler(
         &self,
         params: SubgraphCreateParams,
-    ) -> Box<Future<Item = Value, Error = jsonrpc_core::Error> + Send> {
+    ) -> Box<dyn Future<Item = Value, Error = jsonrpc_core::Error> + Send> {
         let logger = self.logger.clone();
 
         info!(logger, "Received subgraph_create request"; "params" => format!("{:?}", params));
@@ -93,7 +93,7 @@ where
     fn deploy_handler(
         &self,
         params: SubgraphDeployParams,
-    ) -> Box<Future<Item = Value, Error = jsonrpc_core::Error> + Send> {
+    ) -> Box<dyn Future<Item = Value, Error = jsonrpc_core::Error> + Send> {
         let logger = self.logger.clone();
 
         info!(logger, "Received subgraph_deploy request"; "params" => format!("{:?}", params));
@@ -120,7 +120,7 @@ where
     fn remove_handler(
         &self,
         params: SubgraphRemoveParams,
-    ) -> Box<Future<Item = Value, Error = jsonrpc_core::Error> + Send> {
+    ) -> Box<dyn Future<Item = Value, Error = jsonrpc_core::Error> + Send> {
         let logger = self.logger.clone();
 
         info!(logger, "Received subgraph_remove request"; "params" => format!("{:?}", params));
@@ -145,7 +145,7 @@ where
     fn reassign_handler(
         &self,
         params: SubgraphReassignParams,
-    ) -> Box<Future<Item = Value, Error = jsonrpc_core::Error> + Send> {
+    ) -> Box<dyn Future<Item = Value, Error = jsonrpc_core::Error> + Send> {
         let logger = self.logger.clone();
 
         info!(logger, "Received subgraph_reassignment request"; "params" => format!("{:?}", params));

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -338,7 +338,7 @@ where
     Q: GraphQlRunner,
     S: AsyncRead + AsyncWrite + Send + 'static,
 {
-    type Future = Box<Future<Item = Self::Item, Error = Self::Error> + Send>;
+    type Future = Box<dyn Future<Item = Self::Item, Error = Self::Error> + Send>;
     type Item = ();
     type Error = ();
 

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -71,7 +71,7 @@ where
     fn serve(
         &mut self,
         port: u16,
-    ) -> Result<Box<Future<Item = (), Error = ()> + Send>, Self::ServeError> {
+    ) -> Result<Box<dyn Future<Item = (), Error = ()> + Send>, Self::ServeError> {
         let logger = self.logger.clone();
         let error_logger = self.logger.clone();
 

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -20,7 +20,7 @@ pub(crate) struct UnsupportedFilter {
     pub value: Value,
 }
 
-type FilterExpression<QS> = Box<BoxableExpression<QS, Pg, SqlType = Bool>>;
+type FilterExpression<QS> = Box<dyn BoxableExpression<QS, Pg, SqlType = Bool>>;
 
 trait IntoFilter<QS> {
     fn into_filter(self, attribute: String, op: &str) -> FilterExpression<QS>;

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -196,10 +196,10 @@ impl Drop for NotificationListener {
 impl EventProducer<JsonNotification> for NotificationListener {
     fn take_event_stream(
         &mut self,
-    ) -> Option<Box<Stream<Item = JsonNotification, Error = ()> + Send>> {
+    ) -> Option<Box<dyn Stream<Item = JsonNotification, Error = ()> + Send>> {
         self.output
             .take()
-            .map(|s| Box::new(s) as Box<Stream<Item = JsonNotification, Error = ()> + Send>)
+            .map(|s| Box::new(s) as Box<dyn Stream<Item = JsonNotification, Error = ()> + Send>)
     }
 }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -267,7 +267,10 @@ impl Store {
     /// Receive store events from Postgres and send them to all active
     /// subscriptions. Detect stale subscriptions in the process and
     /// close them.
-    fn handle_store_events(&self, store_events: Box<Stream<Item = StoreEvent, Error = ()> + Send>) {
+    fn handle_store_events(
+        &self,
+        store_events: Box<dyn Stream<Item = StoreEvent, Error = ()> + Send>,
+    ) {
         let logger = self.logger.clone();
         let subscriptions = self.subscriptions.clone();
 
@@ -1181,7 +1184,10 @@ impl ChainStore for Store {
         Ok(self.genesis_block_ptr)
     }
 
-    fn upsert_blocks<'a, B, E>(&self, blocks: B) -> Box<Future<Item = (), Error = E> + Send + 'a>
+    fn upsert_blocks<'a, B, E>(
+        &self,
+        blocks: B,
+    ) -> Box<dyn Future<Item = (), Error = E> + Send + 'a>
     where
         B: Stream<Item = EthereumBlock, Error = E> + Send + 'a,
         E: From<Error> + Send + 'a,

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -23,9 +23,11 @@ impl StoreEventListener {
 }
 
 impl EventProducer<StoreEvent> for StoreEventListener {
-    fn take_event_stream(&mut self) -> Option<Box<Stream<Item = StoreEvent, Error = ()> + Send>> {
+    fn take_event_stream(
+        &mut self,
+    ) -> Option<Box<dyn Stream<Item = StoreEvent, Error = ()> + Send>> {
         self.notification_listener.take_event_stream().map(
-            |stream| -> Box<Stream<Item = _, Error = _> + Send> {
+            |stream| -> Box<dyn Stream<Item = _, Error = _> + Send> {
                 Box::new(stream.map(|notification| {
                     // Create StoreEvent from JSON
                     let change: StoreEvent = serde_json::from_value(notification.payload.clone())

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -2074,7 +2074,7 @@ fn throttle_subscription_delivers() {
 #[test]
 fn throttle_subscription_throttles() {
     run_test(
-        |store| -> Box<Future<Item = (), Error = tokio_timer::timeout::Error<()>> + Send> {
+        |store| -> Box<dyn Future<Item = (), Error = tokio_timer::timeout::Error<()>> + Send> {
             // Throttle for a very long time (30s)
             let subscription = subscribe_and_consume(store.clone(), &TEST_SUBGRAPH_ID, "user")
                 .throttle_while_syncing(


### PR DESCRIPTION
The warnings are all instances of 'trait objects without an explicit `dyn`
are deprecated'

