### PR TITLE
Subdivide `transact_block` stopwatch category

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.16.1",
  "graph-graphql 0.16.1",
+ "graph-mock 0.16.1",
  "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -751,10 +751,12 @@ where
         // Transact entity operations into the store and update the
         // subgraph's block stream pointer
         let _section = ctx.host_metrics.stopwatch.start_section("transact_block");
+        let subgraph_id = ctx.inputs.deployment_id.clone();
+        let stopwatch = ctx.host_metrics.stopwatch.clone();
         let start = Instant::now();
         ctx.inputs
             .store
-            .transact_block_operations(ctx.inputs.deployment_id.clone(), block_ptr_after, mods)
+            .transact_block_operations(subgraph_id, block_ptr_after, mods, stopwatch)
             .map(|should_migrate| {
                 let elapsed = start.elapsed().as_secs_f64();
                 metrics.block_ops_transaction_duration.observe(elapsed);

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -625,6 +625,7 @@ pub trait Store: Send + Sync + 'static {
         subgraph_id: SubgraphDeploymentId,
         block_ptr_to: EthereumBlockPointer,
         mods: Vec<EntityModification>,
+        stopwatch: StopwatchMetrics,
     ) -> Result<bool, StoreError>;
 
     /// Apply the specified metadata operations.

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -188,6 +188,7 @@ impl Store for MockStore {
         _: SubgraphDeploymentId,
         _: EthereumBlockPointer,
         _: Vec<EntityModification>,
+        _: StopwatchMetrics,
     ) -> Result<bool, StoreError> {
         unimplemented!();
     }
@@ -487,6 +488,7 @@ impl Store for FakeStore {
         _: SubgraphDeploymentId,
         _: EthereumBlockPointer,
         _: Vec<EntityModification>,
+        _: StopwatchMetrics,
     ) -> Result<bool, StoreError> {
         unimplemented!();
     }

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -30,3 +30,4 @@ hex = "0.4.0"
 parity-wasm = "0.40"
 test-store = { path = "../test-store" }
 hex-literal = "0.2"
+graph-mock = { path = "../../mock" }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -566,12 +566,16 @@ impl Store {
                     let section = stopwatch.start_section("check_interface_entity_uniqueness");
                     self.check_interface_entity_uniqueness(conn, &key)?;
                     section.end();
+
+                    let _section = stopwatch.start_section("apply_entity_modifications_update");
                     conn.update(&key, &data, history_event).map(|_| 0)
                 }
                 Insert { key, data } => {
                     let section = stopwatch.start_section("check_interface_entity_uniqueness");
                     self.check_interface_entity_uniqueness(conn, &key)?;
                     section.end();
+
+                    let _section = stopwatch.start_section("apply_entity_modifications_insert");
                     conn.insert(&key, &data, history_event).map(|_| 1)
                 }
                 Remove { key } => conn

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -553,6 +553,7 @@ impl Store {
         conn: &e::Connection,
         mods: Vec<EntityModification>,
         history_event: Option<&HistoryEvent>,
+        stopwatch: StopwatchMetrics,
     ) -> Result<(), StoreError> {
         let mut count = 0;
 
@@ -562,11 +563,15 @@ impl Store {
             let do_count = !modification.entity_key().subgraph_id.is_meta();
             let n = match modification {
                 Overwrite { key, data } => {
+                    let section = stopwatch.start_section("check_interface_entity_uniqueness");
                     self.check_interface_entity_uniqueness(conn, &key)?;
+                    section.end();
                     conn.update(&key, &data, history_event).map(|_| 0)
                 }
                 Insert { key, data } => {
+                    let section = stopwatch.start_section("check_interface_entity_uniqueness");
                     self.check_interface_entity_uniqueness(conn, &key)?;
+                    section.end();
                     conn.insert(&key, &data, history_event).map(|_| 1)
                 }
                 Remove { key } => conn
@@ -854,6 +859,7 @@ impl StoreTrait for Store {
         subgraph_id: SubgraphDeploymentId,
         block_ptr_to: EthereumBlockPointer,
         mods: Vec<EntityModification>,
+        stopwatch: StopwatchMetrics,
     ) -> Result<bool, StoreError> {
         // All operations should apply only to entities in this subgraph or
         // the subgraph of subgraphs
@@ -889,7 +895,9 @@ impl StoreTrait for Store {
                 let event: StoreEvent = mods.iter().collect();
 
                 // Make the changes
-                self.apply_entity_modifications(&econn, mods, Some(&history_event))?;
+                let section = stopwatch.start_section("apply_entity_modifications");
+                self.apply_entity_modifications(&econn, mods, Some(&history_event), stopwatch)?;
+                section.end();
 
                 // Update the subgraph block pointer, without an event source; this way
                 // no entity history is recorded for the block pointer update itself

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -77,12 +77,17 @@ pub fn transact_entity_operations(
     subgraph_id: SubgraphDeploymentId,
     block_ptr_to: EthereumBlockPointer,
     ops: Vec<EntityOperation>,
-    _: StopwatchMetrics,
 ) -> Result<bool, StoreError> {
     let mut entity_cache = EntityCache::new();
     entity_cache.append(ops);
     let mods = entity_cache
         .as_modifications(store.as_ref())
         .expect("failed to convert to modifications");
-    store.transact_block_operations(subgraph_id, block_ptr_to, mods)
+    let metrics_registry = Arc::new(MockMetricsRegistry::new());
+    let stopwatch_metrics = StopwatchMetrics::new(
+        Logger::root(slog::Discard, o!()),
+        subgraph_id.clone(),
+        metrics_registry.clone(),
+    );
+    store.transact_block_operations(subgraph_id, block_ptr_to, mods, stopwatch_metrics)
 }

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -77,6 +77,7 @@ pub fn transact_entity_operations(
     subgraph_id: SubgraphDeploymentId,
     block_ptr_to: EthereumBlockPointer,
     ops: Vec<EntityOperation>,
+    _: StopwatchMetrics,
 ) -> Result<bool, StoreError> {
     let mut entity_cache = EntityCache::new();
     entity_cache.append(ops);


### PR DESCRIPTION
In local tests, most time is spent in `apply_entity_modifications`. Dashboard PR https://github.com/graphprotocol/instrumentation/pull/2.

