### PR TITLE
docker: Preload pg_stat_statements in Postgres

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     image: postgres
     ports:
       - '5432:5432'
+    command: ["postgres", "-cshared_preload_libraries=pg_stat_statements"]
     environment:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in


### PR DESCRIPTION
This is needed so that we can enable pg_stat_statements the extension when
we create our schema

