### PR TITLE
Update readme to reflect default Postgres port

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -69,7 +69,7 @@ can access these via:
 - IPFS:
   - `127.0.0.1:5001` or `/ip4/127.0.0.1/tcp/5001`
 - Postgres:
-  - `postgresql://graph-node:let-me-in@localhost:8545/graph-node`
+  - `postgresql://graph-node:let-me-in@localhost:5432/graph-node`
 
 Once this is up and running, you can use
 [`graph-cli`](https://github.com/graphprotocol/graph-cli) to create and


### PR DESCRIPTION
Came across a small inconsistency in the docs where the 8545 was being used rather than the default Postgres port. Sharing a pull request with the relevant change

