### PR TITLE
Allow a data source to create another in the same block it was created

### DIFF
--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -97,16 +97,13 @@ where
         )
     }
 
-    fn process_trigger_in_runtime_hosts<I>(
+    fn process_trigger_in_runtime_hosts(
         logger: &Logger,
-        hosts: I,
+        hosts: impl Iterator<Item = Arc<T::Host>>,
         block: Arc<EthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
-    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>
-    where
-        I: IntoIterator<Item = Arc<T::Host>>,
-    {
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
         let logger = logger.to_owned();
         match trigger {
             EthereumTrigger::Log(log) => {
@@ -114,10 +111,7 @@ where
                     .transaction_for_log(&log)
                     .map(Arc::new)
                     .ok_or_else(|| format_err!("Found no transaction for event"));
-                let matching_hosts: Vec<_> = hosts
-                    .into_iter()
-                    .filter(|host| host.matches_log(&log))
-                    .collect();
+                let matching_hosts: Vec<_> = hosts.filter(|host| host.matches_log(&log)).collect();
                 let log = Arc::new(log);
 
                 // Process the log in each host in the same order the corresponding data

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -621,15 +621,11 @@ where
     stream::iter_ok::<_, CancelableError<Error>>(triggers)
         // Process events from the block stream
         .fold(block_state, move |block_state, trigger| {
-            let logger = logger.clone();
-            let block = block.clone();
-            let runtime_hosts = runtime_hosts.clone();
-
             // Process the log in each host in the same order the corresponding
             // data sources have been created
             SubgraphInstance::<T>::process_trigger_in_runtime_hosts(
                 &logger,
-                runtime_hosts.iter().map(|host| host.clone()),
+                runtime_hosts.iter().cloned(),
                 block.clone(),
                 trigger,
                 block_state,

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -13,7 +13,7 @@ pub trait BlockStream: Stream<Item = EthereumBlockWithTriggers, Error = Error> {
     ) -> Result<EthereumBlockWithTriggers, Error>;
 }
 
-pub trait BlockStreamBuilder: Clone + Send + Sync {
+pub trait BlockStreamBuilder: Clone + Send + Sync + 'static {
     type Stream: BlockStream + Send + 'static;
 
     fn build(

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -39,15 +39,13 @@ where
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;
 
     /// Like `process_trigger` but processes an Ethereum event in a given list of hosts.
-    fn process_trigger_in_runtime_hosts<I>(
+    fn process_trigger_in_runtime_hosts(
         logger: &Logger,
-        hosts: I,
+        hosts: impl Iterator<Item = Arc<T::Host>>,
         block: Arc<EthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
-    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>
-    where
-        I: IntoIterator<Item = Arc<T::Host>>;
+    ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;
 
     /// Adds dynamic data sources to the subgraph.
     fn add_dynamic_data_sources(&mut self, runtime_hosts: Vec<Arc<T::Host>>) -> Result<(), Error>;


### PR DESCRIPTION
Resolves #1105, this involved some refactoring to `instance_manager::process_block`.

This was tested by uncommenting this line on this subgraph https://github.com/graphprotocol/aragon-subgraph/blob/sistemico/canary/canary/src/mappings/apm.ts#L42. Previously it would print the expected error, now it spawns the data source and processes its events on the same block.