### PR TITLE
Use subgraph loading IPFS timeout in `SubgraphProvider` as well

### DIFF
--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -8,6 +8,7 @@ use graph::prelude::{
     SubgraphAssignmentProvider as SubgraphAssignmentProviderTrait, *,
 };
 
+use crate::subgraph::registrar::IPFS_SUBGRAPH_LOADING_TIMEOUT;
 use crate::DataSourceLoader;
 
 pub struct SubgraphAssignmentProvider<L, Q, S> {
@@ -44,7 +45,12 @@ where
             logger_factory,
             event_stream: Some(event_stream),
             event_sink,
-            resolver,
+            resolver: Arc::new(
+                resolver
+                    .as_ref()
+                    .clone()
+                    .with_timeout(*IPFS_SUBGRAPH_LOADING_TIMEOUT),
+            ),
             subgraphs_running: Arc::new(Mutex::new(HashSet::new())),
             store,
             graphql_runner,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -5,7 +5,7 @@ use std::{env, iter};
 
 lazy_static! {
     // The timeout for IPFS requests in seconds
-    static ref IPFS_SUBGRAPH_LOADING_TIMEOUT: Duration = Duration::from_secs(
+    pub static ref IPFS_SUBGRAPH_LOADING_TIMEOUT: Duration = Duration::from_secs(
         env::var("GRAPH_IPFS_SUBGRAPH_LOADING_TIMEOUT")
             .unwrap_or("60".into())
             .parse::<u64>()


### PR DESCRIPTION
This was forgotten when merging #1238.

