### PR TITLE
Remove use of `.wait()`

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -508,10 +508,10 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
     })
     .map(move |(network_name, network_identifier)| {
         info!(
-        stores_logger,
-        "Connected to Ethereum";
-        "network" => &network_name,
-        "network_version" => &network_identifier.net_version,
+            stores_logger,
+            "Connected to Ethereum";
+            "network" => &network_name,
+            "network_version" => &network_identifier.net_version,
         );
         (
             network_name.to_string(),


### PR DESCRIPTION
This was causing the node to hang at startup if the `network_identifiers` calls had to retry, for example due to rate limits. Most of the diff is from having to indent the rest of main.

