### PR TITLE
Fix parsing block hashes/numbers from GraphQL results

### DIFF
--- a/graph/src/data/graphql/values.rs
+++ b/graph/src/data/graphql/values.rs
@@ -3,7 +3,7 @@ use graphql_parser::query::{Name, Value};
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 
-use crate::prelude::format_err;
+use crate::prelude::{format_err, BigInt};
 use web3::types::{H160, H256};
 
 pub trait TryFromValue: Sized {
@@ -80,6 +80,19 @@ impl TryFromValue for H256 {
                     .map_err(|e| format_err!("Cannot parse H256 value from string `{}`: {}", s, e))
             }
             _ => Err(format_err!("Cannot parse value into an H256: {:?}", value)),
+        }
+    }
+}
+
+impl TryFromValue for BigInt {
+    fn try_from_value(value: &Value) -> Result<Self, Error> {
+        match value {
+            Value::String(s) => BigInt::from_str(s)
+                .map_err(|e| format_err!("Cannot parse BigInt value from string `{}`: {}", s, e)),
+            _ => Err(format_err!(
+                "Cannot parse value into an BigInt: {:?}",
+                value
+            )),
         }
     }
 }

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -1,6 +1,5 @@
 use graphql_parser::{query as q, query::Name, schema as s, schema::ObjectType};
 use std::collections::{BTreeMap, HashMap};
-use std::str::FromStr;
 
 use graph::data::graphql::{TryFromValue, ValueList, ValueMap};
 use graph::data::subgraph::schema::SUBGRAPHS_ID;
@@ -149,22 +148,9 @@ impl IndexingStatusWithoutNode {
         let number_key = format!("{}Number", prefix);
 
         match (
+            value.get_optional::<H256>(hash_key.as_ref())?,
             value
-                .get_optional::<q::Value>(hash_key.as_ref())?
-                .and_then(|value| match value {
-                    q::Value::String(s) => Some(s),
-                    _ => None,
-                })
-                .map(|s| H256::from_str(s.as_ref()))
-                .transpose()?,
-            value
-                .get_optional::<q::Value>(number_key.as_ref())?
-                .and_then(|value| match value {
-                    q::Value::String(s) => Some(s),
-                    _ => None,
-                })
-                .map(|s| BigInt::from_str(s.as_ref()))
-                .transpose()?
+                .get_optional::<BigInt>(number_key.as_ref())?
                 .map(|n| n.to_u64()),
         ) {
             // Only return an Ethereum block if we can parse both the block hash and number


### PR DESCRIPTION
This fixes the following error when querying the index node server:

    failed to parse subgraph deployments: Invalid character 'x' at position

