### PR TITLE
Pull in transaction receipts only when necessary

### DIFF
--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -195,12 +195,10 @@ where
                     })
                 }))
             }
-            EthereumTrigger::Block(_, trigger_type) => {
+            EthereumTrigger::Block(ptr, trigger_type) => {
                 let matching_hosts: Vec<_> = hosts
                     .into_iter()
-                    .filter(|host| {
-                        host.matches_block(trigger_type.clone(), block.number.unwrap().as_u64())
-                    })
+                    .filter(|host| host.matches_block(trigger_type.clone(), ptr.number))
                     .collect();
 
                 Box::new(

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -195,7 +195,7 @@ where
                     })
                 }))
             }
-            EthereumTrigger::Block(trigger_type) => {
+            EthereumTrigger::Block(_, trigger_type) => {
                 let matching_hosts: Vec<_> = hosts
                     .into_iter()
                     .filter(|host| {

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -128,7 +128,7 @@ where
     fn process_trigger(
         &self,
         logger: &Logger,
-        block: Arc<EthereumBlock>,
+        block: Arc<ThinEthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
@@ -144,7 +144,7 @@ where
     fn process_trigger_in_runtime_hosts(
         logger: &Logger,
         hosts: impl Iterator<Item = Arc<T::Host>>,
-        block: Arc<EthereumBlock>,
+        block: Arc<ThinEthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
@@ -199,10 +199,7 @@ where
                 let matching_hosts: Vec<_> = hosts
                     .into_iter()
                     .filter(|host| {
-                        host.matches_block(
-                            trigger_type.clone(),
-                            block.block.number.unwrap().as_u64(),
-                        )
+                        host.matches_block(trigger_type.clone(), block.number.unwrap().as_u64())
                     })
                     .collect();
 

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -128,7 +128,7 @@ where
     fn process_trigger(
         &self,
         logger: &Logger,
-        block: Arc<ThinEthereumBlock>,
+        block: Arc<LightEthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
@@ -144,7 +144,7 @@ where
     fn process_trigger_in_runtime_hosts(
         logger: &Logger,
         hosts: impl Iterator<Item = Arc<T::Host>>,
-        block: Arc<ThinEthereumBlock>,
+        block: Arc<LightEthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -50,6 +50,8 @@ struct IndexingContext<B, T: RuntimeHostBuilder, S> {
 
     /// Sensors to measue the execution of eth rpc calls
     pub ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
+
+    pub block_stream_metrics: Arc<BlockStreamMetrics>,
 }
 
 pub struct SubgraphInstanceManager {
@@ -354,6 +356,11 @@ impl SubgraphInstanceManager {
             registry.clone(),
             deployment_id.to_string(),
         ));
+        let block_stream_metrics = Arc::new(BlockStreamMetrics::new(
+            registry.clone(),
+            ethrpc_metrics.clone(),
+            deployment_id.clone(),
+        ));
         let instance =
             SubgraphInstance::from_manifest(&logger, manifest, host_builder, host_metrics.clone())?;
 
@@ -381,6 +388,7 @@ impl SubgraphInstanceManager {
             subgraph_metrics,
             host_metrics,
             ethrpc_metrics,
+            block_stream_metrics,
         };
 
         // Keep restarting the subgraph until it terminates. The subgraph
@@ -453,7 +461,7 @@ where
             ctx.state.call_filter.clone(),
             ctx.state.block_filter.clone(),
             ctx.inputs.templates_use_calls,
-            ctx.ethrpc_metrics.clone(),
+            ctx.block_stream_metrics.clone(),
         )
         .from_err()
         .cancelable(&block_stream_canceler, || CancelableError::Cancel);

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -608,7 +608,7 @@ where
     }
 
     // Obtain current and new block pointer (after this block is processed)
-    let thin_block = Arc::new(block.thin_block());
+    let light_block = Arc::new(block.light_block());
     let block_ptr_after = EthereumBlockPointer::from(&block);
     let block_ptr_for_new_data_sources = block_ptr_after.clone();
 
@@ -620,7 +620,7 @@ where
         logger.clone(),
         ctx,
         BlockState::default(),
-        thin_block.clone(),
+        light_block.clone(),
         triggers,
     )
     .and_then(move |(ctx, block_state)| {
@@ -658,7 +658,7 @@ where
                 // Reprocess the triggers from this block that match the new data sources
                 let logger = logger.clone();
                 let logger1 = logger.clone();
-                let thin_block = thin_block.clone();
+                let light_block = light_block.clone();
                 Box::new(
                     eth_adapter
                         .clone()
@@ -706,7 +706,7 @@ where
                                         SubgraphInstance::<T>::process_trigger_in_runtime_hosts(
                                             &logger,
                                             runtime_hosts.iter().cloned(),
-                                            thin_block.clone(),
+                                            light_block.clone(),
                                             trigger,
                                             block_state,
                                         )

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -601,7 +601,6 @@ where
 
     // Obtain current and new block pointer (after this block is processed)
     let thin_block = Arc::new(block.thin_block());
-    let block_ptr_now = thin_block.parent_ptr();
     let block_ptr_after = EthereumBlockPointer::from(&block);
     let block_ptr_for_new_data_sources = block_ptr_after.clone();
 
@@ -741,12 +740,7 @@ where
         let start = Instant::now();
         ctx.inputs
             .store
-            .transact_block_operations(
-                ctx.inputs.deployment_id.clone(),
-                block_ptr_now,
-                block_ptr_after,
-                mods,
-            )
+            .transact_block_operations(ctx.inputs.deployment_id.clone(), block_ptr_after, mods)
             .map(|should_migrate| {
                 let elapsed = start.elapsed().as_secs_f64();
                 metrics.block_ops_transaction_duration.observe(elapsed);

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -650,11 +650,14 @@ where
 
                 // Reprocess the triggers from this block that match the new data sources
                 let logger = logger.clone();
+                let logger1 = logger.clone();
                 let thin_block = thin_block.clone();
                 Box::new(
                     eth_adapter
+                        .clone()
                         .triggers_in_block(
-                            &logger,
+                            logger,
+                            ctx.inputs.store.clone(),
                             ctx.ethrpc_metrics.clone(),
                             EthereumLogFilter::from_data_sources(data_sources.iter()),
                             EthereumCallFilter::from_data_sources(data_sources.iter()),
@@ -666,12 +669,12 @@ where
 
                             if triggers.len() == 1 {
                                 info!(
-                                    logger,
+                                    logger1,
                                     "1 trigger found in this block for the new data sources"
                                 );
                             } else if triggers.len() > 1 {
                                 info!(
-                                    logger,
+                                    logger1,
                                     "{} triggers found in this block for the new data sources",
                                     triggers.len()
                                 );
@@ -680,14 +683,14 @@ where
                             // Add entity operations for the new data sources to the block state
                             // and add runtimes for the data sources to the subgraph instance.
                             persist_dynamic_data_sources(
-                                logger.clone(),
+                                logger1.clone(),
                                 &mut ctx,
                                 &mut block_state.entity_cache,
                                 data_sources,
                                 block_ptr_for_new_data_sources,
                             );
 
-                            let logger = logger.clone();
+                            let logger = logger1.clone();
                             let thin_block = thin_block.clone();
                             Box::new(
                                 stream::iter_ok(triggers)

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -502,9 +502,11 @@ where
         .fold(ctx, move |ctx, block| {
             let subgraph_metrics = ctx.subgraph_metrics.clone();
             let start = Instant::now();
-            subgraph_metrics
-                .block_trigger_count
-                .observe(block.triggers.len() as f64);
+            if block.triggers.len() > 0 {
+                subgraph_metrics
+                    .block_trigger_count
+                    .observe(block.triggers.len() as f64);
+            }
             process_block(
                 logger.clone(),
                 ctx.inputs.eth_adapter.clone(),

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -770,7 +770,7 @@ fn process_triggers<B, T: RuntimeHostBuilder, S>(
     logger: Logger,
     ctx: IndexingContext<B, T, S>,
     block_state: BlockState,
-    block: Arc<ThinEthereumBlock>,
+    block: Arc<LightEthereumBlock>,
     triggers: Vec<EthereumTrigger>,
 ) -> impl Future<Item = (IndexingContext<B, T, S>, BlockState), Error = CancelableError<Error>>
 where

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -620,7 +620,7 @@ where
         logger.clone(),
         ctx,
         BlockState::default(),
-        Arc::new(block.thin_block()),
+        thin_block.clone(),
         triggers,
     )
     .and_then(move |(ctx, block_state)| {
@@ -698,7 +698,6 @@ where
                             );
 
                             let logger = logger1.clone();
-                            let thin_block = thin_block.clone();
                             Box::new(
                                 stream::iter_ok(triggers)
                                     .fold(block_state, move |block_state, trigger| {

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -756,7 +756,7 @@ where
             let trigger_type = match trigger {
                 EthereumTrigger::Log(_) => TriggerType::Event,
                 EthereumTrigger::Call(_) => TriggerType::Call,
-                EthereumTrigger::Block(_) => TriggerType::Block,
+                EthereumTrigger::Block(..) => TriggerType::Block,
             };
             let start = Instant::now();
             ctx.state

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -48,7 +48,6 @@ fn insert_and_query(
     transact_entity_operations(
         &STORE,
         subgraph_id.clone(),
-        GENESIS_PTR.clone(),
         BLOCK_ONE.clone(),
         insert_ops.collect::<Vec<_>>(),
     )?;

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -86,7 +86,7 @@ fn multiple_data_sources_per_subgraph() {
         fn process_log(
             &self,
             _: Logger,
-            _: Arc<ThinEthereumBlock>,
+            _: Arc<LightEthereumBlock>,
             _: Arc<Transaction>,
             _: Arc<Log>,
             _: BlockState,
@@ -97,7 +97,7 @@ fn multiple_data_sources_per_subgraph() {
         fn process_call(
             &self,
             _logger: Logger,
-            _block: Arc<ThinEthereumBlock>,
+            _block: Arc<LightEthereumBlock>,
             _transaction: Arc<Transaction>,
             _call: Arc<EthereumCall>,
             _state: BlockState,
@@ -108,7 +108,7 @@ fn multiple_data_sources_per_subgraph() {
         fn process_block(
             &self,
             _logger: Logger,
-            _block: Arc<ThinEthereumBlock>,
+            _block: Arc<LightEthereumBlock>,
             _trigger_type: EthereumBlockTriggerType,
             _state: BlockState,
         ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -86,7 +86,7 @@ fn multiple_data_sources_per_subgraph() {
         fn process_log(
             &self,
             _: Logger,
-            _: Arc<EthereumBlock>,
+            _: Arc<ThinEthereumBlock>,
             _: Arc<Transaction>,
             _: Arc<Log>,
             _: BlockState,
@@ -97,7 +97,7 @@ fn multiple_data_sources_per_subgraph() {
         fn process_call(
             &self,
             _logger: Logger,
-            _block: Arc<EthereumBlock>,
+            _block: Arc<ThinEthereumBlock>,
             _transaction: Arc<Transaction>,
             _call: Arc<EthereumCall>,
             _state: BlockState,
@@ -108,7 +108,7 @@ fn multiple_data_sources_per_subgraph() {
         fn process_block(
             &self,
             _logger: Logger,
-            _block: Arc<EthereumBlock>,
+            _block: Arc<ThinEthereumBlock>,
             _trigger_type: EthereumBlockTriggerType,
             _state: BlockState,
         ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {

--- a/datasource/ethereum/src/block_ingestor.rs
+++ b/datasource/ethereum/src/block_ingestor.rs
@@ -95,7 +95,7 @@ where
                 // Ask for latest block from Ethereum node
                 self.eth_adapter.latest_block(&self.logger)
                     // Compare latest block with head ptr, alert user if far behind
-                    .and_then(move |latest_block: ThinEthereumBlock| -> Box<dyn Future<Item=_, Error=_> + Send> {
+                    .and_then(move |latest_block: LightEthereumBlock| -> Box<dyn Future<Item=_, Error=_> + Send> {
                         match head_block_ptr_opt {
                             None => {
                                 info!(

--- a/datasource/ethereum/src/block_ingestor.rs
+++ b/datasource/ethereum/src/block_ingestor.rs
@@ -95,7 +95,7 @@ where
                 // Ask for latest block from Ethereum node
                 self.eth_adapter.latest_block(&self.logger)
                     // Compare latest block with head ptr, alert user if far behind
-                    .and_then(move |latest_block: Block<Transaction>| -> Box<dyn Future<Item=_, Error=_> + Send> {
+                    .and_then(move |latest_block: ThinEthereumBlock| -> Box<dyn Future<Item=_, Error=_> + Send> {
                         match head_block_ptr_opt {
                             None => {
                                 info!(

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -361,13 +361,10 @@ where
                             let to_limit =
                                 cmp::min(head_ptr.number - reorg_threshold, next_start_block - 1);
 
-                            let to = if block_filter.trigger_every_block {
-                                // If there is a block trigger on every block, go
-                                // one block at a time.
-                                from
-                            } else {
-                                // Otherwise use ETHEREUM_BLOCK_RANGE_SIZE to ensure the subgraph
-                                //  block ptr is updated frequently.
+                            // The range should not be too small, due to the overhead of finding
+                            // triggers for each range, neither too large, so that progress is
+                            // commited frequently and memory usage is under control.
+                            let to = {
                                 let speedup = if from < *ETHEREUM_FAST_SCAN_END {
                                     FAST_SCAN_SPEEDUP
                                 } else {

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -969,22 +969,6 @@ where
     S: Store,
     C: ChainStore,
 {
-    fn triggers_in_block(
-        &self,
-        log_filter: EthereumLogFilter,
-        call_filter: EthereumCallFilter,
-        block_filter: EthereumBlockFilter,
-        descendant_block: BlockFinality,
-    ) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send> {
-        Box::new(self.ctx.eth_adapter.triggers_in_block(
-            &self.ctx.logger,
-            self.ctx.metrics.ethrpc_metrics.clone(),
-            log_filter,
-            call_filter,
-            block_filter,
-            descendant_block,
-        ))
-    }
 }
 
 impl<S, C> Stream for BlockStream<S, C>

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -228,36 +228,6 @@ where
             || self.block_filter.contract_addresses.len() > 0
     }
 
-    /// Update the block pointer for `self.subgraph_id`, and, if needed,
-    /// migrate its database schema
-    fn set_block_ptr_with_no_changes(
-        &self,
-        from: EthereumBlockPointer,
-        to: EthereumBlockPointer,
-    ) -> Result<(), Error> {
-        let result =
-            self.subgraph_store
-                .set_block_ptr_with_no_changes(self.subgraph_id.clone(), from, to);
-
-        match result {
-            Ok(should_migrate) => {
-                if should_migrate {
-                    self.subgraph_store.migrate_subgraph_deployment(
-                        &self.logger,
-                        &self.subgraph_id,
-                        &to,
-                    );
-                }
-                Ok(())
-            }
-            Err(e) => Err(format_err!(
-                "Failed to skip {} irrelevant blocks: {}",
-                to.number - from.number,
-                e
-            )),
-        }
-    }
-
     /// Perform reconciliation steps until there are blocks to yield or we are up-to-date.
     fn next_blocks(
         &self,

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -571,7 +571,6 @@ where
             // Walk back to one block short of subgraph_ptr.number
             let offset = head_ptr.number - subgraph_ptr.number - 1;
             let head_ancestor_opt = ctx.chain_store.ancestor_block(head_ptr, offset).unwrap();
-            let include_calls_in_blocks = self.include_calls_in_blocks();
             let logger = self.logger.clone();
             match head_ancestor_opt {
                 None => {
@@ -593,7 +592,7 @@ where
                         // Note that head_ancestor is a child of subgraph_ptr.
                         let eth_adapter = self.eth_adapter.clone();
                         let block_future = {
-                            let block_with_calls = if !include_calls_in_blocks {
+                            let block_with_calls = if !self.include_calls_in_blocks() {
                                 Box::new(future::ok(EthereumBlockWithCalls {
                                     ethereum_block: head_ancestor,
                                     calls: None,

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -376,7 +376,6 @@ where
                                 cmp::min(from + speedup * *ETHEREUM_BLOCK_RANGE_SIZE - 1, to_limit)
                             };
 
-                            let logger = ctx.logger.clone();
                             debug!(ctx.logger, "Scanning blocks [{}, {}]", from, to);
                             Box::new(
                                 ctx.eth_adapter
@@ -390,20 +389,7 @@ where
                                         call_filter.clone(),
                                         block_filter.clone(),
                                     )
-                                    .map(move |descendant_blocks| {
-                                        debug!(
-                                            logger,
-                                            "Found {} trigger(s)",
-                                            descendant_blocks
-                                                .iter()
-                                                .map(|b| b.triggers.len())
-                                                .sum::<usize>()
-                                        );
-
-                                        ReconciliationStep::ProcessDescendantBlocks(
-                                            descendant_blocks,
-                                        )
-                                    }),
+                                    .map(ReconciliationStep::ProcessDescendantBlocks),
                             )
                         },
                     ),

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -488,7 +488,7 @@ where
                         .map_err(|e| e.compat())
                         .and_then(move |block| {
                             block.ok_or_else(|| {
-                                format_err!("eth node did not find block {:?}", hash).compat()
+                                format_err!("Ethereum node did not find block {:?}", hash).compat()
                             })
                         })
                 })
@@ -519,7 +519,8 @@ where
                         .map_err(|e| e.compat())
                         .and_then(move |block| {
                             block.ok_or_else(|| {
-                                format_err!("eth node did not find block {:?}", block_num).compat()
+                                format_err!("Ethereum node did not find block {:?}", block_num)
+                                    .compat()
                             })
                         })
                 })

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -521,7 +521,7 @@ where
     fn latest_block(
         &self,
         logger: &Logger,
-    ) -> Box<dyn Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send> {
+    ) -> Box<dyn Future<Item = ThinEthereumBlock, Error = EthereumAdapterError> + Send> {
         let web3 = self.web3.clone();
 
         Box::new(
@@ -569,7 +569,7 @@ where
         &self,
         logger: &Logger,
         block_hash: H256,
-    ) -> Box<dyn Future<Item = Option<Block<Transaction>>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Option<ThinEthereumBlock>, Error = Error> + Send> {
         let web3 = self.web3.clone();
         let logger = logger.clone();
 
@@ -593,7 +593,7 @@ where
     fn load_full_block(
         &self,
         logger: &Logger,
-        block: Block<Transaction>,
+        block: ThinEthereumBlock,
     ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send> {
         let logger = logger.clone();
         let block_hash = block.hash.expect("block is missing block hash");

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -1079,7 +1079,7 @@ where
             self.load_blocks_rpc(logger.clone(), missing_blocks.into_iter().collect())
                 .collect()
                 .map(move |new_blocks| {
-                    if let Err(e) = chain_store.upsert_thin_blocks(new_blocks.clone()) {
+                    if let Err(e) = chain_store.upsert_light_blocks(new_blocks.clone()) {
                         error!(logger, "Error writing to block cache {}", e);
                     }
                     blocks.extend(new_blocks);

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -473,7 +473,7 @@ where
         &self,
         logger: Logger,
         ids: Vec<H256>,
-    ) -> impl Stream<Item = ThinEthereumBlock, Error = Error> + Send {
+    ) -> impl Stream<Item = LightEthereumBlock, Error = Error> + Send {
         let web3 = self.web3.clone();
 
         stream::iter_ok::<_, Error>(ids.into_iter().map(move |hash| {
@@ -587,7 +587,7 @@ where
     fn latest_block(
         &self,
         logger: &Logger,
-    ) -> Box<dyn Future<Item = ThinEthereumBlock, Error = EthereumAdapterError> + Send> {
+    ) -> Box<dyn Future<Item = LightEthereumBlock, Error = EthereumAdapterError> + Send> {
         let web3 = self.web3.clone();
 
         Box::new(
@@ -617,7 +617,7 @@ where
         &self,
         logger: &Logger,
         block_hash: H256,
-    ) -> Box<dyn Future<Item = ThinEthereumBlock, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = LightEthereumBlock, Error = Error> + Send> {
         Box::new(
             self.block_by_hash(&logger, block_hash)
                 .and_then(move |block_opt| {
@@ -635,7 +635,7 @@ where
         &self,
         logger: &Logger,
         block_hash: H256,
-    ) -> Box<dyn Future<Item = Option<ThinEthereumBlock>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Option<LightEthereumBlock>, Error = Error> + Send> {
         let web3 = self.web3.clone();
         let logger = logger.clone();
 
@@ -659,7 +659,7 @@ where
     fn load_full_block(
         &self,
         logger: &Logger,
-        block: ThinEthereumBlock,
+        block: LightEthereumBlock,
     ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send> {
         let logger = logger.clone();
         let block_hash = block.hash.expect("block is missing block hash");
@@ -1041,14 +1041,14 @@ where
                 }),
             )
                 as Box<dyn Future<Item = _, Error = _> + Send>,
-            BlockFinality::NonFinal(fat_block) => Box::new(future::ok({
+            BlockFinality::NonFinal(full_block) => Box::new(future::ok({
                 let mut triggers = Vec::new();
                 triggers.append(&mut parse_log_triggers(
                     log_filter,
-                    &fat_block.ethereum_block,
+                    &full_block.ethereum_block,
                 ));
-                triggers.append(&mut parse_call_triggers(call_filter, &fat_block));
-                triggers.append(&mut parse_block_triggers(block_filter, &fat_block));
+                triggers.append(&mut parse_call_triggers(call_filter, &full_block));
+                triggers.append(&mut parse_block_triggers(block_filter, &full_block));
                 EthereumBlockWithTriggers::new(triggers, ethereum_block)
             })),
         })
@@ -1060,7 +1060,7 @@ where
         logger: Logger,
         chain_store: Arc<dyn ChainStore>,
         block_hashes: HashSet<H256>,
-    ) -> Box<dyn Stream<Item = ThinEthereumBlock, Error = Error> + Send> {
+    ) -> Box<dyn Stream<Item = LightEthereumBlock, Error = Error> + Send> {
         // Search for the block in the store first then use json-rpc as a backup.
         let mut blocks = chain_store
             .blocks(block_hashes.iter().cloned().collect())

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -462,48 +462,6 @@ where
                     .map_err(|e| e.into_inner().unwrap_or(EthereumContractCallError::Timeout))
             })
     }
-
-    fn block_range_to_ptrs(
-        &self,
-        logger: &Logger,
-        from: u64,
-        to: u64,
-    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
-        let eth = self.clone();
-        let logger = logger.clone();
-
-        // Generate `EthereumBlockPointers` from `to` backwards to `from`
-        Box::new(
-            self.block_hash_by_block_number(&logger, to)
-                .map(move |block_hash_opt| EthereumBlockPointer {
-                    hash: block_hash_opt.unwrap(),
-                    number: to,
-                })
-                .and_then(move |block_pointer| {
-                    stream::unfold(block_pointer, move |descendant_block_pointer| {
-                        if descendant_block_pointer.number < from {
-                            return None;
-                        }
-                        // Populate the parent block pointer
-                        Some(
-                            eth.block_parent_hash(&logger, descendant_block_pointer.hash)
-                                .map(move |block_hash_opt| {
-                                    let parent_block_pointer = EthereumBlockPointer {
-                                        hash: block_hash_opt.unwrap(),
-                                        number: descendant_block_pointer.number - 1,
-                                    };
-                                    (descendant_block_pointer, parent_block_pointer)
-                                }),
-                        )
-                    })
-                    .collect()
-                })
-                .map(move |mut block_pointers| {
-                    block_pointers.reverse();
-                    block_pointers
-                }),
-        )
-    }
 }
 
 impl<T> EthereumAdapterTrait for EthereumAdapter<T>
@@ -1118,6 +1076,48 @@ where
                 stream::iter_ok(blocks)
             })
             .flatten_stream(),
+        )
+    }
+
+    fn block_range_to_ptrs(
+        &self,
+        logger: &Logger,
+        from: u64,
+        to: u64,
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+        let eth = self.clone();
+        let logger = logger.clone();
+
+        // Generate `EthereumBlockPointers` from `to` backwards to `from`
+        Box::new(
+            self.block_hash_by_block_number(&logger, to)
+                .map(move |block_hash_opt| EthereumBlockPointer {
+                    hash: block_hash_opt.unwrap(),
+                    number: to,
+                })
+                .and_then(move |block_pointer| {
+                    stream::unfold(block_pointer, move |descendant_block_pointer| {
+                        if descendant_block_pointer.number < from {
+                            return None;
+                        }
+                        // Populate the parent block pointer
+                        Some(
+                            eth.block_parent_hash(&logger, descendant_block_pointer.hash)
+                                .map(move |block_hash_opt| {
+                                    let parent_block_pointer = EthereumBlockPointer {
+                                        hash: block_hash_opt.unwrap(),
+                                        number: descendant_block_pointer.number - 1,
+                                    };
+                                    (descendant_block_pointer, parent_block_pointer)
+                                }),
+                        )
+                    })
+                    .collect()
+                })
+                .map(move |mut block_pointers| {
+                    block_pointers.reverse();
+                    block_pointers
+                }),
         )
     }
 }

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -897,7 +897,7 @@ where
         Box::new(calls)
     }
 
-    fn blocks_with_logs(
+    fn logs_in_block_range(
         &self,
         logger: &Logger,
         subgraph_metrics: Arc<SubgraphEthRpcMetrics>,
@@ -916,7 +916,7 @@ where
         )
     }
 
-    fn blocks_with_calls(
+    fn calls_in_block_range(
         &self,
         logger: &Logger,
         subgraph_metrics: Arc<SubgraphEthRpcMetrics>,

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -1057,4 +1057,93 @@ where
             .and_then(move |output| call.function.decode_output(&output).map_err(From::from)),
         )
     }
+
+    fn triggers_in_block(
+        &self,
+        logger: &Logger,
+        log_filter: EthereumLogFilter,
+        call_filter: EthereumCallFilter,
+        block_filter: EthereumBlockFilter,
+        ethereum_block: BlockFinality,
+    ) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send> {
+        Box::new(
+            match &ethereum_block {
+                BlockFinality::Final(block) => self.blocks_with_triggers(
+                    logger,
+                    block.number(),
+                    block.number(),
+                    log_filter.clone(),
+                    call_filter.clone(),
+                    block_filter.clone(),
+                ),
+                BlockFinality::NonFinal(fat_block) => Box::new(future::ok({
+                    let mut triggers = Vec::new();
+                    triggers.append(&mut parse_log_triggers(
+                        log_filter,
+                        &fat_block.ethereum_block,
+                    ));
+                    triggers.append(&mut parse_call_triggers(call_filter, &fat_block));
+                    triggers.append(&mut parse_block_triggers(block_filter, &fat_block));
+                    triggers
+                })),
+            }
+            .map(|triggers| EthereumBlockWithTriggers::new(ethereum_block, triggers)),
+        )
+    }
+}
+
+fn parse_log_triggers(
+    log_filter: EthereumLogFilter,
+    block: &EthereumBlock,
+) -> Vec<EthereumTrigger> {
+    block
+        .transaction_receipts
+        .iter()
+        .flat_map(move |receipt| {
+            let log_filter = log_filter.clone();
+            receipt
+                .logs
+                .iter()
+                .filter(move |log| log_filter.matches(log))
+                .map(move |log| EthereumTrigger::Log(log.clone()))
+        })
+        .collect()
+}
+
+fn parse_call_triggers(
+    call_filter: EthereumCallFilter,
+    block: &EthereumBlockWithCalls,
+) -> Vec<EthereumTrigger> {
+    block.calls.as_ref().map_or(vec![], |calls| {
+        calls
+            .iter()
+            .filter(move |call| call_filter.matches(call))
+            .map(move |call| EthereumTrigger::Call(call.clone()))
+            .collect()
+    })
+}
+
+fn parse_block_triggers(
+    block_filter: EthereumBlockFilter,
+    block: &EthereumBlockWithCalls,
+) -> Vec<EthereumTrigger> {
+    let block_ptr = EthereumBlockPointer::from(&block.ethereum_block);
+    let trigger_every_block = block_filter.trigger_every_block;
+    let call_filter = EthereumCallFilter::from(block_filter);
+    let mut triggers = block.calls.as_ref().map_or(vec![], |calls| {
+        calls
+            .iter()
+            .filter(move |call| call_filter.matches(call))
+            .map(move |call| {
+                EthereumTrigger::Block(block_ptr, EthereumBlockTriggerType::WithCallTo(call.to))
+            })
+            .collect::<Vec<EthereumTrigger>>()
+    });
+    if trigger_every_block {
+        triggers.push(EthereumTrigger::Block(
+            block_ptr,
+            EthereumBlockTriggerType::Every,
+        ));
+    }
+    triggers
 }

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -726,14 +726,14 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         // Scan the block range from triggers to find relevant blocks
         if !log_filter.is_empty() {
             trigger_futs.push(Box::new(
-                eth.blocks_with_logs(&logger, subgraph_metrics.clone(), from, to, log_filter)
+                eth.logs_in_block_range(&logger, subgraph_metrics.clone(), from, to, log_filter)
                     .map(|logs: Vec<Log>| logs.into_iter().map(EthereumTrigger::Log).collect()),
             ))
         }
 
         if !call_filter.is_empty() {
             trigger_futs.push(Box::new(
-                eth.blocks_with_calls(&logger, subgraph_metrics.clone(), from, to, call_filter)
+                eth.calls_in_block_range(&logger, subgraph_metrics.clone(), from, to, call_filter)
                     .map(EthereumTrigger::Call)
                     .collect(),
             ));
@@ -754,7 +754,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
             // a `call_filter` and run `blocks_with_calls`
             let call_filter = EthereumCallFilter::from(block_filter);
             trigger_futs.push(Box::new(
-                eth.blocks_with_calls(&logger, subgraph_metrics.clone(), from, to, call_filter)
+                eth.calls_in_block_range(&logger, subgraph_metrics.clone(), from, to, call_filter)
                     .map(|call| {
                         EthereumTrigger::Block(
                             EthereumBlockPointer::from(&call),
@@ -806,7 +806,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         )
     }
 
-    fn blocks_with_logs(
+    fn logs_in_block_range(
         &self,
         logger: &Logger,
         subgraph_metrics: Arc<SubgraphEthRpcMetrics>,
@@ -815,7 +815,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         log_filter: EthereumLogFilter,
     ) -> Box<dyn Future<Item = Vec<Log>, Error = Error> + Send>;
 
-    fn blocks_with_calls(
+    fn calls_in_block_range(
         &self,
         logger: &Logger,
         subgraph_metrics: Arc<SubgraphEthRpcMetrics>,

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -605,7 +605,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     fn latest_block(
         &self,
         logger: &Logger,
-    ) -> Box<dyn Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send>;
+    ) -> Box<dyn Future<Item = ThinEthereumBlock, Error = EthereumAdapterError> + Send>;
 
     fn load_block(
         &self,
@@ -634,13 +634,13 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         &self,
         logger: &Logger,
         block_hash: H256,
-    ) -> Box<dyn Future<Item = Option<Block<Transaction>>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Option<ThinEthereumBlock>, Error = Error> + Send>;
 
     /// Load full information for the specified `block` (in particular, transaction receipts).
     fn load_full_block(
         &self,
         logger: &Logger,
-        block: Block<Transaction>,
+        block: ThinEthereumBlock,
     ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send>;
 
     /// Load block pointer for the specified `block number`.

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -748,26 +748,21 @@ pub trait EthereumAdapter: Send + Sync + 'static {
                             .collect()
                     }),
             ))
-        }
-
-        match block_filter.contract_addresses.len() {
-            0 => (),
-            _ => {
-                // To determine which blocks include a call to addresses
-                // in the block filter, transform the `block_filter` into
-                // a `call_filter` and run `blocks_with_calls`
-                let call_filter = EthereumCallFilter::from(block_filter);
-                trigger_futs.push(Box::new(
-                    eth.blocks_with_calls(&logger, subgraph_metrics.clone(), from, to, call_filter)
-                        .map(|call| {
-                            EthereumTrigger::Block(
-                                EthereumBlockPointer::from(&call),
-                                EthereumBlockTriggerType::WithCallTo(call.to),
-                            )
-                        })
-                        .collect(),
-                ));
-            }
+        } else if !block_filter.contract_addresses.is_empty() {
+            // To determine which blocks include a call to addresses
+            // in the block filter, transform the `block_filter` into
+            // a `call_filter` and run `blocks_with_calls`
+            let call_filter = EthereumCallFilter::from(block_filter);
+            trigger_futs.push(Box::new(
+                eth.blocks_with_calls(&logger, subgraph_metrics.clone(), from, to, call_filter)
+                    .map(|call| {
+                        EthereumTrigger::Block(
+                            EthereumBlockPointer::from(&call),
+                            EthereumBlockTriggerType::WithCallTo(call.to),
+                        )
+                    })
+                    .collect(),
+            ));
         }
 
         let logger1 = logger.clone();

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -552,6 +552,43 @@ impl SubgraphEthRpcMetrics {
     }
 }
 
+#[derive(Clone)]
+pub struct BlockStreamMetrics {
+    pub ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
+    pub blocks_behind: Box<Gauge>,
+    pub reverted_blocks: Box<Gauge>,
+}
+
+impl BlockStreamMetrics {
+    pub fn new<M: MetricsRegistry>(
+        registry: Arc<M>,
+        ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
+        deployment_id: SubgraphDeploymentId,
+    ) -> Self {
+        let blocks_behind = registry
+            .new_gauge(
+                format!("subgraph_blocks_behind_{}", deployment_id.to_string()),
+                String::from(
+                    "Track the number of blocks a subgraph deployment is behind the HEAD block",
+                ),
+                HashMap::new(),
+            )
+            .expect("failed to create `subgraph_blocks_behind` gauge");
+        let reverted_blocks = registry
+            .new_gauge(
+                format!("subgraph_reverted_blocks_{}", deployment_id.to_string()),
+                String::from("Track the last reverted block for a subgraph deployment"),
+                HashMap::new(),
+            )
+            .expect("Failed to create `subgraph_reverted_blocks` gauge");
+        Self {
+            ethrpc_metrics,
+            blocks_behind,
+            reverted_blocks,
+        }
+    }
+}
+
 /// Common trait for components that watch and manage access to Ethereum.
 ///
 /// Implementations may be implemented against an in-process Ethereum node

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -647,7 +647,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         log_filter: EthereumLogFilter,
         call_filter: EthereumCallFilter,
         block_filter: EthereumBlockFilter,
-    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Vec<EthereumTrigger>, Error = Error> + Send>;
 
     /// Find the first few blocks in the specified range containing at least one transaction with
     /// at least one log entry matching the specified `log_filter`.
@@ -668,7 +668,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         from: u64,
         to: u64,
         log_filter: EthereumLogFilter,
-    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Vec<Log>, Error = Error> + Send>;
 
     fn blocks_with_calls(
         &self,
@@ -677,7 +677,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         from: u64,
         to: u64,
         call_filter: EthereumCallFilter,
-    ) -> Box<dyn Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send>;
+    ) -> Box<dyn Stream<Item = EthereumCall, Error = Error> + Send>;
 
     fn blocks(
         &self,

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -570,6 +570,12 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         logger: &Logger,
     ) -> Box<dyn Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send>;
 
+    fn load_block(
+        &self,
+        logger: &Logger,
+        block_hash: H256,
+    ) -> Box<dyn Future<Item = ThinEthereumBlock, Error = Error> + Send>;
+
     /// Find a block by its hash.
     fn block_by_hash(
         &self,
@@ -698,6 +704,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     fn triggers_in_block(
         &self,
         logger: &Logger,
+        subgraph_metrics: Arc<SubgraphEthRpcMetrics>,
         log_filter: EthereumLogFilter,
         call_filter: EthereumCallFilter,
         block_filter: EthereumBlockFilter,

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -605,13 +605,13 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     fn latest_block(
         &self,
         logger: &Logger,
-    ) -> Box<dyn Future<Item = ThinEthereumBlock, Error = EthereumAdapterError> + Send>;
+    ) -> Box<dyn Future<Item = LightEthereumBlock, Error = EthereumAdapterError> + Send>;
 
     fn load_block(
         &self,
         logger: &Logger,
         block_hash: H256,
-    ) -> Box<dyn Future<Item = ThinEthereumBlock, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = LightEthereumBlock, Error = Error> + Send>;
 
     /// Load Ethereum blocks in bulk, returning results as they come back as a Stream.
     /// May use the `chain_store` as a cache.
@@ -620,7 +620,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         logger: Logger,
         chain_store: Arc<dyn ChainStore>,
         block_hashes: HashSet<H256>,
-    ) -> Box<dyn Stream<Item = ThinEthereumBlock, Error = Error> + Send>;
+    ) -> Box<dyn Stream<Item = LightEthereumBlock, Error = Error> + Send>;
 
     /// Reorg safety: `to` must be a final block.
     fn block_range_to_ptrs(
@@ -635,13 +635,13 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         &self,
         logger: &Logger,
         block_hash: H256,
-    ) -> Box<dyn Future<Item = Option<ThinEthereumBlock>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Option<LightEthereumBlock>, Error = Error> + Send>;
 
     /// Load full information for the specified `block` (in particular, transaction receipts).
     fn load_full_block(
         &self,
         logger: &Logger,
-        block: ThinEthereumBlock,
+        block: LightEthereumBlock,
     ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send>;
 
     /// Load block pointer for the specified `block number`.

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -775,6 +775,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
             }
         }
 
+        let logger1 = logger.clone();
         Box::new(
             trigger_futs
                 .concat2()
@@ -788,6 +789,8 @@ pub trait EthereumAdapter: Send + Sync + 'static {
                             map
                         });
 
+                    debug!(logger, "Found {} relevant block(s)", block_hashes.len());
+
                     // Make sure `to` is included, even if empty.
                     block_hashes.insert(to_hash.unwrap());
                     triggers_by_block.entry(to).or_insert(Vec::new());
@@ -795,7 +798,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
                     (block_hashes, triggers_by_block)
                 })
                 .and_then(move |(block_hashes, mut triggers_by_block)| {
-                    self.load_blocks(logger.clone(), chain_store, block_hashes)
+                    self.load_blocks(logger1, chain_store, block_hashes)
                         .map(move |block| {
                             EthereumBlockWithTriggers::new(
                                 // All blocks with triggers should are in `triggers_by_block`, and

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -694,4 +694,13 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         call: EthereumContractCall,
         cache: Arc<dyn EthereumCallCache>,
     ) -> Box<dyn Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send>;
+
+    fn triggers_in_block(
+        &self,
+        logger: &Logger,
+        log_filter: EthereumLogFilter,
+        call_filter: EthereumCallFilter,
+        block_filter: EthereumBlockFilter,
+        ethereum_block: BlockFinality,
+    ) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send>;
 }

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -12,7 +12,8 @@ pub use self::adapter::{
 pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpdateStream};
 pub use self::stream::{BlockStream, BlockStreamBuilder};
 pub use self::types::{
-    EthereumBlock, EthereumBlockData, EthereumBlockPointer, EthereumBlockTriggerType,
-    EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall, EthereumCallData,
-    EthereumEventData, EthereumTransactionData, EthereumTrigger,
+    BlockFinality, EthereumBlock, EthereumBlockData, EthereumBlockPointer,
+    EthereumBlockTriggerType, EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall,
+    EthereumCallData, EthereumEventData, EthereumTransactionData, EthereumTrigger,
+    ThinEthereumBlock, ThinEthereumBlockExt,
 };

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -15,5 +15,5 @@ pub use self::types::{
     BlockFinality, EthereumBlock, EthereumBlockData, EthereumBlockPointer,
     EthereumBlockTriggerType, EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall,
     EthereumCallData, EthereumEventData, EthereumTransactionData, EthereumTrigger,
-    ThinEthereumBlock, ThinEthereumBlockExt,
+    LightEthereumBlock, LightEthereumBlockExt,
 };

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -4,10 +4,10 @@ mod stream;
 mod types;
 
 pub use self::adapter::{
-    EthGetLogsFilter, EthereumAdapter, EthereumAdapterError, EthereumBlockFilter,
-    EthereumCallFilter, EthereumContractCall, EthereumContractCallError, EthereumContractState,
-    EthereumContractStateError, EthereumContractStateRequest, EthereumLogFilter,
-    EthereumNetworkIdentifier, ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
+    BlockStreamMetrics, EthGetLogsFilter, EthereumAdapter, EthereumAdapterError,
+    EthereumBlockFilter, EthereumCallFilter, EthereumContractCall, EthereumContractCallError,
+    EthereumContractState, EthereumContractStateError, EthereumContractStateRequest,
+    EthereumLogFilter, EthereumNetworkIdentifier, ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
 };
 pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpdateStream};
 pub use self::stream::{BlockStream, BlockStreamBuilder};

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -25,7 +25,7 @@ pub trait BlockStreamBuilder: Clone + Send + Sync + 'static {
         log_filter: EthereumLogFilter,
         call_filter: EthereumCallFilter,
         block_filter: EthereumBlockFilter,
-        include_calls_in_blocks: bool,
+        templates_use_calls: bool,
         ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
     ) -> Self::Stream;
 }

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -18,6 +18,6 @@ pub trait BlockStreamBuilder: Clone + Send + Sync + 'static {
         call_filter: EthereumCallFilter,
         block_filter: EthereumBlockFilter,
         templates_use_calls: bool,
-        ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
+        ethrpc_metrics: Arc<BlockStreamMetrics>,
     ) -> Self::Stream;
 }

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -4,13 +4,13 @@ use futures::Stream;
 use crate::prelude::*;
 
 pub trait BlockStream: Stream<Item = EthereumBlockWithTriggers, Error = Error> {
-    fn parse_triggers(
+    fn triggers_in_block(
+        &self,
         log_filter: EthereumLogFilter,
         call_filter: EthereumCallFilter,
         block_filter: EthereumBlockFilter,
-        include_calls_in_blocks: bool,
-        descendant_block: EthereumBlockWithCalls,
-    ) -> Result<EthereumBlockWithTriggers, Error>;
+        descendant_block: BlockFinality,
+    ) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send>;
 }
 
 pub trait BlockStreamBuilder: Clone + Send + Sync + 'static {

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -26,5 +26,6 @@ pub trait BlockStreamBuilder: Clone + Send + Sync + 'static {
         call_filter: EthereumCallFilter,
         block_filter: EthereumBlockFilter,
         include_calls_in_blocks: bool,
+        ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
     ) -> Self::Stream;
 }

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -3,15 +3,7 @@ use futures::Stream;
 
 use crate::prelude::*;
 
-pub trait BlockStream: Stream<Item = EthereumBlockWithTriggers, Error = Error> {
-    fn triggers_in_block(
-        &self,
-        log_filter: EthereumLogFilter,
-        call_filter: EthereumCallFilter,
-        block_filter: EthereumBlockFilter,
-        descendant_block: BlockFinality,
-    ) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send>;
-}
+pub trait BlockStream: Stream<Item = EthereumBlockWithTriggers, Error = Error> {}
 
 pub trait BlockStreamBuilder: Clone + Send + Sync + 'static {
     type Stream: BlockStream + Send + 'static;

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -37,6 +37,9 @@ impl LightEthereumBlockExt for LightEthereumBlock {
     }
 }
 
+/// This is used in `EthereumAdapter::triggers_in_block`, called when re-processing a block for
+/// newly created data sources. This allows the re-processing to be reorg safe without having to
+/// always fetch the full block data.
 #[derive(Clone, Debug)]
 pub enum BlockFinality {
     /// If a block is final, we only need the header and the triggers.

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -89,7 +89,7 @@ impl EthereumCall {
 
 #[derive(Clone, Debug)]
 pub enum EthereumTrigger {
-    Block(EthereumBlockTriggerType),
+    Block(EthereumBlockPointer, EthereumBlockTriggerType),
     Call(EthereumCall),
     Log(Log),
 }
@@ -106,7 +106,15 @@ impl EthereumTrigger {
             // We only handle logs that are in a block and therefore have a `transaction_index`.
             EthereumTrigger::Log(log) => Some(log.transaction_index.unwrap().as_u64()),
             EthereumTrigger::Call(call) => Some(call.transaction_index),
-            EthereumTrigger::Block(_) => None,
+            EthereumTrigger::Block(_, _) => None,
+        }
+    }
+
+    pub fn block_number(&self) -> u64 {
+        match self {
+            EthereumTrigger::Block(block_ptr, _) => block_ptr.number,
+            EthereumTrigger::Call(call) => call.block_number,
+            EthereumTrigger::Log(log) => log.block_number.unwrap().as_u64(),
         }
     }
 }
@@ -333,6 +341,15 @@ impl From<(H256, i64)> for EthereumBlockPointer {
         EthereumBlockPointer {
             hash,
             number: number as u64,
+        }
+    }
+}
+
+impl<'a> From<&'a EthereumCall> for EthereumBlockPointer {
+    fn from(call: &'a EthereumCall) -> EthereumBlockPointer {
+        EthereumBlockPointer {
+            hash: call.block_hash,
+            number: call.block_number,
         }
     }
 }

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -53,6 +53,13 @@ impl BlockFinality {
             BlockFinality::NonFinal(block) => block.ethereum_block.block.clone(),
         }
     }
+
+    pub fn number(&self) -> u64 {
+        match self {
+            BlockFinality::Final(block) => block.number(),
+            BlockFinality::NonFinal(block) => block.ethereum_block.block.number(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -62,7 +69,7 @@ pub struct EthereumBlockWithTriggers {
 }
 
 impl EthereumBlockWithTriggers {
-    pub fn new(ethereum_block: BlockFinality, mut triggers: Vec<EthereumTrigger>) -> Self {
+    pub fn new(mut triggers: Vec<EthereumTrigger>, ethereum_block: BlockFinality) -> Self {
         // Sort the triggers
         triggers.sort_by(|a, b| {
             let a_tx_index = a.transaction_index();
@@ -186,13 +193,6 @@ impl EthereumTrigger {
             EthereumTrigger::Block(block_ptr, _) => block_ptr.hash,
             EthereumTrigger::Call(call) => call.block_hash,
             EthereumTrigger::Log(log) => log.block_hash.unwrap(),
-        }
-    }
-
-    pub fn block_ptr(&self) -> EthereumBlockPointer {
-        EthereumBlockPointer {
-            hash: self.block_hash(),
-            number: self.block_number(),
         }
     }
 }

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -3,16 +3,16 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use web3::types::*;
 
-pub type ThinEthereumBlock = Block<Transaction>;
+pub type LightEthereumBlock = Block<Transaction>;
 
-pub trait ThinEthereumBlockExt {
+pub trait LightEthereumBlockExt {
     fn number(&self) -> u64;
     fn transaction_for_log(&self, log: &Log) -> Option<Transaction>;
     fn transaction_for_call(&self, call: &EthereumCall) -> Option<Transaction>;
     fn parent_ptr(&self) -> EthereumBlockPointer;
 }
 
-impl ThinEthereumBlockExt for ThinEthereumBlock {
+impl LightEthereumBlockExt for LightEthereumBlock {
     fn number(&self) -> u64 {
         self.number.unwrap().as_u64()
     }
@@ -40,14 +40,14 @@ impl ThinEthereumBlockExt for ThinEthereumBlock {
 #[derive(Clone, Debug)]
 pub enum BlockFinality {
     /// If a block is final, we only need the header and the triggers.
-    Final(ThinEthereumBlock),
+    Final(LightEthereumBlock),
 
     // If a block may still be reorged, we need to work with more local data.
     NonFinal(EthereumBlockWithCalls),
 }
 
 impl BlockFinality {
-    pub fn thin_block(&self) -> ThinEthereumBlock {
+    pub fn thin_block(&self) -> LightEthereumBlock {
         match self {
             BlockFinality::Final(block) => block.clone(),
             BlockFinality::NonFinal(block) => block.ethereum_block.block.clone(),
@@ -101,7 +101,7 @@ pub struct EthereumBlockWithCalls {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct EthereumBlock {
-    pub block: ThinEthereumBlock,
+    pub block: LightEthereumBlock,
     pub transaction_receipts: Vec<TransactionReceipt>,
 }
 

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -40,7 +40,7 @@ impl ThinEthereumBlockExt for ThinEthereumBlock {
 #[derive(Clone, Debug)]
 pub enum BlockFinality {
     /// If a block is final, we only need the header and the triggers.
-    Final(Block<Transaction>),
+    Final(ThinEthereumBlock),
 
     // If a block may still be reorged, we need to work with more local data.
     NonFinal(EthereumBlockWithCalls),
@@ -101,7 +101,7 @@ pub struct EthereumBlockWithCalls {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct EthereumBlock {
-    pub block: Block<Transaction>,
+    pub block: ThinEthereumBlock,
     pub transaction_receipts: Vec<TransactionReceipt>,
 }
 

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -50,7 +50,7 @@ pub enum BlockFinality {
 }
 
 impl BlockFinality {
-    pub fn thin_block(&self) -> LightEthereumBlock {
+    pub fn light_block(&self) -> LightEthereumBlock {
         match self {
             BlockFinality::Final(block) => block.clone(),
             BlockFinality::NonFinal(block) => block.ethereum_block.block.clone(),

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -9,6 +9,7 @@ pub trait ThinEthereumBlockExt {
     fn number(&self) -> u64;
     fn transaction_for_log(&self, log: &Log) -> Option<Transaction>;
     fn transaction_for_call(&self, call: &EthereumCall) -> Option<Transaction>;
+    fn parent_ptr(&self) -> EthereumBlockPointer;
 }
 
 impl ThinEthereumBlockExt for ThinEthereumBlock {
@@ -26,6 +27,13 @@ impl ThinEthereumBlockExt for ThinEthereumBlock {
         call.transaction_hash
             .and_then(|hash| self.transactions.iter().find(|tx| tx.hash == hash))
             .cloned()
+    }
+
+    fn parent_ptr(&self) -> EthereumBlockPointer {
+        EthereumBlockPointer {
+            hash: self.parent_hash,
+            number: self.number() - 1,
+        }
     }
 }
 
@@ -338,14 +346,6 @@ pub struct EthereumBlockPointer {
 }
 
 impl EthereumBlockPointer {
-    /// Creates a pointer to the parent of the specified block.
-    pub fn to_parent(&self) -> EthereumBlockPointer {
-        EthereumBlockPointer {
-            hash: self.hash,
-            number: self.number - 1,
-        }
-    }
-
     /// Encodes the block hash into a hexadecimal string **without** a "0x" prefix.
     /// Hashes are stored in the database in this format.
     ///

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -117,6 +117,21 @@ impl EthereumTrigger {
             EthereumTrigger::Log(log) => log.block_number.unwrap().as_u64(),
         }
     }
+
+    pub fn block_hash(&self) -> H256 {
+        match self {
+            EthereumTrigger::Block(block_ptr, _) => block_ptr.hash,
+            EthereumTrigger::Call(call) => call.block_hash,
+            EthereumTrigger::Log(log) => log.block_hash.unwrap(),
+        }
+    }
+
+    pub fn block_ptr(&self) -> EthereumBlockPointer {
+        EthereumBlockPointer {
+            hash: self.block_hash(),
+            number: self.block_number(),
+        }
+    }
 }
 
 /// Ethereum block data.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -997,7 +997,7 @@ pub trait ChainStore: Send + Sync + 'static {
         unimplemented!()
     }
 
-    fn upsert_thin_blocks(&self, blocks: Vec<ThinEthereumBlock>) -> Result<(), Error>;
+    fn upsert_thin_blocks(&self, blocks: Vec<LightEthereumBlock>) -> Result<(), Error>;
 
     /// Try to update the head block pointer to the block with the highest block number.
     ///
@@ -1028,7 +1028,7 @@ pub trait ChainStore: Send + Sync + 'static {
     fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error>;
 
     /// Returns the blocks present in the store.
-    fn blocks(&self, hashes: Vec<H256>) -> Result<Vec<ThinEthereumBlock>, Error>;
+    fn blocks(&self, hashes: Vec<H256>) -> Result<Vec<LightEthereumBlock>, Error>;
 
     /// Get the `offset`th ancestor of `block_hash`, where offset=0 means the block matching
     /// `block_hash` and offset=1 means its parent. Returns None if unable to complete due to

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1000,8 +1000,6 @@ pub trait SubgraphDeploymentStore: Send + Sync + 'static {
 
 /// Common trait for blockchain store implementations.
 pub trait ChainStore: Send + Sync + 'static {
-    type ChainHeadUpdateListener: ChainHeadUpdateListener;
-
     /// Get a pointer to this blockchain's genesis block.
     fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error>;
 
@@ -1010,6 +1008,7 @@ pub trait ChainStore: Send + Sync + 'static {
     where
         B: Stream<Item = EthereumBlock, Error = E> + Send + 'a,
         E: From<Error> + Send + 'a,
+        Self: Sized,
     {
         unimplemented!()
     }
@@ -1045,7 +1044,7 @@ pub trait ChainStore: Send + Sync + 'static {
     fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error>;
 
     /// Returns the blocks present in the store.
-    fn blocks(&self, hashes: impl Iterator<Item = H256>) -> Result<Vec<ThinEthereumBlock>, Error>;
+    fn blocks(&self, hashes: Vec<H256>) -> Result<Vec<ThinEthereumBlock>, Error>;
 
     /// Get the `offset`th ancestor of `block_hash`, where offset=0 means the block matching
     /// `block_hash` and offset=1 means its parent. Returns None if unable to complete due to

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1006,13 +1006,15 @@ pub trait ChainStore: Send + Sync + 'static {
     fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error>;
 
     /// Insert blocks into the store (or update if they are already present).
-    fn upsert_blocks<'a, B, E>(
-        &self,
-        blocks: B,
-    ) -> Box<dyn Future<Item = (), Error = E> + Send + 'a>
+    fn upsert_blocks<'a, B, E>(&self, _: B) -> Box<dyn Future<Item = (), Error = E> + Send + 'a>
     where
         B: Stream<Item = EthereumBlock, Error = E> + Send + 'a,
-        E: From<Error> + Send + 'a;
+        E: From<Error> + Send + 'a,
+    {
+        unimplemented!()
+    }
+
+    fn upsert_thin_blocks(&self, blocks: Vec<ThinEthereumBlock>) -> Result<(), Error>;
 
     /// Try to update the head block pointer to the block with the highest block number.
     ///
@@ -1042,8 +1044,8 @@ pub trait ChainStore: Send + Sync + 'static {
     /// The head block pointer will be None on initial set up.
     fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error>;
 
-    /// Get Some(block) if it is present in the chain store, or None.
-    fn block(&self, block_hash: H256) -> Result<Option<EthereumBlock>, Error>;
+    /// Returns the blocks present in the store.
+    fn blocks(&self, hashes: impl Iterator<Item = H256>) -> Result<Vec<ThinEthereumBlock>, Error>;
 
     /// Get the `offset`th ancestor of `block_hash`, where offset=0 means the block matching
     /// `block_hash` and offset=1 means its parent. Returns None if unable to complete due to

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -997,7 +997,7 @@ pub trait ChainStore: Send + Sync + 'static {
         unimplemented!()
     }
 
-    fn upsert_thin_blocks(&self, blocks: Vec<LightEthereumBlock>) -> Result<(), Error>;
+    fn upsert_light_blocks(&self, blocks: Vec<LightEthereumBlock>) -> Result<(), Error>;
 
     /// Try to update the head block pointer to the block with the highest block number.
     ///

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -611,20 +611,6 @@ pub trait Store: Send + Sync + 'static {
     /// rainbow table.
     fn find_ens_name(&self, _hash: &str) -> Result<Option<String>, QueryExecutionError>;
 
-    /// Updates the block pointer.  Careful: this is only safe to use if it is known that no store
-    /// changes are needed to go from `block_ptr_from` to `block_ptr_to`.
-    ///
-    /// `block_ptr_from` must match the current value of the subgraph block pointer.
-    ///
-    /// Return `true` if the subgraph mentioned in `history_event` should have
-    /// its schema migrated at `block_ptr_to`
-    fn set_block_ptr_with_no_changes(
-        &self,
-        subgraph_id: SubgraphDeploymentId,
-        block_ptr_from: EthereumBlockPointer,
-        block_ptr_to: EthereumBlockPointer,
-    ) -> Result<bool, StoreError>;
-
     /// Transact the entity changes from a single block atomically into the store, and update the
     /// subgraph block pointer to `block_ptr_to`.
     ///

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -626,17 +626,15 @@ pub trait Store: Send + Sync + 'static {
     ) -> Result<bool, StoreError>;
 
     /// Transact the entity changes from a single block atomically into the store, and update the
-    /// subgraph block pointer from `block_ptr_from` to `block_ptr_to`.
+    /// subgraph block pointer to `block_ptr_to`.
     ///
-    /// `block_ptr_from` must match the current value of the subgraph block pointer.
-    /// `block_ptr_to` must point to a child block of `block_ptr_from`.
+    /// `block_ptr_to` must point to a child block of the current subgraph block pointer.
     ///
     /// Return `true` if the subgraph mentioned in `history_event` should have
     /// its schema migrated at `block_ptr_to`
     fn transact_block_operations(
         &self,
         subgraph_id: SubgraphDeploymentId,
-        block_ptr_from: EthereumBlockPointer,
         block_ptr_to: EthereumBlockPointer,
         mods: Vec<EntityModification>,
     ) -> Result<bool, StoreError>;

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -24,7 +24,7 @@ pub trait RuntimeHost: Send + Sync + Debug + 'static {
     fn process_log(
         &self,
         logger: Logger,
-        block: Arc<ThinEthereumBlock>,
+        block: Arc<LightEthereumBlock>,
         transaction: Arc<Transaction>,
         log: Arc<Log>,
         state: BlockState,
@@ -34,7 +34,7 @@ pub trait RuntimeHost: Send + Sync + Debug + 'static {
     fn process_call(
         &self,
         logger: Logger,
-        block: Arc<ThinEthereumBlock>,
+        block: Arc<LightEthereumBlock>,
         transaction: Arc<Transaction>,
         call: Arc<EthereumCall>,
         state: BlockState,
@@ -44,7 +44,7 @@ pub trait RuntimeHost: Send + Sync + Debug + 'static {
     fn process_block(
         &self,
         logger: Logger,
-        block: Arc<ThinEthereumBlock>,
+        block: Arc<LightEthereumBlock>,
         trigger_type: EthereumBlockTriggerType,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -24,7 +24,7 @@ pub trait RuntimeHost: Send + Sync + Debug + 'static {
     fn process_log(
         &self,
         logger: Logger,
-        block: Arc<EthereumBlock>,
+        block: Arc<ThinEthereumBlock>,
         transaction: Arc<Transaction>,
         log: Arc<Log>,
         state: BlockState,
@@ -34,7 +34,7 @@ pub trait RuntimeHost: Send + Sync + Debug + 'static {
     fn process_call(
         &self,
         logger: Logger,
-        block: Arc<EthereumBlock>,
+        block: Arc<ThinEthereumBlock>,
         transaction: Arc<Transaction>,
         call: Arc<EthereumCall>,
         state: BlockState,
@@ -44,7 +44,7 @@ pub trait RuntimeHost: Send + Sync + Debug + 'static {
     fn process_block(
         &self,
         logger: Logger,
-        block: Arc<EthereumBlock>,
+        block: Arc<ThinEthereumBlock>,
         trigger_type: EthereumBlockTriggerType,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -23,7 +23,7 @@ pub trait SubgraphInstance<H: RuntimeHost> {
     fn process_trigger(
         &self,
         logger: &Logger,
-        block: Arc<ThinEthereumBlock>,
+        block: Arc<LightEthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;
@@ -32,7 +32,7 @@ pub trait SubgraphInstance<H: RuntimeHost> {
     fn process_trigger_in_runtime_hosts(
         logger: &Logger,
         hosts: impl Iterator<Item = Arc<H>>,
-        block: Arc<ThinEthereumBlock>,
+        block: Arc<LightEthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -23,7 +23,7 @@ pub trait SubgraphInstance<H: RuntimeHost> {
     fn process_trigger(
         &self,
         logger: &Logger,
-        block: Arc<EthereumBlock>,
+        block: Arc<ThinEthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;
@@ -32,7 +32,7 @@ pub trait SubgraphInstance<H: RuntimeHost> {
     fn process_trigger_in_runtime_hosts(
         logger: &Logger,
         hosts: impl Iterator<Item = Arc<H>>,
-        block: Arc<EthereumBlock>,
+        block: Arc<ThinEthereumBlock>,
         trigger: EthereumTrigger,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send>;

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -39,13 +39,14 @@ pub mod prelude {
     pub use web3;
 
     pub use crate::components::ethereum::{
-        BlockFinality, BlockStream, BlockStreamBuilder, ChainHeadUpdate, ChainHeadUpdateListener,
-        ChainHeadUpdateStream, EthereumAdapter, EthereumAdapterError, EthereumBlock,
-        EthereumBlockData, EthereumBlockFilter, EthereumBlockPointer, EthereumBlockTriggerType,
-        EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall, EthereumCallData,
-        EthereumCallFilter, EthereumContractCall, EthereumContractCallError, EthereumEventData,
-        EthereumLogFilter, EthereumNetworkIdentifier, EthereumTransactionData, EthereumTrigger,
-        ProviderEthRpcMetrics, SubgraphEthRpcMetrics, ThinEthereumBlock, ThinEthereumBlockExt,
+        BlockFinality, BlockStream, BlockStreamBuilder, BlockStreamMetrics, ChainHeadUpdate,
+        ChainHeadUpdateListener, ChainHeadUpdateStream, EthereumAdapter, EthereumAdapterError,
+        EthereumBlock, EthereumBlockData, EthereumBlockFilter, EthereumBlockPointer,
+        EthereumBlockTriggerType, EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall,
+        EthereumCallData, EthereumCallFilter, EthereumContractCall, EthereumContractCallError,
+        EthereumEventData, EthereumLogFilter, EthereumNetworkIdentifier, EthereumTransactionData,
+        EthereumTrigger, ProviderEthRpcMetrics, SubgraphEthRpcMetrics, ThinEthereumBlock,
+        ThinEthereumBlockExt,
     };
     pub use crate::components::graphql::{
         GraphQlRunner, QueryResultFuture, SubscriptionResultFuture,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -39,13 +39,13 @@ pub mod prelude {
     pub use web3;
 
     pub use crate::components::ethereum::{
-        BlockStream, BlockStreamBuilder, ChainHeadUpdate, ChainHeadUpdateListener,
+        BlockFinality, BlockStream, BlockStreamBuilder, ChainHeadUpdate, ChainHeadUpdateListener,
         ChainHeadUpdateStream, EthereumAdapter, EthereumAdapterError, EthereumBlock,
         EthereumBlockData, EthereumBlockFilter, EthereumBlockPointer, EthereumBlockTriggerType,
         EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall, EthereumCallData,
         EthereumCallFilter, EthereumContractCall, EthereumContractCallError, EthereumEventData,
         EthereumLogFilter, EthereumNetworkIdentifier, EthereumTransactionData, EthereumTrigger,
-        ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
+        ProviderEthRpcMetrics, SubgraphEthRpcMetrics, ThinEthereumBlock, ThinEthereumBlockExt,
     };
     pub use crate::components::graphql::{
         GraphQlRunner, QueryResultFuture, SubscriptionResultFuture,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -45,8 +45,8 @@ pub mod prelude {
         EthereumBlockTriggerType, EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall,
         EthereumCallData, EthereumCallFilter, EthereumContractCall, EthereumContractCallError,
         EthereumEventData, EthereumLogFilter, EthereumNetworkIdentifier, EthereumTransactionData,
-        EthereumTrigger, ProviderEthRpcMetrics, SubgraphEthRpcMetrics, ThinEthereumBlock,
-        ThinEthereumBlockExt,
+        EthereumTrigger, LightEthereumBlock, LightEthereumBlockExt, ProviderEthRpcMetrics,
+        SubgraphEthRpcMetrics,
     };
     pub use crate::components::graphql::{
         GraphQlRunner, QueryResultFuture, SubscriptionResultFuture,

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -189,7 +189,6 @@ fn insert_test_entities(store: &impl Store, id: SubgraphDeploymentId) {
     transact_entity_operations(
         &STORE,
         id.clone(),
-        GENESIS_PTR.clone(),
         BLOCK_ONE.clone(),
         insert_ops.collect::<Vec<_>>(),
     )

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -57,7 +57,7 @@ impl BlockStreamBuilder for MockBlockStreamBuilder {
         _: EthereumCallFilter,
         _: EthereumBlockFilter,
         _: bool,
-        _: Arc<SubgraphEthRpcMetrics>,
+        _: Arc<BlockStreamMetrics>,
     ) -> Self::Stream {
         MockBlockStream::new()
     }

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -34,13 +34,13 @@ impl EventConsumer<ChainHeadUpdate> for MockBlockStream {
 }
 
 impl BlockStream for MockBlockStream {
-    fn parse_triggers(
+    fn triggers_in_block(
+        &self,
         _: EthereumLogFilter,
         _: EthereumCallFilter,
         _: EthereumBlockFilter,
-        _include_calls_in_blocks: bool,
-        _descendant_block: EthereumBlockWithCalls,
-    ) -> Result<EthereumBlockWithTriggers, Error> {
+        _descendant_block: BlockFinality,
+    ) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send> {
         unimplemented!()
     }
 }

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -66,8 +66,8 @@ impl BlockStreamBuilder for MockBlockStreamBuilder {
         _: EthereumLogFilter,
         _: EthereumCallFilter,
         _: EthereumBlockFilter,
-        _include_calls_in_blocks: bool,
-        ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
+        _: bool,
+        _: Arc<SubgraphEthRpcMetrics>,
     ) -> Self::Stream {
         MockBlockStream::new()
     }

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -33,17 +33,7 @@ impl EventConsumer<ChainHeadUpdate> for MockBlockStream {
     }
 }
 
-impl BlockStream for MockBlockStream {
-    fn triggers_in_block(
-        &self,
-        _: EthereumLogFilter,
-        _: EthereumCallFilter,
-        _: EthereumBlockFilter,
-        _descendant_block: BlockFinality,
-    ) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send> {
-        unimplemented!()
-    }
-}
+impl BlockStream for MockBlockStream {}
 
 #[derive(Clone)]
 pub struct MockBlockStreamBuilder;

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -67,6 +67,7 @@ impl BlockStreamBuilder for MockBlockStreamBuilder {
         _: EthereumCallFilter,
         _: EthereumBlockFilter,
         _include_calls_in_blocks: bool,
+        ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
     ) -> Self::Stream {
         MockBlockStream::new()
     }

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -1,10 +1,8 @@
-use std::collections::HashSet;
-
 use graph::components::ethereum::*;
 use graph::prelude::{
     ethabi, future,
-    web3::types::{Block, Transaction, H256},
-    Arc, Error, EthereumCallCache, Future, Logger,
+    web3::types::{Block, Log, Transaction, H256},
+    Arc, Error, EthereumCallCache, Future, Logger, Stream,
 };
 
 #[derive(Default)]
@@ -96,7 +94,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: EthereumLogFilter,
         _: EthereumCallFilter,
         _: EthereumBlockFilter,
-    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<EthereumTrigger>, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -107,7 +105,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: u64,
         _: u64,
         _: EthereumLogFilter,
-    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<Log>, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -118,7 +116,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: u64,
         _: u64,
         _: EthereumCallFilter,
-    ) -> Box<dyn Future<Item = HashSet<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<dyn Stream<Item = EthereumCall, Error = Error> + Send> {
         unimplemented!();
     }
 
@@ -138,6 +136,17 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: EthereumContractCall,
         _: Arc<dyn EthereumCallCache>,
     ) -> Box<dyn Future<Item = Vec<ethabi::Token>, Error = EthereumContractCallError> + Send> {
+        unimplemented!();
+    }
+
+    fn triggers_in_block(
+        &self,
+        _: &Logger,
+        _: EthereumLogFilter,
+        _: EthereumCallFilter,
+        _: EthereumBlockFilter,
+        _: BlockFinality,
+    ) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send> {
         unimplemented!();
     }
 }

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -147,4 +147,13 @@ impl EthereumAdapter for MockEthereumAdapter {
     ) -> Box<dyn Stream<Item = ThinEthereumBlock, Error = Error> + Send> {
         unimplemented!()
     }
+
+    fn block_range_to_ptrs(
+        &self,
+        _: &Logger,
+        _: u64,
+        _: u64,
+    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+        unimplemented!()
+    }
 }

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -20,7 +20,7 @@ impl EthereumAdapter for MockEthereumAdapter {
     fn latest_block(
         &self,
         _: &Logger,
-    ) -> Box<dyn Future<Item = ThinEthereumBlock, Error = EthereumAdapterError> + Send> {
+    ) -> Box<dyn Future<Item = LightEthereumBlock, Error = EthereumAdapterError> + Send> {
         unimplemented!();
     }
 
@@ -28,7 +28,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         &self,
         _: &Logger,
         _: H256,
-    ) -> Box<dyn Future<Item = ThinEthereumBlock, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = LightEthereumBlock, Error = Error> + Send> {
         unimplemented!()
     }
 
@@ -36,14 +36,14 @@ impl EthereumAdapter for MockEthereumAdapter {
         &self,
         _: &Logger,
         _: H256,
-    ) -> Box<dyn Future<Item = Option<ThinEthereumBlock>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Option<LightEthereumBlock>, Error = Error> + Send> {
         unimplemented!();
     }
 
     fn load_full_block(
         &self,
         _: &Logger,
-        _: ThinEthereumBlock,
+        _: LightEthereumBlock,
     ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send> {
         unimplemented!();
     }
@@ -136,7 +136,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: Logger,
         _: Arc<dyn ChainStore>,
         _: HashSet<H256>,
-    ) -> Box<dyn Stream<Item = ThinEthereumBlock, Error = Error> + Send> {
+    ) -> Box<dyn Stream<Item = LightEthereumBlock, Error = Error> + Send> {
         unimplemented!()
     }
 

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -1,7 +1,7 @@
 use graph::components::ethereum::*;
 use graph::prelude::{
     ethabi, future,
-    web3::types::{Block, Log, Transaction, H256},
+    web3::types::{Log, H256},
     Arc, ChainStore, Error, EthereumCallCache, Future, Logger, Stream,
 };
 use std::collections::HashSet;
@@ -20,7 +20,7 @@ impl EthereumAdapter for MockEthereumAdapter {
     fn latest_block(
         &self,
         _: &Logger,
-    ) -> Box<dyn Future<Item = Block<Transaction>, Error = EthereumAdapterError> + Send> {
+    ) -> Box<dyn Future<Item = ThinEthereumBlock, Error = EthereumAdapterError> + Send> {
         unimplemented!();
     }
 
@@ -36,14 +36,14 @@ impl EthereumAdapter for MockEthereumAdapter {
         &self,
         _: &Logger,
         _: H256,
-    ) -> Box<dyn Future<Item = Option<Block<Transaction>>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Option<ThinEthereumBlock>, Error = Error> + Send> {
         unimplemented!();
     }
 
     fn load_full_block(
         &self,
         _: &Logger,
-        _: Block<Transaction>,
+        _: ThinEthereumBlock,
     ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send> {
         unimplemented!();
     }

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -59,14 +59,6 @@ impl EthereumAdapter for MockEthereumAdapter {
         ))))
     }
 
-    fn block_parent_hash(
-        &self,
-        _: &Logger,
-        _: H256,
-    ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send> {
-        unimplemented!();
-    }
-
     fn block_hash_by_block_number(
         &self,
         _: &Logger,
@@ -150,7 +142,7 @@ impl EthereumAdapter for MockEthereumAdapter {
 
     fn block_range_to_ptrs(
         &self,
-        _: &Logger,
+        _: Logger,
         _: u64,
         _: u64,
     ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -86,7 +86,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         unimplemented!();
     }
 
-    fn blocks_with_logs(
+    fn logs_in_block_range(
         &self,
         _: &Logger,
         _: Arc<SubgraphEthRpcMetrics>,
@@ -97,7 +97,7 @@ impl EthereumAdapter for MockEthereumAdapter {
         unimplemented!();
     }
 
-    fn blocks_with_calls(
+    fn calls_in_block_range(
         &self,
         _: &Logger,
         _: Arc<SubgraphEthRpcMetrics>,

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -2,8 +2,9 @@ use graph::components::ethereum::*;
 use graph::prelude::{
     ethabi, future,
     web3::types::{Block, Log, Transaction, H256},
-    Arc, Error, EthereumCallCache, Future, Logger, Stream,
+    Arc, ChainStore, Error, EthereumCallCache, Future, Logger, Stream,
 };
+use std::collections::HashSet;
 
 #[derive(Default)]
 pub struct MockEthereumAdapter {}
@@ -93,19 +94,6 @@ impl EthereumAdapter for MockEthereumAdapter {
         unimplemented!();
     }
 
-    fn blocks_with_triggers(
-        &self,
-        _: &Logger,
-        _: Arc<SubgraphEthRpcMetrics>,
-        _: u64,
-        _: u64,
-        _: EthereumLogFilter,
-        _: EthereumCallFilter,
-        _: EthereumBlockFilter,
-    ) -> Box<dyn Future<Item = Vec<EthereumTrigger>, Error = Error> + Send> {
-        unimplemented!();
-    }
-
     fn blocks_with_logs(
         &self,
         _: &Logger,
@@ -128,16 +116,6 @@ impl EthereumAdapter for MockEthereumAdapter {
         unimplemented!();
     }
 
-    fn blocks(
-        &self,
-        _: &Logger,
-        _: Arc<SubgraphEthRpcMetrics>,
-        _: u64,
-        _: u64,
-    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
-        unimplemented!();
-    }
-
     fn contract_call(
         &self,
         _: &Logger,
@@ -148,8 +126,9 @@ impl EthereumAdapter for MockEthereumAdapter {
     }
 
     fn triggers_in_block(
-        &self,
-        _: &Logger,
+        self: Arc<Self>,
+        _: Logger,
+        _: Arc<dyn ChainStore>,
         _: Arc<SubgraphEthRpcMetrics>,
         _: EthereumLogFilter,
         _: EthereumCallFilter,
@@ -157,5 +136,15 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: BlockFinality,
     ) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send> {
         unimplemented!();
+    }
+
+    /// Load Ethereum blocks in bulk, returning results as they come back as a Stream.
+    fn load_blocks(
+        &self,
+        _: Logger,
+        _: Arc<dyn ChainStore>,
+        _: HashSet<H256>,
+    ) -> Box<dyn Stream<Item = ThinEthereumBlock, Error = Error> + Send> {
+        unimplemented!()
     }
 }

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -23,6 +23,14 @@ impl EthereumAdapter for MockEthereumAdapter {
         unimplemented!();
     }
 
+    fn load_block(
+        &self,
+        _: &Logger,
+        _: H256,
+    ) -> Box<dyn Future<Item = ThinEthereumBlock, Error = Error> + Send> {
+        unimplemented!()
+    }
+
     fn block_by_hash(
         &self,
         _: &Logger,
@@ -142,6 +150,7 @@ impl EthereumAdapter for MockEthereumAdapter {
     fn triggers_in_block(
         &self,
         _: &Logger,
+        _: Arc<SubgraphEthRpcMetrics>,
         _: EthereumLogFilter,
         _: EthereumCallFilter,
         _: EthereumBlockFilter,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -422,7 +422,7 @@ impl ChainStore for MockStore {
         unimplemented!();
     }
 
-    fn upsert_thin_blocks(&self, _: Vec<ThinEthereumBlock>) -> Result<(), Error> {
+    fn upsert_thin_blocks(&self, _: Vec<LightEthereumBlock>) -> Result<(), Error> {
         unimplemented!();
     }
 
@@ -438,7 +438,7 @@ impl ChainStore for MockStore {
         Ok(None)
     }
 
-    fn blocks(&self, _: Vec<H256>) -> Result<Vec<ThinEthereumBlock>, Error> {
+    fn blocks(&self, _: Vec<H256>) -> Result<Vec<LightEthereumBlock>, Error> {
         unimplemented!();
     }
 
@@ -572,7 +572,7 @@ impl ChainStore for FakeStore {
         unimplemented!();
     }
 
-    fn upsert_thin_blocks(&self, _: Vec<ThinEthereumBlock>) -> Result<(), Error> {
+    fn upsert_thin_blocks(&self, _: Vec<LightEthereumBlock>) -> Result<(), Error> {
         unimplemented!()
     }
 
@@ -588,7 +588,7 @@ impl ChainStore for FakeStore {
         unimplemented!();
     }
 
-    fn blocks(&self, _: Vec<H256>) -> Result<Vec<ThinEthereumBlock>, Error> {
+    fn blocks(&self, _: Vec<H256>) -> Result<Vec<LightEthereumBlock>, Error> {
         unimplemented!();
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -443,6 +443,10 @@ impl ChainStore for MockStore {
         unimplemented!();
     }
 
+    fn upsert_thin_blocks(&self, _: Vec<ThinEthereumBlock>) -> Result<(), Error> {
+        unimplemented!();
+    }
+
     fn attempt_chain_head_update(&self, _: u64) -> Result<Vec<H256>, Error> {
         unimplemented!();
     }
@@ -455,7 +459,7 @@ impl ChainStore for MockStore {
         Ok(None)
     }
 
-    fn block(&self, _: H256) -> Result<Option<EthereumBlock>, Error> {
+    fn blocks(&self, _: impl Iterator<Item = H256>) -> Result<Vec<ThinEthereumBlock>, Error> {
         unimplemented!();
     }
 
@@ -601,6 +605,10 @@ impl ChainStore for FakeStore {
         unimplemented!();
     }
 
+    fn upsert_thin_blocks(&self, _: Vec<ThinEthereumBlock>) -> Result<(), Error> {
+        unimplemented!()
+    }
+
     fn attempt_chain_head_update(&self, _: u64) -> Result<Vec<H256>, Error> {
         unimplemented!();
     }
@@ -613,7 +621,7 @@ impl ChainStore for FakeStore {
         unimplemented!();
     }
 
-    fn block(&self, _: H256) -> Result<Option<EthereumBlock>, Error> {
+    fn blocks(&self, _: impl Iterator<Item = H256>) -> Result<Vec<ThinEthereumBlock>, Error> {
         unimplemented!();
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -422,7 +422,7 @@ impl ChainStore for MockStore {
         unimplemented!();
     }
 
-    fn upsert_thin_blocks(&self, _: Vec<LightEthereumBlock>) -> Result<(), Error> {
+    fn upsert_light_blocks(&self, _: Vec<LightEthereumBlock>) -> Result<(), Error> {
         unimplemented!();
     }
 
@@ -572,7 +572,7 @@ impl ChainStore for FakeStore {
         unimplemented!();
     }
 
-    fn upsert_thin_blocks(&self, _: Vec<LightEthereumBlock>) -> Result<(), Error> {
+    fn upsert_light_blocks(&self, _: Vec<LightEthereumBlock>) -> Result<(), Error> {
         unimplemented!()
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -196,7 +196,6 @@ impl Store for MockStore {
         &self,
         _: SubgraphDeploymentId,
         _: EthereumBlockPointer,
-        _: EthereumBlockPointer,
         _: Vec<EntityModification>,
     ) -> Result<bool, StoreError> {
         unimplemented!();
@@ -521,7 +520,6 @@ impl Store for FakeStore {
     fn transact_block_operations(
         &self,
         _: SubgraphDeploymentId,
-        _: EthereumBlockPointer,
         _: EthereumBlockPointer,
         _: Vec<EntityModification>,
     ) -> Result<bool, StoreError> {

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -183,15 +183,6 @@ impl Store for MockStore {
         unimplemented!();
     }
 
-    fn set_block_ptr_with_no_changes(
-        &self,
-        _: SubgraphDeploymentId,
-        _: EthereumBlockPointer,
-        _: EthereumBlockPointer,
-    ) -> Result<bool, StoreError> {
-        unimplemented!();
-    }
-
     fn transact_block_operations(
         &self,
         _: SubgraphDeploymentId,
@@ -505,15 +496,6 @@ impl Store for FakeStore {
     }
 
     fn block_ptr(&self, _: SubgraphDeploymentId) -> Result<EthereumBlockPointer, Error> {
-        unimplemented!();
-    }
-
-    fn set_block_ptr_with_no_changes(
-        &self,
-        _: SubgraphDeploymentId,
-        _: EthereumBlockPointer,
-        _: EthereumBlockPointer,
-    ) -> Result<bool, StoreError> {
         unimplemented!();
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -11,15 +11,6 @@ use graph::prelude::*;
 use graph_graphql::prelude::api_schema;
 use web3::types::H256;
 
-/// A mock `ChainHeadUpdateListener`
-pub struct MockChainHeadUpdateListener {}
-
-impl ChainHeadUpdateListener for MockChainHeadUpdateListener {
-    fn subscribe(&self) -> ChainHeadUpdateStream {
-        unimplemented!();
-    }
-}
-
 #[derive(Debug)]
 pub struct MockStore {
     schemas: HashMap<SubgraphDeploymentId, Schema>,
@@ -426,8 +417,6 @@ impl SubgraphDeploymentStore for MockStore {
 }
 
 impl ChainStore for MockStore {
-    type ChainHeadUpdateListener = MockChainHeadUpdateListener;
-
     fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error> {
         Ok(EthereumBlockPointer {
             hash: H256::zero(),
@@ -459,7 +448,7 @@ impl ChainStore for MockStore {
         Ok(None)
     }
 
-    fn blocks(&self, _: impl Iterator<Item = H256>) -> Result<Vec<ThinEthereumBlock>, Error> {
+    fn blocks(&self, _: Vec<H256>) -> Result<Vec<ThinEthereumBlock>, Error> {
         unimplemented!();
     }
 
@@ -591,8 +580,6 @@ impl Store for FakeStore {
 }
 
 impl ChainStore for FakeStore {
-    type ChainHeadUpdateListener = MockChainHeadUpdateListener;
-
     fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error> {
         unimplemented!();
     }
@@ -621,7 +608,7 @@ impl ChainStore for FakeStore {
         unimplemented!();
     }
 
-    fn blocks(&self, _: impl Iterator<Item = H256>) -> Result<Vec<ThinEthereumBlock>, Error> {
+    fn blocks(&self, _: Vec<H256>) -> Result<Vec<ThinEthereumBlock>, Error> {
         unimplemented!();
     }
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -584,6 +584,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     let subgraph_instance_manager = SubgraphInstanceManager::new(
         &logger_factory,
         stores.clone(),
+        eth_adapters.clone(),
         runtime_host_builder,
         block_stream_builder,
         metrics_registry.clone(),

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -371,7 +371,7 @@ impl RuntimeHostTrait for RuntimeHost {
     fn process_call(
         &self,
         logger: Logger,
-        block: Arc<EthereumBlock>,
+        block: Arc<ThinEthereumBlock>,
         transaction: Arc<Transaction>,
         call: Arc<EthereumCall>,
         state: BlockState,
@@ -524,7 +524,7 @@ impl RuntimeHostTrait for RuntimeHost {
     fn process_block(
         &self,
         logger: Logger,
-        block: Arc<EthereumBlock>,
+        block: Arc<ThinEthereumBlock>,
         trigger_type: EthereumBlockTriggerType,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
@@ -535,8 +535,8 @@ impl RuntimeHostTrait for RuntimeHost {
 
         debug!(
             logger, "Start processing Ethereum block";
-            "hash" => block.block.hash.unwrap().to_string(),
-            "number" => &block.block.number.unwrap().to_string(),
+            "hash" => block.hash.unwrap().to_string(),
+            "number" => &block.number.unwrap().to_string(),
             "handler" => &block_handler.handler,
             "data_source" => &self.data_source_name,
         );
@@ -576,8 +576,8 @@ impl RuntimeHostTrait for RuntimeHost {
                     );
                     info!(
                         logger, "Done processing Ethereum block";
-                        "hash" => block.block.hash.unwrap().to_string(),
-                        "number" => &block.block.number.unwrap().to_string(),
+                        "hash" => block.hash.unwrap().to_string(),
+                        "number" => &block.number.unwrap().to_string(),
                         "handler" => &block_handler.handler,
                         "ms" => elapsed.as_millis(),
                     );
@@ -589,7 +589,7 @@ impl RuntimeHostTrait for RuntimeHost {
     fn process_log(
         &self,
         logger: Logger,
-        block: Arc<EthereumBlock>,
+        block: Arc<ThinEthereumBlock>,
         transaction: Arc<Transaction>,
         log: Arc<Log>,
         state: BlockState,

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -371,7 +371,7 @@ impl RuntimeHostTrait for RuntimeHost {
     fn process_call(
         &self,
         logger: Logger,
-        block: Arc<ThinEthereumBlock>,
+        block: Arc<LightEthereumBlock>,
         transaction: Arc<Transaction>,
         call: Arc<EthereumCall>,
         state: BlockState,
@@ -524,7 +524,7 @@ impl RuntimeHostTrait for RuntimeHost {
     fn process_block(
         &self,
         logger: Logger,
-        block: Arc<ThinEthereumBlock>,
+        block: Arc<LightEthereumBlock>,
         trigger_type: EthereumBlockTriggerType,
         state: BlockState,
     ) -> Box<dyn Future<Item = BlockState, Error = Error> + Send> {
@@ -589,7 +589,7 @@ impl RuntimeHostTrait for RuntimeHost {
     fn process_log(
         &self,
         logger: Logger,
-        block: Arc<ThinEthereumBlock>,
+        block: Arc<LightEthereumBlock>,
         transaction: Arc<Transaction>,
         log: Arc<Log>,
         state: BlockState,

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -198,7 +198,7 @@ impl HostExports {
         &self,
         task_sink: &mut impl Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>,
         logger: &Logger,
-        block: &ThinEthereumBlock,
+        block: &LightEthereumBlock,
         unresolved_call: UnresolvedContractCall,
     ) -> Result<Option<Vec<Token>>, HostExportError<impl ExportError>> {
         let start_time = Instant::now();

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -198,7 +198,7 @@ impl HostExports {
         &self,
         task_sink: &mut impl Sink<SinkItem = Box<dyn Future<Item = (), Error = ()> + Send>>,
         logger: &Logger,
-        block: &EthereumBlock,
+        block: &ThinEthereumBlock,
         unresolved_call: UnresolvedContractCall,
     ) -> Result<Option<Vec<Token>>, HostExportError<impl ExportError>> {
         let start_time = Instant::now();

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -135,7 +135,7 @@ pub struct MappingRequest {
 pub(crate) struct MappingContext {
     pub(crate) logger: Logger,
     pub(crate) host_exports: Arc<crate::host_exports::HostExports>,
-    pub(crate) block: Arc<ThinEthereumBlock>,
+    pub(crate) block: Arc<LightEthereumBlock>,
     pub(crate) state: BlockState,
 }
 

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -135,7 +135,7 @@ pub struct MappingRequest {
 pub(crate) struct MappingContext {
     pub(crate) logger: Logger,
     pub(crate) host_exports: Arc<crate::host_exports::HostExports>,
-    pub(crate) block: Arc<EthereumBlock>,
+    pub(crate) block: Arc<ThinEthereumBlock>,
     pub(crate) state: BlockState,
 }
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -180,7 +180,7 @@ where
     ) -> Result<BlockState, FailureError> {
         self.start_time = Instant::now();
 
-        let block = self.ctx.block.block.clone();
+        let block = self.ctx.block.clone();
 
         // Prepare an EthereumEvent for the WASM runtime
         // Decide on the destination type using the mapping
@@ -189,7 +189,7 @@ where
             RuntimeValue::from(
                 self.asc_new::<AscEthereumEvent<AscEthereumTransaction_0_0_2>, _>(
                     &EthereumEventData {
-                        block: EthereumBlockData::from(&block),
+                        block: EthereumBlockData::from(block.as_ref()),
                         transaction: EthereumTransactionData::from(transaction.deref()),
                         address: log.address,
                         log_index: log.log_index.unwrap_or(U256::zero()),
@@ -202,7 +202,7 @@ where
         } else {
             RuntimeValue::from(self.asc_new::<AscEthereumEvent<AscEthereumTransaction>, _>(
                 &EthereumEventData {
-                    block: EthereumBlockData::from(&block),
+                    block: EthereumBlockData::from(block.as_ref()),
                     transaction: EthereumTransactionData::from(transaction.deref()),
                     address: log.address,
                     log_index: log.log_index.unwrap_or(U256::zero()),
@@ -267,7 +267,7 @@ where
         let call = EthereumCallData {
             to: call.to,
             from: call.from,
-            block: EthereumBlockData::from(&self.ctx.block.block),
+            block: EthereumBlockData::from(self.ctx.block.as_ref()),
             transaction: EthereumTransactionData::from(transaction.deref()),
             inputs,
             outputs,
@@ -299,7 +299,7 @@ where
         self.start_time = Instant::now();
 
         // Prepare an EthereumBlock for the WASM runtime
-        let arg = EthereumBlockData::from(&self.ctx.block.block);
+        let arg = EthereumBlockData::from(self.ctx.block.as_ref());
 
         let result = self.module.clone().invoke_export(
             handler_name,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -815,26 +815,6 @@ impl StoreTrait for Store {
             })
     }
 
-    fn set_block_ptr_with_no_changes(
-        &self,
-        subgraph_id: SubgraphDeploymentId,
-        block_ptr_from: EthereumBlockPointer,
-        block_ptr_to: EthereumBlockPointer,
-    ) -> Result<bool, StoreError> {
-        let ops = SubgraphDeploymentEntity::update_ethereum_block_pointer_operations(
-            &subgraph_id,
-            block_ptr_from,
-            block_ptr_to,
-            "skip blocks with no changes",
-        );
-        let conn = self.get_entity_conn(&subgraph_id).map_err(Error::from)?;
-        let event = conn.transaction(|| self.apply_metadata_operations_with_conn(&conn, ops))?;
-
-        // Send the event separately, because NOTIFY uses a global DB lock.
-        conn.transaction(|| conn.send_store_event(&event))?;
-        conn.should_migrate(&subgraph_id, &block_ptr_to)
-    }
-
     fn transact_block_operations(
         &self,
         subgraph_id: SubgraphDeploymentId,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1070,7 +1070,7 @@ impl ChainStore for Store {
         }))
     }
 
-    fn upsert_thin_blocks(&self, blocks: Vec<ThinEthereumBlock>) -> Result<(), Error> {
+    fn upsert_thin_blocks(&self, blocks: Vec<LightEthereumBlock>) -> Result<(), Error> {
         use crate::db_schema::ethereum_blocks::dsl::*;
 
         let conn = self.conn.clone();
@@ -1148,7 +1148,7 @@ impl ChainStore for Store {
             .map_err(Error::from)
     }
 
-    fn blocks(&self, hashes: Vec<H256>) -> Result<Vec<ThinEthereumBlock>, Error> {
+    fn blocks(&self, hashes: Vec<H256>) -> Result<Vec<LightEthereumBlock>, Error> {
         use crate::db_schema::ethereum_blocks::dsl::*;
         use diesel::dsl::any;
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -821,7 +821,9 @@ impl StoreTrait for Store {
         block_ptr_to: EthereumBlockPointer,
         mods: Vec<EntityModification>,
     ) -> Result<bool, StoreError> {
+        // Improvement: Move this inside the transaction.
         let block_ptr_from = self.block_ptr(subgraph_id.clone())?;
+        assert!(block_ptr_from.number < block_ptr_to.number);
 
         // All operations should apply only to entities in this subgraph or
         // the subgraph of subgraphs

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1070,7 +1070,7 @@ impl ChainStore for Store {
         }))
     }
 
-    fn upsert_thin_blocks(&self, blocks: Vec<LightEthereumBlock>) -> Result<(), Error> {
+    fn upsert_light_blocks(&self, blocks: Vec<LightEthereumBlock>) -> Result<(), Error> {
         use crate::db_schema::ethereum_blocks::dsl::*;
 
         let conn = self.conn.clone();

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -838,14 +838,10 @@ impl StoreTrait for Store {
     fn transact_block_operations(
         &self,
         subgraph_id: SubgraphDeploymentId,
-        block_ptr_from: EthereumBlockPointer,
         block_ptr_to: EthereumBlockPointer,
         mods: Vec<EntityModification>,
     ) -> Result<bool, StoreError> {
-        // Sanity check on block numbers
-        if block_ptr_from.number != block_ptr_to.number - 1 {
-            panic!("transact_block_operations must transact a single block only");
-        }
+        let block_ptr_from = self.block_ptr(subgraph_id.clone())?;
 
         // All operations should apply only to entities in this subgraph or
         // the subgraph of subgraphs

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -174,7 +174,6 @@ fn insert_test_data(store: Arc<DieselStore>) {
     transact_entity_operations(
         &store,
         TEST_SUBGRAPH_ID.clone(),
-        *TEST_BLOCK_0_PTR,
         *TEST_BLOCK_1_PTR,
         vec![test_entity_1],
     )
@@ -203,7 +202,6 @@ fn insert_test_data(store: Arc<DieselStore>) {
     transact_entity_operations(
         &store,
         TEST_SUBGRAPH_ID.clone(),
-        *TEST_BLOCK_1_PTR,
         *TEST_BLOCK_2_PTR,
         vec![test_entity_2, test_entity_3_1],
     )
@@ -222,7 +220,6 @@ fn insert_test_data(store: Arc<DieselStore>) {
     transact_entity_operations(
         &store,
         TEST_SUBGRAPH_ID.clone(),
-        *TEST_BLOCK_2_PTR,
         *TEST_BLOCK_3_PTR,
         vec![test_entity_3_2],
     )
@@ -310,7 +307,6 @@ fn delete_entity() {
         transact_entity_operations(
             &store,
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
             *TEST_BLOCK_4_PTR,
             vec![EntityOperation::Remove {
                 key: entity_key.clone(),
@@ -425,7 +421,6 @@ fn insert_entity() {
         transact_entity_operations(
             &store,
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
             *TEST_BLOCK_4_PTR,
             vec![test_entity],
         )
@@ -474,7 +469,6 @@ fn update_existing() {
         transact_entity_operations(
             &store,
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
             *TEST_BLOCK_4_PTR,
             vec![op],
         )
@@ -519,7 +513,6 @@ fn partially_update_existing() {
         transact_entity_operations(
             &store,
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
             *TEST_BLOCK_4_PTR,
             vec![EntityOperation::Set {
                 key: entity_key.clone(),
@@ -1594,7 +1587,6 @@ fn revert_block_with_delete() {
         transact_entity_operations(
             &store,
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
             *TEST_BLOCK_4_PTR,
             vec![EntityOperation::Remove { key: del_key }],
         )
@@ -1666,7 +1658,6 @@ fn revert_block_with_partial_update() {
         transact_entity_operations(
             &store,
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
             *TEST_BLOCK_4_PTR,
             vec![EntityOperation::Set {
                 key: entity_key.clone(),
@@ -1795,14 +1786,8 @@ fn revert_block_with_dynamic_data_source_operations() {
         ops.extend(dynamic_ds.write_entity_operations("dynamic-data-source"));
 
         // Add user and dynamic data source to the store
-        transact_entity_operations(
-            &store,
-            TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
-            *TEST_BLOCK_4_PTR,
-            ops,
-        )
-        .unwrap();
+        transact_entity_operations(&store, TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_4_PTR, ops)
+            .unwrap();
 
         // Verify that the user is no longer the original
         assert_ne!(
@@ -1955,7 +1940,6 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
         transact_entity_operations(
             &store,
             subgraph_id.clone(),
-            *TEST_BLOCK_0_PTR,
             *TEST_BLOCK_1_PTR,
             added_entities
                 .iter()
@@ -1998,7 +1982,6 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
         transact_entity_operations(
             &store,
             subgraph_id.clone(),
-            *TEST_BLOCK_1_PTR,
             *TEST_BLOCK_2_PTR,
             vec![update_op, delete_op],
         )
@@ -2092,7 +2075,6 @@ fn throttle_subscription_delivers() {
         transact_entity_operations(
             &store,
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
             *TEST_BLOCK_4_PTR,
             vec![user4],
         )
@@ -2142,7 +2124,6 @@ fn throttle_subscription_throttles() {
             transact_entity_operations(
                 &store,
                 TEST_SUBGRAPH_ID.clone(),
-                *TEST_BLOCK_3_PTR,
                 *TEST_BLOCK_4_PTR,
                 vec![user4],
             )

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -2251,7 +2251,6 @@ fn handle_large_string_with_index() {
         store
             .transact_block_operations(
                 TEST_SUBGRAPH_ID.clone(),
-                *TEST_BLOCK_3_PTR,
                 *TEST_BLOCK_4_PTR,
                 vec![
                     make_insert_op(ONE, &long_text),

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -73,7 +73,6 @@ lazy_static! {
 pub fn transact_entity_operations(
     store: &Arc<Store>,
     subgraph_id: SubgraphDeploymentId,
-    block_ptr_from: EthereumBlockPointer,
     block_ptr_to: EthereumBlockPointer,
     ops: Vec<EntityOperation>,
 ) -> Result<bool, StoreError> {
@@ -82,5 +81,5 @@ pub fn transact_entity_operations(
     let mods = entity_cache
         .as_modifications(store.as_ref())
         .expect("failed to convert to modifications");
-    store.transact_block_operations(subgraph_id, block_ptr_from, block_ptr_to, mods)
+    store.transact_block_operations(subgraph_id, block_ptr_to, mods)
 }


### PR DESCRIPTION
When processing blocks considered final, we fetch the triggers only to drop them and re-process them from the transaction receipts. This is a wasteful process, particularly of disk space because we cache hundreds of GBs worth of transaction receipts we don't really need.

This PR makes it so that we only request and store transaction receipts when they are actually necessary, which is when processing blocks that may still be reorged. `blocks_with_triggers` now returns richer information instead of dropping it, the return type was changed from `EthereumBlockPointer` to `EthereumBlockWithTriggers`.

One thing that makes this change tricky is that we may need to re-process a block for dynamic data sources, at which point we again need to know if the block is final or not, and need extra information for non-final blocks. This is encoded in the `BlockFinality` enum and the trigger re-processing is encapsulated `triggers_in_block`. Some code got moved from the block stream to the ethereum adapter so that it could be shared between the block stream and the instance manager.

Since this touched some of the block stream, I took the opportunity to refactor it a bit. We no longer have special logic for advancing through an empty range, instead we insert a dummy block for `to` with no triggers, and use the normal processing logic to advance. The special casing was in some sense an optimization, but it was optimizing the fastest possible case which is an empty range, so it was considerable complexity for no real gain. In doing this, `transact_block_operations` got a bit simpler, it was only used to advance one block a time when it's perfectly capable of skipping blocks. Also it no longer takes a `block_ptr_from`, it doesn't make sense for that to be anything other than the current block pointer, so we just assume that. Also, some of the types in the block stream state machine got simplified a bit.

Sorry if this is a lot in one PR! Please ask if some change needs clarification or more comments. I tested this with Moloch and Betoken, both synced fine. I avoided any non-trivial change to reversion code, any changes there are just formatting and minor refactors.