### PR TITLE
Ensure `to_snake_case()` is applied only once to entity fields in query results

### DIFF
--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -84,6 +84,10 @@ impl SqlName {
         }
         Ok(())
     }
+
+    pub fn from_snake_case(s: String) -> Self {
+        SqlName(s)
+    }
 }
 
 impl From<&str> for SqlName {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -136,7 +136,7 @@ impl EntityData {
                     // Simply ignore keys that do not have an underlying table
                     // column; those will be things like the block_range that
                     // is used internally for versioning
-                    if let Some(column) = table.column(&SqlName::from(&*key)).ok() {
+                    if let Some(column) = table.column(&SqlName::from_snake_case(key)).ok() {
                         let value = Self::value_from_json(&column.column_type, json)?;
                         if value != Value::Null {
                             entity.insert(column.field.clone(), value);


### PR DESCRIPTION
Solves the issue stemming from the fact that `to_snake_case()` is not idempotent for special cases containing numeric characters (see issue for details: https://github.com/whatisinternet/Inflector/issues/74). 
Now we do not apply the function to field names that are already in snake case format.


