### PR TITLE
store: Reduce the size of string prefixes we index

### DIFF
--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -55,10 +55,13 @@ use crate::notification_listener::JsonNotification;
 use crate::relational::{IdType, Layout};
 use crate::store::Store;
 
-/// The size of string prefixes that we index. This should be large enough
-/// that we catch most strings, but small enough so that we can still insert
-/// it into a Postgres BTree index
-pub(crate) const STRING_PREFIX_SIZE: usize = 2048;
+/// The size of string prefixes that we index. This is chosen so that we
+/// will index strings that people will do string comparisons like
+/// `=` or `!=` on; if text longer than this is stored in a String attribute
+/// it is highly unlikely that they will be used for exact string operations.
+/// This also makes sure that we do not put strings into a BTree index that's
+/// bigger than Postgres' limit on such strings which is about 2k
+pub const STRING_PREFIX_SIZE: usize = 256;
 
 /// The type of operation that led to a history entry. When we revert a block,
 /// we reverse the effects of that operation; e.g., an `Insert` entry in the

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -45,6 +45,7 @@ pub mod db_schema_for_tests {
 #[cfg(debug_assertions)]
 pub mod layout_for_tests {
     pub use crate::block_range::*;
+    pub use crate::entities::STRING_PREFIX_SIZE;
     pub use crate::relational::*;
 }
 

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -918,7 +918,7 @@ create index attr_1_2_scalar_int
 create index attr_1_3_scalar_big_decimal
     on rel.\"scalar\" using btree(\"big_decimal\");
 create index attr_1_4_scalar_string
-    on rel.\"scalar\" using btree(left(\"string\", 2048));
+    on rel.\"scalar\" using btree(left(\"string\", 256));
 create index attr_1_5_scalar_bytes
     on rel.\"scalar\" using btree(\"bytes\");
 create index attr_1_6_scalar_big_int
@@ -968,7 +968,7 @@ type SongStat @entity {
 create index attr_0_0_musician_id
     on rel.\"musician\" using btree(\"id\");
 create index attr_0_1_musician_name
-    on rel.\"musician\" using btree(left(\"name\", 2048));
+    on rel.\"musician\" using btree(left(\"name\", 256));
 create index attr_0_2_musician_main_band
     on rel.\"musician\" using btree(\"main_band\");
 create index attr_0_3_musician_bands
@@ -986,7 +986,7 @@ create table rel.\"band\" (
 create index attr_1_0_band_id
     on rel.\"band\" using btree(\"id\");
 create index attr_1_1_band_name
-    on rel.\"band\" using btree(left(\"name\", 2048));
+    on rel.\"band\" using btree(left(\"name\", 256));
 create index attr_1_2_band_original_songs
     on rel.\"band\" using gin(\"original_songs\");
 
@@ -1002,7 +1002,7 @@ create table rel.\"song\" (
 create index attr_2_0_song_id
     on rel.\"song\" using btree(\"id\");
 create index attr_2_1_song_title
-    on rel.\"song\" using btree(left(\"title\", 2048));
+    on rel.\"song\" using btree(left(\"title\", 256));
 create index attr_2_2_song_written_by
     on rel.\"song\" using btree(\"written_by\");
 

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -250,10 +250,10 @@ impl Comparison {
 
 /// Produce a comparison between the string column `column` and the string
 /// value `text` that makes it obvious to Postgres' optimizer that it can
-/// first consult the partial index on `left(column, 2048)` instead of going
-/// straight to a sequential scan of the underlying table. We do this by
-/// writing the comparison `column op text` in a way that
-/// involves `left(column, 2048)`
+/// first consult the partial index on `left(column, STRING_PREFIX_SIZE)`
+/// instead of going straight to a sequential scan of the underlying table.
+/// We do this by writing the comparison `column op text` in a way that
+/// involves `left(column, STRING_PREFIX_SIZE)`
 #[derive(Constructor)]
 struct PrefixComparison<'a> {
     op: Comparison,
@@ -299,13 +299,13 @@ impl<'a> QueryFragment<Pg> for PrefixComparison<'a> {
 
         // For the various comparison operators, we want to write the condition
         // `column op text` in a way that lets Postgres use the index on
-        // `left(column, 2048)`. If at all possible, we also want the condition
-        // in a form that only uses the index, or if that's not possible, in
-        // a form where Postgres can first reduce the number of rows where
-        // a full comparison between `column` and `text` is needed by consulting
-        // the index.
+        // `left(column, STRING_PREFIX_SIZE)`. If at all possible, we also want
+        // the condition in a form that only uses the index, or if that's not
+        // possible, in a form where Postgres can first reduce the number of
+        // rows where a full comparison between `column` and `text` is needed
+        // by consulting the index.
         //
-        // To ease notation, let `N = 2048` and write a string stored in
+        // To ease notation, let `N = STRING_PREFIX_SIZE` and write a string stored in
         // `column` as `uv` where `len(u) <= N`; that means that `v` is only
         // nonempty if `len(uv) > N`. We similarly split `text` into `st` where
         // `len(s) <= N`. In other words, `u = left(column, N)` and

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -13,6 +13,7 @@ use graph::data::store::scalar;
 use graph::data::subgraph::schema::*;
 use graph::data::subgraph::*;
 use graph::prelude::*;
+use graph_store_postgres::layout_for_tests::STRING_PREFIX_SIZE;
 use graph_store_postgres::Store as DieselStore;
 use web3::types::{Address, H256};
 
@@ -2339,7 +2340,7 @@ fn handle_large_string_with_index() {
 
         // Make sure we check the full string and not just a prefix
         let mut prefix = long_text.clone();
-        prefix.truncate(2048);
+        prefix.truncate(STRING_PREFIX_SIZE);
         let query = EntityQuery::new(
             TEST_SUBGRAPH_ID.clone(),
             vec![USER.to_owned()],


### PR DESCRIPTION
The previous size of 2k was the largest we could store in a Postgres BTree
index, but it's excessive for supporting normal string operations; anything
beyond a few hundred bytes is text, and very unlikely to be accessed
through 'hard' string comparisons; it's much more likely that such text
will be accessed through word searches and similar for which the BTree
index is of no use anyway.

We lower the prefix size to 256 to reduce the size of the index for
attributes that do store large text entries.

