### PR TITLE
Remove assertion that events are ordered

### DIFF
--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -950,9 +950,6 @@ where
                         .as_u64();
                     let block_ptr = EthereumBlockPointer::from((hash, number));
                     if !block_ptrs.contains(&block_ptr) {
-                        if let Some(prev) = block_ptrs.last() {
-                            assert!(prev.number < number);
-                        }
                         block_ptrs.push(block_ptr);
                     }
                 }


### PR DESCRIPTION
The assertion assumes that events from `log_stream` are ordered by block number. We've observed that this isn't the case in production.