### PR TITLE
Allow nested filter

### DIFF
--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -27,9 +27,9 @@ pub fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
     let mut schema = input_schema.clone();
     add_builtin_scalar_types(&mut schema)?;
     add_order_direction_enum(&mut schema);
-    add_field_arguments(&mut schema, &input_schema)?;
     add_types_for_object_types(&mut schema, &object_types)?;
     add_types_for_interface_types(&mut schema, &interface_types)?;
+    add_field_arguments(&mut schema, &input_schema)?;
     add_query_type(&mut schema, &object_types, &interface_types)?;
     add_subscription_type(&mut schema, &object_types, &interface_types)?;
     Ok(schema)

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1192,3 +1192,56 @@ fn subscription_gets_result_even_without_events() {
         )])),
     );
 }
+
+#[test]
+fn can_use_nested_filter() {
+    let result = execute_query_document(
+        graphql_parser::parse_query(
+            "
+        query {
+            musicians(orderBy: id) {
+                name
+                bands(where: { originalSongs: [\"s1\", \"s3\", \"s4\"] }) { id }
+            }
+        }
+        ",
+        )
+        .expect("invalid test query"),
+    );
+
+    assert_eq!(
+        result.data.unwrap(),
+        object_value(vec![(
+            "musicians",
+            q::Value::List(vec![
+                object_value(vec![
+                    ("name", q::Value::String(String::from("John"))),
+                    (
+                        "bands",
+                        q::Value::List(vec![object_value(vec![(
+                            "id",
+                            q::Value::String(String::from("b2"))
+                        )])])
+                    )
+                ]),
+                object_value(vec![
+                    ("name", q::Value::String(String::from("Lisa"))),
+                    ("bands", q::Value::List(vec![]))
+                ]),
+                object_value(vec![
+                    ("name", q::Value::String(String::from("Tom"))),
+                    (
+                        "bands",
+                        q::Value::List(vec![object_value(vec![
+                            (("id", q::Value::String(String::from("b2"))))
+                        ])])
+                    )
+                ]),
+                object_value(vec![
+                    ("name", q::Value::String(String::from("Valerie"))),
+                    ("bands", q::Value::List(vec![]))
+                ])
+            ])
+        )])
+    )
+}


### PR DESCRIPTION
By adding the filters after the `where` types are added. Resolves https://github.com/graphprotocol/support/issues/25.