### PR TITLE
Docker: Make waiting for IPFS/Postgres work with full URLs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,19 +47,20 @@ EXPOSE 8020
 # Start everything on startup
 ADD start-node /usr/local/bin
 
+RUN apt-get install gawk
+
 # Wait for IPFS and Postgres to start up.
 #
-# The sed/awk commands below take the IPFS and Postgres and extract
-# hostname:port from them (sed), using port 80 as a fallback (awk).
+# The awk commands below take the IPFS and Postgres and extract
+# hostname:port from them. The IPFS port defaults to 443 for HTTPS
+# and 80 for HTTP. The Postgres port defaults to 5432.
 CMD wait-for-it.sh \
       $(echo $ipfs | \
-        sed -E -e 's@([a-z]+:\/\/)([^\/]+).*$@\2@' | \
-        awk -F[:] '{ print $1":"($2 ? $2 : 80) }') \
+        gawk 'match($0, /^([a-z]+:\/\/)?([^\/:]+)(:([0-9]+))?.*$/, m) { print m[2]":"(m[4] ? m[4] : (m[1] == "https://" ? 443 : 80)) }') \
       -t 30 \
     && wait-for-it.sh \
          $(echo $postgres_host | \
-           sed -E -e 's@([a-z]+:\/\/)([^\/]+).*$@\2@' | \
-           awk -F[:] '{ print $1":"($2 ? $2 : 80) }') \
+           gawk 'match($0, /^([a-z]+:\/\/)?([^\/:]+)(:([0-9]+))?.*$/, m) { print m[2]":"(m[4] ? m[4] : 5432) }') \
          -t 30 \
     && sleep 5 \
     && start-node

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,20 @@ EXPOSE 8020
 
 # Start everything on startup
 ADD start-node /usr/local/bin
-CMD wait-for-it.sh $ipfs -t 30 \
-    && wait-for-it.sh $postgres_host -t 30 \
+
+# Wait for IPFS and Postgres to start up.
+#
+# The sed/awk commands below take the IPFS and Postgres and extract
+# hostname:port from them (sed), using port 80 as a fallback (awk).
+CMD wait-for-it.sh \
+      $(echo $ipfs | \
+        sed -E -e 's@([a-z]+:\/\/)([^\/]+).*$@\2@' | \
+        awk -F[:] '{ print $1":"($2 ? $2 : 80) }') \
+      -t 30 \
+    && wait-for-it.sh \
+         $(echo $postgres_host | \
+           sed -E -e 's@([a-z]+:\/\/)([^\/]+).*$@\2@' | \
+           awk -F[:] '{ print $1":"($2 ? $2 : 80) }') \
+         -t 30 \
     && sleep 5 \
     && start-node


### PR DESCRIPTION
Previously, you could only set the `ipfs` and `postgres_host` variables to `<hostname>:<port>` because `wait-for-it.sh` doesn't support full URLs.

Now you can specify full URLs and the `Dockerfile` will extract hostname and port from these. For IPFS, the port will default to 443 (HTTPS) or 80 (HTTP). For Postgres, it will default to 5432.

## Try locally

1. Check out the PR branch.
2. Enter the `docker/` directory.
3. Run `docker build .`
4. Once the build has finished, run `docker run -it -e -e ipfs=https://api.thegraph.com/ipfs/ -e postgres_host=http://host.docker.internal:5432/ <image>`.

## Log from testing this locally

```sh
➜  docker git:(jannis/docker-full-ipfs-and-postgres-urls) ✗ docker run -it -e ipfs=https://api.thegraph.com/ipfs/ -e postgres_host=http://host.docker.internal:5432/ 83318427cd21
wait-for-it.sh: waiting 30 seconds for api.thegraph.com:443
wait-for-it.sh: api.thegraph.com:443 is available after 0 seconds
wait-for-it.sh: waiting 30 seconds for host.docker.internal:5432
wait-for-it.sh: host.docker.internal:5432 is available after 0 seconds

➜  docker git:(jannis/docker-full-ipfs-and-postgres-urls) ✗ docker run -it -e ipfs=https://api.thegraph.com/ipfs/ -e postgres_host=host.docker.internal:5432 83318427cd21
wait-for-it.sh: waiting 30 seconds for api.thegraph.com:443
wait-for-it.sh: api.thegraph.com:443 is available after 0 seconds
wait-for-it.sh: waiting 30 seconds for host.docker.internal:5432
wait-for-it.sh: host.docker.internal:5432 is available after 0 seconds

➜  docker git:(jannis/docker-full-ipfs-and-postgres-urls) ✗ docker run -it -e ipfs=https://api.thegraph.com/ipfs/ -e postgres_host=host.docker.internal:5432 83318427cd21
wait-for-it.sh: waiting 30 seconds for api.thegraph.com:443
wait-for-it.sh: api.thegraph.com:443 is available after 0 seconds
wait-for-it.sh: waiting 30 seconds for host.docker.internal:5432
wait-for-it.sh: host.docker.internal:5432 is available after 0 seconds

➜  docker git:(jannis/docker-full-ipfs-and-postgres-urls) ✗ docker run -it -e ipfs=http://api.thegraph.com/ipfs/ -e postgres_host=host.docker.internal:5432 83318427cd21
wait-for-it.sh: waiting 30 seconds for api.thegraph.com:80
wait-for-it.sh: api.thegraph.com:80 is available after 0 seconds
wait-for-it.sh: waiting 30 seconds for host.docker.internal:5432
wait-for-it.sh: host.docker.internal:5432 is available after 0 seconds

➜  docker git:(jannis/docker-full-ipfs-and-postgres-urls) ✗ docker run -it -e ipfs=http://api.thegraph.com/ipfs/ -e postgres_host=host.docker.internal:5432/foo/bar 83318427cd21
wait-for-it.sh: waiting 30 seconds for api.thegraph.com:80
wait-for-it.sh: api.thegraph.com:80 is available after 0 seconds
wait-for-it.sh: waiting 30 seconds for host.docker.internal:5432
wait-for-it.sh: host.docker.internal:5432 is available after 0 seconds
```