### PR TITLE
Create new RPC method: update_query_prices()

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -327,23 +327,26 @@ where
         )))
     }
 
-    fn update_subgraph_price(
+    fn update_subgraph_query_price(
         &self,
         hash: SubgraphDeploymentId,
-        price: f32,
+        price: u64,
     ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static> {
-        Box::new(future::result(update_subgraph_price(
+        Box::new(future::result(update_subgraph_query_price(
             self.store.clone(),
             hash,
             price,
         )))
     }
 
-    fn update_all_prices(
+    fn update_subgraph_query_prices(
         &self,
-        price: f32,
+        prices: Vec<(SubgraphDeploymentId, u64)>,
     ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static> {
-        Box::new(future::result(update_all_prices(self.store.clone(), price)))
+        Box::new(future::result(update_subgraph_query_prices(
+            self.store.clone(),
+            prices,
+        )))
     }
 }
 
@@ -959,14 +962,87 @@ fn reassign_subgraph(
     Ok(())
 }
 
-fn update_subgraph_price(
-    _store: Arc<impl Store>,
-    _hash: SubgraphDeploymentId,
-    _price: f32,
+fn update_subgraph_query_price(
+    store: Arc<impl Store>,
+    hash: SubgraphDeploymentId,
+    price: u64,
 ) -> Result<(), SubgraphRegistrarError> {
+    let mut ops = vec![];
+
+    let current_deployment = store.find(
+        SubgraphDeploymentEntity::query()
+            .filter(EntityFilter::new_equal("id", hash.clone().to_string())),
+    )?;
+
+    let current_query_price = current_deployment
+        .first()
+        .and_then(|d| d.get("queryPrice"))
+        .ok_or_else(|| SubgraphRegistrarError::DeploymentNotFound(hash.clone().to_string()))?;
+
+    if current_query_price.to_string() == price.to_string() {
+        return Err(SubgraphRegistrarError::DeploymentAssignmentUnchanged(
+            hash.clone().to_string(),
+        ));
+    }
+
+    ops.push(MetadataOperation::AbortUnless {
+        description: "Deployment assignment is unchanged".to_owned(),
+        query: SubgraphDeploymentAssignmentEntity::query().filter(EntityFilter::And(vec![
+            EntityFilter::new_equal("queryPrice", current_query_price.to_string()),
+            EntityFilter::new_equal("id", hash.clone().to_string()),
+        ])),
+        entity_ids: vec![hash.clone().to_string()],
+    });
+
+    ops.extend(SubgraphDeploymentEntity::update_query_price_operations(
+        &hash, price,
+    ));
+
+    store.apply_metadata_operations(ops)?;
+
     Ok(())
 }
 
-fn update_all_prices(_store: Arc<impl Store>, _price: f32) -> Result<(), SubgraphRegistrarError> {
+fn update_subgraph_query_prices(
+    store: Arc<impl Store>,
+    prices: Vec<(SubgraphDeploymentId, u64)>,
+) -> Result<(), SubgraphRegistrarError> {
+    let mut ops = vec![];
+
+    for subgraph_price in prices {
+        let hash = subgraph_price.0;
+        let price = subgraph_price.1;
+        let current_deployment = store.find(
+            SubgraphDeploymentEntity::query()
+                .filter(EntityFilter::new_equal("id", hash.to_string())),
+        )?;
+
+        let current_query_price = current_deployment
+            .first()
+            .and_then(|d| d.get("queryPrice"))
+            .ok_or_else(|| SubgraphRegistrarError::DeploymentNotFound(hash.clone().to_string()))?;
+
+        if current_query_price.to_string() == price.to_string() {
+            return Err(SubgraphRegistrarError::DeploymentAssignmentUnchanged(
+                hash.clone().to_string(),
+            ));
+        }
+
+        ops.push(MetadataOperation::AbortUnless {
+            description: "Deployment assignment is unchanged".to_owned(),
+            query: SubgraphDeploymentAssignmentEntity::query().filter(EntityFilter::And(vec![
+                EntityFilter::new_equal("queryPrice", current_query_price.to_string()),
+                EntityFilter::new_equal("id", hash.clone().to_string()),
+            ])),
+            entity_ids: vec![hash.clone().to_string()],
+        });
+
+        ops.extend(SubgraphDeploymentEntity::update_query_price_operations(
+            &hash, price,
+        ));
+    }
+
+    store.apply_metadata_operations(ops)?;
+
     Ok(())
 }

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -326,6 +326,25 @@ where
             node_id,
         )))
     }
+
+    fn update_subgraph_price(
+        &self,
+        hash: SubgraphDeploymentId,
+        price: f32,
+    ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static> {
+        Box::new(future::result(update_subgraph_price(
+            self.store.clone(),
+            hash,
+            price,
+        )))
+    }
+
+    fn update_all_prices(
+        &self,
+        price: f32,
+    ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static> {
+        Box::new(future::result(update_all_prices(self.store.clone(), price)))
+    }
 }
 
 fn handle_assignment_event<P>(
@@ -937,5 +956,17 @@ fn reassign_subgraph(
 
     store.apply_metadata_operations(ops)?;
 
+    Ok(())
+}
+
+fn update_subgraph_price(
+    _store: Arc<impl Store>,
+    _hash: SubgraphDeploymentId,
+    _price: f32,
+) -> Result<(), SubgraphRegistrarError> {
+    Ok(())
+}
+
+fn update_all_prices(_store: Arc<impl Store>, _price: f32) -> Result<(), SubgraphRegistrarError> {
     Ok(())
 }

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -41,14 +41,14 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
         node_id: NodeId,
     ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
 
-    fn update_subgraph_price(
+    fn update_subgraph_query_price(
         &self,
         hash: SubgraphDeploymentId,
-        price: f32,
+        price: u64,
     ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
 
-    fn update_all_prices(
+    fn update_subgraph_query_prices(
         &self,
-        price: f32,
+        prices: Vec<(SubgraphDeploymentId, u64)>,
     ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
 }

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -40,4 +40,15 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
         hash: SubgraphDeploymentId,
         node_id: NodeId,
     ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
+
+    fn update_subgraph_price(
+        &self,
+        hash: SubgraphDeploymentId,
+        price: f32,
+    ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
+
+    fn update_all_prices(
+        &self,
+        price: f32,
+    ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
 }

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -41,12 +41,6 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
         node_id: NodeId,
     ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
 
-    fn update_subgraph_query_price(
-        &self,
-        hash: SubgraphDeploymentId,
-        price: u64,
-    ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
-
     fn update_subgraph_query_prices(
         &self,
         prices: Vec<(SubgraphDeploymentId, u64)>,

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -239,6 +239,8 @@ pub enum SubgraphRegistrarError {
     DeploymentNotFound(String),
     #[fail(display = "deployment assignment unchanged: {}", _0)]
     DeploymentAssignmentUnchanged(String),
+    #[fail(display = "query price unchanged, deployment: {}, price: {}", _0, _1)]
+    QueryPriceUnchanged(String, String),
     #[fail(display = "subgraph registrar internal query error: {}", _0)]
     QueryExecutionError(QueryExecutionError),
     #[fail(display = "subgraph registrar error with store: {}", _0)]

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -393,7 +393,7 @@ impl SubgraphDeploymentEntity {
 
     pub fn update_query_price_operations(
         id: &SubgraphDeploymentId,
-        price: BigDecimal,
+        price: u64,
     ) -> Vec<MetadataOperation> {
         let mut entity = Entity::new();
         entity.set("queryPrice", price);


### PR DESCRIPTION
Resolves #1157

Graph-node operators may want to apply regular query pricing updates based upon their system and market analysis. This PR adds an endpoint that allows one with access to update the `query_price` for any existing deployment on the node. 