### PR TITLE
Add Ethereum network indexer (phase 1: blocks only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,6 +514,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +565,19 @@ dependencies = [
  "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "derive_state_machine_future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -640,6 +684,11 @@ dependencies = [
  "redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dtoa"
@@ -795,6 +844,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +867,11 @@ dependencies = [
 [[package]]
 name = "foreign-types-shared"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fragile"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -916,6 +978,7 @@ dependencies = [
  "ipfs-api 0.5.1 (git+https://github.com/ferristseng/rust-ipfs-api)",
  "isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mockall 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -946,13 +1009,21 @@ dependencies = [
 name = "graph-chain-ethereum"
 version = "0.17.0"
 dependencies = [
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.17.0",
+ "graph-core 0.17.0",
  "graph-mock 0.17.0",
+ "graph-store-postgres 0.17.0",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mockall 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "test-store 0.1.0",
 ]
 
 [[package]]
@@ -1345,6 +1416,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,6 +1792,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "downcast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fragile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mockall_derive 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1874,11 @@ dependencies = [
 [[package]]
 name = "nodrop"
 version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2023,6 +2129,32 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "predicates"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "float-cmp 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2394,6 +2526,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rent_to_own"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "reqwest"
 version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,6 +2867,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "state_machine_future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "derive_state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rent_to_own 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "static_assertions"
@@ -3185,6 +3332,11 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3591,8 +3743,12 @@ dependencies = [
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum ctor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3b4c17619643c1252b5f690084b82639dd7fac141c57c8e77a00e0148132092c"
+"checksum darling 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9158d690bc62a3a57c3e45b85e4d50de2008b39345592c64efd79345c7e24be0"
+"checksum darling_core 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d2a368589465391e127e10c9e3a08efc8df66fd49b87dc8524c764bbe7f2ef82"
+"checksum darling_macro 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "244e8987bd4e174385240cde20a3657f607fb0797563c28255c353b5819a07b1"
 "checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
 "checksum derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2159be042979966de68315bce7034bb000c775f22e3e834e1c52ff78f041cae8"
+"checksum derive_state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1220ad071cb8996454c20adf547a34ba3ac793759dab793d9dc04996a373ac83"
 "checksum diesel 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d7cc03b910de9935007861dce440881f69102aaaedfd4bc5a6f40340ca5840c"
 "checksum diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "adbaf5e1344edeedc4d1cead2dc3ce6fc4115bb26b3704c533b92717940f2fb5"
 "checksum diesel-dynamic-schema 1.0.0 (git+https://github.com/diesel-rs/diesel-dynamic-schema?rev=a8ec4fb1)" = "<none>"
@@ -3604,6 +3760,7 @@ dependencies = [
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+"checksum downcast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
@@ -3621,9 +3778,11 @@ dependencies = [
 "checksum fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d1a683d1234507e4f3bf2736eeddf0de1dc65996dc0164d57eba0a74bcf29489"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f87e68aa82b2de08a6e037f1385455759df6e445a8df5e005b4297191dbf18aa"
+"checksum float-cmp 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75224bec9bfe1a65e2d34132933f2de7fe79900c96a0174307554244ece8150e"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum fragile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f8140122fa0d5dcb9fc8627cfce2b37cc1500f752636d46ea28bc26785c2f9"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -3652,6 +3811,7 @@ dependencies = [
 "checksum hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
 "checksum hyper-multipart-rfc7578 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da7afa9e68d0f45a2790fe76b49b52b50db057502d839187341a7575060c65b9"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
+"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum impl-codec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2050d823639fbeae26b2b5ba09aca8907793117324858070ade0673c49f793b"
 "checksum impl-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f39b9963cf5f12fcc4ae4b30a6927ed67d6b4ea4cbe7d17a41131163b401303b"
@@ -3695,12 +3855,15 @@ dependencies = [
 "checksum mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum mockall 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7601dfc82314f4e4ad844055452f71c1d5d171e4b530f817b9353bb2e63a271d"
+"checksum mockall_derive 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a26211f315c132a546ed185f3a17f7617a8e58d8511025d5f8665017194cf8be"
 "checksum multiaddr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "46c47add5e6a96020ca53393aebf77193fd5f578a4e7a73ab505f41e4be06e8c"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
 "checksum multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c62469025f45dee2464ef9fc845f4683c543993792c1993e7d903c17a4546b74"
 "checksum native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2e0a1a39eab95caf4f5556da9289b9e68f0aafac901b2ce80daaf020d3b733a8"
 "checksum num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9c3f34cdd24f334cb265d9bf8bfa8a241920d026916785747a92f0e55541a1a"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
@@ -3729,6 +3892,9 @@ dependencies = [
 "checksum postgres-shared 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ffac35b3e0029b404c24a3b82149b4e904f293e8ca4a327eefa24d3ca50df36f"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum pq-sys 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
+"checksum predicates 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a9bfe52247e5cc9b2f943682a85a5549fb9662245caf094504e69a2f03fe64d4"
+"checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+"checksum predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum primitive-types 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2288eb2a39386c4bc817974cc413afe173010dc80e470fcb1e9a35580869f024"
 "checksum proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "982a35d1194084ba319d65c4a68d24ca28f5fdb5b8bc20899e4eef8641ea5178"
@@ -3769,6 +3935,7 @@ dependencies = [
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9b01330cce219c1c6b2e209e5ed64ccd587ae5c67bed91c0b49eecf02ae40e21"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rent_to_own 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05a51ad2b1c5c710fa89e6b1631068dab84ed687bc6a5fe061ad65da3d0c25b2"
 "checksum reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 "checksum rlp 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fa2f7f9c612d133da9101ef7bcd3e603ca7098901eca852e71f87a83dd3e6b59"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
@@ -3810,6 +3977,7 @@ dependencies = [
 "checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "530e1d624baae485bce12e6647acb76aafa253346ee8a16751974eed5a24b13d"
 "checksum static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum stringprep 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
@@ -3852,6 +4020,7 @@ dependencies = [
 "checksum tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+"checksum treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum tungstenite 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e9573852f935883137b7f0824832493ce7418bf290c8cf164b7aafc9b0a99aa0"

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -11,3 +11,12 @@ graph = { path = "../../graph" }
 mock = { package = "graph-mock", path = "../../mock" }
 lazy_static = "1.2.0"
 hex-literal = "0.2"
+state_machine_future = "0.2"
+
+[dev-dependencies]
+diesel = { version = "1.4.2", features = ["postgres", "serde_json", "numeric", "r2d2"] }
+mockall = "0.5.0"
+graph-core = { path = "../../core" }
+graph-store-postgres = { path = "../../store/postgres" }
+pretty_assertions = "0.6.1"
+test-store = { path = "../../store/test-store" }

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.17.0"
 edition = "2018"
 
 [dependencies]
+chrono = "0.4"
 failure = "0.1.6"
 futures = "0.1.21"
 jsonrpc-core = "13.2.0"

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1118,50 +1118,6 @@ where
         )
     }
 
-    fn triggers_in_block(
-        self: Arc<Self>,
-        logger: Logger,
-        chain_store: Arc<dyn ChainStore>,
-        subgraph_metrics: Arc<SubgraphEthRpcMetrics>,
-        log_filter: EthereumLogFilter,
-        call_filter: EthereumCallFilter,
-        block_filter: EthereumBlockFilter,
-        ethereum_block: BlockFinality,
-    ) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send> {
-        Box::new(match &ethereum_block {
-            BlockFinality::Final(block) => Box::new(
-                self.blocks_with_triggers(
-                    logger,
-                    chain_store,
-                    subgraph_metrics,
-                    block.number(),
-                    block.number(),
-                    log_filter.clone(),
-                    call_filter.clone(),
-                    block_filter.clone(),
-                )
-                .map(|blocks| {
-                    assert!(blocks.len() <= 1);
-                    blocks
-                        .into_iter()
-                        .next()
-                        .unwrap_or(EthereumBlockWithTriggers::new(vec![], ethereum_block))
-                }),
-            )
-                as Box<dyn Future<Item = _, Error = _> + Send>,
-            BlockFinality::NonFinal(full_block) => Box::new(future::ok({
-                let mut triggers = Vec::new();
-                triggers.append(&mut parse_log_triggers(
-                    log_filter,
-                    &full_block.ethereum_block,
-                ));
-                triggers.append(&mut parse_call_triggers(call_filter, &full_block));
-                triggers.append(&mut parse_block_triggers(block_filter, &full_block));
-                EthereumBlockWithTriggers::new(triggers, ethereum_block)
-            })),
-        })
-    }
-
     /// Load Ethereum blocks in bulk, returning results as they come back as a Stream.
     fn load_blocks(
         &self,
@@ -1213,60 +1169,4 @@ where
                 .collect(),
         )
     }
-}
-
-fn parse_log_triggers(
-    log_filter: EthereumLogFilter,
-    block: &EthereumBlock,
-) -> Vec<EthereumTrigger> {
-    block
-        .transaction_receipts
-        .iter()
-        .flat_map(move |receipt| {
-            let log_filter = log_filter.clone();
-            receipt
-                .logs
-                .iter()
-                .filter(move |log| log_filter.matches(log))
-                .map(move |log| EthereumTrigger::Log(log.clone()))
-        })
-        .collect()
-}
-
-fn parse_call_triggers(
-    call_filter: EthereumCallFilter,
-    block: &EthereumBlockWithCalls,
-) -> Vec<EthereumTrigger> {
-    block.calls.as_ref().map_or(vec![], |calls| {
-        calls
-            .iter()
-            .filter(move |call| call_filter.matches(call))
-            .map(move |call| EthereumTrigger::Call(call.clone()))
-            .collect()
-    })
-}
-
-fn parse_block_triggers(
-    block_filter: EthereumBlockFilter,
-    block: &EthereumBlockWithCalls,
-) -> Vec<EthereumTrigger> {
-    let block_ptr = EthereumBlockPointer::from(&block.ethereum_block);
-    let trigger_every_block = block_filter.trigger_every_block;
-    let call_filter = EthereumCallFilter::from(block_filter);
-    let mut triggers = block.calls.as_ref().map_or(vec![], |calls| {
-        calls
-            .iter()
-            .filter(move |call| call_filter.matches(call))
-            .map(move |call| {
-                EthereumTrigger::Block(block_ptr, EthereumBlockTriggerType::WithCallTo(call.to))
-            })
-            .collect::<Vec<EthereumTrigger>>()
-    });
-    if trigger_every_block {
-        triggers.push(EthereumTrigger::Block(
-            block_ptr,
-            EthereumBlockTriggerType::Every,
-        ));
-    }
-    triggers
 }

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -684,6 +684,34 @@ where
         )
     }
 
+    fn block_by_number(
+        &self,
+        logger: &Logger,
+        block_number: u64,
+    ) -> Box<dyn Future<Item = Option<LightEthereumBlock>, Error = Error> + Send> {
+        let web3 = self.web3.clone();
+        let logger = logger.clone();
+
+        Box::new(
+            retry("eth_getBlockByNumber RPC call", &logger)
+                .no_limit()
+                .timeout_secs(*JSON_RPC_TIMEOUT)
+                .run(move || {
+                    web3.eth()
+                        .block_with_txs(BlockId::Number(block_number.into()))
+                        .from_err()
+                })
+                .map_err(move |e| {
+                    e.into_inner().unwrap_or_else(move || {
+                        format_err!(
+                            "Ethereum node took too long to return block {}",
+                            block_number
+                        )
+                    })
+                }),
+        )
+    }
+
     fn load_full_block(
         &self,
         logger: &Logger,

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -883,6 +883,44 @@ where
         )
     }
 
+    fn uncles(
+        &self,
+        logger: &Logger,
+        block: &LightEthereumBlock,
+    ) -> Box<dyn Future<Item = Vec<Option<Block<H256>>>, Error = Error> + Send> {
+        let block_hash = block.hash.unwrap();
+        let n = block.uncles.len();
+
+        Box::new(
+            futures::stream::futures_ordered((0..n).map(move |index| {
+                let web3 = self.web3.clone();
+
+                retry("eth_getUncleByBlockHashAndIndex RPC call", &logger)
+                    .no_limit()
+                    .timeout_secs(60)
+                    .run(move || {
+                        web3.eth()
+                            .uncle(block_hash.clone().into(), index.into())
+                            .map_err(move |e| {
+                                format_err!(
+                                    "could not get uncle {} for block {:?} ({} uncles): {}",
+                                    index,
+                                    block_hash,
+                                    n,
+                                    e
+                                )
+                            })
+                    })
+                    .map_err(move |e| {
+                        e.into_inner().unwrap_or_else(move || {
+                            format_err!("Ethereum node took too long to return uncle")
+                        })
+                    })
+            }))
+            .collect(),
+        )
+    }
+
     fn is_on_main_chain(
         &self,
         logger: &Logger,

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -723,7 +723,7 @@ where
         // The early return is necessary for correctness, otherwise we'll
         // request an empty batch which is not valid in JSON-RPC.
         if block.transactions.is_empty() {
-            info!(logger, "Block {} contains no transactions", block_hash);
+            trace!(logger, "Block {} contains no transactions", block_hash);
             return Box::new(future::ok(EthereumBlock {
                 block,
                 transaction_receipts: Vec::new(),

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -10,8 +10,8 @@ use std::time::Instant;
 use ethabi::ParamType;
 use graph::components::ethereum::{EthereumAdapter as EthereumAdapterTrait, *};
 use graph::prelude::{
-    debug, err_msg, error, ethabi, format_err, hex, info, retry, stream, tiny_keccak, tokio_timer,
-    trace, warn, web3, ChainStore, Error, EthereumCallCache, Logger,
+    debug, err_msg, error, ethabi, format_err, hex, retry, stream, tiny_keccak, tokio_timer, trace,
+    warn, web3, ChainStore, Error, EthereumCallCache, Logger,
 };
 use web3::api::Web3;
 use web3::transports::batch::Batch;

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -4,10 +4,12 @@ extern crate graph;
 extern crate jsonrpc_core;
 #[macro_use]
 extern crate lazy_static;
+extern crate state_machine_future;
 
 mod block_ingestor;
 mod block_stream;
 mod ethereum_adapter;
+pub mod network_indexer;
 mod transport;
 
 pub use self::block_ingestor::{BlockIngestor, BlockIngestorMetrics};

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -4,6 +4,7 @@ extern crate graph;
 extern crate jsonrpc_core;
 #[macro_use]
 extern crate lazy_static;
+extern crate chrono;
 extern crate state_machine_future;
 
 mod block_ingestor;

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -1,11 +1,5 @@
-extern crate failure;
-extern crate futures;
-extern crate graph;
-extern crate jsonrpc_core;
 #[macro_use]
 extern crate lazy_static;
-extern crate chrono;
-extern crate state_machine_future;
 
 mod block_ingestor;
 mod block_stream;

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -1,0 +1,169 @@
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use graph::prelude::*;
+
+use super::*;
+
+/// Metrics for analyzing the block writer performance.
+struct BlockWriterMetrics {
+    /// Stopwatch for measuring the overall time spent writing.
+    stopwatch: StopwatchMetrics,
+
+    /// Metric for aggregating over all transaction calls.
+    transaction: Aggregate,
+}
+
+impl BlockWriterMetrics {
+    /// Creates new block writer metrics for a given subgraph.
+    pub fn new(
+        subgraph_id: &SubgraphDeploymentId,
+        stopwatch: StopwatchMetrics,
+        registry: Arc<dyn MetricsRegistry>,
+    ) -> Self {
+        let transaction = Aggregate::new(
+            format!("{}_transaction", subgraph_id.to_string()),
+            "Transactions to the store",
+            registry.clone(),
+        );
+
+        Self {
+            stopwatch,
+            transaction,
+        }
+    }
+}
+
+/// Component that writes Ethereum blocks to the network subgraph store.
+pub struct BlockWriter {
+    /// The network subgraph ID (e.g. `ethereum_mainnet_v0`).
+    subgraph_id: SubgraphDeploymentId,
+
+    /// Logger.
+    logger: Logger,
+
+    /// Store that manages the network subgraph.
+    store: Arc<dyn Store>,
+
+    /// Metrics for analyzing the block writer performance.
+    metrics: Arc<Mutex<BlockWriterMetrics>>,
+}
+
+impl BlockWriter {
+    /// Creates a new block writer for the given subgraph ID.
+    pub fn new(
+        subgraph_id: SubgraphDeploymentId,
+        logger: &Logger,
+        store: Arc<dyn Store>,
+        stopwatch: StopwatchMetrics,
+        metrics_registry: Arc<dyn MetricsRegistry>,
+    ) -> Self {
+        let logger = logger.new(o!("component" => "BlockWriter"));
+        let metrics = Arc::new(Mutex::new(BlockWriterMetrics::new(
+            &subgraph_id,
+            stopwatch,
+            metrics_registry,
+        )));
+        Self {
+            store,
+            subgraph_id,
+            logger,
+            metrics,
+        }
+    }
+
+    /// Writes a block to the store and updates the network subgraph block pointer.
+    pub fn write(&self, block: BlockWithUncles) -> impl Future<Item = (), Error = Error> {
+        let logger = self.logger.new(o!(
+            "block" => format_block(&block),
+        ));
+
+        // Write using a write context that we can thread through futures.
+        let context = WriteContext {
+            logger,
+            subgraph_id: self.subgraph_id.clone(),
+            store: self.store.clone(),
+            cache: EntityCache::new(),
+            metrics: self.metrics.clone(),
+        };
+        context.write(block)
+    }
+}
+
+/// Internal context for writing a block.
+struct WriteContext {
+    logger: Logger,
+    subgraph_id: SubgraphDeploymentId,
+    store: Arc<dyn Store>,
+    cache: EntityCache,
+    metrics: Arc<Mutex<BlockWriterMetrics>>,
+}
+
+/// Internal result type used to thread WriteContext through the chain of futures
+/// when writing blocks to the store.
+type WriteContextResult = Box<dyn Future<Item = WriteContext, Error = Error> + Send>;
+
+impl WriteContext {
+    /// Updates an entity to a new value (potentially merging it with existing data).
+    fn set_entity(mut self, value: impl TryIntoEntity + ToEntityKey) -> WriteContextResult {
+        self.cache.set(
+            value.to_entity_key(self.subgraph_id.clone()),
+            match value.try_into_entity() {
+                Ok(entity) => entity,
+                Err(e) => return Box::new(future::err(e.into())),
+            },
+        );
+        Box::new(future::ok(self))
+    }
+
+    /// Writes a block to the store.
+    fn write(self, block: BlockWithUncles) -> impl Future<Item = (), Error = Error> {
+        debug!(self.logger, "Write block");
+
+        let block = Arc::new(block);
+        let block_for_uncles = block.clone();
+        let block_for_store = block.clone();
+
+        Box::new(
+            // Add the block entity
+            self.set_entity(block.as_ref())
+                // Add uncle block entities
+                .and_then(move |context| {
+                    futures::stream::iter_ok::<_, Error>(block_for_uncles.uncles.clone())
+                        .fold(context, |context, ommer| context.set_entity(ommer.unwrap()))
+                })
+                // Transact everything into the store
+                .and_then(move |context| {
+                    let cache = context.cache;
+                    let metrics = context.metrics;
+                    let store = context.store;
+                    let subgraph_id = context.subgraph_id;
+
+                    let stopwatch = { metrics.lock().unwrap().stopwatch.clone() };
+
+                    // Collect all entity modifications to be made
+                    let modifications = match cache.as_modifications(store.as_ref()) {
+                        Ok(mods) => mods,
+                        Err(e) => return future::err(e.into()),
+                    };
+
+                    // Transact entity modifications into the store
+                    let started = Instant::now();
+                    future::result(
+                        store
+                            .transact_block_operations(
+                                subgraph_id.clone(),
+                                EthereumBlockPointer::from(&block_for_store.block),
+                                modifications,
+                                stopwatch,
+                            )
+                            .map_err(|e| e.into())
+                            .map(move |_| {
+                                let mut metrics = metrics.lock().unwrap();
+                                metrics.transaction.update_duration(started.elapsed());
+                            }),
+                    )
+                }),
+        )
+    }
+}

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use std::time::Instant;
 
 use graph::prelude::*;

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -107,10 +107,7 @@ type WriteContextResult = Box<dyn Future<Item = WriteContext, Error = Error> + S
 
 impl WriteContext {
     /// Updates an entity to a new value (potentially merging it with existing data).
-    fn set_entity(
-        mut self,
-        value: impl TryIntoEntity + ToEntityKey,
-    ) -> WriteContextResult {
+    fn set_entity(mut self, value: impl TryIntoEntity + ToEntityKey) -> WriteContextResult {
         self.cache.set(
             value.to_entity_key(self.subgraph_id.clone()),
             match value.try_into_entity() {
@@ -138,9 +135,7 @@ impl WriteContext {
                 // Add uncle block entities
                 .and_then(move |context| {
                     futures::stream::iter_ok::<_, Error>(block_for_ommers.ommers.clone())
-                        .fold(context, move |context, ommer| {
-                            context.set_entity(ommer)
-                        })
+                        .fold(context, move |context, ommer| context.set_entity(ommer))
                 })
                 // Transact everything into the store
                 .and_then(move |context| {

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -138,7 +138,6 @@ impl WriteContext {
                 // Add uncle block entities
                 .and_then(move |context| {
                     futures::stream::iter_ok::<_, Error>(block_for_ommers.ommers.clone())
-                        .filter_map(|ommer| ommer)
                         .fold(context, move |context, ommer| {
                             context.set_entity(ommer)
                         })

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -77,7 +77,7 @@ impl BlockWriter {
         block: BlockWithOmmers,
     ) -> impl Future<Item = EthereumBlockPointer, Error = Error> {
         let logger = self.logger.new(o!(
-            "block" => format_block(&block),
+            "block" => format!("{}", block),
         ));
 
         // Write using a write context that we can thread through futures.

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -130,6 +130,7 @@ impl WriteContext {
                 // Add uncle block entities
                 .and_then(move |context| {
                     futures::stream::iter_ok::<_, Error>(block_for_uncles.uncles.clone())
+                        .filter(|ommer| ommer.is_some())
                         .fold(context, |context, ommer| context.set_entity(ommer.unwrap()))
                 })
                 // Transact everything into the store

--- a/chain/ethereum/src/network_indexer/convert.rs
+++ b/chain/ethereum/src/network_indexer/convert.rs
@@ -1,0 +1,161 @@
+use graph::prelude::*;
+use web3::types::{Block, H160, H256};
+
+use super::*;
+
+/// A value that can be converted to an entity ID.
+pub trait ToEntityId {
+    fn to_entity_id(&self) -> String;
+}
+
+/// A value that can be converted to an entity key.
+pub trait ToEntityKey {
+    fn to_entity_key(&self, subgraph_id: SubgraphDeploymentId) -> EntityKey;
+}
+
+/// A value that can (maybe) be converted to an entity.
+pub trait TryIntoEntity {
+    fn try_into_entity(&self) -> Result<Entity, Error>;
+}
+
+/**
+ * Implementations of these traits for various Ethereum types.
+ */
+
+impl ToEntityId for H160 {
+    fn to_entity_id(&self) -> String {
+        format!("{:x}", self)
+    }
+}
+
+impl ToEntityId for H256 {
+    fn to_entity_id(&self) -> String {
+        format!("{:x}", self)
+    }
+}
+
+impl ToEntityId for Block<H256> {
+    fn to_entity_id(&self) -> String {
+        format!("{:x}", self.hash.unwrap())
+    }
+}
+
+impl ToEntityKey for Block<H256> {
+    fn to_entity_key(&self, subgraph_id: SubgraphDeploymentId) -> EntityKey {
+        EntityKey {
+            subgraph_id,
+            entity_type: "Block".into(),
+            entity_id: format!("{:x}", self.hash.unwrap()),
+        }
+    }
+}
+
+impl ToEntityKey for EthereumBlockPointer {
+    fn to_entity_key(&self, subgraph_id: SubgraphDeploymentId) -> EntityKey {
+        EntityKey {
+            subgraph_id,
+            entity_type: "Block".into(),
+            entity_id: format!("{:x}", self.hash),
+        }
+    }
+}
+
+impl ToEntityId for BlockWithUncles {
+    fn to_entity_id(&self) -> String {
+        (*self).block.block.hash.unwrap().to_entity_id()
+    }
+}
+
+impl ToEntityKey for &BlockWithUncles {
+    fn to_entity_key(&self, subgraph_id: SubgraphDeploymentId) -> EntityKey {
+        EntityKey {
+            subgraph_id,
+            entity_type: "Block".into(),
+            entity_id: format!("{:x}", (*self).block.block.hash.unwrap()),
+        }
+    }
+}
+
+impl TryIntoEntity for Block<H256> {
+    fn try_into_entity(&self) -> Result<Entity, Error> {
+        Ok(Entity::from(vec![
+            ("id", format!("{:x}", self.hash.unwrap()).into()),
+            ("number", self.number.unwrap().into()),
+            ("hash", self.hash.unwrap().into()),
+            ("parent", self.parent_hash.to_entity_id().into()),
+            (
+                "nonce",
+                self.nonce.map_or(Value::Null, |nonce| nonce.into()),
+            ),
+            ("transactionsRoot", self.transactions_root.into()),
+            ("transactionCount", (self.transactions.len() as i32).into()),
+            ("stateRoot", self.state_root.into()),
+            ("receiptsRoot", self.receipts_root.into()),
+            ("extraData", self.extra_data.clone().into()),
+            ("gasLimit", self.gas_limit.into()),
+            ("gasUsed", self.gas_used.into()),
+            ("timestamp", self.timestamp.into()),
+            ("logsBloom", self.logs_bloom.into()),
+            ("mixHash", self.mix_hash.into()),
+            ("difficulty", self.difficulty.into()),
+            ("totalDifficulty", self.total_difficulty.into()),
+            ("ommerCount", (self.uncles.len() as i32).into()),
+            ("ommerHash", self.uncles_hash.into()),
+            (
+                "ommers",
+                self.uncles
+                    .iter()
+                    .map(|hash| hash.to_entity_id())
+                    .collect::<Vec<_>>()
+                    .into(),
+            ),
+            ("size", self.size.into()),
+            ("sealFields", self.seal_fields.clone().into()),
+        ] as Vec<(_, Value)>))
+    }
+}
+
+impl TryIntoEntity for &BlockWithUncles {
+    fn try_into_entity(&self) -> Result<Entity, Error> {
+        let inner = self.inner();
+
+        Ok(Entity::from(vec![
+            ("id", format!("{:x}", inner.hash.unwrap()).into()),
+            ("number", inner.number.unwrap().into()),
+            ("hash", inner.hash.unwrap().into()),
+            ("parent", inner.parent_hash.to_entity_id().into()),
+            (
+                "nonce",
+                inner.nonce.map_or(Value::Null, |nonce| nonce.into()),
+            ),
+            ("transactionsRoot", inner.transactions_root.into()),
+            ("transactionCount", (inner.transactions.len() as i32).into()),
+            ("stateRoot", inner.state_root.into()),
+            ("receiptsRoot", inner.receipts_root.into()),
+            ("extraData", inner.extra_data.clone().into()),
+            ("gasLimit", inner.gas_limit.into()),
+            ("gasUsed", inner.gas_used.into()),
+            ("timestamp", inner.timestamp.into()),
+            ("logsBloom", inner.logs_bloom.into()),
+            ("mixHash", inner.mix_hash.into()),
+            ("difficulty", inner.difficulty.into()),
+            ("totalDifficulty", inner.total_difficulty.into()),
+            ("ommerCount", (self.uncles.len() as i32).into()),
+            ("ommerHash", inner.uncles_hash.into()),
+            (
+                "ommers",
+                self.uncles
+                    .iter()
+                    .map(|ommer| {
+                        ommer
+                            .as_ref()
+                            .map_or(Value::Null, |ommer| Value::String(ommer.to_entity_id()))
+                    })
+                    .collect::<Vec<_>>()
+                    .into(),
+            ),
+            ("size", inner.size.into()),
+            ("sealFields", inner.seal_fields.clone().into()),
+        ] as Vec<(_, Value)>))
+    }
+}

--- a/chain/ethereum/src/network_indexer/convert.rs
+++ b/chain/ethereum/src/network_indexer/convert.rs
@@ -1,38 +1,6 @@
 use graph::prelude::*;
-use web3::types::{H160, H256};
 
 use super::*;
-
-/// A value that can be converted to an entity ID.
-pub trait ToEntityId {
-    fn to_entity_id(&self) -> String;
-}
-
-/// A value that can be converted to an entity key.
-pub trait ToEntityKey {
-    fn to_entity_key(&self, subgraph_id: SubgraphDeploymentId) -> EntityKey;
-}
-
-/// A value that can (maybe) be converted to an entity.
-pub trait TryIntoEntity {
-    fn try_into_entity(&self) -> Result<Entity, Error>;
-}
-
-/**
- * Implementations of these traits for various Ethereum types.
- */
-
-impl ToEntityId for H160 {
-    fn to_entity_id(&self) -> String {
-        format!("{:x}", self)
-    }
-}
-
-impl ToEntityId for H256 {
-    fn to_entity_id(&self) -> String {
-        format!("{:x}", self)
-    }
-}
 
 impl ToEntityId for Ommer {
     fn to_entity_id(&self) -> String {
@@ -46,16 +14,6 @@ impl ToEntityKey for Ommer {
             subgraph_id,
             entity_type: "Block".into(),
             entity_id: format!("{:x}", self.0.hash.unwrap()),
-        }
-    }
-}
-
-impl ToEntityKey for EthereumBlockPointer {
-    fn to_entity_key(&self, subgraph_id: SubgraphDeploymentId) -> EntityKey {
-        EntityKey {
-            subgraph_id,
-            entity_type: "Block".into(),
-            entity_id: format!("{:x}", self.hash),
         }
     }
 }
@@ -77,7 +35,7 @@ impl ToEntityKey for &BlockWithOmmers {
 }
 
 impl TryIntoEntity for Ommer {
-    fn try_into_entity(&self) -> Result<Entity, Error> {
+    fn try_into_entity(self) -> Result<Entity, Error> {
         let inner = &self.0;
 
         Ok(Entity::from(vec![
@@ -120,7 +78,7 @@ impl TryIntoEntity for Ommer {
 }
 
 impl TryIntoEntity for &BlockWithOmmers {
-    fn try_into_entity(&self) -> Result<Entity, Error> {
+    fn try_into_entity(self) -> Result<Entity, Error> {
         let inner = self.inner();
 
         Ok(Entity::from(vec![

--- a/chain/ethereum/src/network_indexer/convert.rs
+++ b/chain/ethereum/src/network_indexer/convert.rs
@@ -144,13 +144,10 @@ impl TryIntoEntity for &BlockWithUncles {
             ("ommerHash", inner.uncles_hash.into()),
             (
                 "ommers",
-                self.uncles
+                self.inner()
+                    .uncles
                     .iter()
-                    .map(|ommer| {
-                        ommer
-                            .as_ref()
-                            .map_or(Value::Null, |ommer| Value::String(ommer.to_entity_id()))
-                    })
+                    .map(|hash| hash.to_entity_id())
                     .collect::<Vec<_>>()
                     .into(),
             ),

--- a/chain/ethereum/src/network_indexer/ethereum.graphql
+++ b/chain/ethereum/src/network_indexer/ethereum.graphql
@@ -1,0 +1,83 @@
+""" Block is an Ethereum block."""
+type Block @entity {
+  id: ID!
+
+  """The number of this block, starting at 0 for the genesis block."""
+  number: BigInt!
+
+  """The block hash of this block."""
+  hash: Bytes!
+
+  """The parent block of this block."""
+  parent: Block
+
+  """The block nonce, an 8 byte sequence determined by the miner."""
+  nonce: Bytes!
+
+  """The keccak256 hash of the root of the trie of transactions in this block."""
+  transactionsRoot: Bytes!
+
+  """The number of transactions in this block."""
+  transactionCount: Int!
+
+  """The keccak256 hash of the state trie after this block was processed."""
+  stateRoot: Bytes!
+
+  """The keccak256 hash of the trie of transaction receipts in this block."""
+  receiptsRoot: Bytes!
+
+  # """The account that mined this block."""
+  # miner: Account!
+
+  """An arbitrary data field supplied by the miner."""
+  extraData: Bytes!
+
+  """The maximum amount of gas that was available to transactions in this block."""
+  gasLimit: BigInt!
+
+  """The amount of gas that was used executing transactions in this block."""
+  gasUsed: BigInt!
+
+  """The unix timestamp at which this block was mined."""
+  timestamp: BigInt!
+
+  """
+  A bloom filter that can be used to check if a block may
+  contain log entries matching a filter.
+  """
+  logsBloom: Bytes!
+
+  """The hash that was used as an input to the PoW process."""
+  mixHash: Bytes!
+
+  """A measure of the difficulty of mining this block."""
+  difficulty: BigInt!
+
+  """The sum of all difficulty values up to and including this block."""
+  totalDifficulty: BigInt!
+
+  """The number of ommers (AKA uncles) associated with this block."""
+  ommerCount: Int!
+
+  # """
+  # A list of ommer (AKA uncle) blocks associated with this block.
+  # """
+  ommers: [Block]!
+
+  """The keccak256 hash of all the ommers (AKA uncles) associated with this block."""
+  ommerHash: Bytes!
+
+  # """
+  # A list of transactions associated with this block.
+  # """
+  # transactions: [Transaction!]
+
+  # """The logs emitted in this block."""
+  # logs: [Log!]!
+
+  """Size of the block in bytes."""
+  size: BigInt
+
+  """Seal fields."""
+  sealFields: [Bytes!]!
+}

--- a/chain/ethereum/src/network_indexer/ethereum.graphql
+++ b/chain/ethereum/src/network_indexer/ethereum.graphql
@@ -56,6 +56,9 @@ type Block @entity {
   """The sum of all difficulty values up to and including this block."""
   totalDifficulty: BigInt!
 
+  """Whether the block is an ommer."""
+  isOmmer: Boolean!
+
   """The number of ommers (AKA uncles) associated with this block."""
   ommerCount: Int!
 

--- a/chain/ethereum/src/network_indexer/metrics.rs
+++ b/chain/ethereum/src/network_indexer/metrics.rs
@@ -25,11 +25,7 @@ pub struct NetworkIndexerMetrics {
     pub fetch_full_block: Aggregate,
     pub fetch_ommers: Aggregate,
     pub load_local_head: Aggregate,
-    pub collect_reorg_data: Aggregate,
-    pub fetch_new_blocks: Aggregate,
-    pub load_parent_block: Aggregate,
-    pub find_common_ancestor: Aggregate,
-    pub revert_blocks: Aggregate,
+    pub revert_local_head: Aggregate,
     pub write_block: Aggregate,
 
     // Problems
@@ -39,11 +35,7 @@ pub struct NetworkIndexerMetrics {
     pub fetch_full_block_problems: Box<Gauge>,
     pub fetch_ommers_problems: Box<Gauge>,
     pub load_local_head_problems: Box<Gauge>,
-    pub collect_reorg_data_problems: Box<Gauge>,
-    pub fetch_new_blocks_problems: Box<Gauge>,
-    pub load_parent_block_problems: Box<Gauge>,
-    pub find_common_ancestor_problems: Box<Gauge>,
-    pub revert_blocks_problems: Box<Gauge>,
+    pub revert_local_head_problems: Box<Gauge>,
     pub write_block_problems: Box<Gauge>,
 
     // Timestamp for the last received chain update, i.e.
@@ -146,33 +138,9 @@ impl NetworkIndexerMetrics {
                 registry.clone(),
             ),
 
-            collect_reorg_data: Aggregate::new(
-                format!("{}_collect_reorg_data", subgraph_id),
-                "Collect data to handle a reorg",
-                registry.clone(),
-            ),
-
-            fetch_new_blocks: Aggregate::new(
-                format!("{}_fetch_new_blocks", subgraph_id),
-                "Fetch new blocks for a reorg",
-                registry.clone(),
-            ),
-
-            load_parent_block: Aggregate::new(
-                format!("{}_load_parent_block", subgraph_id),
-                "Load the parent of a block from the store",
-                registry.clone(),
-            ),
-
-            find_common_ancestor: Aggregate::new(
-                format!("{}_find_common_ancestor", subgraph_id),
-                "Identify the common ancestor for a reorg",
-                registry.clone(),
-            ),
-
-            revert_blocks: Aggregate::new(
-                format!("{}_revert_blocks", subgraph_id),
-                "Revert blocks in the store",
+            revert_local_head: Aggregate::new(
+                format!("{}_revert_local_head", subgraph_id),
+                "Revert the local head block in the store",
                 registry.clone(),
             ),
 
@@ -266,71 +234,15 @@ impl NetworkIndexerMetrics {
                     .as_str(),
                 ),
 
-            collect_reorg_data_problems: registry
+            revert_local_head_problems: registry
                 .new_gauge(
-                    format!("{}_collect_reorg_data_problems", subgraph_id),
-                    "Problems collecting data for handling a reorg".into(),
+                    format!("{}_revert_local_head_problems", subgraph_id),
+                    "Problems reverting the local head block during a reorg".into(),
                     HashMap::new(),
                 )
                 .expect(
                     format!(
-                        "failed to create metric `{}_collect_reorg_data_problems",
-                        subgraph_id
-                    )
-                    .as_str(),
-                ),
-
-            fetch_new_blocks_problems: registry
-                .new_gauge(
-                    format!("{}_fetch_new_blocks_problems", subgraph_id),
-                    "Problems fetching new blocks for a reorg".into(),
-                    HashMap::new(),
-                )
-                .expect(
-                    format!(
-                        "failed to create metric `{}_fetch_new_blocks_problems",
-                        subgraph_id
-                    )
-                    .as_str(),
-                ),
-
-            load_parent_block_problems: registry
-                .new_gauge(
-                    format!("{}_load_parent_block_problems", subgraph_id),
-                    "Problems loading a parent block from the store".into(),
-                    HashMap::new(),
-                )
-                .expect(
-                    format!(
-                        "failed to create metric `{}_load_parent_block_problems",
-                        subgraph_id
-                    )
-                    .as_str(),
-                ),
-
-            find_common_ancestor_problems: registry
-                .new_gauge(
-                    format!("{}_find_common_ancestor_problems", subgraph_id),
-                    "Problems identifying the common ancestor for a reorg".into(),
-                    HashMap::new(),
-                )
-                .expect(
-                    format!(
-                        "failed to create metric `{}_find_common_ancestor_problems",
-                        subgraph_id
-                    )
-                    .as_str(),
-                ),
-
-            revert_blocks_problems: registry
-                .new_gauge(
-                    format!("{}_revert_blocks_problems", subgraph_id),
-                    "Problems reverting old blocks during a reorg".into(),
-                    HashMap::new(),
-                )
-                .expect(
-                    format!(
-                        "failed to create metric `{}_revert_blocks_problems",
+                        "failed to create metric `{}_revert_local_head_problems",
                         subgraph_id
                     )
                     .as_str(),

--- a/chain/ethereum/src/network_indexer/metrics.rs
+++ b/chain/ethereum/src/network_indexer/metrics.rs
@@ -1,0 +1,338 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use graph::prelude::{
+    Aggregate, Counter, Gauge, MetricsRegistry, StopwatchMetrics, SubgraphDeploymentId,
+};
+
+pub struct NetworkIndexerMetrics {
+    // Overall indexing time, broken down into standard sections
+    pub stopwatch: StopwatchMetrics,
+
+    // High-level syncing status
+    pub chain_head: Box<Gauge>,
+    pub local_head: Box<Gauge>,
+
+    // Reorg stats
+    pub reorg_count: Box<Counter>,
+    pub reorg_cancel_count: Box<Counter>,
+    pub reorg_depth: Aggregate,
+
+    // Different stages of the algorithm
+    pub poll_chain_head: Aggregate,
+    pub fetch_block_by_number: Aggregate,
+    pub fetch_block_by_hash: Aggregate,
+    pub fetch_full_block: Aggregate,
+    pub fetch_ommers: Aggregate,
+    pub load_local_head: Aggregate,
+    pub fetch_new_blocks: Aggregate,
+    pub collect_old_blocks: Aggregate,
+    pub revert_blocks: Aggregate,
+    pub write_block: Aggregate,
+
+    // Problems
+    pub poll_chain_head_problems: Box<Gauge>,
+    pub fetch_block_by_number_problems: Box<Gauge>,
+    pub fetch_block_by_hash_problems: Box<Gauge>,
+    pub fetch_full_block_problems: Box<Gauge>,
+    pub fetch_ommers_problems: Box<Gauge>,
+    pub load_local_head_problems: Box<Gauge>,
+    pub fetch_new_blocks_problems: Box<Gauge>,
+    pub collect_old_blocks_problems: Box<Gauge>,
+    pub revert_blocks_problems: Box<Gauge>,
+    pub write_block_problems: Box<Gauge>,
+
+    // Timestamp for the last received chain update, i.e.
+    // a chain head that was different from before
+    pub last_new_chain_head_time: Box<Gauge>,
+
+    // Timestamp for the last written block; if this is old,
+    // it indicates that the network indexer is not healthy
+    pub last_written_block_time: Box<Gauge>,
+}
+
+impl NetworkIndexerMetrics {
+    pub fn new(
+        subgraph_id: SubgraphDeploymentId,
+        stopwatch: StopwatchMetrics,
+        registry: Arc<dyn MetricsRegistry>,
+    ) -> Self {
+        Self {
+            stopwatch,
+
+            chain_head: registry
+                .new_gauge(
+                    format!("{}_chain_head", subgraph_id),
+                    "The current chain head block".into(),
+                    HashMap::new(),
+                )
+                .expect(format!("failed to register metric `{}_chain_head`", subgraph_id).as_str()),
+
+            local_head: registry
+                .new_gauge(
+                    format!("{}_local_head", subgraph_id),
+                    "The current local head block".into(),
+                    HashMap::new(),
+                )
+                .expect(format!("failed to register metric `{}_local_head`", subgraph_id).as_str()),
+
+            reorg_count: registry
+                .new_counter(
+                    format!("{}_reorg_count", subgraph_id),
+                    "The number of reorgs handled".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!("failed to register metric `{}_reorg_count`", subgraph_id).as_str(),
+                ),
+
+            reorg_cancel_count: registry
+                .new_counter(
+                    format!("{}_reorg_cancel_count", subgraph_id),
+                    "The number of reorgs that had to be canceled / restarted".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to register metric `{}_reorg_cancel_count`",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            reorg_depth: Aggregate::new(
+                format!("{}_reorg_depth", subgraph_id),
+                "The depth of reorgs over time",
+                registry.clone(),
+            ),
+
+            poll_chain_head: Aggregate::new(
+                format!("{}_poll_chain_head", subgraph_id),
+                "Polling the network's chain head",
+                registry.clone(),
+            ),
+
+            fetch_block_by_number: Aggregate::new(
+                format!("{}_fetch_block_by_number", subgraph_id),
+                "Fetching a block using a block number",
+                registry.clone(),
+            ),
+
+            fetch_block_by_hash: Aggregate::new(
+                format!("{}_fetch_block_by_hash", subgraph_id),
+                "Fetching a block using a block hash",
+                registry.clone(),
+            ),
+
+            fetch_full_block: Aggregate::new(
+                format!("{}_fetch_full_block", subgraph_id),
+                "Fetching a full block",
+                registry.clone(),
+            ),
+
+            fetch_ommers: Aggregate::new(
+                format!("{}_fetch_ommers", subgraph_id),
+                "Fetching the ommers of a block",
+                registry.clone(),
+            ),
+
+            load_local_head: Aggregate::new(
+                format!("{}_load_local_head", subgraph_id),
+                "Load the local head block from the store",
+                registry.clone(),
+            ),
+
+            fetch_new_blocks: Aggregate::new(
+                format!("{}_fetch_new_blocks", subgraph_id),
+                "Fetch new blocks for a reorg",
+                registry.clone(),
+            ),
+
+            collect_old_blocks: Aggregate::new(
+                format!("{}_collect_old_blocks", subgraph_id),
+                "Collect old blocks for a reorg",
+                registry.clone(),
+            ),
+
+            revert_blocks: Aggregate::new(
+                format!("{}_revert_blocks", subgraph_id),
+                "Revert blocks in the store",
+                registry.clone(),
+            ),
+
+            write_block: Aggregate::new(
+                format!("{}_write_block", subgraph_id),
+                "Write a block to the store",
+                registry.clone(),
+            ),
+
+            poll_chain_head_problems: registry
+                .new_gauge(
+                    format!("{}_poll_chain_head_problems", subgraph_id),
+                    "Problems polling the chain head".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_poll_chain_head_problems",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            fetch_block_by_number_problems: registry
+                .new_gauge(
+                    format!("{}_fetch_block_by_number_problems", subgraph_id),
+                    "Problems fetching a block by number".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_fetch_block_by_number_problems",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            fetch_block_by_hash_problems: registry
+                .new_gauge(
+                    format!("{}_fetch_block_by_hash_problems", subgraph_id),
+                    "Problems fetching a block by hash".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_fetch_block_by_hash_problems",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            fetch_full_block_problems: registry
+                .new_gauge(
+                    format!("{}_fetch_full_block_problems", subgraph_id),
+                    "Problems fetching a full block".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_fetch_full_block_problems",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            fetch_ommers_problems: registry
+                .new_gauge(
+                    format!("{}_fetch_ommers_problems", subgraph_id),
+                    "Problems fetching ommers of a block".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_fetch_ommers_problem",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            load_local_head_problems: registry
+                .new_gauge(
+                    format!("{}_load_local_head_problems", subgraph_id),
+                    "Problems loading the local head block".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_load_local_head_problem",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            fetch_new_blocks_problems: registry
+                .new_gauge(
+                    format!("{}_fetch_new_blocks_problems", subgraph_id),
+                    "Problems fetching new blocks for a reorg".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_fetch_new_blocks_problem",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            collect_old_blocks_problems: registry
+                .new_gauge(
+                    format!("{}_collect_old_blocks_problems", subgraph_id),
+                    "Problems collecting old blocks for a reorg".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_collect_old_blocks_problems",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            revert_blocks_problems: registry
+                .new_gauge(
+                    format!("{}_revert_blocks_problems", subgraph_id),
+                    "Problems reverting old blocks during a reorg".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_revert_blocks_problems",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            write_block_problems: registry
+                .new_gauge(
+                    format!("{}_write_block_problems", subgraph_id),
+                    "Problems writing a block to the store".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_write_block_problems",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            last_new_chain_head_time: registry
+                .new_gauge(
+                    format!("{}_last_new_chain_head_time", subgraph_id),
+                    "The last time a chain head was received that was different from before".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_last_written_block_time",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            last_written_block_time: registry
+                .new_gauge(
+                    format!("{}_last_written_block_time", subgraph_id),
+                    "The last time a block was written to the store".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_last_written_block_time",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+        }
+    }
+}

--- a/chain/ethereum/src/network_indexer/metrics.rs
+++ b/chain/ethereum/src/network_indexer/metrics.rs
@@ -25,8 +25,10 @@ pub struct NetworkIndexerMetrics {
     pub fetch_full_block: Aggregate,
     pub fetch_ommers: Aggregate,
     pub load_local_head: Aggregate,
+    pub collect_reorg_data: Aggregate,
     pub fetch_new_blocks: Aggregate,
-    pub collect_old_blocks: Aggregate,
+    pub load_parent_block: Aggregate,
+    pub find_common_ancestor: Aggregate,
     pub revert_blocks: Aggregate,
     pub write_block: Aggregate,
 
@@ -37,8 +39,10 @@ pub struct NetworkIndexerMetrics {
     pub fetch_full_block_problems: Box<Gauge>,
     pub fetch_ommers_problems: Box<Gauge>,
     pub load_local_head_problems: Box<Gauge>,
+    pub collect_reorg_data_problems: Box<Gauge>,
     pub fetch_new_blocks_problems: Box<Gauge>,
-    pub collect_old_blocks_problems: Box<Gauge>,
+    pub load_parent_block_problems: Box<Gauge>,
+    pub find_common_ancestor_problems: Box<Gauge>,
     pub revert_blocks_problems: Box<Gauge>,
     pub write_block_problems: Box<Gauge>,
 
@@ -142,15 +146,27 @@ impl NetworkIndexerMetrics {
                 registry.clone(),
             ),
 
+            collect_reorg_data: Aggregate::new(
+                format!("{}_collect_reorg_data", subgraph_id),
+                "Collect data to handle a reorg",
+                registry.clone(),
+            ),
+
             fetch_new_blocks: Aggregate::new(
                 format!("{}_fetch_new_blocks", subgraph_id),
                 "Fetch new blocks for a reorg",
                 registry.clone(),
             ),
 
-            collect_old_blocks: Aggregate::new(
-                format!("{}_collect_old_blocks", subgraph_id),
-                "Collect old blocks for a reorg",
+            load_parent_block: Aggregate::new(
+                format!("{}_load_parent_block", subgraph_id),
+                "Load the parent of a block from the store",
+                registry.clone(),
+            ),
+
+            find_common_ancestor: Aggregate::new(
+                format!("{}_find_common_ancestor", subgraph_id),
+                "Identify the common ancestor for a reorg",
                 registry.clone(),
             ),
 
@@ -230,7 +246,7 @@ impl NetworkIndexerMetrics {
                 )
                 .expect(
                     format!(
-                        "failed to create metric `{}_fetch_ommers_problem",
+                        "failed to create metric `{}_fetch_ommers_problems",
                         subgraph_id
                     )
                     .as_str(),
@@ -244,7 +260,21 @@ impl NetworkIndexerMetrics {
                 )
                 .expect(
                     format!(
-                        "failed to create metric `{}_load_local_head_problem",
+                        "failed to create metric `{}_load_local_head_problems",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            collect_reorg_data_problems: registry
+                .new_gauge(
+                    format!("{}_collect_reorg_data_problems", subgraph_id),
+                    "Problems collecting data for handling a reorg".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_collect_reorg_data_problems",
                         subgraph_id
                     )
                     .as_str(),
@@ -258,21 +288,35 @@ impl NetworkIndexerMetrics {
                 )
                 .expect(
                     format!(
-                        "failed to create metric `{}_fetch_new_blocks_problem",
+                        "failed to create metric `{}_fetch_new_blocks_problems",
                         subgraph_id
                     )
                     .as_str(),
                 ),
 
-            collect_old_blocks_problems: registry
+            load_parent_block_problems: registry
                 .new_gauge(
-                    format!("{}_collect_old_blocks_problems", subgraph_id),
-                    "Problems collecting old blocks for a reorg".into(),
+                    format!("{}_load_parent_block_problems", subgraph_id),
+                    "Problems loading a parent block from the store".into(),
                     HashMap::new(),
                 )
                 .expect(
                     format!(
-                        "failed to create metric `{}_collect_old_blocks_problems",
+                        "failed to create metric `{}_load_parent_block_problems",
+                        subgraph_id
+                    )
+                    .as_str(),
+                ),
+
+            find_common_ancestor_problems: registry
+                .new_gauge(
+                    format!("{}_find_common_ancestor_problems", subgraph_id),
+                    "Problems identifying the common ancestor for a reorg".into(),
+                    HashMap::new(),
+                )
+                .expect(
+                    format!(
+                        "failed to create metric `{}_find_common_ancestor_problems",
                         subgraph_id
                     )
                     .as_str(),

--- a/chain/ethereum/src/network_indexer/mod.rs
+++ b/chain/ethereum/src/network_indexer/mod.rs
@@ -1,0 +1,101 @@
+use graph::prelude::*;
+use web3::types::{Block, TransactionReceipt, H256};
+
+mod block_writer;
+mod convert;
+mod network_indexer;
+mod subgraph;
+
+pub use self::block_writer::*;
+pub use self::convert::*;
+pub use self::network_indexer::*;
+pub use self::subgraph::*;
+
+pub use self::network_indexer::NetworkIndexerEvent;
+
+const NETWORK_INDEXER_VERSION: u32 = 0;
+
+/// Helper type to bundle blocks and their uncles together.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BlockWithUncles {
+    pub block: EthereumBlock,
+    pub uncles: Vec<Option<Block<H256>>>,
+}
+
+impl BlockWithUncles {
+    pub fn inner(&self) -> &LightEthereumBlock {
+        &self.block.block
+    }
+
+    pub fn _transaction_receipts(&self) -> &Vec<TransactionReceipt> {
+        &self.block.transaction_receipts
+    }
+}
+
+/**
+ * Logging helpers.
+ */
+
+pub(crate) fn format_light_block(block: &LightEthereumBlock) -> String {
+    format!(
+        "{} ({})",
+        block
+            .number
+            .map_or(String::from("none"), |number| format!("#{}", number)),
+        block
+            .hash
+            .map_or(String::from("-"), |hash| format!("{:x}", hash))
+    )
+}
+
+pub(crate) fn format_block(block: &BlockWithUncles) -> String {
+    format_light_block(block.inner())
+}
+
+pub(crate) fn format_block_pointer(ptr: &EthereumBlockPointer) -> String {
+    format!("#{} ({:x})", ptr.number, ptr.hash)
+}
+
+pub fn create<S>(
+    subgraph_name: String,
+    logger: &Logger,
+    adapter: Arc<dyn EthereumAdapter>,
+    store: Arc<S>,
+    metrics_registry: Arc<dyn MetricsRegistry>,
+    start_block: Option<EthereumBlockPointer>,
+) -> impl Future<Item = NetworkIndexer, Error = ()>
+where
+    S: Store + ChainStore,
+{
+    // Create a subgraph name and ID
+    let id_str = format!(
+        "{}_v{}",
+        subgraph_name.replace("/", "_"),
+        NETWORK_INDEXER_VERSION
+    );
+    let subgraph_id = SubgraphDeploymentId::new(id_str).expect("valid network subgraph ID");
+    let subgraph_name = SubgraphName::new(subgraph_name).expect("valid network subgraph name");
+
+    let logger = logger.new(o!(
+      "subgraph_name" => subgraph_name.to_string(),
+      "subgraph_id" => subgraph_id.to_string(),
+    ));
+
+    // Ensure subgraph, the wire up the tracer and indexer
+    subgraph::ensure_subgraph_exists(
+        subgraph_name,
+        subgraph_id.clone(),
+        logger.clone(),
+        store.clone(),
+        start_block,
+    )
+    .and_then(move |_| {
+        future::ok(NetworkIndexer::new(
+            subgraph_id.clone(),
+            &logger,
+            adapter.clone(),
+            store.clone(),
+            metrics_registry.clone(),
+        ))
+    })
+}

--- a/chain/ethereum/src/network_indexer/mod.rs
+++ b/chain/ethereum/src/network_indexer/mod.rs
@@ -31,10 +31,6 @@ impl BlockWithOmmers {
     pub fn inner(&self) -> &LightEthereumBlock {
         &self.block.block
     }
-
-    pub fn _transaction_receipts(&self) -> &Vec<TransactionReceipt> {
-        &self.block.transaction_receipts
-    }
 }
 
 /**

--- a/chain/ethereum/src/network_indexer/mod.rs
+++ b/chain/ethereum/src/network_indexer/mod.rs
@@ -3,6 +3,7 @@ use web3::types::{Block, TransactionReceipt, H256};
 
 mod block_writer;
 mod convert;
+mod metrics;
 mod network_indexer;
 mod subgraph;
 

--- a/chain/ethereum/src/network_indexer/mod.rs
+++ b/chain/ethereum/src/network_indexer/mod.rs
@@ -16,14 +16,18 @@ pub use self::network_indexer::NetworkIndexerEvent;
 
 const NETWORK_INDEXER_VERSION: u32 = 0;
 
-/// Helper type to bundle blocks and their uncles together.
+/// Helper type to represent ommer blocks.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct BlockWithUncles {
+pub struct Ommer(Block<H256>);
+
+/// Helper type to bundle blocks and their ommers together.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BlockWithOmmers {
     pub block: EthereumBlock,
-    pub uncles: Vec<Option<Block<H256>>>,
+    pub ommers: Vec<Option<Ommer>>,
 }
 
-impl BlockWithUncles {
+impl BlockWithOmmers {
     pub fn inner(&self) -> &LightEthereumBlock {
         &self.block.block
     }
@@ -49,7 +53,7 @@ pub(crate) fn format_light_block(block: &LightEthereumBlock) -> String {
     )
 }
 
-pub(crate) fn format_block(block: &BlockWithUncles) -> String {
+pub(crate) fn format_block(block: &BlockWithOmmers) -> String {
     format_light_block(block.inner())
 }
 

--- a/chain/ethereum/src/network_indexer/mod.rs
+++ b/chain/ethereum/src/network_indexer/mod.rs
@@ -1,5 +1,6 @@
 use graph::prelude::*;
-use web3::types::{Block, TransactionReceipt, H256};
+use std::fmt;
+use web3::types::{Block, H256};
 
 mod block_writer;
 mod convert;
@@ -33,28 +34,10 @@ impl BlockWithOmmers {
     }
 }
 
-/**
- * Logging helpers.
- */
-
-pub(crate) fn format_light_block(block: &LightEthereumBlock) -> String {
-    format!(
-        "{} ({})",
-        block
-            .number
-            .map_or(String::from("none"), |number| format!("#{}", number)),
-        block
-            .hash
-            .map_or(String::from("-"), |hash| format!("{:x}", hash))
-    )
-}
-
-pub(crate) fn format_block(block: &BlockWithOmmers) -> String {
-    format_light_block(block.inner())
-}
-
-pub(crate) fn format_block_pointer(ptr: &EthereumBlockPointer) -> String {
-    format!("#{} ({:x})", ptr.number, ptr.hash)
+impl fmt::Display for BlockWithOmmers {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.inner().format())
+    }
 }
 
 pub fn create<S>(

--- a/chain/ethereum/src/network_indexer/mod.rs
+++ b/chain/ethereum/src/network_indexer/mod.rs
@@ -1,5 +1,6 @@
 use graph::prelude::*;
 use std::fmt;
+use std::ops::Deref;
 use web3::types::{Block, H256};
 
 mod block_writer;
@@ -20,6 +21,48 @@ const NETWORK_INDEXER_VERSION: u32 = 0;
 /// Helper type to represent ommer blocks.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Ommer(Block<H256>);
+
+impl From<Block<H256>> for Ommer {
+    fn from(block: Block<H256>) -> Self {
+        Self(block)
+    }
+}
+
+impl From<LightEthereumBlock> for Ommer {
+    fn from(block: LightEthereumBlock) -> Self {
+        Self(Block {
+            hash: block.hash,
+            parent_hash: block.parent_hash,
+            uncles_hash: block.uncles_hash,
+            author: block.author,
+            state_root: block.state_root,
+            transactions_root: block.transactions_root,
+            receipts_root: block.receipts_root,
+            number: block.number,
+            gas_used: block.gas_used,
+            gas_limit: block.gas_limit,
+            extra_data: block.extra_data,
+            logs_bloom: block.logs_bloom,
+            timestamp: block.timestamp,
+            difficulty: block.difficulty,
+            total_difficulty: block.total_difficulty,
+            seal_fields: block.seal_fields,
+            uncles: block.uncles,
+            transactions: block.transactions.into_iter().map(|tx| tx.hash).collect(),
+            size: block.size,
+            mix_hash: block.mix_hash,
+            nonce: block.nonce,
+        })
+    }
+}
+
+impl Deref for Ommer {
+    type Target = Block<H256>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// Helper type to bundle blocks and their ommers together.
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/chain/ethereum/src/network_indexer/mod.rs
+++ b/chain/ethereum/src/network_indexer/mod.rs
@@ -24,7 +24,7 @@ pub struct Ommer(Block<H256>);
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct BlockWithOmmers {
     pub block: EthereumBlock,
-    pub ommers: Vec<Option<Ommer>>,
+    pub ommers: Vec<Ommer>,
 }
 
 impl BlockWithOmmers {

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -567,9 +567,11 @@ enum StateMachine {
     ///
     ///   E.g.:
     ///
-    ///      a---b---c---x
-    ///          \
-    ///           +--d---e---f
+    ///   ```ignore
+    ///   a---b---c---x
+    ///       \
+    ///        +--d---e---f
+    ///   ```
     ///
     ///   In that case we need to do the following:
     ///

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -1,0 +1,1258 @@
+use futures::future::{loop_fn, Loop};
+use futures::sync::mpsc::{channel, Receiver, Sender};
+use futures::try_ready;
+use state_machine_future::*;
+use std::collections::VecDeque;
+use std::fmt;
+use std::ops::Range;
+use std::str::FromStr;
+
+use graph::prelude::*;
+use web3::types::H256;
+
+use super::block_writer::BlockWriter;
+use super::*;
+
+/// Terminology used in this component:
+///
+/// Head / head block:
+///   The most recent block of a chain.
+///
+/// Local head:
+///   The block that the network indexer is at locally.
+///   We get this from the store.
+///
+/// Chain head:
+///   The block that the network is at.
+///   We get this from the Ethereum node(s).
+///
+/// Common ancestor (during a reorg):
+///   The most recent block that two versions of a chain (e.g. the locally
+///   indexed version and the latest version that the network recognizes)
+///   have in common.
+///
+///   When handling a reorg, this is the block after which the new version
+///   has diverged. All blocks up to and including the common ancestor
+///   remain untouched during the reorg. The blocks after the common ancestor
+///   are reverted and the blocks from the new version are added after the
+///   common ancestor.
+///
+///   The common ancestor is identified by traversing new blocks from a reorg
+///   back to the most recent block that we already have indexed locally.
+///
+/// Old blocks (during a reorg):
+///   Blocks after the common ancestor that are indexed locally but are
+///   being removed as part of a reorg. We collect these from the store by
+///   traversing from the current local head back to the common ancestor.
+///
+/// New blocks (during a reorg):
+///   Blocks between the common ancestor and the block that triggered the
+///   reorg. After reverting the old blocks, these are the blocks that need
+///   to be fetched from the network and added after the common ancestor.
+///
+///   We collect these from the network by traversing from the block that
+///   triggered the reorg back to the common ancestor.
+
+/**
+ * Helper types.
+ */
+
+type LocalHeadFuture = Box<dyn Future<Item = Option<EthereumBlockPointer>, Error = Error> + Send>;
+type ChainHeadFuture = Box<dyn Future<Item = LightEthereumBlock, Error = Error> + Send>;
+type BlockFuture = Box<dyn Future<Item = Option<BlockWithUncles>, Error = Error> + Send>;
+type BlockStream = Box<dyn Stream<Item = Option<BlockWithUncles>, Error = Error> + Send>;
+type NewBlocksFuture = Box<dyn Future<Item = VecDeque<BlockWithUncles>, Error = Error> + Send>;
+type CollectBlocksToRevertFuture =
+    Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send>;
+type RevertBlocksFuture = Box<dyn Future<Item = EthereumBlockPointer, Error = Error> + Send>;
+type AddBlockFuture = Box<dyn Future<Item = EthereumBlockPointer, Error = Error> + Send>;
+type SendEventFuture = Box<dyn Future<Item = (), Error = Error> + Send>;
+
+/**
+ * Helpers to create futures and streams.
+ */
+
+fn load_local_head(subgraph_id: SubgraphDeploymentId, store: Arc<dyn Store>) -> LocalHeadFuture {
+    Box::new(future::result(store.clone().block_ptr(subgraph_id.clone())))
+}
+
+fn poll_chain_head(logger: Logger, adapter: Arc<dyn EthereumAdapter>) -> ChainHeadFuture {
+    Box::new(adapter.latest_block(&logger).from_err())
+}
+
+fn fetch_block_and_uncles_by_number(
+    logger: Logger,
+    adapter: Arc<dyn EthereumAdapter>,
+    block_number: u64,
+) -> BlockFuture {
+    let logger_for_full_block = logger.clone();
+    let adapter_for_full_block = adapter.clone();
+
+    let logger_for_uncles = logger.clone();
+    let adapter_for_uncles = adapter.clone();
+
+    Box::new(
+        adapter
+            .block_by_number(&logger, block_number)
+            .from_err()
+            .and_then(move |block| match block {
+                None => Box::new(future::ok(None))
+                    as Box<dyn Future<Item = Option<EthereumBlock>, Error = _> + Send>,
+                Some(block) => Box::new(
+                    adapter_for_full_block
+                        .load_full_block(&logger_for_full_block, block)
+                        .map(|block| Some(block))
+                        .from_err(),
+                ),
+            })
+            .and_then(move |block| match block {
+                None => Box::new(future::ok(None))
+                    as Box<dyn Future<Item = Option<BlockWithUncles>, Error = _> + Send>,
+                Some(block) => Box::new(
+                    adapter_for_uncles
+                        .uncles(&logger_for_uncles, &block.block)
+                        .and_then(move |uncles| future::ok(BlockWithUncles { block, uncles }))
+                        .map(|block| Some(block)),
+                ),
+            }),
+    )
+}
+
+fn fetch_block_and_uncles(
+    logger: Logger,
+    adapter: Arc<dyn EthereumAdapter>,
+    block_hash: H256,
+) -> BlockFuture {
+    let logger_for_full_block = logger.clone();
+    let adapter_for_full_block = adapter.clone();
+
+    let logger_for_uncles = logger.clone();
+    let adapter_for_uncles = adapter.clone();
+
+    Box::new(
+        adapter
+            .block_by_hash(&logger, block_hash)
+            .from_err()
+            .and_then(move |block| match block {
+                None => Box::new(future::ok(None))
+                    as Box<dyn Future<Item = Option<EthereumBlock>, Error = _> + Send>,
+                Some(block) => Box::new(
+                    adapter_for_full_block
+                        .load_full_block(&logger_for_full_block, block)
+                        .map(|block| Some(block))
+                        .from_err(),
+                ),
+            })
+            .and_then(move |block| match block {
+                None => Box::new(future::ok(None))
+                    as Box<dyn Future<Item = Option<BlockWithUncles>, Error = _> + Send>,
+                Some(block) => Box::new(
+                    adapter_for_uncles
+                        .uncles(&logger_for_uncles, &block.block)
+                        .and_then(move |uncles| future::ok(BlockWithUncles { block, uncles }))
+                        .map(|block| Some(block)),
+                ),
+            }),
+    )
+}
+
+fn fetch_blocks(
+    logger: Logger,
+    adapter: Arc<dyn EthereumAdapter>,
+    block_numbers: Range<u64>,
+) -> BlockStream {
+    Box::new(
+        futures::stream::iter_ok::<_, Error>(block_numbers)
+            .map(move |block_number| {
+                fetch_block_and_uncles_by_number(logger.clone(), adapter.clone(), block_number)
+            })
+            .buffered(100),
+    )
+}
+
+fn fetch_new_blocks(
+    logger: Logger,
+    subgraph_id: SubgraphDeploymentId,
+    adapter: Arc<dyn EthereumAdapter>,
+    store: Arc<dyn Store>,
+    head: BlockWithUncles,
+) -> NewBlocksFuture {
+    // Start at `head` and go back block by block until we find a block that we
+    // already have in the store. That block is the common ancestor. Collect all
+    // blocks as we go. Then, return all blocks including the common ancestor and
+    // head.
+    Box::new(
+        loop_fn(vec![head], move |mut blocks| {
+            let store = store.clone();
+
+            // Get the last block from the list
+            let (block_entity_key, number, hash, parent_hash) = {
+                let block = blocks.last().unwrap();
+                (
+                    block.to_entity_key(subgraph_id.clone()),
+                    block.inner().number.clone().unwrap(),
+                    block.inner().hash.clone().unwrap(),
+                    block.inner().parent_hash.clone(),
+                )
+            };
+
+            trace!(
+                logger,
+                "Fetch block on new chain";
+                "block" => format!("#{} ({:x})", number, hash),
+            );
+
+            // Look it up from the store
+            match store.get(block_entity_key) {
+                Ok(None) => {
+                    // We don't have the block yet, continue with its parent
+                    Box::new(
+                        fetch_block_and_uncles(
+                            logger.clone(),
+                            adapter.clone(),
+                            parent_hash.clone(),
+                        )
+                        .and_then(move |parent| match parent {
+                            None => future::err(format_err!(
+                                "failed to fetch parent block {:x}",
+                                parent_hash
+                            )),
+
+                            Some(parent) => {
+                                blocks.push(parent);
+                                future::ok(Loop::Continue(blocks))
+                            }
+                        }),
+                    )
+                }
+
+                Ok(Some(_)) => {
+                    trace!(
+                        logger,
+                        "Found common ancestor";
+                        "block" => format!("#{} ({:x})", number, hash),
+                    );
+
+                    // We have the block already, so this is the block after which
+                    // the chain was forked
+                    Box::new(future::ok(Loop::Break(blocks)))
+                        as Box<dyn Future<Item = Loop<_, _>, Error = Error> + Send>
+                }
+
+                // Looking up the block failed, propoagate the error so we can
+                // retry handling the reorg
+                Err(e) => Box::new(future::err(e.into()))
+                    as Box<dyn Future<Item = Loop<_, _>, Error = Error> + Send>,
+            }
+        })
+        // Reverse the blocks so that the common ancestor comes first.
+        .map(|mut blocks: Vec<BlockWithUncles>| {
+            blocks.reverse();
+            VecDeque::from(blocks)
+        }),
+    )
+}
+
+fn write_block(block_writer: Arc<BlockWriter>, block: BlockWithUncles) -> AddBlockFuture {
+    let block_ptr = block.inner().into();
+    Box::new(block_writer.write(block).map(move |_| block_ptr))
+}
+
+fn collect_blocks_to_revert(
+    logger: Logger,
+    subgraph_id: SubgraphDeploymentId,
+    store: Arc<dyn Store>,
+    head: EthereumBlockPointer,
+    common_ancestor: EthereumBlockPointer,
+) -> CollectBlocksToRevertFuture {
+    Box::new(loop_fn(vec![head], move |mut blocks| {
+        let logger = logger.clone();
+        let store = store.clone();
+
+        // Get the last block from the list
+        let block_ptr = blocks.last().unwrap().clone();
+        let block_ptr_for_missing_parent = block_ptr.clone();
+        let block_ptr_for_invalid_parent = block_ptr.clone();
+
+        trace!(
+            logger,
+            "Collect old block";
+            "common_ancestor" => format_block_pointer(&common_ancestor),
+            "block" => format_block_pointer(&block_ptr),
+        );
+
+        // If we've reached the common ancestor, terminate the loop and return
+        // the blocks we have collected up to here
+        if block_ptr == common_ancestor {
+            trace!(logger, "Reached common ancestor");
+
+            return Box::new(future::ok(Loop::Break(blocks)))
+                as Box<dyn Future<Item = _, Error = _> + Send>;
+        }
+
+        // Look this block up from the store
+        Box::new(
+            future::result(
+                store
+                    .get(block_ptr.to_entity_key(subgraph_id.clone()))
+                    .map_err(|e| e.into())
+                    .and_then(|entity| {
+                        entity.ok_or_else(|| {
+                            format_err!(
+                                "block {} is missing in store",
+                                format_block_pointer(&block_ptr)
+                            )
+                        })
+                    }),
+            )
+            // Get the parent hash from the block
+            .and_then(move |block| {
+                future::result(
+                    block
+                        .get("parent")
+                        .ok_or_else(move || {
+                            format_err!(
+                                "block {} has no parent",
+                                format_block_pointer(&block_ptr_for_missing_parent),
+                            )
+                        })
+                        .and_then(|value| {
+                            let s = value
+                                .clone()
+                                .as_string()
+                                .expect("the `parent` field of `Block` is a reference/string");
+
+                            H256::from_str(s.as_str()).map_err(|e| {
+                                format_err!(
+                                    "block {} has an invalid parent `{}`: {}",
+                                    format_block_pointer(&block_ptr_for_invalid_parent),
+                                    s,
+                                    e,
+                                )
+                            })
+                        }),
+                )
+            })
+            .and_then(move |parent_hash: H256| {
+                // Create a block pointer for the parent
+                let parent_ptr = EthereumBlockPointer {
+                    number: block_ptr.number - 1,
+                    hash: parent_hash,
+                };
+
+                // Add the parent block pointer for the next iteration
+                blocks.push(parent_ptr);
+                future::ok(Loop::Continue(blocks))
+            }),
+        )
+    }))
+}
+
+fn revert_blocks(
+    subgraph_id: SubgraphDeploymentId,
+    logger: Logger,
+    store: Arc<dyn Store>,
+    event_sink: Sender<NetworkIndexerEvent>,
+    blocks: Vec<EthereumBlockPointer>,
+) -> RevertBlocksFuture {
+    // The common ancestor is the last block (we're looking at the blocks
+    // starting with the most recent old block, because we're reverting in
+    // reverse order).
+    let common_ancestor = blocks
+        .last()
+        .expect("no blocks to revert, what kind of 'reorg' is this?")
+        .clone();
+
+    let logger_for_complete = logger.clone();
+
+    Box::new(
+        // Iterate over pairs of blocks in the order they need to be reverted:
+        // (local_head, local_head-1), ..., (local_head-n, common_ancestor).
+        stream::iter_ok(
+            blocks[0..]
+                .to_owned()
+                .into_iter()
+                .zip(blocks[1..].to_owned().into_iter()),
+        )
+        .for_each(move |(from, to)| {
+            let event_sink = event_sink.clone();
+            let logger = logger.clone();
+
+            let logger_for_revert_err = logger.clone();
+            let from_for_revert_err = from.clone();
+            let to_for_revert_err = to.clone();
+
+            let logger_for_send_err = logger.clone();
+            let from_for_send_err = from.clone();
+            let to_for_send_err = to.clone();
+
+            debug!(
+                logger,
+                "Revert old block";
+                "to" => format_block_pointer(&to),
+                "from" => format_block_pointer(&from),
+            );
+
+            future::result(store.revert_block_operations(
+                subgraph_id.clone(),
+                from.clone(),
+                to.clone(),
+            ))
+            .map_err(move |e| {
+                debug!(
+                    logger_for_revert_err,
+                    "Reverting block failed";
+                    "error" => format!("{}", e),
+                    "to" => format_block_pointer(&to_for_revert_err),
+                    "from" => format_block_pointer(&from_for_revert_err),
+                );
+
+                // Instead of an error we return the last block that we managed
+                // to revert to; this will become the new local head
+                from_for_revert_err
+            })
+            .and_then(move |_| {
+                send_event(
+                    event_sink.clone(),
+                    NetworkIndexerEvent::Revert {
+                        from: from.clone(),
+                        to: to.clone(),
+                    },
+                )
+                .map_err(move |e| {
+                    debug!(
+                        logger_for_send_err,
+                        "Sending revert event failed";
+                        "error" => format!("{}", e),
+                        "to" => format_block_pointer(&to_for_send_err),
+                        "from" => format_block_pointer(&from_for_send_err),
+                    );
+
+                    // Instead of an error we return the last block that we managed
+                    // to revert to; this will become the new local head
+                    from_for_send_err
+                })
+            })
+        })
+        .then(move |result| match result {
+            Ok(_) => {
+                debug!(
+                    logger_for_complete,
+                    "Revert old blocks complete; process next blocks"
+                );
+                future::ok(common_ancestor)
+            }
+            Err(block) => {
+                debug!(
+                    logger_for_complete,
+                    "Revert old blocks failed; \
+                     setting local head to the last block we managed to revert to"
+                );
+                future::ok(block)
+            }
+        }),
+    )
+}
+
+fn send_event(
+    event_sink: Sender<NetworkIndexerEvent>,
+    event: NetworkIndexerEvent,
+) -> SendEventFuture {
+    Box::new(
+        event_sink
+            .send(event)
+            .map(|_| ())
+            .map_err(|e| format_err!("failed to emit events: {}", e)),
+    )
+}
+
+/**
+ * Network tracer implementation.
+ */
+
+/// Context for the network tracer.
+pub struct Context {
+    subgraph_id: SubgraphDeploymentId,
+    logger: Logger,
+    adapter: Arc<dyn EthereumAdapter>,
+    store: Arc<dyn Store>,
+    event_sink: Sender<NetworkIndexerEvent>,
+    block_writer: Arc<BlockWriter>,
+}
+
+/// Events emitted by the network tracer.
+#[derive(Debug, PartialEq, Clone)]
+pub enum NetworkIndexerEvent {
+    Revert {
+        from: EthereumBlockPointer,
+        to: EthereumBlockPointer,
+    },
+    AddBlock(EthereumBlockPointer),
+}
+
+impl fmt::Display for NetworkIndexerEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NetworkIndexerEvent::Revert { from, to } => write!(
+                f,
+                "Revert from {} to {}",
+                format_block_pointer(&from),
+                format_block_pointer(&to),
+            ),
+            NetworkIndexerEvent::AddBlock(block) => {
+                write!(f, "Add block {}", format_block_pointer(&block))
+            }
+        }
+    }
+}
+
+/// State machine that handles block fetching and block reorganizations.
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "Context")]
+enum StateMachine {
+    /// The indexer start in an empty state and immediately moves on
+    /// to loading the local head block from the store.
+    #[state_machine_future(start, transitions(LoadLocalHead))]
+    Start,
+
+    /// This state waits until the local head block has been loaded from the
+    /// store. It then moves on to polling the chain head block.
+    #[state_machine_future(transitions(PollChainHead, Failed))]
+    LoadLocalHead { local_head: LocalHeadFuture },
+
+    /// This state waits until the chain head block has been polled
+    /// successfully.
+    ///
+    /// Based on the (local head, chain head) pair, the indexer then moves
+    /// on to fetching and processing a range of blocks starting at
+    /// local head + 1 up, leading up to the chain head. This is done
+    /// in chunks of e.g. 100 blocks at a time for two reasons:
+    ///
+    /// 1. To limit the amount of blocks we keep in memory.
+    /// 2. To be able to re-evaluate the chain head and check for reorgs
+    ///    frequently.
+    #[state_machine_future(transitions(ProcessBlocks, PollChainHead, Failed))]
+    PollChainHead {
+        local_head: Option<EthereumBlockPointer>,
+        chain_head: ChainHeadFuture,
+    },
+
+    /// This state takes the next block from the stream. If the stream is
+    /// exhausted, it transitions back to polling the chain head block
+    /// and deciding on the next chunk of blocks to fetch. If there is still
+    /// a block to read from the stream, it's passed on to vetting for
+    /// validation and reorg checking.
+    #[state_machine_future(transitions(VetBlock, PollChainHead, Failed))]
+    ProcessBlocks {
+        local_head: Option<EthereumBlockPointer>,
+        chain_head: LightEthereumBlock,
+        next_blocks: BlockStream,
+    },
+
+    /// This state vets incoming blocks with regards to two aspects:
+    ///
+    /// 1. Does the block have a number and hash? This is a requirement for
+    ///    indexing to continue. If not, the indexer re-evaluates the chain
+    ///    head and starts over.
+    ///
+    /// 2. Is the block the successor of the local head block? If yes, move
+    ///    on to indexing this block. If not, we have a reorg.
+    ///
+    /// Notes on the reorg handling:
+    ///
+    ///   By checking parent/child succession, we ensure that there are no gaps
+    ///   in the indexed data (class mathematical induction). So if the local
+    ///   head is `x` and a block `f` comes in that is not a successor/child, it
+    ///   must be on a different version/fork of the chain.
+    ///
+    ///   E.g.:
+    ///
+    ///      a---b---c---x
+    ///          \
+    ///           +--d---e---f
+    ///
+    ///   In that case we need to do the following:
+    ///
+    ///   1. Find the common ancestor of `x` and `f`, which is the block after
+    ///      which the two versions diverged (in the above example: `b`).
+    ///
+    ///   2. Collect old blocks betweeen the common ancestor and (including)
+    ///      the local head that need to be reverted (in the above example:
+    ///      `c`, `x`).
+    ///
+    ///   3. Fetch new blocks between the common ancestor and (including) `f`
+    ///      that are to be inserted instead of the old blocks in order to
+    ///      make the incoming block (`f`) the local head (in the above
+    ///      example: `d`, `e`, `f`).
+    #[state_machine_future(transitions(FetchNewBlocks, AddBlock, PollChainHead, Failed))]
+    VetBlock {
+        local_head: Option<EthereumBlockPointer>,
+        chain_head: LightEthereumBlock,
+        next_blocks: BlockStream,
+        block: BlockWithUncles,
+    },
+
+    /// This state waits until all new blocks from the incoming block back to
+    /// the common ancestor are available. Identifying the common ancestor is
+    /// part of this process.
+    ///
+    /// If successful, the indexer moves on to collecting old blocks and
+    /// reverting the indexed data to the common ancestor. If fetching the new
+    /// blocks fails, it discards any new information and re-evaluates the chain
+    /// head.
+    ///
+    /// The new blocks that were fetched are prepending to the incoming blocks
+    /// stream, so that after reverting blocks the indexer can proceed with these
+    /// as if no reorg happened. It'll still want to vet these blocks so it wouldn't
+    /// be wise to just index the blocks without further checks.
+    ///
+    /// Note: This state also carries over the incoming block stream to not lose
+    /// its blocks. This is because even if there was a reorg, the blocks following
+    /// the current block that made us detect it will likely be valid successors.
+    /// So once the reorg has been handled, the indexer should be able to
+    /// continue with the remaining blocks on the stream.
+    ///
+    /// Only when going back to re-evaluating the chain head, the incoming
+    /// blocks stream is thrown away in the hope that of receiving a better
+    /// chain head with different blocks leading up to it.
+    #[state_machine_future(transitions(RevertToCommonAncestor, PollChainHead, Failed))]
+    FetchNewBlocks {
+        local_head: Option<EthereumBlockPointer>,
+        chain_head: LightEthereumBlock,
+        next_blocks: BlockStream,
+        new_blocks: NewBlocksFuture,
+    },
+
+    /// This state collects and reverts old blocks in the store. If successful,
+    /// the indexer moves on to processing the blocks regularly (at this point,
+    /// the incoming blocks stream includes new blocks for the reorg, the
+    /// block that triggered the reorg and any blocks that were already in the
+    /// stream following the block that triggered the reorg).
+    ///
+    /// After reverting, the local head is updated to the common ancestor.
+    ///
+    /// If reverting fails at any block, the local head is updated to the
+    /// last block that we managed to revert to. Following that, the indexer
+    /// re-evaluates the chain head and starts over.
+    ///
+    /// Note: failing to revert an old block locally may be something that
+    /// the indexer cannot recover from, so it may run into a loop at this
+    /// point.
+    #[state_machine_future(transitions(ProcessBlocks, PollChainHead, Failed))]
+    RevertToCommonAncestor {
+        local_head: Option<EthereumBlockPointer>,
+        chain_head: LightEthereumBlock,
+        next_blocks: BlockStream,
+        new_local_head: RevertBlocksFuture,
+    },
+
+    /// This state waits until a block has been written and an event for it
+    /// has been sent out. After that, the indexer continues processing the
+    /// next block. If anything goes wrong at this point, it's back to
+    /// re-evaluating the chain head and fetching (potentially) different
+    /// blocks for indexing.
+    #[state_machine_future(transitions(ProcessBlocks, PollChainHead, Failed))]
+    AddBlock {
+        chain_head: LightEthereumBlock,
+        next_blocks: BlockStream,
+        old_local_head: Option<EthereumBlockPointer>,
+        new_local_head: AddBlockFuture,
+    },
+
+    /// This is unused, the indexing never ends.
+    #[state_machine_future(ready)]
+    Ready(()),
+
+    /// State for fatal errors that cause the indexing to terminate. This should
+    /// almost never happen. If it does, it should cause the entire node to crash
+    /// and restart.
+    #[state_machine_future(error)]
+    Failed(Error),
+}
+
+impl PollStateMachine for StateMachine {
+    fn poll_start<'a, 'c>(
+        _state: &'a mut RentToOwn<'a, Start>,
+        context: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterStart, Error> {
+        // Abort if the output stream has been closed. Depending on how the
+        // network indexer is wired up, this could mean that the system shutting
+        // down.
+        try_ready!(context.event_sink.poll_ready());
+
+        info!(context.logger, "Start indexing network data");
+
+        // Start by loading the local head from the store. This is the most
+        // recent block we managed to index until now.
+        transition!(LoadLocalHead {
+            local_head: load_local_head(context.subgraph_id.clone(), context.store.clone())
+        })
+    }
+
+    fn poll_load_local_head<'a, 'c>(
+        state: &'a mut RentToOwn<'a, LoadLocalHead>,
+        context: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterLoadLocalHead, Error> {
+        // Abort if the output stream has been closed.
+        try_ready!(context.event_sink.poll_ready());
+
+        info!(context.logger, "Load local head block");
+
+        // Wait until we have the local head block; fail if we can't get it from
+        // the store because that means the indexed data is broken.
+        let local_head = try_ready!(state.local_head.poll());
+
+        // Move on to poll the chain head.
+        transition!(PollChainHead {
+            local_head,
+            chain_head: poll_chain_head(context.logger.clone(), context.adapter.clone()),
+        })
+    }
+
+    fn poll_poll_chain_head<'a, 'c>(
+        state: &'a mut RentToOwn<'a, PollChainHead>,
+        context: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterPollChainHead, Error> {
+        // Abort if the output stream has been closed.
+        try_ready!(context.event_sink.poll_ready());
+
+        match state.chain_head.poll() {
+            // Wait until we have the chain head block.
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+
+            // We have a (new?) chain head, decide what to do.
+            Ok(Async::Ready(chain_head)) => {
+                // Validate the chain head.
+                if chain_head.number.is_none() || chain_head.hash.is_none() {
+                    // This is fairly irregular, so log a warning.
+                    warn!(
+                        context.logger,
+                        "Chain head block number or hash missing; try again";
+                        "block" => format_light_block(&chain_head),
+                    );
+
+                    // Chain head was invalid, try getting a better one.
+                    transition!(PollChainHead {
+                        local_head: state.local_head,
+                        chain_head: poll_chain_head(
+                            context.logger.clone(),
+                            context.adapter.clone()
+                        ),
+                    })
+                }
+
+                let state = state.take();
+
+                debug!(
+                    context.logger,
+                    "Identify next blocks to index";
+                    "chain_head" => format_light_block(&chain_head),
+                    "local_head" => state.local_head.map_or(
+                        String::from("none"), |ptr| format_block_pointer(&ptr)
+                    ),
+                );
+
+                // If we're already at the chain head, keep polling it.
+                if Some((&chain_head).into()) == state.local_head {
+                    debug!(
+                        context.logger,
+                        "Already at chain head; poll chain head again";
+                        "chain_head" => format_light_block(&chain_head),
+                        "local_head" => state.local_head.map_or(
+                            String::from("none"), |ptr| format_block_pointer(&ptr)
+                        ),
+                    );
+
+                    // Chain head was invalid, try getting a better one.
+                    transition!(PollChainHead {
+                        local_head: state.local_head,
+                        chain_head: poll_chain_head(
+                            context.logger.clone(),
+                            context.adapter.clone()
+                        ),
+                    });
+                }
+
+                // Calculate the number of blocks remaining before we are in sync with the
+                // network; fetch no more than 1000 blocks at a time.
+                let chain_head_number = chain_head.number.unwrap().as_u64();
+                let next_block_number = state.local_head.map_or(0u64, |ptr| ptr.number + 1);
+                let remaining_blocks = chain_head_number + 1 - next_block_number;
+                let block_range_size = remaining_blocks.min(1000);
+                let block_numbers = next_block_number..(next_block_number + block_range_size);
+
+                // Ensure we're not trying to fetch beyond the current chain head (note: the
+                // block numbers range end is _exclusive_, hence it must not be greater than
+                // chain head + 1)
+                assert!(
+                    block_numbers.end <= chain_head_number + 1,
+                    "overfetching beyond the chain head; \
+                     this is a bug in the block range calculation"
+                );
+
+                info!(
+                    context.logger,
+                    "Process {} of {} remaining blocks",
+                    block_range_size, remaining_blocks;
+                    "chain_head" => format_light_block(&chain_head),
+                    "local_head" => state.local_head.map_or(
+                        String::from("none"), |ptr| format_block_pointer(&ptr)
+                    ),
+                    "range" => format!("#{}..#{}", block_numbers.start, block_numbers.end-1),
+                );
+
+                // Processing the blocks in this range.
+                transition!(ProcessBlocks {
+                    local_head: state.local_head,
+                    chain_head,
+                    next_blocks: fetch_blocks(
+                        context.logger.clone(),
+                        context.adapter.clone(),
+                        block_numbers
+                    )
+                })
+            }
+
+            Err(e) => {
+                trace!(
+                    context.logger,
+                    "Failed to poll chain head; try again";
+                    "error" => format!("{}", e),
+                );
+
+                let state = state.take();
+
+                transition!(PollChainHead {
+                    local_head: state.local_head,
+                    chain_head: poll_chain_head(context.logger.clone(), context.adapter.clone()),
+                })
+            }
+        }
+    }
+
+    fn poll_process_blocks<'a, 'c>(
+        state: &'a mut RentToOwn<'a, ProcessBlocks>,
+        context: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterProcessBlocks, Error> {
+        // Abort if the output stream has been closed.
+        try_ready!(context.event_sink.poll_ready());
+
+        // Try to read the next block.
+        match state.next_blocks.poll() {
+            // No block ready yet, try again later.
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+
+            // The stream is exhausted, update chain head and fetch the next
+            // range of blocks for processing.
+            Ok(Async::Ready(None)) => {
+                debug!(context.logger, "Check if there are more blocks");
+
+                let state = state.take();
+
+                transition!(PollChainHead {
+                    local_head: state.local_head,
+                    chain_head: poll_chain_head(context.logger.clone(), context.adapter.clone()),
+                })
+            }
+
+            // The block could not be fetched but there was no clear error either;
+            // try starting over with a fresh chain head.
+            Ok(Async::Ready(Some(None))) => {
+                trace!(
+                    context.logger,
+                    "Failed to fetch block; re-evaluate chain head and try again"
+                );
+
+                let state = state.take();
+
+                transition!(PollChainHead {
+                    local_head: state.local_head,
+                    chain_head: poll_chain_head(context.logger.clone(), context.adapter.clone()),
+                })
+            }
+
+            // There is a block ready to be processed; check whether it is valid
+            // and whether it requires a reorg before adding it.
+            Ok(Async::Ready(Some(Some(block)))) => {
+                let state = state.take();
+
+                transition!(VetBlock {
+                    local_head: state.local_head,
+                    chain_head: state.chain_head,
+                    next_blocks: state.next_blocks,
+                    block,
+                })
+            }
+
+            // Fetching blocks failed; we have no choice but to start over again
+            // with a fresh chain head.
+            Err(e) => {
+                trace!(
+                    context.logger,
+                    "Failed to fetch block; re-evaluate chain head and try again";
+                    "error" => format!("{}", e),
+                );
+
+                let state = state.take();
+
+                transition!(PollChainHead {
+                    local_head: state.local_head,
+                    chain_head: poll_chain_head(context.logger.clone(), context.adapter.clone()),
+                })
+            }
+        }
+    }
+
+    fn poll_vet_block<'a, 'c>(
+        state: &'a mut RentToOwn<'a, VetBlock>,
+        context: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterVetBlock, Error> {
+        // Abort if the output stream has been closed.
+        try_ready!(context.event_sink.poll_ready());
+
+        let state = state.take();
+        let block = state.block;
+
+        // Validate the block.
+        if block.inner().number.is_none() || block.inner().hash.is_none() {
+            // This is fairly irregular, so log a warning.
+            warn!(
+                context.logger,
+                "Block number or hash missing; trying again";
+                "block" => format_block(&block),
+            );
+
+            // The block is invalid, throw away the entire stream and
+            // start with re-checking the chain head block again.
+            transition!(PollChainHead {
+                local_head: state.local_head,
+                chain_head: poll_chain_head(context.logger.clone(), context.adapter.clone()),
+            })
+        }
+
+        // If we encounter a block that has a smaller number than our
+        // local head block, then we throw away the block stream and
+        // try to start over with a fresh chain head block.
+        //
+        // The assumption here is that maybe the network provider being
+        // used is temporarily serving from an outdated node.
+        let block_number = block.inner().number.unwrap().as_u64();
+        let local_head_number = state.local_head.map_or(0u64, |ptr| ptr.number);
+        if block_number < local_head_number {
+            // This is pretty irregular, so make log a warning.
+            warn!(
+                context.logger,
+                "Received older block than the local head; \
+                 re-evaluate chain head and try again";
+                "local_head" => state.local_head.map_or(
+                    String::from("none"), |ptr| format_block_pointer(&ptr)
+                ),
+                "block" => format_block(&block),
+            );
+
+            transition!(PollChainHead {
+                local_head: state.local_head,
+                chain_head: poll_chain_head(context.logger.clone(), context.adapter.clone()),
+            })
+        }
+
+        // Check whether we have a reorg (parent of the new block != our local head).
+        if block.inner().parent_ptr() != state.local_head {
+            info!(
+                context.logger,
+                "Block requires a reorg";
+                "local_head" => state.local_head.map_or(
+                    String::from("none"), |ptr| format_block_pointer(&ptr)
+                ),
+                "parent" => block.inner().parent_ptr().map_or(
+                    String::from("none"), |ptr| format_block_pointer(&ptr)
+                ),
+                "block" => format_block(&block),
+            );
+
+            // We are dealing with a reorg; fetch all new blocks from the incoming
+            // block back to the common ancestor.
+            transition!(FetchNewBlocks {
+                local_head: state.local_head,
+                chain_head: state.chain_head,
+                next_blocks: state.next_blocks,
+                new_blocks: fetch_new_blocks(
+                    context.logger.clone(),
+                    context.subgraph_id.clone(),
+                    context.adapter.clone(),
+                    context.store.clone(),
+                    block
+                ),
+            })
+        } else {
+            let event_sink = context.event_sink.clone();
+
+            // The block is a regular successor to the local head.
+            // Add the block and move on.
+            transition!(AddBlock {
+                // Remember the old local head in case we need to roll back.
+                old_local_head: state.local_head,
+
+                // Carry over the current chain head and the incoming blocks stream.
+                chain_head: state.chain_head,
+                next_blocks: state.next_blocks,
+
+                // Index the block.
+                new_local_head: Box::new(
+                    // Write block to the store.
+                    write_block(context.block_writer.clone(), block)
+                        // Send an `AddBlock` event for it.
+                        .and_then(move |block_ptr| {
+                            send_event(event_sink, NetworkIndexerEvent::AddBlock(block_ptr.clone()))
+                                .and_then(move |_| {
+                                    // Return the new block so we can update the local head.
+                                    future::ok(block_ptr)
+                                })
+                        })
+                )
+            })
+        }
+    }
+
+    fn poll_fetch_new_blocks<'a, 'c>(
+        state: &'a mut RentToOwn<'a, FetchNewBlocks>,
+        context: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterFetchNewBlocks, Error> {
+        // Abort if the output stream has been closed.
+        try_ready!(context.event_sink.poll_ready());
+
+        match state.new_blocks.poll() {
+            // Don't have the new blocks yet, try again later.
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+
+            // Have the new blocks, now revert to the common ancestor, prepend
+            // the new blocks to the incoming blocks stream and move towards
+            // the block that triggered the reorg.
+            Ok(Async::Ready(mut new_blocks)) => {
+                // The first block is the common ancestor.
+                let common_ancestor = new_blocks.pop_front().expect(
+                    "reorgs without a common ancestor are invalid \
+                     as they are entirely different chains",
+                );
+
+                let state = state.take();
+
+                let common_ancestor_ptr = common_ancestor.inner().into();
+                let local_head_ptr = state
+                    .local_head
+                    .expect("cannot have a reorg if there is no local head block yet")
+                    .into();
+
+                let subgraph_id_for_revert = context.subgraph_id.clone();
+                let logger_for_revert = context.logger.clone();
+                let store_for_revert = context.store.clone();
+                let event_sink_for_revert = context.event_sink.clone();
+
+                transition!(RevertToCommonAncestor {
+                    local_head: state.local_head,
+                    chain_head: state.chain_head,
+
+                    // Make the blocks from the forked branch the next ones to process
+                    // before any other incoming blocks
+                    next_blocks: Box::new(
+                        stream::iter_ok(new_blocks.into_iter().map(|block| Some(block)))
+                            .chain(state.next_blocks)
+                    ),
+
+                    // Identify the sequence of block pointers we need to
+                    // revert, going back from the local head to the common
+                    // ancestor; then revert all of those by reverting them in
+                    // the store and emitting revert events.
+                    //
+                    // If reverting fails, we update the local head to the most
+                    // recent block that we managed to revert to.
+                    new_local_head: Box::new(
+                        collect_blocks_to_revert(
+                            context.logger.clone(),
+                            context.subgraph_id.clone(),
+                            context.store.clone(),
+                            local_head_ptr,
+                            common_ancestor_ptr,
+                        )
+                        .and_then(move |block_ptrs| {
+                            revert_blocks(
+                                subgraph_id_for_revert,
+                                logger_for_revert,
+                                store_for_revert,
+                                event_sink_for_revert,
+                                block_ptrs,
+                            )
+                        })
+                    )
+                })
+            }
+
+            // Fetching the new blocks failed.
+            Err(e) => {
+                trace!(
+                    context.logger,
+                    "Fetching new blocks failed; \
+                     re-evaluate chain head and try again";
+                    "error" => format!("{}", e)
+                );
+
+                let state = state.take();
+
+                transition!(PollChainHead {
+                    local_head: state.local_head,
+                    chain_head: poll_chain_head(context.logger.clone(), context.adapter.clone()),
+                })
+            }
+        }
+    }
+
+    fn poll_revert_to_common_ancestor<'a, 'c>(
+        state: &'a mut RentToOwn<'a, RevertToCommonAncestor>,
+        context: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterRevertToCommonAncestor, Error> {
+        // Abort if the output stream has been closed.
+        try_ready!(context.event_sink.poll_ready());
+
+        match state.new_local_head.poll() {
+            // Reverting has not finished yet, try again later.
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+
+            // The revert finished and the common ancestor should become our new
+            // local head. Continue processing the blocks that we pulled in for
+            // the reorg.
+            Ok(Async::Ready(block_ptr)) => {
+                let state = state.take();
+
+                transition!(ProcessBlocks {
+                    // Set the local head to the block we have reverted to
+                    local_head: Some(block_ptr),
+                    chain_head: state.chain_head,
+                    next_blocks: state.next_blocks,
+                })
+            }
+
+            // There was an error reverting; re-evaluate the chain head
+            // and try again.
+            Err(e) => {
+                warn!(
+                    context.logger,
+                    "Failed to handle reorg, re-evaluate chain head and try again";
+                    "error" => format!("{}", e),
+                );
+
+                let state = state.take();
+
+                transition!(PollChainHead {
+                    local_head: state.local_head,
+                    chain_head: poll_chain_head(context.logger.clone(), context.adapter.clone()),
+                })
+            }
+        }
+    }
+
+    fn poll_add_block<'a, 'c>(
+        state: &'a mut RentToOwn<'a, AddBlock>,
+        context: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterAddBlock, Error> {
+        // Abort if the output stream has been closed.
+        try_ready!(context.event_sink.poll_ready());
+
+        match state.new_local_head.poll() {
+            // Adding the block is not complete yet, try again later.
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
+
+            // We have the new local block, update it and continue processing blocks.
+            Ok(Async::Ready(block_ptr)) => {
+                let state = state.take();
+
+                transition!(ProcessBlocks {
+                    local_head: Some(block_ptr),
+                    chain_head: state.chain_head,
+                    next_blocks: state.next_blocks,
+                })
+            }
+
+            // Something went wrong, back to re-evaluating the chain head it is!
+            Err(e) => {
+                trace!(
+                    context.logger,
+                    "Failed to add block, re-evaluate chain head and try again";
+                    "error" => format!("{}", e),
+                );
+
+                let state = state.take();
+
+                transition!(PollChainHead {
+                    local_head: state.old_local_head,
+                    chain_head: poll_chain_head(context.logger.clone(), context.adapter.clone()),
+                })
+            }
+        }
+    }
+}
+
+pub struct NetworkIndexer {
+    output: Option<Receiver<NetworkIndexerEvent>>,
+}
+
+impl NetworkIndexer {
+    pub fn new<S>(
+        subgraph_id: SubgraphDeploymentId,
+        logger: &Logger,
+        adapter: Arc<dyn EthereumAdapter>,
+        store: Arc<S>,
+        metrics_registry: Arc<dyn MetricsRegistry>,
+    ) -> Self
+    where
+        S: Store + ChainStore,
+    {
+        let logger = logger.new(o!("component" => "NetworkIndexer"));
+        let logger_for_err = logger.clone();
+
+        let stopwatch = StopwatchMetrics::new(
+            logger.clone(),
+            subgraph_id.clone(),
+            metrics_registry.clone(),
+        );
+
+        let block_writer = Arc::new(BlockWriter::new(
+            subgraph_id.clone(),
+            &logger,
+            store.clone(),
+            stopwatch,
+            metrics_registry.clone(),
+        ));
+
+        // Create a channel for emitting events
+        let (event_sink, output) = channel(100);
+
+        // Create state machine that emits block and revert events for the network
+        let state_machine = StateMachine::start(Context {
+            subgraph_id,
+            logger,
+            adapter,
+            store,
+            event_sink,
+            block_writer,
+        });
+
+        // Launch state machine
+        tokio::spawn(state_machine.map_err(move |e| {
+            error!(logger_for_err, "Network indexer failed: {}", e);
+        }));
+
+        Self {
+            output: Some(output),
+        }
+    }
+}
+
+impl EventProducer<NetworkIndexerEvent> for NetworkIndexer {
+    fn take_event_stream(
+        &mut self,
+    ) -> Option<Box<dyn Stream<Item = NetworkIndexerEvent, Error = ()> + Send>> {
+        self.output
+            .take()
+            .map(|s| Box::new(s) as Box<dyn Stream<Item = NetworkIndexerEvent, Error = ()> + Send>)
+    }
+}

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use std::ops::Range;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Instant;
 
 use graph::prelude::*;
 use web3::types::H256;
@@ -88,8 +89,10 @@ macro_rules! track_future {
     ($metrics: expr, $metric: ident, $metric_problems: ident, $expr: expr) => {{
         let metrics_for_measure = $metrics.clone();
         let metrics_for_err = $metrics.clone();
+        let start_time = Instant::now();
         $expr
-            .measure(move |_, duration| {
+            .inspect(move |_| {
+                let duration = start_time.elapsed();
                 metrics_for_measure.$metric.update_duration(duration);
             })
             .map_err(move |e| {

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -809,7 +809,7 @@ impl PollStateMachine for StateMachine {
                     "local_head" => state.local_head.map_or(
                         String::from("none"), |ptr| format!("{}", ptr)
                     ),
-                    "range" => format!("#{}..#{}", block_numbers.start, block_numbers.end-1),
+                    "range" => format!("[#{}..#{}]", block_numbers.start, block_numbers.end-1),
                 );
 
                 // Processing the blocks in this range.

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -980,7 +980,7 @@ impl PollStateMachine for StateMachine {
             let event_sink = context.event_sink.clone();
             let metrics_for_written_block = context.metrics.clone();
 
-            let section = { context.metrics.stopwatch.start_section("transact_block") };
+            let section = context.metrics.stopwatch.start_section("transact_block");
 
             // The block is a regular successor to the local head.
             // Add the block and move on.

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -604,7 +604,7 @@ fn revert_blocks(
                 .map_err(move |e| {
                     debug!(
                         logger_for_send_err,
-                        "Sending revert event failed";
+                        "Failed to send revert event";
                         "error" => format!("{}", e),
                         "to" => format_block_pointer(&to_for_send_err),
                         "from" => format_block_pointer(&from_for_send_err),
@@ -627,7 +627,7 @@ fn revert_blocks(
             Err(block) => {
                 debug!(
                     logger_for_complete,
-                    "Revert old blocks failed; \
+                    "Failed to revert old blocks; \
                      setting local head to the last block we managed to revert to"
                 );
                 future::ok(block)
@@ -1356,7 +1356,7 @@ impl PollStateMachine for StateMachine {
             Err(e) => {
                 trace!(
                     context.logger,
-                    "Fetching new blocks failed; \
+                    "Failed to fetch new blocks; \
                      re-evaluate chain head and try again";
                     "error" => format!("{}", e)
                 );

--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -1,0 +1,170 @@
+use futures::future::FutureResult;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use graph::data::subgraph::schema::*;
+use graph::prelude::*;
+
+fn check_subgraph_exists<S>(
+    store: Arc<S>,
+    subgraph_id: SubgraphDeploymentId,
+) -> impl Future<Item = bool, Error = Error>
+where
+    S: Store,
+{
+    future::result(
+        store
+            .get(SubgraphDeploymentEntity::key(subgraph_id))
+            .map_err(|e| e.into())
+            .map(|entity| entity.map_or(false, |_| true)),
+    )
+}
+
+fn create_subgraph<S>(
+    store: Arc<S>,
+    subgraph_name: SubgraphName,
+    subgraph_id: SubgraphDeploymentId,
+    start_block: Option<EthereumBlockPointer>,
+) -> FutureResult<(), Error>
+where
+    S: Store + ChainStore,
+{
+    let mut ops = vec![];
+
+    // Ensure the subgraph itself doesn't already exist
+    ops.push(MetadataOperation::AbortUnless {
+        description: "Subgraph entity should not exist".to_owned(),
+        query: SubgraphEntity::query()
+            .filter(EntityFilter::new_equal("name", subgraph_name.to_string())),
+        entity_ids: vec![],
+    });
+
+    // Create the subgraph entity (e.g. `ethereum/mainnet`)
+    let created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let subgraph_entity_id = generate_entity_id();
+    ops.extend(
+        SubgraphEntity::new(subgraph_name.clone(), None, None, created_at)
+            .write_operations(&subgraph_entity_id)
+            .into_iter()
+            .map(|op| op.into()),
+    );
+
+    // Ensure the subgraph version doesn't already exist
+    ops.push(MetadataOperation::AbortUnless {
+        description: "Subgraph version should not exist".to_owned(),
+        query: SubgraphVersionEntity::query()
+            .filter(EntityFilter::new_equal("id", subgraph_id.to_string())),
+        entity_ids: vec![],
+    });
+
+    // Create a subgraph version entity; we're using the same ID for
+    // version and deployment to make clear they belong together
+    let version_entity_id = subgraph_id.to_string();
+    ops.extend(
+        SubgraphVersionEntity::new(subgraph_entity_id.clone(), subgraph_id.clone(), created_at)
+            .write_operations(&version_entity_id)
+            .into_iter()
+            .map(|op| op.into()),
+    );
+
+    // Immediately make this version the current one
+    ops.extend(SubgraphEntity::update_pending_version_operations(
+        &subgraph_entity_id,
+        None,
+    ));
+    ops.extend(SubgraphEntity::update_current_version_operations(
+        &subgraph_entity_id,
+        Some(version_entity_id),
+    ));
+
+    // Ensure the deployment doesn't already exist
+    ops.push(MetadataOperation::AbortUnless {
+        description: "Subgraph deployment entity must not exist".to_owned(),
+        query: SubgraphDeploymentEntity::query()
+            .filter(EntityFilter::new_equal("id", subgraph_id.to_string())),
+        entity_ids: vec![],
+    });
+
+    // Create a fake manifest
+    let manifest = SubgraphManifest {
+        id: subgraph_id.clone(),
+        location: subgraph_name.to_string(),
+        spec_version: String::from("0.0.1"),
+        description: None,
+        repository: None,
+        schema: Schema::parse(include_str!("./ethereum.graphql"), subgraph_id.clone())
+            .expect("valid Ethereum network subgraph schema"),
+        data_sources: vec![],
+        templates: vec![],
+    };
+
+    // Create deployment entity
+    let chain_head_block = match store.chain_head_ptr() {
+        Ok(block_ptr) => block_ptr,
+        Err(e) => return future::err(e.into()),
+    };
+    ops.extend(
+        SubgraphDeploymentEntity::new(&manifest, false, false, start_block, chain_head_block)
+            .create_operations(&manifest.id),
+    );
+
+    // Create a deployment assignment entity
+    ops.extend(
+        SubgraphDeploymentAssignmentEntity::new(NodeId::new("__builtin").unwrap())
+            .write_operations(&subgraph_id)
+            .into_iter()
+            .map(|op| op.into()),
+    );
+
+    future::result(
+        store
+            .create_subgraph_deployment(&manifest.schema, ops)
+            .map_err(|e| e.into()),
+    )
+}
+
+pub fn ensure_subgraph_exists<S>(
+    subgraph_name: SubgraphName,
+    subgraph_id: SubgraphDeploymentId,
+    logger: Logger,
+    store: Arc<S>,
+    start_block: Option<EthereumBlockPointer>,
+) -> impl Future<Item = (), Error = ()>
+where
+    S: Store + ChainStore,
+{
+    debug!(logger, "Ensure that the network subgraph exists");
+
+    let logger_for_created = logger.clone();
+    let logger_for_err = logger.clone();
+
+    check_subgraph_exists(store.clone(), subgraph_id.clone())
+        .from_err()
+        .and_then(move |subgraph_exists| {
+            if subgraph_exists {
+                debug!(logger, "Network subgraph deployment already exists");
+                Box::new(future::ok(())) as Box<dyn Future<Item = _, Error = _> + Send>
+            } else {
+                debug!(logger, "Network subgraph deployment needs to be created");
+                Box::new(
+                    create_subgraph(
+                        store.clone(),
+                        subgraph_name.clone(),
+                        subgraph_id.clone(),
+                        start_block,
+                    )
+                    .inspect(move |_| {
+                        debug!(logger_for_created, "Created Ethereum network subgraph");
+                    }),
+                )
+            }
+        })
+        .map_err(move |e| {
+            error!(
+                logger_for_err,
+                "Failed to ensure Ethereum network subgraph exists: {}", e
+            );
+        })
+}

--- a/chain/ethereum/tests/network_indexer.rs
+++ b/chain/ethereum/tests/network_indexer.rs
@@ -1,0 +1,447 @@
+#[macro_use]
+extern crate pretty_assertions;
+
+use diesel::connection::Connection;
+use diesel::pg::PgConnection;
+use std::convert::TryInto;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use graph::mock::*;
+use graph::prelude::*;
+use graph_chain_ethereum::network_indexer::{
+    self as network_indexer, BlockWithUncles, NetworkIndexerEvent,
+};
+use graph_core::MetricsRegistry;
+use graph_store_postgres::Store as DieselStore;
+use web3::types::{H256, H64};
+
+use test_store::*;
+
+// Helper to wipe the store clean.
+fn remove_test_data(store: Arc<DieselStore>) {
+    let url = postgres_test_url();
+    let conn = PgConnection::establish(url.as_str()).expect("Failed to connect to Postgres");
+    graph_store_postgres::store::delete_all_entities_for_test_use_only(&store, &conn)
+        .expect("Failed to remove entity test data");
+}
+
+// Helper to run network indexer against test chains.
+pub fn run_network_indexer(
+    store: Arc<DieselStore>,
+    start_block: Option<EthereumBlockPointer>,
+    chains: Vec<Vec<BlockWithUncles>>,
+) -> Vec<NetworkIndexerEvent> {
+    // Simulate an Ethereum network using a mock adapter
+    let adapter = create_mock_ethereum_adapter(chains);
+
+    let subgraph_name = SubgraphName::new("ethereum/testnet").unwrap();
+    let logger = LOGGER.clone();
+    let prometheus_registry = Arc::new(Registry::new());
+    let metrics_registry = Arc::new(MetricsRegistry::new(logger.clone(), prometheus_registry));
+
+    // Create the network indexer
+    let mut indexer = network_indexer::create(
+        subgraph_name.to_string(),
+        &logger,
+        adapter,
+        store.clone(),
+        metrics_registry,
+        start_block,
+    )
+    .wait()
+    .expect("failed to create network indexer");
+
+    let (event_sink, event_stream) = futures::sync::mpsc::channel(100);
+
+    // Run network indexer and forward its events to the channel
+    tokio::spawn(
+        indexer
+            .take_event_stream()
+            .expect("failed to take stream from indexer")
+            .timeout(Duration::from_secs(2))
+            .map_err(|_| ())
+            .forward(event_sink.sink_map_err(|_| ()))
+            .map(|_| ()),
+    );
+
+    event_stream
+        .collect()
+        .wait()
+        .expect("failed to get events from the stream")
+}
+
+// Helper to run tests against a clean store.
+fn run_test<R, F>(test: F)
+where
+    F: FnOnce(Arc<DieselStore>) -> R + Send + 'static,
+    R: IntoFuture<Item = ()> + Send + 'static,
+    R::Error: Send + Debug,
+    R::Future: Send,
+{
+    let store = STORE.clone();
+
+    // Lock regardless of poisoning. This also forces sequential test execution.
+    let mut runtime = match STORE_RUNTIME.lock() {
+        Ok(guard) => guard,
+        Err(err) => err.into_inner(),
+    };
+
+    runtime
+        .block_on(future::lazy(move || {
+            // Reset store before running
+            remove_test_data(store.clone());
+
+            // Run test
+            test(store.clone())
+        }))
+        .expect("failed to run test with clean store");
+}
+
+// Helper to create a sequence of linked blocks.
+fn create_blocks(n: u64, parent: Option<&BlockWithUncles>) -> Vec<BlockWithUncles> {
+    let start = parent.map_or(0, |block| block.inner().number.unwrap().as_u64() + 1);
+
+    (start..start + n).fold(vec![], |mut blocks, number| {
+        let mut block = BlockWithUncles::default();
+
+        // Set required fields
+        block.block.block.nonce = Some(H64::random());
+        block.block.block.mix_hash = Some(H256::random());
+
+        // Use the index as the block number
+        block.block.block.number = Some(number.into());
+
+        // Use a random hash as the block hash (should be unique)
+        block.block.block.hash = Some(H256::random());
+
+        if number == start {
+            // Set the parent hash for the first block only if a
+            // parent was passed in; otherwise we're dealing with
+            // the genesis block
+            if let Some(parent_block) = parent {
+                block.block.block.parent_hash = parent_block.inner().hash.unwrap().clone();
+            }
+        } else {
+            // Set the parent hash for all blocks but the genesis block
+            block.block.block.parent_hash =
+                blocks.last().unwrap().block.block.hash.clone().unwrap();
+        }
+
+        blocks.push(block);
+        blocks
+    })
+}
+
+fn create_fork(
+    original_blocks: Vec<BlockWithUncles>,
+    base: u64,
+    total: u64,
+) -> Vec<BlockWithUncles> {
+    let mut blocks = original_blocks[0..(base as usize) + 1].to_vec();
+    let new_blocks = create_blocks((total - base - 1).try_into().unwrap(), blocks.last());
+    blocks.extend(new_blocks);
+    blocks
+}
+
+struct Chains {
+    chain_index: Option<usize>,
+    chains: Vec<Vec<BlockWithUncles>>,
+}
+
+impl Chains {
+    pub fn new(chains: Vec<Vec<BlockWithUncles>>) -> Self {
+        Self {
+            chain_index: None,
+            chains,
+        }
+    }
+
+    pub fn index(&self) -> Option<usize> {
+        self.chain_index.clone()
+    }
+
+    pub fn next_chain(&mut self) -> Option<&Vec<BlockWithUncles>> {
+        let next_index = self.chain_index.map_or(0, |index| index + 1);
+        self.chain_index.replace(next_index);
+        self.chains.get(next_index)
+    }
+
+    pub fn current_chain(&self) -> Option<&Vec<BlockWithUncles>> {
+        self.chain_index.and_then(|index| self.chains.get(index))
+    }
+}
+
+fn create_mock_ethereum_adapter(chains: Vec<Vec<BlockWithUncles>>) -> Arc<MockEthereumAdapter> {
+    let chains = Arc::new(Mutex::new(Chains::new(chains)));
+
+    // Create the mock Ethereum adapter.
+    let mut adapter = MockEthereumAdapter::new();
+
+    // Make it so that each time we poll a new remote head, we
+    // switch to the next version of the chain
+    let chains_for_latest_block = chains.clone();
+    adapter.expect_latest_block().returning(move |_: &Logger| {
+        let mut chains = chains_for_latest_block.lock().unwrap();
+        Box::new(future::result(
+            chains
+                .next_chain()
+                // .expect("exhausted chain versions used in this test; this is ok")
+                .ok_or_else(|| {
+                    format_err!("exhausted chain versions used in this test; this is ok")
+                })
+                .and_then(|chain| chain.last().ok_or_else(|| format_err!("empty block chain")))
+                .map_err(Into::into)
+                .map(|block| block.block.block.clone()),
+        ))
+    });
+
+    let chains_for_block_by_number = chains.clone();
+    adapter
+        .expect_block_by_number()
+        .returning(move |_, number: u64| {
+            let chains = chains_for_block_by_number.lock().unwrap();
+            Box::new(future::result(
+                chains
+                    .current_chain()
+                    .ok_or_else(|| format_err!("unknown chain {:?}", chains.index()))
+                    .map(|chain| {
+                        chain
+                            .iter()
+                            .find(|block| block.inner().number.unwrap().as_u64() == number)
+                            .map(|block| block.clone().block.block)
+                    }),
+            ))
+        });
+
+    let chains_for_block_by_hash = chains.clone();
+    adapter
+        .expect_block_by_hash()
+        .returning(move |_, hash: H256| {
+            let chains = chains_for_block_by_hash.lock().unwrap();
+            Box::new(future::result(
+                chains
+                    .current_chain()
+                    .ok_or_else(|| format_err!("unknown chain {:?}", chains.index()))
+                    .map(|chain| {
+                        chain
+                            .iter()
+                            .find(|block| block.inner().hash.unwrap() == hash)
+                            .map(|block| block.clone().block.block)
+                    }),
+            ))
+        });
+
+    let chains_for_load_full_block = chains.clone();
+    adapter
+        .expect_load_full_block()
+        .returning(move |_, block: LightEthereumBlock| {
+            let chains = chains_for_load_full_block.lock().unwrap();
+            Box::new(future::result(
+                chains
+                    .current_chain()
+                    .ok_or_else(|| format_err!("unknown chain {:?}", chains.index()))
+                    .map_err(Into::into)
+                    .map(|chain| {
+                        chain
+                            .iter()
+                            .find(|b| b.inner().number.unwrap() == block.number.unwrap())
+                            .expect(
+                                format!(
+                                    "full block {} [{:x}] not found",
+                                    block.number.unwrap(),
+                                    block.hash.unwrap()
+                                )
+                                .as_str(),
+                            )
+                            .clone()
+                            .block
+                    }),
+            ))
+        });
+
+    // For now return no uncles
+    adapter
+        .expect_uncles()
+        .returning(move |_, _| Box::new(future::ok(vec![])));
+
+    Arc::new(adapter)
+}
+
+// GIVEN  a fresh subgraph (local head = none)
+// AND    a chain with 10 blocks
+// WHEN   running the `NetworkIndexer`
+// EXPECT 10 `AddBlock` events are emitted, one for each block
+#[test]
+fn indexing_starts_at_genesis() {
+    run_test(|store: Arc<DieselStore>| -> Result<(), ()> {
+        // Create test chain
+        let blocks = create_blocks(10, None);
+        let chains = vec![blocks.clone()];
+
+        // Run network indexer and collect its events
+        let events = run_network_indexer(store, None, chains);
+
+        // Assert that the events emitted by the indexer match all
+        // blocks _after_ block #2 (because the network subgraph already
+        // had that one)
+        assert_eq!(
+            events,
+            blocks
+                .into_iter()
+                .map(|block| NetworkIndexerEvent::AddBlock(block.inner().into()))
+                .collect::<Vec<_>>()
+        );
+
+        Ok(())
+    });
+}
+
+// GIVEN  an existing subgraph (local head = block #2)
+// AND    a chain with 10 blocks
+// WHEN   running the `NetworkIndexer`
+// EXPECT 7 `AddBlock` events are emitted, one for each remaining block
+#[test]
+fn indexing_resumes_from_local_head() {
+    run_test(|store: Arc<DieselStore>| -> Result<(), ()> {
+        // Create test chain
+        let blocks = create_blocks(10, None);
+        let chains = vec![blocks.clone()];
+
+        // Run network indexer and collect its events
+        let events = run_network_indexer(store, Some(blocks[2].inner().into()), chains);
+
+        // Assert that the events emitted by the indexer are only
+        // for the blocks #3-#9.
+        assert_eq!(
+            events,
+            blocks[3..]
+                .to_owned()
+                .into_iter()
+                .map(|block| NetworkIndexerEvent::AddBlock(block.inner().into()))
+                .collect::<Vec<_>>()
+        );
+
+        Ok(())
+    });
+}
+
+// GIVEN  a fresh subgraph (local head = none)
+// AND    a chain with 10 blocks
+// WHEN   running the `NetworkIndexer`
+// EXPECT 10 `AddBlock` events are emitted, one for each block
+#[test]
+fn indexing_picks_up_new_remote_head() {
+    run_test(|store: Arc<DieselStore>| -> Result<(), ()> {
+        // The first time we pull the remote head, there are 10 blocks
+        let chain_10 = create_blocks(10, None);
+
+        // The second time we pull the remote head, there are 20 blocks;
+        // the first 10 blocks are identical to before, so this simulates
+        // 10 new blocks being added to the same chain
+        let chain_20 = create_fork(chain_10.clone(), 9, 20);
+
+        // Use the two above chains in the test
+        let chains = vec![chain_10.clone(), chain_20.clone()];
+
+        // Run network indexer and collect its events
+        let events = run_network_indexer(store, None, chains);
+
+        // Assert that the events emitted by the indexer match the blocks 1:1,
+        // despite them requiring two remote head updates
+        assert_eq!(
+            events,
+            chain_20
+                .into_iter()
+                .map(|block| NetworkIndexerEvent::AddBlock(block.inner().into()))
+                .collect::<Vec<_>>()
+        );
+
+        Ok(())
+    });
+}
+
+// GIVEN  a fresh subgraph (local head = none)
+// AND    a chain with 10 blocks with a gap (#6 missing)
+// WHEN   running the `NetworkIndexer`
+// EXPECT only `AddBlock` events for blocks #0-#5 are emitted
+#[test]
+fn indexing_does_not_move_past_a_gap() {
+    run_test(|store: Arc<DieselStore>| -> Result<(), ()> {
+        // Create test chain
+        let mut blocks = create_blocks(10, None);
+        // Remove block #6
+        blocks.remove(5);
+        let chains = vec![blocks.clone()];
+
+        // Run network indexer and collect its events
+        let events = run_network_indexer(store, None, chains);
+
+        // Assert that only blocks #0 - #4 were indexed and nothing more
+        assert_eq!(
+            events,
+            blocks[0..5]
+                .to_owned()
+                .into_iter()
+                .map(|block| NetworkIndexerEvent::AddBlock(block.inner().into()))
+                .collect::<Vec<_>>()
+        );
+
+        Ok(())
+    });
+}
+
+// GIVEN  a fresh subgraph (local head = none)
+// AND    10 blocks for one version of the chain
+// AND    20 blocks for a fork of the chain that starts after block #3
+// WHEN   running the `NetworkIndexer`
+// EXPECT 10 `AddBlock` events is emitted for the first branch,
+//        7 `Revert` events are emitted to revert back to block #3
+//        17 `AddBlock` events are emitted for blocks #4-#20 of the fork
+#[test]
+fn indexing_handles_single_reorg() {
+    run_test(|store: Arc<DieselStore>| -> Result<(), ()> {
+        // Create the initial chain
+        let initial_chain = create_blocks(10, None);
+
+        // Create a forked chain after block #2
+        let forked_chain = create_fork(initial_chain.clone(), 2, 20);
+
+        // Run the network indexer and collect its events
+        let chains = vec![initial_chain.clone(), forked_chain.clone()];
+        let events = run_network_indexer(store, None, chains);
+
+        // Verify that the following events are emitted:
+        //
+        // - 10 `AddBlock` events for blocks #0 to #9 of the initial chain
+        // - 7 `Revert` events from #9 to #8, ..., #3 to #2 (the fork base)
+        // - 17 `AddBlock` events for blocks #3 to #20 of the fork
+        assert_eq!(
+            events,
+            // The 10 `AddBlock` events for the initial version of the chain
+            initial_chain
+                .iter()
+                .map(|block| NetworkIndexerEvent::AddBlock(block.inner().into()))
+                .chain(
+                    // The 7 `Revert` events
+                    vec![(9, 8), (8, 7), (7, 6), (6, 5), (5, 4), (4, 3), (3, 2)]
+                        .into_iter()
+                        .map(|(from, to)| {
+                            NetworkIndexerEvent::Revert {
+                                from: initial_chain[from].inner().into(),
+                                to: initial_chain[to].inner().into(),
+                            }
+                        })
+                )
+                .chain(
+                    // The 17 `AddBlock` events for the new chain
+                    forked_chain[3..]
+                        .iter()
+                        .map(|block| NetworkIndexerEvent::AddBlock(block.inner().into()))
+                )
+                .collect::<Vec<_>>()
+        );
+
+        Ok(())
+    });
+}

--- a/chain/ethereum/tests/network_indexer.rs
+++ b/chain/ethereum/tests/network_indexer.rs
@@ -577,23 +577,23 @@ fn indexing_handles_consecutive_reorgs() {
         // Create a forked chain after block #3
         let third_chain = create_fork(initial_chain.clone(), 2, 30);
 
-        // Run the network indexer for 3s and collect its events
+        // Run the network indexer for 10s and collect its events
         let chains = vec![
             initial_chain.clone(),
             second_chain.clone(),
             third_chain.clone(),
         ];
-        run_network_indexer(store, None, chains, Duration::from_secs(3)).and_then(
+        run_network_indexer(store, None, chains, Duration::from_secs(10)).and_then(
             move |(chains, events)| {
                 thread::spawn(move || {
-                    // Trigger the first reorg after 1s
+                    // Trigger the first reorg after 2s
                     {
-                        thread::sleep(Duration::from_secs(1));
+                        thread::sleep(Duration::from_secs(2));
                         chains.lock().unwrap().advance_to_next_chain();
                     }
-                    // Trigger the second reorg after 2s
+                    // Trigger the second reorg after 4s
                     {
-                        thread::sleep(Duration::from_secs(1));
+                        thread::sleep(Duration::from_secs(2));
                         chains.lock().unwrap().advance_to_next_chain();
                     }
                 });

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -26,6 +26,7 @@ ipfs-api = { git = "https://github.com/ferristseng/rust-ipfs-api", branch = "mas
 parity-wasm = "0.40"
 failure = "0.1.6"
 lazy_static = "1.2.0"
+mockall = "0.5"
 num-bigint = { version = "^0.2.3", features = ["serde"] }
 num-traits = "0.2"
 rand = "0.6.1"

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -1,6 +1,8 @@
 use ethabi::{Bytes, Error as ABIError, Function, ParamType, Token};
 use failure::SyncFailure;
 use futures::Future;
+use mockall::predicate::*;
+use mockall::*;
 use petgraph::graphmap::GraphMap;
 use std::cmp;
 use std::collections::{HashMap, HashSet};
@@ -608,6 +610,7 @@ impl BlockStreamMetrics {
 ///
 /// Implementations may be implemented against an in-process Ethereum node
 /// or a remote node over RPC.
+#[automock]
 pub trait EthereumAdapter: Send + Sync + 'static {
     /// Ask the Ethereum node for some identifying information about the Ethereum network it is
     /// connected to.

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -719,121 +719,6 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         block_hash: H256,
     ) -> Box<dyn Future<Item = Vec<EthereumCall>, Error = Error> + Send>;
 
-    /// Returns blocks with triggers, corresponding to the specified range and filters.
-    /// If a block contains no triggers, there may be no corresponding item in the stream.
-    /// However the `to` block will always be present, even if triggers are empty.
-    ///
-    /// Careful: don't use this function without considering race conditions.
-    /// Chain reorgs could happen at any time, and could affect the answer received.
-    /// Generally, it is only safe to use this function with blocks that have received enough
-    /// confirmations to guarantee no further reorgs, **and** where the Ethereum node is aware of
-    /// those confirmations.
-    /// If the Ethereum node is far behind in processing blocks, even old blocks can be subject to
-    /// reorgs.
-    /// It is recommended that `to` be far behind the block number of latest block the Ethereum
-    /// node is aware of.
-    fn blocks_with_triggers(
-        self: Arc<Self>,
-        logger: Logger,
-        chain_store: Arc<dyn ChainStore>,
-        subgraph_metrics: Arc<SubgraphEthRpcMetrics>,
-        from: u64,
-        to: u64,
-        log_filter: EthereumLogFilter,
-        call_filter: EthereumCallFilter,
-        block_filter: EthereumBlockFilter,
-    ) -> Box<dyn Future<Item = Vec<EthereumBlockWithTriggers>, Error = Error> + Send> {
-        // Each trigger filter needs to be queried for the same block range
-        // and the blocks yielded need to be deduped. If any error occurs
-        // while searching for a trigger type, the entire operation fails.
-        let eth = self.clone();
-        let mut trigger_futs: futures::stream::FuturesUnordered<
-            Box<dyn Future<Item = Vec<EthereumTrigger>, Error = Error> + Send>,
-        > = futures::stream::FuturesUnordered::new();
-
-        // Scan the block range from triggers to find relevant blocks
-        if !log_filter.is_empty() {
-            trigger_futs.push(Box::new(
-                eth.logs_in_block_range(&logger, subgraph_metrics.clone(), from, to, log_filter)
-                    .map(|logs: Vec<Log>| logs.into_iter().map(EthereumTrigger::Log).collect()),
-            ))
-        }
-
-        if !call_filter.is_empty() {
-            trigger_futs.push(Box::new(
-                eth.calls_in_block_range(&logger, subgraph_metrics.clone(), from, to, call_filter)
-                    .map(EthereumTrigger::Call)
-                    .collect(),
-            ));
-        }
-
-        if block_filter.trigger_every_block {
-            trigger_futs.push(Box::new(
-                self.block_range_to_ptrs(logger.clone(), from, to)
-                    .map(move |ptrs| {
-                        ptrs.into_iter()
-                            .map(|ptr| EthereumTrigger::Block(ptr, EthereumBlockTriggerType::Every))
-                            .collect()
-                    }),
-            ))
-        } else if !block_filter.contract_addresses.is_empty() {
-            // To determine which blocks include a call to addresses
-            // in the block filter, transform the `block_filter` into
-            // a `call_filter` and run `blocks_with_calls`
-            let call_filter = EthereumCallFilter::from(block_filter);
-            trigger_futs.push(Box::new(
-                eth.calls_in_block_range(&logger, subgraph_metrics.clone(), from, to, call_filter)
-                    .map(|call| {
-                        EthereumTrigger::Block(
-                            EthereumBlockPointer::from(&call),
-                            EthereumBlockTriggerType::WithCallTo(call.to),
-                        )
-                    })
-                    .collect(),
-            ));
-        }
-
-        let logger1 = logger.clone();
-        Box::new(
-            trigger_futs
-                .concat2()
-                .join(self.clone().block_hash_by_block_number(&logger, to))
-                .map(move |(triggers, to_hash)| {
-                    let mut block_hashes: HashSet<H256> =
-                        triggers.iter().map(EthereumTrigger::block_hash).collect();
-                    let mut triggers_by_block: HashMap<u64, Vec<EthereumTrigger>> =
-                        triggers.into_iter().fold(HashMap::new(), |mut map, t| {
-                            map.entry(t.block_number()).or_default().push(t);
-                            map
-                        });
-
-                    debug!(logger, "Found {} relevant block(s)", block_hashes.len());
-
-                    // Make sure `to` is included, even if empty.
-                    block_hashes.insert(to_hash.unwrap());
-                    triggers_by_block.entry(to).or_insert(Vec::new());
-
-                    (block_hashes, triggers_by_block)
-                })
-                .and_then(move |(block_hashes, mut triggers_by_block)| {
-                    self.load_blocks(logger1, chain_store, block_hashes)
-                        .map(move |block| {
-                            EthereumBlockWithTriggers::new(
-                                // All blocks with triggers are in `triggers_by_block`, and will be
-                                // accessed here exactly once.
-                                triggers_by_block.remove(&block.number()).unwrap(),
-                                BlockFinality::Final(block),
-                            )
-                        })
-                        .collect()
-                        .map(|mut blocks| {
-                            blocks.sort_by_key(|block| block.ethereum_block.number());
-                            blocks
-                        })
-                }),
-        )
-    }
-
     fn logs_in_block_range(
         &self,
         logger: &Logger,
@@ -859,17 +744,223 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         call: EthereumContractCall,
         cache: Arc<dyn EthereumCallCache>,
     ) -> Box<dyn Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send>;
+}
 
-    fn triggers_in_block(
-        self: Arc<Self>,
-        logger: Logger,
-        chain_store: Arc<dyn ChainStore>,
-        subgraph_metrics: Arc<SubgraphEthRpcMetrics>,
-        log_filter: EthereumLogFilter,
-        call_filter: EthereumCallFilter,
-        block_filter: EthereumBlockFilter,
-        ethereum_block: BlockFinality,
-    ) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send>;
+fn parse_log_triggers(
+    log_filter: EthereumLogFilter,
+    block: &EthereumBlock,
+) -> Vec<EthereumTrigger> {
+    block
+        .transaction_receipts
+        .iter()
+        .flat_map(move |receipt| {
+            let log_filter = log_filter.clone();
+            receipt
+                .logs
+                .iter()
+                .filter(move |log| log_filter.matches(log))
+                .map(move |log| EthereumTrigger::Log(log.clone()))
+        })
+        .collect()
+}
+
+fn parse_call_triggers(
+    call_filter: EthereumCallFilter,
+    block: &EthereumBlockWithCalls,
+) -> Vec<EthereumTrigger> {
+    block.calls.as_ref().map_or(vec![], |calls| {
+        calls
+            .iter()
+            .filter(move |call| call_filter.matches(call))
+            .map(move |call| EthereumTrigger::Call(call.clone()))
+            .collect()
+    })
+}
+
+fn parse_block_triggers(
+    block_filter: EthereumBlockFilter,
+    block: &EthereumBlockWithCalls,
+) -> Vec<EthereumTrigger> {
+    let block_ptr = EthereumBlockPointer::from(&block.ethereum_block);
+    let trigger_every_block = block_filter.trigger_every_block;
+    let call_filter = EthereumCallFilter::from(block_filter);
+    let mut triggers = block.calls.as_ref().map_or(vec![], |calls| {
+        calls
+            .iter()
+            .filter(move |call| call_filter.matches(call))
+            .map(move |call| {
+                EthereumTrigger::Block(block_ptr, EthereumBlockTriggerType::WithCallTo(call.to))
+            })
+            .collect::<Vec<EthereumTrigger>>()
+    });
+    if trigger_every_block {
+        triggers.push(EthereumTrigger::Block(
+            block_ptr,
+            EthereumBlockTriggerType::Every,
+        ));
+    }
+    triggers
+}
+
+pub fn triggers_in_block(
+    adapter: Arc<dyn EthereumAdapter>,
+    logger: Logger,
+    chain_store: Arc<dyn ChainStore>,
+    subgraph_metrics: Arc<SubgraphEthRpcMetrics>,
+    log_filter: EthereumLogFilter,
+    call_filter: EthereumCallFilter,
+    block_filter: EthereumBlockFilter,
+    ethereum_block: BlockFinality,
+) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send> {
+    Box::new(match &ethereum_block {
+        BlockFinality::Final(block) => Box::new(
+            blocks_with_triggers(
+                adapter,
+                logger,
+                chain_store,
+                subgraph_metrics,
+                block.number(),
+                block.number(),
+                log_filter.clone(),
+                call_filter.clone(),
+                block_filter.clone(),
+            )
+            .map(|blocks| {
+                assert!(blocks.len() <= 1);
+                blocks
+                    .into_iter()
+                    .next()
+                    .unwrap_or(EthereumBlockWithTriggers::new(vec![], ethereum_block))
+            }),
+        ) as Box<dyn Future<Item = _, Error = _> + Send>,
+        BlockFinality::NonFinal(full_block) => Box::new(future::ok({
+            let mut triggers = Vec::new();
+            triggers.append(&mut parse_log_triggers(
+                log_filter,
+                &full_block.ethereum_block,
+            ));
+            triggers.append(&mut parse_call_triggers(call_filter, &full_block));
+            triggers.append(&mut parse_block_triggers(block_filter, &full_block));
+            EthereumBlockWithTriggers::new(triggers, ethereum_block)
+        })),
+    })
+}
+
+/// Returns blocks with triggers, corresponding to the specified range and filters.
+/// If a block contains no triggers, there may be no corresponding item in the stream.
+/// However the `to` block will always be present, even if triggers are empty.
+///
+/// Careful: don't use this function without considering race conditions.
+/// Chain reorgs could happen at any time, and could affect the answer received.
+/// Generally, it is only safe to use this function with blocks that have received enough
+/// confirmations to guarantee no further reorgs, **and** where the Ethereum node is aware of
+/// those confirmations.
+/// If the Ethereum node is far behind in processing blocks, even old blocks can be subject to
+/// reorgs.
+/// It is recommended that `to` be far behind the block number of latest block the Ethereum
+/// node is aware of.
+pub fn blocks_with_triggers(
+    adapter: Arc<dyn EthereumAdapter>,
+    logger: Logger,
+    chain_store: Arc<dyn ChainStore>,
+    subgraph_metrics: Arc<SubgraphEthRpcMetrics>,
+    from: u64,
+    to: u64,
+    log_filter: EthereumLogFilter,
+    call_filter: EthereumCallFilter,
+    block_filter: EthereumBlockFilter,
+) -> Box<dyn Future<Item = Vec<EthereumBlockWithTriggers>, Error = Error> + Send> {
+    // Each trigger filter needs to be queried for the same block range
+    // and the blocks yielded need to be deduped. If any error occurs
+    // while searching for a trigger type, the entire operation fails.
+    let eth = adapter.clone();
+    let mut trigger_futs: futures::stream::FuturesUnordered<
+        Box<dyn Future<Item = Vec<EthereumTrigger>, Error = Error> + Send>,
+    > = futures::stream::FuturesUnordered::new();
+
+    // Scan the block range from triggers to find relevant blocks
+    if !log_filter.is_empty() {
+        trigger_futs.push(Box::new(
+            eth.logs_in_block_range(&logger, subgraph_metrics.clone(), from, to, log_filter)
+                .map(|logs: Vec<Log>| logs.into_iter().map(EthereumTrigger::Log).collect()),
+        ))
+    }
+
+    if !call_filter.is_empty() {
+        trigger_futs.push(Box::new(
+            eth.calls_in_block_range(&logger, subgraph_metrics.clone(), from, to, call_filter)
+                .map(EthereumTrigger::Call)
+                .collect(),
+        ));
+    }
+
+    if block_filter.trigger_every_block {
+        trigger_futs.push(Box::new(
+            adapter
+                .block_range_to_ptrs(logger.clone(), from, to)
+                .map(move |ptrs| {
+                    ptrs.into_iter()
+                        .map(|ptr| EthereumTrigger::Block(ptr, EthereumBlockTriggerType::Every))
+                        .collect()
+                }),
+        ))
+    } else if !block_filter.contract_addresses.is_empty() {
+        // To determine which blocks include a call to addresses
+        // in the block filter, transform the `block_filter` into
+        // a `call_filter` and run `blocks_with_calls`
+        let call_filter = EthereumCallFilter::from(block_filter);
+        trigger_futs.push(Box::new(
+            eth.calls_in_block_range(&logger, subgraph_metrics.clone(), from, to, call_filter)
+                .map(|call| {
+                    EthereumTrigger::Block(
+                        EthereumBlockPointer::from(&call),
+                        EthereumBlockTriggerType::WithCallTo(call.to),
+                    )
+                })
+                .collect(),
+        ));
+    }
+
+    let logger1 = logger.clone();
+    Box::new(
+        trigger_futs
+            .concat2()
+            .join(adapter.clone().block_hash_by_block_number(&logger, to))
+            .map(move |(triggers, to_hash)| {
+                let mut block_hashes: HashSet<H256> =
+                    triggers.iter().map(EthereumTrigger::block_hash).collect();
+                let mut triggers_by_block: HashMap<u64, Vec<EthereumTrigger>> =
+                    triggers.into_iter().fold(HashMap::new(), |mut map, t| {
+                        map.entry(t.block_number()).or_default().push(t);
+                        map
+                    });
+
+                debug!(logger, "Found {} relevant block(s)", block_hashes.len());
+
+                // Make sure `to` is included, even if empty.
+                block_hashes.insert(to_hash.unwrap());
+                triggers_by_block.entry(to).or_insert(Vec::new());
+
+                (block_hashes, triggers_by_block)
+            })
+            .and_then(move |(block_hashes, mut triggers_by_block)| {
+                adapter
+                    .load_blocks(logger1, chain_store, block_hashes)
+                    .map(move |block| {
+                        EthereumBlockWithTriggers::new(
+                            // All blocks with triggers are in `triggers_by_block`, and will be
+                            // accessed here exactly once.
+                            triggers_by_block.remove(&block.number()).unwrap(),
+                            BlockFinality::Final(block),
+                        )
+                    })
+                    .collect()
+                    .map(|mut blocks| {
+                        blocks.sort_by_key(|block| block.ethereum_block.number());
+                        blocks
+                    })
+            }),
+    )
 }
 
 #[cfg(test)]

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -652,6 +652,12 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         block_hash: H256,
     ) -> Box<dyn Future<Item = Option<LightEthereumBlock>, Error = Error> + Send>;
 
+    fn block_by_number(
+        &self,
+        logger: &Logger,
+        block_number: u64,
+    ) -> Box<dyn Future<Item = Option<LightEthereumBlock>, Error = Error> + Send>;
+
     /// Load full information for the specified `block` (in particular, transaction receipts).
     fn load_full_block(
         &self,

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -687,6 +687,13 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         block_number: u64,
     ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send>;
 
+    /// Obtain all uncle blocks for a given block hash.
+    fn uncles(
+        &self,
+        logger: &Logger,
+        block: &LightEthereumBlock,
+    ) -> Box<dyn Future<Item = Vec<Option<Block<H256>>>, Error = Error> + Send>;
+
     /// Check if `block_ptr` refers to a block that is on the main chain, according to the Ethereum
     /// node.
     ///

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -4,10 +4,11 @@ mod stream;
 mod types;
 
 pub use self::adapter::{
-    BlockStreamMetrics, EthGetLogsFilter, EthereumAdapter, EthereumAdapterError,
-    EthereumBlockFilter, EthereumCallFilter, EthereumContractCall, EthereumContractCallError,
-    EthereumContractState, EthereumContractStateError, EthereumContractStateRequest,
-    EthereumLogFilter, EthereumNetworkIdentifier, ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
+    blocks_with_triggers, triggers_in_block, BlockStreamMetrics, EthGetLogsFilter, EthereumAdapter,
+    EthereumAdapterError, EthereumBlockFilter, EthereumCallFilter, EthereumContractCall,
+    EthereumContractCallError, EthereumContractState, EthereumContractStateError,
+    EthereumContractStateRequest, EthereumLogFilter, EthereumNetworkIdentifier,
+    ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
 };
 pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpdateStream};
 pub use self::stream::{BlockStream, BlockStreamBuilder};

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -8,7 +8,7 @@ pub use self::adapter::{
     EthereumAdapterError, EthereumBlockFilter, EthereumCallFilter, EthereumContractCall,
     EthereumContractCallError, EthereumContractState, EthereumContractStateError,
     EthereumContractStateRequest, EthereumLogFilter, EthereumNetworkIdentifier,
-    ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
+    MockEthereumAdapter, ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
 };
 pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpdateStream};
 pub use self::stream::{BlockStream, BlockStreamBuilder};

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -1,6 +1,7 @@
 use ethabi::LogParam;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::fmt;
 use web3::types::*;
 
 pub type LightEthereumBlock = Block<Transaction>;
@@ -10,6 +11,7 @@ pub trait LightEthereumBlockExt {
     fn transaction_for_log(&self, log: &Log) -> Option<Transaction>;
     fn transaction_for_call(&self, call: &EthereumCall) -> Option<Transaction>;
     fn parent_ptr(&self) -> Option<EthereumBlockPointer>;
+    fn format(&self) -> String;
 }
 
 impl LightEthereumBlockExt for LightEthereumBlock {
@@ -37,6 +39,16 @@ impl LightEthereumBlockExt for LightEthereumBlock {
                 number: n - 1,
             }),
         }
+    }
+
+    fn format(&self) -> String {
+        format!(
+            "{} ({})",
+            self.number
+                .map_or(String::from("none"), |number| format!("#{}", number)),
+            self.hash
+                .map_or(String::from("-"), |hash| format!("{:x}", hash))
+        )
     }
 }
 
@@ -403,6 +415,12 @@ impl EthereumBlockPointer {
     /// implements `H256::to_string`.
     pub fn hash_hex(&self) -> String {
         format!("{:x}", self.hash)
+    }
+}
+
+impl fmt::Display for EthereumBlockPointer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "#{} ({:x})", self.number, self.hash)
     }
 }
 

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -92,7 +92,7 @@ pub struct EthereumBlockWithCalls {
     pub calls: Option<Vec<EthereumCall>>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct EthereumBlock {
     pub block: LightEthereumBlock,
     pub transaction_receipts: Vec<TransactionReceipt>,

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -4,6 +4,8 @@ use std::cmp::Ordering;
 use std::fmt;
 use web3::types::*;
 
+use crate::prelude::{EntityKey, SubgraphDeploymentId, ToEntityKey};
+
 pub type LightEthereumBlock = Block<Transaction>;
 
 pub trait LightEthereumBlockExt {
@@ -510,6 +512,16 @@ impl From<EthereumBlockPointer> for H256 {
 impl From<EthereumBlockPointer> for u64 {
     fn from(ptr: EthereumBlockPointer) -> Self {
         ptr.number
+    }
+}
+
+impl ToEntityKey for EthereumBlockPointer {
+    fn to_entity_key(&self, subgraph: SubgraphDeploymentId) -> EntityKey {
+        EntityKey {
+            subgraph_id: subgraph,
+            entity_type: "Block".into(),
+            entity_id: format!("{:x}", self.hash),
+        }
     }
 }
 

--- a/graph/src/components/metrics/aggregate.rs
+++ b/graph/src/components/metrics/aggregate.rs
@@ -1,0 +1,88 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::prelude::*;
+
+pub struct Aggregate {
+    /// Number of values.
+    n: u64,
+
+    /// Sum over all values.
+    sum: f64,
+
+    /// Moving average over the values.
+    avg: f64,
+
+    /// Latest value.
+    cur: f64,
+
+    /// Metrics for Prometheus.
+    count_gauge: Box<Gauge>,
+    sum_gauge: Box<Gauge>,
+    avg_gauge: Box<Gauge>,
+    cur_gauge: Box<Gauge>,
+}
+
+impl Aggregate {
+    pub fn new(name: String, help: &str, registry: Arc<dyn MetricsRegistry>) -> Self {
+        let count_gauge = registry
+            .new_gauge(
+                format!("{}_count", name),
+                format!("{} (count)", help),
+                HashMap::new(),
+            )
+            .expect(format!("failed to register metric `{}_count`", name).as_str());
+
+        let sum_gauge = registry
+            .new_gauge(
+                format!("{}_sum", name),
+                format!("{} (sum)", help),
+                HashMap::new(),
+            )
+            .expect(format!("failed to register metric `{}_sum`", name).as_str());
+
+        let avg_gauge = registry
+            .new_gauge(
+                format!("{}_avg", name),
+                format!("{} (avg)", help),
+                HashMap::new(),
+            )
+            .expect(format!("failed to register metric `{}_avg`", name).as_str());
+        let cur_gauge = registry
+            .new_gauge(
+                format!("{}_cur", name),
+                format!("{} (cur)", help),
+                HashMap::new(),
+            )
+            .expect(format!("failed to register metric `{}_cur`", name).as_str());
+
+        Aggregate {
+            n: 0,
+            sum: 0.0,
+            avg: 0.0,
+            cur: 0.0,
+            count_gauge,
+            sum_gauge,
+            avg_gauge,
+            cur_gauge,
+        }
+    }
+
+    pub fn update(&mut self, x: f64) {
+        // Update aggregate values.
+        self.n += 1;
+        self.sum += x;
+        self.cur = x;
+        self.avg = self.avg + (x - self.avg) / (self.n as f64);
+
+        // Update gauges
+        self.count_gauge.set(self.n as f64);
+        self.sum_gauge.set(self.sum);
+        self.avg_gauge.set(self.avg);
+        self.cur_gauge.set(self.cur);
+    }
+
+    pub fn update_duration(&mut self, x: Duration) {
+        self.update(x.as_secs_f64())
+    }
+}

--- a/graph/src/components/metrics/aggregate.rs
+++ b/graph/src/components/metrics/aggregate.rs
@@ -5,27 +5,21 @@ use crate::prelude::*;
 
 pub struct Aggregate {
     /// Number of values.
-    n: u64,
+    count: Box<Gauge>,
 
     /// Sum over all values.
-    sum: f64,
+    sum: Box<Gauge>,
 
     /// Moving average over the values.
-    avg: f64,
+    avg: Box<Gauge>,
 
     /// Latest value.
-    cur: f64,
-
-    /// Metrics for Prometheus.
-    count_gauge: Box<Gauge>,
-    sum_gauge: Box<Gauge>,
-    avg_gauge: Box<Gauge>,
-    cur_gauge: Box<Gauge>,
+    cur: Box<Gauge>,
 }
 
 impl Aggregate {
     pub fn new(name: String, help: &str, registry: Arc<dyn MetricsRegistry>) -> Self {
-        let count_gauge = registry
+        let count = registry
             .new_gauge(
                 format!("{}_count", name),
                 format!("{} (count)", help),
@@ -33,7 +27,7 @@ impl Aggregate {
             )
             .expect(format!("failed to register metric `{}_count`", name).as_str());
 
-        let sum_gauge = registry
+        let sum = registry
             .new_gauge(
                 format!("{}_sum", name),
                 format!("{} (sum)", help),
@@ -41,14 +35,15 @@ impl Aggregate {
             )
             .expect(format!("failed to register metric `{}_sum`", name).as_str());
 
-        let avg_gauge = registry
+        let avg = registry
             .new_gauge(
                 format!("{}_avg", name),
                 format!("{} (avg)", help),
                 HashMap::new(),
             )
             .expect(format!("failed to register metric `{}_avg`", name).as_str());
-        let cur_gauge = registry
+
+        let cur = registry
             .new_gauge(
                 format!("{}_cur", name),
                 format!("{} (cur)", help),
@@ -57,32 +52,30 @@ impl Aggregate {
             .expect(format!("failed to register metric `{}_cur`", name).as_str());
 
         Aggregate {
-            n: 0,
-            sum: 0.0,
-            avg: 0.0,
-            cur: 0.0,
-            count_gauge,
-            sum_gauge,
-            avg_gauge,
-            cur_gauge,
+            count,
+            sum,
+            avg,
+            cur,
         }
     }
 
-    pub fn update(&mut self, x: f64) {
-        // Update aggregate values.
-        self.n += 1;
-        self.sum += x;
-        self.cur = x;
-        self.avg = self.avg + (x - self.avg) / (self.n as f64);
+    pub fn update(&self, x: f64) {
+        // Update count
+        self.count.inc();
+        let n = self.count.get();
 
-        // Update gauges
-        self.count_gauge.set(self.n as f64);
-        self.sum_gauge.set(self.sum);
-        self.avg_gauge.set(self.avg);
-        self.cur_gauge.set(self.cur);
+        // Update sum
+        self.sum.add(x);
+
+        // Update current value
+        self.cur.set(x);
+
+        // Update aggregate value.
+        let avg = self.avg.get();
+        self.avg.set(avg + (x - avg) / n);
     }
 
-    pub fn update_duration(&mut self, x: Duration) {
+    pub fn update_duration(&self, x: Duration) {
         self.update(x.as_secs_f64())
     }
 }

--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -3,11 +3,13 @@ pub use prometheus::{
     Counter, CounterVec, Error as PrometheusError, Gauge, GaugeVec, Histogram, HistogramOpts,
     HistogramVec, Opts, Registry,
 };
-
 use std::collections::HashMap;
 
 /// Metrics for measuring where time is spent during indexing.
 pub mod stopwatch;
+
+/// Aggregates over individual values.
+pub mod aggregate;
 
 pub trait MetricsRegistry: Send + Sync + 'static {
     fn new_gauge(

--- a/graph/src/data/store/ethereum.rs
+++ b/graph/src/data/store/ethereum.rs
@@ -1,0 +1,64 @@
+use std::convert::TryFrom;
+use std::str::FromStr;
+
+use super::scalar;
+use crate::prelude::*;
+use web3::types::{Address, Bytes, H2048, H256, H64, U128, U256};
+
+impl From<U128> for Value {
+    fn from(n: U128) -> Value {
+        Value::BigInt(scalar::BigInt::from_signed_u256(&n.into()))
+    }
+}
+
+impl From<Address> for Value {
+    fn from(address: Address) -> Value {
+        Value::Bytes(scalar::Bytes::from(address.as_ref()))
+    }
+}
+
+impl From<H64> for Value {
+    fn from(hash: H64) -> Value {
+        Value::Bytes(scalar::Bytes::from(hash.as_ref()))
+    }
+}
+
+impl From<H256> for Value {
+    fn from(hash: H256) -> Value {
+        Value::Bytes(scalar::Bytes::from(hash.as_ref()))
+    }
+}
+
+impl From<H2048> for Value {
+    fn from(hash: H2048) -> Value {
+        Value::Bytes(scalar::Bytes::from(hash.as_ref()))
+    }
+}
+
+impl From<Bytes> for Value {
+    fn from(bytes: Bytes) -> Value {
+        Value::Bytes(scalar::Bytes::from(bytes.0.as_slice()))
+    }
+}
+
+impl TryFrom<Value> for Option<H256> {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Bytes(bytes) => {
+                let hex = format!("{}", bytes);
+                Ok(Some(H256::from_str(hex.trim_start_matches("0x"))?))
+            }
+            Value::String(s) => Ok(Some(H256::from_str(s.as_str())?)),
+            Value::Null => Ok(None),
+            _ => Err(format_err!("Value is not an H256")),
+        }
+    }
+}
+
+impl From<U256> for Value {
+    fn from(n: U256) -> Value {
+        Value::BigInt(BigInt::from_unsigned_u256(&n))
+    }
+}

--- a/graph/src/data/store/ethereum.rs
+++ b/graph/src/data/store/ethereum.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use super::scalar;
 use crate::prelude::*;
-use web3::types::{Address, Bytes, H2048, H256, H64, U128, U256};
+use web3::types::{Address, Bytes, H160, H2048, H256, H64, U128, U256};
 
 impl From<U128> for Value {
     fn from(n: U128) -> Value {
@@ -60,5 +60,17 @@ impl TryFrom<Value> for Option<H256> {
 impl From<U256> for Value {
     fn from(n: U256) -> Value {
         Value::BigInt(BigInt::from_unsigned_u256(&n))
+    }
+}
+
+impl ToEntityId for H160 {
+    fn to_entity_id(&self) -> String {
+        format!("{:x}", self)
+    }
+}
+
+impl ToEntityId for H256 {
+    fn to_entity_id(&self) -> String {
+        format!("{:x}", self)
     }
 }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -11,7 +11,7 @@ use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
 use crate::data::subgraph::SubgraphDeploymentId;
-use crate::prelude::{format_err, QueryExecutionError};
+use crate::prelude::{format_err, EntityKey, QueryExecutionError};
 
 /// Custom scalars in GraphQL.
 pub mod scalar;
@@ -493,6 +493,21 @@ impl<'a> From<Vec<(&'a str, Value)>> for Entity {
             entries.into_iter().map(|(k, v)| (String::from(k), v)),
         ))
     }
+}
+
+/// A value that can (maybe) be converted to an `Entity`.
+pub trait TryIntoEntity {
+    fn try_into_entity(self) -> Result<Entity, Error>;
+}
+
+/// A value that can be converted to an `Entity` ID.
+pub trait ToEntityId {
+    fn to_entity_id(&self) -> String;
+}
+
+/// A value that can be converted to an `Entity` key.
+pub trait ToEntityKey {
+    fn to_entity_key(&self, subgraph: SubgraphDeploymentId) -> EntityKey;
 }
 
 #[test]

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,4 +1,3 @@
-use ethabi::Address;
 use failure::Error;
 use graphql_parser::query;
 use graphql_parser::schema;
@@ -10,13 +9,15 @@ use std::fmt;
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
-use web3::types::H256;
 
 use crate::data::subgraph::SubgraphDeploymentId;
 use crate::prelude::{format_err, QueryExecutionError};
 
 /// Custom scalars in GraphQL.
 pub mod scalar;
+
+// Ethereum compatibility.
+pub mod ethereum;
 
 /// A pair of subgraph ID and entity type name.
 pub type SubgraphEntityPair = (SubgraphDeploymentId, String);
@@ -379,43 +380,6 @@ impl From<u64> for Value {
     }
 }
 
-impl<T> From<Vec<T>> for Value
-where
-    Value: From<T>,
-{
-    fn from(list: Vec<T>) -> Value {
-        Value::List(list.into_iter().map(Value::from).collect::<Vec<_>>())
-    }
-}
-
-impl From<Address> for Value {
-    fn from(address: Address) -> Value {
-        Value::Bytes(scalar::Bytes::from(address.as_ref()))
-    }
-}
-
-impl From<H256> for Value {
-    fn from(hash: H256) -> Value {
-        Value::Bytes(scalar::Bytes::from(hash.as_ref()))
-    }
-}
-
-impl TryFrom<Value> for Option<H256> {
-    type Error = Error;
-
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
-        match value {
-            Value::Bytes(bytes) => {
-                let hex = format!("{}", bytes);
-                Ok(Some(H256::from_str(hex.trim_start_matches("0x"))?))
-            }
-            Value::String(s) => Ok(Some(H256::from_str(s.as_str())?)),
-            Value::Null => Ok(None),
-            _ => Err(format_err!("Value is not an H256")),
-        }
-    }
-}
-
 impl TryFrom<Value> for Option<scalar::BigInt> {
     type Error = Error;
 
@@ -425,6 +389,15 @@ impl TryFrom<Value> for Option<scalar::BigInt> {
             Value::Null => Ok(None),
             _ => Err(format_err!("Value is not an BigInt")),
         }
+    }
+}
+
+impl<T> From<Vec<T>> for Value
+where
+    T: Into<Value>,
+{
+    fn from(values: Vec<T>) -> Value {
+        Value::List(values.into_iter().map(Into::into).collect())
     }
 }
 

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -58,7 +58,7 @@ impl SubgraphDeploymentId {
         }
 
         // Check that the ID contains only allowed characters.
-        if !s.chars().all(|c| c.is_ascii_alphanumeric()) {
+        if !s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
             return Err(());
         }
 

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -2,8 +2,7 @@ use failure::Error;
 use futures::sync::oneshot;
 use std::fmt;
 use std::sync::{Arc, Mutex, Weak};
-use std::time::{Duration, Instant};
-use tokio::prelude::{future::Fuse, Async, Future, Poll, Stream};
+use tokio::prelude::{future::Fuse, Future, Poll, Stream};
 
 /// A cancelable stream or future.
 ///
@@ -209,9 +208,6 @@ pub trait FutureExtension: Future + Sized {
         guard: &impl Canceler,
         on_cancel: C,
     ) -> Cancelable<Self, C>;
-
-    /// Measures the time it takes for the future to complete.
-    fn measure<C: FnOnce(&Self::Item, Duration)>(self, callback: C) -> Measure<Self, C>;
 }
 
 impl<F: Future> FutureExtension for F {
@@ -227,10 +223,6 @@ impl<F: Future> FutureExtension for F {
             cancel_receiver: cancel_receiver.fuse(),
             on_cancel,
         }
-    }
-
-    fn measure<C: FnOnce(&Self::Item, Duration)>(self, callback: C) -> Measure<Self, C> {
-        Measure::new(self, callback)
     }
 }
 
@@ -255,56 +247,5 @@ where
             CancelableError::Error(e) => e.fmt(f),
             CancelableError::Cancel => write!(f, "operation canceled"),
         }
-    }
-}
-
-/// Wraps a future and measures the time from creation to completion.
-///
-/// Example usage:
-/// ```ignore
-/// extern crate graph;
-/// use graph::prelude::*;
-///
-/// ...
-/// some_future
-///   .measure(|duration| println!("Duration: {:?}", duration))
-/// ```
-#[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
-pub struct Measure<F, C> {
-    inner: F,
-    callback: Option<C>,
-    start: Instant,
-}
-
-impl<F, C> Measure<F, C> {
-    fn new(inner: F, callback: C) -> Self {
-        Self {
-            inner,
-            callback: Some(callback),
-            start: Instant::now(),
-        }
-    }
-}
-
-impl<F, C> Future for Measure<F, C>
-where
-    F: Future,
-    C: FnOnce(&F::Item, Duration),
-{
-    type Item = F::Item;
-    type Error = F::Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll().map(|v| match v {
-            Async::Ready(v) => {
-                (self.callback.take().expect("cannot poll Measure twice"))(
-                    &v,
-                    self.start.elapsed(),
-                );
-                Async::Ready(v)
-            }
-            Async::NotReady => Async::NotReady,
-        })
     }
 }

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -261,7 +261,7 @@ where
 /// Wraps a future and measures the time from creation to completion.
 ///
 /// Example usage:
-/// ```
+/// ```ignore
 /// extern crate graph;
 /// use graph::prelude::*;
 ///

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -53,8 +53,9 @@ pub mod prelude {
     };
     pub use crate::components::link_resolver::{JsonStreamValue, JsonValueStream, LinkResolver};
     pub use crate::components::metrics::{
-        stopwatch::StopwatchMetrics, Collector, Counter, CounterVec, Gauge, GaugeVec, Histogram,
-        HistogramOpts, HistogramVec, MetricsRegistry, Opts, PrometheusError, Registry,
+        aggregate::Aggregate, stopwatch::StopwatchMetrics, Collector, Counter, CounterVec, Gauge,
+        GaugeVec, Histogram, HistogramOpts, HistogramVec, MetricsRegistry, Opts, PrometheusError,
+        Registry,
     };
     pub use crate::components::server::admin::JsonRpcServer;
     pub use crate::components::server::index_node::IndexNodeServer;

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -13,6 +13,11 @@ pub mod ext;
 /// Logging utilities
 pub mod log;
 
+/// Module with mocks for different parts of the system.
+pub mod mock {
+    pub use crate::components::ethereum::MockEthereumAdapter;
+}
+
 /// A prelude that makes all system component traits and data types available.
 ///
 /// Add the following code to import all traits and data types listed below at once.

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -87,6 +87,7 @@ pub mod prelude {
         Query, QueryError, QueryExecutionError, QueryResult, QueryVariables,
     };
     pub use crate::data::schema::Schema;
+    pub use crate::data::store::ethereum::*;
     pub use crate::data::store::scalar::{BigDecimal, BigInt, BigIntSign};
     pub use crate::data::store::{
         AssignmentEvent, Attribute, Entity, NodeId, SubgraphEntityPair, SubgraphVersionSummary,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -91,7 +91,7 @@ pub mod prelude {
     pub use crate::data::store::scalar::{BigDecimal, BigInt, BigIntSign};
     pub use crate::data::store::{
         AssignmentEvent, Attribute, Entity, NodeId, SubgraphEntityPair, SubgraphVersionSummary,
-        Value, ValueType,
+        ToEntityId, ToEntityKey, TryIntoEntity, Value, ValueType,
     };
     pub use crate::data::subgraph::schema::{SubgraphDeploymentEntity, TypedEntity};
     pub use crate::data::subgraph::{

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -40,6 +40,14 @@ impl EthereumAdapter for MockEthereumAdapter {
         unimplemented!();
     }
 
+    fn block_by_number(
+        &self,
+        _logger: &Logger,
+        _block_number: u64,
+    ) -> Box<dyn Future<Item = Option<LightEthereumBlock>, Error = Error> + Send> {
+        unimplemented!();
+    }
+
     fn load_full_block(
         &self,
         _: &Logger,

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -1,7 +1,7 @@
 use graph::components::ethereum::*;
 use graph::prelude::{
     ethabi, future,
-    web3::types::{Log, H256},
+    web3::types::{Block, Log, H256},
     Arc, ChainStore, Error, EthereumCallCache, Future, Logger, Stream,
 };
 use std::collections::HashSet;
@@ -72,6 +72,14 @@ impl EthereumAdapter for MockEthereumAdapter {
         _: &Logger,
         _: u64,
     ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send> {
+        unimplemented!();
+    }
+
+    fn uncles(
+        &self,
+        _: &Logger,
+        _: &LightEthereumBlock,
+    ) -> Box<dyn Future<Item = Vec<Option<Block<H256>>>, Error = Error> + Send> {
         unimplemented!();
     }
 

--- a/mock/src/ethereum_adapter.rs
+++ b/mock/src/ethereum_adapter.rs
@@ -133,19 +133,6 @@ impl EthereumAdapter for MockEthereumAdapter {
         unimplemented!();
     }
 
-    fn triggers_in_block(
-        self: Arc<Self>,
-        _: Logger,
-        _: Arc<dyn ChainStore>,
-        _: Arc<SubgraphEthRpcMetrics>,
-        _: EthereumLogFilter,
-        _: EthereumCallFilter,
-        _: EthereumBlockFilter,
-        _: BlockFinality,
-    ) -> Box<dyn Future<Item = EthereumBlockWithTriggers, Error = Error> + Send> {
-        unimplemented!();
-    }
-
     /// Load Ethereum blocks in bulk, returning results as they come back as a Stream.
     fn load_blocks(
         &self,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -279,6 +279,18 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                 .env("STORE_CONNECTION_POOL_SIZE")
                 .help("Limits the number of connections in the store's connection pool"),
         )
+        .arg(
+            Arg::with_name("network-subgraphs")
+                .takes_value(true)
+                .multiple(true)
+                .min_values(1)
+                .long("network-subgraphs")
+                .value_name("NETWORK_NAME")
+                .help(
+                    "One or more network names to index using built-in subgraphs \
+                     (e.g. 'ethereum/mainnet').",
+                ),
+        )
         .get_matches();
 
     // Set up logger

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -590,7 +590,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                                 .expect("store for network")
                                 .clone(),
                             metrics_registry.clone(),
-                            network_subgraph.into(),
+                            format!("network/{}", network_subgraph).into(),
                             None,
                         );
                         tokio::spawn(indexer.take_event_stream().unwrap().for_each(|_| {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -15,7 +15,7 @@ use graph::prelude::{
     EthereumAdapter as EthereumAdapterTrait, IndexNodeServer as _, JsonRpcServer as _, *,
 };
 use graph::util::security::SafeDisplay;
-use graph_chain_ethereum::{BlockIngestor, BlockStreamBuilder, Transport};
+use graph_chain_ethereum::{network_indexer, BlockIngestor, BlockStreamBuilder, Transport};
 use graph_core::{
     LinkResolver, MetricsRegistry, SubgraphAssignmentProvider as IpfsSubgraphAssignmentProvider,
     SubgraphInstanceManager, SubgraphRegistrar as IpfsSubgraphRegistrar,
@@ -571,6 +571,37 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                 generic_store.clone(),
                 node_id.clone(),
             );
+
+            // Spawn Ethereum network indexers for all networks that are to be indexed
+            if let Some(network_subgraphs) = matches.values_of("network-subgraphs") {
+                network_subgraphs
+                    .into_iter()
+                    .filter(|network_subgraph| network_subgraph.starts_with("ethereum/"))
+                    .for_each(|network_subgraph| {
+                        let network_name = network_subgraph.replace("ethereum/", "");
+                        let network_indexer = network_indexer::create(
+                            network_subgraph.into(),
+                            &logger,
+                            eth_adapters
+                                .get(&network_name)
+                                .expect("adapter for network")
+                                .clone(),
+                            stores
+                                .get(&network_name)
+                                .expect("store for network")
+                                .clone(),
+                            metrics_registry.clone(),
+                            None,
+                        );
+                        tokio::spawn(network_indexer.and_then(|mut indexer| {
+                            indexer.take_event_stream().unwrap().for_each(|_| {
+                                // For now we simply ignore these events; we may later use them
+                                // to drive subgraph indexing
+                                Ok(())
+                            })
+                        }));
+                    })
+            };
 
             if !disable_block_ingestor {
                 // BlockIngestor must be configured to keep at least REORG_THRESHOLD ancestors,

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -385,11 +385,13 @@ where
             (Method::GET, &["subgraphs", "id", _, "graphql"])
             | (Method::GET, &["subgraphs", "name", _, "graphql"])
             | (Method::GET, &["subgraphs", "name", _, _, "graphql"])
+            | (Method::GET, &["subgraphs", "network", _, _, "graphql"])
             | (Method::GET, &["subgraphs", "graphql"]) => self.handle_graphiql(),
 
             (Method::GET, path @ ["subgraphs", "id", _])
             | (Method::GET, path @ ["subgraphs", "name", _])
             | (Method::GET, path @ ["subgraphs", "name", _, _])
+            | (Method::GET, path @ ["subgraphs", "network", _, _])
             | (Method::GET, path @ ["subgraphs"]) => {
                 let dest = format!("/{}/graphql", path.join("/"));
                 self.handle_temp_redirect(&dest)
@@ -406,8 +408,15 @@ where
                 let subgraph_name = format!("{}/{}", subgraph_name_part1, subgraph_name_part2);
                 self.handle_graphql_query_by_name(subgraph_name, req)
             }
+            (Method::POST, ["subgraphs", "network", subgraph_name_part1, subgraph_name_part2]) => {
+                let subgraph_name =
+                    format!("network/{}/{}", subgraph_name_part1, subgraph_name_part2);
+                self.handle_graphql_query_by_name(subgraph_name, req)
+            }
+
             (Method::OPTIONS, ["subgraphs", "name", _])
-            | (Method::OPTIONS, ["subgraphs", "name", _, _]) => self.handle_graphql_options(req),
+            | (Method::OPTIONS, ["subgraphs", "name", _, _])
+            | (Method::OPTIONS, ["subgraphs", "network", _, _]) => self.handle_graphql_options(req),
 
             // `/subgraphs` acts as an alias to `/subgraphs/id/SUBGRAPHS_ID`
             (Method::POST, &["subgraphs"]) => {

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -56,6 +56,14 @@ where
                     Ok(subgraph_name) => store.resolve_subgraph_name_to_id(subgraph_name),
                 }
             }
+            &["subgraphs", "network", _, _] => {
+                let subgraph_name = path_segments[1..].join("/");
+
+                match SubgraphName::new(subgraph_name) {
+                    Err(()) => Ok(None),
+                    Ok(subgraph_name) => store.resolve_subgraph_name_to_id(subgraph_name),
+                }
+            }
             _ => Ok(None),
         }
     }


### PR DESCRIPTION
I consider this generally ready for review!

This PR implements phase 1 of #297, including the following features:

1. A network indexer that indexes blocks from the selected network. (Transactions, logs, receipts, accounts, balances come in the next two phases.) This network indexer handles reorgs to an unlimited depth (bounded only by the memory of the machine the node runs on).

2. A `--network-subgraphs` CLI flag to enable network subgraph indexing per network, e.g. with
   ```sh
   graph-node ... --network-subgraphs ethereum/mainnet ethereum/kovan
   ```

3. A built-in GraphQL schema that allows Ethereum network subgraphs to be queried (or subscribed to) at `/subgraphs/ethereum/mainnet`. Apart from slightly different relationship fields, this schema is heavily based on Geth's [GraphQL schema](https://github.com/ethereum/go-ethereum/blob/master/graphql/schema.go).

4. Tests for basic indexing and reorg handling. These should be extended further by also verifying that the blocks are actually written to the store. Right now they only test the `Revert` and `AddBlock` events emitted by the indexer (which are only emitted after reverting/writing blocks successfully; however that doesn't mean the written data is correct).

## Database size

Regarding the size of the indexed data: The most recent 4000 mainnet blocks resulted in a Postgres database size of 20MB. That makes ~65GB for all 9,000,000 blocks, assuming they are the same size on average. They are probably smaller on average (older blocks were less busy), so we're looking at maybe 50GB just for the blocks (or their headers, rather).

## Review guide

I recommend reviewing commit by commit first. I've consolidated the PR into commits that mostly change only one thing at a time, so it's easier to follow what was added when.

It may help to read up on the terminology used across the network indexer here: https://github.com/graphprotocol/graph-node/blob/ec19ad21c7af971848643d2247ad355ead64ffb9/chain/ethereum/src/network_indexer/network_indexer.rs#L16-L54

The state machine for the network indexer is documented here: https://github.com/graphprotocol/graph-node/blob/ec19ad21c7af971848643d2247ad355ead64ffb9/chain/ethereum/src/network_indexer/network_indexer.rs#L509-L673

---

While this is being reviewed, I'll work on improving the tests to test data correctness and potentially generalizing the network indexer across chains. I've done some initial thinking to identify how the indexer depends on Ethereum right now and I think we can abstract that away.