### PR TITLE
Add `GRAPH_NODE_ID` environment var

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -77,6 +77,9 @@ requests that dont filter on contract address, only event signature.
 
 ## Miscellaneous
 
+- `GRAPH_NODE_ID`: sets the node ID, allowing to run multiple Graph Nodes
+  in parallel and deploy to specific nodes; each ID must be unique among the set
+  of nodes.
 - `GRAPH_LOG`: control log levels, the same way that `RUST_LOG` is described
   [here](https://docs.rs/env_logger/0.6.0/env_logger/)
 - `THEGRAPH_SENTRY_URL`:

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -230,6 +230,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                 .default_value("default")
                 .long("node-id")
                 .value_name("NODE_ID")
+                .env("GRAPH_NODE_ID")
                 .help("a unique identifier for this node"),
         )
         .arg(


### PR DESCRIPTION
This adds and documents the `GRAPH_NODE_ID` env var that can be used to set the Graph Node ID, as an alternative to the `--node-id` CLI argument.

Resolves #1126. 
