### PR TITLE
Fix db contention metric, introduce global counters

### DIFF
--- a/graph/src/components/metrics.rs
+++ b/graph/src/components/metrics.rs
@@ -32,6 +32,8 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         const_labels: HashMap<String, String>,
     ) -> Result<Box<Counter>, PrometheusError>;
 
+    fn global_counter(&self, name: String) -> Result<Counter, PrometheusError>;
+
     fn new_counter_vec(
         &self,
         name: String,

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -62,6 +62,11 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
         Ok(counter)
     }
 
+    fn global_counter(&self, name: String) -> Result<Counter, PrometheusError> {
+        let opts = Opts::new(name, "global_counter".to_owned());
+        Counter::with_opts(opts)
+    }
+
     fn new_counter_vec(
         &self,
         name: String,


### PR DESCRIPTION
It wouldn't work in a multi-network node because the "generic store" would register the metric first and then the store which really owned the subgraph could not register. This removes the counters from the store and lets the metrics registry centralize keeping track of them.