### PR TITLE
Refactor away `guard` from `MetadataOperation::Update`

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -500,7 +500,6 @@ pub enum MetadataOperation {
         entity: String,
         id: String,
         data: Entity,
-        guard: Option<(EntityFilter, String)>,
     },
 }
 

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -157,7 +157,7 @@ impl SubgraphEntity {
         let mut entity = Entity::new();
         entity.set("currentVersion", version_id_opt);
 
-        vec![update_metadata_operation(Self::TYPENAME, id, entity, None)]
+        vec![update_metadata_operation(Self::TYPENAME, id, entity)]
     }
 
     pub fn update_pending_version_operations(
@@ -167,7 +167,7 @@ impl SubgraphEntity {
         let mut entity = Entity::new();
         entity.set("pendingVersion", version_id_opt);
 
-        vec![update_metadata_operation(Self::TYPENAME, id, entity, None)]
+        vec![update_metadata_operation(Self::TYPENAME, id, entity)]
     }
 }
 
@@ -318,27 +318,16 @@ impl SubgraphDeploymentEntity {
 
     pub fn update_ethereum_block_pointer_operations(
         id: &SubgraphDeploymentId,
-        block_ptr_from: EthereumBlockPointer,
         block_ptr_to: EthereumBlockPointer,
-        reason: &str,
     ) -> Vec<MetadataOperation> {
         let mut entity = Entity::new();
         entity.set("latestEthereumBlockHash", block_ptr_to.hash_hex());
         entity.set("latestEthereumBlockNumber", block_ptr_to.number);
 
-        let guard = EntityFilter::And(vec![
-            EntityFilter::new_equal("latestEthereumBlockHash", block_ptr_from.hash_hex()),
-            EntityFilter::new_equal("latestEthereumBlockNumber", block_ptr_from.number),
-        ]);
-        let msg = format!(
-            "advance block pointer ({}) from {} to {}",
-            reason, block_ptr_from.number, block_ptr_to.number
-        );
         vec![update_metadata_operation(
             Self::TYPENAME,
             id.to_string(),
             entity,
-            Some((guard, msg)),
         )]
     }
 
@@ -355,7 +344,6 @@ impl SubgraphDeploymentEntity {
             Self::TYPENAME,
             id.to_string(),
             entity,
-            None,
         )]
     }
 
@@ -370,7 +358,6 @@ impl SubgraphDeploymentEntity {
             Self::TYPENAME,
             id.as_str(),
             entity,
-            None,
         )]
     }
 
@@ -385,7 +372,6 @@ impl SubgraphDeploymentEntity {
             Self::TYPENAME,
             id.as_str(),
             entity,
-            None,
         )]
     }
 }
@@ -1230,13 +1216,11 @@ fn update_metadata_operation(
     entity_type_name: impl Into<String>,
     entity_id: impl Into<String>,
     data: impl Into<Entity>,
-    guard: Option<(EntityFilter, String)>,
 ) -> MetadataOperation {
     MetadataOperation::Update {
         entity: entity_type_name.into(),
         id: entity_id.into(),
         data: data.into(),
-        guard,
     }
 }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -223,12 +223,7 @@ impl Store for MockStore {
                             .push(EntityChange::from_key(key, EntityChangeOperation::Set));
                     }
                 }
-                MetadataOperation::Update {
-                    entity,
-                    id,
-                    data,
-                    guard,
-                } => {
+                MetadataOperation::Update { entity, id, data } => {
                     let key = MetadataOperation::entity_key(entity, id);
                     let entities_of_type = entities
                         .entry(key.subgraph_id.clone())
@@ -238,18 +233,6 @@ impl Store for MockStore {
 
                     if entities_of_type.contains_key(&key.entity_id) {
                         let existing_entity = entities_of_type.get_mut(&key.entity_id).unwrap();
-                        if let Some((filter, _)) = guard {
-                            if !entity_matches_filter(existing_entity, &filter) {
-                                return Err(TransactionAbortError::AbortUnless {
-                                    expected_entity_ids: vec![key.entity_id],
-                                    actual_entity_ids: vec![],
-                                    description:
-                                        "update failed because entity does not match guard"
-                                            .to_owned(),
-                                }
-                                .into());
-                            }
-                        }
                         existing_entity.merge(data);
 
                         entity_changes

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -492,6 +492,21 @@ impl Connection {
         }
     }
 
+    pub(crate) fn find_metadata(
+        &self,
+        entity: &String,
+        id: &String,
+    ) -> Result<Option<Entity>, StoreError> {
+        use self::subgraphs::entities;
+        entities::dsl::entities
+            .filter(entities::entity.eq(entity).and(entities::id.eq(id)))
+            .select(entities::data)
+            .first::<serde_json::Value>(&self.conn)
+            .optional()?
+            .map(|json| entity_from_json(json, entity))
+            .transpose()
+    }
+
     pub(crate) fn delete(
         &self,
         key: &EntityKey,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -727,8 +727,8 @@ impl Store {
         conn: &e::Connection,
     ) -> Result<EthereumBlockPointer, Error> {
         let key = SubgraphDeploymentEntity::key(subgraph_id.clone());
-        let subgraph_entity = self
-            .get_entity(&conn, &key.subgraph_id, &key.entity_type, &key.entity_id)
+        let subgraph_entity = conn
+            .find_metadata(&key.entity_type, &key.entity_id)
             .map_err(|e| format_err!("error reading subgraph entity: {}", e))?
             .ok_or_else(|| {
                 format_err!(
@@ -844,7 +844,7 @@ impl StoreTrait for Store {
 
         let (event, metadata_event, should_migrate) =
             econn.transaction(|| -> Result<_, StoreError> {
-                let block_ptr_from = self.block_ptr(subgraph_id.clone())?;
+                let block_ptr_from = self.block_ptr_with_conn(subgraph_id.clone(), &econn)?;
                 assert!(block_ptr_from.number < block_ptr_to.number);
 
                 // Ensure the history event exists in the database


### PR DESCRIPTION
Following up to #1308 with some more simplification.

The guard was only used in `update_ethereum_block_pointer_operations`, which in turn is only used in reverts or transact block.

For transact block, the guard was made totally redundant as we now fetch the block in the same transaction. For reverts, I was more conservative and just added an assert to replace the guard.