### PR TITLE
Add `dataSource.address` and `.network` host exports

### DIFF
--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -24,6 +24,7 @@ pub(crate) const TIMEOUT_ENV_VAR: &str = "GRAPH_MAPPING_HANDLER_TIMEOUT";
 struct RuntimeHostConfig {
     subgraph_id: SubgraphDeploymentId,
     mapping: Mapping,
+    data_source_network: String,
     data_source_name: String,
     contract: Source,
     templates: Vec<DataSourceTemplate>,
@@ -119,6 +120,7 @@ where
             RuntimeHostConfig {
                 subgraph_id,
                 mapping: data_source.mapping,
+                data_source_network: network_name,
                 data_source_name: data_source.name,
                 contract: data_source.source,
                 templates,
@@ -183,6 +185,8 @@ impl RuntimeHost {
             config.subgraph_id.clone(),
             api_version,
             data_source_name.clone(),
+            config.contract.address.clone(),
+            config.data_source_network,
             config.templates,
             config.mapping.abis,
             ethereum_adapter,

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -186,7 +186,7 @@ impl RuntimeHost {
             api_version,
             data_source_name.clone(),
             config.contract.address.clone(),
-            config.data_source_network,
+            Some(config.data_source_network),
             config.templates,
             config.mapping.abis,
             ethereum_adapter,

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -1,5 +1,5 @@
 use crate::UnresolvedContractCall;
-use ethabi::Token;
+use ethabi::{Address, Token};
 use futures::sync::oneshot;
 use graph::components::ethereum::*;
 use graph::components::store::EntityKey;
@@ -41,6 +41,8 @@ pub(crate) struct HostExports {
     subgraph_id: SubgraphDeploymentId,
     pub(crate) api_version: Version,
     data_source_name: String,
+    data_source_address: Option<Address>,
+    data_source_network: String,
     templates: Vec<DataSourceTemplate>,
     abis: Vec<MappingABI>,
     ethereum_adapter: Arc<dyn EthereumAdapter>,
@@ -62,6 +64,8 @@ impl HostExports {
         subgraph_id: SubgraphDeploymentId,
         api_version: Version,
         data_source_name: String,
+        data_source_address: Option<Address>,
+        data_source_network: String,
         templates: Vec<DataSourceTemplate>,
         abis: Vec<MappingABI>,
         ethereum_adapter: Arc<dyn EthereumAdapter>,
@@ -74,6 +78,8 @@ impl HostExports {
             subgraph_id,
             api_version,
             data_source_name,
+            data_source_address,
+            data_source_network,
             templates,
             abis,
             ethereum_adapter,
@@ -629,6 +635,14 @@ impl HostExports {
         if level == slog::Level::Critical {
             panic!("Critical error logged in mapping");
         }
+    }
+
+    pub(crate) fn data_source_address(&self) -> H160 {
+        self.data_source_address.clone().unwrap_or_default()
+    }
+
+    pub(crate) fn data_source_network(&self) -> String {
+        self.data_source_network.clone()
     }
 }
 

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -42,7 +42,7 @@ pub(crate) struct HostExports {
     pub(crate) api_version: Version,
     data_source_name: String,
     data_source_address: Option<Address>,
-    data_source_network: String,
+    data_source_network: Option<String>,
     templates: Vec<DataSourceTemplate>,
     abis: Vec<MappingABI>,
     ethereum_adapter: Arc<dyn EthereumAdapter>,
@@ -65,7 +65,7 @@ impl HostExports {
         api_version: Version,
         data_source_name: String,
         data_source_address: Option<Address>,
-        data_source_network: String,
+        data_source_network: Option<String>,
         templates: Vec<DataSourceTemplate>,
         abis: Vec<MappingABI>,
         ethereum_adapter: Arc<dyn EthereumAdapter>,
@@ -642,7 +642,7 @@ impl HostExports {
     }
 
     pub(crate) fn data_source_network(&self) -> String {
-        self.data_source_network.clone()
+        self.data_source_network.clone().unwrap_or_default()
     }
 }
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -66,6 +66,8 @@ const DATA_SOURCE_CREATE_INDEX: usize = 35;
 const ENS_NAME_BY_HASH: usize = 36;
 const LOG_LOG: usize = 37;
 const BIG_INT_POW: usize = 38;
+const DATA_SOURCE_ADDRESS: usize = 39;
+const DATA_SOURCE_NETWORK: usize = 40;
 
 /// Transform function index into the function name string
 fn fn_index_to_metrics_string(index: usize) -> Option<String> {
@@ -897,6 +899,20 @@ where
         Ok(None)
     }
 
+    /// function dataSource.address(): Bytes
+    fn data_source_address(&mut self) -> Result<Option<RuntimeValue>, Trap> {
+        Ok(Some(RuntimeValue::from(
+            self.asc_new(&self.ctx.host_exports.data_source_address()),
+        )))
+    }
+
+    /// function dataSource.network(): String
+    fn data_source_network(&mut self) -> Result<Option<RuntimeValue>, Trap> {
+        Ok(Some(RuntimeValue::from(
+            self.asc_new(&self.ctx.host_exports.data_source_network()),
+        )))
+    }
+
     fn ens_name_by_hash(
         &mut self,
         hash_ptr: AscPtr<AscString>,
@@ -1005,6 +1021,8 @@ where
             }
             ENS_NAME_BY_HASH => self.ens_name_by_hash(args.nth_checked(0)?),
             LOG_LOG => self.log_log(args.nth_checked(0)?, args.nth_checked(1)?),
+            DATA_SOURCE_ADDRESS => self.data_source_address(),
+            DATA_SOURCE_NETWORK => self.data_source_network(),
             _ => panic!("Unimplemented function at {}", index),
         };
         // Record execution time
@@ -1110,6 +1128,8 @@ impl ModuleImportResolver for ModuleResolver {
 
             // dataSource
             "dataSource.create" => FuncInstance::alloc_host(signature, DATA_SOURCE_CREATE_INDEX),
+            "dataSource.address" => FuncInstance::alloc_host(signature, DATA_SOURCE_ADDRESS),
+            "dataSource.network" => FuncInstance::alloc_host(signature, DATA_SOURCE_NETWORK),
 
             // ens.nameByHash
             "ens.nameByHash" => FuncInstance::alloc_host(signature, ENS_NAME_BY_HASH),

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -129,7 +129,7 @@ fn mock_host_exports(data_source: DataSource, store: Arc<MockStore>) -> HostExpo
         Version::parse(&data_source.mapping.api_version).unwrap(),
         data_source.name,
         data_source.source.address,
-        data_source.network.unwrap(),
+        data_source.network,
         data_source.templates,
         data_source.mapping.abis,
         mock_ethereum_adapter,

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -128,6 +128,8 @@ fn mock_host_exports(data_source: DataSource, store: Arc<MockStore>) -> HostExpo
         MockStore::user_subgraph_id(),
         Version::parse(&data_source.mapping.api_version).unwrap(),
         data_source.name,
+        data_source.source.address,
+        data_source.network.unwrap(),
         data_source.templates,
         data_source.mapping.abis,
         mock_ethereum_adapter,


### PR DESCRIPTION
Adds support for basic data source introspection. See https://github.com/graphprotocol/graph-ts/pull/90.

Resolves https://github.com/graphprotocol/support/issues/3. Resolves https://github.com/graphprotocol/support/issues/37.

