### PR TITLE
Fix traces being requested when not necessary

### DIFF
--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -35,7 +35,7 @@ where
     ) -> Result<Self, Error> {
         let manifest_id = manifest.id.clone();
         let network_name = manifest.network_name()?;
-        let templates = manifest.templates.unwrap_or_default();
+        let templates = manifest.templates;
 
         // Create a new runtime host for each data source in the subgraph manifest;
         // we use the same order here as in the subgraph manifest to make the

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -186,7 +186,7 @@ impl SubgraphInstanceManager {
 
         let mut templates: Vec<DataSourceTemplate> = vec![];
         for data_source in manifest.data_sources.iter() {
-            for template in data_source.templates.iter().flatten() {
+            for template in data_source.templates.iter() {
                 templates.push(template.clone());
             }
         }
@@ -226,7 +226,7 @@ impl SubgraphInstanceManager {
                 stream_builder,
                 host_builder,
                 include_calls_in_blocks,
-                top_level_templates: top_level_templates.unwrap_or_default(),
+                top_level_templates,
             },
             state: IndexingState {
                 logger,

--- a/core/src/subgraph/validation.rs
+++ b/core/src/subgraph/validation.rs
@@ -9,16 +9,8 @@ pub fn validate_manifest(
     // which has call or block handlers
     let has_invalid_data_source = manifest.data_sources.iter().any(|data_source| {
         let no_source_address = data_source.source.address.is_none();
-        let has_call_handlers = data_source
-            .mapping
-            .call_handlers
-            .as_ref()
-            .map_or(false, |handlers| !handlers.is_empty());
-        let has_block_handlers = data_source
-            .mapping
-            .block_handlers
-            .as_ref()
-            .map_or(false, |handlers| handlers.is_empty());
+        let has_call_handlers = !data_source.mapping.call_handlers.is_empty();
+        let has_block_handlers = !data_source.mapping.block_handlers.is_empty();
 
         no_source_address && (has_call_handlers || has_block_handlers)
     });
@@ -30,26 +22,23 @@ pub fn validate_manifest(
     // Validate that there are no more than one of each type of
     // block_handler in each data source.
     let has_too_many_block_handlers = manifest.data_sources.iter().any(|data_source| {
-        if data_source
-            .mapping
-            .block_handlers
-            .as_ref()
-            .map_or(true, |handlers| handlers.is_empty())
-        {
+        if data_source.mapping.block_handlers.is_empty() {
             return false;
         }
 
         let mut non_filtered_block_handler_count = 0;
         let mut call_filtered_block_handler_count = 0;
-        if let Some(ref handlers) = data_source.mapping.block_handlers {
-            handlers.iter().for_each(|block_handler| {
+        data_source
+            .mapping
+            .block_handlers
+            .iter()
+            .for_each(|block_handler| {
                 if block_handler.filter.is_none() {
                     non_filtered_block_handler_count += 1
                 } else {
                     call_filtered_block_handler_count += 1
                 }
             });
-        }
         return non_filtered_block_handler_count > 1 || call_filtered_block_handler_count > 1;
     });
 

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -22,7 +22,7 @@ fn insert_and_query(
         repository: None,
         schema: schema.clone(),
         data_sources: vec![],
-        templates: None,
+        templates: vec![],
     };
 
     let logger = Logger::root(slog::Discard, o!());

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -138,19 +138,17 @@ impl EthereumLogFilter {
         iter.into_iter().fold(None, |filter_opt, data_source| {
             let contract_addr = data_source.source.address;
 
-            if let Some(ref handlers) = data_source.mapping.event_handlers {
-                filter_opt.extend(
-                    handlers
-                        .iter()
-                        .map(move |event_handler| {
-                            let event_sig = event_handler.topic0();
-                            (contract_addr, event_sig)
-                        })
-                        .collect::<EthereumLogFilter>(),
-                )
-            } else {
-                filter_opt
-            }
+            filter_opt.extend(
+                data_source
+                    .mapping
+                    .event_handlers
+                    .iter()
+                    .map(move |event_handler| {
+                        let event_sig = event_handler.topic0();
+                        (contract_addr, event_sig)
+                    })
+                    .collect::<EthereumLogFilter>(),
+            )
         })
     }
 }
@@ -217,19 +215,17 @@ impl EthereumCallFilter {
             .fold(None, |filter_opt, data_source| {
                 let contract_addr = data_source.source.address.unwrap();
 
-                if let Some(ref handlers) = data_source.mapping.call_handlers {
-                    filter_opt.extend(
-                        handlers
-                            .iter()
-                            .map(move |call_handler| {
-                                let sig = keccak256(call_handler.function.as_bytes());
-                                (contract_addr, [sig[0], sig[1], sig[2], sig[3]])
-                            })
-                            .collect::<EthereumCallFilter>(),
-                    )
-                } else {
-                    filter_opt
-                }
+                filter_opt.extend(
+                    data_source
+                        .mapping
+                        .call_handlers
+                        .iter()
+                        .map(move |call_handler| {
+                            let sig = keccak256(call_handler.function.as_bytes());
+                            (contract_addr, [sig[0], sig[1], sig[2], sig[3]])
+                        })
+                        .collect::<EthereumCallFilter>(),
+                )
             })
     }
 }
@@ -294,7 +290,6 @@ impl EthereumBlockFilter {
                     .mapping
                     .block_handlers
                     .clone()
-                    .unwrap_or(vec![])
                     .into_iter()
                     .any(|block_handler| match block_handler.filter {
                         Some(ref filter) if *filter == BlockHandlerFilter::Call => return true,
@@ -305,7 +300,6 @@ impl EthereumBlockFilter {
                     .mapping
                     .block_handlers
                     .clone()
-                    .unwrap_or(vec![])
                     .into_iter()
                     .any(|block_handler| block_handler.filter.is_none());
 

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -5,9 +5,9 @@ use crate::prelude::*;
 
 pub trait BlockStream: Stream<Item = EthereumBlockWithTriggers, Error = Error> {
     fn parse_triggers(
-        log_filter_opt: Option<EthereumLogFilter>,
-        call_filter_opt: Option<EthereumCallFilter>,
-        block_filter_opt: Option<EthereumBlockFilter>,
+        log_filter: EthereumLogFilter,
+        call_filter: EthereumCallFilter,
+        block_filter: EthereumBlockFilter,
         include_calls_in_blocks: bool,
         descendant_block: EthereumBlockWithCalls,
     ) -> Result<EthereumBlockWithTriggers, Error>;
@@ -21,9 +21,9 @@ pub trait BlockStreamBuilder: Clone + Send + Sync {
         logger: Logger,
         deployment_id: SubgraphDeploymentId,
         network_name: String,
-        log_filter: Option<EthereumLogFilter>,
-        call_filter: Option<EthereumCallFilter>,
-        block_filter: Option<EthereumBlockFilter>,
+        log_filter: EthereumLogFilter,
+        call_filter: EthereumCallFilter,
+        block_filter: EthereumBlockFilter,
         include_calls_in_blocks: bool,
     ) -> Self::Stream;
 }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -14,7 +14,6 @@ use web3::types::H256;
 use crate::data::store::*;
 use crate::data::subgraph::schema::*;
 use crate::prelude::*;
-use crate::util::extend::Extend;
 
 lazy_static! {
     pub static ref SUBSCRIPTION_THROTTLE_INTERVAL: Duration =
@@ -254,10 +253,8 @@ impl StoreEvent {
             *ev1 = Some(ev2);
         }
     }
-}
 
-impl Extend<StoreEvent> for StoreEvent {
-    fn extend(mut self, other: StoreEvent) -> Self {
+    pub fn extend(mut self, other: StoreEvent) -> Self {
         self.changes.extend(other.changes);
         self
     }

--- a/graph/src/util/extend.rs
+++ b/graph/src/util/extend.rs
@@ -1,4 +1,0 @@
-/// A value that can be extended with an instance of the same type.
-pub trait Extend<T> {
-    fn extend(self, other: T) -> Self;
-}

--- a/graph/src/util/extend.rs
+++ b/graph/src/util/extend.rs
@@ -2,16 +2,3 @@
 pub trait Extend<T> {
     fn extend(self, other: T) -> Self;
 }
-
-/// An optional value that can be extended with an instance of its inner type.
-impl<T> Extend<T> for Option<T>
-where
-    T: Extend<T>,
-{
-    fn extend(self, other: T) -> Self {
-        match self {
-            None => Some(other),
-            Some(inner) => Some(inner.extend(other)),
-        }
-    }
-}

--- a/graph/src/util/mod.rs
+++ b/graph/src/util/mod.rs
@@ -6,6 +6,3 @@ pub mod ethereum;
 
 /// Security utilities.
 pub mod security;
-
-/// Extensible valules.
-pub mod extend;

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -74,7 +74,7 @@ fn insert_test_entities(store: &impl Store, id: SubgraphDeploymentId) {
         repository: None,
         schema: test_schema(id.clone()),
         data_sources: vec![],
-        templates: None,
+        templates: vec![],
     };
 
     store

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -35,9 +35,9 @@ impl EventConsumer<ChainHeadUpdate> for MockBlockStream {
 
 impl BlockStream for MockBlockStream {
     fn parse_triggers(
-        _log_filter_opt: Option<EthereumLogFilter>,
-        _call_filter_opt: Option<EthereumCallFilter>,
-        _block_filter_opt: Option<EthereumBlockFilter>,
+        _: EthereumLogFilter,
+        _: EthereumCallFilter,
+        _: EthereumBlockFilter,
         _include_calls_in_blocks: bool,
         _descendant_block: EthereumBlockWithCalls,
     ) -> Result<EthereumBlockWithTriggers, Error> {
@@ -62,9 +62,9 @@ impl BlockStreamBuilder for MockBlockStreamBuilder {
         _logger: Logger,
         _deployment_id: SubgraphDeploymentId,
         _network_name: String,
-        _log_filter: Option<EthereumLogFilter>,
-        _call_filter: Option<EthereumCallFilter>,
-        _block_filter: Option<EthereumBlockFilter>,
+        _: EthereumLogFilter,
+        _: EthereumCallFilter,
+        _: EthereumBlockFilter,
         _include_calls_in_blocks: bool,
     ) -> Self::Stream {
         MockBlockStream::new()

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -98,9 +98,9 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: &Logger,
         _: u64,
         _: u64,
-        _: Option<EthereumLogFilter>,
-        _: Option<EthereumCallFilter>,
-        _: Option<EthereumBlockFilter>,
+        _: EthereumLogFilter,
+        _: EthereumCallFilter,
+        _: EthereumBlockFilter,
     ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
         unimplemented!();
     }

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -168,7 +168,7 @@ fn test_valid_module(
                 parsed_module: data_source.mapping.runtime,
                 abis: data_source.mapping.abis,
                 data_source_name: data_source.name,
-                templates: data_source.templates.unwrap_or_default(),
+                templates: data_source.templates,
                 ethereum_adapter: mock_ethereum_adapter,
                 link_resolver: Arc::new(ipfs_api::IpfsClient::default().into()),
                 store: Arc::new(FakeStore),
@@ -196,15 +196,15 @@ fn mock_data_source(path: &str) -> DataSource {
             language: String::from("wasm/assemblyscript"),
             entities: vec![],
             abis: vec![],
-            event_handlers: Some(vec![]),
-            call_handlers: Some(vec![]),
-            block_handlers: Some(vec![]),
+            event_handlers: vec![],
+            call_handlers: vec![],
+            block_handlers: vec![],
             link: Link {
                 link: "link".to_owned(),
             },
             runtime: Arc::new(runtime.clone()),
         },
-        templates: Some(vec![DataSourceTemplate {
+        templates: vec![DataSourceTemplate {
             kind: String::from("ethereum/contract"),
             name: String::from("example template"),
             network: Some(String::from("mainnet")),
@@ -217,15 +217,15 @@ fn mock_data_source(path: &str) -> DataSource {
                 language: String::from("wasm/assemblyscript"),
                 entities: vec![],
                 abis: vec![],
-                event_handlers: Some(vec![]),
-                call_handlers: Some(vec![]),
-                block_handlers: Some(vec![]),
+                event_handlers: vec![],
+                call_handlers: vec![],
+                block_handlers: vec![],
                 link: Link {
                     link: "link".to_owned(),
                 },
                 runtime: Arc::new(runtime),
             },
-        }]),
+        }],
     }
 }
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -469,7 +469,7 @@ mod tests {
             repository: None,
             schema: schema.clone(),
             data_sources: vec![],
-            templates: None,
+            templates: vec![],
         };
 
         let graphql_runner = Arc::new(TestGraphQlRunner);
@@ -540,7 +540,7 @@ mod tests {
             repository: None,
             schema: schema.clone(),
             data_sources: vec![],
-            templates: None,
+            templates: vec![],
         };
         let graphql_runner = Arc::new(TestGraphQlRunner);
         let store = Arc::new(MockStore::new(vec![(id.clone(), schema)]));

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -85,7 +85,7 @@ mod test {
             repository: None,
             schema: schema.clone(),
             data_sources: vec![],
-            templates: None,
+            templates: vec![],
         };
 
         let store = Arc::new(MockStore::new(vec![(id, schema)]));

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -45,7 +45,6 @@ use graph::prelude::{
     QueryExecutionError, StoreError, StoreEvent, SubgraphDeploymentId, TransactionAbortError,
     ValueType,
 };
-use graph::util::extend::Extend;
 
 use crate::filter::{build_filter, store_filter};
 use crate::functions::set_config;

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -121,7 +121,7 @@ fn insert_test_data(store: Arc<DieselStore>) {
         repository: None,
         schema: Schema::parse("scalar Foo", TEST_SUBGRAPH_ID.clone()).unwrap(),
         data_sources: vec![],
-        templates: None,
+        templates: vec![],
     };
 
     // Create SubgraphDeploymentEntity
@@ -1688,15 +1688,15 @@ fn mock_data_source(path: &str) -> DataSource {
             language: String::from("wasm/assemblyscript"),
             entities: vec![],
             abis: vec![],
-            event_handlers: Some(vec![]),
-            call_handlers: Some(vec![]),
-            block_handlers: Some(vec![]),
+            event_handlers: vec![],
+            call_handlers: vec![],
+            block_handlers: vec![],
             link: Link {
                 link: "link".to_owned(),
             },
             runtime: Arc::new(runtime.clone()),
         },
-        templates: Some(vec![DataSourceTemplate {
+        templates: vec![DataSourceTemplate {
             kind: String::from("ethereum/contract"),
             name: String::from("example template"),
             network: Some(String::from("mainnet")),
@@ -1709,15 +1709,15 @@ fn mock_data_source(path: &str) -> DataSource {
                 language: String::from("wasm/assemblyscript"),
                 entities: vec![],
                 abis: vec![],
-                event_handlers: Some(vec![]),
-                call_handlers: Some(vec![]),
-                block_handlers: Some(vec![]),
+                event_handlers: vec![],
+                call_handlers: vec![],
+                block_handlers: vec![],
                 link: Link {
                     link: "link".to_owned(),
                 },
                 runtime: Arc::new(runtime),
             },
-        }]),
+        }],
     }
 }
 
@@ -1876,7 +1876,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             repository: None,
             schema: Schema::parse("scalar Foo", subgraph_id.clone()).unwrap(),
             data_sources: vec![],
-            templates: None,
+            templates: vec![],
         };
 
         // Create SubgraphDeploymentEntity


### PR DESCRIPTION
This fixes a bug which is easy to reproduce on master:
1. Deploy a subgraph with dynamic data sources but that doesn't use traces.
2. Let it spawn a dynamic data source.
3. Restart the graph-node, the subgraph will start requesting traces even though they're not required.

I believe this bug was introduced in #1087. This regresses indexing speed and may cause the subgraph to stop indexing if the Ethereum node doesn't support traces.

The root cause is that we use `Option<EthereumCallFilter>`, and we request traces if that's `Some`. When first deploying a subgraph that would be `None` so all good, but when restarting after #1087 that would be `Some` but with an empty filter, and the code that requests traces can't tell that `None` and an empty filter are the same thing, which is annoying.

I solved this the hard way by refactoring away the `Option` around most cases of `Option<Vec<_>>` and `Option<Ethereum*Filter>`. It is confusing to have `Option` around something that has its own concept of being empty, since `None` and `Some(empty)` are usually equivalent.