### PR TITLE
store: Handle empty and/or filters in the relational schema

### DIFF
--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -1753,3 +1753,36 @@ fn text_not_in() {
     text_find(vec!["a2b", "a3"], filter(vec![&a1, &a2]));
     text_find(vec!["a2", "a2b"], filter(vec![&a1, &a3]));
 }
+
+#[test]
+fn find_empty_and_or() {
+    // It's somewhat arbitrary that we define empty 'or' and 'and' to
+    // be 'true' and 'false'; it's mostly this way since that's what the
+    // JSONB storage filters do
+
+    // An empty 'or' is 'false'
+    test_find(
+        vec![],
+        EntityQuery {
+            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
+            entity_types: vec!["User".to_owned()],
+            filter: Some(EntityFilter::And(vec![EntityFilter::Or(vec![])])),
+            order_by: None,
+            order_direction: None,
+            range: EntityRange::first(100),
+        },
+    );
+
+    // An empty 'and' is 'true'
+    test_find(
+        vec!["1", "2", "3"],
+        EntityQuery {
+            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
+            entity_types: vec!["User".to_owned()],
+            filter: Some(EntityFilter::Or(vec![EntityFilter::And(vec![])])),
+            order_by: None,
+            order_direction: None,
+            range: EntityRange::first(100),
+        },
+    )
+}


### PR DESCRIPTION
Empty and/or clauses would generate a `()` which leads to SQL syntax
errors. This behavior is a backstop; what should really happen is that
and/or clauses always have at least one predicate in them.

With the previous behavior, we would generate queries like `select ... from
... where ()` which is not valid SQL.

