### PR TITLE
Add Docker setup script for host IP detection

### DIFF
--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -2,6 +2,21 @@
 
 set -e
 
+if ! which docker 2>&1 > /dev/null; then
+    echo "Please install 'docker' first"
+    exit 1
+fi
+
+if ! which docker-compose 2>&1 > /dev/null; then
+    echo "Please install 'docker-compose' first"
+    exit 1
+fi
+
+if ! which jq 2>&1 > /dev/null; then
+    echo "Please install 'jq' first"
+    exit 1
+fi
+
 # Start graph-node so we can inspect it
 docker-compose start graph-node
 

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Start graph-node so we can inspect it
+docker-compose start graph-node
+
+# Identify the container ID
+CONTAINER_ID=$(docker container ls | grep graph-node | cut -d' ' -f1)
+
+# Inspect the container to identify the host IP address
+HOST_IP=$(docker inspect "$CONTAINER_ID" | jq -r .[0].NetworkSettings.Networks[].Gateway)
+
+echo "Host IP: $HOST_IP"
+
+# Inject the host IP into docker-compose.yml
+sed -i -e "s/host.docker.internal/$HOST_IP/g" docker-compose.yml
+
+function stop_graph_node {
+    # Ensure graph-node is stopped
+    docker-compose stop graph-node
+}
+
+trap stop_graph_node EXIT


### PR DESCRIPTION
Running this script starts up graph-node, uses `docker inspect` to obtain the host IP address, injects this IP address into `docker-compose.yml` and stops graph-node again.

Resolves #1024.

