### PR TITLE
Add entity_count and query_price to the Indexing Statuses API

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -657,8 +657,16 @@ fn create_subgraph_version(
         let chain_head_block = chain_store.chain_head_ptr()?;
         let genesis_block = chain_store.genesis_block_ptr()?;
         ops.extend(
-            SubgraphDeploymentEntity::new(&manifest, false, false, genesis_block, chain_head_block)
-                .create_operations(&manifest.id),
+            SubgraphDeploymentEntity::new(
+                &manifest,
+                false,
+                false,
+                genesis_block,
+                chain_head_block,
+                0,
+                0,
+            )
+            .create_operations(&manifest.id),
         );
     }
 

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -27,11 +27,12 @@ fn insert_and_query(
 
     let logger = Logger::root(slog::Discard, o!());
 
-    let ops = SubgraphDeploymentEntity::new(&manifest, false, false, GENESIS_PTR.clone(), None)
-        .create_operations_replace(&subgraph_id)
-        .into_iter()
-        .map(|op| op.into())
-        .collect();
+    let ops =
+        SubgraphDeploymentEntity::new(&manifest, false, false, GENESIS_PTR.clone(), None, 0, 0)
+            .create_operations_replace(&subgraph_id)
+            .into_iter()
+            .map(|op| op.into())
+            .collect();
     STORE
         .create_subgraph_deployment(&logger, &schema, ops)
         .unwrap();

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -214,6 +214,8 @@ pub struct SubgraphDeploymentEntity {
     ethereum_head_block_hash: Option<H256>,
     ethereum_head_block_number: Option<u64>,
     total_ethereum_blocks_count: u64,
+    entity_count: u64,
+    query_price: u64,
 }
 
 impl TypedEntity for SubgraphDeploymentEntity {
@@ -228,6 +230,8 @@ impl SubgraphDeploymentEntity {
         synced: bool,
         earliest_ethereum_block: EthereumBlockPointer,
         latest_ethereum_block: Option<EthereumBlockPointer>,
+        entity_count: u64,
+        query_price: u64,
     ) -> Self {
         let latest_ethereum_block =
             latest_ethereum_block.unwrap_or(earliest_ethereum_block.clone());
@@ -243,6 +247,8 @@ impl SubgraphDeploymentEntity {
             ethereum_head_block_hash: Some(latest_ethereum_block.hash),
             ethereum_head_block_number: Some(latest_ethereum_block.number),
             total_ethereum_blocks_count: latest_ethereum_block.number,
+            entity_count,
+            query_price,
         }
     }
 
@@ -306,7 +312,8 @@ impl SubgraphDeploymentEntity {
                 .map_or(Value::Null, Value::from),
         );
         entity.set("totalEthereumBlocksCount", self.total_ethereum_blocks_count);
-        entity.set("entityCount", 0 as u64);
+        entity.set("entityCount", self.entity_count);
+        entity.set("queryPrice", self.query_price);
         ops.push(set_metadata_operation(
             Self::TYPENAME,
             id.to_string(),
@@ -375,6 +382,21 @@ impl SubgraphDeploymentEntity {
     ) -> Vec<MetadataOperation> {
         let mut entity = Entity::new();
         entity.set("synced", synced);
+
+        vec![update_metadata_operation(
+            Self::TYPENAME,
+            id.as_str(),
+            entity,
+            None,
+        )]
+    }
+
+    pub fn update_query_price_operations(
+        id: &SubgraphDeploymentId,
+        price: BigDecimal,
+    ) -> Vec<MetadataOperation> {
+        let mut entity = Entity::new();
+        entity.set("queryPrice", price);
 
         vec![update_metadata_operation(
             Self::TYPENAME,

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -79,11 +79,12 @@ fn insert_test_entities(store: &impl Store, id: SubgraphDeploymentId) {
 
     let logger = Logger::root(slog::Discard, o!());
 
-    let ops = SubgraphDeploymentEntity::new(&manifest, false, false, GENESIS_PTR.clone(), None)
-        .create_operations_replace(&id)
-        .into_iter()
-        .map(|op| op.into())
-        .collect();
+    let ops =
+        SubgraphDeploymentEntity::new(&manifest, false, false, GENESIS_PTR.clone(), None, 0, 0)
+            .create_operations_replace(&id)
+            .into_iter()
+            .map(|op| op.into())
+            .collect();
     store
         .create_subgraph_deployment(&logger, &schema, ops)
         .unwrap();

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -490,6 +490,8 @@ mod tests {
                         hash: H256::zero(),
                         number: 0,
                     }),
+                    0,
+                    0,
                 )
                 .create_operations(&id),
             )
@@ -567,6 +569,8 @@ mod tests {
                                     hash: H256::zero(),
                                     number: 0,
                                 }),
+                                0,
+                                0,
                             )
                             .create_operations(&id),
                         )

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -105,6 +105,8 @@ mod test {
                         hash: H256::zero(),
                         number: 0,
                     }),
+                    0,
+                    0,
                 )
                 .create_operations(&manifest.id),
             )

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -14,6 +14,8 @@ type SubgraphIndexingStatus {
   failed: Boolean!
   error: String
   chains: [ChainIndexingStatus!]!
+  entityCount: BigInt!
+  queryPrice: BigInt!
 }
 
 interface ChainIndexingStatus {

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -17,6 +17,7 @@ type SubgraphVersion @entity {
 type SubgraphDeployment @entity {
     id: ID! # Subgraph IPFS hash
     manifest: SubgraphManifest!
+    assignment: SubgraphDeploymentAssignment!
     failed: Boolean!
     synced: Boolean!
     earliestEthereumBlockHash: String
@@ -27,6 +28,7 @@ type SubgraphDeployment @entity {
     ethereumHeadBlockHash: String
     totalEthereumBlocksCount: BigInt!
     entityCount: BigInt!
+    queryPrice: BigInt!
     dynamicDataSources: [DynamicEthereumContractDataSource!] @derivedFrom(field: "deployment")
 }
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -154,6 +154,8 @@ fn insert_test_data(store: Arc<DieselStore>) {
         false,
         *TEST_BLOCK_0_PTR,
         Some(*TEST_BLOCK_0_PTR),
+        0,
+        0,
     )
     .create_operations(&*TEST_SUBGRAPH_ID);
     store
@@ -1924,6 +1926,8 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             false,
             *TEST_BLOCK_0_PTR,
             Some(*TEST_BLOCK_0_PTR),
+            0,
+            0,
         )
         .create_operations(&subgraph_id);
         store


### PR DESCRIPTION
Resolves #1156

This PR adds to the surface area of the Indexing Statuses API, now including several additional fields: `entity_count` and `query_price`.  The new fields have also been included in the `SubgraphDeploymentEntity`.
I have created a new branch off master (`hybrid-network`), so we can keep the master branch free of hybrid network specific features.
