### PR TITLE
Optimize store.set entity validation

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -735,6 +735,7 @@ where
             return Err(CancelableError::Cancel);
         }
 
+        let section = ctx.host_metrics.stopwatch.start_section("as_modifications");
         let mods = block_state
             .entity_cache
             .as_modifications(ctx.inputs.store.as_ref())
@@ -744,6 +745,8 @@ where
                     e
                 ))
             })?;
+        section.end();
+
         if !mods.is_empty() {
             info!(logger1, "Applying {} entity operation(s)", mods.len());
         }


### PR DESCRIPTION
If the entity that comes from the mapping is already valid, avoid going to the DB at all. Also add a metrics section for `as_modifications`, since some DB accesses shift from `store_set` to `as_modifications`. Part of #1381.

PR for grafana https://github.com/graphprotocol/instrumentation/pull/3.

