### PR TITLE
Indexing time instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2749,6 +2749,7 @@ name = "test-store"
 version = "0.1.0"
 dependencies = [
  "graph 0.16.1",
+ "graph-mock 0.16.1",
  "graph-store-postgres 0.16.1",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -364,7 +364,8 @@ impl SubgraphInstanceManager {
         ));
         let instance =
             SubgraphInstance::from_manifest(&logger, manifest, host_builder, host_metrics.clone())?;
-        let stopwatch_metrics = StopwatchMetrics::new(deployment_id.clone(), logger.clone());
+        let stopwatch_metrics =
+            StopwatchMetrics::new(logger.clone(), deployment_id.clone(), registry.clone());
 
         // The subgraph state tracks the state of the subgraph instance over time
         let ctx = IndexingContext {

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -32,6 +32,7 @@ struct IndexingState<T: RuntimeHostBuilder> {
     log_filter: EthereumLogFilter,
     call_filter: EthereumCallFilter,
     block_filter: EthereumBlockFilter,
+    stopwatch_metrics: StopwatchMetrics,
     restarts: u64,
 }
 
@@ -363,6 +364,7 @@ impl SubgraphInstanceManager {
         ));
         let instance =
             SubgraphInstance::from_manifest(&logger, manifest, host_builder, host_metrics.clone())?;
+        let stopwatch_metrics = StopwatchMetrics::new(deployment_id.clone(), logger.clone());
 
         // The subgraph state tracks the state of the subgraph instance over time
         let ctx = IndexingContext {
@@ -383,6 +385,7 @@ impl SubgraphInstanceManager {
                 log_filter,
                 call_filter,
                 block_filter,
+                stopwatch_metrics,
                 restarts: 0,
             },
             subgraph_metrics,

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -387,6 +387,7 @@ where
                                 cmp::min(from + speedup * *ETHEREUM_BLOCK_RANGE_SIZE - 1, to_limit)
                             };
 
+                            let section = ctx.metrics.stopwatch.start_section("scan_blocks");
                             info!(ctx.logger, "Scanning blocks [{}, {}]", from, to);
                             Box::new(
                                 ctx.eth_adapter
@@ -400,7 +401,10 @@ where
                                         call_filter.clone(),
                                         block_filter.clone(),
                                     )
-                                    .map(ReconciliationStep::ProcessDescendantBlocks),
+                                    .map(move |blocks| {
+                                        section.end();
+                                        ReconciliationStep::ProcessDescendantBlocks(blocks)
+                                    }),
                             )
                         },
                     ),

--- a/datasource/ethereum/src/block_stream.rs
+++ b/datasource/ethereum/src/block_stream.rs
@@ -585,6 +585,10 @@ where
             Ok(())
         } else {
             // Synced
+
+            // Stop recording time-to-sync metrics.
+            self.metrics.stopwatch.disable();
+
             let mut ops = vec![];
 
             // Set deployment synced flag

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -557,6 +557,7 @@ pub struct BlockStreamMetrics {
     pub ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
     pub blocks_behind: Box<Gauge>,
     pub reverted_blocks: Box<Gauge>,
+    pub stopwatch: StopwatchMetrics,
 }
 
 impl BlockStreamMetrics {
@@ -564,6 +565,7 @@ impl BlockStreamMetrics {
         registry: Arc<M>,
         ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
         deployment_id: SubgraphDeploymentId,
+        stopwatch: StopwatchMetrics,
     ) -> Self {
         let blocks_behind = registry
             .new_gauge(
@@ -585,6 +587,7 @@ impl BlockStreamMetrics {
             ethrpc_metrics,
             blocks_behind,
             reverted_blocks,
+            stopwatch,
         }
     }
 }

--- a/graph/src/components/metrics.rs
+++ b/graph/src/components/metrics.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 /// Metrics for measuring where time is spent during indexing.
 pub mod stopwatch;
 
-pub trait MetricsRegistry: Clone + Send + Sync + 'static + Sized {
+pub trait MetricsRegistry: Send + Sync + 'static {
     fn new_gauge(
         &self,
         name: String,

--- a/graph/src/components/metrics.rs
+++ b/graph/src/components/metrics.rs
@@ -6,6 +6,9 @@ pub use prometheus::{
 
 use std::collections::HashMap;
 
+/// Metrics for measuring where time is spent during indexing.
+pub mod stopwatch;
+
 pub trait MetricsRegistry: Clone + Send + Sync + 'static + Sized {
     fn new_gauge(
         &self,

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -1,72 +1,12 @@
 use crate::prelude::*;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Mutex;
-use std::time::{Duration, Instant};
-
-pub struct StopwatchMetrics {
-    subgraph_id: SubgraphDeploymentId,
-    stopwatch: Stopwatch,
-
-    // Counts the seconds spent in each section of the indexing code.
-    counters: BTreeMap<String, Counter>,
-}
-
-impl StopwatchMetrics {
-    pub fn new(subgraph_id: SubgraphDeploymentId, logger: Logger) -> Self {
-        Self {
-            subgraph_id,
-            stopwatch: Stopwatch {
-                logger,
-                inner: Arc::new(Mutex::new(StopwatchInner::new())),
-            },
-            counters: BTreeMap::new(),
-        }
-    }
-
-    pub fn stopwatch(&self) -> Stopwatch {
-        self.stopwatch.clone()
-    }
-
-    /// Register the current totals and resets the stopwatch.
-    pub fn commit_and_reset(&mut self, registry: impl MetricsRegistry) {
-        let mut stopwatch = self.stopwatch.inner.lock().unwrap();
-
-        // Increase the counters.
-        for (id, time) in &stopwatch.totals {
-            let counter = if let Some(counter) = self.counters.get(id) {
-                counter.clone()
-            } else {
-                let name = format!("{}_{}_secs", self.subgraph_id, id);
-                let help = format!("indexing section {}", id);
-                match registry.new_counter(name, help, HashMap::new()) {
-                    Ok(counter) => {
-                        self.counters.insert(id.clone(), (*counter).clone());
-                        *counter
-                    }
-                    Err(e) => {
-                        error!(self.stopwatch.logger, "failed to register counter";
-                                                      "id" => id,
-                                                      "error" => e.to_string());
-                        return;
-                    }
-                }
-            };
-            counter.inc_by(time.as_secs_f64());
-        }
-
-        // Reset.
-        stopwatch.totals.clear();
-        stopwatch.section_stack.clear();
-
-        // Start the "unknown" section so that all time is accounted for.
-        stopwatch.section_start("unknown".to_owned());
-    }
-}
+use std::time::Instant;
 
 /// This is a "section guard", that closes the section on drop.
 pub struct Section {
     id: String,
-    stopwatch: Stopwatch,
+    stopwatch: StopwatchMetrics,
 }
 
 impl Section {
@@ -82,16 +22,32 @@ impl Drop for Section {
 }
 
 #[derive(Clone)]
-pub struct Stopwatch {
-    logger: Logger,
-    inner: Arc<Mutex<StopwatchInner>>,
-}
+pub struct StopwatchMetrics(Arc<Mutex<StopwatchInner>>);
 
-impl Stopwatch {
+impl StopwatchMetrics {
+    pub fn new(
+        logger: Logger,
+        subgraph_id: SubgraphDeploymentId,
+        registry: Arc<dyn MetricsRegistry>,
+    ) -> Self {
+        let mut inner = StopwatchInner {
+            logger,
+            subgraph_id,
+            registry,
+            counters: HashMap::new(),
+            section_stack: Vec::new(),
+            timer: Instant::now(),
+        };
+
+        // Start a base section so that all time is accounted for.
+        inner.section_start("unknown".to_owned());
+
+        StopwatchMetrics(Arc::new(Mutex::new(inner)))
+    }
+
     pub fn section_start(&self, id: &str) -> Section {
         let id = id.to_owned();
-        let mut stopwatch = self.inner.lock().unwrap();
-        stopwatch.section_start(id.clone());
+        self.0.lock().unwrap().section_start(id.clone());
         Section {
             id,
             stopwatch: self.clone(),
@@ -99,7 +55,7 @@ impl Stopwatch {
     }
 
     fn section_end(&self, id: String) {
-        self.inner.lock().unwrap().section_end(id, &self.logger)
+        self.0.lock().unwrap().section_end(id)
     }
 }
 
@@ -107,8 +63,12 @@ impl Stopwatch {
 /// break down indexing into _sequential_ sections, and register the total time spent in each. So
 /// that there is no double counting, time spent in child sections doesn't count for the parent.
 struct StopwatchInner {
-    // When a section is popped, we add the time spent to its total.
-    totals: BTreeMap<String, Duration>,
+    logger: Logger,
+    subgraph_id: SubgraphDeploymentId,
+    registry: Arc<dyn MetricsRegistry>,
+
+    // Counts the seconds spent in each section of the indexing code.
+    counters: HashMap<String, Counter>,
 
     // The top section is the one that's currently executing.
     section_stack: Vec<String>,
@@ -118,18 +78,33 @@ struct StopwatchInner {
 }
 
 impl StopwatchInner {
-    fn new() -> Self {
-        Self {
-            totals: BTreeMap::new(),
-            section_stack: Vec::new(),
-            timer: Instant::now(), // Overwritten on first section start.
-        }
-    }
-
     fn record_and_reset(&mut self) {
-        if let Some(current_section) = self.section_stack.last() {
-            *self.totals.entry(current_section.clone()).or_default() += self.timer.elapsed();
+        if let Some(section) = self.section_stack.last() {
+            // Get or create the counter.
+            let counter = if let Some(counter) = self.counters.get(section) {
+                counter.clone()
+            } else {
+                let name = format!("{}_{}_secs", self.subgraph_id, section);
+                let help = format!("indexing section {}", section);
+                match self.registry.new_counter(name, help, HashMap::new()) {
+                    Ok(counter) => {
+                        self.counters.insert(section.clone(), (*counter).clone());
+                        *counter
+                    }
+                    Err(e) => {
+                        error!(self.logger, "failed to register counter";
+                                            "id" => section,
+                                            "error" => e.to_string());
+                        return;
+                    }
+                }
+            };
+
+            // Register the current timer.
+            counter.inc_by(self.timer.elapsed().as_secs_f64());
         }
+
+        // Reset the timer.
         self.timer = Instant::now();
     }
 
@@ -138,18 +113,18 @@ impl StopwatchInner {
         self.section_stack.push(id);
     }
 
-    fn section_end(&mut self, id: String, logger: &Logger) {
+    fn section_end(&mut self, id: String) {
         // Validate that the expected section is running.
         match self.section_stack.last() {
             Some(current_section) if current_section == &id => {
                 self.record_and_reset();
                 self.section_stack.pop();
             }
-            Some(current_section) => error!(logger, "`section_end` with mismatched section";
-                                                    "current" => current_section,
-                                                    "received" => id),
-            None => error!(logger, "`section_end` with no current section";
-                                    "received" => id),
+            Some(current_section) => error!(self.logger, "`section_end` with mismatched section";
+                                                        "current" => current_section,
+                                                        "received" => id),
+            None => error!(self.logger, "`section_end` with no current section";
+                                        "received" => id),
         }
     }
 }

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -21,6 +21,19 @@ impl Drop for Section {
     }
 }
 
+/// Usage example:
+/// ```ignore
+/// // Start counting time for the "main_section".
+/// let _main_section = stopwatch.start_section("main_section");
+/// // do stuff...
+/// // Pause timer for "main_section", start for "child_section".
+/// let chid_section = stopwatch.start_section("child_section");
+/// // do stuff...
+/// // Register time spent in "child_section", implicitly going back to "main_section".
+/// section.end();
+/// // do stuff...
+/// // At the end of the scope `_main_section` is dropped, which is equivalent to calling
+/// // `_main_section.end()`.
 #[derive(Clone)]
 pub struct StopwatchMetrics {
     disabled: Arc<AtomicBool>,

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -1,0 +1,185 @@
+use crate::prelude::*;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+pub struct StopwatchMetrics {
+    subgraph_id: SubgraphDeploymentId,
+    stopwatch: Stopwatch,
+
+    // Counts the seconds spent in each section of the indexing code.
+    counters: BTreeMap<String, Counter>,
+}
+
+impl StopwatchMetrics {
+    pub fn new(subgraph_id: SubgraphDeploymentId, logger: Logger) -> Self {
+        Self {
+            subgraph_id,
+            stopwatch: Stopwatch {
+                logger,
+                inner: Arc::new(Mutex::new(StopwatchInner::new())),
+            },
+            counters: BTreeMap::new(),
+        }
+    }
+
+    pub fn stopwatch(&self) -> Stopwatch {
+        self.stopwatch.clone()
+    }
+
+    /// Register the current totals and resets the stopwatch.
+    pub fn commit_and_reset(&mut self, registry: impl MetricsRegistry) {
+        let mut stopwatch = match self.stopwatch.inner.try_lock() {
+            Ok(stopwatch) => stopwatch,
+            Err(e) => {
+                error!(self.stopwatch.logger, "could not lock stopwatch for commit";
+                                              "error" => e.to_string());
+                return;
+            }
+        };
+
+        // Increase the counters.
+        for (id, time) in &stopwatch.totals {
+            let counter = if let Some(counter) = self.counters.get(id) {
+                counter.clone()
+            } else {
+                let mut name = id.clone();
+                name.push_str("_secs");
+                let help = format!("indexing section {}", id);
+                let mut labels = HashMap::new();
+                labels.insert("subgraph_id".to_owned(), (*self.subgraph_id).clone());
+                match registry.new_counter(name, help, labels) {
+                    Ok(counter) => {
+                        self.counters.insert(id.clone(), (*counter).clone());
+                        *counter
+                    }
+                    Err(e) => {
+                        error!(self.stopwatch.logger, "failed to register counter";
+                                                      "id" => id,
+                                                      "error" => e.to_string());
+                        return;
+                    }
+                }
+            };
+            counter.inc_by(time.as_secs_f64());
+        }
+
+        // Reset.
+        stopwatch.totals.clear();
+        stopwatch.section_stack.clear();
+
+        // Start the "unknown" section so that all time is accounted for.
+        stopwatch.section_start("unknown".to_owned());
+    }
+}
+
+/// This is a "section guard", that closes the section on drop.
+pub struct Section {
+    id: String,
+    stopwatch: Stopwatch,
+}
+
+impl Section {
+    // A more readable `drop`.
+    pub fn end(self) {}
+}
+
+impl Drop for Section {
+    fn drop(&mut self) {
+        self.stopwatch
+            .section_end(std::mem::replace(&mut self.id, String::new()))
+    }
+}
+
+#[derive(Clone)]
+pub struct Stopwatch {
+    logger: Logger,
+    inner: Arc<Mutex<StopwatchInner>>,
+}
+
+impl Stopwatch {
+    pub fn section_start(&self, id: &str) -> Section {
+        let id = id.to_owned();
+        match self.inner.try_lock() {
+            Ok(mut stopwatch) => {
+                stopwatch.section_start(id.clone());
+                Section {
+                    id,
+                    stopwatch: self.clone(),
+                }
+            }
+            Err(e) => {
+                // The stopwatch was used in a non-sequential manner, log error and return a dummy
+                // section, which will also log an error when dropped, making this a noop.
+                error!(self.logger, "cannot `section_start`, stopwatch is being used concurrently";
+                                "error" => e.to_string());
+                Section {
+                    id: String::new(),
+                    stopwatch: Stopwatch {
+                        logger: self.logger.clone(),
+                        inner: Arc::new(Mutex::new(StopwatchInner::new())),
+                    },
+                }
+            }
+        }
+    }
+
+    fn section_end(&self, id: String) {
+        match self.inner.try_lock() {
+            Ok(mut stopwatch) => stopwatch.section_end(id, &self.logger),
+            Err(e) => error!(self.logger, "cannot `section_end`, stopwatch is being used concurrently";
+                                          "error" => e.to_string()),
+        }
+    }
+}
+
+/// We want to account for all subgraph indexing time, based on "wall clock" time. To do this we
+/// break down indexing into _sequential_ sections, and register the total time spent in each. So
+/// that there is no double counting, time spent in child sections doesn't count for the parent.
+struct StopwatchInner {
+    // When a section is popped, we add the time spent to its total.
+    totals: BTreeMap<String, Duration>,
+
+    // The top section is the one that's currently executing.
+    section_stack: Vec<String>,
+
+    // The timer is reset whenever a section starts or ends.
+    timer: Instant,
+}
+
+impl StopwatchInner {
+    fn new() -> Self {
+        Self {
+            totals: BTreeMap::new(),
+            section_stack: Vec::new(),
+            timer: Instant::now(), // Overwritten on first section start.
+        }
+    }
+
+    fn record_and_reset(&mut self) {
+        if let Some(current_section) = self.section_stack.last() {
+            *self.totals.entry(current_section.clone()).or_default() += self.timer.elapsed();
+        }
+        self.timer = Instant::now();
+    }
+
+    fn section_start(&mut self, id: String) {
+        self.record_and_reset();
+        self.section_stack.push(id);
+    }
+
+    fn section_end(&mut self, id: String, logger: &Logger) {
+        // Validate that the expected section is running.
+        match self.section_stack.last() {
+            Some(current_section) if current_section == &id => {
+                self.record_and_reset();
+                self.section_stack.pop();
+            }
+            Some(current_section) => error!(logger, "`section_end` with mismatched section";
+                                                    "current" => current_section,
+                                                    "received" => id),
+            None => error!(logger, "`section_end` with no current section";
+                                    "received" => id),
+        }
+    }
+}

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -49,7 +49,7 @@ impl StopwatchMetrics {
         let mut inner = StopwatchInner {
             total_counter: *registry
                 .new_counter(
-                    format!("{}_total_secs", subgraph_id),
+                    format!("{}_sync_total_secs", subgraph_id),
                     format!("total time spent syncing"),
                     HashMap::new(),
                 )

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -53,6 +53,7 @@ pub trait RuntimeHost: Send + Sync + Debug + 'static {
 pub struct HostMetrics {
     handler_execution_time: Box<HistogramVec>,
     host_fn_execution_time: Box<HistogramVec>,
+    pub stopwatch: StopwatchMetrics,
 }
 
 impl fmt::Debug for HostMetrics {
@@ -63,7 +64,11 @@ impl fmt::Debug for HostMetrics {
 }
 
 impl HostMetrics {
-    pub fn new<M: MetricsRegistry>(registry: Arc<M>, subgraph_hash: String) -> Self {
+    pub fn new<M: MetricsRegistry>(
+        registry: Arc<M>,
+        subgraph_hash: String,
+        stopwatch: StopwatchMetrics,
+    ) -> Self {
         let handler_execution_time = registry
             .new_histogram_vec(
                 format!("subgraph_handler_execution_time_{}", subgraph_hash),
@@ -85,6 +90,7 @@ impl HostMetrics {
         Self {
             handler_execution_time,
             host_fn_execution_time,
+            stopwatch,
         }
     }
 

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -53,9 +53,8 @@ pub mod prelude {
     };
     pub use crate::components::link_resolver::{JsonStreamValue, JsonValueStream, LinkResolver};
     pub use crate::components::metrics::{
-        stopwatch::{Stopwatch, StopwatchMetrics},
-        Collector, Counter, CounterVec, Gauge, GaugeVec, Histogram, HistogramOpts, HistogramVec,
-        MetricsRegistry, Opts, PrometheusError, Registry,
+        stopwatch::StopwatchMetrics, Collector, Counter, CounterVec, Gauge, GaugeVec, Histogram,
+        HistogramOpts, HistogramVec, MetricsRegistry, Opts, PrometheusError, Registry,
     };
     pub use crate::components::server::admin::JsonRpcServer;
     pub use crate::components::server::index_node::IndexNodeServer;

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -53,6 +53,7 @@ pub mod prelude {
     };
     pub use crate::components::link_resolver::{JsonStreamValue, JsonValueStream, LinkResolver};
     pub use crate::components::metrics::{
+        stopwatch::{Stopwatch, StopwatchMetrics},
         Collector, Counter, CounterVec, Gauge, GaugeVec, Histogram, HistogramOpts, HistogramVec,
         MetricsRegistry, Opts, PrometheusError, Registry,
     };

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -511,6 +511,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                             &logger,
                             network_identifier,
                             postgres_conn_pool.clone(),
+                            metrics_registry.clone(),
                         )),
                     )
                 }

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -48,13 +48,16 @@ pub fn spawn_module(
                 } = request;
 
                 // Start the WASMI module runtime.
+                let section = host_metrics.stopwatch.start_section("module_init");
                 let module = WasmiModule::from_valid_module_with_ctx(
                     valid_module.clone(),
                     ctx,
                     task_sender.clone(),
                     host_metrics.clone(),
                 )?;
+                section.end();
 
+                let _section = host_metrics.stopwatch.start_section("run_handler");
                 let result = match trigger {
                     MappingTrigger::Log {
                         transaction,

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -464,7 +464,13 @@ where
         )?;
 
         Ok(Some(match entity_option {
-            Some(entity) => RuntimeValue::from(self.asc_new(&entity)),
+            Some(entity) => {
+                let _section = self
+                    .host_metrics
+                    .stopwatch
+                    .start_section("store_get_asc_new");
+                RuntimeValue::from(self.asc_new(&entity))
+            }
             None => RuntimeValue::from(0),
         }))
     }

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -156,7 +156,7 @@ where
             ctx,
             valid_module: valid_module.clone(),
             task_sink,
-            host_metrics: host_metrics.clone(),
+            host_metrics,
             start_time: Instant::now(),
             running_start: true,
 
@@ -454,6 +454,7 @@ where
         entity_ptr: AscPtr<AscString>,
         id_ptr: AscPtr<AscString>,
     ) -> Result<Option<RuntimeValue>, Trap> {
+        let _section = self.host_metrics.stopwatch.start_section("store_get");
         let entity_ptr = self.asc_get(entity_ptr);
         let id_ptr = self.asc_get(id_ptr);
         let entity_option = self.ctx.host_exports.store_get(
@@ -950,6 +951,7 @@ where
         index: usize,
         args: RuntimeArgs,
     ) -> Result<Option<RuntimeValue>, Trap> {
+        let _section = self.host_metrics.stopwatch.start_section("host_export");
         let start = Instant::now();
         let res = match index {
             ABORT_FUNC_INDEX => self.abort(

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -39,9 +39,15 @@ fn test_valid_module_and_store(
     let store = Arc::new(MockStore::user_store());
     let metrics_registry = Arc::new(MockMetricsRegistry::new());
     let deployment_id = MockStore::user_subgraph_id();
+    let stopwatch_metrics = StopwatchMetrics::new(
+        Logger::root(slog::Discard, o!()),
+        deployment_id.clone(),
+        metrics_registry.clone(),
+    );
     let host_metrics = Arc::new(HostMetrics::new(
         metrics_registry,
         deployment_id.to_string(),
+        stopwatch_metrics,
     ));
 
     let (task_sender, task_receiver) = channel(100);

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -659,7 +659,7 @@ impl Store {
                 *self
                     .registry
                     .new_counter(
-                        format!("{}_get_conn_secs", subgraph),
+                        format!("{}_get_entity_conn_secs", subgraph),
                         format!("total time spent waiting for a DB connection"),
                         HashMap::new(),
                     )

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "Provides static store instance for tests."
 
 [dependencies]
+graph-mock = { path = "../../mock" }
 graph = { path = "../../graph" }
 graph-store-postgres = { path = "../postgres" }
 lazy_static = "1.1"

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::tokio::runtime::Runtime;
 use graph::log;
-#[allow(unused_imports)]
 use graph::prelude::{Store as _, *};
+use graph_mock::MockMetricsRegistry;
 use graph_store_postgres::connection_pool::create_connection_pool;
 use graph_store_postgres::{Store, StoreConfig};
 use hex_literal::hex;
@@ -19,6 +19,7 @@ pub fn postgres_test_url() -> String {
 
 pub const NETWORK_NAME: &str = "fake_network";
 pub const NETWORK_VERSION: &str = "graph test suite";
+
 lazy_static! {
     pub static ref LOGGER:Logger = match env::var_os("GRAPH_LOG") {
         Some(_) => log::logger(false),
@@ -52,6 +53,7 @@ lazy_static! {
                 &logger,
                 net_identifiers,
                 postgres_conn_pool,
+                Arc::new(MockMetricsRegistry::new()),
             )))
         })).expect("could not create Diesel Store instance for test suite")
     };


### PR DESCRIPTION
Resolves #1302.

This adds Prometheus metrics for measuring the total time to sync a subgraph, broken down by sections. This PR marks some sections and a convenient API is introduced for marking sections as needed. This also introduces a metric for measuring the impact of DB contention on performance. Grafana panels were added to display these metrics, which looks like this (timings for syncing erc20 up to about block 5400000):

<img width="641" alt="Captura de Tela 2019-11-07 às 13 10 07" src="https://user-images.githubusercontent.com/9885558/68406097-f577a000-015f-11ea-8430-c96c44832031.png">

See https://github.com/graphprotocol/instrumentation/pull/1 for the panels.