### PR TITLE
store: Make sure query generation doesn't fail

### DIFF
--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -493,10 +493,7 @@ fn conflicting_entity() {
         let chair = "Chair".to_owned();
         let result = layout.conflicting_entity(&conn, &id.to_owned(), vec![&dog, &ferret, &chair]);
         assert!(result.is_err());
-        assert_eq!(
-            "store error: unknown table 'Chair'",
-            result.err().unwrap().to_string()
-        );
+        assert_eq!("unknown table 'Chair'", result.err().unwrap().to_string());
         Ok(())
     })
 }


### PR DESCRIPTION
We had a few places were query generation could fail because of an unknown
table or column. That then makes it impossible to print the failed query
for debugging purposes.

This commit changes things so that these errors are detected before we
construct QueryFragments.

