### PR TITLE
Only report indexing statuses for assigned deployments

### DIFF
--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -190,13 +190,13 @@ struct IndexingStatuses(Vec<IndexingStatus>);
 impl From<&QueryResult> for IndexingStatuses {
     fn from(result: &QueryResult) -> Self {
         // Extract deployment assignment IDs from the query result
-        let assignments = dbg!(result.data.as_ref().map_or(vec![], |value| {
+        let assignments = result.data.as_ref().map_or(vec![], |value| {
             value
                 .get_required::<q::Value>("subgraphDeploymentAssignments")
                 .expect("no subgraph deployment assignments in the result")
                 .get_values::<AssignmentId>()
                 .expect("failed to parse subgraph deployment assignments")
-        }));
+        });
 
         IndexingStatuses(
             result
@@ -213,10 +213,10 @@ impl From<&QueryResult> for IndexingStatuses {
                 .into_iter()
                 // Filter out those deployments for which there is no active assignment
                 .filter(|status: &IndexingStatus| {
-                    dbg!(assignments
+                    assignments
                         .iter()
                         .find(|id| id.0 == status.subgraph)
-                        .is_some())
+                        .is_some()
                 })
                 .collect(),
         )

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -14,6 +14,7 @@ type SubgraphIndexingStatus {
   failed: Boolean!
   error: String
   chains: [ChainIndexingStatus!]!
+  node: String!
 }
 
 interface ChainIndexingStatus {

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -5,6 +5,7 @@ scalar ID
 scalar String
 
 type Query {
+  indexingStatusesForSubgraphName(subgraphName: String!): [SubgraphIndexingStatus!]!
   indexingStatuses(subgraphs: [String!]): [SubgraphIndexingStatus!]!
 }
 

--- a/server/index-node/src/schema.rs
+++ b/server/index-node/src/schema.rs
@@ -4,7 +4,7 @@ use graph::prelude::*;
 
 lazy_static! {
     pub static ref SCHEMA: Arc<Schema> = {
-        let raw_schema = dbg!(include_str!("./schema.graphql"));
+        let raw_schema = include_str!("./schema.graphql");
         let document = graphql_parser::parse_schema(&raw_schema).unwrap();
         let (interfaces_for_type, types_for_interface) =
             Schema::collect_interfaces(&document).unwrap();


### PR DESCRIPTION
Instead of returning the indexing status for all subgraph deployments of the node, only include the deployments that are currently assigned.

This is achieved by filtering the deployments before returning them, such that only those are included where a subgraph deployment assignment exists with the same ID. Note: this does not filter by the node ID.

