### PR TITLE
store: Cache Storage objects in the Store

### DIFF
--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -13,8 +13,8 @@ use graphql_parser::schema as s;
 use inflector::Inflector;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{self, Write};
-use std::rc::Rc;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use crate::relational_queries::{
     ClampRangeQuery, ConflictingEntityQuery, EntityData, FilterQuery, FindQuery, InsertQuery,
@@ -120,7 +120,7 @@ pub struct Layout {
     /// The SQL type for columns with GraphQL type `ID`
     id_type: IdType,
     /// Maps the GraphQL name of a type to the relational table
-    pub tables: HashMap<String, Rc<Table>>,
+    pub tables: HashMap<String, Arc<Table>>,
     /// The subgraph id
     pub subgraph: SubgraphDeploymentId,
     /// The database schema for this subgraph
@@ -128,7 +128,7 @@ pub struct Layout {
     /// Map the entity names of interfaces to the list of
     /// database tables that contain entities implementing
     /// that interface
-    pub interfaces: HashMap<String, Vec<Rc<Table>>>,
+    pub interfaces: HashMap<String, Vec<Arc<Table>>>,
     /// Enums defined in the schema and their possible values. The names
     /// are the original GraphQL names
     pub enums: EnumMap,
@@ -197,7 +197,7 @@ impl Layout {
             }
         }
 
-        let tables: Vec<_> = tables.into_iter().map(|table| Rc::new(table)).collect();
+        let tables: Vec<_> = tables.into_iter().map(|table| Arc::new(table)).collect();
         let interfaces = interfaces
             .into_iter()
             .map(|(k, v)| {
@@ -308,7 +308,7 @@ impl Layout {
             .ok_or_else(|| StoreError::UnknownTable(name.to_string()))
     }
 
-    pub fn table_for_entity(&self, entity: &str) -> Result<&Rc<Table>, StoreError> {
+    pub fn table_for_entity(&self, entity: &str) -> Result<&Arc<Table>, StoreError> {
         self.tables
             .get(entity)
             .ok_or_else(|| StoreError::UnknownTable(entity.to_owned()))

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -123,6 +123,10 @@ pub struct Store {
     genesis_block_ptr: EthereumBlockPointer,
     conn: Pool<ConnectionManager<PgConnection>>,
     schema_cache: Mutex<LruCache<SubgraphDeploymentId, SchemaPair>>,
+    /// A cache for the storage metadata for subgraphs. The Store just
+    /// hosts this because it lives long enough, but it is managed from
+    /// the entities module
+    pub(crate) storage_cache: e::StorageCache,
 }
 
 impl Store {
@@ -186,6 +190,7 @@ impl Store {
             genesis_block_ptr: (net_identifiers.genesis_block_hash, config.start_block).into(),
             conn: pool,
             schema_cache: Mutex::new(LruCache::with_capacity(100)),
+            storage_cache: e::make_storage_cache(),
         };
 
         // Add network to store and check network identifiers
@@ -1263,4 +1268,5 @@ impl ChainStore for Store {
 /// Delete all entities. This function exists solely for integration tests
 /// and should never be called from any other code. Unfortunately, Rust makes
 /// it very hard to export items just for testing
+#[cfg(debug_assertions)]
 pub use crate::entities::delete_all_entities_for_test_use_only;

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -120,7 +120,7 @@ where
     runtime
         .block_on(future::lazy(move || {
             // Reset state before starting
-            remove_test_data();
+            remove_test_data(store.clone());
 
             // Seed database with test data
             insert_test_data(store.clone());
@@ -271,10 +271,10 @@ fn create_test_entity(
 }
 
 /// Removes test data from the database behind the store.
-fn remove_test_data() {
+fn remove_test_data(store: Arc<graph_store_postgres::Store>) {
     let url = postgres_test_url();
     let conn = PgConnection::establish(url.as_str()).expect("Failed to connect to Postgres");
-    graph_store_postgres::store::delete_all_entities_for_test_use_only(&conn)
+    graph_store_postgres::store::delete_all_entities_for_test_use_only(&store, &conn)
         .expect("Failed to remove entity test data");
 }
 


### PR DESCRIPTION
With relational schemas, we need a bit of computation to go from the
GraphQL schema to the relational Layout. If possible, we cache the Layout
for the lifetime of the Store

Fixes https://github.com/graphprotocol/graph-node/issues/1177

