### PR TITLE
Index only a prefix of string attributes

### DIFF
--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -391,7 +391,7 @@ impl Store {
                         ));
                     }
                 };
-                Some((attribute, cast_type, direction))
+                Some((attribute, value_type, cast_type, direction))
             }
             None => None,
         };

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -2262,7 +2262,8 @@ fn handle_large_string_with_index() {
             vec![MANUAL.to_owned()],
             EntityRange::first(5),
         )
-        .filter(EntityFilter::Equal(TEXT.to_owned(), long_text.into()));
+        .filter(EntityFilter::Equal(TEXT.to_owned(), long_text.into()))
+        .order_by((TEXT.to_owned(), ValueType::String), EntityOrder::Ascending);
 
         let ids = store
             .find(query)


### PR DESCRIPTION
That avoids the problem described in issue #1133 

The changes should not lead to any observable change in behavior, except that when ordering by a string field, entries with very long values (> 2k characters) are only ordered by their prefix, not their full value.