### PR TITLE
Share mapping threads among data sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ name = "Inflector"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -316,7 +316,7 @@ name = "colored"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -422,7 +422,7 @@ dependencies = [
  "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -461,7 +461,7 @@ dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -480,7 +480,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -511,7 +511,7 @@ name = "derive_more"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -869,10 +869,10 @@ dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.1 (git+https://github.com/ferristseng/rust-ipfs-api)",
  "isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -908,7 +908,7 @@ dependencies = [
  "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.1 (git+https://github.com/ferristseng/rust-ipfs-api)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru_time_cache 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -928,7 +928,7 @@ dependencies = [
  "graph 0.15.1",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -939,7 +939,7 @@ dependencies = [
  "graph 0.15.1",
  "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-store 0.1.0",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -980,7 +980,7 @@ dependencies = [
  "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.1 (git+https://github.com/ferristseng/rust-ipfs-api)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1007,10 +1007,11 @@ dependencies = [
  "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.1 (git+https://github.com/ferristseng/rust-ipfs-api)",
- "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pwasm-utils 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pwasm-utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1037,7 +1038,7 @@ dependencies = [
  "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1047,7 +1048,7 @@ version = "0.15.1"
 dependencies = [
  "graph 0.15.1",
  "jsonrpc-http-server 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1060,7 +1061,7 @@ dependencies = [
  "graph-graphql 0.15.1",
  "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tungstenite 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1085,9 +1086,9 @@ dependencies = [
  "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru_time_cache 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-store 0.1.0",
@@ -1412,7 +1413,7 @@ dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1436,7 +1437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1669,7 +1670,7 @@ name = "native-tls"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1755,7 +1756,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1808,11 +1809,8 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.31.3"
+version = "0.40.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "parking_lot"
@@ -2019,19 +2017,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pwasm-utils"
-version = "0.6.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2362,7 +2360,7 @@ name = "schannel"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2560,7 +2558,7 @@ version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2733,7 +2731,7 @@ dependencies = [
  "graph 0.15.1",
  "graph-store-postgres 0.15.1",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2766,7 +2764,7 @@ name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2864,7 +2862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2904,7 +2902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3256,23 +3254,23 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmi-validation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi-validation 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmi-validation"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3522,7 +3520,7 @@ dependencies = [
 "checksum jsonrpc-server-utils 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d415f51d016a4682878e19dd03e8c0b61cd4394912d7cd3dc48d4f19f061a4e"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)" = "3262021842bf00fe07dbd6cf34ff25c99d7a7ebef8deea84db72be3ea3bb0aff"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
@@ -3567,7 +3565,7 @@ dependencies = [
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parity-codec 3.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2b9df1283109f542d8852cd6b30e9341acc2137481eb6157d2e62af68b0afec9"
-"checksum parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)" = "511379a8194230c2395d2f5fa627a5a7e108a9f976656ce723ae68fca4097bfc"
+"checksum parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1e39faaa292a687ea15120b1ac31899b13586446521df6c149e46f1584671e0f"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
@@ -3589,7 +3587,7 @@ dependencies = [
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e98a83a9f9b331f54b924e68a66acb1bb35cb01fb0a23645139967abefb697e8"
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
-"checksum pwasm-utils 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "efb0dcbddbb600f47a7098d33762a00552c671992171637f5bb310b37fe1f0e4"
+"checksum pwasm-utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d473123ba135028544926f7aa6f34058d8bc6f120c4fcd3777f84af724280b3"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
@@ -3727,8 +3725,8 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
-"checksum wasmi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "48437c526d40a6a593c50c5367dac825b8d6a04411013e866eca66123fb56faa"
-"checksum wasmi-validation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab380192444b3e8522ae79c0a1976e42a82920916ccdfbce3def89f456ea33f3"
+"checksum wasmi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f31d26deb2d9a37e6cfed420edce3ed604eab49735ba89035e13c98f9a528313"
+"checksum wasmi-validation 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6bc0356e3df56e639fc7f7d8a99741915531e27ed735d911ed83d7e1339c8188"
 "checksum web3 0.8.0 (git+https://github.com/graphprotocol/rust-web3?branch=graph-patches)" = "<none>"
 "checksum websocket 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c9faed2bff8af2ea6b9f8b917d3d00b467583f6781fe3def174a9e33c879703"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,6 @@ dependencies = [
  "graph 0.15.1",
  "graph-graphql 0.15.1",
  "graph-mock 0.15.1",
- "graph-runtime-wasm 0.15.1",
  "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipfs-api 0.5.1 (git+https://github.com/ferristseng/rust-ipfs-api)",
@@ -1011,6 +1010,7 @@ dependencies = [
  "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,7 @@ bytes = "0.4.11"
 futures = "0.1.21"
 graph = { path = "../graph" }
 graph-graphql = { path = "../graphql" }
-graph-runtime-wasm = { path = "../runtime/wasm" }
+
 # We're using the latest ipfs-api for the HTTPS support that was merged in
 # https://github.com/ferristseng/rust-ipfs-api/commit/55902e98d868dcce047863859caf596a629d10ec
 # but has not been released yet.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,7 +3,6 @@ extern crate graph;
 extern crate graph_graphql;
 #[cfg(test)]
 extern crate graph_mock;
-extern crate graph_runtime_wasm;
 extern crate lazy_static;
 extern crate semver;
 extern crate serde;

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -34,35 +34,6 @@ impl<T> SubgraphInstance<T>
 where
     T: RuntimeHostBuilder,
 {
-    fn new_host(
-        &mut self,
-        logger: Logger,
-        data_source: DataSource,
-        top_level_templates: Vec<DataSourceTemplate>,
-    ) -> Result<T::Host, Error> {
-        let mapping_request_sender = {
-            let module_bytes = data_source.mapping.runtime.as_ref().clone().to_bytes()?;
-            if let Some(sender) = self.module_cache.get(&module_bytes) {
-                sender.clone()
-            } else {
-                let sender = T::spawn_mapping(
-                    data_source.mapping.runtime.as_ref().clone(),
-                    logger,
-                    self.subgraph_id.clone(),
-                )?;
-                self.module_cache.insert(module_bytes, sender.clone());
-                sender
-            }
-        };
-        self.host_builder.build(
-            self.network.clone(),
-            self.subgraph_id.clone(),
-            data_source,
-            top_level_templates,
-            mapping_request_sender,
-        )
-    }
-
     pub(crate) fn from_manifest(
         logger: &Logger,
         manifest: SubgraphManifest,
@@ -109,6 +80,35 @@ where
             .collect();
 
         Ok(this)
+    }
+
+    fn new_host(
+        &mut self,
+        logger: Logger,
+        data_source: DataSource,
+        top_level_templates: Vec<DataSourceTemplate>,
+    ) -> Result<T::Host, Error> {
+        let mapping_request_sender = {
+            let module_bytes = data_source.mapping.runtime.as_ref().clone().to_bytes()?;
+            if let Some(sender) = self.module_cache.get(&module_bytes) {
+                sender.clone()
+            } else {
+                let sender = T::spawn_mapping(
+                    data_source.mapping.runtime.as_ref().clone(),
+                    logger,
+                    self.subgraph_id.clone(),
+                )?;
+                self.module_cache.insert(module_bytes, sender.clone());
+                sender
+            }
+        };
+        self.host_builder.build(
+            self.network.clone(),
+            self.subgraph_id.clone(),
+            data_source,
+            top_level_templates,
+            mapping_request_sender,
+        )
     }
 }
 

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -1,8 +1,11 @@
+use futures::sync::mpsc::Sender;
 use lazy_static::lazy_static;
+use std::collections::HashMap;
 use std::env;
 use std::str::FromStr;
 
 use graph::prelude::{SubgraphInstance as SubgraphInstanceTrait, *};
+use graph_runtime_wasm::{MappingRequest, RuntimeHostBuilder};
 use web3::types::Log;
 
 lazy_static! {
@@ -12,30 +15,72 @@ lazy_static! {
             .unwrap_or_else(|_| panic!("failed to parse env var GRAPH_SUBGRAPH_MAX_DATA_SOURCES")));
 }
 
-pub struct SubgraphInstance<T>
-where
-    T: RuntimeHostBuilder + Sync,
-{
+pub struct SubgraphInstance<S> {
+    subgraph_id: SubgraphDeploymentId,
+    network: String,
+    host_builder: RuntimeHostBuilder<S>,
+
     /// Runtime hosts, one for each data source mapping.
     ///
     /// The runtime hosts are created and added in the same order the
     /// data sources appear in the subgraph manifest. Incoming block
     /// stream events are processed by the mappings in this same order.
-    hosts: Vec<Arc<T::Host>>,
+    hosts: Vec<Arc<dyn RuntimeHost>>,
+
+    /// Maps a serialized module to a channel to the thread in which the module is instantiated.
+    module_cache: HashMap<Vec<u8>, Sender<MappingRequest>>,
 }
 
-impl<T> SubgraphInstanceTrait<T> for SubgraphInstance<T>
+impl<S> SubgraphInstance<S>
 where
-    T: RuntimeHostBuilder + Sync,
+    S: Store + SubgraphDeploymentStore + EthereumCallCache,
 {
-    fn from_manifest(
+    fn new_host(
+        &mut self,
+        logger: Logger,
+        data_source: DataSource,
+        top_level_templates: Vec<DataSourceTemplate>,
+    ) -> Result<impl RuntimeHost, Error> {
+        let mapping_request_sender = {
+            let module_bytes = data_source.mapping.runtime.as_ref().clone().to_bytes()?;
+            if let Some(sender) = self.module_cache.get(&module_bytes) {
+                sender.clone()
+            } else {
+                let sender = graph_runtime_wasm::spawn_module(
+                    data_source.mapping.runtime.as_ref().clone(),
+                    logger,
+                    self.subgraph_id.clone(),
+                    &data_source.name,
+                )?;
+                self.module_cache.insert(module_bytes, sender.clone());
+                sender
+            }
+        };
+        self.host_builder.build(
+            self.network.clone(),
+            self.subgraph_id.clone(),
+            data_source,
+            top_level_templates,
+            mapping_request_sender,
+        )
+    }
+
+    pub(crate) fn from_manifest(
         logger: &Logger,
         manifest: SubgraphManifest,
-        host_builder: &T,
+        host_builder: RuntimeHostBuilder<S>,
     ) -> Result<Self, Error> {
-        let manifest_id = manifest.id.clone();
-        let network_name = manifest.network_name()?;
+        let subgraph_id = manifest.id.clone();
+        let network = manifest.network_name()?;
         let templates = manifest.templates;
+
+        let mut this = SubgraphInstance {
+            host_builder,
+            subgraph_id,
+            network,
+            hosts: Vec::new(),
+            module_cache: HashMap::new(),
+        };
 
         // Create a new runtime host for each data source in the subgraph manifest;
         // we use the same order here as in the subgraph manifest to make the
@@ -43,15 +88,7 @@ where
         let (hosts, errors): (_, Vec<_>) = manifest
             .data_sources
             .into_iter()
-            .map(|d| {
-                host_builder.build(
-                    &logger,
-                    network_name.clone(),
-                    manifest_id.clone(),
-                    d,
-                    templates.clone(),
-                )
-            })
+            .map(|d| this.new_host(logger.clone(), d, templates.clone()))
             .partition(|res| res.is_ok());
 
         if !errors.is_empty() {
@@ -67,15 +104,20 @@ where
             ));
         }
 
-        Ok(SubgraphInstance {
-            hosts: hosts
-                .into_iter()
-                .map(Result::unwrap)
-                .map(Arc::new)
-                .collect(),
-        })
-    }
+        this.hosts = hosts
+            .into_iter()
+            .map(Result::unwrap)
+            .map(|host| Arc::new(host) as Arc<dyn RuntimeHost>)
+            .collect();
 
+        Ok(this)
+    }
+}
+
+impl<S> SubgraphInstanceTrait for SubgraphInstance<S>
+where
+    S: Store + SubgraphDeploymentStore + EthereumCallCache,
+{
     /// Returns true if the subgraph has a handler for an Ethereum event.
     fn matches_log(&self, log: &Log) -> bool {
         self.hosts.iter().any(|host| host.matches_log(log))
@@ -99,7 +141,7 @@ where
 
     fn process_trigger_in_runtime_hosts(
         logger: &Logger,
-        hosts: impl Iterator<Item = Arc<T::Host>>,
+        hosts: impl Iterator<Item = Arc<dyn RuntimeHost>>,
         block: Arc<EthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
@@ -171,10 +213,15 @@ where
         }
     }
 
-    fn add_dynamic_data_sources(&mut self, runtime_hosts: Vec<Arc<T::Host>>) -> Result<(), Error> {
+    fn add_dynamic_data_source(
+        &mut self,
+        logger: &Logger,
+        data_source: DataSource,
+        top_level_templates: Vec<DataSourceTemplate>,
+    ) -> Result<Arc<dyn RuntimeHost>, Error> {
         // Protect against creating more than the allowed maximum number of data sources
         if let Some(max_data_sources) = *MAX_DATA_SOURCES {
-            if self.hosts.len() + runtime_hosts.len() > max_data_sources {
+            if self.hosts.len() >= max_data_sources {
                 return Err(format_err!(
                     "Limit of {} data sources per subgraph exceeded",
                     max_data_sources
@@ -182,9 +229,8 @@ where
             }
         }
 
-        // Add the runtime hosts
-        self.hosts.extend(runtime_hosts);
-
-        Ok(())
+        let host = Arc::new(self.new_host(logger.clone(), data_source, top_level_templates)?);
+        self.hosts.push(host.clone());
+        Ok(host)
     }
 }

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -238,7 +238,7 @@ impl SubgraphInstanceManager {
     }
 
     fn stop_subgraph(instances: SharedInstanceKeepAliveMap, id: SubgraphDeploymentId) {
-        // Drop the cancel guard to shut down the sujbgraph now
+        // Drop the cancel guard to shut down the subgraph now
         let mut instances = instances.write().unwrap();
         instances.remove(&id);
     }

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -24,7 +24,7 @@ pub struct SubgraphAssignmentProvider<L, Q, S> {
 
 impl<L, Q, S> SubgraphAssignmentProvider<L, Q, S>
 where
-    L: LinkResolver,
+    L: LinkResolver + Clone,
     Q: GraphQlRunner,
     S: Store,
 {
@@ -74,7 +74,7 @@ where
 
 impl<L, Q, S> SubgraphAssignmentProviderTrait for SubgraphAssignmentProvider<L, Q, S>
 where
-    L: LinkResolver,
+    L: LinkResolver + Clone,
     Q: GraphQlRunner,
     S: Store + SubgraphDeploymentStore,
 {

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -37,7 +37,7 @@ pub struct SubgraphRegistrar<L, P, S, CS> {
 
 impl<L, P, S, CS> SubgraphRegistrar<L, P, S, CS>
 where
-    L: LinkResolver,
+    L: LinkResolver + Clone,
     P: SubgraphAssignmentProviderTrait,
     S: Store,
     CS: ChainStore,

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -10,18 +10,14 @@ use ipfs_api::IpfsClient;
 use walkdir::WalkDir;
 
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::fs::read_to_string;
 use std::io::Cursor;
-use std::sync::Mutex;
 use std::time::Duration;
 use std::time::Instant;
 
-use graph::components::ethereum::*;
 use graph::prelude::*;
-use graph_core::{LinkResolver, SubgraphInstanceManager};
-use graph_mock::{FakeStore, MockBlockStreamBuilder, MockStore};
-use web3::types::*;
+use graph_core::LinkResolver;
+use graph_mock::MockStore;
 
 use crate::tokio::timer::Delay;
 
@@ -69,6 +65,7 @@ fn add_subgraph_to_ipfs(
 
 #[ignore]
 #[test]
+#[cfg(any())]
 fn multiple_data_sources_per_subgraph() {
     #[derive(Debug)]
     struct MockRuntimeHost {}

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -1,7 +1,6 @@
 extern crate graph;
 extern crate graph_core;
 extern crate graph_mock;
-extern crate graph_runtime_wasm;
 extern crate ipfs_api;
 extern crate semver;
 extern crate walkdir;

--- a/datasource/ethereum/src/block_ingestor.rs
+++ b/datasource/ethereum/src/block_ingestor.rs
@@ -4,32 +4,30 @@ use std::time::Instant;
 use graph::prelude::*;
 use web3::types::*;
 
-pub struct BlockIngestor<S, E>
+pub struct BlockIngestor<S>
 where
     S: ChainStore,
-    E: EthereumAdapter,
 {
     chain_store: Arc<S>,
-    eth_adapter: Arc<E>,
+    eth_adapter: Arc<dyn EthereumAdapter>,
     ancestor_count: u64,
     network_name: String,
     logger: Logger,
     polling_interval: Duration,
 }
 
-impl<S, E> BlockIngestor<S, E>
+impl<S> BlockIngestor<S>
 where
     S: ChainStore,
-    E: EthereumAdapter,
 {
     pub fn new(
         chain_store: Arc<S>,
-        eth_adapter: Arc<E>,
+        eth_adapter: Arc<dyn EthereumAdapter>,
         ancestor_count: u64,
         network_name: String,
         logger_factory: &LoggerFactory,
         polling_interval: Duration,
-    ) -> Result<BlockIngestor<S, E>, Error> {
+    ) -> Result<BlockIngestor<S>, Error> {
         let logger = logger_factory.component_logger(
             "BlockIngestor",
             Some(ComponentLoggerConfig {

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -960,7 +960,7 @@ where
         &self,
         logger: &Logger,
         call: EthereumContractCall,
-        cache: Arc<impl EthereumCallCache>,
+        cache: Arc<dyn EthereumCallCache>,
     ) -> Box<dyn Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send> {
         // Emit custom error for type mismatches.
         for (token, kind) in call

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -23,7 +23,7 @@ graphql-parser = "0.2.3"
 # https://github.com/ferristseng/rust-ipfs-api/commit/55902e98d868dcce047863859caf596a629d10ec
 # but has not been released yet.
 ipfs-api = { git = "https://github.com/ferristseng/rust-ipfs-api", branch = "master", features = ["hyper-tls"] }
-parity-wasm = "0.31"
+parity-wasm = "0.40"
 failure = "0.1.2"
 lazy_static = "1.2.0"
 num-bigint = { version = "^0.2.3", features = ["serde"] }

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -541,6 +541,6 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         &self,
         logger: &Logger,
         call: EthereumContractCall,
-        cache: Arc<impl EthereumCallCache>,
+        cache: Arc<dyn EthereumCallCache>,
     ) -> Box<dyn Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send>;
 }

--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -18,9 +18,11 @@ pub type JsonValueStream =
     Box<dyn Stream<Item = JsonStreamValue, Error = failure::Error> + Send + 'static>;
 
 /// Resolves links to subgraph manifests and resources referenced by them.
-pub trait LinkResolver: Clone + Send + Sync + 'static + Sized {
+pub trait LinkResolver: Send + Sync + 'static {
     /// Updates the timeout used by the resolver.
-    fn with_timeout(self, timeout: Duration) -> Self;
+    fn with_timeout(self, timeout: Duration) -> Self
+    where
+        Self: Sized;
 
     /// Fetches the link contents as bytes.
     fn cat(

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1137,7 +1137,7 @@ impl EntityCache {
 
     pub fn get(
         &mut self,
-        store: &dyn Store,
+        store: &(impl Store + ?Sized),
         key: &EntityKey,
     ) -> Result<Option<Entity>, QueryExecutionError> {
         let current = match self.current.get(&key) {
@@ -1211,7 +1211,7 @@ impl EntityCache {
     /// to the current state is actually needed
     pub fn as_modifications(
         mut self,
-        store: &dyn Store,
+        store: &(impl Store + ?Sized),
     ) -> Result<Vec<EntityModification>, QueryExecutionError> {
         let missing = self
             .updates

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 use web3::types::{Log, Transaction};
 
 /// Common trait for runtime host implementations.
-pub trait RuntimeHost: Send + Sync + Debug {
+pub trait RuntimeHost: Send + Sync + Debug + 'static {
     /// Returns true if the RuntimeHost has a handler for an Ethereum event.
     fn matches_log(&self, log: &Log) -> bool;
 
@@ -44,18 +44,4 @@ pub trait RuntimeHost: Send + Sync + Debug {
         trigger_type: EthereumBlockTriggerType,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;
-}
-
-pub trait RuntimeHostBuilder: Clone + Send + Sync + 'static {
-    type Host: RuntimeHost;
-
-    /// Build a new runtime host for a subgraph data source.
-    fn build(
-        &self,
-        logger: &Logger,
-        network_name: String,
-        subgraph_id: SubgraphDeploymentId,
-        data_source: DataSource,
-        top_level_templates: Vec<DataSourceTemplate>,
-    ) -> Result<Self::Host, Error>;
 }

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -15,7 +15,7 @@ pub struct BlockState {
 }
 
 /// Represents a loaded instance of a subgraph.
-pub trait SubgraphInstance {
+pub trait SubgraphInstance<H: RuntimeHost> {
     /// Returns true if the subgraph has a handler for an Ethereum event.
     fn matches_log(&self, log: &Log) -> bool;
 
@@ -31,7 +31,7 @@ pub trait SubgraphInstance {
     /// Like `process_trigger` but processes an Ethereum event in a given list of hosts.
     fn process_trigger_in_runtime_hosts(
         logger: &Logger,
-        hosts: impl Iterator<Item = Arc<dyn RuntimeHost>>,
+        hosts: impl Iterator<Item = Arc<H>>,
         block: Arc<EthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
@@ -43,5 +43,5 @@ pub trait SubgraphInstance {
         logger: &Logger,
         data_source: DataSource,
         top_level_templates: Vec<DataSourceTemplate>,
-    ) -> Result<Arc<dyn RuntimeHost>, Error>;
+    ) -> Result<Arc<H>, Error>;
 }

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -15,17 +15,7 @@ pub struct BlockState {
 }
 
 /// Represents a loaded instance of a subgraph.
-pub trait SubgraphInstance<T>: Sized + Sync
-where
-    T: RuntimeHostBuilder,
-{
-    /// Creates a subgraph instance from a manifest.
-    fn from_manifest(
-        logger: &Logger,
-        manifest: SubgraphManifest,
-        host_builder: &T,
-    ) -> Result<Self, Error>;
-
+pub trait SubgraphInstance {
     /// Returns true if the subgraph has a handler for an Ethereum event.
     fn matches_log(&self, log: &Log) -> bool;
 
@@ -41,12 +31,17 @@ where
     /// Like `process_trigger` but processes an Ethereum event in a given list of hosts.
     fn process_trigger_in_runtime_hosts(
         logger: &Logger,
-        hosts: impl Iterator<Item = Arc<T::Host>>,
+        hosts: impl Iterator<Item = Arc<dyn RuntimeHost>>,
         block: Arc<EthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;
 
     /// Adds dynamic data sources to the subgraph.
-    fn add_dynamic_data_sources(&mut self, runtime_hosts: Vec<Arc<T::Host>>) -> Result<(), Error>;
+    fn add_dynamic_data_source(
+        &mut self,
+        logger: &Logger,
+        data_source: DataSource,
+        top_level_templates: Vec<DataSourceTemplate>,
+    ) -> Result<Arc<dyn RuntimeHost>, Error>;
 }

--- a/graph/src/components/subgraph/mod.rs
+++ b/graph/src/components/subgraph/mod.rs
@@ -7,7 +7,7 @@ mod registrar;
 
 pub use crate::prelude::Entity;
 
-pub use self::host::RuntimeHost;
+pub use self::host::{RuntimeHost, RuntimeHostBuilder};
 pub use self::instance::{BlockState, DataSourceTemplateInfo, SubgraphInstance};
 pub use self::instance_manager::SubgraphInstanceManager;
 pub use self::loader::DataSourceLoader;

--- a/graph/src/components/subgraph/mod.rs
+++ b/graph/src/components/subgraph/mod.rs
@@ -7,7 +7,7 @@ mod registrar;
 
 pub use crate::prelude::Entity;
 
-pub use self::host::{RuntimeHost, RuntimeHostBuilder};
+pub use self::host::RuntimeHost;
 pub use self::instance::{BlockState, DataSourceTemplateInfo, SubgraphInstance};
 pub use self::instance_manager::SubgraphInstanceManager;
 pub use self::loader::DataSourceLoader;

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -62,7 +62,7 @@ pub mod prelude {
         SUBSCRIPTION_THROTTLE_INTERVAL,
     };
     pub use crate::components::subgraph::{
-        BlockState, DataSourceLoader, DataSourceTemplateInfo, RuntimeHost, RuntimeHostBuilder,
+        BlockState, DataSourceLoader, DataSourceTemplateInfo, RuntimeHost,
         SubgraphAssignmentProvider, SubgraphInstance, SubgraphInstanceManager, SubgraphRegistrar,
         SubgraphVersionSwitchingMode,
     };

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -62,7 +62,7 @@ pub mod prelude {
         SUBSCRIPTION_THROTTLE_INTERVAL,
     };
     pub use crate::components::subgraph::{
-        BlockState, DataSourceLoader, DataSourceTemplateInfo, RuntimeHost,
+        BlockState, DataSourceLoader, DataSourceTemplateInfo, RuntimeHost, RuntimeHostBuilder,
         SubgraphAssignmentProvider, SubgraphInstance, SubgraphInstanceManager, SubgraphRegistrar,
         SubgraphVersionSwitchingMode,
     };

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -17,7 +17,7 @@ use graph_core::{
     SubgraphInstanceManager, SubgraphRegistrar as IpfsSubgraphRegistrar,
 };
 use graph_datasource_ethereum::{BlockStreamBuilder, Transport};
-use graph_runtime_wasm::RuntimeHostBuilder;
+use graph_runtime_wasm::RuntimeHostBuilder as WASMRuntimeHostBuilder;
 use graph_server_http::GraphQLServer as GraphQLQueryServer;
 use graph_server_index_node::IndexNodeServer;
 use graph_server_json_rpc::JsonRpcServer;
@@ -563,7 +563,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
         *REORG_THRESHOLD,
     );
     let runtime_host_builder =
-        RuntimeHostBuilder::new(eth_adapters.clone(), link_resolver.clone(), stores.clone());
+        WASMRuntimeHostBuilder::new(eth_adapters.clone(), link_resolver.clone(), stores.clone());
 
     let subgraph_instance_manager = SubgraphInstanceManager::new(
         &logger_factory,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -17,7 +17,7 @@ use graph_core::{
     SubgraphInstanceManager, SubgraphRegistrar as IpfsSubgraphRegistrar,
 };
 use graph_datasource_ethereum::{BlockStreamBuilder, Transport};
-use graph_runtime_wasm::RuntimeHostBuilder as WASMRuntimeHostBuilder;
+use graph_runtime_wasm::RuntimeHostBuilder;
 use graph_server_http::GraphQLServer as GraphQLQueryServer;
 use graph_server_index_node::IndexNodeServer;
 use graph_server_json_rpc::JsonRpcServer;
@@ -563,7 +563,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
         *REORG_THRESHOLD,
     );
     let runtime_host_builder =
-        WASMRuntimeHostBuilder::new(eth_adapters.clone(), link_resolver.clone(), stores.clone());
+        RuntimeHostBuilder::new(eth_adapters.clone(), link_resolver.clone(), stores.clone());
 
     let subgraph_instance_manager = SubgraphInstanceManager::new(
         &logger_factory,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -10,7 +10,9 @@ use std::time::Duration;
 
 use graph::components::forward;
 use graph::log::logger;
-use graph::prelude::{IndexNodeServer as _, JsonRpcServer as _, *};
+use graph::prelude::{
+    EthereumAdapter as EthereumAdapterTrait, IndexNodeServer as _, JsonRpcServer as _, *,
+};
 use graph::util::security::SafeDisplay;
 use graph_core::{
     LinkResolver, SubgraphAssignmentProvider as IpfsSubgraphAssignmentProvider,
@@ -708,13 +710,7 @@ fn parse_ethereum_networks_and_nodes(
     logger: Logger,
     networks: clap::Values,
     connection_type: ConnectionType,
-) -> Result<
-    HashMap<
-        String,
-        Arc<graph_datasource_ethereum::EthereumAdapter<graph_datasource_ethereum::Transport>>,
-    >,
-    Error,
-> {
+) -> Result<HashMap<String, Arc<dyn EthereumAdapterTrait>>, Error> {
     networks
         .map(|network| {
             if network.starts_with("wss://")
@@ -769,7 +765,7 @@ fn parse_ethereum_networks_and_nodes(
                     Arc::new(graph_datasource_ethereum::EthereumAdapter::new(
                         transport,
                         *ETHEREUM_START_BLOCK,
-                    )),
+                    )) as Arc<dyn EthereumAdapter>,
                 ))
             }
         })

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -16,6 +16,7 @@ graph-runtime-derive = { path = "../derive" }
 semver = "0.9.0"
 parity-wasm = "0.40"
 lazy_static = "1.4"
+uuid = { version = "0.7.4", features = ["v4"] }
 
 [dev-dependencies]
 graphql-parser = "0.2.3"

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -9,12 +9,13 @@ futures = "0.1.21"
 hex = "0.4.0"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
-wasmi = "0.5"
-pwasm-utils = "0.6.1"
+wasmi = "0.5.1"
+pwasm-utils = "0.11"
 bs58 = "0.3.0"
 graph-runtime-derive = { path = "../derive" }
 semver = "0.9.0"
-parity-wasm = "0.31"
+parity-wasm = "0.40"
+lazy_static = "1.4"
 
 [dev-dependencies]
 graphql-parser = "0.2.3"

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -549,7 +549,6 @@ impl RuntimeHostTrait for RuntimeHost {
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
         let logger = logger.clone();
-        let mapping_request_sender = self.mapping_request_sender.clone();
 
         let block = block.clone();
         let transaction = transaction.clone();
@@ -676,7 +675,7 @@ impl RuntimeHostTrait for RuntimeHost {
         let start_time = Instant::now();
 
         Box::new(
-            mapping_request_sender
+            self.mapping_request_sender
                 .clone()
                 .send(MappingRequest {
                     ctx: MappingContext {

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -50,15 +50,12 @@ where
     S: Store + SubgraphDeploymentStore + EthereumCallCache,
 {
     pub fn new(
-        ethereum_adapters: HashMap<String, Arc<impl EthereumAdapter>>,
+        ethereum_adapters: HashMap<String, Arc<dyn EthereumAdapter>>,
         link_resolver: Arc<dyn LinkResolver>,
         stores: HashMap<String, Arc<S>>,
     ) -> Self {
         RuntimeHostBuilder {
-            ethereum_adapters: ethereum_adapters
-                .into_iter()
-                .map(|(key, adapter)| (key, adapter as Arc<dyn EthereumAdapter>))
-                .collect(),
+            ethereum_adapters,
             link_resolver,
             stores,
         }

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -130,7 +130,7 @@ pub struct RuntimeHost<E, L, S> {
     data_source_call_handlers: Vec<MappingCallHandler>,
     data_source_block_handlers: Vec<MappingBlockHandler>,
     mapping_request_sender: Sender<MappingRequest<E, L, S>>,
-    host_exports: HostExports<E, L, S>,
+    host_exports: Arc<HostExports<E, L, S>>,
     _guard: oneshot::Sender<()>,
 }
 
@@ -197,8 +197,9 @@ impl<E, L, S> RuntimeHost<E, L, S> {
             format!("mapping-{}-{}", &config.subgraph_id, data_source_name),
         )?;
 
-        // Create new instance of externally hosted functions invoker
-        let host_exports = HostExports::new(
+        // Create new instance of externally hosted functions invoker. The `Arc` is simply to avoid
+        // implementing `Clone` for `HostExports`.
+        let host_exports = Arc::new(HostExports::new(
             config.subgraph_id.clone(),
             api_version,
             config.data_source_name,
@@ -211,7 +212,7 @@ impl<E, L, S> RuntimeHost<E, L, S> {
                 .ok()
                 .and_then(|s| u64::from_str(&s).ok())
                 .map(Duration::from_secs),
-        );
+        ));
 
         Ok(RuntimeHost {
             data_source_name,

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -132,7 +132,6 @@ pub struct RuntimeHost {
     data_source_block_handlers: Vec<MappingBlockHandler>,
     mapping_request_sender: Sender<MappingRequest>,
     host_exports: Arc<HostExports>,
-    _guard: oneshot::Sender<()>,
 }
 
 impl RuntimeHost {
@@ -177,10 +176,11 @@ impl RuntimeHost {
             .clone();
         let data_source_name = config.data_source_name;
 
-        let (mapping_request_sender, cancel_guard) = crate::mapping::handle(
+        let mapping_request_sender = crate::mapping::handle(
             config.mapping.runtime.as_ref().clone(),
             logger.clone(),
-            format!("mapping-{}-{}", &config.subgraph_id, &data_source_name),
+            config.subgraph_id.clone(),
+            &data_source_name,
         )?;
 
         // Create new instance of externally hosted functions invoker. The `Arc` is simply to avoid
@@ -209,7 +209,6 @@ impl RuntimeHost {
             data_source_block_handlers: config.mapping.block_handlers,
             mapping_request_sender,
             host_exports,
-            _guard: cancel_guard,
         })
     }
 

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -49,23 +49,6 @@ pub(crate) struct HostExports<E, L, S> {
     handler_timeout: Option<Duration>,
 }
 
-// `HostExports` gets cloned on every handler call so that should not be expensive.
-impl<E, L, S> Clone for HostExports<E, L, S> {
-    fn clone(&self) -> Self {
-        Self {
-            subgraph_id: self.subgraph_id.clone(),
-            ethereum_adapter: self.ethereum_adapter.clone(),
-            link_resolver: self.link_resolver.clone(),
-            store: self.store.clone(),
-            handler_timeout: self.handler_timeout.clone(),
-            api_version: self.api_version.clone(),
-            data_source_name: self.data_source_name.clone(),
-            templates: self.templates.clone(),
-            abis: self.abis.clone(),
-        }
-    }
-}
-
 impl<E, L, S> HostExports<E, L, S>
 where
     E: EthereumAdapter,

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -19,9 +19,9 @@ pub(crate) struct UnresolvedContractCall {
     pub function_args: Vec<ethabi::Token>,
 }
 
-#[derive(Debug)]
-pub(crate) struct MappingContext {
+pub(crate) struct MappingContext<E, L, S> {
     logger: Logger,
+    host_exports: host_exports::HostExports<E, L, S>,
     block: Arc<EthereumBlock>,
     state: BlockState,
 }
@@ -29,10 +29,11 @@ pub(crate) struct MappingContext {
 /// Cloning an `MappingContext` clones all its fields,
 /// except the `state_operations`, since they are an output
 /// accumulator and are therefore initialized with an empty state.
-impl Clone for MappingContext {
+impl<E, L, S> Clone for MappingContext<E, L, S> {
     fn clone(&self) -> Self {
         MappingContext {
             logger: self.logger.clone(),
+            host_exports: self.host_exports.clone(),
             block: self.block.clone(),
             state: BlockState::default(),
         }

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -1,15 +1,20 @@
 mod asc_abi;
-mod host;
-mod module;
 mod to_from;
+
+/// Public interface of the crate, receives triggers to be processed.
+mod host;
+pub use self::host::{RuntimeHost, RuntimeHostBuilder, RuntimeHostConfig};
+
+/// Pre-processes modules and manages their threads. Serves as an interface from `host` to `module`.
+mod mapping;
+
+/// Deals with wasmi.
+mod module;
 
 /// Runtime-agnostic implementation of exports to WASM.
 mod host_exports;
 
-use graph::prelude::*;
-use web3::types::Address;
-
-pub use self::host::{RuntimeHost, RuntimeHostBuilder, RuntimeHostConfig};
+use graph::prelude::web3::types::Address;
 
 #[derive(Clone, Debug)]
 pub(crate) struct UnresolvedContractCall {
@@ -17,25 +22,4 @@ pub(crate) struct UnresolvedContractCall {
     pub contract_address: Address,
     pub function_name: String,
     pub function_args: Vec<ethabi::Token>,
-}
-
-pub(crate) struct MappingContext<E, L, S> {
-    logger: Logger,
-    host_exports: host_exports::HostExports<E, L, S>,
-    block: Arc<EthereumBlock>,
-    state: BlockState,
-}
-
-/// Cloning an `MappingContext` clones all its fields,
-/// except the `state_operations`, since they are an output
-/// accumulator and are therefore initialized with an empty state.
-impl<E, L, S> Clone for MappingContext<E, L, S> {
-    fn clone(&self) -> Self {
-        MappingContext {
-            logger: self.logger.clone(),
-            host_exports: self.host_exports.clone(),
-            block: self.block.clone(),
-            state: BlockState::default(),
-        }
-    }
 }

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -3,11 +3,10 @@ mod to_from;
 
 /// Public interface of the crate, receives triggers to be processed.
 mod host;
-pub use self::host::{RuntimeHostBuilder, RuntimeHostConfig};
+pub use host::RuntimeHostBuilder;
 
 /// Pre-processes modules and manages their threads. Serves as an interface from `host` to `module`.
 mod mapping;
-pub use mapping::{spawn_module, MappingRequest};
 
 /// Deals with wasmi.
 mod module;

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -3,10 +3,11 @@ mod to_from;
 
 /// Public interface of the crate, receives triggers to be processed.
 mod host;
-pub use self::host::{RuntimeHost, RuntimeHostBuilder, RuntimeHostConfig};
+pub use self::host::{RuntimeHostBuilder, RuntimeHostConfig};
 
 /// Pre-processes modules and manages their threads. Serves as an interface from `host` to `module`.
 mod mapping;
+pub use mapping::{spawn_module, MappingRequest};
 
 /// Deals with wasmi.
 mod module;
@@ -15,6 +16,7 @@ mod module;
 mod host_exports;
 
 use graph::prelude::web3::types::Address;
+use graph::prelude::{Store, SubgraphDeploymentStore};
 
 #[derive(Clone, Debug)]
 pub(crate) struct UnresolvedContractCall {
@@ -23,3 +25,6 @@ pub(crate) struct UnresolvedContractCall {
     pub function_name: String,
     pub function_args: Vec<ethabi::Token>,
 }
+
+trait RuntimeStore: Store + SubgraphDeploymentStore {}
+impl<S: Store + SubgraphDeploymentStore> RuntimeStore for S {}

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -140,7 +140,7 @@ pub(crate) struct MappingRequest<E, L, S> {
 
 pub(crate) struct MappingContext<E, L, S> {
     pub(crate) logger: Logger,
-    pub(crate) host_exports: crate::host_exports::HostExports<E, L, S>,
+    pub(crate) host_exports: Arc<crate::host_exports::HostExports<E, L, S>>,
     pub(crate) block: Arc<EthereumBlock>,
     pub(crate) state: BlockState,
 }

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -13,7 +13,6 @@ pub fn spawn_module(
     parsed_module: parity_wasm::elements::Module,
     logger: Logger,
     subgraph_id: SubgraphDeploymentId,
-    data_source_name: &str,
 ) -> Result<mpsc::Sender<MappingRequest>, Error> {
     let valid_module = Arc::new(ValidModule::new(parsed_module)?);
 
@@ -34,7 +33,7 @@ pub fn spawn_module(
     // dropping the `mapping_request_receiver` which ultimately causes the
     // subgraph to fail the next time it tries to handle an event.
     let conf =
-        thread::Builder::new().name(format!("mapping-{}-{}", &subgraph_id, data_source_name));
+        thread::Builder::new().name(format!("mapping-{}-{}", &subgraph_id, uuid::Uuid::new_v4()));
     conf.spawn(move || {
         // Pass incoming triggers to the WASM module and return entity changes;
         // Stop when canceled because all RuntimeHosts and their senders were dropped.

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -34,6 +34,7 @@ where
     // `task_receiver`.
     let (task_sender, task_receiver) = mpsc::channel(100);
     tokio::spawn(task_receiver.for_each(tokio::spawn));
+
     // Spawn a dedicated thread for the runtime.
     //
     // In case of failure, this thread may panic or simply terminate,
@@ -58,6 +59,7 @@ where
                     result_sender,
                 } = request;
 
+                // Start the WASMI module runtime.
                 let module = WasmiModule::from_valid_module_with_ctx(
                     valid_module.clone(),
                     ctx,

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -1,0 +1,208 @@
+use crate::module::WasmiModule;
+use ethabi::LogParam;
+use futures::sync::mpsc;
+use futures::sync::oneshot;
+use graph::components::ethereum::*;
+use graph::prelude::*;
+use std::thread;
+use std::time::Instant;
+use web3::types::{Log, Transaction};
+
+/// The first channel is for mapping requests, the second is a cancelation guard.
+pub(crate) fn handle<E, L, S>(
+    parsed_module: parity_wasm::elements::Module,
+    logger: Logger,
+    thread_name: String,
+) -> Result<(mpsc::Sender<MappingRequest<E, L, S>>, oneshot::Sender<()>), Error>
+where
+    E: EthereumAdapter,
+    L: LinkResolver,
+    S: Store + SubgraphDeploymentStore + EthereumCallCache,
+{
+    let valid_module = Arc::new(ValidModule::new(parsed_module)?);
+
+    // Create channel for canceling the module
+    let (cancel_sender, cancel_receiver) = oneshot::channel();
+
+    // Create channel for event handling requests
+    let (mapping_request_sender, mapping_request_receiver) = mpsc::channel(100);
+
+    // wasmi modules are not `Send` therefore they cannot be scheduled by
+    // the regular tokio executor, so we create a dedicated thread.
+    //
+    // This thread can spawn tasks on the runtime by sending them to
+    // `task_receiver`.
+    let (task_sender, task_receiver) = mpsc::channel(100);
+    tokio::spawn(task_receiver.for_each(tokio::spawn));
+    // Spawn a dedicated thread for the runtime.
+    //
+    // In case of failure, this thread may panic or simply terminate,
+    // dropping the `mapping_request_receiver` which ultimately causes the
+    // subgraph to fail the next time it tries to handle an event.
+    let conf = thread::Builder::new().name(thread_name);
+    conf.spawn(move || {
+        // Pass incoming triggers to the WASM module and return entity changes;
+        // Stop when cancelled.
+        let canceler = cancel_receiver.into_stream();
+        mapping_request_receiver
+            .select(
+                canceler
+                    .map(|_| panic!("WASM module thread cancelled"))
+                    .map_err(|_| ()),
+            )
+            .map_err(|()| err_msg("Cancelled"))
+            .for_each(move |request| -> Result<(), Error> {
+                let MappingRequest {
+                    ctx,
+                    trigger,
+                    result_sender,
+                } = request;
+
+                let module = WasmiModule::from_valid_module_with_ctx(
+                    valid_module.clone(),
+                    ctx,
+                    task_sender.clone(),
+                )?;
+
+                let result = match trigger {
+                    MappingTrigger::Log {
+                        transaction,
+                        log,
+                        params,
+                        handler,
+                    } => module.handle_ethereum_log(
+                        handler.handler.as_str(),
+                        transaction,
+                        log,
+                        params,
+                    ),
+                    MappingTrigger::Call {
+                        transaction,
+                        call,
+                        inputs,
+                        outputs,
+                        handler,
+                    } => module.handle_ethereum_call(
+                        handler.handler.as_str(),
+                        transaction,
+                        call,
+                        inputs,
+                        outputs,
+                    ),
+                    MappingTrigger::Block { handler } => {
+                        module.handle_ethereum_block(handler.handler.as_str())
+                    }
+                };
+
+                result_sender
+                    .send((result, future::ok(Instant::now())))
+                    .map_err(|_| err_msg("WASM module result receiver dropped."))
+            })
+            .wait()
+            .unwrap_or_else(|e| {
+                debug!(logger, "WASM runtime thread terminating";
+                           "reason" => e.to_string())
+            });
+    })
+    .map(|_| ())
+    .map_err(|e| format_err!("Spawning WASM runtime thread failed: {}", e))?;
+
+    Ok((mapping_request_sender, cancel_sender))
+}
+
+#[derive(Debug)]
+pub(crate) enum MappingTrigger {
+    Log {
+        transaction: Arc<Transaction>,
+        log: Arc<Log>,
+        params: Vec<LogParam>,
+        handler: MappingEventHandler,
+    },
+    Call {
+        transaction: Arc<Transaction>,
+        call: Arc<EthereumCall>,
+        inputs: Vec<LogParam>,
+        outputs: Vec<LogParam>,
+        handler: MappingCallHandler,
+    },
+    Block {
+        handler: MappingBlockHandler,
+    },
+}
+
+type MappingResponse = (Result<BlockState, Error>, futures::Finished<Instant, Error>);
+
+pub(crate) struct MappingRequest<E, L, S> {
+    pub(crate) ctx: MappingContext<E, L, S>,
+    pub(crate) trigger: MappingTrigger,
+    pub(crate) result_sender: oneshot::Sender<MappingResponse>,
+}
+
+pub(crate) struct MappingContext<E, L, S> {
+    pub(crate) logger: Logger,
+    pub(crate) host_exports: crate::host_exports::HostExports<E, L, S>,
+    pub(crate) block: Arc<EthereumBlock>,
+    pub(crate) state: BlockState,
+}
+
+/// Cloning an `MappingContext` clones all its fields,
+/// except the `state_operations`, since they are an output
+/// accumulator and are therefore initialized with an empty state.
+impl<E, L, S> Clone for MappingContext<E, L, S> {
+    fn clone(&self) -> Self {
+        MappingContext {
+            logger: self.logger.clone(),
+            host_exports: self.host_exports.clone(),
+            block: self.block.clone(),
+            state: BlockState::default(),
+        }
+    }
+}
+
+/// A pre-processed and valid WASM module, ready to be started as a WasmiModule.
+pub(crate) struct ValidModule {
+    pub(super) module: wasmi::Module,
+    pub(super) user_module: Option<String>,
+}
+
+impl ValidModule {
+    /// Pre-process and validate the module.
+    pub fn new(parsed_module: parity_wasm::elements::Module) -> Result<Self, Error> {
+        // Inject metering calls, which are used for checking timeouts.
+        let parsed_module = pwasm_utils::inject_gas_counter(parsed_module, &Default::default())
+            .map_err(|_| err_msg("failed to inject gas counter"))?;
+
+        // `inject_gas_counter` injects an import so the section must exist.
+        let import_section = parsed_module.import_section().unwrap().clone();
+
+        // Hack: AS currently puts all user imports in one module, in addition
+        // to the built-in "env" module. The name of that module is not fixed,
+        // to able able to infer the name we allow only one module with imports,
+        // with "env" being optional.
+        let mut user_modules: Vec<_> = import_section
+            .entries()
+            .into_iter()
+            .map(|import| import.module().to_owned())
+            .filter(|module| module != "env")
+            .collect();
+        user_modules.dedup();
+        let user_module = match user_modules.len() {
+            0 => None,
+            1 => Some(user_modules.into_iter().next().unwrap()),
+            _ => return Err(err_msg("WASM module has multiple import sections")),
+        };
+
+        let module = wasmi::Module::from_parity_wasm_module(parsed_module).map_err(|e| {
+            format_err!(
+                "Invalid module `{}`: {}",
+                user_module.as_ref().unwrap_or(&String::new()),
+                e
+            )
+        })?;
+
+        Ok(ValidModule {
+            module,
+            user_module,
+        })
+    }
+}

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -79,11 +79,11 @@ fn format_wasmi_error(e: Error) -> String {
 }
 
 /// A WASM module based on wasmi that powers a subgraph runtime.
-pub(crate) struct WasmiModule<T, L, S, U> {
+pub(crate) struct WasmiModule<U> {
     pub module: ModuleRef,
     memory: MemoryRef,
 
-    pub ctx: MappingContext<T, L, S>,
+    pub ctx: MappingContext,
     pub(crate) valid_module: Arc<ValidModule>,
     pub(crate) task_sink: U,
 
@@ -101,11 +101,8 @@ pub(crate) struct WasmiModule<T, L, S, U> {
     arena_free_size: u32,
 }
 
-impl<E, L, S, U> WasmiModule<E, L, S, U>
+impl<U> WasmiModule<U>
 where
-    E: EthereumAdapter,
-    L: LinkResolver,
-    S: Store + SubgraphDeploymentStore + EthereumCallCache + Send + Sync + 'static,
     U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
         + Clone
         + Send
@@ -115,7 +112,7 @@ where
     /// Creates a new wasmi module
     pub fn from_valid_module_with_ctx(
         valid_module: Arc<ValidModule>,
-        ctx: MappingContext<E, L, S>,
+        ctx: MappingContext,
         task_sink: U,
     ) -> Result<Self, FailureError> {
         // Build import resolver
@@ -306,11 +303,8 @@ where
     }
 }
 
-impl<T, L, S, U> AscHeap for WasmiModule<T, L, S, U>
+impl<U> AscHeap for WasmiModule<U>
 where
-    T: EthereumAdapter,
-    L: LinkResolver,
-    S: Store + SubgraphDeploymentStore + EthereumCallCache + Send + Sync + 'static,
     U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
         + Clone
         + Send
@@ -356,11 +350,8 @@ where
 impl<E> HostError for HostExportError<E> where E: fmt::Debug + fmt::Display + Send + Sync + 'static {}
 
 // Implementation of externals.
-impl<T, L, S, U> WasmiModule<T, L, S, U>
+impl<U> WasmiModule<U>
 where
-    T: EthereumAdapter,
-    L: LinkResolver,
-    S: Store + SubgraphDeploymentStore + EthereumCallCache + Send + Sync + 'static,
     U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
         + Clone
         + Send
@@ -916,11 +907,8 @@ where
     }
 }
 
-impl<T, L, S, U> Externals for WasmiModule<T, L, S, U>
+impl<U> Externals for WasmiModule<U>
 where
-    T: EthereumAdapter,
-    L: LinkResolver,
-    S: Store + SubgraphDeploymentStore + EthereumCallCache + Send + Sync + 'static,
     U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
         + Clone
         + Send

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -138,7 +138,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         &self,
         _: &Logger,
         _: EthereumContractCall,
-        _: Arc<impl EthereumCallCache>,
+        _: Arc<dyn EthereumCallCache>,
     ) -> Box<dyn Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send> {
         unimplemented!();
     }
@@ -262,11 +262,8 @@ fn mock_context() -> MappingContext {
     }
 }
 
-impl<T, L, S, U> WasmiModule<T, L, S, U>
+impl<U> WasmiModule<U>
 where
-    T: EthereumAdapter,
-    L: LinkResolver,
-    S: Store + SubgraphDeploymentStore + EthereumCallCache + Send + Sync + 'static,
     U: Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>
         + Clone
         + Send

--- a/runtime/wasm/src/module/test/abi.rs
+++ b/runtime/wasm/src/module/test/abi.rs
@@ -4,8 +4,7 @@ use super::*;
 fn unbounded_loop() {
     // Set handler timeout to 3 seconds.
     env::set_var(crate::host::TIMEOUT_ENV_VAR, "3");
-    let valid_module = test_valid_module(mock_data_source("wasm_test/non_terminating.wasm"));
-    let mut module = WasmiModule::from_valid_module_with_ctx(valid_module, mock_context()).unwrap();
+    let mut module = test_module(mock_data_source("wasm_test/non_terminating.wasm"));
     module.start_time = Instant::now();
     let err = module
         .module
@@ -20,8 +19,7 @@ fn unbounded_loop() {
 
 #[test]
 fn unbounded_recursion() {
-    let valid_module = test_valid_module(mock_data_source("wasm_test/non_terminating.wasm"));
-    let mut module = WasmiModule::from_valid_module_with_ctx(valid_module, mock_context()).unwrap();
+    let mut module = test_module(mock_data_source("wasm_test/non_terminating.wasm"));
     let err = module
         .module
         .clone()
@@ -32,8 +30,7 @@ fn unbounded_recursion() {
 
 #[test]
 fn abi_array() {
-    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_classes.wasm"));
-    let mut module = WasmiModule::from_valid_module_with_ctx(valid_module, mock_context()).unwrap();
+    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
 
     let vec = vec![
         "1".to_owned(),
@@ -61,8 +58,7 @@ fn abi_array() {
 
 #[test]
 fn abi_subarray() {
-    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_classes.wasm"));
-    let mut module = WasmiModule::from_valid_module_with_ctx(valid_module, mock_context()).unwrap();
+    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
 
     let vec: Vec<u8> = vec![1, 2, 3, 4];
     let vec_obj: AscPtr<TypedArray<u8>> = module.asc_new(&*vec);
@@ -76,8 +72,7 @@ fn abi_subarray() {
 
 #[test]
 fn abi_bytes_and_fixed_bytes() {
-    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_classes.wasm"));
-    let mut module = WasmiModule::from_valid_module_with_ctx(valid_module, mock_context()).unwrap();
+    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
     let bytes1: Vec<u8> = vec![42, 45, 7, 245, 45];
     let bytes2: Vec<u8> = vec![3, 12, 0, 1, 255];
 
@@ -98,8 +93,7 @@ fn abi_bytes_and_fixed_bytes() {
 /// and assert the final token is the same as the starting one.
 #[test]
 fn abi_ethabi_token_identity() {
-    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_token.wasm"));
-    let mut module = WasmiModule::from_valid_module_with_ctx(valid_module, mock_context()).unwrap();
+    let mut module = test_module(mock_data_source("wasm_test/abi_token.wasm"));
 
     // Token::Address
     let address = H160([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
@@ -204,8 +198,7 @@ fn abi_ethabi_token_identity() {
 fn abi_store_value() {
     use graph::data::store::Value;
 
-    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_store_value.wasm"));
-    let mut module = WasmiModule::from_valid_module_with_ctx(valid_module, mock_context()).unwrap();
+    let mut module = test_module(mock_data_source("wasm_test/abi_store_value.wasm"));
 
     // Value::Null
     let null_value_ptr: AscPtr<AscEnum<StoreValueKind>> = module
@@ -311,8 +304,7 @@ fn abi_store_value() {
 
 #[test]
 fn abi_h160() {
-    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_classes.wasm"));
-    let mut module = WasmiModule::from_valid_module_with_ctx(valid_module, mock_context()).unwrap();
+    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
     let address = H160::zero();
 
     // As an `Uint8Array`
@@ -331,8 +323,7 @@ fn abi_h160() {
 
 #[test]
 fn string() {
-    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_classes.wasm"));
-    let mut module = WasmiModule::from_valid_module_with_ctx(valid_module, mock_context()).unwrap();
+    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
     let string = "    漢字Double_Me🇧🇷  ";
     let trimmed_string_ptr = module.asc_new(string);
     let trimmed_string_obj: AscPtr<AscString> =
@@ -343,8 +334,7 @@ fn string() {
 
 #[test]
 fn abi_big_int() {
-    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_classes.wasm"));
-    let mut module = WasmiModule::from_valid_module_with_ctx(valid_module, mock_context()).unwrap();
+    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
 
     // Test passing in 0 and increment it by 1
     let old_uint = U256::zero();
@@ -367,8 +357,7 @@ fn abi_big_int() {
 
 #[test]
 fn big_int_to_string() {
-    let valid_module = test_valid_module(mock_data_source("wasm_test/big_int_to_string.wasm"));
-    let mut module = WasmiModule::from_valid_module_with_ctx(valid_module, mock_context()).unwrap();
+    let mut module = test_module(mock_data_source("wasm_test/big_int_to_string.wasm"));
 
     let big_int_str = "30145144166666665000000000000000000";
     let big_int = BigInt::from_str(big_int_str).unwrap();
@@ -383,8 +372,7 @@ fn big_int_to_string() {
 #[test]
 #[should_panic]
 fn invalid_discriminant() {
-    let valid_module = test_valid_module(mock_data_source("wasm_test/abi_store_value.wasm"));
-    let mut module = WasmiModule::from_valid_module_with_ctx(valid_module, mock_context()).unwrap();
+    let mut module = test_module(mock_data_source("wasm_test/abi_store_value.wasm"));
 
     let value_ptr = module
         .module

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -1,12 +1,12 @@
 use ethabi;
 use std::collections::HashMap;
 
-use crate::web3::types as web3;
 use graph::components::ethereum::{
     EthereumBlockData, EthereumCallData, EthereumEventData, EthereumTransactionData,
 };
 use graph::data::store;
 use graph::prelude::serde_json;
+use graph::prelude::web3::types as web3;
 use graph::prelude::{BigDecimal, BigInt};
 
 use crate::asc_abi::class::*;

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -27,6 +27,6 @@ uuid = { version = "0.7.4", features = ["v4"] }
 [dev-dependencies]
 graphql-parser = "0.2.3"
 hex = "0.4.0"
-parity-wasm = "0.31"
+parity-wasm = "0.40"
 test-store = { path = "../test-store" }
 hex-literal = "0.2"


### PR DESCRIPTION
Resolves #1269. What this does is share the runtime thread among dynamic data sources, dramatically reducing the amount of threads we spawn. In a subgraph with lots of data sources, it seemed to go from 1GB RAM and 2600 threads to 200MB RAM and 100 threads. So this should save some memory and prevent us from hitting OS limits on the number of threads.

I ended up refactoring more than I expected along the way, and there is some back and forth so I don't recommend reading commit by commit. Summary of changes:

- The map of runtime module to request sender, which is the important part of this PR, is kept in `SubgraphInstance`, that types was pretty bare so I gave it more stuff to do.
- `HostExports` is no longer put in `ValidModule`, but passed in with every `MappingRequest`. This is because `HostExports` can be different for each data source sharing a module.
- `WasmiModuleConfig` was removed, it mostly just duplicated `HostExports`.
- To better organize the runtime crate, I created a module `mapping.rs` which now contains the thread creation, `ValidModule` and some other types.
- Because we now pass the request sender to `RuntimeHost` on creation, the `RuntimeHostBuilder` became really hard to deal with, so I removed it. I don't think much abstraction was lost.
- I experimented with using more trait objects (`dyn Trait`) to keep the profusion of generics and trait bounds under control and make the code look cleaner. I think it mostly worked out.