### PR TITLE
Reduce number of queries during GraphQL execution

### DIFF
--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -209,7 +209,7 @@ fn follow_interface_reference() {
                     parent: Legged
                   }";
 
-    let query = "query { legged(id: \"child\") { parent { id } } }";
+    let query = "query @verify { legged(id: \"child\") { ... on Animal { parent { id } } } }";
 
     let parent = (
         Entity::from(vec![

--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -19,6 +19,8 @@ use graph::prelude::*;
 use graph_core::LinkResolver;
 use graph_mock::{MockEthereumAdapter, MockStore};
 
+use test_store::LOGGER;
+
 use crate::tokio::timer::Delay;
 
 /// Adds subgraph located in `test/subgraphs/`, replacing "link to" placeholders
@@ -242,7 +244,7 @@ fn subgraph_provider_events() {
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime
         .block_on(future::lazy(|| {
-            let logger = Logger::root(slog::Discard, o!());
+            let logger = LOGGER.clone();
             let logger_factory = LoggerFactory::new(logger.clone(), None);
             let ipfs = Arc::new(IpfsClient::default());
             let resolver = Arc::new(LinkResolver::from(IpfsClient::default()));

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -82,10 +82,20 @@ impl EntityFilter {
 }
 
 /// The order in which entities should be restored from a store.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EntityOrder {
     Ascending,
     Descending,
+}
+
+impl EntityOrder {
+    /// Return `"asc"` or `"desc"` as is used in SQL
+    pub fn to_sql(&self) -> &'static str {
+        match self {
+            EntityOrder::Ascending => "asc",
+            EntityOrder::Descending => "desc",
+        }
+    }
 }
 
 /// How many entities to return, how many to skip etc.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -79,6 +79,28 @@ impl EntityFilter {
             attribute_values.into_iter().map(Into::into).collect(),
         )
     }
+
+    pub fn and_maybe(self, other: Option<Self>) -> Self {
+        use EntityFilter as f;
+        match other {
+            Some(other) => match (self, other) {
+                (f::And(mut fs1), f::And(mut fs2)) => {
+                    fs1.append(&mut fs2);
+                    f::And(fs1)
+                }
+                (f::And(mut fs1), f2) => {
+                    fs1.push(f2);
+                    f::And(fs1)
+                }
+                (f1, f::And(mut fs2)) => {
+                    fs2.push(f1);
+                    f::And(fs2)
+                }
+                (f1, f2) => f::And(vec![f1, f2]),
+            },
+            None => self,
+        }
+    }
 }
 
 /// The order in which entities should be restored from a store.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -58,6 +58,7 @@ pub enum EntityFilter {
     NotStartsWith(Attribute, Value),
     EndsWith(Attribute, Value),
     NotEndsWith(Attribute, Value),
+    Intersects(Attribute, Vec<Value>),
 }
 
 // Define some convenience methods

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -139,6 +139,16 @@ pub struct EntityQuery {
 
     /// A range to limit the size of the result.
     pub range: EntityRange,
+
+    /// A field by which to window the results. This affects how `order_by`,
+    /// `order_direction`, and `range` are interpreted. If `window` is `None`,
+    /// they are applied to the entire query. If the value is `Some("attr")`,
+    /// ordering and range limiting is applied for each distinct value of the
+    /// `attr` field separately. The latter is useful when the query has a
+    /// clause like `where attr in (v1, v2, ..)` so that the result will have
+    /// `range` many results for each of `v1`, `v2`, etc., and each ordered
+    /// according to `order_by` and `order_direction`.
+    pub window: Option<String>,
 }
 
 impl EntityQuery {
@@ -154,6 +164,7 @@ impl EntityQuery {
             order_by: None,
             order_direction: None,
             range,
+            window: None,
         }
     }
 
@@ -170,6 +181,11 @@ impl EntityQuery {
 
     pub fn range(mut self, range: EntityRange) -> Self {
         self.range = range;
+        self
+    }
+
+    pub fn window_by(mut self, window: String) -> Self {
+        self.window = Some(window);
         self
     }
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -198,8 +198,10 @@ impl fmt::Display for QueryExecutionError {
                            return smaller collections", complexity, max_complexity)
             }
             TooDeep(max_depth) => write!(f, "query has a depth that exceeds the limit of `{}`", max_depth),
-            IncorrectPrefetchResult{ .. } => write!(f, "Running query with prefetch and single query resolution yielded different results. \
-                    This is a bug. Please open an issue at https://github.com/graphprotocol/graph-node")
+            IncorrectPrefetchResult{ .. } => write!(f, "Running query with prefetch \
+                           and single query resolution yielded different results. \
+                           This is a bug. Please open an issue at \
+                           https://github.com/graphprotocol/graph-node")
         }
     }
 }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -204,6 +204,14 @@ impl Value {
         }
     }
 
+    pub fn as_str(&self) -> Option<&str> {
+        if let Value::String(s) = self {
+            Some(s.as_str())
+        } else {
+            None
+        }
+    }
+
     pub fn is_string(&self) -> bool {
         match self {
             Value::String(_) => true,
@@ -484,13 +492,19 @@ impl DerefMut for Entity {
     }
 }
 
-impl Into<query::Value> for Entity {
-    fn into(self) -> query::Value {
+impl Into<BTreeMap<String, query::Value>> for Entity {
+    fn into(self) -> BTreeMap<String, query::Value> {
         let mut fields = BTreeMap::new();
         for (attr, value) in self.iter() {
             fields.insert(attr.to_string(), value.clone().into());
         }
-        query::Value::Object(fields)
+        fields
+    }
+}
+
+impl Into<query::Value> for Entity {
+    fn into(self) -> query::Value {
+        query::Value::Object(self.into())
     }
 }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -381,10 +381,10 @@ impl From<u64> for Value {
 
 impl<T> From<Vec<T>> for Value
 where
-    T: Into<Value>,
+    Value: From<T>,
 {
     fn from(list: Vec<T>) -> Value {
-        Value::List(list.into_iter().map(|v| v.into()).collect::<Vec<_>>())
+        Value::List(list.into_iter().map(Value::from).collect::<Vec<_>>())
     }
 }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -371,9 +371,12 @@ impl From<u64> for Value {
     }
 }
 
-impl From<Vec<Value>> for Value {
-    fn from(list: Vec<Value>) -> Value {
-        Value::List(list)
+impl<T> From<Vec<T>> for Value
+where
+    T: Into<Value>,
+{
+    fn from(list: Vec<T>) -> Value {
+        Value::List(list.into_iter().map(|v| v.into()).collect::<Vec<_>>())
     }
 }
 

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -250,7 +250,7 @@ where
 
     let ictx = ctx.as_introspection_context();
     let introspection_query_type = sast::get_root_query_type(&ictx.schema.document).unwrap();
-    for (_, fields) in collect_fields(ctx.clone(), query_type, selection_set, None) {
+    for (_, fields) in collect_fields(ctx, query_type, selection_set, None) {
         let name = fields[0].name.clone();
         let selections = fields.into_iter().map(|f| q::Selection::Field(f.clone()));
         // See if this is an introspection or data field. We don't worry about
@@ -316,7 +316,7 @@ where
     let mut result_map: BTreeMap<String, q::Value> = BTreeMap::new();
 
     // Group fields with the same response key, so we can execute them together
-    let grouped_field_set = collect_fields(ctx.clone(), object_type, selection_set, None);
+    let grouped_field_set = collect_fields(ctx, object_type, selection_set, None);
 
     // Process all field groups in order
     for (response_key, fields) in grouped_field_set {
@@ -364,7 +364,7 @@ where
 
 /// Collects fields of a selection set.
 pub fn collect_fields<'a, R>(
-    ctx: ExecutionContext<'a, R>,
+    ctx: &ExecutionContext<'a, R>,
     object_type: &s::ObjectType,
     selection_set: &'a q::SelectionSet,
     visited_fragments: Option<HashSet<&'a q::Name>>,
@@ -421,7 +421,7 @@ where
                             // We have a fragment that applies to the current object type,
                             // collect its fields into response key groups
                             let fragment_grouped_field_set = collect_fields(
-                                ctx.clone(),
+                                ctx,
                                 object_type,
                                 &fragment.selection_set,
                                 Some(visited_fragments.clone()),
@@ -447,7 +447,7 @@ where
 
                 if applies {
                     let fragment_grouped_field_set = collect_fields(
-                        ctx.clone(),
+                        ctx,
                         object_type,
                         &fragment.selection_set,
                         Some(visited_fragments.clone()),

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -14,6 +14,12 @@ use crate::query::ast as qast;
 use crate::schema::ast as sast;
 use crate::values::coercion;
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ExecutionMode {
+    Prefetch,
+    Verify,
+}
+
 /// Contextual information passed around during query execution.
 #[derive(Clone)]
 pub struct ExecutionContext<'a, R>
@@ -43,6 +49,8 @@ where
 
     /// Max value for `first`.
     pub max_first: u32,
+
+    pub mode: ExecutionMode,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -77,6 +85,7 @@ where
             variable_values: self.variable_values.clone(),
             deadline: self.deadline,
             max_first: std::u32::MAX,
+            mode: ExecutionMode::Prefetch,
         }
     }
 
@@ -263,30 +272,32 @@ where
     }
 
     // If we are getting 'normal' data, prefetch it from the database
-    let initial_data = if data_set.items.is_empty() {
-        None
+    let mut values = if data_set.items.is_empty() {
+        BTreeMap::default()
     } else {
-        ctx.resolver.prefetch(&ctx, &data_set)?
+        let initial_data = ctx.resolver.prefetch(&ctx, &data_set)?;
+        let values = execute_selection_set_to_map(&ctx, &data_set, query_type, &initial_data)?;
+        if ctx.mode == ExecutionMode::Verify {
+            let single_values = execute_selection_set_to_map(&ctx, &data_set, query_type, &None)?;
+            if values != single_values {
+                return Err(vec![QueryExecutionError::IncorrectPrefetchResult {
+                    single: q::Value::Object(single_values),
+                    prefetch: q::Value::Object(values),
+                }]);
+            }
+        }
+        values
     };
 
-    // Execute the root selection set against the root query type
-    if data_set.items.is_empty() {
-        // Only introspection
-        execute_selection_set(&ictx, &intro_set, introspection_query_type, &None)
-    } else if intro_set.items.is_empty() {
-        // Only data
-        execute_selection_set(&ctx, &data_set, query_type, &initial_data)
-    } else {
-        // Both introspection and data
-        let mut values = execute_selection_set_to_map(&ctx, &data_set, query_type, &initial_data)?;
+    if !intro_set.items.is_empty() {
         values.extend(execute_selection_set_to_map(
             &ictx,
             &intro_set,
             introspection_query_type,
             &None,
         )?);
-        Ok(q::Value::Object(values))
     }
+    Ok(q::Value::Object(values))
 }
 
 /// Executes a selection set, requiring the result to be of the given object type.

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -886,7 +886,7 @@ where
 }
 
 /// Merges the selection sets of several fields into a single selection set.
-fn merge_selection_sets(fields: Vec<&q::Field>) -> q::SelectionSet {
+pub fn merge_selection_sets(fields: Vec<&q::Field>) -> q::SelectionSet {
     let (span, items) = fields
         .iter()
         .fold((None, vec![]), |(span, mut items), field| {

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -670,7 +670,7 @@ where
                     .resolver
                     .resolve_objects(
                         object_value,
-                        &field.name,
+                        field,
                         field_definition,
                         t.into(),
                         argument_values,
@@ -703,7 +703,7 @@ where
                     .resolver
                     .resolve_objects(
                         object_value,
-                        &field.name,
+                        field,
                         field_definition,
                         t.into(),
                         argument_values,

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -275,7 +275,13 @@ where
     let mut values = if data_set.items.is_empty() {
         BTreeMap::default()
     } else {
-        let initial_data = ctx.resolver.prefetch(&ctx, &data_set)?;
+        // Allow turning prefetch of as a safety valve. Once we are confident
+        // prefetching contains no more bugs, we should remove this env variable
+        let initial_data = if std::env::var_os("GRAPH_GRAPHQL_NO_PREFETCH").is_some() {
+            None
+        } else {
+            ctx.resolver.prefetch(&ctx, &data_set)?
+        };
         let values = execute_selection_set_to_map(&ctx, &data_set, query_type, &initial_data)?;
         if ctx.mode == ExecutionMode::Verify {
             let single_values = execute_selection_set_to_map(&ctx, &data_set, query_type, &None)?;

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -1,6 +1,7 @@
 use graphql_parser::query as q;
 use graphql_parser::schema as s;
 use indexmap::IndexMap;
+use lazy_static::lazy_static;
 use std::cmp;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Deref;
@@ -13,6 +14,10 @@ use crate::prelude::*;
 use crate::query::ast as qast;
 use crate::schema::ast as sast;
 use crate::values::coercion;
+
+lazy_static! {
+    static ref NO_PREFETCH: bool = std::env::var_os("GRAPH_GRAPHQL_NO_PREFETCH").is_some();
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ExecutionMode {
@@ -246,7 +251,7 @@ where
     };
 
     // Split the toplevel fields into introspection fields and
-    // 'normal' data fields
+    // regular data fields
     let mut data_set = q::SelectionSet {
         span: selection_set.span.clone(),
         items: Vec::new(),
@@ -271,13 +276,13 @@ where
         }
     }
 
-    // If we are getting 'normal' data, prefetch it from the database
+    // If we are getting regular data, prefetch it from the database
     let mut values = if data_set.items.is_empty() {
         BTreeMap::default()
     } else {
         // Allow turning prefetch of as a safety valve. Once we are confident
         // prefetching contains no more bugs, we should remove this env variable
-        let initial_data = if std::env::var_os("GRAPH_GRAPHQL_NO_PREFETCH").is_some() {
+        let initial_data = if *NO_PREFETCH {
             None
         } else {
             ctx.resolver.prefetch(&ctx, &data_set)?
@@ -295,6 +300,7 @@ where
         values
     };
 
+    // Resolve introspection fields, if there are any
     if !intro_set.items.is_empty() {
         values.extend(execute_selection_set_to_map(
             &ictx,

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -226,7 +226,6 @@ where
 pub fn execute_root_selection_set<'a, R>(
     ctx: &ExecutionContext<'a, R>,
     selection_set: &'a q::SelectionSet,
-    initial_value: &Option<q::Value>,
 ) -> Result<q::Value, Vec<QueryExecutionError>>
 where
     R: Resolver,
@@ -266,18 +265,18 @@ where
     // Execute the root selection set against the root query type
     if data_set.items.is_empty() {
         // Only introspection
-        execute_selection_set(&ictx, &intro_set, introspection_query_type, initial_value)
+        execute_selection_set(&ictx, &intro_set, introspection_query_type, &None)
     } else if intro_set.items.is_empty() {
         // Only data
-        execute_selection_set(&ctx, &data_set, query_type, initial_value)
+        execute_selection_set(&ctx, &data_set, query_type, &None)
     } else {
         // Both introspection and data
-        let mut values = execute_selection_set_to_map(&ctx, &data_set, query_type, initial_value)?;
+        let mut values = execute_selection_set_to_map(&ctx, &data_set, query_type, &None)?;
         values.extend(execute_selection_set_to_map(
             &ictx,
             &intro_set,
             introspection_query_type,
-            initial_value,
+            &None,
         )?);
         Ok(q::Value::Object(values))
     }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -262,16 +262,23 @@ where
         }
     }
 
+    // If we are getting 'normal' data, prefetch it from the database
+    let initial_data = if data_set.items.is_empty() {
+        None
+    } else {
+        ctx.resolver.prefetch(&ctx, &data_set)?
+    };
+
     // Execute the root selection set against the root query type
     if data_set.items.is_empty() {
         // Only introspection
         execute_selection_set(&ictx, &intro_set, introspection_query_type, &None)
     } else if intro_set.items.is_empty() {
         // Only data
-        execute_selection_set(&ctx, &data_set, query_type, &None)
+        execute_selection_set(&ctx, &data_set, query_type, &initial_data)
     } else {
         // Both introspection and data
-        let mut values = execute_selection_set_to_map(&ctx, &data_set, query_type, &None)?;
+        let mut values = execute_selection_set_to_map(&ctx, &data_set, query_type, &initial_data)?;
         values.extend(execute_selection_set_to_map(
             &ictx,
             &intro_set,

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -44,6 +44,10 @@ impl<'a> ObjectOrInterface<'a> {
             ObjectOrInterface::Interface(interface) => &interface.fields,
         }
     }
+
+    pub fn field(&self, name: &s::Name) -> Option<&s::Field> {
+        self.fields().iter().find(|field| &field.name == name)
+    }
 }
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -52,7 +52,7 @@ pub trait Resolver: Clone + Send + Sync {
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,
-        field: &q::Name,
+        field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -57,7 +57,7 @@ pub trait Resolver: Clone + Send + Sync {
         &self,
         ctx: &ExecutionContext<'a, Self>,
         selection_set: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, QueryExecutionError>;
+    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>>;
 
     /// Resolves entities referenced by a parent object.
     fn resolve_objects(

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -48,6 +48,13 @@ impl<'a> ObjectOrInterface<'a> {
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
 pub trait Resolver: Clone + Send + Sync {
+    /// Prepare for executing a query by prefetching as much data as possible
+    fn prefetch<'a>(
+        &self,
+        ctx: &ExecutionContext<'a, Self>,
+        selection_set: &q::SelectionSet,
+    ) -> Result<Option<q::Value>, QueryExecutionError>;
+
     /// Resolves entities referenced by a parent object.
     fn resolve_objects(
         &self,

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -459,7 +459,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         &self,
         _: &ExecutionContext<'r, Self>,
         _: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, QueryExecutionError> {
+    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
         Ok(None)
     }
 

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -455,6 +455,14 @@ impl<'a> IntrospectionResolver<'a> {
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
 impl<'a> Resolver for IntrospectionResolver<'a> {
+    fn prefetch<'r>(
+        &self,
+        _: &ExecutionContext<'r, Self>,
+        _: &q::SelectionSet,
+    ) -> Result<Option<q::Value>, QueryExecutionError> {
+        Ok(None)
+    }
+
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -458,14 +458,14 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,
-        field: &q::Name,
+        field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
         _max_first: u32,
     ) -> Result<q::Value, QueryExecutionError> {
-        match field.as_str() {
+        match field.name.as_str() {
             "possibleTypes" => {
                 let type_names = object_field(parent, "possibleTypes")
                     .and_then(|value| match value {
@@ -489,7 +489,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
                     Ok(q::Value::Null)
                 }
             }
-            _ => object_field(parent, field.as_str())
+            _ => object_field(parent, field.name.as_str())
                 .map_or(Ok(q::Value::Null), |value| Ok(value.clone())),
         }
     }

--- a/graphql/src/query/ext.rs
+++ b/graphql/src/query/ext.rs
@@ -1,0 +1,26 @@
+//! Extension traits for graphql_parser::query structs
+
+use graphql_parser::query as q;
+
+use std::collections::BTreeMap;
+
+pub trait ValueExt {
+    fn as_object(&self) -> &BTreeMap<q::Name, q::Value>;
+    fn as_string(&self) -> &str;
+}
+
+impl ValueExt for q::Value {
+    fn as_object(&self) -> &BTreeMap<q::Name, q::Value> {
+        match self {
+            q::Value::Object(object) => object,
+            _ => panic!("expected a Value::Object"),
+        }
+    }
+
+    fn as_string(&self) -> &str {
+        match self {
+            q::Value::String(string) => string,
+            _ => panic!("expected a Value::String"),
+        }
+    }
+}

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -61,6 +61,16 @@ where
             Err(errors) => return QueryResult::from(errors),
         };
 
+    let mode = if let q::OperationDefinition::Query(query) = operation {
+        if query.directives.iter().any(|dir| dir.name == "verify") {
+            ExecutionMode::Verify
+        } else {
+            ExecutionMode::Prefetch
+        }
+    } else {
+        ExecutionMode::Prefetch
+    };
+
     // Create a fresh execution context
     let ctx = ExecutionContext {
         logger: query_logger.clone(),
@@ -71,6 +81,7 @@ where
         variable_values: Arc::new(coerced_variable_values),
         deadline: options.deadline,
         max_first: options.max_first,
+        mode,
     };
 
     let result = match operation {

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -10,6 +10,9 @@ use crate::schema::ast as sast;
 /// Utilities for working with GraphQL query ASTs.
 pub mod ast;
 
+/// Extension traits
+pub mod ext;
+
 /// Options available for query execution.
 pub struct QueryExecutionOptions<R>
 where

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -95,7 +95,7 @@ where
                         max_complexity,
                     )])
                 }
-                (Ok(_), _) => execute_root_selection_set(&ctx, selection_set, &None),
+                (Ok(_), _) => execute_root_selection_set(&ctx, selection_set),
             }
         }
         // Everything else (e.g. mutations) is unsupported

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -566,7 +566,7 @@ fn entity_validation() {
         thing.set("name", name);
         thing.set("stuff", "less");
         thing.set("favorite_color", "red");
-        thing.set("things", vec![]);
+        thing.set("things", store::Value::List(vec![]));
         thing
     }
 
@@ -619,10 +619,7 @@ fn entity_validation() {
     }
 
     let mut thing = make_thing("t1");
-    thing.set(
-        "things",
-        store::Value::from(vec!["thing1".into(), "thing2".into()]),
-    );
+    thing.set("things", store::Value::from(vec!["thing1", "thing2"]));
     check(thing, "");
 
     let thing = make_thing("t2");

--- a/graphql/src/schema/ext.rs
+++ b/graphql/src/schema/ext.rs
@@ -1,0 +1,17 @@
+use graphql_parser::schema as s;
+
+pub trait ObjectTypeExt {
+    fn field(&self, name: &s::Name) -> Option<&s::Field>;
+}
+
+impl ObjectTypeExt for s::ObjectType {
+    fn field(&self, name: &s::Name) -> Option<&s::Field> {
+        self.fields.iter().find(|field| &field.name == name)
+    }
+}
+
+impl ObjectTypeExt for s::InterfaceType {
+    fn field(&self, name: &s::Name) -> Option<&s::Field> {
+        self.fields.iter().find(|field| &field.name == name)
+    }
+}

--- a/graphql/src/schema/mod.rs
+++ b/graphql/src/schema/mod.rs
@@ -5,3 +5,5 @@ pub mod api;
 pub mod ast;
 
 pub use self::api::{api_schema, APISchemaError};
+
+pub mod ext;

--- a/graphql/src/store/mod.rs
+++ b/graphql/src/store/mod.rs
@@ -1,3 +1,4 @@
+mod prefetch;
 mod query;
 mod resolver;
 

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -739,8 +739,11 @@ fn fetch<S: Store>(
         };
         query.filter = Some(filter.and_maybe(query.filter));
         // Apply order by/range conditions to each batch of children, grouped
-        // by parent
-        query.window = Some(join.child_field.to_owned());
+        // by parent, but only if we have more than one parent, as the
+        // queries without a window are simpler
+        if parents.len() > 1 {
+            query.window = Some(join.child_field.to_owned());
+        }
     }
 
     store

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -311,7 +311,7 @@ pub fn run<'a, R, S>(
     ctx: &ExecutionContext<'a, R>,
     selection_set: &q::SelectionSet,
     store: Arc<S>,
-) -> Result<q::Value, QueryExecutionError>
+) -> Result<q::Value, Vec<QueryExecutionError>>
 where
     R: Resolver,
     S: Store,
@@ -334,7 +334,7 @@ fn execute_root_selection_set<'a, R, S>(
     ctx: &ExecutionContext<'a, R>,
     store: &S,
     selection_set: &'a q::SelectionSet,
-) -> Result<Vec<Node>, QueryExecutionError>
+) -> Result<Vec<Node>, Vec<QueryExecutionError>>
 where
     R: Resolver,
     S: Store,
@@ -342,7 +342,7 @@ where
     // Obtain the root Query type and fail if there isn't one
     let query_type = match sast::get_root_query_type(&ctx.schema.document) {
         Some(t) => t,
-        None => return Err(QueryExecutionError::NoRootQueryObjectType),
+        None => return Err(vec![QueryExecutionError::NoRootQueryObjectType]),
     };
 
     // Split the toplevel fields into introspection fields and
@@ -372,7 +372,6 @@ where
 
     // Execute the root selection set against the root query type
     execute_selection_set(&ctx, store, make_root_node(), &data_set, &query_type.into())
-        .map_err(|mut e| e.pop().unwrap())
 }
 
 fn object_or_interface_from_type<'a>(

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -1,0 +1,749 @@
+//! Run a GraphQL query and fetch all the entitied needed to build the
+//! final result
+
+use graphql_parser::query as q;
+use graphql_parser::schema as s;
+use lazy_static::lazy_static;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::ops::Deref;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Instant;
+
+use graph::prelude::{Entity, EntityFilter, QueryExecutionError, Store, Value as StoreValue};
+
+use crate::execution::{ExecutionContext, ObjectOrInterface, Resolver};
+use crate::query::ast as qast;
+use crate::schema::ast as sast;
+use crate::store::build_query;
+
+lazy_static! {
+    static ref ARG_FIRST: String = String::from("first");
+    static ref ARG_SKIP: String = String::from("skip");
+    static ref ARG_ID: String = String::from("id");
+}
+
+pub const PREFETCH_KEY: &str = ":prefetch";
+
+/// Similar to the TypeCondition from graphql_parser, but with
+/// derives that make it possible to use it as the key in a HashMap
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum TypeCondition {
+    Any,
+    On(q::Name),
+}
+
+impl TypeCondition {
+    /// Return a `TypeCondition` that matches when `self` and `other` match
+    /// simultaneously. If the two conditions can never match at the same time,
+    /// return `None`
+    fn and(&self, other: &Self) -> Option<Self> {
+        use TypeCondition::*;
+        match (self, other) {
+            (Any, _) => Some(other.clone()),
+            (_, Any) => Some(self.clone()),
+            (On(name1), On(name2)) if name1 == name2 => Some(self.clone()),
+            _ => None,
+        }
+    }
+
+    fn matches(&self, entities: &Vec<Node>) -> bool {
+        use TypeCondition::*;
+        match self {
+            Any => true,
+            On(name) => entities.iter().any(|entity| entity.typename() == name),
+        }
+    }
+
+    /// Return the type that matches this condition; for `Any`, use `object_type`
+    fn matching_type<'a>(
+        &self,
+        schema: &'a s::Document,
+        object_type: &'a ObjectOrInterface<'a>,
+    ) -> Option<ObjectOrInterface<'a>> {
+        use TypeCondition::*;
+
+        match self {
+            Any => Some(object_type.to_owned()),
+            On(name) => object_or_interface_by_name(schema, name),
+        }
+    }
+}
+
+impl From<Option<q::TypeCondition>> for TypeCondition {
+    fn from(cond: Option<q::TypeCondition>) -> Self {
+        match cond {
+            None => TypeCondition::Any,
+            Some(q::TypeCondition::On(name)) => TypeCondition::On(name),
+        }
+    }
+}
+
+/// Intermediate data structure to hold the results of prefetching entities
+/// and their nested associations. For each association of `entity`, `children`
+/// has an entry mapping the response key to the list of nodes.
+#[derive(Debug, Clone)]
+struct Node {
+    entity: Entity,
+    children: BTreeMap<String, Vec<Rc<Node>>>,
+}
+
+impl From<Entity> for Node {
+    fn from(entity: Entity) -> Self {
+        Node {
+            entity,
+            children: BTreeMap::default(),
+        }
+    }
+}
+
+/// Convert a list of nodes into a `q::Value::List` where each node has also
+/// been converted to a `q::Value`
+fn node_list_as_value(nodes: Vec<Rc<Node>>) -> q::Value {
+    q::Value::List(
+        nodes
+            .into_iter()
+            .map(|node| Rc::try_unwrap(node).unwrap_or_else(|rc| rc.as_ref().clone()))
+            .map(|node| node.into())
+            .collect(),
+    )
+}
+
+/// We pass the root node of the result around as a vec of nodes, not as
+/// a single node so that we can use the same functions on interior node
+/// lists which are the result of querying the database. The root list
+/// consists of exactly one entry, and that entry has an empty
+/// (not even a `__typename`) entity.
+///
+/// That distinguishes it from both the result of a query that matches
+/// nothing (an empty `Vec`), and a result that finds just one entity
+/// (the entity is not completely empty)
+fn is_root_node(nodes: &Vec<Node>) -> bool {
+    if let Some(node) = nodes.iter().next() {
+        node.entity.is_empty()
+    } else {
+        false
+    }
+}
+
+fn make_root_node() -> Vec<Node> {
+    vec![Node {
+        entity: Entity::new(),
+        children: BTreeMap::default(),
+    }]
+}
+
+/// Recursively convert a `Node` into the corresponding `q::Value`, which is
+/// always a `q::Value::Object`. The entity's associations are mapped to
+/// entries `r:{response_key}` as that name is guaranteed to not conflict
+/// with any field of the entity. Also add an entry `:prefetch` so that
+/// the resolver can later tell whether the `q::Value` was produced by prefetch
+/// and should therefore have `r:{response_key}` entries.
+impl From<Node> for q::Value {
+    fn from(node: Node) -> Self {
+        let mut map: BTreeMap<_, _> = node.entity.into();
+        map.insert(PREFETCH_KEY.to_owned(), q::Value::Boolean(true));
+        for (key, nodes) in node.children.into_iter() {
+            map.insert(format!("r:{}", key), node_list_as_value(nodes));
+        }
+        q::Value::Object(map)
+    }
+}
+
+impl Deref for Node {
+    type Target = Entity;
+
+    fn deref(&self) -> &Self::Target {
+        &self.entity
+    }
+}
+
+impl Node {
+    fn typename(&self) -> &str {
+        self.get("__typename")
+            .expect("all entities have a __typename")
+            .as_str()
+            .expect("__typename must be a string")
+    }
+}
+
+/// Encapsulate how we should join a list of parent entities with a list of
+/// child entities.
+#[derive(Debug)]
+struct Join<'a> {
+    /// The object type of the child entities
+    child_type: ObjectOrInterface<'a>,
+    /// The name of the field in the parent type
+    parent_field: &'a str,
+    /// Whether the parent field is a list or scalar
+    parent_is_list: bool,
+    /// The name of the field in the child type
+    child_field: &'a str,
+    /// Whether the child field is a list or a scalar
+    child_is_list: bool,
+}
+
+impl<'a> Join<'a> {
+    /// Construct a `Join` based on the parent field pointing to the child
+    fn new(schema: &'a s::Document, field: &'a s::Field) -> Self {
+        let child_type = object_or_interface_from_type(&schema, &field.field_type)
+            .expect("we only collect fields that are objects or interfaces");
+
+        let (parent_field, parent_is_list, child_field, child_is_list) =
+            if let Some(derived_from_field) = sast::get_derived_from_field(child_type, field) {
+                let is_list = sast::is_list_or_non_null_list_field(derived_from_field);
+                ("id", false, derived_from_field.name.as_str(), is_list)
+            } else {
+                let is_list = sast::is_list_or_non_null_list_field(field);
+                (field.name.as_str(), is_list, "id", false)
+            };
+        Join {
+            child_type,
+            parent_field,
+            parent_is_list,
+            child_field,
+            child_is_list,
+        }
+    }
+
+    /// Perform the join. The child nodes are distributed into the parent nodes
+    /// according to the join condition, and are stored in the `response_key`
+    /// entry in each parent's `children` map.
+    ///
+    /// The `children` must contain the nodes in the correct order for each
+    /// parent; we simply pick out matching children for each parent but
+    /// otherwise maintain the order in `children`
+    fn perform(&self, parents: &mut Vec<Node>, children: Vec<Node>, response_key: &str) {
+        let children: Vec<_> = children.into_iter().map(|child| Rc::new(child)).collect();
+
+        if is_root_node(parents) {
+            let root = parents
+                .first_mut()
+                .expect("is_root_node checked that we have a node");
+            root.children.insert(response_key.to_owned(), children);
+            return;
+        }
+
+        // Build a map child_key -> Vec<child> for joining
+        let mut grouped: BTreeMap<&str, Vec<Rc<Node>>> = BTreeMap::default();
+        for child in children.iter() {
+            match child
+                .get(self.child_field)
+                .expect("child must have a value in child_field")
+            {
+                StoreValue::String(key) => grouped.entry(key).or_default().push(child.clone()),
+                StoreValue::List(list) => {
+                    for key in list {
+                        match key {
+                            StoreValue::String(key) => {
+                                grouped.entry(key).or_default().push(child.clone())
+                            }
+                            _ => unreachable!("a list of join keys contains only strings"),
+                        }
+                    }
+                }
+                _ => unreachable!("join fields are strings or lists"),
+            }
+        }
+
+        // Add appropriate children using grouped map
+        for parent in parents.iter_mut() {
+            // Set the `response_key` field in `parent`. Make sure that even
+            // if `parent` has no mathcing `children`, the field gets set (to
+            // an empty `Vec`)
+            // This is complicated by the fact that, if there was a type
+            // condition, we should only change parents that meet the type
+            // condition; we set it for all parents regardless, as that does
+            // not cause problems in later processing, but make sure that we
+            // do not clobber an entry under this `response_key` that might
+            // have been set by a previous join by appending values rather
+            // than using straight insert into the parent
+            let mut values = parent
+                .get(self.parent_field)
+                .and_then(|key| match key {
+                    StoreValue::String(key) => {
+                        grouped.get(key.as_str()).map(|values| values.clone())
+                    }
+                    StoreValue::List(keys) => {
+                        // Note that each `grouped.get` returns a vec with
+                        // at most one element, and since `key` is the id
+                        // of that element, the resulting `values` will not
+                        // contain duplicates
+                        Some(
+                            keys.iter()
+                                .filter_map(|key| key.as_str())
+                                .filter_map(|key| grouped.get(key))
+                                .flatten()
+                                .map(|rc| rc.clone())
+                                .collect::<Vec<_>>(),
+                        )
+                    }
+                    StoreValue::Null => None,
+                    _ => unreachable!("join fields must be strings or lists of strings"),
+                })
+                .unwrap_or(vec![]);
+            parent
+                .children
+                .entry(response_key.to_owned())
+                .or_default()
+                .append(&mut values);
+        }
+    }
+}
+
+/// Run the query in `ctx` in such a manner that we only perform one query
+/// per 'level' in the query. A query like `musicians { id bands { id } }`
+/// will perform two queries: one for musicians, and one for bands, regardless
+/// of how many musicians there are.
+///
+/// The returned value contains a `q::Value::Object` that contains a tree of
+/// all the entities (converted into objects) in the form in which they need
+/// to be returned. Nested object fields appear under the key `r:response_key`
+/// in these objects, and are always `q::Value::List` of objects. In addition,
+/// each entity has a property `:prefetch` set so that the resolver can
+/// tell whether the `r:response_key` associations should be there.
+///
+/// For the above example, the returned object would have one entry under
+/// `r:musicians`, which is a list of all the musicians; each musician has an
+/// entry `r:bands` that contains a list of the bands for that musician. Note
+/// that even for single-object fields, we return a list
+pub fn run<'a, R, S>(
+    ctx: &ExecutionContext<'a, R>,
+    selection_set: &q::SelectionSet,
+    store: Arc<S>,
+) -> Result<q::Value, QueryExecutionError>
+where
+    R: Resolver,
+    S: Store,
+{
+    execute_root_selection_set(ctx, store.as_ref(), selection_set).map(|nodes| {
+        let mut map = BTreeMap::default();
+        map.insert(PREFETCH_KEY.to_owned(), q::Value::Boolean(true));
+        q::Value::Object(nodes.into_iter().fold(map, |mut map, node| {
+            // For root nodes, we only care about the children
+            for (key, nodes) in node.children.into_iter() {
+                map.insert(format!("r:{}", key), node_list_as_value(nodes));
+            }
+            map
+        }))
+    })
+}
+
+/// Executes the root selection set of a query.
+fn execute_root_selection_set<'a, R, S>(
+    ctx: &ExecutionContext<'a, R>,
+    store: &S,
+    selection_set: &'a q::SelectionSet,
+) -> Result<Vec<Node>, QueryExecutionError>
+where
+    R: Resolver,
+    S: Store,
+{
+    // Obtain the root Query type and fail if there isn't one
+    let query_type = match sast::get_root_query_type(&ctx.schema.document) {
+        Some(t) => t,
+        None => return Err(QueryExecutionError::NoRootQueryObjectType),
+    };
+
+    // Split the toplevel fields into introspection fields and
+    // 'normal' data fields
+    let mut data_set = q::SelectionSet {
+        span: selection_set.span.clone(),
+        items: Vec::new(),
+    };
+
+    for (_, type_fields) in collect_fields(ctx, &query_type.into(), selection_set, None) {
+        let fields = match type_fields.get(&TypeCondition::Any) {
+            None => return Ok(vec![]),
+            Some(fields) => fields,
+        };
+
+        let name = fields[0].name.clone();
+        let selections = fields
+            .into_iter()
+            .map(|f| q::Selection::Field((*f).clone()));
+        // See if this is an introspection or data field. We don't worry about
+        // nonexistant fields; those will cause an error later when we execute
+        // the data_set SelectionSet
+        if sast::get_field(query_type, &name).is_some() {
+            data_set.items.extend(selections)
+        }
+    }
+
+    // Execute the root selection set against the root query type
+    execute_selection_set(&ctx, store, make_root_node(), &data_set, &query_type.into())
+        .map_err(|mut e| e.pop().unwrap())
+}
+
+fn object_or_interface_from_type<'a>(
+    schema: &'a s::Document,
+    field_type: &'a s::Type,
+) -> Option<ObjectOrInterface<'a>> {
+    match field_type {
+        s::Type::NonNullType(inner_type) => object_or_interface_from_type(schema, inner_type),
+        s::Type::ListType(inner_type) => object_or_interface_from_type(schema, inner_type),
+        s::Type::NamedType(name) => object_or_interface_by_name(schema, name),
+    }
+}
+
+fn object_or_interface_by_name<'a>(
+    schema: &'a s::Document,
+    name: &s::Name,
+) -> Option<ObjectOrInterface<'a>> {
+    match sast::get_named_type(schema, name) {
+        Some(s::TypeDefinition::Object(t)) => Some(t.into()),
+        Some(s::TypeDefinition::Interface(t)) => Some(t.into()),
+        _ => None,
+    }
+}
+
+fn execute_selection_set<'a, R, S>(
+    ctx: &ExecutionContext<'a, R>,
+    store: &S,
+    mut parents: Vec<Node>,
+    selection_set: &'a q::SelectionSet,
+    object_type: &ObjectOrInterface,
+) -> Result<Vec<Node>, Vec<QueryExecutionError>>
+where
+    R: Resolver,
+    S: Store,
+{
+    let mut errors: Vec<QueryExecutionError> = Vec::new();
+
+    // Group fields with the same response key, so we can execute them together
+    let grouped_field_set = collect_fields(ctx, object_type, selection_set, None);
+
+    // Process all field groups in order
+    for (response_key, type_map) in grouped_field_set {
+        match ctx.deadline {
+            Some(deadline) if deadline < Instant::now() => {
+                errors.push(QueryExecutionError::Timeout);
+                break;
+            }
+            _ => (),
+        }
+
+        for (type_cond, fields) in type_map {
+            if !type_cond.matches(&parents) {
+                continue;
+            }
+
+            let concrete_type = type_cond
+                .matching_type(&ctx.schema.document, object_type)
+                .expect("collect_fields does not create type conditions for nonexistent types");
+
+            if let Some(ref field) = concrete_type.field(&fields[0].name) {
+                let ctx = ctx.for_field(&fields[0]);
+                let join = Join::new(&ctx.schema.document, field);
+
+                match execute_field(
+                    &ctx,
+                    store,
+                    &concrete_type,
+                    &parents,
+                    &join,
+                    &fields[0],
+                    field,
+                ) {
+                    Ok(children) => {
+                        let child_selection_set = crate::execution::merge_selection_sets(fields);
+                        let child_object_type =
+                            object_or_interface_from_type(&ctx.schema.document, &field.field_type)
+                                .expect("type of child field is object or interface");
+                        match execute_selection_set(
+                            &ctx,
+                            store,
+                            children,
+                            &child_selection_set,
+                            &child_object_type,
+                        ) {
+                            Ok(children) => join.perform(&mut parents, children, response_key),
+                            Err(mut e) => errors.append(&mut e),
+                        }
+                    }
+                    Err(mut e) => {
+                        errors.append(&mut e);
+                    }
+                };
+            } else {
+                errors.push(QueryExecutionError::UnknownField(
+                    fields[0].position,
+                    object_type.name().to_owned(),
+                    fields[0].name.clone(),
+                ))
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(parents)
+    } else {
+        if errors.is_empty() {
+            errors.push(QueryExecutionError::EmptySelectionSet(
+                object_type.name().to_owned(),
+            ));
+        }
+        Err(errors)
+    }
+}
+
+/// Collects fields of a selection set. The resulting map indicates for each
+/// response key from which types to fetch what fields to express the effect
+/// of fragment spreads
+fn collect_fields<'a, R>(
+    ctx: &ExecutionContext<'a, R>,
+    object_type: &ObjectOrInterface,
+    selection_set: &'a q::SelectionSet,
+    visited_fragments: Option<HashSet<&'a q::Name>>,
+) -> HashMap<&'a String, HashMap<TypeCondition, Vec<&'a q::Field>>>
+where
+    R: Resolver,
+{
+    let mut visited_fragments = visited_fragments.unwrap_or_default();
+    let mut grouped_fields: HashMap<_, HashMap<_, Vec<_>>> = HashMap::new();
+
+    // Only consider selections that are not skipped and should be included
+    let selections: Vec<_> = selection_set
+        .items
+        .iter()
+        .filter(|selection| !qast::skip_selection(selection, ctx.variable_values.deref()))
+        .filter(|selection| qast::include_selection(selection, ctx.variable_values.deref()))
+        .collect();
+
+    fn is_reference_field(
+        schema: &s::Document,
+        object_type: &ObjectOrInterface,
+        field: &q::Field,
+    ) -> bool {
+        object_type
+            .field(&field.name)
+            .map(|field_def| sast::get_type_definition_from_field(schema, field_def))
+            .unwrap_or(None)
+            .map(|type_def| match type_def {
+                s::TypeDefinition::Interface(_) | s::TypeDefinition::Object(_) => true,
+                _ => false,
+            })
+            .unwrap_or(false)
+    }
+
+    for selection in selections {
+        match selection {
+            q::Selection::Field(ref field) => {
+                // Only consider fields that point to objects or interfaces, and
+                // ignore nonexistent fields
+                if is_reference_field(&ctx.schema.document, object_type, field) {
+                    let response_key = qast::get_response_key(field);
+
+                    // Create a field group for this response key and add the field
+                    // with no type condition
+                    grouped_fields
+                        .entry(response_key)
+                        .or_default()
+                        .entry(TypeCondition::Any)
+                        .or_default()
+                        .push(field);
+                }
+            }
+
+            q::Selection::FragmentSpread(spread) => {
+                // Only consider the fragment if it hasn't already been included,
+                // as would be the case if the same fragment spread ...Foo appeared
+                // twice in the same selection set
+                if !visited_fragments.contains(&spread.fragment_name) {
+                    visited_fragments.insert(&spread.fragment_name);
+
+                    qast::get_fragment(&ctx.document, &spread.fragment_name).map(|fragment| {
+                        let fragment_grouped_field_set = collect_fields(
+                            ctx,
+                            object_type,
+                            &fragment.selection_set,
+                            Some(visited_fragments.clone()),
+                        );
+
+                        // Add all items from each fragments group to the field group
+                        // with the corresponding response key
+                        let fragment_cond =
+                            TypeCondition::from(Some(fragment.type_condition.clone()));
+                        for (response_key, type_fields) in fragment_grouped_field_set {
+                            for (type_cond, mut group) in type_fields {
+                                if let Some(cond) = fragment_cond.and(&type_cond) {
+                                    grouped_fields
+                                        .entry(response_key)
+                                        .or_default()
+                                        .entry(cond)
+                                        .or_default()
+                                        .append(&mut group);
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+
+            q::Selection::InlineFragment(fragment) => {
+                let fragment_cond = TypeCondition::from(fragment.type_condition.clone());
+                // Fields for this fragment need to be looked up in the type
+                // mentioned in the condition
+                let fragment_type = fragment_cond.matching_type(&ctx.schema.document, object_type);
+
+                // The `None` case here indicates an error where the type condition
+                // mentions a nonexistent type; the overall query execution logic will catch
+                // that
+                if let Some(fragment_type) = fragment_type {
+                    let fragment_grouped_field_set = collect_fields(
+                        ctx,
+                        &fragment_type,
+                        &fragment.selection_set,
+                        Some(visited_fragments.clone()),
+                    );
+
+                    for (response_key, type_fields) in fragment_grouped_field_set {
+                        for (type_cond, mut group) in type_fields {
+                            if let Some(cond) = fragment_cond.and(&type_cond) {
+                                grouped_fields
+                                    .entry(response_key)
+                                    .or_default()
+                                    .entry(cond)
+                                    .or_default()
+                                    .append(&mut group);
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    grouped_fields
+}
+
+/// Executes a field.
+fn execute_field<'a, R, S>(
+    ctx: &ExecutionContext<'a, R>,
+    store: &S,
+    object_type: &ObjectOrInterface<'_>,
+    parents: &Vec<Node>,
+    join: &Join<'a>,
+    field: &'a q::Field,
+    field_definition: &'a s::Field,
+) -> Result<Vec<Node>, Vec<QueryExecutionError>>
+where
+    R: Resolver,
+    S: Store,
+{
+    let mut argument_values = match object_type {
+        ObjectOrInterface::Object(object_type) => {
+            crate::execution::coerce_argument_values(ctx, object_type, field)
+        }
+        ObjectOrInterface::Interface(interface_type) => {
+            // This assumes that all implementations of the interface accept
+            // the same arguments for this field
+            match ctx
+                .schema
+                .types_for_interface
+                .get(&interface_type.name)
+                .expect("interface type exists")
+                .first()
+            {
+                Some(object_type) => {
+                    crate::execution::coerce_argument_values(ctx, &object_type, field)
+                }
+                None => {
+                    // Nobody is implementing this interface
+                    return Ok(vec![]);
+                }
+            }
+        }
+    }?;
+
+    if !argument_values.contains_key(&*ARG_FIRST) {
+        let first = if sast::is_list_or_non_null_list_field(field_definition) {
+            // This makes `build_range` use the default, 100
+            q::Value::Null
+        } else {
+            // For non-list fields, get up to 2 entries so we can spot
+            // ambiguous references that should only have one entry
+            q::Value::Int(2.into())
+        };
+        argument_values.insert(&*ARG_FIRST, first);
+    }
+
+    if !argument_values.contains_key(&*ARG_SKIP) {
+        // Use the default in build_range
+        argument_values.insert(&*ARG_SKIP, q::Value::Null);
+    }
+
+    fetch(
+        store,
+        &parents,
+        &join,
+        &argument_values,
+        ctx.schema.types_for_interface(),
+        ctx.max_first,
+    )
+    .map_err(|e| vec![e])
+}
+
+/// Query child entities for `parents` from the store. The `join` indicates
+/// in which child field to look for the parent's id/join field
+fn fetch<S: Store>(
+    store: &S,
+    parents: &Vec<Node>,
+    join: &Join<'_>,
+    arguments: &HashMap<&q::Name, q::Value>,
+    types_for_interface: &BTreeMap<s::Name, Vec<s::ObjectType>>,
+    max_first: u32,
+) -> Result<Vec<Node>, QueryExecutionError> {
+    let mut query = build_query(join.child_type, arguments, types_for_interface, max_first)?;
+
+    if let Some(q::Value::String(id)) = arguments.get(&*ARG_ID) {
+        query.filter = Some(
+            EntityFilter::Equal(ARG_ID.to_owned(), StoreValue::from(id.to_owned()))
+                .and_maybe(query.filter),
+        );
+    }
+
+    if !is_root_node(parents) {
+        // For anything but the root node, restrict the children we select
+        // by the parent list
+        let mut ids = if join.parent_is_list {
+            parents
+                .iter()
+                .filter_map(|entity| entity.get(join.parent_field))
+                .flat_map(|list| match list {
+                    StoreValue::List(values) => values.iter().filter_map(|value| value.as_str()),
+                    _ => unreachable!("parent_field is not a list of strings"),
+                })
+                .collect::<Vec<_>>()
+        } else {
+            parents
+                .iter()
+                .filter_map(|entity| entity.get(join.parent_field))
+                .filter_map(|value| match value {
+                    StoreValue::String(s) => Some(s.as_str()),
+                    StoreValue::Null => None,
+                    _ => unreachable!("parent_field must be a string or null"),
+                })
+                .collect::<Vec<_>>()
+        };
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+        ids.sort_unstable();
+        ids.dedup();
+        let ids = ids.into_iter().map(|id| StoreValue::from(id)).collect();
+        let filter = if join.child_is_list {
+            EntityFilter::Intersects(join.child_field.to_owned(), ids)
+        } else {
+            EntityFilter::In(join.child_field.to_owned(), ids)
+        };
+        query.filter = Some(filter.and_maybe(query.filter));
+        // Apply order by/range conditions to each batch of children, grouped
+        // by parent
+        query.window = Some(join.child_field.to_owned());
+    }
+
+    store
+        .find(query)
+        .map(|entities| entities.into_iter().map(|entity| entity.into()).collect())
+}

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -31,6 +31,7 @@ pub fn build_query<'a>(
         filter: build_filter(entity, arguments)?,
         order_by: build_order_by(entity, arguments)?,
         order_direction: build_order_direction(arguments)?,
+        window: None,
     })
 }
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -243,7 +243,7 @@ where
         &self,
         ctx: &ExecutionContext<'r, Self>,
         selection_set: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, QueryExecutionError> {
+    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
         super::prefetch::run(ctx, selection_set, self.store.clone()).map(|value| Some(value))
     }
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -160,6 +160,14 @@ impl<S> Resolver for StoreResolver<S>
 where
     S: Store,
 {
+    fn prefetch<'r>(
+        &self,
+        _: &ExecutionContext<'r, Self>,
+        _: &q::SelectionSet,
+    ) -> Result<Option<q::Value>, QueryExecutionError> {
+        Ok(None)
+    }
+
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -203,19 +203,15 @@ where
         if let Some(q::Value::List(children)) = Self::get_child(parent, field) {
             if children.len() > 1 {
                 let derived_from_field =
-                    sast::get_derived_from_field(object_type, field_definition);
+                    sast::get_derived_from_field(object_type, field_definition)
+                        .expect("only derived fields can lead to multiple children here");
 
-                match derived_from_field {
-                    Some(derived_from_field) => {
-                        return Err(QueryExecutionError::AmbiguousDerivedFromResult(
-                            field.position.clone(),
-                            field.name.to_owned(),
-                            object_type.name().to_owned(),
-                            derived_from_field.name.to_owned(),
-                        ));
-                    }
-                    None => return Ok(q::Value::Null),
-                }
+                return Err(QueryExecutionError::AmbiguousDerivedFromResult(
+                    field.position.clone(),
+                    field.name.to_owned(),
+                    object_type.name().to_owned(),
+                    derived_from_field.name.to_owned(),
+                ));
             } else {
                 return Ok(children
                     .into_iter()

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -157,7 +157,10 @@ where
             .unwrap_or(true)
     }
 
-    fn get_child<'a>(parent: &'a Option<q::Value>, field: &q::Field) -> Option<&'a q::Value> {
+    fn get_prefetched_child<'a>(
+        parent: &'a Option<q::Value>,
+        field: &q::Field,
+    ) -> Option<&'a q::Value> {
         match parent {
             Some(q::Value::Object(map)) => {
                 let key = format!("r:{}", qast::get_response_key(field));
@@ -180,7 +183,7 @@ where
         field: &q::Field,
         object_type: ObjectOrInterface<'_>,
     ) -> Result<q::Value, QueryExecutionError> {
-        if let Some(child) = Self::get_child(parent, field) {
+        if let Some(child) = Self::get_prefetched_child(parent, field) {
             Ok(child.clone())
         } else {
             Err(QueryExecutionError::ResolveEntitiesError(format!(
@@ -200,7 +203,7 @@ where
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
     ) -> Result<q::Value, QueryExecutionError> {
-        if let Some(q::Value::List(children)) = Self::get_child(parent, field) {
+        if let Some(q::Value::List(children)) = Self::get_prefetched_child(parent, field) {
             if children.len() > 1 {
                 let derived_from_field =
                     sast::get_derived_from_field(object_type, field_definition)

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -163,7 +163,7 @@ where
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,
-        _field: &q::Name,
+        _field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -63,6 +63,7 @@ where
         variable_values: Arc::new(coerced_variable_values),
         deadline: None,
         max_first: options.max_first,
+        mode: ExecutionMode::Prefetch,
     };
 
     match operation {
@@ -218,6 +219,7 @@ where
         variable_values,
         deadline: timeout.map(|t| Instant::now() + t),
         max_first,
+        mode: ExecutionMode::Prefetch,
     };
 
     // We have established that this exists earlier in the subscription execution

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -117,7 +117,7 @@ where
     let subscription_type = sast::get_root_subscription_type(&ctx.schema.document)
         .ok_or(QueryExecutionError::NoRootSubscriptionObjectType)?;
 
-    let grouped_field_set = collect_fields(ctx.clone(), &subscription_type, &selection_set, None);
+    let grouped_field_set = collect_fields(ctx, &subscription_type, &selection_set, None);
 
     if grouped_field_set.is_empty() {
         return Err(SubscriptionError::from(QueryExecutionError::EmptyQuery));

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -15,7 +15,7 @@ impl Resolver for MockResolver {
     fn resolve_objects<'a>(
         &self,
         _parent: &Option<q::Value>,
-        _field: &q::Name,
+        _field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -12,6 +12,14 @@ use graph_graphql::prelude::*;
 pub struct MockResolver;
 
 impl Resolver for MockResolver {
+    fn prefetch<'r>(
+        &self,
+        _: &ExecutionContext<'r, Self>,
+        _: &q::SelectionSet,
+    ) -> Result<Option<q::Value>, QueryExecutionError> {
+        Ok(None)
+    }
+
     fn resolve_objects<'a>(
         &self,
         _parent: &Option<q::Value>,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -16,7 +16,7 @@ impl Resolver for MockResolver {
         &self,
         _: &ExecutionContext<'r, Self>,
         _: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, QueryExecutionError> {
+    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
         Ok(None)
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -105,6 +105,7 @@ impl MockStore {
             order_by,
             order_direction,
             range: _,
+            window: _,
         } = query;
 
         // List all entities with correct type

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -217,6 +217,7 @@ impl Store for MockStore {
                     } else {
                         let mut new_entity = data;
                         new_entity.insert("id".to_owned(), key.entity_id.clone().into());
+                        new_entity.insert("__typename".to_owned(), key.entity_type.clone().into());
                         new_entity.retain(|_k, v| *v != Value::Null);
                         entities_of_type.insert(key.entity_id.clone(), new_entity);
 

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -4,8 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use graph::data::graphql::{TryFromValue, ValueList, ValueMap};
 use graph::data::subgraph::schema::SUBGRAPHS_ID;
 use graph::prelude::*;
-use graph_graphql::prelude::{object_value, ObjectOrInterface, Resolver};
-
+use graph_graphql::prelude::{object_value, ExecutionContext, ObjectOrInterface, Resolver};
 use web3::types::H256;
 
 /// Resolver for the index node GraphQL API.
@@ -501,6 +500,14 @@ where
     R: GraphQlRunner,
     S: Store + SubgraphDeploymentStore,
 {
+    fn prefetch<'r>(
+        &self,
+        _: &ExecutionContext<'r, Self>,
+        _: &q::SelectionSet,
+    ) -> Result<Option<q::Value>, QueryExecutionError> {
+        Ok(None)
+    }
+
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -504,7 +504,7 @@ where
         &self,
         _: &ExecutionContext<'r, Self>,
         _: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, QueryExecutionError> {
+    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
         Ok(None)
     }
 

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -504,14 +504,14 @@ where
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,
-        field: &q::Name,
+        field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
         _max_first: u32,
     ) -> Result<q::Value, QueryExecutionError> {
-        match (parent, object_type.name(), field.as_str()) {
+        match (parent, object_type.name(), field.name.as_str()) {
             // The top-level `indexingStatuses` field
             (None, "SubgraphIndexingStatus", "indexingStatuses") => {
                 self.resolve_indexing_statuses(arguments)

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -22,7 +22,7 @@
 use diesel::connection::SimpleConnection;
 use diesel::debug_query;
 use diesel::deserialize::QueryableByName;
-use diesel::dsl::{any, sql};
+use diesel::dsl::any;
 use diesel::pg::{Pg, PgConnection};
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use diesel::sql_types::{Integer, Jsonb, Nullable, Text};
@@ -49,9 +49,9 @@ use graph::prelude::{
 };
 
 use crate::block_range::{block_number, BlockNumber};
-use crate::filter::build_filter;
 use crate::history_event::HistoryEvent;
 use crate::jsonb::PgJsonbExpressionMethods as _;
+use crate::jsonb_queries::FilterQuery;
 use crate::notification_listener::JsonNotification;
 use crate::relational::{IdType, Layout};
 use crate::store::Store;
@@ -882,76 +882,7 @@ impl JsonStorage {
         first: Option<u32>,
         skip: u32,
     ) -> Result<Vec<Entity>, QueryExecutionError> {
-        let entities = self.clone();
-        let mut query = if entity_types.len() == 1 {
-            // If there is only one entity_type, which is the case in all
-            // queries that do not involve interfaces, leaving out `any`
-            // lets Postgres use the primary key index on the entities table
-            let entity_type = entity_types.first().unwrap();
-            entities
-                .table
-                .select((&self.data, &self.entity))
-                .filter((&self.entity).eq(entity_type))
-                .into_boxed::<Pg>()
-        } else {
-            entities
-                .table
-                .select((&self.data, &self.entity))
-                .filter((&self.entity).eq(any(entity_types)))
-                .into_boxed::<Pg>()
-        };
-
-        if let Some(filter) = filter {
-            let filter = build_filter(filter).map_err(|e| {
-                QueryExecutionError::FilterNotSupportedError(format!("{}", e.value), e.filter)
-            })?;
-            query = query.filter(filter);
-        }
-
-        if let Some((attribute, value_type, direction)) = order {
-            let cast = match value_type {
-                ValueType::BigInt | ValueType::BigDecimal => "::numeric",
-                ValueType::Boolean => "::boolean",
-                ValueType::Bytes => "",
-                ValueType::ID => "",
-                ValueType::Int => "::bigint",
-                ValueType::String => "",
-                ValueType::List => {
-                    return Err(QueryExecutionError::OrderByNotSupportedForType(
-                        "List".to_string(),
-                    ));
-                }
-            };
-
-            query = match value_type {
-                ValueType::String => query.order(
-                    sql::<Text>("left(data ->")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data', ")
-                        .sql(&STRING_PREFIX_SIZE.to_string())
-                        .sql(") ")
-                        .sql(direction)
-                        .sql(" NULLS LAST"),
-                ),
-                _ => query.order(
-                    sql::<Text>("(data ->")
-                        .bind::<Text, _>(attribute)
-                        .sql("->> 'data')")
-                        .sql(cast)
-                        .sql(" ")
-                        .sql(direction)
-                        .sql(" NULLS LAST"),
-                ),
-            };
-        }
-        query = query.then_order_by(entities.id.asc());
-
-        if let Some(first) = first {
-            query = query.limit(first as i64);
-        }
-        if skip > 0 {
-            query = query.offset(skip as i64);
-        }
+        let query = FilterQuery::new(&self.table, entity_types, filter, order, first, skip)?;
 
         let query_debug_info = debug_query(&query).to_string();
 

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -43,7 +43,7 @@ use graph::data::schema::Schema as SubgraphSchema;
 use graph::data::subgraph::schema::SUBGRAPHS_ID;
 use graph::prelude::{
     debug, format_err, info, serde_json, warn, AttributeIndexDefinition, Entity, EntityChange,
-    EntityChangeOperation, EntityFilter, EntityKey, EntityModification, Error,
+    EntityChangeOperation, EntityFilter, EntityKey, EntityModification, EntityOrder, Error,
     EthereumBlockPointer, Logger, QueryExecutionError, StoreError, StoreEvent,
     SubgraphDeploymentId, SubgraphDeploymentStore, ValueType,
 };
@@ -421,7 +421,7 @@ impl Connection {
         &self,
         entity_types: Vec<String>,
         filter: Option<EntityFilter>,
-        order: Option<(String, ValueType, &str)>,
+        order: Option<(String, ValueType, EntityOrder)>,
         first: Option<u32>,
         skip: u32,
         block: BlockNumber,
@@ -878,7 +878,7 @@ impl JsonStorage {
         conn: &PgConnection,
         entity_types: Vec<String>,
         filter: Option<EntityFilter>,
-        order: Option<(String, ValueType, &str)>,
+        order: Option<(String, ValueType, EntityOrder)>,
         first: Option<u32>,
         skip: u32,
     ) -> Result<Vec<Entity>, QueryExecutionError> {

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -43,8 +43,8 @@ use graph::data::schema::Schema as SubgraphSchema;
 use graph::data::subgraph::schema::SUBGRAPHS_ID;
 use graph::prelude::{
     debug, format_err, info, serde_json, warn, AttributeIndexDefinition, Entity, EntityChange,
-    EntityChangeOperation, EntityFilter, EntityKey, EntityModification, EntityOrder, Error,
-    EthereumBlockPointer, Logger, QueryExecutionError, StoreError, StoreEvent,
+    EntityChangeOperation, EntityFilter, EntityKey, EntityModification, EntityOrder, EntityRange,
+    Error, EthereumBlockPointer, Logger, QueryExecutionError, StoreError, StoreEvent,
     SubgraphDeploymentId, SubgraphDeploymentStore, ValueType,
 };
 
@@ -422,14 +422,13 @@ impl Connection {
         entity_types: Vec<String>,
         filter: Option<EntityFilter>,
         order: Option<(String, ValueType, EntityOrder)>,
-        first: Option<u32>,
-        skip: u32,
+        range: EntityRange,
         block: BlockNumber,
     ) -> Result<Vec<Entity>, QueryExecutionError> {
         match &*self.storage {
-            Storage::Json(json) => json.query(&self.conn, entity_types, filter, order, first, skip),
+            Storage::Json(json) => json.query(&self.conn, entity_types, filter, order, range),
             Storage::Relational(layout) => {
-                layout.query(&self.conn, entity_types, filter, order, first, skip, block)
+                layout.query(&self.conn, entity_types, filter, order, range, block)
             }
         }
     }
@@ -879,10 +878,9 @@ impl JsonStorage {
         entity_types: Vec<String>,
         filter: Option<EntityFilter>,
         order: Option<(String, ValueType, EntityOrder)>,
-        first: Option<u32>,
-        skip: u32,
+        range: EntityRange,
     ) -> Result<Vec<Entity>, QueryExecutionError> {
-        let query = FilterQuery::new(&self.table, entity_types, filter, order, first, skip)?;
+        let query = FilterQuery::new(&self.table, entity_types, filter, order, range)?;
 
         let query_debug_info = debug_query(&query).to_string();
 

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -423,13 +423,22 @@ impl Connection {
         filter: Option<EntityFilter>,
         order: Option<(String, ValueType, EntityOrder)>,
         range: EntityRange,
+        window: Option<String>,
         block: BlockNumber,
     ) -> Result<Vec<Entity>, QueryExecutionError> {
         match &*self.storage {
-            Storage::Json(json) => json.query(&self.conn, entity_types, filter, order, range),
-            Storage::Relational(layout) => {
-                layout.query(&self.conn, entity_types, filter, order, range, block)
+            Storage::Json(json) => {
+                json.query(&self.conn, entity_types, filter, order, range, window)
             }
+            Storage::Relational(layout) => layout.query(
+                &self.conn,
+                entity_types,
+                filter,
+                order,
+                range,
+                window,
+                block,
+            ),
         }
     }
 
@@ -879,13 +888,14 @@ impl JsonStorage {
         filter: Option<EntityFilter>,
         order: Option<(String, ValueType, EntityOrder)>,
         range: EntityRange,
+        window: Option<String>,
     ) -> Result<Vec<Entity>, QueryExecutionError> {
-        let query = FilterQuery::new(&self.table, entity_types, filter, order, range)?;
+        let query = FilterQuery::new(&self.table, entity_types, filter, order, range, window)?;
 
         let query_debug_info = debug_query(&query).to_string();
 
         let values = query
-            .load::<(serde_json::Value, String)>(conn)
+            .load::<(String, serde_json::Value, String)>(conn)
             .map_err(|e| {
                 QueryExecutionError::ResolveEntitiesError(format!(
                     "{}, query = {:?}",
@@ -894,7 +904,7 @@ impl JsonStorage {
             })?;
         values
             .into_iter()
-            .map(|(value, entity_type)| {
+            .map(|(_, value, entity_type)| {
                 entity_from_json(value, &entity_type).map_err(QueryExecutionError::from)
             })
             .collect()

--- a/store/postgres/src/jsonb_queries.rs
+++ b/store/postgres/src/jsonb_queries.rs
@@ -1,0 +1,171 @@
+///! This module generates queries for the JSONB storage scheme.
+///
+///  We really only need that for supporting `EntityQuery`
+use diesel::pg::Pg;
+use diesel::prelude::BoxableExpression;
+use diesel::query_builder::{AstPass, Query, QueryFragment, QueryId};
+use diesel::query_dsl::RunQueryDsl;
+use diesel::result::QueryResult;
+use diesel::sql_types::{Array, Bool, Jsonb, Text};
+
+use graph::prelude::{EntityFilter, QueryExecutionError, ValueType};
+
+use crate::entities::{EntityTable, STRING_PREFIX_SIZE};
+use crate::filter::build_filter;
+use crate::relational::PRIMARY_KEY_COLUMN;
+
+pub struct OrderDetails {
+    attribute: String,
+    cast: &'static str,
+    prefix_only: bool,
+    direction: &'static str,
+}
+
+pub struct FilterQuery<'a> {
+    table: &'a EntityTable,
+    entity_types: Vec<String>,
+    filter: Option<Box<dyn BoxableExpression<EntityTable, Pg, SqlType = Bool>>>,
+    order: Option<OrderDetails>,
+    first: Option<u32>,
+    skip: u32,
+}
+
+impl<'a> FilterQuery<'a> {
+    pub fn new(
+        table: &'a EntityTable,
+        entity_types: Vec<String>,
+        filter: Option<EntityFilter>,
+        order: Option<(String, ValueType, &str)>,
+        first: Option<u32>,
+        skip: u32,
+    ) -> Result<Self, QueryExecutionError> {
+        let order = if let Some((attribute, value_type, direction)) = order {
+            let cast = match value_type {
+                ValueType::BigInt | ValueType::BigDecimal => "::numeric",
+                ValueType::Boolean => "::boolean",
+                ValueType::Bytes => "",
+                ValueType::ID => "",
+                ValueType::Int => "::bigint",
+                ValueType::String => "",
+                ValueType::List => {
+                    return Err(QueryExecutionError::OrderByNotSupportedForType(
+                        "List".to_string(),
+                    ));
+                }
+            };
+
+            let direction = if direction.eq_ignore_ascii_case("asc") {
+                "asc"
+            } else if direction.eq_ignore_ascii_case("desc") {
+                "desc"
+            } else {
+                unreachable!("GraphQL validation makes sure we only get asc or desc")
+            };
+
+            let prefix_only = &attribute != PRIMARY_KEY_COLUMN && value_type == ValueType::String;
+            Some(OrderDetails {
+                attribute,
+                cast,
+                prefix_only,
+                direction,
+            })
+        } else {
+            None
+        };
+        let filter = if let Some(filter) = filter {
+            Some(build_filter(filter).map_err(|e| {
+                QueryExecutionError::FilterNotSupportedError(format!("{}", e.value), e.filter)
+            })?)
+        } else {
+            None
+        };
+        Ok(FilterQuery {
+            table,
+            entity_types,
+            filter,
+            order,
+            first,
+            skip,
+        })
+    }
+
+    fn order_by(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql("\n order by ");
+        if let Some(order) = &self.order {
+            if order.prefix_only {
+                out.push_sql("left(data ->");
+                out.push_bind_param::<Text, _>(&order.attribute)?;
+                out.push_sql("->> 'data', ");
+                out.push_sql(&STRING_PREFIX_SIZE.to_string());
+                out.push_sql(") ");
+            } else {
+                if &order.attribute == PRIMARY_KEY_COLUMN {
+                    out.push_identifier(PRIMARY_KEY_COLUMN)?;
+                } else {
+                    out.push_sql("(data ->");
+                    out.push_bind_param::<Text, _>(&order.attribute)?;
+                    out.push_sql("->> 'data')");
+                    out.push_sql(&order.cast);
+                }
+                out.push_sql(" ");
+            }
+            out.push_sql(&order.direction);
+            out.push_sql(" nulls last, ");
+        }
+        out.push_identifier(PRIMARY_KEY_COLUMN)
+    }
+
+    fn limit(&self, out: &mut AstPass<Pg>) {
+        if let Some(first) = &self.first {
+            out.push_sql("\n limit ");
+            out.push_sql(&first.to_string());
+        }
+        if self.skip > 0 {
+            out.push_sql("\noffset ");
+            out.push_sql(&self.skip.to_string());
+        }
+    }
+}
+
+impl<'a> QueryFragment<Pg> for FilterQuery<'a> {
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+        out.push_sql("select data, entity\n  from ");
+        self.table.walk_ast(out.reborrow())?;
+        out.push_sql(" \n where ");
+        if self.entity_types.len() == 1 {
+            // If there is only one entity_type, which is the case in all
+            // queries that do not involve interfaces, leaving out `any`
+            // lets Postgres use the primary key index on the entities table
+            let entity_type = self
+                .entity_types
+                .first()
+                .expect("we checked that there is exactly one entity_type");
+            out.push_sql("entity = ");
+            out.push_bind_param::<Text, _>(&entity_type)?;
+        } else {
+            out.push_sql("entity = any(");
+            out.push_bind_param::<Array<Text>, _>(&self.entity_types)?;
+            out.push_sql(")")
+        }
+        if let Some(filter) = &self.filter {
+            out.push_sql(" and ");
+            filter.walk_ast(out.reborrow())?;
+        }
+        self.order_by(&mut out)?;
+        self.limit(&mut out);
+        Ok(())
+    }
+}
+
+impl<'a> QueryId for FilterQuery<'a> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a> Query for FilterQuery<'a> {
+    type SqlType = (Jsonb, Text);
+}
+
+impl<'a, Conn> RunQueryDsl<Conn> for FilterQuery<'a> {}

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -29,6 +29,7 @@ mod filter;
 mod functions;
 mod history_event;
 mod jsonb;
+mod jsonb_queries;
 mod notification_listener;
 pub mod relational;
 mod relational_queries;

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -366,6 +366,7 @@ impl Layout {
         filter: Option<EntityFilter>,
         order: Option<(String, ValueType, EntityOrder)>,
         range: EntityRange,
+        window: Option<String>,
         block: BlockNumber,
     ) -> Result<Vec<Entity>, QueryExecutionError> {
         let filter = filter.as_ref();
@@ -387,18 +388,30 @@ impl Layout {
         // table, we are querying an interface, and the order is on an attribute
         // in that interface so that all tables have a column for that. It is
         // therefore enough to just look at the first table to get the name
-        let order = match (order, table_filter_pairs.first()) {
-            (_, None) => {
-                unreachable!("an entity query always contains at least one entity type/table");
-            }
-            (Some((ref attribute, _, direction)), Some((table, _))) => {
-                let column = table.column_for_field(&attribute)?;
+        let first_table = table_filter_pairs
+            .first()
+            .expect("an entity query always contains at least one entity type/table")
+            .0;
+        let order = match order {
+            Some((ref attribute, _, direction)) => {
+                let column = first_table.column_for_field(&attribute)?;
                 Some((&column.name, direction))
             }
-            (None, _) => None,
+            None => None,
         };
 
-        let query = FilterQuery::new(&self.schema, table_filter_pairs, order, range, block);
+        let window = window
+            .map(|window| first_table.column_for_field(&window))
+            .transpose()?
+            .map(|column| &column.name);
+        let query = FilterQuery::new(
+            &self.schema,
+            table_filter_pairs,
+            order,
+            range,
+            window,
+            block,
+        );
         let query_debug_info = query.clone();
 
         let values = query.load::<EntityData>(conn).map_err(|e| {

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -22,7 +22,7 @@ use crate::relational_queries::{
 };
 use graph::prelude::{
     format_err, Entity, EntityChange, EntityChangeOperation, EntityFilter, EntityKey, EntityOrder,
-    QueryExecutionError, StoreError, StoreEvent, SubgraphDeploymentId, ValueType,
+    EntityRange, QueryExecutionError, StoreError, StoreEvent, SubgraphDeploymentId, ValueType,
 };
 
 use crate::block_range::{BlockNumber, BLOCK_RANGE_COLUMN};
@@ -365,8 +365,7 @@ impl Layout {
         entity_types: Vec<String>,
         filter: Option<EntityFilter>,
         order: Option<(String, ValueType, EntityOrder)>,
-        first: Option<u32>,
-        skip: u32,
+        range: EntityRange,
         block: BlockNumber,
     ) -> Result<Vec<Entity>, QueryExecutionError> {
         let filter = filter.as_ref();
@@ -383,12 +382,6 @@ impl Layout {
                     })
             })
             .collect::<Result<Vec<_>, StoreError>>()?;
-        let first = first.map(|first| first.to_string());
-        let skip = if skip == 0 {
-            None
-        } else {
-            Some(skip.to_string())
-        };
 
         // Get the name of the column we order by; if there is more than one
         // table, we are querying an interface, and the order is on an attribute
@@ -405,7 +398,7 @@ impl Layout {
             (None, _) => None,
         };
 
-        let query = FilterQuery::new(&self.schema, table_filter_pairs, order, first, skip, block);
+        let query = FilterQuery::new(&self.schema, table_filter_pairs, order, range, block);
         let query_debug_info = query.clone();
 
         let values = query.load::<EntityData>(conn).map_err(|e| {

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -21,7 +21,7 @@ use crate::relational_queries::{
     QueryFilter, RevertClampQuery, RevertRemoveQuery,
 };
 use graph::prelude::{
-    format_err, Entity, EntityChange, EntityChangeOperation, EntityFilter, EntityKey,
+    format_err, Entity, EntityChange, EntityChangeOperation, EntityFilter, EntityKey, EntityOrder,
     QueryExecutionError, StoreError, StoreEvent, SubgraphDeploymentId, ValueType,
 };
 
@@ -364,7 +364,7 @@ impl Layout {
         conn: &PgConnection,
         entity_types: Vec<String>,
         filter: Option<EntityFilter>,
-        order: Option<(String, ValueType, &str)>,
+        order: Option<(String, ValueType, EntityOrder)>,
         first: Option<u32>,
         skip: u32,
         block: BlockNumber,

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -16,7 +16,8 @@ use std::str::FromStr;
 
 use graph::data::store::scalar;
 use graph::prelude::{
-    format_err, serde_json, Attribute, Entity, EntityFilter, EntityKey, StoreError, Value,
+    format_err, serde_json, Attribute, Entity, EntityFilter, EntityKey, EntityOrder, StoreError,
+    Value,
 };
 
 use crate::block_range::{
@@ -964,7 +965,7 @@ impl<'a, Conn> RunQueryDsl<Conn> for ConflictingEntityQuery<'a> {}
 pub struct FilterQuery<'a> {
     schema: &'a str,
     table_filter_pairs: Vec<(&'a Table, Option<QueryFilter<'a>>)>,
-    order: Option<(&'a SqlName, &'a str)>,
+    order: Option<(&'a SqlName, EntityOrder)>,
     first: Option<String>,
     skip: Option<String>,
     block: BlockNumber,
@@ -976,7 +977,7 @@ impl<'a> FilterQuery<'a> {
         if let Some((name, direction)) = &self.order {
             out.push_identifier(name.as_str())?;
             out.push_sql(" ");
-            out.push_sql(direction);
+            out.push_sql(direction.to_sql());
             if name.as_str() != PRIMARY_KEY_COLUMN {
                 out.push_sql(", ");
                 out.push_identifier(PRIMARY_KEY_COLUMN)?;

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -16,8 +16,8 @@ use std::str::FromStr;
 
 use graph::data::store::scalar;
 use graph::prelude::{
-    format_err, serde_json, Attribute, Entity, EntityFilter, EntityKey, EntityOrder, StoreError,
-    Value,
+    format_err, serde_json, Attribute, Entity, EntityFilter, EntityKey, EntityOrder, EntityRange,
+    StoreError, Value,
 };
 
 use crate::block_range::{
@@ -966,8 +966,7 @@ pub struct FilterQuery<'a> {
     schema: &'a str,
     table_filter_pairs: Vec<(&'a Table, Option<QueryFilter<'a>>)>,
     order: Option<(&'a SqlName, EntityOrder)>,
-    first: Option<String>,
-    skip: Option<String>,
+    range: EntityRange,
     block: BlockNumber,
 }
 
@@ -999,13 +998,13 @@ impl<'a> FilterQuery<'a> {
     }
 
     fn limit(&self, out: &mut AstPass<Pg>) {
-        if let Some(first) = &self.first {
+        if let Some(first) = &self.range.first {
             out.push_sql("\n limit ");
-            out.push_sql(first);
+            out.push_sql(&first.to_string());
         }
-        if let Some(skip) = &self.skip {
+        if self.range.skip > 0 {
             out.push_sql("\noffset ");
-            out.push_sql(skip);
+            out.push_sql(&self.range.skip.to_string());
         }
     }
 

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -967,16 +967,22 @@ pub struct FilterQuery<'a> {
     table_filter_pairs: Vec<(&'a Table, Option<QueryFilter<'a>>)>,
     order: Option<(&'a SqlName, EntityOrder)>,
     range: EntityRange,
+    window: Option<&'a SqlName>,
     block: BlockNumber,
 }
 
+// The queries are a little tricky because we need to defer generating
+// JSONB until we actually know which rows we really need to make these
+// queries fast; otherwise, Postgres spends too much time generating
+// JSONB, most of which will never get used
 impl<'a> FilterQuery<'a> {
     fn order_by(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
-        out.push_sql("\n order by ");
+        out.push_sql("order by ");
         if let Some((name, direction)) = &self.order {
             out.push_identifier(name.as_str())?;
             out.push_sql(" ");
             out.push_sql(direction.to_sql());
+            out.push_sql(" nulls last");
             if name.as_str() != PRIMARY_KEY_COLUMN {
                 out.push_sql(", ");
                 out.push_identifier(PRIMARY_KEY_COLUMN)?;
@@ -987,9 +993,14 @@ impl<'a> FilterQuery<'a> {
         }
     }
 
-    fn add_sort_key(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+    fn select_sort_key_and_window(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        if let Some(window) = self.window {
+            out.push_sql(", e.");
+            out.push_identifier(window.as_str())?;
+        }
+
         if let Some((name, _)) = self.order {
-            if name.as_str() != PRIMARY_KEY_COLUMN {
+            if name.as_str() != PRIMARY_KEY_COLUMN && Some(name) != self.window {
                 out.push_sql(", e.");
                 out.push_identifier(name.as_str())?;
             }
@@ -1005,6 +1016,45 @@ impl<'a> FilterQuery<'a> {
         if self.range.skip > 0 {
             out.push_sql("\noffset ");
             out.push_sql(&self.range.skip.to_string());
+        }
+    }
+
+    fn rank_window(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        if let Some(window) = self.window {
+            out.push_sql(", rank() over (partition by ");
+            out.push_identifier(window.as_str())?;
+            out.push_sql(" ");
+            self.order_by(out)?;
+            out.push_sql(") as pos");
+        }
+        Ok(())
+    }
+
+    // Generate (taking optionality of either clause into account)
+    //    where {pos} > {order.skip} and {pos} <= {order.first + order.skip}
+    //  `pos` must be the name of the column we order by and 'conj' must be
+    // either 'and ' or 'where ' depending on where we add this clause
+    fn limit_per_window(&self, pos: &str, conj: &str, out: &mut AstPass<Pg>) {
+        if self.window.is_some() {
+            let have_first = self.range.first.is_some();
+            let have_skip = self.range.skip > 0;
+            if have_first || have_skip {
+                out.push_sql("\n ");
+                out.push_sql(conj);
+            }
+            if have_skip {
+                out.push_sql(pos);
+                out.push_sql(" > ");
+                out.push_sql(&self.range.skip.to_string());
+                if self.range.first.is_some() {
+                    out.push_sql(" and ");
+                }
+            }
+            if let Some(first) = self.range.first {
+                out.push_sql(pos);
+                out.push_sql(" <= ");
+                out.push_sql(&(first + self.range.skip).to_string());
+            }
         }
     }
 
@@ -1027,9 +1077,199 @@ impl<'a> FilterQuery<'a> {
         BlockRangeContainsClause::new(self.block).walk_ast(out.reborrow())?;
         if let Some(filter) = filter {
             out.push_sql(" and ");
-            filter.walk_ast(out)?;
+            filter.walk_ast(out.reborrow())?;
+        }
+        out.push_sql("\n");
+        Ok(())
+    }
+
+    fn select_entity_and_data(table: &Table, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql("select ");
+        out.push_bind_param::<Text, _>(&table.object)?;
+        out.push_sql(" as entity, to_jsonb(e.*) as data");
+        Ok(())
+    }
+
+    /// Generate the `matches` CTE for `query_window` and `query_no_window`
+    /// When there is no window, we can already order and limit the results
+    /// of this `union all` query
+    fn select_matches(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        for (i, (table, filter)) in self.table_filter_pairs.iter().enumerate() {
+            if i > 0 {
+                out.push_sql("\nunion all\n");
+            }
+            out.push_sql("select ");
+            out.push_bind_param::<Text, _>(&table.object)?;
+            out.push_sql(" as entity, e.id, e.vid");
+            self.select_sort_key_and_window(out)?;
+            self.filtered_rows(table, filter, out.reborrow())?;
+        }
+        out.push_sql("\n ");
+        if self.window.is_none() {
+            self.order_by(out)?;
+            self.limit(out);
         }
         Ok(())
+    }
+
+    fn matches_to_json(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        for (i, (table, _)) in self.table_filter_pairs.iter().enumerate() {
+            if i > 0 {
+                out.push_sql("\nunion all\n");
+            }
+            out.push_sql("select m.entity, to_jsonb(e.*) as data, e.id");
+            self.select_sort_key_and_window(out)?;
+            out.push_sql("\n  from ");
+            out.push_identifier(&self.schema)?;
+            out.push_sql(".");
+            out.push_identifier(table.name.as_str())?;
+            out.push_sql(" e,");
+            out.push_sql(" matches m");
+            out.push_sql("\n where e.vid = m.vid and m.entity = ");
+            out.push_bind_param::<Text, _>(&table.object)?;
+            self.limit_per_window("m.pos", "\n   and ", out);
+        }
+        out.push_sql("\n ");
+        Ok(())
+    }
+    /// Only one table/filter pair, and no window
+    ///
+    /// Generate a query
+    ///   select '..' as entity, to_jsonb(e.*) as data
+    ///     from table e
+    ///    where filter
+    ///    order by .. limit .. skip ..
+    fn query_no_window_one_entity(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        let (table, filter) = self
+            .table_filter_pairs
+            .first()
+            .expect("we already checked that there is exactly one table");
+        Self::select_entity_and_data(table, &mut out)?;
+        self.filtered_rows(table, filter, out.reborrow())?;
+        self.order_by(&mut out)?;
+        self.limit(&mut out);
+        Ok(())
+    }
+
+    /// Only one table/filter pair, and a window
+    ///
+    /// Generate a query
+    ///   select '..' as entity, to_jsonb(e.*) as data
+    ///     from (select *, rank() over (partition by window order by ..) as pos
+    ///             from table e
+    ///            where filter) e
+    ///     where e.pos > skip and e.pos <= first + skip
+    ///     order by ..
+    fn query_window_one_entity(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        let (table, filter) = self
+            .table_filter_pairs
+            .first()
+            .expect("we already checked that there is exactly one table");
+        Self::select_entity_and_data(table, &mut out)?;
+        out.push_sql(" from (\n");
+        out.push_sql("select *");
+        self.rank_window(&mut out)?;
+        self.filtered_rows(table, filter, out.reborrow())?;
+        out.push_sql(") e");
+        self.limit_per_window("e.pos", "where ", &mut out);
+        out.push_sql("\n ");
+        self.order_by(&mut out)
+    }
+
+    fn query_no_window(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        // We have multiple tables which might have different schemas since
+        // the entity_types come from implementing the same interface. We
+        // need to do the query in two steps: first we build a CTE with the
+        // id's of entities matching the filter and order/limit. As a second
+        // step, we get matching rows from the underlying tables and convert
+        // them to JSONB.
+        //
+        // Overall, we generate a query
+        //
+        // with matches as (
+        //   select '...' as entity, id, vid
+        //     from table1
+        //    where entity_filter
+        //    union all
+        //    ...
+        //    order by ...
+        //    limit n offset m)
+        // select m.entity, to_jsonb(e.*) as data, sort_key, id
+        //   from table1 e, matches m
+        //  where e.vid = matches.vid and m.entity = '...'
+        //  union all
+        //  ...
+        //  order by ...
+        //
+        // If we have a window, we change the `matches` in the outer
+        // select to
+        //   (select *, rank() over (partition by {window} order by {order}) as pos
+        //    from matches m)
+        // We also do not do order by/limit inside the `matches` CTE, and
+        // replace the order by/limit on the outer query with
+        //    and m.pos > {skip} and m.pos <= {range.first + range.skip}
+
+        // Step 1: build matches CTE
+        out.push_sql("with matches as (");
+        self.select_matches(&mut out)?;
+        out.push_sql(")\n");
+
+        // Step 2: convert to JSONB
+        self.matches_to_json(&mut out)?;
+        self.order_by(&mut out)?;
+        Ok(())
+    }
+
+    fn query_window(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        // This is almost the same as `query_no_window`, except that we need to
+        // rank results in the `matches` CTE, and use `matches.pos` to restrict
+        // the rows that we return rather than use an `order by`
+        //
+        // Note that a CTE is an optimization fence, and since we use
+        // `matches` multiple times, we actually want to materialize it first
+        // before we fill in JSON data in the main query. As a consequence, we
+        // restrict the matches results per window in the `matches` CTE to
+        // avoid a possibly gigantic materialized `matches` view rather than
+        // leave that to the main query
+        //
+        // Overall, we generate a query
+        //
+        // with matches as (
+        //   -- limit the matches in each window
+        //   select e.*
+        //     from (
+        //       -- rank matches in the overall set of matching rows
+        //       select e.*,
+        //              rank() over (partition by window order by ..)
+        //         from (
+        //           -- find matching rows across all entity types
+        //           select '...' as entity, id, vid
+        //             from table1
+        //            where entity_filter
+        //            union all
+        //                  ...) e) e
+        //    where e.pos > skip and e.pos <= first + skip)
+        // select m.entity, to_jsonb(e.*) as data, sort_key, id
+        //   from table1 e, matches m
+        //  where e.vid = matches.vid and m.entity = '...'
+        //  union all
+        //  ...
+        //  order by ...
+
+        // Step 1: build matches CTE
+        out.push_sql("with matches as (");
+        out.push_sql("select e.* from (");
+        out.push_sql("select e.*");
+        self.rank_window(&mut out)?;
+        out.push_sql("\n from (");
+        self.select_matches(&mut out)?;
+        out.push_sql(") e) e\n");
+        self.limit_per_window("e.pos", " where ", &mut out);
+        out.push_sql(")\n");
+        // Step 2: convert to JSONB
+        self.matches_to_json(&mut out)?;
+        out.push_sql("\n ");
+        self.order_by(&mut out)
     }
 }
 
@@ -1040,96 +1280,12 @@ impl<'a> QueryFragment<Pg> for FilterQuery<'a> {
             return Ok(());
         }
 
-        // The queries are a little tricky because we need to defer generating
-        // JSONB until we actually know which rows we really need to make these
-        // queries fast; otherwise, Postgres spends too much time generating
-        // JSONB, most of which will never get used
-        if self.table_filter_pairs.len() == 1 {
-            // The common case is that we have just one table; for that we
-            // can generate a simpler/faster query. We generate
-            // select '..' as entity, to_jsonb(e.*) as data
-            // from (
-            //   select *
-            //     from schema.table
-            //    where entity_filter
-            //      and block_range @> INTMAX
-            //    order by ...
-            //    limit n offset m
-            // ) e
-            let (table, filter) = self
-                .table_filter_pairs
-                .first()
-                .expect("we just checked that there is exactly one");
-            out.push_sql("select ");
-            out.push_bind_param::<Text, _>(&table.object)?;
-            out.push_sql(
-                " as entity, to_jsonb(e.*) as data\n  from (\n  select *\
-                 \n",
-            );
-            self.filtered_rows(table, filter, out.reborrow())?;
-            self.order_by(&mut out)?;
-            self.limit(&mut out);
-            // close the outer select
-            out.push_sql(") e");
-        } else {
-            // We have multiple tables which might have different schemas since
-            // the entity_types come from implementing the same interface. We
-            // need to do the query in two steps: first we build a CTE with the
-            // id's of entities matching the filter and order/limit. As a second
-            // step, we get matching rows from the underlying tables and convert
-            // them to JSONB.
-            //
-            // Overall, we generate a query
-            //
-            // with matches as (
-            //   select '...' as entity, id, vid
-            //     from table1
-            //    where entity_filter
-            //    union all
-            //    ...
-            //    order by ...
-            //    limit n offset m)
-            // select matches.entity, to_jsonb(e.*) as data, sort_key, id
-            //   from table1 e, matches
-            //  where e.vid = matches.vid and matches.entity = '...'
-            //  union all
-            //  ...
-            //  order by ...
-
-            // Step 1: build matches CTE
-            out.push_sql("with matches as (");
-            for (i, (table, filter)) in self.table_filter_pairs.iter().enumerate() {
-                if i > 0 {
-                    out.push_sql("\nunion all\n");
-                }
-                out.push_sql("select ");
-                out.push_bind_param::<Text, _>(&table.object)?;
-                out.push_sql(" as entity, e.id, e.vid");
-                self.add_sort_key(&mut out)?;
-                self.filtered_rows(table, filter, out.reborrow())?;
-            }
-            self.order_by(&mut out)?;
-            self.limit(&mut out);
-            out.push_sql(")\n");
-
-            // Step 2: convert to JSONB
-            for (i, (table, _)) in self.table_filter_pairs.iter().enumerate() {
-                if i > 0 {
-                    out.push_sql("\nunion all\n");
-                }
-                out.push_sql("select matches.entity, to_jsonb(e.*) as data, e.id");
-                self.add_sort_key(&mut out)?;
-                out.push_sql("\n  from ");
-                out.push_identifier(&self.schema)?;
-                out.push_sql(".");
-                out.push_identifier(table.name.as_str())?;
-                out.push_sql(" e, matches");
-                out.push_sql("\n where e.vid = matches.vid and matches.entity = ");
-                out.push_bind_param::<Text, _>(&table.object)?;
-            }
-            self.order_by(&mut out)?;
+        match (self.table_filter_pairs.len(), self.window) {
+            (1, None) => self.query_no_window_one_entity(out),
+            (1, Some(_)) => self.query_window_one_entity(out),
+            (_, None) => self.query_no_window(out),
+            (_, Some(_)) => self.query_window(out),
         }
-        Ok(())
     }
 }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -357,6 +357,7 @@ impl Store {
             query.filter,
             order,
             query.range,
+            query.window,
             BLOCK_NUMBER_MAX,
         )
     }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -345,13 +345,7 @@ impl Store {
         // Add order by filters to query
         let order = match query.order_by {
             Some((attribute, value_type)) => {
-                let direction = query
-                    .order_direction
-                    .map(|direction| match direction {
-                        EntityOrder::Ascending => "ASC",
-                        EntityOrder::Descending => "DESC",
-                    })
-                    .unwrap_or("ASC");
+                let direction = query.order_direction.unwrap_or(EntityOrder::Ascending);
                 Some((attribute, value_type, direction))
             }
             None => None,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -356,8 +356,7 @@ impl Store {
             query.entity_types,
             query.filter,
             order,
-            query.range.first,
-            query.range.skip,
+            query.range,
             BLOCK_NUMBER_MAX,
         )
     }

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -426,6 +426,7 @@ fn count_scalar_entities(conn: &PgConnection, layout: &Layout) -> usize {
                 first: None,
                 skip: 0,
             },
+            None,
             BLOCK_NUMBER_MAX,
         )
         .expect("Count query failed")
@@ -516,6 +517,7 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
                 query.filter,
                 order,
                 query.range,
+                None,
                 BLOCK_NUMBER_MAX,
             )
             .expect("layout.query failed to execute query");
@@ -1654,6 +1656,7 @@ fn text_find(expected_entity_ids: Vec<&str>, filter: EntityFilter) {
                 query.filter,
                 order,
                 query.range,
+                None,
                 BLOCK_NUMBER_MAX,
             )
             .expect("layout.query failed to execute query");

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -546,6 +546,7 @@ fn find_interface() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -558,6 +559,7 @@ fn find_interface() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -570,6 +572,7 @@ fn find_interface() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -583,6 +586,7 @@ fn find_interface() {
             order_by: Some(("id".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -595,6 +599,7 @@ fn find_interface() {
             order_by: Some(("id".to_owned(), ValueType::String)),
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -613,6 +618,7 @@ fn find_string_contains() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -629,6 +635,7 @@ fn find_list_contains() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         }
     }
 
@@ -654,6 +661,7 @@ fn find_string_equal() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -670,6 +678,7 @@ fn find_string_equal() {
             order_by: Some(("id".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -688,6 +697,7 @@ fn find_string_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -706,6 +716,7 @@ fn find_string_greater_than() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -724,6 +735,7 @@ fn find_string_less_than_order_by_asc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -742,6 +754,7 @@ fn find_string_less_than_order_by_desc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -763,6 +776,7 @@ fn find_string_less_than_range() {
                 first: Some(1),
                 skip: 1,
             },
+            window: None,
         },
     )
 }
@@ -781,6 +795,7 @@ fn find_string_multiple_and() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -799,6 +814,7 @@ fn find_string_ends_with() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -817,6 +833,7 @@ fn find_string_not_ends_with() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -835,6 +852,7 @@ fn find_string_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -853,6 +871,7 @@ fn find_string_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -871,6 +890,7 @@ fn find_float_equal() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -889,6 +909,7 @@ fn find_float_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -907,6 +928,7 @@ fn find_float_greater_than() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -925,6 +947,7 @@ fn find_float_less_than() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -943,6 +966,7 @@ fn find_float_less_than_order_by_desc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -964,6 +988,7 @@ fn find_float_less_than_range() {
                 first: Some(1),
                 skip: 1,
             },
+            window: None,
         },
     )
 }
@@ -985,6 +1010,7 @@ fn find_float_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1006,6 +1032,7 @@ fn find_float_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1024,6 +1051,7 @@ fn find_int_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1042,6 +1070,7 @@ fn find_int_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1060,6 +1089,7 @@ fn find_int_greater_than() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1078,6 +1108,7 @@ fn find_int_greater_or_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1096,6 +1127,7 @@ fn find_int_less_than() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1114,6 +1146,7 @@ fn find_int_less_or_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1132,6 +1165,7 @@ fn find_int_less_than_order_by_desc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1153,6 +1187,7 @@ fn find_int_less_than_range() {
                 first: Some(1),
                 skip: 1,
             },
+            window: None,
         },
     )
 }
@@ -1171,6 +1206,7 @@ fn find_int_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1189,6 +1225,7 @@ fn find_int_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1207,6 +1244,7 @@ fn find_bool_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1225,6 +1263,7 @@ fn find_bool_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1243,6 +1282,7 @@ fn find_bool_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1261,6 +1301,7 @@ fn find_bool_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1279,6 +1320,7 @@ fn find_bytes_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1297,6 +1339,7 @@ fn find_null_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1312,6 +1355,7 @@ fn find_null_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1330,6 +1374,7 @@ fn find_null_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -1345,6 +1390,7 @@ fn find_null_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1360,6 +1406,7 @@ fn find_order_by_float() {
             order_by: Some(("weight".to_owned(), ValueType::BigDecimal)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1371,6 +1418,7 @@ fn find_order_by_float() {
             order_by: Some(("weight".to_owned(), ValueType::BigDecimal)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1386,6 +1434,7 @@ fn find_order_by_id() {
             order_by: Some(("id".to_owned(), ValueType::ID)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1397,6 +1446,7 @@ fn find_order_by_id() {
             order_by: Some(("id".to_owned(), ValueType::ID)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1412,6 +1462,7 @@ fn find_order_by_int() {
             order_by: Some(("age".to_owned(), ValueType::Int)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1423,6 +1474,7 @@ fn find_order_by_int() {
             order_by: Some(("age".to_owned(), ValueType::Int)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1438,6 +1490,7 @@ fn find_order_by_string() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1449,6 +1502,7 @@ fn find_order_by_string() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1467,6 +1521,7 @@ fn find_where_nested_and_or() {
             order_by: Some(("id".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1485,6 +1540,7 @@ fn find_enum_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1503,6 +1559,7 @@ fn find_enum_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1521,6 +1578,7 @@ fn find_enum_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1539,6 +1597,7 @@ fn find_enum_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1577,6 +1636,7 @@ fn text_find(expected_entity_ids: Vec<&str>, filter: EntityFilter) {
             order_by: Some(("id".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         };
 
         let order = match query.order_by {
@@ -1743,6 +1803,7 @@ fn find_empty_and_or() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -1756,6 +1817,7 @@ fn find_empty_and_or() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -501,13 +501,7 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
 
         let order = match query.order_by {
             Some((attribute, value_type)) => {
-                let direction = query
-                    .order_direction
-                    .map(|direction| match direction {
-                        EntityOrder::Ascending => "ASC",
-                        EntityOrder::Descending => "DESC",
-                    })
-                    .unwrap_or("ASC");
+                let direction = query.order_direction.unwrap_or(EntityOrder::Ascending);
                 Some((attribute, value_type, direction))
             }
             None => None,
@@ -1586,13 +1580,7 @@ fn text_find(expected_entity_ids: Vec<&str>, filter: EntityFilter) {
 
         let order = match query.order_by {
             Some((attribute, value_type)) => {
-                let direction = query
-                    .order_direction
-                    .map(|direction| match direction {
-                        EntityOrder::Ascending => "ASC",
-                        EntityOrder::Descending => "DESC",
-                    })
-                    .unwrap_or("ASC");
+                let direction = query.order_direction.unwrap_or(EntityOrder::Ascending);
                 Some((attribute, value_type, direction))
             }
             None => None,

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -169,14 +169,7 @@ fn insert_user_entity(
             .unwrap_or(Value::Null),
     );
     if let Some(drinks) = drinks {
-        user.insert(
-            "drinks".to_owned(),
-            drinks
-                .into_iter()
-                .map(|drink| drink.into())
-                .collect::<Vec<_>>()
-                .into(),
-        );
+        user.insert("drinks".to_owned(), drinks.into());
     }
 
     insert_entity(conn, layout, entity_type, user);
@@ -632,12 +625,7 @@ fn find_string_contains() {
 #[test]
 fn find_list_contains() {
     fn query(v: Vec<&str>) -> EntityQuery {
-        let drinks: Option<Value> = Some(
-            v.into_iter()
-                .map(|drink| drink.into())
-                .collect::<Vec<_>>()
-                .into(),
-        );
+        let drinks: Option<Value> = Some(v.into());
         let filter = Some(EntityFilter::Contains("drinks".into(), drinks.into()));
         EntityQuery {
             subgraph_id: THINGS_SUBGRAPH_ID.clone(),

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -422,8 +422,10 @@ fn count_scalar_entities(conn: &PgConnection, layout: &Layout) -> usize {
             vec!["Scalar".to_owned()],
             Some(filter),
             None,
-            None,
-            0,
+            EntityRange {
+                first: None,
+                skip: 0,
+            },
             BLOCK_NUMBER_MAX,
         )
         .expect("Count query failed")
@@ -513,8 +515,7 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
                 query.entity_types,
                 query.filter,
                 order,
-                query.range.first,
-                query.range.skip,
+                query.range,
                 BLOCK_NUMBER_MAX,
             )
             .expect("layout.query failed to execute query");
@@ -1592,8 +1593,7 @@ fn text_find(expected_entity_ids: Vec<&str>, filter: EntityFilter) {
                 query.entity_types,
                 query.filter,
                 order,
-                query.range.first,
-                query.range.skip,
+                query.range,
                 BLOCK_NUMBER_MAX,
             )
             .expect("layout.query failed to execute query");

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -18,7 +18,13 @@ use graph_store_postgres::Store as DieselStore;
 use web3::types::{Address, H256};
 
 const USER_GQL: &str = "
-    type User @entity {
+    interface ColorAndAge {
+        id: ID!,
+        age: Int,
+        favorite_color: String
+    }
+
+    type User implements ColorAndAge @entity {
         id: ID!,
         name: String,
         bin_name: Bytes,
@@ -27,6 +33,13 @@ const USER_GQL: &str = "
         seconds_age: BigInt,
         weight: BigDecimal,
         coffee: Boolean,
+        favorite_color: String
+    }
+
+    type Person implements ColorAndAge @entity {
+        id: ID!,
+        name: String,
+        age: Int,
         favorite_color: String
     }
 
@@ -2328,4 +2341,192 @@ fn handle_large_string_with_index() {
 
         Ok(())
     })
+}
+
+#[derive(Clone)]
+struct WindowQuery(EntityQuery, Arc<DieselStore>);
+
+impl WindowQuery {
+    fn new(store: &Arc<DieselStore>) -> Self {
+        WindowQuery(
+            EntityQuery {
+                subgraph_id: TEST_SUBGRAPH_ID.clone(),
+                entity_types: vec![USER.to_owned()],
+                filter: Some(EntityFilter::GreaterThan("age".into(), Value::from(0))),
+                order_by: None,
+                order_direction: None,
+                range: EntityRange::first(10),
+                window: Some("favorite_color".to_owned()),
+            },
+            store.clone(),
+        )
+    }
+
+    fn first(self, first: u32) -> Self {
+        WindowQuery(
+            EntityQuery {
+                range: EntityRange::first(first),
+                ..self.0
+            },
+            self.1,
+        )
+    }
+
+    fn skip(self, skip: u32) -> Self {
+        WindowQuery(
+            EntityQuery {
+                range: EntityRange {
+                    first: self.0.range.first,
+                    skip,
+                },
+                ..self.0
+            },
+            self.1,
+        )
+    }
+
+    fn order(self, attr: &str, dir: EntityOrder) -> Self {
+        WindowQuery(
+            EntityQuery {
+                order_by: Some((attr.to_owned(), ValueType::String)),
+                order_direction: Some(dir),
+                ..self.0
+            },
+            self.1,
+        )
+    }
+
+    fn above(self, age: i32) -> Self {
+        WindowQuery(
+            EntityQuery {
+                filter: Some(EntityFilter::GreaterThan("age".into(), Value::from(age))),
+                ..self.0
+            },
+            self.1,
+        )
+    }
+
+    fn against_color_and_age(self) -> Self {
+        WindowQuery(
+            EntityQuery {
+                entity_types: vec![USER.to_owned(), "Person".to_owned()],
+                ..self.0
+            },
+            self.1,
+        )
+    }
+
+    fn expect(&self, expected_ids: Vec<&str>, qid: &str) {
+        let query = self.0.clone();
+        let store = &self.1;
+        let entity_ids = store
+            .find(query)
+            .expect("store.find failed to execute query")
+            .into_iter()
+            .map(|entity| match entity.get("id") {
+                Some(Value::String(id)) => id.to_owned(),
+                Some(_) => panic!("store.find returned entity with non-string ID attribute"),
+                None => panic!("store.find returned entity with no ID attribute"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(expected_ids, entity_ids, "Failed query: {}", qid);
+    }
+}
+
+#[test]
+fn window() {
+    fn make_color_end_age(entity_type: &str, id: &str, color: &str, age: i32) -> EntityOperation {
+        let mut entity = Entity::new();
+
+        entity.set("id", id.to_owned());
+        entity.set("age", age);
+        entity.set("favorite_color", color);
+        EntityOperation::Set {
+            key: EntityKey {
+                subgraph_id: TEST_SUBGRAPH_ID.clone(),
+                entity_type: entity_type.to_owned(),
+                entity_id: id.to_owned(),
+            },
+            data: entity,
+        }
+    }
+
+    fn make_user(id: &str, color: &str, age: i32) -> EntityOperation {
+        make_color_end_age(USER, id, color, age)
+    }
+
+    fn make_person(id: &str, color: &str, age: i32) -> EntityOperation {
+        make_color_end_age("Person", id, color, age)
+    }
+
+    let ops = vec![
+        make_user("4", "green", 34),
+        make_user("5", "green", 17),
+        make_user("6", "green", 41),
+        make_user("7", "red", 25),
+        make_user("8", "red", 45),
+        make_user("9", "yellow", 37),
+        make_user("10", "blue", 27),
+        make_user("11", "blue", 19),
+        make_person("p1", "green", 12),
+        make_person("p2", "red", 15),
+    ];
+
+    run_test(|store| -> Result<(), ()> {
+        use EntityOrder::*;
+
+        transact_entity_operations(&store, TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_3_PTR, ops)
+            .expect("Failed to create test users");
+
+        // Get the first 2 entries in each 'color group'
+        WindowQuery::new(&store)
+            .first(2)
+            .expect(vec!["1", "10", "11", "2", "3", "4", "5", "7", "9"], "q1");
+
+        WindowQuery::new(&store)
+            .first(1)
+            .expect(vec!["1", "10", "2", "4", "9"], "q2");
+
+        WindowQuery::new(&store)
+            .first(1)
+            .skip(1)
+            .expect(vec!["11", "3", "5", "7"], "q3");
+
+        WindowQuery::new(&store)
+            .first(1)
+            .skip(1)
+            .order("id", Descending)
+            .expect(vec!["7", "5", "10", "1"], "q4");
+
+        WindowQuery::new(&store)
+            .first(1)
+            .skip(1)
+            .order("favorite_color", Descending)
+            .expect(vec!["7", "5", "11", "3"], "q5");
+
+        WindowQuery::new(&store)
+            .first(1)
+            .skip(1)
+            .order("favorite_color", Descending)
+            .above(25)
+            .expect(vec!["8", "6", "3"], "q6");
+
+        // Check queries for interfaces
+        WindowQuery::new(&store)
+            .first(1)
+            .skip(1)
+            .order("favorite_color", Descending)
+            .above(12)
+            .against_color_and_age()
+            .expect(vec!["7", "5", "11", "3"], "q7");
+
+        WindowQuery::new(&store)
+            .first(1)
+            .order("age", Ascending)
+            .above(12)
+            .against_color_and_age()
+            .expect(vec!["p2", "5", "11", "3", "9"], "q8");
+
+        Ok(())
+    });
 }

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -571,6 +571,7 @@ fn find_string_contains() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -589,6 +590,7 @@ fn find_string_equal() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -607,6 +609,7 @@ fn find_string_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -625,6 +628,7 @@ fn find_string_greater_than() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -643,6 +647,7 @@ fn find_string_less_than_order_by_asc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -661,6 +666,7 @@ fn find_string_less_than_order_by_desc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -682,6 +688,7 @@ fn find_string_less_than_range() {
                 first: Some(1),
                 skip: 1,
             },
+            window: None,
         },
     )
 }
@@ -700,6 +707,7 @@ fn find_string_multiple_and() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -718,6 +726,7 @@ fn find_string_ends_with() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -736,6 +745,7 @@ fn find_string_not_ends_with() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -754,6 +764,7 @@ fn find_string_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -772,6 +783,7 @@ fn find_string_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -790,6 +802,7 @@ fn find_float_equal() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -808,6 +821,7 @@ fn find_float_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -826,6 +840,7 @@ fn find_float_greater_than() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -844,6 +859,7 @@ fn find_float_less_than() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -862,6 +878,7 @@ fn find_float_less_than_order_by_desc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -883,6 +900,7 @@ fn find_float_less_than_range() {
                 first: Some(1),
                 skip: 1,
             },
+            window: None,
         },
     )
 }
@@ -904,6 +922,7 @@ fn find_float_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -925,6 +944,7 @@ fn find_float_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -943,6 +963,7 @@ fn find_int_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -961,6 +982,7 @@ fn find_int_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -979,6 +1001,7 @@ fn find_int_greater_than() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -997,6 +1020,7 @@ fn find_int_greater_or_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1015,6 +1039,7 @@ fn find_int_less_than() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1033,6 +1058,7 @@ fn find_int_less_or_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1051,6 +1077,7 @@ fn find_int_less_than_order_by_desc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1072,6 +1099,7 @@ fn find_int_less_than_range() {
                 first: Some(1),
                 skip: 1,
             },
+            window: None,
         },
     )
 }
@@ -1090,6 +1118,7 @@ fn find_int_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1108,6 +1137,7 @@ fn find_int_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1126,6 +1156,7 @@ fn find_bool_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1144,6 +1175,7 @@ fn find_bool_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1162,6 +1194,7 @@ fn find_bool_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1180,6 +1213,7 @@ fn find_bool_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1198,6 +1232,7 @@ fn find_bytes_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1216,6 +1251,7 @@ fn find_null_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1231,6 +1267,7 @@ fn find_null_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1249,6 +1286,7 @@ fn find_null_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1264,6 +1302,7 @@ fn find_order_by_float() {
             order_by: Some(("weight".to_owned(), ValueType::BigDecimal)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1275,6 +1314,7 @@ fn find_order_by_float() {
             order_by: Some(("weight".to_owned(), ValueType::BigDecimal)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1290,6 +1330,7 @@ fn find_order_by_id() {
             order_by: Some(("id".to_owned(), ValueType::ID)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1301,6 +1342,7 @@ fn find_order_by_id() {
             order_by: Some(("id".to_owned(), ValueType::ID)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1316,6 +1358,7 @@ fn find_order_by_int() {
             order_by: Some(("age".to_owned(), ValueType::Int)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1327,6 +1370,7 @@ fn find_order_by_int() {
             order_by: Some(("age".to_owned(), ValueType::Int)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1342,6 +1386,7 @@ fn find_order_by_string() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1353,6 +1398,7 @@ fn find_order_by_string() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1371,6 +1417,7 @@ fn find_where_nested_and_or() {
             order_by: Some(("id".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1496,6 +1543,7 @@ fn check_basic_revert(
         order_by: Some(("name".to_owned(), ValueType::String)),
         order_direction: Some(EntityOrder::Descending),
         range: EntityRange::first(100),
+        window: None,
     };
 
     let subscription = subscribe_and_consume(store.clone(), subgraph_id, entity_type);
@@ -1568,6 +1616,7 @@ fn revert_block_with_delete() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         };
 
         // Delete entity with id=2


### PR DESCRIPTION
For a query like `parents { id children { id } }` we used to run `1 + number(parents)` queries, one to get the parents, and then one query to get the children of each parent. The more deeply a query was nested, the more this effect compounded.

With this PR, we will now run 2 queries: one to get the parents, and one to get all children for the parents.

It is possible to have `graph-node` compare the results of execution with and without prefetching by adding a `@verify` directive to the query, as in `query stuff @verify { .. }` (this must use the form with an explicit `query` keyword) In this mode, the query will be executed in the old and the new way; if the two results differ, the query returns an error that contains both result for manual comparison.

It is also possible to completely turn off prefetching by setting the environment variable `GRAPH_GRAPHQL_NO_PREFETCH`; if that variable is set to anything at all, query execution behaves like it did before this PR. (see #1340)
