### PR TITLE
Use an env var for json-rpc timeouts, increase default

### DIFF
--- a/datasource/ethereum/src/ethereum_adapter.rs
+++ b/datasource/ethereum/src/ethereum_adapter.rs
@@ -49,10 +49,10 @@ lazy_static! {
 
     /// This should not be too large that it causes requests to timeout without us catching it, nor
     /// too small that it causes us to timeout requests that would've succeeded.
-    static ref JSON_RPC_TIMEOUT: u64 = std::env::var("ETHEREUM_JSON_RPC_TIMEOUT")
+    static ref JSON_RPC_TIMEOUT: u64 = std::env::var("GRAPH_ETHEREUM_JSON_RPC_TIMEOUT")
             .unwrap_or("120".into())
             .parse::<u64>()
-            .expect("invalid ETHEREUM_JSON_RPC_TIMEOUT env var");
+            .expect("invalid GRAPH_ETHEREUM_JSON_RPC_TIMEOUT env var");
 }
 
 impl<T> EthereumAdapter<T>

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -34,6 +34,7 @@ those.
   calls to make when scanning logs for a subgraph. Defaults to 100.
 - `GRAPH_ETHEREUM_MAX_EVENT_ONLY_RANGE`: Maximum range size for `eth.getLogs`
   requests that dont filter on contract address, only event signature.
+- `ETHEREUM_JSON_RPC_TIMEOUT`: Timeout for Ethereum JSON-RPC requests.
 
 ## Running mapping handlers
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -34,7 +34,7 @@ those.
   calls to make when scanning logs for a subgraph. Defaults to 100.
 - `GRAPH_ETHEREUM_MAX_EVENT_ONLY_RANGE`: Maximum range size for `eth.getLogs`
   requests that dont filter on contract address, only event signature.
-- `ETHEREUM_JSON_RPC_TIMEOUT`: Timeout for Ethereum JSON-RPC requests.
+- `GRAPH_ETHEREUM_JSON_RPC_TIMEOUT`: Timeout for Ethereum JSON-RPC requests.
 
 ## Running mapping handlers
 


### PR DESCRIPTION
I noticed with erc20 that some eth_getLogs requests could take over a minute and still complete successfully.