### PR TITLE
Add optional limit for GraphQL over WebSocket operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,6 +1056,7 @@ dependencies = [
  "graph-graphql 0.15.1",
  "graphql-parser 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tungstenite 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -70,6 +70,9 @@ those.
   with introspection done by graphql clients.
 - `GRAPH_GRAPHQL_MAX_DEPTH`: maximum depth of a graphql query. Default (and
   maximum) is 255.
+- `GRAPH_GRAPHQL_MAX_OPERATIONS_PER_CONNECTION`: maximum number of GraphQL
+  operations per WebSocket connection. Any operation created after the limit
+  will return an error to the client. Default: unlimited.
 
 ## Tokio
 

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -9,6 +9,7 @@ graph = { path = "../../graph" }
 graphql-parser = "0.2.1"
 graph-graphql = { path = "../../graphql" }
 hyper = "0.12.7"
+lazy_static = "1.2.0"
 serde = "1.0"
 serde_derive = "1.0"
 tokio-tungstenite = "0.6"


### PR DESCRIPTION
This limit can be configured using the `GRAPH_GRAPHQL_MAX_OPERATIONS_PER_CONNECTION` environment variable. The default is unlimited.

Needed for DAOstack.

