### PR TITLE
Bump ethabi to the latest graph-patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "8.0.0"
-source = "git+https://github.com/graphprotocol/ethabi.git?branch=graph-patches#7b0f48cdda6e5553e2644d72152a3168e858fbb4"
+source = "git+https://github.com/graphprotocol/ethabi.git?branch=graph-patches#da9e2bf596da19c1739d390a5579c856b2d5e78c"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This introduces lossy UTF-8 string decoding, allowing subgraphs to
handle invalid strings instead of failing to decode them.

