### PR TITLE
Index subgraphs from the genesis block rather than block 1

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -873,7 +873,7 @@ fn create_subgraph_version(
                     logger,
                     "Set subgraph start block";
                     "block_number" => format!("{:?}", start_block.map(|block| block.number)),
-                    "block_hashr" => format!("{:?}", start_block.map(|block| block.hash)),
+                    "block_hash" => format!("{:?}", start_block.map(|block| block.hash)),
                 );
 
                 // Apply the subgraph versioning and deployment operations,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -531,7 +531,7 @@ fn resolve_subgraph_chain_blocks(
             min_start_block => Box::new(
                 ethereum_adapter
                     .block_pointer_from_number(logger, min_start_block - 1)
-                    .map(move |block_ptr| Some(block_ptr))
+                    .map(Some)
                     .map_err(move |_| {
                         SubgraphRegistrarError::ManifestValidationError(vec![
                             SubgraphManifestValidationError::BlockNotFound(

--- a/core/src/subgraph/validation.rs
+++ b/core/src/subgraph/validation.rs
@@ -5,6 +5,11 @@ pub fn validate_manifest(
 ) -> Result<SubgraphManifest, SubgraphRegistrarError> {
     let mut errors: Vec<SubgraphManifestValidationError> = Vec::new();
 
+    // Validate that the manifest has at least one data source
+    if manifest.data_sources.is_empty() {
+        errors.push(SubgraphManifestValidationError::NoDataSources);
+    }
+
     // Validate that the manifest has a `source` address in each data source
     // which has call or block handlers
     let has_invalid_data_source = manifest.data_sources.iter().any(|data_source| {

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -27,7 +27,7 @@ fn insert_and_query(
 
     let logger = Logger::root(slog::Discard, o!());
 
-    let ops = SubgraphDeploymentEntity::new(&manifest, false, false, GENESIS_PTR.clone(), None)
+    let ops = SubgraphDeploymentEntity::new(&manifest, false, false, None, None)
         .create_operations_replace(&subgraph_id)
         .into_iter()
         .map(|op| op.into())
@@ -48,7 +48,7 @@ fn insert_and_query(
     transact_entity_operations(
         &STORE,
         subgraph_id.clone(),
-        BLOCK_ONE.clone(),
+        GENESIS_PTR.clone(),
         insert_ops.collect::<Vec<_>>(),
     )?;
 

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -435,3 +435,15 @@ impl<'a> From<&'a BlockFinality> for EthereumBlockPointer {
         }
     }
 }
+
+impl From<EthereumBlockPointer> for H256 {
+    fn from(ptr: EthereumBlockPointer) -> Self {
+        ptr.hash
+    }
+}
+
+impl From<EthereumBlockPointer> for u64 {
+    fn from(ptr: EthereumBlockPointer) -> Self {
+        ptr.number
+    }
+}

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -9,7 +9,7 @@ pub trait LightEthereumBlockExt {
     fn number(&self) -> u64;
     fn transaction_for_log(&self, log: &Log) -> Option<Transaction>;
     fn transaction_for_call(&self, call: &EthereumCall) -> Option<Transaction>;
-    fn parent_ptr(&self) -> EthereumBlockPointer;
+    fn parent_ptr(&self) -> Option<EthereumBlockPointer>;
 }
 
 impl LightEthereumBlockExt for LightEthereumBlock {
@@ -29,10 +29,13 @@ impl LightEthereumBlockExt for LightEthereumBlock {
             .cloned()
     }
 
-    fn parent_ptr(&self) -> EthereumBlockPointer {
-        EthereumBlockPointer {
-            hash: self.parent_hash,
-            number: self.number() - 1,
+    fn parent_ptr(&self) -> Option<EthereumBlockPointer> {
+        match self.number() {
+            0 => None,
+            n => Some(EthereumBlockPointer {
+                hash: self.parent_hash,
+                number: n - 1,
+            }),
         }
     }
 }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -595,7 +595,10 @@ pub enum TransactionAbortError {
 /// Common trait for store implementations.
 pub trait Store: Send + Sync + 'static {
     /// Get a pointer to the most recently processed block in the subgraph.
-    fn block_ptr(&self, subgraph_id: SubgraphDeploymentId) -> Result<EthereumBlockPointer, Error>;
+    fn block_ptr(
+        &self,
+        subgraph_id: SubgraphDeploymentId,
+    ) -> Result<Option<EthereumBlockPointer>, Error>;
 
     /// Looks up an entity using the given store key.
     fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError>;

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -396,7 +396,7 @@ impl TryFrom<Value> for Option<H256> {
         match value {
             Value::Bytes(bytes) => {
                 let hex = format!("{}", bytes);
-                Ok(Some(H256::from_str(hex.as_str().trim_start_matches("0x"))?))
+                Ok(Some(H256::from_str(hex.trim_start_matches("0x"))?))
             }
             Value::String(s) => Ok(Some(H256::from_str(s.as_str())?)),
             Value::Null => Ok(None),

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -396,7 +396,7 @@ impl TryFrom<Value> for Option<H256> {
         match value {
             Value::Bytes(bytes) => {
                 let hex = format!("{}", bytes);
-                Ok(Some(H256::from_str(hex.as_str())?))
+                Ok(Some(H256::from_str(hex.as_str().trim_start_matches("0x"))?))
             }
             Value::String(s) => Ok(Some(H256::from_str(s.as_str())?)),
             Value::Null => Ok(None),

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -321,6 +321,8 @@ pub enum SubgraphAssignmentProviderEvent {
 
 #[derive(Fail, Debug)]
 pub enum SubgraphManifestValidationError {
+    #[fail(display = "subgraph has no data sources")]
+    NoDataSources,
     #[fail(display = "subgraph source address is required")]
     SourceAddressRequired,
     #[fail(display = "subgraph cannot index data from different Ethereum networks")]

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -314,7 +314,7 @@ impl SubgraphDeploymentEntity {
         block_ptr_to: EthereumBlockPointer,
     ) -> Vec<MetadataOperation> {
         let mut entity = Entity::new();
-        entity.set("latestEthereumBlockHash", block_ptr_to.hash_hex());
+        entity.set("latestEthereumBlockHash", block_ptr_to.hash);
         entity.set("latestEthereumBlockNumber", block_ptr_to.number);
 
         vec![update_metadata_operation(

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -239,7 +239,7 @@ impl SubgraphDeploymentEntity {
             latest_ethereum_block_number: earliest_ethereum_block.map(Into::into),
             ethereum_head_block_hash: chain_head_block.map(Into::into),
             ethereum_head_block_number: chain_head_block.map(Into::into),
-            total_ethereum_blocks_count: 0,
+            total_ethereum_blocks_count: chain_head_block.map_or(0, |block| block.number + 1),
         }
     }
 

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -209,8 +209,8 @@ pub struct SubgraphDeploymentEntity {
     synced: bool,
     earliest_ethereum_block_hash: Option<H256>,
     earliest_ethereum_block_number: Option<u64>,
-    latest_ethereum_block_hash: H256,
-    latest_ethereum_block_number: u64,
+    latest_ethereum_block_hash: Option<H256>,
+    latest_ethereum_block_number: Option<u64>,
     ethereum_head_block_hash: Option<H256>,
     ethereum_head_block_number: Option<u64>,
     total_ethereum_blocks_count: u64,
@@ -226,23 +226,20 @@ impl SubgraphDeploymentEntity {
         source_manifest: &SubgraphManifest,
         failed: bool,
         synced: bool,
-        earliest_ethereum_block: EthereumBlockPointer,
-        latest_ethereum_block: Option<EthereumBlockPointer>,
+        earliest_ethereum_block: Option<EthereumBlockPointer>,
+        chain_head_block: Option<EthereumBlockPointer>,
     ) -> Self {
-        let latest_ethereum_block =
-            latest_ethereum_block.unwrap_or(earliest_ethereum_block.clone());
-
         Self {
             manifest: SubgraphManifestEntity::from(source_manifest),
             failed,
             synced,
-            earliest_ethereum_block_hash: Some(earliest_ethereum_block.hash),
-            earliest_ethereum_block_number: Some(earliest_ethereum_block.number),
-            latest_ethereum_block_hash: earliest_ethereum_block.hash,
-            latest_ethereum_block_number: earliest_ethereum_block.number,
-            ethereum_head_block_hash: Some(latest_ethereum_block.hash),
-            ethereum_head_block_number: Some(latest_ethereum_block.number),
-            total_ethereum_blocks_count: latest_ethereum_block.number,
+            earliest_ethereum_block_hash: earliest_ethereum_block.map(Into::into),
+            earliest_ethereum_block_number: earliest_ethereum_block.map(Into::into),
+            latest_ethereum_block_hash: earliest_ethereum_block.map(Into::into),
+            latest_ethereum_block_number: earliest_ethereum_block.map(Into::into),
+            ethereum_head_block_hash: chain_head_block.map(Into::into),
+            ethereum_head_block_number: chain_head_block.map(Into::into),
+            total_ethereum_blocks_count: 0,
         }
     }
 
@@ -279,31 +276,27 @@ impl SubgraphDeploymentEntity {
         entity.set("synced", self.synced);
         entity.set(
             "earliestEthereumBlockHash",
-            self.earliest_ethereum_block_hash
-                .map_or(Value::Null, |hash| Value::from(format!("{:x}", hash))),
+            Value::from(self.earliest_ethereum_block_hash),
         );
         entity.set(
             "earliestEthereumBlockNumber",
-            self.earliest_ethereum_block_number
-                .map_or(Value::Null, Value::from),
+            Value::from(self.earliest_ethereum_block_number),
         );
         entity.set(
             "latestEthereumBlockHash",
-            format!("{:x}", self.latest_ethereum_block_hash),
+            Value::from(self.latest_ethereum_block_hash),
         );
         entity.set(
             "latestEthereumBlockNumber",
-            self.latest_ethereum_block_number,
+            Value::from(self.latest_ethereum_block_number),
         );
         entity.set(
             "ethereumHeadBlockHash",
-            self.ethereum_head_block_hash
-                .map_or(Value::Null, |hash| Value::from(format!("{:x}", hash))),
+            Value::from(self.ethereum_head_block_hash),
         );
         entity.set(
             "ethereumHeadBlockNumber",
-            self.ethereum_head_block_number
-                .map_or(Value::Null, Value::from),
+            Value::from(self.ethereum_head_block_number),
         );
         entity.set("totalEthereumBlocksCount", self.total_ethereum_blocks_count);
         entity.set("entityCount", 0 as u64);

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use graph::prelude::*;
 use graph_graphql::prelude::*;
-use test_store::{transact_entity_operations, BLOCK_ONE, GENESIS_PTR, STORE};
+use test_store::{transact_entity_operations, GENESIS_PTR, STORE};
 
 lazy_static! {
     static ref TEST_SUBGRAPH_ID: SubgraphDeploymentId = {
@@ -77,7 +77,7 @@ fn insert_test_entities(store: &impl Store, id: SubgraphDeploymentId) {
         templates: vec![],
     };
 
-    let ops = SubgraphDeploymentEntity::new(&manifest, false, false, GENESIS_PTR.clone(), None)
+    let ops = SubgraphDeploymentEntity::new(&manifest, false, false, None, None)
         .create_operations_replace(&id)
         .into_iter()
         .map(|op| op.into())
@@ -189,7 +189,7 @@ fn insert_test_entities(store: &impl Store, id: SubgraphDeploymentId) {
     transact_entity_operations(
         &STORE,
         id.clone(),
-        BLOCK_ONE.clone(),
+        GENESIS_PTR.clone(),
         insert_ops.collect::<Vec<_>>(),
     )
     .unwrap();

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -179,7 +179,7 @@ impl Store for MockStore {
         }
     }
 
-    fn block_ptr(&self, _: SubgraphDeploymentId) -> Result<EthereumBlockPointer, Error> {
+    fn block_ptr(&self, _: SubgraphDeploymentId) -> Result<Option<EthereumBlockPointer>, Error> {
         unimplemented!();
     }
 
@@ -478,7 +478,7 @@ impl Store for FakeStore {
         }
     }
 
-    fn block_ptr(&self, _: SubgraphDeploymentId) -> Result<EthereumBlockPointer, Error> {
+    fn block_ptr(&self, _: SubgraphDeploymentId) -> Result<Option<EthereumBlockPointer>, Error> {
         unimplemented!();
     }
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -479,10 +479,7 @@ mod tests {
                     &manifest,
                     false,
                     false,
-                    EthereumBlockPointer {
-                        hash: H256::zero(),
-                        number: 0,
-                    },
+                    None,
                     Some(EthereumBlockPointer {
                         hash: H256::zero(),
                         number: 0,
@@ -553,10 +550,7 @@ mod tests {
                                 &manifest,
                                 false,
                                 false,
-                                EthereumBlockPointer {
-                                    hash: H256::zero(),
-                                    number: 0,
-                                },
+                                None,
                                 Some(EthereumBlockPointer {
                                     hash: H256::zero(),
                                     number: 0,

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -97,10 +97,7 @@ mod test {
                     &manifest,
                     false,
                     false,
-                    EthereumBlockPointer {
-                        hash: H256::zero(),
-                        number: 0,
-                    },
+                    None,
                     Some(EthereumBlockPointer {
                         hash: H256::zero(),
                         number: 0,

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -19,12 +19,12 @@ type SubgraphDeployment @entity {
     manifest: SubgraphManifest!
     failed: Boolean!
     synced: Boolean!
-    earliestEthereumBlockHash: String
+    earliestEthereumBlockHash: Bytes
     earliestEthereumBlockNumber: BigInt
-    latestEthereumBlockHash: String!
-    latestEthereumBlockNumber: BigInt!
+    latestEthereumBlockHash: Bytes
+    latestEthereumBlockNumber: BigInt
     ethereumHeadBlockNumber: BigInt
-    ethereumHeadBlockHash: String
+    ethereumHeadBlockHash: Bytes
     totalEthereumBlocksCount: BigInt!
     entityCount: BigInt!
     dynamicDataSources: [DynamicEthereumContractDataSource!] @derivedFrom(field: "deployment")


### PR DESCRIPTION
This makes the latest Ethereum block pointer of subgraph deployments optional. New deployments are then initialized with the block pointer set to `None`. This instructs the block stream to start with block number 0 (genesis) instead of the next block after the current block pointer.

@leoyvens Any ideas for a good test for this?