### PR TITLE
Refactor triggers

### DIFF
--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -969,44 +969,10 @@ where
         triggers.append(&mut parse_call_triggers(call_filter, &descendant_block));
         triggers.append(&mut parse_block_triggers(block_filter, &descendant_block));
 
-        let tx_hash_indexes = descendant_block
-            .ethereum_block
-            .transaction_receipts
-            .iter()
-            .map(|receipt| (receipt.transaction_hash, receipt.transaction_index.as_u64()))
-            .collect::<HashMap<H256, u64>>();
-
-        // Ensure all `Call` and `Log` triggers have a transaction index
-        for trigger in triggers.iter() {
-            match trigger {
-                EthereumTrigger::Log(log) => {
-                    if !tx_hash_indexes
-                        .get(&log.transaction_hash.unwrap())
-                        .is_some()
-                    {
-                        return Err(format_err!(
-                            "Unable to determine transaction index for Ethereum event."
-                        ));
-                    }
-                }
-                EthereumTrigger::Call(call) => {
-                    if !tx_hash_indexes
-                        .get(&call.transaction_hash.unwrap())
-                        .is_some()
-                    {
-                        return Err(format_err!(
-                            "Unable to determine transaction index for Ethereum call."
-                        ));
-                    }
-                }
-                EthereumTrigger::Block(_) => continue,
-            }
-        }
-
         // Sort the triggers
         triggers.sort_by(|a, b| {
-            let a_tx_index = a.transaction_index(&tx_hash_indexes).unwrap();
-            let b_tx_index = b.transaction_index(&tx_hash_indexes).unwrap();
+            let a_tx_index = a.transaction_index();
+            let b_tx_index = b.transaction_index();
             if a_tx_index.is_none() && b_tx_index.is_none() {
                 return Ordering::Equal;
             }

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -15,7 +15,7 @@ pub struct EthereumBlockWithCalls {
     pub calls: Option<Vec<EthereumCall>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct EthereumBlock {
     pub block: Block<Transaction>,
     pub transaction_receipts: Vec<TransactionReceipt>,
@@ -32,38 +32,6 @@ impl EthereumBlock {
         call.transaction_hash
             .and_then(|hash| self.block.transactions.iter().find(|tx| tx.hash == hash))
             .cloned()
-    }
-}
-
-// Remove this and derive after a new web3 is released.
-impl Default for EthereumBlock {
-    fn default() -> Self {
-        Self {
-            block: Block {
-                hash: Some(H256::default()),
-                parent_hash: H256::default(),
-                uncles_hash: H256::default(),
-                author: H160::default(),
-                state_root: H256::default(),
-                transactions_root: H256::default(),
-                receipts_root: H256::default(),
-                number: None,
-                gas_used: U256::default(),
-                gas_limit: U256::default(),
-                extra_data: Bytes(vec![]),
-                logs_bloom: H2048::default(),
-                timestamp: U256::default(),
-                difficulty: U256::default(),
-                total_difficulty: U256::default(),
-                seal_fields: vec![],
-                uncles: vec![],
-                transactions: vec![],
-                size: None,
-                mix_hash: Some(H256::default()),
-                nonce: None,
-            },
-            transaction_receipts: vec![],
-        }
     }
 }
 

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -3,14 +3,14 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use web3::types::*;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub struct EthereumBlockWithTriggers {
     pub ethereum_block: EthereumBlock,
     pub triggers: Vec<EthereumTrigger>,
     pub calls: Option<Vec<EthereumCall>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub struct EthereumBlockWithCalls {
     pub ethereum_block: EthereumBlock,
     pub calls: Option<Vec<EthereumCall>>,
@@ -68,7 +68,7 @@ impl Default for EthereumBlock {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EthereumCall {
     pub from: Address,
     pub to: Address,
@@ -114,14 +114,14 @@ impl EthereumCall {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub enum EthereumTrigger {
     Block(EthereumBlockTriggerType),
     Call(EthereumCall),
     Log(Log),
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub enum EthereumBlockTriggerType {
     Every,
     WithCallTo(Address),
@@ -151,7 +151,7 @@ impl EthereumTrigger {
 }
 
 /// Ethereum block data.
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default)]
 pub struct EthereumBlockData {
     pub hash: H256,
     pub parent_hash: H256,
@@ -292,7 +292,7 @@ impl Clone for EthereumCallData {
 /// A block hash and block number from a specific Ethereum block.
 ///
 /// Maximum block number supported: 2^63 - 1
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct EthereumBlockPointer {
     pub hash: H256,
     pub number: u64,


### PR DESCRIPTION
Simplify how we order triggers by taking advantage of logs and calls already knowing their transaction index. And some small cleanups.