### PR TITLE
Define start_block in the subgraph manifest

### DIFF
--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -194,7 +194,7 @@ where
             EthereumTrigger::Block(trigger_type) => {
                 let matching_hosts: Vec<_> = hosts
                     .into_iter()
-                    .filter(|host| host.matches_block(trigger_type.clone()))
+                    .filter(|host| host.matches_block(trigger_type.clone(), block.block.number.unwrap().as_u64()))
                     .collect();
 
                 Box::new(

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -194,7 +194,12 @@ where
             EthereumTrigger::Block(trigger_type) => {
                 let matching_hosts: Vec<_> = hosts
                     .into_iter()
-                    .filter(|host| host.matches_block(trigger_type.clone(), block.block.number.unwrap().as_u64()))
+                    .filter(|host| {
+                        host.matches_block(
+                            trigger_type.clone(),
+                            block.block.number.unwrap().as_u64(),
+                        )
+                    })
                     .collect();
 
                 Box::new(

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -17,6 +17,7 @@ type SharedInstanceKeepAliveMap = Arc<RwLock<HashMap<SubgraphDeploymentId, Cance
 struct IndexingInputs<B, S> {
     deployment_id: SubgraphDeploymentId,
     network_name: String,
+    start_blocks: Vec<u64>,
     store: Arc<S>,
     stream_builder: B,
     templates_use_calls: bool,
@@ -186,6 +187,7 @@ impl SubgraphInstanceManager {
         let log_filter = EthereumLogFilter::from_data_sources(&manifest.data_sources);
         let call_filter = EthereumCallFilter::from_data_sources(&manifest.data_sources);
         let block_filter = EthereumBlockFilter::from_data_sources(&manifest.data_sources);
+        let start_blocks = manifest.start_blocks();
 
         // Identify whether there are templates with call handlers or
         // block handlers with call filters; in this case, we need to
@@ -206,6 +208,7 @@ impl SubgraphInstanceManager {
             inputs: IndexingInputs {
                 deployment_id,
                 network_name,
+                start_blocks,
                 store,
                 stream_builder,
                 templates_use_calls,
@@ -282,6 +285,7 @@ where
             logger.clone(),
             ctx.inputs.deployment_id.clone(),
             ctx.inputs.network_name.clone(),
+            ctx.inputs.start_blocks.clone(),
             ctx.state.log_filter.clone(),
             ctx.state.call_filter.clone(),
             ctx.state.block_filter.clone(),

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -526,6 +526,7 @@ fn resolve_subgraph_chain_blocks(
             .data_sources
             .clone()
             .into_iter()
+            .map(|data_source| data_source.source.start_block)
             .min()
             .map(|block_number| {
                 ethereum_adapter
@@ -913,7 +914,7 @@ fn create_subgraph_version(
                         .create_operations(&manifest.id),
                     );
                     deployment_store
-                        .create_subgraph_deployment(&logger, &manifest.schema, ops)
+                        .create_subgraph_deployment(&manifest.schema, ops)
                         .map_err(|e| SubgraphRegistrarError::SubgraphDeploymentError(e))
                 }
             })

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -507,7 +507,7 @@ fn create_subgraph(
     Ok(CreateSubgraphResult { id: entity_id })
 }
 
-/// Resolves the chain head block and subgraph start block
+/// Resolves the chain head block and the subgraph's earliest block
 fn resolve_subgraph_chain_blocks(
     manifest: SubgraphManifest,
     chain_store: Arc<impl ChainStore>,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -881,8 +881,8 @@ fn create_subgraph_version(
                 // stream. (the initial block range starts with earliest_block + 1)
                 info!(
                     logger,
-                    "Set the earliest available Ethereum block, start_block: {}",
-                    earliest_block.number + 1
+                    "Set subgraph start block";
+                    "block_number" => earliest_block.number + 1
                 );
 
                 // Apply the subgraph versioning and deployment operations,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -527,6 +527,9 @@ fn resolve_subgraph_chain_blocks(
             .map(|data_source| data_source.source.start_block)
             .min()
             .map(move |block_number| {
+                // Resolve a block pointer representation of the earliest subgraph start_block
+                // Since the block stream steps start with subgraph_ptr we use a saturating
+                // subtraction to set to earliest_block - 1
                 ethereum_adapter
                     .block_pointer_from_number(logger, block_number.saturating_sub(1))
                     .from_err()
@@ -874,6 +877,8 @@ fn create_subgraph_version(
                 &logger.clone(),
             )
             .and_then(move |(chain_head_block, earliest_block)| {
+                // Log earliest_block + 1 in order to accurately represent the start of the block
+                // stream. (the initial block range starts with earliest_block + 1)
                 info!(
                     logger,
                     "Set the earliest available Ethereum block, start_block: {}",

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -530,7 +530,7 @@ fn resolve_subgraph_chain_blocks(
             .min()
             .map(|block_number| {
                 ethereum_adapter
-                    .block_pointer_from_number(logger, block_number)
+                    .block_pointer_from_number(logger, block_number.saturating_sub(1))
                     .map(|pointer| Some(pointer))
                     .and_then(|pointer_opt| {
                         Ok(pointer_opt.and_then(|pointer| {
@@ -893,7 +893,7 @@ fn create_subgraph_version(
                 info!(
                     logger,
                     "Set the earliest available Ethereum block, start_block: {}",
-                    earliest_block.number
+                    earliest_block.number + 1
                 );
 
                 // Apply the subgraph versioning and deployment operations,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -712,9 +712,9 @@ fn create_subgraph_version(
                     if !validated {
                         warn!(
                             logger,
-                            "Unable to confirm block number {} as the start block for the '{}' data source, address: {}",
-                            &block_number.to_string(),
+                            "Start block for '{}' may lead to skipping on chain data, block number: {}, address: {}",
                             &data_source.name,
+                            &block_number.to_string(),
                             source_address
                                 .map(|a| a.to_string())
                                 .unwrap_or("unspecified".to_string())
@@ -725,7 +725,7 @@ fn create_subgraph_version(
                 Err(e) => {
                     warn!(
                         logger,
-                        "Start block number {} for the '{}' data source will not be used to filter the stream due to an error validating. Error: {}",
+                        "Unable to validate start block for '{}', block_num: {}, error: {}",
                         &block_number.to_string(),
                         &data_source.name,
                         e

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -23,26 +23,25 @@ use graph::prelude::{
     SubgraphRegistrar as SubgraphRegistrarTrait, *,
 };
 
-pub struct SubgraphRegistrar<L, P, S, CS, E> {
+pub struct SubgraphRegistrar<L, P, S, CS> {
     logger: Logger,
     logger_factory: LoggerFactory,
     resolver: Arc<L>,
     provider: Arc<P>,
     store: Arc<S>,
     chain_stores: HashMap<String, Arc<CS>>,
-    ethereum_adapters: HashMap<String, Arc<E>>,
+    ethereum_adapters: HashMap<String, Arc<dyn EthereumAdapter>>,
     node_id: NodeId,
     version_switching_mode: SubgraphVersionSwitchingMode,
     assignment_event_stream_cancel_guard: CancelGuard, // cancels on drop
 }
 
-impl<L, P, S, CS, E> SubgraphRegistrar<L, P, S, CS, E>
+impl<L, P, S, CS> SubgraphRegistrar<L, P, S, CS>
 where
     L: LinkResolver + Clone,
     P: SubgraphAssignmentProviderTrait,
     S: Store,
     CS: ChainStore,
-    E: EthereumAdapter,
 {
     pub fn new(
         logger_factory: &LoggerFactory,
@@ -50,7 +49,7 @@ where
         provider: Arc<P>,
         store: Arc<S>,
         chain_stores: HashMap<String, Arc<CS>>,
-        ethereum_adapters: HashMap<String, Arc<E>>,
+        ethereum_adapters: HashMap<String, Arc<dyn EthereumAdapter>>,
         node_id: NodeId,
         version_switching_mode: SubgraphVersionSwitchingMode,
     ) -> Self {
@@ -271,13 +270,12 @@ where
     }
 }
 
-impl<L, P, S, CS, E> SubgraphRegistrarTrait for SubgraphRegistrar<L, P, S, CS, E>
+impl<L, P, S, CS> SubgraphRegistrarTrait for SubgraphRegistrar<L, P, S, CS>
 where
     L: LinkResolver,
     P: SubgraphAssignmentProviderTrait,
     S: Store,
     CS: ChainStore,
-    E: EthereumAdapter,
 {
     fn create_subgraph(
         &self,
@@ -511,7 +509,7 @@ fn create_subgraph(
 fn resolve_subgraph_chain_blocks(
     manifest: SubgraphManifest,
     chain_store: Arc<impl ChainStore>,
-    ethereum_adapter: Arc<impl EthereumAdapter>,
+    ethereum_adapter: Arc<dyn EthereumAdapter>,
     logger: &Logger,
 ) -> Box<
     dyn Future<
@@ -760,7 +758,7 @@ fn create_subgraph_version(
     logger: &Logger,
     store: Arc<impl Store>,
     chain_store: Arc<impl ChainStore>,
-    ethereum_adapter: Arc<impl EthereumAdapter>,
+    ethereum_adapter: Arc<dyn EthereumAdapter>,
     name: SubgraphName,
     manifest: SubgraphManifest,
     node_id: NodeId,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -685,21 +685,9 @@ fn create_subgraph_version(
         .into_iter()
         .map(|data_source| {
             let source_address = data_source.source.address;
-            let block_number = match data_source
+            let block_number = data_source
                 .source
-                .start_block
-                .and_then(|block_str| block_str.parse::<u64>().ok())
-            {
-                Some(number) => number,
-                None => {
-                    warn!(
-                        logger,
-                        "Start block invalid or not specified for the '{}' data source",
-                        &data_source.name
-                    );
-                    return None
-                },
-            };
+                .start_block;
 
             // Validate that the start block provided for the Data Source is indeed the block that
             // contains the contract creation transaction. Allow the block to be used as the

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -79,7 +79,7 @@ fn multiple_data_sources_per_subgraph() {
             true
         }
 
-        fn matches_block(&self, _call: EthereumBlockTriggerType) -> bool {
+        fn matches_block(&self, _call: EthereumBlockTriggerType, _block_number: u64) -> bool {
             true
         }
 

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -15,8 +15,9 @@ use std::time::Duration;
 use std::time::Instant;
 
 use graph::prelude::*;
-use graph_core::LinkResolver;
-use graph_mock::MockStore;
+use graph_core::{LinkResolver, SubgraphInstanceManager};
+use graph_mock::{FakeStore, MockBlockStreamBuilder, MockEthereumAdapter, MockStore};
+use web3::types::*;
 
 use crate::tokio::timer::Delay;
 
@@ -247,6 +248,12 @@ fn subgraph_provider_events() {
                 .into_iter()
                 .map(|s| ("mainnet".to_string(), s))
                 .collect();
+            let mock_ethereum_adapter = Arc::new(MockEthereumAdapter::default());
+            let ethereum_adapters: HashMap<String, Arc<MockEthereumAdapter>> =
+                vec![mock_ethereum_adapter]
+                    .into_iter()
+                    .map(|e| ("mainnet".to_string(), e))
+                    .collect();
             let graphql_runner = Arc::new(graph_core::GraphQlRunner::new(&logger, store.clone()));
             let mut provider = graph_core::SubgraphAssignmentProvider::new(
                 &logger_factory,
@@ -263,6 +270,7 @@ fn subgraph_provider_events() {
                 Arc::new(provider),
                 store.clone(),
                 stores,
+                ethereum_adapters,
                 node_id.clone(),
                 SubgraphVersionSwitchingMode::Instant,
             );

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -248,8 +248,8 @@ fn subgraph_provider_events() {
                 .into_iter()
                 .map(|s| ("mainnet".to_string(), s))
                 .collect();
-            let mock_ethereum_adapter = Arc::new(MockEthereumAdapter::default());
-            let ethereum_adapters: HashMap<String, Arc<MockEthereumAdapter>> =
+            let mock_ethereum_adapter = Arc::new(MockEthereumAdapter::default()) as Arc<dyn EthereumAdapter>;
+            let ethereum_adapters: HashMap<String, Arc<dyn EthereumAdapter>> =
                 vec![mock_ethereum_adapter]
                     .into_iter()
                     .map(|e| ("mainnet".to_string(), e))

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -15,9 +15,8 @@ use std::time::Duration;
 use std::time::Instant;
 
 use graph::prelude::*;
-use graph_core::{LinkResolver, SubgraphInstanceManager};
-use graph_mock::{FakeStore, MockBlockStreamBuilder, MockEthereumAdapter, MockStore};
-use web3::types::*;
+use graph_core::LinkResolver;
+use graph_mock::{MockEthereumAdapter, MockStore};
 
 use crate::tokio::timer::Delay;
 
@@ -248,7 +247,8 @@ fn subgraph_provider_events() {
                 .into_iter()
                 .map(|s| ("mainnet".to_string(), s))
                 .collect();
-            let mock_ethereum_adapter = Arc::new(MockEthereumAdapter::default()) as Arc<dyn EthereumAdapter>;
+            let mock_ethereum_adapter =
+                Arc::new(MockEthereumAdapter::default()) as Arc<dyn EthereumAdapter>;
             let ethereum_adapters: HashMap<String, Arc<dyn EthereumAdapter>> =
                 vec![mock_ethereum_adapter]
                     .into_iter()

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -169,17 +169,11 @@ where
         log_filter: EthereumLogFilter,
         call_filter: EthereumCallFilter,
         block_filter: EthereumBlockFilter,
+        start_blocks: Vec<u64>,
         templates_use_calls: bool,
         reorg_threshold: u64,
         logger: Logger,
     ) -> Self {
-        let mut start_blocks = Vec::new();
-        start_blocks.append(&mut log_filter.start_blocks());
-        start_blocks.append(&mut call_filter.start_blocks());
-        start_blocks.append(&mut block_filter.start_blocks());
-        start_blocks.sort();
-        start_blocks.dedup();
-
         BlockStream {
             state: Mutex::new(BlockStreamState::New),
             consecutive_err_count: 0,
@@ -1271,6 +1265,7 @@ where
         logger: Logger,
         deployment_id: SubgraphDeploymentId,
         network_name: String,
+        start_blocks: Vec<u64>,
         log_filter: EthereumLogFilter,
         call_filter: EthereumCallFilter,
         block_filter: EthereumBlockFilter,
@@ -1307,6 +1302,7 @@ where
             log_filter,
             call_filter,
             block_filter,
+            start_blocks,
             templates_use_calls,
             self.reorg_threshold,
             logger,

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -374,8 +374,9 @@ where
                         // chain head.
 
                         // As an optimization, instead of advancing one block, we will use an
-                        // Ethereum RPC call to find the first few blocks between the subgraph
-                        // ptr and the reorg threshold that has event(s) we are interested in.
+                        // Ethereum RPC call to find the first few blocks that have event(s) we
+                        // are interested in that lie within the block range between the subgraph ptr
+                        // and either the next data source start_block or the reorg threshold.
                         // Note that we use block numbers here.
                         // This is an artifact of Ethereum RPC limitations.
                         // It is only safe to use block numbers because we are beyond the reorg
@@ -384,6 +385,8 @@ where
                         // Start with first block after subgraph ptr
                         let from = subgraph_ptr.number + 1;
 
+                        // Get the next subsequent data source start block to ensure the block range
+                        // is aligned with data source.
                         let next_start_block: u64 = start_blocks
                             .into_iter()
                             .filter(|block_num| block_num > &from)

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -16,7 +16,6 @@ use web3::types::{Filter, *};
 #[derive(Clone)]
 pub struct EthereumAdapter<T: web3::Transport> {
     web3: Arc<Web3<T>>,
-    start_block: u64,
 }
 
 lazy_static! {
@@ -47,10 +46,9 @@ where
     T: web3::BatchTransport + Send + Sync + 'static,
     T::Out: Send,
 {
-    pub fn new(transport: T, start_block: u64) -> Self {
+    pub fn new(transport: T) -> Self {
         EthereumAdapter {
             web3: Arc::new(Web3::new(transport)),
-            start_block,
         }
     }
 
@@ -441,7 +439,6 @@ where
         logger: &Logger,
     ) -> Box<dyn Future<Item = EthereumNetworkIdentifier, Error = Error> + Send> {
         let logger = logger.clone();
-        let start_block = self.start_block;
 
         let web3 = self.web3.clone();
         let net_version_future = retry("net_version RPC call", &logger)
@@ -455,11 +452,7 @@ where
             .timeout_secs(30)
             .run(move || {
                 web3.eth()
-                    .block(if start_block > 0 {
-                        BlockNumber::Number(start_block).into()
-                    } else {
-                        BlockNumber::Earliest.into()
-                    })
+                    .block(BlockNumber::Earliest.into())
                     .from_err()
                     .and_then(|gen_block_opt| {
                         future::result(

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -993,7 +993,8 @@ where
         let addresses: Vec<H160> = call_filter
             .contract_addresses_function_signatures
             .iter()
-            .map(|(addr, _fsigs)| *addr)
+            .filter(|(_addr, (start_block, _fsigs))| start_block <= &to)
+            .map(|(addr, (_start_block, _fsigs))| *addr)
             .collect::<HashSet<H160>>()
             .into_iter()
             .collect::<Vec<H160>>();

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -663,6 +663,67 @@ where
         )
     }
 
+    fn validate_start_block(
+        &self,
+        logger: &Logger,
+        block_number: u64,
+        source_address: Option<H160>,
+    ) -> Box<dyn Future<Item = (EthereumBlockPointer, bool), Error = EthereumAdapterError> + Send>
+    {
+        let eth = self.clone();
+        let eth2 = self.clone();
+        let logging = logger.clone();
+        let thelogger = logger.clone();
+
+        Box::new(
+            self.block_hash_by_block_number(logger, block_number)
+                .and_then(move |block_hash_opt| {
+                    block_hash_opt.ok_or_else(|| {
+                        format_err!(
+                            "Ethereum node could not find start block hash by block number {}",
+                            &block_number
+                        )
+                    })
+                })
+                .and_then(move |block_hash| eth.block_by_hash(&logging, block_hash))
+                .and_then(move |block_opt| {
+                    block_opt.ok_or_else(|| {
+                        format_err!(
+                            "Ethereum node could not find start block by hash {}",
+                            &block_number
+                        )
+                    })
+                })
+                .from_err()
+                .and_then(move |block| eth2.load_full_block(&thelogger.clone(), block))
+                .map(move |full_block| {
+                    if full_block
+                        .transaction_receipts
+                        .iter()
+                        .filter(|receipt| {
+                            receipt.contract_address == source_address
+                                && receipt.contract_address.is_some()
+                        })
+                        .any(|receipt| {
+                            match full_block
+                                .block
+                                .transactions
+                                .iter()
+                                .find(|&transaction| transaction.hash == receipt.transaction_hash)
+                            {
+                                Some(t) => t.to.is_none(),
+                                None => false,
+                            }
+                        })
+                    {
+                        (EthereumBlockPointer::from(full_block), true)
+                    } else {
+                        (EthereumBlockPointer::from(full_block), false)
+                    }
+                }),
+        )
+    }
+
     fn block_parent_hash(
         &self,
         logger: &Logger,

--- a/datasource/ethereum/tests/adapter.rs
+++ b/datasource/ethereum/tests/adapter.rs
@@ -166,7 +166,7 @@ fn contract_call() {
     )));
 
     let logger = Logger::root(slog::Discard, o!());
-    let adapter = EthereumAdapter::new(transport, 0u64);
+    let adapter = EthereumAdapter::new(transport);
     let balance_of = Function {
         name: "balanceOf".to_owned(),
         inputs: vec![Param {

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -32,10 +32,6 @@ those.
   request (defaults to 10000).
 - `ETHEREUM_PARALLEL_BLOCK_RANGES`: Maximum number of parallel `eth_getLogs`
   calls to make when scanning logs for a subgraph. Defaults to 100.
-- `ETHEREUM_START_BLOCK`: the block number at which subgraphs should start
-  indexing (defaults to the genesis block). Can save some time while debugging
-  subgraphs locally. _Warning:_ Do not use this in production, as it may
-  cause subgraphs to be only indexed partially.
 - `GRAPH_ETHEREUM_MAX_EVENT_ONLY_RANGE`: Maximum range size for `eth.getLogs`
   requests that dont filter on contract address, only event signature.
 

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -480,7 +480,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         block: Block<Transaction>,
     ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send>;
 
-    /// Load full information for the specified `block number` (in particular, transaction receipts).
+    /// Load block pointer for the specified `block number`.
     fn block_pointer_from_number(
         &self,
         logger: &Logger,

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -308,9 +308,7 @@ impl EthereumCallFilter {
         iter.into_iter()
             .filter_map(|data_source| data_source.source.address.map(|addr| (addr, data_source)))
             .map(|(contract_addr, data_source)| {
-                let start_block = data_source
-                    .source
-                    .start_block;
+                let start_block = data_source.source.start_block;
                 data_source
                     .mapping
                     .call_handlers
@@ -427,9 +425,7 @@ impl EthereumBlockFilter {
                     trigger_every_block: has_block_handler_without_filter,
                     contract_addresses: if has_block_handler_with_call_filter {
                         vec![(
-                            data_source
-                                .source
-                                .start_block,
+                            data_source.source.start_block,
                             data_source.source.address.unwrap().to_owned(),
                         )]
                         .into_iter()

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -270,6 +270,8 @@ impl EthereumLogFilter {
 
 #[derive(Clone, Debug)]
 pub struct EthereumCallFilter {
+    // Each call filter has a map of filters keyed by address, each containing a tuple with
+    // start_block and the set of function signatures
     pub contract_addresses_function_signatures: HashMap<Address, (u64, HashSet<[u8; 4]>)>,
 }
 

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -488,12 +488,11 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send>;
 
     /// Load full information for the specified `block number` (in particular, transaction receipts).
-    fn validate_start_block(
+    fn block_pointer_from_number(
         &self,
         logger: &Logger,
         block_number: u64,
-        source_address: Option<H160>,
-    ) -> Box<dyn Future<Item = (EthereumBlockPointer, bool), Error = EthereumAdapterError> + Send>;
+    ) -> Box<dyn Future<Item = EthereumBlockPointer, Error = EthereumAdapterError> + Send>;
 
     /// Find the hash for the parent block of the provided block hash
     fn block_parent_hash(

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -446,6 +446,14 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         block: Block<Transaction>,
     ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send>;
 
+    /// Load full information for the specified `block number` (in particular, transaction receipts).
+    fn validate_start_block(
+        &self,
+        logger: &Logger,
+        block_number: u64,
+        source_address: Option<H160>,
+    ) -> Box<dyn Future<Item = (EthereumBlockPointer, bool), Error = EthereumAdapterError> + Send>;
+
     /// Find the hash for the parent block of the provided block hash
     fn block_parent_hash(
         &self,

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -21,6 +21,7 @@ pub trait BlockStreamBuilder: Clone + Send + Sync + 'static {
         logger: Logger,
         deployment_id: SubgraphDeploymentId,
         network_name: String,
+        start_blocks: Vec<u64>,
         log_filter: EthereumLogFilter,
         call_filter: EthereumCallFilter,
         block_filter: EthereumBlockFilter,

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -1,7 +1,7 @@
 use ethabi::LogParam;
 use serde::{Deserialize, Serialize};
-use web3::types::*;
 use std::cmp::Ordering;
+use web3::types::*;
 
 #[derive(Clone, Debug)]
 pub struct EthereumBlockWithTriggers {
@@ -278,17 +278,16 @@ impl EthereumBlockPointer {
         format!("{:x}", self.hash)
     }
 
-    pub fn minimum_block_number(blocks: Vec<Self>) -> Option<Self> {
-        blocks.iter()
-            .fold(None, |a: Option<EthereumBlockPointer>, &b| {
-                match a {
-                    Some(a) => match PartialOrd::partial_cmp(&a.number, &b.number) {
-                        None => None,
-                        Some(Ordering::Less) => Some(a),
-                        Some(_) => Some(b),
-                    },
-                    None => Some(b),
-                }
+    pub fn earliest_block(blocks: Vec<Self>) -> Option<Self> {
+        blocks
+            .iter()
+            .fold(None, |a: Option<EthereumBlockPointer>, &b| match a {
+                Some(a) => match PartialOrd::partial_cmp(&a.number, &b.number) {
+                    None => None,
+                    Some(Ordering::Less) => Some(a),
+                    Some(_) => Some(b),
+                },
+                None => Some(b),
             })
     }
 }

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -1,6 +1,5 @@
 use ethabi::LogParam;
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
 use web3::types::*;
 
 #[derive(Clone, Debug)]
@@ -276,19 +275,6 @@ impl EthereumBlockPointer {
     /// implements `H256::to_string`.
     pub fn hash_hex(&self) -> String {
         format!("{:x}", self.hash)
-    }
-
-    pub fn earliest_block(blocks: Vec<Self>) -> Option<Self> {
-        blocks
-            .iter()
-            .fold(None, |a: Option<EthereumBlockPointer>, &b| match a {
-                Some(a) => match PartialOrd::partial_cmp(&a.number, &b.number) {
-                    None => None,
-                    Some(Ordering::Less) => Some(a),
-                    Some(_) => Some(b),
-                },
-                None => Some(b),
-            })
     }
 }
 

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -1,6 +1,7 @@
 use ethabi::LogParam;
 use serde::{Deserialize, Serialize};
 use web3::types::*;
+use std::cmp::Ordering;
 
 #[derive(Clone, Debug)]
 pub struct EthereumBlockWithTriggers {
@@ -275,6 +276,20 @@ impl EthereumBlockPointer {
     /// implements `H256::to_string`.
     pub fn hash_hex(&self) -> String {
         format!("{:x}", self.hash)
+    }
+
+    pub fn minimum_block_number(blocks: Vec<Self>) -> Option<Self> {
+        blocks.iter()
+            .fold(None, |a: Option<EthereumBlockPointer>, &b| {
+                match a {
+                    Some(a) => match PartialOrd::partial_cmp(&a.number, &b.number) {
+                        None => None,
+                        Some(Ordering::Less) => Some(a),
+                        Some(_) => Some(b),
+                    },
+                    None => Some(b),
+                }
+            })
     }
 }
 

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -15,7 +15,7 @@ pub trait RuntimeHost: Send + Sync + Debug + 'static {
     fn matches_call(&self, call: &EthereumCall) -> bool;
 
     /// Returns true if the RuntimeHost has a handler for an Ethereum block.
-    fn matches_block(&self, call: EthereumBlockTriggerType) -> bool;
+    fn matches_block(&self, call: EthereumBlockTriggerType, block_number: u64) -> bool;
 
     /// Process an Ethereum event and return a vector of entity operations.
     fn process_log(

--- a/graph/src/data/graphql/values.rs
+++ b/graph/src/data/graphql/values.rs
@@ -41,11 +41,10 @@ impl TryFromValue for String {
 impl TryFromValue for u64 {
     fn try_from_value(value: &Value) -> Result<Self, Error> {
         match value {
-            Value::Int(n) => {
-              n.as_i64().map(|n| n as u64).ok_or_else(|| {format_err!(
-                "Cannot parse value into an integer/u64: {:?}",
-                n
-            )})},
+            Value::Int(n) => n
+                .as_i64()
+                .map(|n| n as u64)
+                .ok_or_else(|| format_err!("Cannot parse value into an integer/u64: {:?}", n)),
             _ => Err(format_err!(
                 "Cannot parse value into an integer/u64: {:?}",
                 value

--- a/graph/src/data/graphql/values.rs
+++ b/graph/src/data/graphql/values.rs
@@ -38,6 +38,21 @@ impl TryFromValue for String {
     }
 }
 
+impl TryFromValue for u64 {
+    fn try_from_value(value: &Value) -> Result<Self, Error> {
+        match value {
+            Value::Int(n) => {
+              n.as_i64().map(|n| n as u64).ok_or_else(|| {format_err!(
+                "Cannot parse value into an integer/u64: {:?}",
+                n
+            )})},
+            _ => Err(format_err!(
+                "Cannot parse value into an integer/u64: {:?}",
+                value
+            )),
+        }
+    }
+}
 impl TryFromValue for H160 {
     fn try_from_value(value: &Value) -> Result<Self, Error> {
         match value {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -881,6 +881,13 @@ impl SubgraphManifest {
             _ => Err(SubgraphManifestValidationError::MultipleEthereumNetworks),
         }
     }
+
+    pub fn start_blocks(&self) -> Vec<u64> {
+        self.data_sources
+            .iter()
+            .map(|data_source| data_source.source.start_block)
+            .collect()
+    }
 }
 
 impl UnresolvedSubgraphManifest {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -387,6 +387,7 @@ pub struct Source {
     #[serde(default, deserialize_with = "deserialize_address")]
     pub address: Option<Address>,
     pub abi: String,
+    #[serde(rename = "startBlock")]
     pub start_block: Option<String>,
 }
 
@@ -643,8 +644,7 @@ impl UnresolvedDataSource {
             templates,
         } = self;
 
-        info!(logger, "Resolve data source"; "name" => &name);
-
+        info!(logger, "Resolve data source"; "name" => &name, "source" => &source.start_block);
         mapping
             .resolve(resolver, logger.clone())
             .join(
@@ -697,7 +697,7 @@ impl DataSource {
             source: Source {
                 address: Some(address),
                 abi: template.source.abi,
-                start_block: None,
+                start_block: Some("0".to_string()),
             },
             mapping: template.mapping,
             templates: Vec::new(),

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -330,7 +330,7 @@ pub enum SubgraphManifestValidationError {
     #[fail(display = "subgraph data source has too many similar block handlers")]
     DataSourceBlockHandlerLimitExceeded,
     #[fail(display = "the specified block must exist on the Ethereum network")]
-    StartBlockNotFound(String),
+    BlockNotFound(String),
 }
 
 #[derive(Fail, Debug)]

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -327,6 +327,8 @@ pub enum SubgraphManifestValidationError {
     EthereumNetworkRequired,
     #[fail(display = "subgraph data source has too many similar block handlers")]
     DataSourceBlockHandlerLimitExceeded,
+    #[fail(display = "the specified block must exist on the Ethereum network")]
+    StartBlockNotFound(String),
 }
 
 #[derive(Fail, Debug)]
@@ -385,6 +387,7 @@ pub struct Source {
     #[serde(default, deserialize_with = "deserialize_address")]
     pub address: Option<Address>,
     pub abi: String,
+    pub start_block: Option<String>,
 }
 
 impl From<EthereumContractSourceEntity> for Source {
@@ -392,6 +395,7 @@ impl From<EthereumContractSourceEntity> for Source {
         Self {
             address: entity.address,
             abi: entity.abi,
+            start_block: entity.start_block,
         }
     }
 }
@@ -693,6 +697,7 @@ impl DataSource {
             source: Source {
                 address: Some(address),
                 abi: template.source.abi,
+                start_block: None,
             },
             mapping: template.mapping,
             templates: Vec::new(),

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -387,8 +387,8 @@ pub struct Source {
     #[serde(default, deserialize_with = "deserialize_address")]
     pub address: Option<Address>,
     pub abi: String,
-    #[serde(rename = "startBlock")]
-    pub start_block: Option<String>,
+    #[serde(rename = "startBlock", default)]
+    pub start_block: u64,
 }
 
 impl From<EthereumContractSourceEntity> for Source {
@@ -697,7 +697,7 @@ impl DataSource {
             source: Source {
                 address: Some(address),
                 abi: template.source.abi,
-                start_block: Some("0".to_string()),
+                start_block: 0,
             },
             mapping: template.mapping,
             templates: Vec::new(),

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -245,6 +245,8 @@ pub enum SubgraphRegistrarError {
     StoreError(StoreError),
     #[fail(display = "subgraph validation error: {:?}", _0)]
     ManifestValidationError(Vec<SubgraphManifestValidationError>),
+    #[fail(display = "subgraph deployment error: {}", _0)]
+    SubgraphDeploymentError(StoreError),
     #[fail(display = "subgraph registrar error: {}", _0)]
     Unknown(failure::Error),
 }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -715,7 +715,7 @@ impl TryFromValue for EthereumContractSourceEntity {
         Ok(Self {
             address: map.get_optional("address")?,
             abi: map.get_required("abi")?,
-            start_block: map.get_required("startBlock")?,
+            start_block: map.get_optional("startBlock")?.unwrap_or_default(),
         })
     }
 }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -673,7 +673,7 @@ impl<'a, 'b, 'c>
 pub struct EthereumContractSourceEntity {
     pub address: Option<super::Address>,
     pub abi: String,
-    pub start_block: Option<String>,
+    pub start_block: u64,
 }
 
 impl TypedEntity for EthereumContractSourceEntity {
@@ -687,7 +687,7 @@ impl WriteOperations for EthereumContractSourceEntity {
         entity.set("id", id);
         entity.set("address", self.address);
         entity.set("abi", self.abi);
-        entity.set("start_block", self.start_block);
+        entity.set("startBlock", self.start_block);
         ops.add(Self::TYPENAME, id.to_owned(), entity);
     }
 }
@@ -715,7 +715,7 @@ impl TryFromValue for EthereumContractSourceEntity {
         Ok(Self {
             address: map.get_optional("address")?,
             abi: map.get_required("abi")?,
-            start_block: map.get_optional("startBlock")?,
+            start_block: map.get_required("startBlock")?,
         })
     }
 }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -673,6 +673,7 @@ impl<'a, 'b, 'c>
 pub struct EthereumContractSourceEntity {
     pub address: Option<super::Address>,
     pub abi: String,
+    pub start_block: Option<String>,
 }
 
 impl TypedEntity for EthereumContractSourceEntity {
@@ -695,6 +696,7 @@ impl From<super::Source> for EthereumContractSourceEntity {
         Self {
             address: source.address,
             abi: source.abi,
+            start_block: source.start_block,
         }
     }
 }
@@ -712,6 +714,7 @@ impl TryFromValue for EthereumContractSourceEntity {
         Ok(Self {
             address: map.get_optional("address")?,
             abi: map.get_required("abi")?,
+            start_block: map.get_optional("startBlock")?,
         })
     }
 }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -687,6 +687,7 @@ impl WriteOperations for EthereumContractSourceEntity {
         entity.set("id", id);
         entity.set("address", self.address);
         entity.set("abi", self.abi);
+        entity.set("start_block", self.start_block);
         ops.add(Self::TYPENAME, id.to_owned(), entity);
     }
 }

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -62,6 +62,7 @@ impl BlockStreamBuilder for MockBlockStreamBuilder {
         _logger: Logger,
         _deployment_id: SubgraphDeploymentId,
         _network_name: String,
+        _start_blocks: Vec<u64>,
         _: EthereumLogFilter,
         _: EthereumCallFilter,
         _: EthereumBlockFilter,

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -5,7 +5,7 @@ use graph::prelude::{
     Arc,
     ethabi,
     EthereumCallCache,
-    web3::types::{Block, Transaction, H160, H256},
+    web3::types::{Block, Transaction, H256},
     Error, Future, Logger,
 };
 
@@ -43,13 +43,11 @@ impl EthereumAdapter for MockEthereumAdapter {
         unimplemented!();
     }
 
-    fn validate_start_block(
+    fn block_pointer_from_number(
         &self,
         _: &Logger,
         _: u64,
-        _: Option<H160>,
-    ) -> Box<dyn Future<Item = (EthereumBlockPointer, bool), Error = EthereumAdapterError> + Send>
-    {
+    ) -> Box<dyn Future<Item = EthereumBlockPointer, Error = EthereumAdapterError> + Send> {
         unimplemented!()
     }
 

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -5,7 +5,7 @@ use graph::prelude::{
     Arc,
     ethabi,
     EthereumCallCache,
-    web3::types::{Block, Transaction, H256},
+    web3::types::{Block, Transaction, H160, H256},
     Error, Future, Logger,
 };
 
@@ -41,6 +41,16 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: Block<Transaction>,
     ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send> {
         unimplemented!();
+    }
+
+    fn validate_start_block(
+        &self,
+        _: &Logger,
+        _: u64,
+        _: Option<H160>,
+    ) -> Box<dyn Future<Item = (EthereumBlockPointer, bool), Error = EthereumAdapterError> + Send>
+    {
+        unimplemented!()
     }
 
     fn block_parent_hash(

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -2,11 +2,9 @@ use std::collections::HashSet;
 
 use graph::components::ethereum::*;
 use graph::prelude::{
-    Arc,
     ethabi,
-    EthereumCallCache,
     web3::types::{Block, Transaction, H256},
-    Error, Future, Logger,
+    Arc, Error, EthereumCallCache, Future, Logger,
 };
 
 #[derive(Default)]

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -1,0 +1,128 @@
+use std::collections::HashSet;
+
+use graph::components::ethereum::*;
+use graph::prelude::{
+    Arc,
+    ethabi,
+    EthereumCallCache,
+    web3::types::{Block, Transaction, H256},
+    Error, Future, Logger,
+};
+
+#[derive(Default)]
+pub struct MockEthereumAdapter {}
+
+impl EthereumAdapter for MockEthereumAdapter {
+    fn net_identifiers(
+        &self,
+        _: &Logger,
+    ) -> Box<dyn Future<Item = EthereumNetworkIdentifier, Error = Error> + Send> {
+        unimplemented!();
+    }
+
+    fn latest_block(
+        &self,
+        _: &Logger,
+    ) -> Box<dyn Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send> {
+        unimplemented!();
+    }
+
+    fn block_by_hash(
+        &self,
+        _: &Logger,
+        _: H256,
+    ) -> Box<dyn Future<Item = Option<Block<Transaction>>, Error = Error> + Send> {
+        unimplemented!();
+    }
+
+    fn load_full_block(
+        &self,
+        _: &Logger,
+        _: Block<Transaction>,
+    ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send> {
+        unimplemented!();
+    }
+
+    fn block_parent_hash(
+        &self,
+        _: &Logger,
+        _: H256,
+    ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send> {
+        unimplemented!();
+    }
+
+    fn block_hash_by_block_number(
+        &self,
+        _: &Logger,
+        _: u64,
+    ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send> {
+        unimplemented!();
+    }
+
+    fn is_on_main_chain(
+        &self,
+        _: &Logger,
+        _: EthereumBlockPointer,
+    ) -> Box<dyn Future<Item = bool, Error = Error> + Send> {
+        unimplemented!();
+    }
+
+    fn calls_in_block(
+        &self,
+        _: &Logger,
+        _: u64,
+        _: H256,
+    ) -> Box<dyn Future<Item = Vec<EthereumCall>, Error = Error> + Send> {
+        unimplemented!();
+    }
+
+    fn blocks_with_triggers(
+        &self,
+        _: &Logger,
+        _: u64,
+        _: u64,
+        _: EthereumLogFilter,
+        _: EthereumCallFilter,
+        _: EthereumBlockFilter,
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+        unimplemented!();
+    }
+
+    fn blocks_with_logs(
+        &self,
+        _: &Logger,
+        _: u64,
+        _: u64,
+        _: EthereumLogFilter,
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+        unimplemented!();
+    }
+
+    fn blocks_with_calls(
+        &self,
+        _: &Logger,
+        _: u64,
+        _: u64,
+        _: EthereumCallFilter,
+    ) -> Box<dyn Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send> {
+        unimplemented!();
+    }
+
+    fn blocks(
+        &self,
+        _: &Logger,
+        _: u64,
+        _: u64,
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+        unimplemented!();
+    }
+
+    fn contract_call(
+        &self,
+        _: &Logger,
+        _: EthereumContractCall,
+        _: Arc<impl EthereumCallCache>,
+    ) -> Box<dyn Future<Item = Vec<ethabi::Token>, Error = EthereumContractCallError> + Send> {
+        unimplemented!();
+    }
+}

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use graph::components::ethereum::*;
 use graph::prelude::{
-    ethabi,
+    ethabi, future,
     web3::types::{Block, Transaction, H256},
     Arc, Error, EthereumCallCache, Future, Logger,
 };
@@ -46,7 +46,10 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: &Logger,
         _: u64,
     ) -> Box<dyn Future<Item = EthereumBlockPointer, Error = EthereumAdapterError> + Send> {
-        unimplemented!()
+        Box::new(future::ok(EthereumBlockPointer::from((
+            H256::zero(),
+            0 as i64,
+        ))))
     }
 
     fn block_parent_hash(

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -127,7 +127,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         &self,
         _: &Logger,
         _: EthereumContractCall,
-        _: Arc<impl EthereumCallCache>,
+        _: Arc<dyn EthereumCallCache>,
     ) -> Box<dyn Future<Item = Vec<ethabi::Token>, Error = EthereumContractCallError> + Send> {
         unimplemented!();
     }

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -6,7 +6,9 @@ extern crate graphql_parser;
 extern crate rand;
 
 mod block_stream;
+mod ethereum_adapter;
 mod store;
 
 pub use self::block_stream::{MockBlockStream, MockBlockStreamBuilder};
+pub use self::ethereum_adapter::MockEthereumAdapter;
 pub use self::store::{FakeStore, MockStore};

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -600,6 +600,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
         Arc::new(subgraph_provider),
         generic_store.clone(),
         stores,
+        eth_adapters.clone(),
         node_id.clone(),
         version_switching_mode,
     ));

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -745,7 +745,8 @@ fn parse_ethereum_networks_and_nodes(
 
                 Ok((
                     name.to_string(),
-                    Arc::new(graph_datasource_ethereum::EthereumAdapter::new(transport)) as Arc<dyn EthereumAdapter>,
+                    Arc::new(graph_datasource_ethereum::EthereumAdapter::new(transport))
+                        as Arc<dyn EthereumAdapter>,
                 ))
             }
         })

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -338,15 +338,16 @@ impl RuntimeHost {
 
 impl RuntimeHostTrait for RuntimeHost {
     fn matches_log(&self, log: &Log) -> bool {
-        self.matches_log_address(log) && self.matches_log_signature(log)
+        self.matches_log_address(log) && self.matches_log_signature(log) && self.data_source_contract.start_block <= log.block_number.unwrap().as_u64()
+
     }
 
     fn matches_call(&self, call: &EthereumCall) -> bool {
-        self.matches_call_address(call) && self.matches_call_function(call)
+        self.matches_call_address(call) && self.matches_call_function(call) && self.data_source_contract.start_block <= call.block_number
     }
 
-    fn matches_block(&self, block_trigger_type: EthereumBlockTriggerType) -> bool {
-        self.matches_block_trigger(block_trigger_type)
+    fn matches_block(&self, block_trigger_type: EthereumBlockTriggerType, block_number: u64) -> bool {
+        self.matches_block_trigger(block_trigger_type) && self.data_source_contract.start_block <= block_number
     }
 
     fn process_call(

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -338,16 +338,24 @@ impl RuntimeHost {
 
 impl RuntimeHostTrait for RuntimeHost {
     fn matches_log(&self, log: &Log) -> bool {
-        self.matches_log_address(log) && self.matches_log_signature(log) && self.data_source_contract.start_block <= log.block_number.unwrap().as_u64()
-
+        self.matches_log_address(log)
+            && self.matches_log_signature(log)
+            && self.data_source_contract.start_block <= log.block_number.unwrap().as_u64()
     }
 
     fn matches_call(&self, call: &EthereumCall) -> bool {
-        self.matches_call_address(call) && self.matches_call_function(call) && self.data_source_contract.start_block <= call.block_number
+        self.matches_call_address(call)
+            && self.matches_call_function(call)
+            && self.data_source_contract.start_block <= call.block_number
     }
 
-    fn matches_block(&self, block_trigger_type: EthereumBlockTriggerType, block_number: u64) -> bool {
-        self.matches_block_trigger(block_trigger_type) && self.data_source_contract.start_block <= block_number
+    fn matches_block(
+        &self,
+        block_trigger_type: EthereumBlockTriggerType,
+        block_number: u64,
+    ) -> bool {
+        self.matches_block_trigger(block_trigger_type)
+            && self.data_source_contract.start_block <= block_number
     }
 
     fn process_call(

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -75,6 +75,7 @@ fn mock_data_source(path: &str) -> DataSource {
         source: Source {
             address: Some(Address::from_str("0123123123012312312301231231230123123123").unwrap()),
             abi: String::from("123123"),
+            start_block: 0,
         },
         mapping: Mapping {
             kind: String::from("ethereum/events"),

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -11,7 +11,6 @@ use std::str::FromStr;
 use wasmi::nan_preserving_float::F64;
 
 use crate::host_exports::HostExports;
-use graph::components::ethereum::*;
 use graph::components::store::*;
 use graph::data::store::scalar;
 use graph::data::subgraph::*;
@@ -62,7 +61,7 @@ fn test_module(
         + Sync
         + 'static,
 > {
-    test_module_and_store(data_source).0
+    test_valid_module_and_store(data_source).0
 }
 
 fn mock_data_source(path: &str) -> DataSource {
@@ -311,7 +310,7 @@ fn ipfs_map() {
 
     let mut run_ipfs_map = move |json_string| -> Result<Vec<EntityModification>, Error> {
         let (mut module, store) =
-            test_module_and_store(mock_data_source("wasm_test/ipfs_map.wasm"));
+            test_valid_module_and_store(mock_data_source("wasm_test/ipfs_map.wasm"));
         let hash = if json_string == BAD_IPFS_HASH {
             "Qm".to_string()
         } else {
@@ -763,7 +762,8 @@ fn entity_store() {
     }
 
     fn load_and_set_user_name(id: &str, name: &str) -> (Arc<MockStore>, EntityCache) {
-        let (mut module, store) = test_module_and_store(mock_data_source("wasm_test/store.wasm"));
+        let (mut module, store) =
+            test_valid_module_and_store(mock_data_source("wasm_test/store.wasm"));
         module
             .module
             .clone()

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -4,7 +4,7 @@ extern crate ipfs_api;
 use ethabi::Token;
 use futures::sync::mpsc::channel;
 use hex;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::env;
 use std::io::Cursor;
 use std::str::FromStr;
@@ -17,133 +17,15 @@ use graph::data::store::scalar;
 use graph::data::subgraph::*;
 use graph::prelude::Error;
 use graph_core;
-use web3::types::{Address, Block, Transaction, H160, H256};
+use web3::types::{Address, H160};
 
 use super::*;
 
-use self::graph_mock::MockStore;
+use self::graph_mock::{MockEthereumAdapter, MockStore};
 
 mod abi;
 
-#[derive(Default)]
-struct MockEthereumAdapter {}
-
-impl EthereumAdapter for MockEthereumAdapter {
-    fn net_identifiers(
-        &self,
-        _: &Logger,
-    ) -> Box<dyn Future<Item = EthereumNetworkIdentifier, Error = Error> + Send> {
-        unimplemented!();
-    }
-
-    fn latest_block(
-        &self,
-        _: &Logger,
-    ) -> Box<dyn Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send> {
-        unimplemented!();
-    }
-
-    fn block_by_hash(
-        &self,
-        _: &Logger,
-        _: H256,
-    ) -> Box<dyn Future<Item = Option<Block<Transaction>>, Error = Error> + Send> {
-        unimplemented!();
-    }
-
-    fn load_full_block(
-        &self,
-        _: &Logger,
-        _: Block<Transaction>,
-    ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send> {
-        unimplemented!();
-    }
-
-    fn block_parent_hash(
-        &self,
-        _: &Logger,
-        _: H256,
-    ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send> {
-        unimplemented!();
-    }
-
-    fn block_hash_by_block_number(
-        &self,
-        _: &Logger,
-        _: u64,
-    ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send> {
-        unimplemented!();
-    }
-
-    fn is_on_main_chain(
-        &self,
-        _: &Logger,
-        _: EthereumBlockPointer,
-    ) -> Box<dyn Future<Item = bool, Error = Error> + Send> {
-        unimplemented!();
-    }
-
-    fn calls_in_block(
-        &self,
-        _: &Logger,
-        _: u64,
-        _: H256,
-    ) -> Box<dyn Future<Item = Vec<EthereumCall>, Error = Error> + Send> {
-        unimplemented!();
-    }
-
-    fn blocks_with_triggers(
-        &self,
-        _: &Logger,
-        _: u64,
-        _: u64,
-        _: EthereumLogFilter,
-        _: EthereumCallFilter,
-        _: EthereumBlockFilter,
-    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
-        unimplemented!();
-    }
-
-    fn blocks_with_logs(
-        &self,
-        _: &Logger,
-        _: u64,
-        _: u64,
-        _: EthereumLogFilter,
-    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
-        unimplemented!();
-    }
-
-    fn blocks_with_calls(
-        &self,
-        _: &Logger,
-        _: u64,
-        _: u64,
-        _: EthereumCallFilter,
-    ) -> Box<dyn Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send> {
-        unimplemented!();
-    }
-
-    fn blocks(
-        &self,
-        _: &Logger,
-        _: u64,
-        _: u64,
-    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
-        unimplemented!();
-    }
-
-    fn contract_call(
-        &self,
-        _: &Logger,
-        _: EthereumContractCall,
-        _: Arc<dyn EthereumCallCache>,
-    ) -> Box<dyn Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send> {
-        unimplemented!();
-    }
-}
-
-fn test_module_and_store(
+fn test_valid_module_and_store(
     data_source: DataSource,
 ) -> (
     WasmiModule<

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -101,7 +101,6 @@ fn initiate_schema(logger: &Logger, conn: &PgConnection, blocking_conn: &PgConne
 pub struct StoreConfig {
     pub postgres_url: String,
     pub network_name: String,
-    pub start_block: u64,
 }
 
 #[derive(Clone)]
@@ -159,7 +158,7 @@ impl Store {
                 config.network_name.clone(),
             ),
             network_name: config.network_name.clone(),
-            genesis_block_ptr: (net_identifiers.genesis_block_hash, config.start_block).into(),
+            genesis_block_ptr: (net_identifiers.genesis_block_hash, 0 as u64).into(),
             conn: pool,
             schema_cache: Mutex::new(LruCache::with_capacity(100)),
             storage_cache: e::make_storage_cache(),

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -73,6 +73,7 @@ type EthereumContractSource @entity {
     id: ID!
     address: String!
     abi: String!
+    start_block: String
 }
 
 type EthereumContractMapping @entity {

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -73,7 +73,7 @@ type EthereumContractSource @entity {
     id: ID!
     address: String!
     abi: String!
-    start_block: String
+    start_block: BigInt
 }
 
 type EthereumContractMapping @entity {

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1718,6 +1718,7 @@ fn mock_data_source(path: &str) -> DataSource {
         source: Source {
             address: Some(Address::from_str("0123123123012312312301231231230123123123").unwrap()),
             abi: String::from("123123"),
+            start_block: None,
         },
         mapping: Mapping {
             kind: String::from("ethereum/events"),

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1718,7 +1718,7 @@ fn mock_data_source(path: &str) -> DataSource {
         source: Source {
             address: Some(Address::from_str("0123123123012312312301231231230123123123").unwrap()),
             abi: String::from("123123"),
-            start_block: None,
+            start_block: 0,
         },
         mapping: Mapping {
             kind: String::from("ethereum/events"),

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -48,7 +48,6 @@ lazy_static! {
                 StoreConfig {
                     postgres_url,
                     network_name: NETWORK_NAME.to_owned(),
-                    start_block: 0u64,
                 },
                 &logger,
                 net_identifiers,


### PR DESCRIPTION
Resolves #1131

Start blocks can now be defined per data source in the manifest and are used to resolve a subgraph wide earliest Ethereum block value.

The subgraph registrar logs warnings if the start blocks do not represent the block where the data source's contract (if specified) was created. 
The permissive nature of the start block validation allows flexibility for a subgraph owner to filter the chain as they see fit.  