### PR TITLE
Use retrying link resolver to load subgraph files

### DIFF
--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -49,7 +49,8 @@ where
                 resolver
                     .as_ref()
                     .clone()
-                    .with_timeout(*IPFS_SUBGRAPH_LOADING_TIMEOUT),
+                    .with_timeout(*IPFS_SUBGRAPH_LOADING_TIMEOUT)
+                    .with_retries(),
             ),
             subgraphs_running: Arc::new(Mutex::new(HashSet::new())),
             store,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -63,7 +63,8 @@ where
                 resolver
                     .as_ref()
                     .clone()
-                    .with_timeout(*IPFS_SUBGRAPH_LOADING_TIMEOUT),
+                    .with_timeout(*IPFS_SUBGRAPH_LOADING_TIMEOUT)
+                    .with_retries(),
             ),
             provider,
             store,

--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -24,6 +24,11 @@ pub trait LinkResolver: Send + Sync + 'static {
     where
         Self: Sized;
 
+    /// Enables infinite retries.
+    fn with_retries(self) -> Self
+    where
+        Self: Sized;
+
     /// Fetches the link contents as bytes.
     fn cat(
         &self,


### PR DESCRIPTION
This allows to configure the link resolver so that it retries requests indefinitely using our `retry` utility.

By default, this will be disabled but we'll want to enable it for the resolver used when loading subgraphs manifest files and dynamic data sources. The reason this would be good is that it would allow us to tolerate intermittent IPFS issues during startup.

Resolves #1239.