### PR TITLE
Smarter use of eth_getLogs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "flate2"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +872,7 @@ dependencies = [
  "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1771,6 +1777,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordermap"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,6 +1863,15 @@ dependencies = [
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "petgraph"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "phf"
@@ -3454,6 +3474,7 @@ dependencies = [
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
 "checksum fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d1a683d1234507e4f3bf2736eeddf0de1dc65996dc0164d57eba0a74bcf29489"
+"checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f87e68aa82b2de08a6e037f1385455759df6e445a8df5e005b4297191dbf18aa"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -3542,6 +3563,7 @@ dependencies = [
 "checksum openssl 0.10.18 (registry+https://github.com/rust-lang/crates.io-index)" = "b90119d71b0a3596588da04bf7c2c42f2978cfa1217a94119d8ec9e963c7729c"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.41 (registry+https://github.com/rust-lang/crates.io-index)" = "e4c77cdd67d31759b22aa72cfda3c65c12348f9e6c5420946b403c022fd0311a"
+"checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parity-codec 3.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2b9df1283109f542d8852cd6b30e9341acc2137481eb6157d2e62af68b0afec9"
@@ -3551,6 +3573,7 @@ dependencies = [
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
 "checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
 "checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -157,7 +157,7 @@ where
                     .from_block(from.into())
                     .to_block(to.into())
                     .address(filter.contracts.clone())
-                    .topics(Some(filter.event_sigs.clone()), None, None, None)
+                    .topics(Some(filter.event_signatures.clone()), None, None, None)
                     .build();
 
                 // Request logs from client

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -223,9 +223,9 @@ where
         // Collect all event sigs
         let eth = self.clone();
         let step = match filter.contracts.is_empty() {
-            // `to - from` is the size of the full range.
+            // `to - from + 1`  blocks will be scanned.
             false => to - from,
-            true => (to - from).min(*MAX_EVENT_ONLY_RANGE),
+            true => (to - from).min(*MAX_EVENT_ONLY_RANGE - 1),
         };
 
         stream::unfold((from, step), move |(start, step)| {

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -38,6 +38,7 @@ slog = { version = "2.2.3", features = ["release_max_level_trace", "max_level_tr
 slog-async = "2.3.0"
 slog-envlogger = "2.1.0"
 slog-term = "2.4.1"
+petgraph = "0.4.13"
 tiny-keccak = "1.4.2"
 tokio = "0.1.22"
 tokio-executor = "0.1.5"

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -10,6 +10,8 @@ use web3::types::*;
 use super::types::*;
 use crate::prelude::*;
 
+pub type EventSig = H256;
+
 /// A collection of attributes that (kind of) uniquely identify an Ethereum blockchain.
 pub struct EthereumNetworkIdentifier {
     pub net_version: String,
@@ -86,7 +88,7 @@ impl From<Error> for EthereumAdapterError {
 
 #[derive(Clone, Debug)]
 pub struct EthereumLogFilter {
-    pub contract_address_and_event_sig_pairs: HashSet<(Option<Address>, H256)>,
+    pub contract_address_and_event_sig_pairs: HashSet<(Option<Address>, EventSig)>,
 }
 
 impl EthereumLogFilter {
@@ -150,6 +152,12 @@ impl EthereumLogFilter {
             contract_address_and_event_sig_pairs,
         } = self;
         contract_address_and_event_sig_pairs.is_empty()
+    }
+
+    pub fn eth_log_filters(self) -> impl Iterator<Item = (Vec<Address>, Vec<EventSig>)> {
+        self.contract_address_and_event_sig_pairs
+            .into_iter()
+            .map(|(address, event)| (address.into_iter().collect(), vec![event]))
     }
 }
 

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -4,8 +4,8 @@ mod stream;
 mod types;
 
 pub use self::adapter::{
-    EthereumAdapter, EthereumAdapterError, EthereumBlockFilter, EthereumCallFilter,
-    EthereumContractCall, EthereumContractCallError, EthereumContractState,
+    EthGetLogsFilter, EthereumAdapter, EthereumAdapterError, EthereumBlockFilter,
+    EthereumCallFilter, EthereumContractCall, EthereumContractCallError, EthereumContractState,
     EthereumContractStateError, EthereumContractStateRequest, EthereumLogFilter,
     EthereumNetworkIdentifier, EventSig,
 };

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -7,7 +7,7 @@ pub use self::adapter::{
     EthGetLogsFilter, EthereumAdapter, EthereumAdapterError, EthereumBlockFilter,
     EthereumCallFilter, EthereumContractCall, EthereumContractCallError, EthereumContractState,
     EthereumContractStateError, EthereumContractStateRequest, EthereumLogFilter,
-    EthereumNetworkIdentifier, EventSig,
+    EthereumNetworkIdentifier,
 };
 pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpdateStream};
 pub use self::stream::{BlockStream, BlockStreamBuilder};

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -7,7 +7,7 @@ pub use self::adapter::{
     EthereumAdapter, EthereumAdapterError, EthereumBlockFilter, EthereumCallFilter,
     EthereumContractCall, EthereumContractCallError, EthereumContractState,
     EthereumContractStateError, EthereumContractStateRequest, EthereumLogFilter,
-    EthereumNetworkIdentifier,
+    EthereumNetworkIdentifier, EventSig,
 };
 pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpdateStream};
 pub use self::stream::{BlockStream, BlockStreamBuilder};


### PR DESCRIPTION
Currently we merge all log filters for a subgraph in a single large filter. This is can be bad for two reasons:
- It returns false positives, which may be slowing down the calls.
- The filter can become too broad with many data sources, timing out on Alchemy or returning too many logs on Infura, requiring the range to be further split up.

This PR splits the `eth_getLogs` calls so that we don't request contract-event combinations we don't actually need, and even split it up a bit more than necessary for more parallel requests.

I tested with the NuoNetwork subgraph for speed and correctness, and we no longer get timeouts on it, probably because we're splitting up the call for the thousands of dynamic data sources per event, which splits it in five parallel requests. I Also tested wildcard event signatures still work.

The ERC20 subgraph didn't spend too much time getting logs, though I didn't wait for it to get very far and I'm not sure what the situation was before. At least on a cold DB the slowest thing was downloading receipts, as usual.

I expected we'll be tweaking this based on the behaviour of specific subgraphs on specific Ethereum node providers, but for now I'll consider that this fixes #1130.