### PR TITLE
Improve separation of responsibilities between Store and entities::Connection

### DIFF
--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -141,7 +141,7 @@ where
                         self_clone
                             .store
                             .clone()
-                            .build_entity_attribute_indexes(index_definitions)
+                            .build_entity_attribute_indexes(&subgraph.id, index_definitions)
                             .map(|_| {
                                 info!(
                                     logger,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -650,6 +650,7 @@ pub trait Store: Send + Sync + 'static {
     /// Build indexes for a set of subgraph entity attributes
     fn build_entity_attribute_indexes(
         &self,
+        subgraph: &SubgraphDeploymentId,
         indexes: Vec<AttributeIndexDefinition>,
     ) -> Result<(), SubgraphAssignmentProviderError>;
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -308,6 +308,7 @@ impl Store for MockStore {
 
     fn build_entity_attribute_indexes(
         &self,
+        _: &SubgraphDeploymentId,
         _: Vec<AttributeIndexDefinition>,
     ) -> Result<(), SubgraphAssignmentProviderError> {
         Ok(())
@@ -473,6 +474,7 @@ impl Store for FakeStore {
 
     fn build_entity_attribute_indexes(
         &self,
+        _: &SubgraphDeploymentId,
         _: Vec<AttributeIndexDefinition>,
     ) -> Result<(), SubgraphAssignmentProviderError> {
         Ok(())

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -52,6 +52,7 @@ use crate::filter::build_filter;
 use crate::functions::set_config;
 use crate::history_event::HistoryEvent;
 use crate::jsonb::PgJsonbExpressionMethods as _;
+use crate::notification_listener::JsonNotification;
 use crate::relational::{IdType, Layout};
 use crate::store::Store;
 
@@ -684,6 +685,11 @@ impl<'a> Connection<'a> {
             );
             Ok(storage.needs_migrating())
         })
+    }
+
+    pub(crate) fn send_store_event(&self, event: &StoreEvent) -> Result<(), StoreError> {
+        let v = serde_json::to_value(event)?;
+        JsonNotification::send("store_events", &v, &*self.conn)
     }
 }
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -2291,7 +2291,9 @@ fn handle_large_string_with_index() {
             attribute_name: NAME.to_owned(),
             entity_name: USER.to_owned(),
         };
-        store.build_entity_attribute_indexes(vec![index]).unwrap();
+        store
+            .build_entity_attribute_indexes(&*TEST_SUBGRAPH_ID, vec![index])
+            .unwrap();
 
         // We have to produce a massive string (1_000_000 chars) because
         // the repeated text compresses so well. This leads to an error


### PR DESCRIPTION
The `entities::Connection` struct looked like an instance would be used with any number of subgraphs, when we really only ever use it for one subgraph plus the metadata subgraph. These changes make that separation clearer and also remove some of the ugly back-and-forth between the store and the connection.