### PR TITLE
Validate entities on `store.set`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,6 +1002,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.15.1",
  "graph-core 0.15.1",
+ "graph-graphql 0.15.1",
  "graph-mock 0.15.1",
  "graph-runtime-derive 0.15.1",
  "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -33,7 +33,7 @@ where
         skip: i32,
     ) -> Result<Query, Error> {
         // Obtain the "subgraphs" schema
-        let schema = self.store.subgraph_schema(&SUBGRAPHS_ID)?;
+        let schema = self.store.api_schema(&SUBGRAPHS_ID)?;
 
         // Construct a query for the subgraph deployment and all its
         // dynamic data sources

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -67,7 +67,7 @@ fn insert_and_query(
     };
     let document = graphql_parser::parse_query(query).unwrap();
     let query = Query {
-        schema: STORE.subgraph_schema(&subgraph_id).unwrap(),
+        schema: STORE.api_schema(&subgraph_id).unwrap(),
         document,
         variables: None,
     };

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -991,6 +991,12 @@ pub trait SubgraphDeploymentStore: Send + Sync + 'static {
     /// Return the GraphQL schema that was derived from the user's schema by
     /// adding a root query type etc. to it
     fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error>;
+
+    /// Return true if the subgraph uses the relational storage scheme; if
+    /// it is false, the subgraph uses JSONB storage. This method exposes
+    /// store internals that should really be hidden and should be used
+    /// sparingly and only when absolutely needed
+    fn uses_relational_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<bool, Error>;
 }
 
 /// Common trait for blockchain store implementations.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -985,7 +985,9 @@ pub trait Store: Send + Sync + 'static {
 }
 
 pub trait SubgraphDeploymentStore: Send + Sync + 'static {
-    fn subgraph_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error>;
+    /// Return the GraphQL schema that was derived from the user's schema by
+    /// adding a root query type etc. to it
+    fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error>;
 }
 
 /// Common trait for blockchain store implementations.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -985,6 +985,9 @@ pub trait Store: Send + Sync + 'static {
 }
 
 pub trait SubgraphDeploymentStore: Send + Sync + 'static {
+    /// Return the GraphQL schema supplied by the user
+    fn input_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error>;
+
     /// Return the GraphQL schema that was derived from the user's schema by
     /// adding a root query type etc. to it
     fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error>;

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1114,7 +1114,7 @@ impl EntityCache {
     pub fn get(
         &mut self,
         store: &dyn Store,
-        key: EntityKey,
+        key: &EntityKey,
     ) -> Result<Option<Entity>, QueryExecutionError> {
         let current = match self.current.get(&key) {
             None => {
@@ -1196,7 +1196,7 @@ impl EntityCache {
             .filter(|key| !self.current.contains_key(&key))
             .collect::<Vec<_>>();
         for key in missing {
-            self.get(store, key)?;
+            self.get(store, &key)?;
         }
         let mut mods = Vec::new();
         for (key, update) in self.updates {

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -257,6 +257,26 @@ impl Value {
             None
         }
     }
+
+    /// Return the name of the type of this value for display to the user
+    pub fn type_name(&self) -> String {
+        match self {
+            Value::BigDecimal(_) => "BigDecimal".to_owned(),
+            Value::BigInt(_) => "BigInt".to_owned(),
+            Value::Bool(_) => "Boolean".to_owned(),
+            Value::Bytes(_) => "Bytes".to_owned(),
+            Value::Int(_) => "Int".to_owned(),
+            Value::List(values) => {
+                if let Some(v) = values.first() {
+                    format!("[{}]", v.type_name())
+                } else {
+                    "[Any]".to_owned()
+                }
+            }
+            Value::Null => "Null".to_owned(),
+            Value::String(_) => "String".to_owned(),
+        }
+    }
 }
 
 impl fmt::Display for Value {
@@ -270,10 +290,14 @@ impl fmt::Display for Value {
                 Value::BigDecimal(d) => d.to_string(),
                 Value::Bool(b) => b.to_string(),
                 Value::Null => "null".to_string(),
-                Value::List(ref values) => values
-                    .into_iter()
-                    .map(|value| format!("{}", value))
-                    .collect(),
+                Value::List(ref values) => format!(
+                    "[{}]",
+                    values
+                        .into_iter()
+                        .map(|value| format!("{}", value))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
                 Value::Bytes(ref bytes) => bytes.to_string(),
                 Value::BigInt(ref number) => number.to_string(),
             }

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -28,7 +28,7 @@ pub mod prelude {
     pub use super::execution::{ExecutionContext, ObjectOrInterface, Resolver};
     pub use super::introspection::{introspection_schema, IntrospectionResolver};
     pub use super::query::{execute_query, QueryExecutionOptions};
-    pub use super::schema::{api_schema, APISchemaError};
+    pub use super::schema::{api_schema, ast::validate_entity, APISchemaError};
     pub use super::store::{build_query, StoreResolver};
     pub use super::subscription::{execute_subscription, SubscriptionExecutionOptions};
     pub use super::values::{object_value, MaybeCoercible};

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -110,18 +110,6 @@ pub fn get_object_type_definitions(schema: &Document) -> Vec<&ObjectType> {
         .collect()
 }
 
-/// Returns all object type definitions in the schema.
-pub fn get_object_type_definitions_mut(schema: &mut Document) -> Vec<&mut ObjectType> {
-    schema
-        .definitions
-        .iter_mut()
-        .filter_map(|d| match d {
-            Definition::TypeDefinition(TypeDefinition::Object(t)) => Some(t),
-            _ => None,
-        })
-        .collect()
-}
-
 /// Returns the object type with the given name.
 pub fn get_object_type_mut<'a>(
     schema: &'a mut Document,
@@ -140,18 +128,6 @@ pub fn get_interface_type_definitions(schema: &Document) -> Vec<&InterfaceType> 
     schema
         .definitions
         .iter()
-        .filter_map(|d| match d {
-            Definition::TypeDefinition(TypeDefinition::Interface(t)) => Some(t),
-            _ => None,
-        })
-        .collect()
-}
-
-/// Returns all interface definitions in the schema.
-pub fn get_interface_type_definitions_mut(schema: &mut Document) -> Vec<&mut InterfaceType> {
-    schema
-        .definitions
-        .iter_mut()
         .filter_map(|d| match d {
             Definition::TypeDefinition(TypeDefinition::Interface(t)) => Some(t),
             _ => None,
@@ -406,7 +382,7 @@ pub fn is_list_or_non_null_list_field(field: &Field) -> bool {
     }
 }
 
-pub fn unpack_type<'a>(schema: &'a Document, t: &Type) -> Option<&'a TypeDefinition> {
+fn unpack_type<'a>(schema: &'a Document, t: &Type) -> Option<&'a TypeDefinition> {
     use self::Type::*;
 
     match t {

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -414,6 +414,10 @@ impl SubgraphDeploymentStore for MockStore {
         schema.document = api_schema(&schema.document)?;
         return Ok(Arc::new(schema));
     }
+
+    fn uses_relational_schema(&self, _: &SubgraphDeploymentId) -> Result<bool, Error> {
+        Ok(true)
+    }
 }
 
 impl ChainStore for MockStore {

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -73,6 +73,12 @@ impl MockStore {
             type User @entity {
                 id: ID!,
                 name: String,
+            }
+            # Needed by ipfs_map in runtime/wasm/src/test.rs
+            type Thing @entity {
+                id: ID!,
+                value: String,
+                extra: String
             }";
         let subgraph = Self::user_subgraph_id();
         let schema =

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -400,6 +400,10 @@ impl Store for MockStore {
 }
 
 impl SubgraphDeploymentStore for MockStore {
+    fn input_schema(&self, _: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
+        unimplemented!()
+    }
+
     fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
         if *subgraph_id == *SUBGRAPHS_ID {
             // The subgraph of subgraphs schema is built-in.

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -400,7 +400,7 @@ impl Store for MockStore {
 }
 
 impl SubgraphDeploymentStore for MockStore {
-    fn subgraph_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
+    fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
         if *subgraph_id == *SUBGRAPHS_ID {
             // The subgraph of subgraphs schema is built-in.
             let raw_schema = include_str!("../../store/postgres/src/subgraphs.graphql").to_owned();

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -8,6 +8,7 @@ ethabi = { git = "https://github.com/graphprotocol/ethabi.git", branch = "graph-
 futures = "0.1.21"
 hex = "0.4.0"
 graph = { path = "../../graph" }
+graph-graphql = { path = "../../graphql" }
 tiny-keccak = "1.4.2"
 wasmi = "0.5"
 pwasm-utils = "0.6.1"

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -74,7 +74,7 @@ impl<T, L, S> RuntimeHostBuilderTrait for RuntimeHostBuilder<T, L, S>
 where
     T: EthereumAdapter,
     L: LinkResolver,
-    S: Store,
+    S: Store + SubgraphDeploymentStore,
 {
     type Host = RuntimeHost;
 
@@ -177,7 +177,7 @@ impl RuntimeHost {
     where
         T: EthereumAdapter,
         L: LinkResolver,
-        S: Store,
+        S: Store + SubgraphDeploymentStore,
     {
         let logger = logger.new(o!(
             "component" => "RuntimeHost",
@@ -321,7 +321,7 @@ impl RuntimeHost {
                 })
                 .wait()
                 .unwrap_or_else(|e| {
-                    debug!(module_logger, "WASM runtime thread terminating"; 
+                    debug!(module_logger, "WASM runtime thread terminating";
                            "reason" => e.to_string())
                 });
         })

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -174,7 +174,7 @@ where
         let result = ctx
             .state
             .entity_cache
-            .get(self.store.as_ref(), store_key)
+            .get(self.store.as_ref(), &store_key)
             .map_err(HostExportError)
             .map(|ok| ok.to_owned());
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -102,7 +102,7 @@ impl<T, L, S, U> ValidModule<T, L, S, U>
 where
     T: EthereumAdapter,
     L: LinkResolver,
-    S: Store + Send + Sync + 'static,
+    S: Store + SubgraphDeploymentStore + Send + Sync + 'static,
     U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
         + Clone
         + Send
@@ -202,7 +202,7 @@ impl<T, L, S, U> WasmiModule<T, L, S, U>
 where
     T: EthereumAdapter,
     L: LinkResolver,
-    S: Store + Send + Sync + 'static,
+    S: Store + SubgraphDeploymentStore + Send + Sync + 'static,
     U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
         + Clone
         + Send
@@ -412,7 +412,7 @@ impl<T, L, S, U> AscHeap for WasmiModule<T, L, S, U>
 where
     T: EthereumAdapter,
     L: LinkResolver,
-    S: Store + Send + Sync + 'static,
+    S: Store + SubgraphDeploymentStore + Send + Sync + 'static,
     U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
         + Clone
         + Send
@@ -462,7 +462,7 @@ impl<T, L, S, U> WasmiModule<T, L, S, U>
 where
     T: EthereumAdapter,
     L: LinkResolver,
-    S: Store + Send + Sync + 'static,
+    S: Store + SubgraphDeploymentStore + Send + Sync + 'static,
     U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
         + Clone
         + Send
@@ -992,7 +992,7 @@ impl<T, L, S, U> Externals for WasmiModule<T, L, S, U>
 where
     T: EthereumAdapter,
     L: LinkResolver,
-    S: Store + Send + Sync + 'static,
+    S: Store + SubgraphDeploymentStore + Send + Sync + 'static,
     U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
         + Clone
         + Send

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -265,7 +265,7 @@ impl<T, L, S, U> WasmiModule<T, L, S, U>
 where
     T: EthereumAdapter,
     L: LinkResolver,
-    S: Store + Send + Sync + 'static,
+    S: Store + SubgraphDeploymentStore + Send + Sync + 'static,
     U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
         + Clone
         + Send

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -454,28 +454,25 @@ mod tests {
     #[test]
     fn posting_invalid_query_yields_error_response() {
         let logger = Logger::root(slog::Discard, o!());
-        let id = SubgraphDeploymentId::new("testschema").unwrap();
-        let schema = Schema::parse(
-            "\
-             scalar String \
-             type Query @entity { name: String } \
-             ",
-            id.clone(),
-        )
-        .unwrap();
+        let store = Arc::new(MockStore::user_store());
+        let id = MockStore::user_subgraph_id();
+        let schema = store
+            .input_schema(&id)
+            .expect("Failed to get schema")
+            .as_ref()
+            .clone();
         let manifest = SubgraphManifest {
             id: id.clone(),
             location: "".to_owned(),
             spec_version: "".to_owned(),
             description: None,
             repository: None,
-            schema: schema.clone(),
+            schema,
             data_sources: vec![],
             templates: vec![],
         };
 
         let graphql_runner = Arc::new(TestGraphQlRunner);
-        let store = Arc::new(MockStore::new(vec![(id.clone(), schema)]));
         store
             .apply_metadata_operations(
                 SubgraphDeploymentEntity::new(
@@ -527,27 +524,24 @@ mod tests {
     #[test]
     fn posting_valid_queries_yields_result_response() {
         let logger = Logger::root(slog::Discard, o!());
-        let id = SubgraphDeploymentId::new("testschema").unwrap();
-        let schema = Schema::parse(
-            "\
-             scalar String \
-             type Query @entity { name: String } \
-             ",
-            id.clone(),
-        )
-        .unwrap();
+        let store = Arc::new(MockStore::user_store());
+        let id = MockStore::user_subgraph_id();
+        let schema = store
+            .input_schema(&id)
+            .expect("Failed to get schema")
+            .as_ref()
+            .clone();
         let manifest = SubgraphManifest {
             id: id.clone(),
             location: "".to_owned(),
             spec_version: "".to_owned(),
             description: None,
             repository: None,
-            schema: schema.clone(),
+            schema,
             data_sources: vec![],
             templates: vec![],
         };
         let graphql_runner = Arc::new(TestGraphQlRunner);
-        let store = Arc::new(MockStore::new(vec![(id.clone(), schema)]));
 
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
         runtime

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -203,7 +203,7 @@ where
             Ok(true) => (),
         }
 
-        let schema = match self.store.subgraph_schema(id) {
+        let schema = match self.store.api_schema(id) {
             Ok(schema) => schema,
             Err(e) => {
                 return Box::new(future::err(GraphQLServerError::InternalError(

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -295,7 +295,7 @@ where
             // The query is against the subgraph of subgraphs
             schema: self
                 .store
-                .subgraph_schema(&SUBGRAPHS_ID)
+                .api_schema(&SUBGRAPHS_ID)
                 .map_err(QueryExecutionError::StoreError)?,
 
             // We're querying all deployments that match the provided filter
@@ -389,7 +389,7 @@ where
             // The query is against the subgraph of subgraphs
             schema: self
                 .store
-                .subgraph_schema(&SUBGRAPHS_ID)
+                .api_schema(&SUBGRAPHS_ID)
                 .map_err(QueryExecutionError::StoreError)?,
 
             // We're querying all deployments that match the provided filter

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -164,7 +164,7 @@ where
                             let subgraph_id = subgraph_id.lock().unwrap().clone().unwrap();
 
                             // Get the subgraph schema
-                            let schema = match store2.subgraph_schema(&subgraph_id) {
+                            let schema = match store2.api_schema(&subgraph_id) {
                                 Ok(schema) => schema,
                                 Err(e) => {
                                     error!(logger2, "Failed to establish WS connection, could not find schema";

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -44,7 +44,7 @@ use graph::prelude::{
     debug, format_err, info, serde_json, warn, AttributeIndexDefinition, Entity, EntityChange,
     EntityChangeOperation, EntityFilter, EntityKey, EntityModification, Error,
     EthereumBlockPointer, Logger, QueryExecutionError, StoreError, StoreEvent,
-    SubgraphDeploymentId, TransactionAbortError, ValueType,
+    SubgraphDeploymentId, SubgraphDeploymentStore, TransactionAbortError, ValueType,
 };
 
 use crate::block_range::{block_number, BlockNumber};
@@ -1409,7 +1409,7 @@ impl Storage {
                 })
             }
             V::Relational => {
-                let subgraph_schema = store.raw_subgraph_schema(subgraph)?;
+                let subgraph_schema = store.input_schema(subgraph)?;
                 let layout = Layout::new(
                     &subgraph_schema.document,
                     IdType::String,

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -797,6 +797,13 @@ impl Connection {
             None => create_split_schema(&self.conn, &schema_name),
         }
     }
+
+    pub(crate) fn uses_relational_schema(&self) -> bool {
+        match &*self.storage {
+            Storage::Json(_) => false,
+            Storage::Relational(_) => true,
+        }
+    }
 }
 
 // Find the database schema for `subgraph`. If no explicit schema exists,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -381,7 +381,7 @@ impl Store {
         // if that's Fred the Dog, Fred the Cat or both.
         //
         // This assumes that there are no concurrent writes to a subgraph.
-        let schema = self.subgraph_schema(&key.subgraph_id)?;
+        let schema = self.api_schema(&key.subgraph_id)?;
         let types_for_interface = schema.types_for_interface();
         let types_with_shared_interface = Vec::from_iter(
             schema
@@ -1085,7 +1085,7 @@ impl StoreTrait for Store {
 }
 
 impl SubgraphDeploymentStore for Store {
-    fn subgraph_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
+    fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
         Ok(self.cached_schema(subgraph_id)?.api)
     }
 }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1087,6 +1087,11 @@ impl SubgraphDeploymentStore for Store {
     fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error> {
         Ok(self.cached_schema(subgraph_id)?.api)
     }
+
+    fn uses_relational_schema(&self, subgraph: &SubgraphDeploymentId) -> Result<bool, Error> {
+        self.get_entity_conn(subgraph)
+            .map(|econn| econn.uses_relational_schema())
+    }
 }
 
 impl ChainStore for Store {

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -2170,7 +2170,7 @@ fn throttle_subscription_throttles() {
 fn subgraph_schema_types_have_subgraph_id_directive() {
     run_test(|store| -> Result<(), ()> {
         let schema = store
-            .subgraph_schema(&TEST_SUBGRAPH_ID)
+            .api_schema(&TEST_SUBGRAPH_ID)
             .expect("test subgraph should have a schema");
         for typedef in schema
             .document


### PR DESCRIPTION
These changes make it so that we now validate entities against the subgraph schema when mappings call `store.set`.

This is a user-visible change, and can lead to subgraphs that were previously working to now fail because of the additional validation - those subgraphs would have produced errors when invaid data was queried, but syncing would have seemingly worked.

Fixes https://github.com/graphprotocol/graph-node/issues/615