### PR TITLE
Use a separate timeout for loading subgraph files from IPFS

### DIFF
--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -240,6 +240,7 @@ mod tests {
         env::set_var(MAX_IPFS_FILE_SIZE_VAR, "200");
         let file: &[u8] = &[0u8; 201];
         let client = ipfs_api::IpfsClient::default();
+        let resolver = super::LinkResolver::from(client.clone());
 
         let logger = Logger::root(slog::Discard, o!());
 
@@ -247,7 +248,7 @@ mod tests {
         let link = runtime.block_on(client.add(file)).unwrap().hash;
         let err = runtime
             .block_on(LinkResolver::cat(
-                &client.into(),
+                &resolver,
                 &logger,
                 &Link { link: link.clone() },
             ))
@@ -264,11 +265,12 @@ mod tests {
 
     fn json_round_trip(text: &'static str) -> Result<Vec<Value>, failure::Error> {
         let client = ipfs_api::IpfsClient::default();
+        let resolver = super::LinkResolver::from(client.clone());
 
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
         let link = runtime.block_on(client.add(text.as_bytes())).unwrap().hash;
         runtime.block_on(
-            LinkResolver::json_stream(&client.into(), &Link { link: link.clone() })
+            LinkResolver::json_stream(&resolver, &Link { link: link.clone() })
                 .and_then(|stream| stream.map(|sv| sv.value).collect()),
         )
     }

--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -100,10 +100,9 @@ impl From<ipfs_api::IpfsClient> for LinkResolver {
 }
 
 impl LinkResolverTrait for LinkResolver {
-    fn with_timeout(&self, timeout: Duration) -> Self {
-        let mut other = self.clone();
-        other.timeout = timeout;
-        other
+    fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
     }
 
     /// Supports links of the form `/ipfs/ipfs_hash` or just `ipfs_hash`.

--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -29,14 +29,10 @@ lazy_static! {
     static ref MAX_IPFS_CACHE_SIZE: u64 = read_u64_from_env("GRAPH_MAX_IPFS_CACHE_SIZE")
         .unwrap_or(50);
 
-}
-
-// The timeout for IPFS requests in seconds
-fn ipfs_timeout() -> Duration {
-    let timeout = env::var("GRAPH_IPFS_TIMEOUT").ok().map(|s| {
-        u64::from_str(&s).unwrap_or_else(|_| panic!("failed to parse env var GRAPH_IPFS_TIMEOUT"))
-    });
-    Duration::from_secs(timeout.unwrap_or(60))
+    // The timeout for IPFS requests in seconds
+    static ref IPFS_TIMEOUT: Duration = Duration::from_secs(
+        read_u64_from_env("GRAPH_IPFS_TIMEOUT").unwrap_or(60)
+    );
 }
 
 fn read_u64_from_env(name: &str) -> Option<u64> {
@@ -98,7 +94,7 @@ impl From<ipfs_api::IpfsClient> for LinkResolver {
             cache: Arc::new(Mutex::new(LruCache::with_capacity(
                 *MAX_IPFS_CACHE_SIZE as usize,
             ))),
-            timeout: ipfs_timeout(),
+            timeout: *IPFS_TIMEOUT,
         }
     }
 }

--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -100,10 +100,10 @@ impl From<ipfs_api::IpfsClient> for LinkResolver {
 }
 
 impl LinkResolverTrait for LinkResolver {
-    fn with_timeout(&self, timeout: Duration) -> Box<Self> {
+    fn with_timeout(&self, timeout: Duration) -> Self {
         let mut other = self.clone();
         other.timeout = timeout;
-        Box::new(other)
+        other
     }
 
     /// Supports links of the form `/ipfs/ipfs_hash` or just `ipfs_hash`.

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::iter;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::ops::Deref;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use super::validation;
 use graph::data::subgraph::schema::{
@@ -46,7 +47,12 @@ where
         SubgraphRegistrar {
             logger,
             logger_factory,
-            resolver,
+            resolver: Arc::new(
+                *resolver
+                    .clone()
+                    .deref()
+                    .with_timeout(Duration::from_secs(60)),
+            ),
             provider,
             store,
             chain_stores,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -1,7 +1,18 @@
+use lazy_static::lazy_static;
 use std::collections::{HashMap, HashSet};
-use std::iter;
 use std::ops::Deref;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::{env, iter};
+
+lazy_static! {
+    // The timeout for IPFS requests in seconds
+    static ref IPFS_SUBGRAPH_LOADING_TIMEOUT: Duration = Duration::from_secs(
+        env::var("GRAPH_IPFS_SUBGRAPH_LOADING_TIMEOUT")
+            .unwrap_or("60".into())
+            .parse::<u64>()
+            .expect("invalid IPFS subgraph loading timeout")
+    );
+}
 
 use super::validation;
 use graph::data::subgraph::schema::{
@@ -51,7 +62,7 @@ where
                 *resolver
                     .clone()
                     .deref()
-                    .with_timeout(Duration::from_secs(60)),
+                    .with_timeout(*IPFS_SUBGRAPH_LOADING_TIMEOUT),
             ),
             provider,
             store,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -1,6 +1,5 @@
 use lazy_static::lazy_static;
 use std::collections::{HashMap, HashSet};
-use std::ops::Deref;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::{env, iter};
 
@@ -60,8 +59,8 @@ where
             logger_factory,
             resolver: Arc::new(
                 resolver
+                    .as_ref()
                     .clone()
-                    .deref()
                     .with_timeout(*IPFS_SUBGRAPH_LOADING_TIMEOUT),
             ),
             provider,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -59,7 +59,7 @@ where
             logger,
             logger_factory,
             resolver: Arc::new(
-                *resolver
+                resolver
                     .clone()
                     .deref()
                     .with_timeout(*IPFS_SUBGRAPH_LOADING_TIMEOUT),

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -45,7 +45,8 @@ those.
   take (in seconds, default is unlimited)
 - `GRAPH_IPFS_SUBGRAPH_LOADING_TIMEOUT`: timeout for IPFS requests made to load
   subgraph files from IPFS (in seconds, default is 60).
-- `GRAPH_IPFS_TIMEOUT`: timeout for IPFS requests (in seconds, default is 60).
+- `GRAPH_IPFS_TIMEOUT`: timeout for IPFS requests from mappings using `ipfs.cat`
+  or `ipfs.map` (in seconds, default is 60).
 - `GRAPH_MAX_IPFS_FILE_BYTES`: maximum size for a file that can be retrieved
   with `ipfs.cat` (in bytes, default is unlimited)
 - `GRAPH_MAX_IPFS_MAP_FILE_SIZE`: maximum size of files that can be processed

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -43,8 +43,9 @@ those.
 
 - `GRAPH_MAPPING_HANDLER_TIMEOUT`: amount of time a mapping handler is allowed to
   take (in seconds, default is unlimited)
-- `GRAPH_IPFS_TIMEOUT`: timeout for ipfs requests. In seconds, default is 60.
-  seconds.
+- `GRAPH_IPFS_SUBGRAPH_LOADING_TIMEOUT`: timeout for IPFS requests made to load
+  subgraph files from IPFS (in seconds, default is 60).
+- `GRAPH_IPFS_TIMEOUT`: timeout for IPFS requests (in seconds, default is 60).
 - `GRAPH_MAX_IPFS_FILE_BYTES`: maximum size for a file that can be retrieved
   with `ipfs.cat` (in bytes, default is unlimited)
 - `GRAPH_MAX_IPFS_MAP_FILE_SIZE`: maximum size of files that can be processed

--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -1,6 +1,7 @@
 use failure;
 use serde_json::Value;
 use slog::Logger;
+use std::time::Duration;
 use tokio::prelude::*;
 
 use crate::data::subgraph::Link;
@@ -18,6 +19,9 @@ pub type JsonValueStream =
 
 /// Resolves links to subgraph manifests and resources referenced by them.
 pub trait LinkResolver: Send + Sync + 'static + Sized {
+    /// Creates a new link resolver that implements the given timeout.
+    fn with_timeout(&self, timeout: Duration) -> Box<Self>;
+
     /// Fetches the link contents as bytes.
     fn cat(
         &self,

--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -18,9 +18,9 @@ pub type JsonValueStream =
     Box<dyn Stream<Item = JsonStreamValue, Error = failure::Error> + Send + 'static>;
 
 /// Resolves links to subgraph manifests and resources referenced by them.
-pub trait LinkResolver: Send + Sync + 'static + Sized {
-    /// Creates a new link resolver that implements the given timeout.
-    fn with_timeout(&self, timeout: Duration) -> Self;
+pub trait LinkResolver: Clone + Send + Sync + 'static + Sized {
+    /// Updates the timeout used by the resolver.
+    fn with_timeout(self, timeout: Duration) -> Self;
 
     /// Fetches the link contents as bytes.
     fn cat(

--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -20,7 +20,7 @@ pub type JsonValueStream =
 /// Resolves links to subgraph manifests and resources referenced by them.
 pub trait LinkResolver: Send + Sync + 'static + Sized {
     /// Creates a new link resolver that implements the given timeout.
-    fn with_timeout(&self, timeout: Duration) -> Box<Self>;
+    fn with_timeout(&self, timeout: Duration) -> Self;
 
     /// Fetches the link contents as bytes.
     fn cat(


### PR DESCRIPTION
Before, whatever you set as the IPFS timeout was used not just for `ipfs.cat` in mappings, but also for loading subgraphs. Now, when you set the timeout to a short duration (like 2s), subgraphs would often fail to start up. Restricting the time spent in `ipfs.cat` is reasonable thing to do though, so the timeout used for `ipfs.cat` and subgraph loading should be independent.

This change adds a `with_timeout` method to `LinkResolver` to create a cloned resolver that has its own timeout. This is then used in the `SubgraphRegistrar` to set the timeout for manifest resolution based on the `GRAPH_IPFS_SUBGRAPH_LOADING_TIMEOUT` environment variable (default: 60 seconds).

