### PR TITLE
Two smallish changes

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -730,7 +730,7 @@ fn create_subgraph_version(
     if deployment_exists {
         store.apply_metadata_operations(ops)?
     } else {
-        store.create_subgraph_deployment(logger, &manifest.schema, ops)?;
+        store.create_subgraph_deployment(&manifest.schema, ops)?;
     }
 
     debug!(

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -32,9 +32,7 @@ fn insert_and_query(
         .into_iter()
         .map(|op| op.into())
         .collect();
-    STORE
-        .create_subgraph_deployment(&logger, &schema, ops)
-        .unwrap();
+    STORE.create_subgraph_deployment(&schema, ops).unwrap();
 
     let insert_ops = entities
         .into_iter()

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -954,7 +954,6 @@ pub trait Store: Send + Sync + 'static {
     /// version
     fn create_subgraph_deployment(
         &self,
-        subgraph_logger: &Logger,
         schema: &Schema,
         ops: Vec<MetadataOperation>,
     ) -> Result<(), StoreError>;

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -77,16 +77,12 @@ fn insert_test_entities(store: &impl Store, id: SubgraphDeploymentId) {
         templates: vec![],
     };
 
-    let logger = Logger::root(slog::Discard, o!());
-
     let ops = SubgraphDeploymentEntity::new(&manifest, false, false, GENESIS_PTR.clone(), None)
         .create_operations_replace(&id)
         .into_iter()
         .map(|op| op.into())
         .collect();
-    store
-        .create_subgraph_deployment(&logger, &schema, ops)
-        .unwrap();
+    store.create_subgraph_deployment(&schema, ops).unwrap();
 
     let entities = vec![
         Entity::from(vec![

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -381,7 +381,6 @@ impl Store for MockStore {
 
     fn create_subgraph_deployment(
         &self,
-        _logger: &Logger,
         _schema: &Schema,
         ops: Vec<MetadataOperation>,
     ) -> Result<(), StoreError> {
@@ -542,7 +541,6 @@ impl Store for FakeStore {
 
     fn create_subgraph_deployment(
         &self,
-        _logger: &Logger,
         _schema: &Schema,
         _ops: Vec<MetadataOperation>,
     ) -> Result<(), StoreError> {

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -498,7 +498,7 @@ fn ipfs_map() {
     let errmsg = run_ipfs_map(BAD_IPFS_HASH.to_string())
         .unwrap_err()
         .to_string();
-    assert!(errmsg.contains("api returned error \\'invalid \\'ipfs ref\\' path\\'"))
+    assert!(errmsg.contains("api returned error"))
 }
 
 #[test]

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -736,22 +736,12 @@ impl Connection {
     /// It is an error if `deployment_schemas` already has an entry for this
     /// `subgraph_id`. Note that `self` must be a connection for the subgraph
     /// of subgraphs
-    pub(crate) fn create_schema(
-        &self,
-        schema: &SubgraphSchema,
-        lock_timeout: u64,
-    ) -> Result<(), StoreError> {
+    pub(crate) fn create_schema(&self, schema: &SubgraphSchema) -> Result<(), StoreError> {
         assert_eq!(
             &*SUBGRAPHS_ID,
             self.storage.subgraph(),
             "create_schema can only be called on a Connection for the metadata subgraph"
         );
-
-        // Creating JSONB storage used to require a lock on event_meta_data. To
-        // avoid locking up indexing completely, do not hold a lock for longer
-        // than `lock_timeout`
-        self.conn
-            .batch_execute(&format!("set local lock_timeout to '{}s'", lock_timeout))?;
 
         // Check if there already is an entry for this subgraph. If so, do
         // nothing


### PR DESCRIPTION
The first is something I ran into when I inadvertently updated ipfs on my machine.

The second, removing the lock timeout on graph deployment, is something I should have done as part of d4995c00 but didn't in case we needed to reintroduce the foreign key. Now that we have run without that for a while we can also remove the machinery around not failing subgraph deployments because of the foreign key.