### PR TITLE
store: Produce correct query when ordering by id

### DIFF
--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -911,15 +911,22 @@ impl<'a> FilterQuery<'a> {
             out.push_identifier(name.as_str())?;
             out.push_sql(" ");
             out.push_sql(direction);
-            out.push_sql(", ");
+            if name.as_str() != PRIMARY_KEY_COLUMN {
+                out.push_sql(", ");
+                out.push_identifier(PRIMARY_KEY_COLUMN)?;
+            }
+            Ok(())
+        } else {
+            out.push_identifier(PRIMARY_KEY_COLUMN)
         }
-        out.push_identifier(PRIMARY_KEY_COLUMN)
     }
 
     fn add_sort_key(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
         if let Some((name, _)) = self.order {
-            out.push_sql(", e.");
-            out.push_identifier(name.as_str())?;
+            if name.as_str() != PRIMARY_KEY_COLUMN {
+                out.push_sql(", e.");
+                out.push_identifier(name.as_str())?;
+            }
         }
         Ok(())
     }

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -587,6 +587,31 @@ fn find_interface() {
             range: EntityRange::first(100),
         },
     );
+
+    // Test that we can order by id
+    test_find(
+        vec!["pluto", "garfield"],
+        EntityQuery {
+            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
+            entity_types: vec!["Cat".to_owned(), "Dog".to_owned()],
+            filter: None,
+            order_by: Some(("id".to_owned(), ValueType::String)),
+            order_direction: Some(EntityOrder::Descending),
+            range: EntityRange::first(100),
+        },
+    );
+
+    test_find(
+        vec!["garfield", "pluto"],
+        EntityQuery {
+            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
+            entity_types: vec!["Cat".to_owned(), "Dog".to_owned()],
+            filter: None,
+            order_by: Some(("id".to_owned(), ValueType::String)),
+            order_direction: None,
+            range: EntityRange::first(100),
+        },
+    );
 }
 
 #[test]
@@ -648,6 +673,22 @@ fn find_string_equal() {
             )])),
             order_by: None,
             order_direction: None,
+            range: EntityRange::first(100),
+        },
+    );
+
+    // Test that we can order by id
+    test_find(
+        vec!["2"],
+        EntityQuery {
+            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
+            entity_types: vec!["User".to_owned()],
+            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
+                "name".to_owned(),
+                "Cindini".into(),
+            )])),
+            order_by: Some(("id".to_owned(), ValueType::String)),
+            order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
         },
     )


### PR DESCRIPTION
When the EntityQuery explicitly ordered by id, we would generate a SQL
query that selected `id` twice which makes `order by id` ambiguous.

