### PR TITLE
Make 'Scanning blocks' log at info level instead of debug

### DIFF
--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -373,7 +373,7 @@ where
                                 cmp::min(from + speedup * *ETHEREUM_BLOCK_RANGE_SIZE - 1, to_limit)
                             };
 
-                            debug!(ctx.logger, "Scanning blocks [{}, {}]", from, to);
+                            info!(ctx.logger, "Scanning blocks [{}, {}]", from, to);
                             Box::new(
                                 ctx.eth_adapter
                                     .blocks_with_triggers(


### PR DESCRIPTION
It's an infrequent log and a good indicator of progress.

