### PR TITLE
store: Remove foreign key into event_meta_data

### DIFF
--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -1392,8 +1392,7 @@ pub(crate) fn create_schema(
         "create table {}.entity_history
          (
            id           serial primary key,
-           event_id     integer references event_meta_data(id)
-                          on update cascade on delete cascade,
+           event_id     integer,
            entity       varchar not null,
            entity_id    varchar not null,
            data_before  jsonb,

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -2162,7 +2162,11 @@ fn subgraph_schema_types_have_subgraph_id_directive() {
     })
 }
 
+// After removing the foreign key constraint from a subgraph's
+// entity_history table to event_meta_data subgraph creation does not take
+// a lock anymore, which makes this test fail.
 #[test]
+#[ignore]
 fn create_subgraph_deployment_tolerates_locks() {
     run_test(|store| -> Result<(), ()> {
         use diesel::connection::SimpleConnection;


### PR DESCRIPTION
The foreign key constraint from a subgraph's entity_history table into
event_meta_data requires a lock on subgraph creation that prevents subgraph
deployment during an autovacuum of event_meta_data.

We remove the foreign key constraint so that subgraph deploys can proceed
even when event_meta_data is being autovacuumed.

