### PR TITLE
Handle Geth reverts and empty responses

### DIFF
--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -391,6 +391,7 @@ where
                             // 0xfe is the "designated bad instruction" of the EVM, and Solidity
                             // uses it for asserts.
                             const PARITY_BAD_INSTRUCTION_FE: &str = "Bad instruction fe";
+                            const PARITY_BAD_JUMP_PREFIX: &str = "Bad jump";
                             const GANACHE_VM_EXECUTION_ERROR: i64 = -32000;
                             const GANACHE_REVERT_MESSAGE: &str =
                                 "VM Exception while processing transaction: revert";
@@ -425,6 +426,7 @@ where
                                     match rpc_error.data.as_ref().and_then(|d| d.as_str()) {
                                         Some(data)
                                             if data.starts_with(PARITY_REVERT_PREFIX)
+                                                || data.starts_with(PARITY_BAD_JUMP_PREFIX)
                                                 || data == PARITY_BAD_INSTRUCTION_FE =>
                                         {
                                             let reason = if data == PARITY_BAD_INSTRUCTION_FE {

--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -1008,11 +1008,11 @@ where
             }
             // Decode the return values according to the ABI
             .and_then(move |output| {
-                // We got a `0x` response. For Geth, this can mean a revert. It can also be that
-                // the contract actually returned an empty response. A view call is meant to return
-                // something, so we treat empty responses the same as reverts. See support/#85 for
-                // a use case.
                 if output.is_empty() {
+                    // We got a `0x` response. For Geth, this can mean a revert. It can also be
+                    // that the contract actually returned an empty response. A view call is meant
+                    // to return something, so we treat empty responses the same as reverts. See
+                    // support/#85 for a use case.
                     Err(EthereumContractCallError::Revert("empty response".into()))
                 } else {
                     call.function.decode_output(&output).map_err(From::from)


### PR DESCRIPTION
We previously held back from accepting a `0x` from Geth as a revert, because it was used for timeouts. Geth has since fixed that and timeouts have a different response, so `0x` is a determinstic response. So using `try_` calls against Geth is now ok.

It can also be that the contract returned an empty response, but that's also an error, even if not techinically a revert, so we treat it the same. Resolves https://github.com/graphprotocol/graph-ts/issues/85.
