### PR TITLE
Limit number of Ethereum request retries (defaults to 10)

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -38,6 +38,9 @@ those.
   cause subgraphs to be only indexed partially.
 - `GRAPH_ETHEREUM_MAX_EVENT_ONLY_RANGE`: Maximum range size for `eth.getLogs`
   requests that dont filter on contract address, only event signature.
+- `GRAPH_ETHEREUM_REQUEST_RETRIES`: Number of times to retry JSON-RPC requests
+  made against Ethereum. A higher number can help with instable Ethereum
+  nodes/APIs (defaults to 10).
 
 ## Running mapping handlers
 


### PR DESCRIPTION
Resolves #1276.

This adds a new `GRAPH_ETHEREUM_REQUEST_RETRIES` environment variable that defines the number of times Graph Node retries requests made to Ethereum. This avoids retrying requests indefinitely, which can lead to subgraphs being stuck and problems not being noticed.