### PR TITLE
Fix race condition in stopwatch

### DIFF
--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -57,7 +57,7 @@ pub fn spawn_module(
                 )?;
                 section.end();
 
-                let _section = host_metrics.stopwatch.start_section("run_handler");
+                let section = host_metrics.stopwatch.start_section("run_handler");
                 let result = match trigger {
                     MappingTrigger::Log {
                         transaction,
@@ -87,6 +87,7 @@ pub fn spawn_module(
                         module.handle_ethereum_block(handler.handler.as_str())
                     }
                 };
+                section.end();
 
                 result_sender
                     .send((result, future::ok(Instant::now())))


### PR DESCRIPTION
We've seen the `transact_block` section start before `run_handler` ended because the section was being dropped only after the result was sent.

