### PR TITLE
Docker: Support multiple Ethereum networks

### DIFF
--- a/docker/start-node
+++ b/docker/start-node
@@ -5,5 +5,5 @@ set -x
 
 graph-node \
   --postgres-url "postgresql://$postgres_user:$postgres_pass@$postgres_host/$postgres_db" \
-  --ethereum-rpc "$ethereum" \
+  --ethereum-rpc $(echo $ethereum) \
   --ipfs "$ipfs"


### PR DESCRIPTION
This splits up the `ethereum` environment variable into multiple strings and passes each value on to graph-node as a separate `--ethereum-rpc` argument. Prior to this, a value like

```
ethereum: "mainnet:... ropsten:..."
```

would be passed in as a single `--ethereum-rpc` argument and would fail to parse.

Resolves #1328.