### PR TITLE
Set min_idle_connections on ConnectionPool

### DIFF
--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -158,6 +158,7 @@ impl Store {
             // turns off this timeout and makes it possible that work needing
             // a database connection blocks for a very long time
             .connection_timeout(Duration::from_secs(6 * 60 * 60))
+            .min_idle(Some(1))
             .max_size(config.conn_pool_size)
             .build(conn_manager)
             .unwrap();


### PR DESCRIPTION
Since adding support for multiple networks on one `graph-node`, there are nodes with idle connection pools for networks they are not using.

The `idle_timeout` defaults to `10` minutes: https://docs.diesel.rs/r2d2/struct.Builder.html#method.idle_timeout.