### PR TITLE
Expose reverts to mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,11 +486,6 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -687,7 +682,7 @@ dependencies = [
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -701,7 +696,7 @@ dependencies = [
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -713,7 +708,7 @@ dependencies = [
  "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -909,7 +904,7 @@ dependencies = [
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-envlogger 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -953,6 +948,7 @@ dependencies = [
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1034,7 +1030,7 @@ dependencies = [
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1703,7 +1699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2814,10 +2810,10 @@ dependencies = [
 
 [[package]]
 name = "tiny-keccak"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3506,7 +3502,6 @@ dependencies = [
 "checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
-"checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum ctor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3b4c17619643c1252b5f690084b82639dd7fac141c57c8e77a00e0148132092c"
@@ -3739,7 +3734,7 @@ dependencies = [
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e9175261fbdb60781fcd388a4d6cc7e14764a2b629a7ad94abb439aed223a44f"
+"checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "94a1f9396aec29d31bb16c24d155cfa144d1af91c40740125db3131bdaf76da8"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"

--- a/datasource/ethereum/Cargo.toml
+++ b/datasource/ethereum/Cargo.toml
@@ -10,3 +10,4 @@ jsonrpc-core = "13.0.0"
 graph = { path = "../../graph" }
 lazy_static = "1.2.0"
 hex-literal = "0.2"
+tiny-keccak = "1.5.0"

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -104,7 +104,6 @@ where
                         }
                         traces
                     })
-                    .from_err::<EthereumContractCallError>()
                     .from_err()
                     .then(move |result| {
                         if result.is_err() {
@@ -377,10 +376,7 @@ where
                             value: None,
                             data: Some(call_data.clone()),
                         };
-                        web3.eth()
-                            .call(req, block_number_opt)
-                            .from_err::<EthereumContractCallError>()
-                            .from_err()
+                        web3.eth().call(req, block_number_opt).from_err()
                     })
                     .map_err(|e| {
                         e.into_inner().unwrap_or_else(|| {
@@ -408,12 +404,7 @@ where
         let net_version_future = retry("net_version RPC call", &logger)
             .no_limit()
             .timeout_secs(20)
-            .run(move || {
-                web3.net()
-                    .version()
-                    .from_err::<EthereumContractCallError>()
-                    .from_err()
-            });
+            .run(move || web3.net().version().from_err());
 
         let web3 = self.web3.clone();
         let gen_block_hash_future = retry("eth_getBlockByNumber(0, false) RPC call", &logger)
@@ -426,7 +417,6 @@ where
                     } else {
                         BlockNumber::Earliest.into()
                     })
-                    .from_err::<EthereumContractCallError>()
                     .from_err()
                     .and_then(|gen_block_opt| {
                         future::result(
@@ -500,7 +490,6 @@ where
                 .run(move || {
                     web3.eth()
                         .block_with_txs(BlockId::Hash(block_hash))
-                        .from_err::<EthereumContractCallError>()
                         .from_err()
                 })
                 .map_err(move |e| {
@@ -552,7 +541,6 @@ where
                             batching_web3
                                 .eth()
                                 .transaction_receipt(tx_hash)
-                                .from_err::<EthereumContractCallError>()
                                 .from_err()
                                 .map_err(EthereumAdapterError::Unknown)
                                 .and_then(move |receipt_opt| {
@@ -609,7 +597,6 @@ where
                     batching_web3
                         .transport()
                         .submit_batch()
-                        .from_err::<EthereumContractCallError>()
                         .from_err()
                         .map_err(EthereumAdapterError::Unknown)
                         .and_then(move |_| {
@@ -647,7 +634,6 @@ where
                 .run(move || {
                     web3.eth()
                         .block(BlockId::Hash(descendant_block_hash))
-                        .from_err::<EthereumContractCallError>()
                         .from_err()
                         .map(|block_opt| block_opt.map(|block| block.parent_hash))
                 })
@@ -676,7 +662,6 @@ where
                 .run(move || {
                     web3.eth()
                         .block(BlockId::Number(block_number.into()))
-                        .from_err::<EthereumContractCallError>()
                         .from_err()
                         .map(|block_opt| block_opt.map(|block| block.hash.unwrap()))
                 })
@@ -956,7 +941,7 @@ where
                 Bytes(call_data),
                 Some(call.block_ptr.number.into()),
             )
-            .map_err(EthereumContractCallError::from)
+            .map_err(EthereumContractCallError::Error)
             .and_then(move |output| {
                 // Decode the return values according to the ABI
                 call.function

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -5,7 +5,6 @@ use slog::Logger;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use tiny_keccak::keccak256;
-use web3::error::Error as Web3Error;
 use web3::types::*;
 
 use super::types::*;
@@ -45,8 +44,6 @@ pub struct EthereumContractCall {
 
 #[derive(Fail, Debug)]
 pub enum EthereumContractCallError {
-    #[fail(display = "call error: {}", _0)]
-    CallError(Error),
     #[fail(display = "ABI error: {}", _0)]
     ABIError(SyncFailure<ABIError>),
     /// `Token` is not of expected `ParamType`
@@ -56,21 +53,9 @@ pub enum EthereumContractCallError {
     Error(Error),
 }
 
-impl From<Web3Error> for EthereumContractCallError {
-    fn from(e: Web3Error) -> Self {
-        EthereumContractCallError::CallError(failure::err_msg(e.to_string()))
-    }
-}
-
 impl From<ABIError> for EthereumContractCallError {
     fn from(e: ABIError) -> Self {
         EthereumContractCallError::ABIError(SyncFailure::new(e))
-    }
-}
-
-impl From<Error> for EthereumContractCallError {
-    fn from(e: Error) -> Self {
-        EthereumContractCallError::Error(e)
     }
 }
 

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -50,7 +50,11 @@ pub enum EthereumContractCallError {
     #[fail(display = "type mismatch, token {:?} is not of kind {:?}", _0, _1)]
     TypeError(Token, ParamType),
     #[fail(display = "call error: {}", _0)]
-    Error(Error),
+    Web3Error(web3::Error),
+    #[fail(display = "call reverted: {}", _0)]
+    Revert(String),
+    #[fail(display = "ethereum node took too long to perform call")]
+    Timeout,
 }
 
 impl From<ABIError> for EthereumContractCallError {

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -23,6 +23,7 @@ pub mod log;
 pub mod prelude {
     pub use ethabi;
     pub use failure::{self, bail, err_msg, format_err, Error, Fail, SyncFailure};
+    pub use hex;
     pub use serde_derive::{Deserialize, Serialize};
     pub use serde_json;
     pub use slog::{self, crit, debug, error, info, o, trace, warn, Logger};

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -535,7 +535,7 @@ where
         }))
     }
 
-    /// function ethereum.call(call: SmartContractCall): Array<Token>
+    /// function ethereum.call(call: SmartContractCall): Array<Token> | null
     fn ethereum_call(
         &mut self,
         call_ptr: AscPtr<AscUnresolvedContractCall>,
@@ -545,7 +545,10 @@ where
             .valid_module
             .host_exports
             .ethereum_call(&mut self.ctx, call)?;
-        Ok(Some(RuntimeValue::from(self.asc_new(&*result))))
+        Ok(Some(match result {
+            Some(tokens) => RuntimeValue::from(self.asc_new(tokens.as_slice())),
+            None => RuntimeValue::from(0),
+        }))
     }
 
     /// function typeConversion.bytesToString(bytes: Bytes): string

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -828,5 +828,7 @@ fn ens_name_by_hash() {
     assert_eq!(data, "dealdrafts");
 
     let hash = module.asc_new("impossible keccak hash");
-    assert!(dbg!(module.takes_ptr_returns_ptr::<_, AscString>("nameByHash", hash,)).is_null());
+    assert!(module
+        .takes_ptr_returns_ptr::<_, AscString>("nameByHash", hash)
+        .is_null());
 }


### PR DESCRIPTION
Resolves https://github.com/graphprotocol/graph-node/issues/1120.

This detects a revert JSON-RPC response for contract calls on common clients and gives it special treatment by returning `null` to the mapping. The detection is based on empirical testing done against Infura and Alchemy mainnet and also Ganache. I didn't test directly against Geth and Parity, but I believe Infura does the same as Geth while Alchemy does the same as Parity. We can't claim this to be complete because there's no standard for the Ethereum client behaviour, the detection is a best effort.

In particular the Infura/Geth response is not even a JSON-RPC error, this was causing us to return a value to the mapping for a reverted call, which is a determinism bug, and this may still happen for contract languages other than Solidity which was the only one tested, so we should recommend against running a production Graph node against Infura/Geth.

See https://github.com/graphprotocol/graph-ts/pull/74 and https://github.com/graphprotocol/graph-cli/pull/332 for the AssemblyScript API.

To test this, run this subgraph https://github.com/leoyvens/subgraph-revert-test. It has two data sources, one to test Solidity reverts with a reason and another for reverts without reason. Comment out one of the data sources to test the other in isolation. Against Alchemy both data sources will have the revert detected, but against Infura the reverts without reason cannot be detected and will fail the subgraph.