### PR TITLE
Reduce number of queries during GraphQL execution

### DIFF
--- a/core/tests/tests.rs
+++ b/core/tests/tests.rs
@@ -19,6 +19,8 @@ use graph::prelude::*;
 use graph_core::LinkResolver;
 use graph_mock::{MockEthereumAdapter, MockStore};
 
+use test_store::LOGGER;
+
 use crate::tokio::timer::Delay;
 
 /// Adds subgraph located in `test/subgraphs/`, replacing "link to" placeholders
@@ -242,7 +244,7 @@ fn subgraph_provider_events() {
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime
         .block_on(future::lazy(|| {
-            let logger = Logger::root(slog::Discard, o!());
+            let logger = LOGGER.clone();
             let logger_factory = LoggerFactory::new(logger.clone(), None);
             let ipfs = Arc::new(IpfsClient::default());
             let resolver = Arc::new(LinkResolver::from(IpfsClient::default()));

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -203,8 +203,13 @@ impl EntityQuery {
         self
     }
 
-    pub fn order_by(mut self, by: (String, ValueType), direction: EntityOrder) -> Self {
-        self.order_by = Some(by);
+    pub fn order_by(
+        mut self,
+        attribute: &str,
+        value_type: ValueType,
+        direction: EntityOrder,
+    ) -> Self {
+        self.order_by = Some((attribute.to_owned(), value_type));
         self.order_direction = Some(direction);
         self
     }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -78,6 +78,28 @@ impl EntityFilter {
             attribute_values.into_iter().map(Into::into).collect(),
         )
     }
+
+    pub fn and_maybe(self, other: Option<Self>) -> Self {
+        use EntityFilter as f;
+        match other {
+            Some(other) => match (self, other) {
+                (f::And(mut fs1), f::And(mut fs2)) => {
+                    fs1.append(&mut fs2);
+                    f::And(fs1)
+                }
+                (f::And(mut fs1), f2) => {
+                    fs1.push(f2);
+                    f::And(fs1)
+                }
+                (f1, f::And(mut fs2)) => {
+                    fs2.push(f1);
+                    f::And(fs2)
+                }
+                (f1, f2) => f::And(vec![f1, f2]),
+            },
+            None => self,
+        }
+    }
 }
 
 /// The order in which entities should be restored from a store.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -138,6 +138,16 @@ pub struct EntityQuery {
 
     /// A range to limit the size of the result.
     pub range: EntityRange,
+
+    /// A field by which to window the results. This affects how `order_by`,
+    /// `order_direction`, and `range` are interpreted. If `window` is `None`,
+    /// they are applied to the entire query. If the value is `Some("attr")`,
+    /// ordering and range limiting is applied for each distinct value of the
+    /// `attr` field separately. The latter is useful when the query has a
+    /// clause like `where attr in (v1, v2, ..)` so that the result will have
+    /// `range` many results for each of `v1`, `v2`, etc., and each ordered
+    /// according to `order_by` and `order_direction`.
+    pub window: Option<String>,
 }
 
 impl EntityQuery {
@@ -153,6 +163,7 @@ impl EntityQuery {
             order_by: None,
             order_direction: None,
             range,
+            window: None,
         }
     }
 
@@ -169,6 +180,11 @@ impl EntityQuery {
 
     pub fn range(mut self, range: EntityRange) -> Self {
         self.range = range;
+        self
+    }
+
+    pub fn window_by(mut self, window: String) -> Self {
+        self.window = Some(window);
         self
     }
 }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -170,27 +170,36 @@ pub struct EntityQuery {
     /// `range` many results for each of `v1`, `v2`, etc., and each ordered
     /// according to `order_by` and `order_direction`.
     pub window: Option<String>,
+
+    _force_use_of_new: (),
 }
 
 impl EntityQuery {
-    pub fn new(
-        subgraph_id: SubgraphDeploymentId,
-        entity_types: Vec<String>,
-        range: EntityRange,
-    ) -> Self {
+    pub fn new(subgraph_id: SubgraphDeploymentId, entity_types: Vec<String>) -> Self {
         EntityQuery {
             subgraph_id,
             entity_types,
             filter: None,
             order_by: None,
             order_direction: None,
-            range,
+            range: EntityRange::first(100),
             window: None,
+            _force_use_of_new: (),
         }
     }
 
     pub fn filter(mut self, filter: EntityFilter) -> Self {
         self.filter = Some(filter);
+        self
+    }
+
+    pub fn order_direction(mut self, direction: EntityOrder) -> Self {
+        self.order_direction = Some(direction);
+        self
+    }
+
+    pub fn order_by_attribute(mut self, by: (String, ValueType)) -> Self {
+        self.order_by = Some(by);
         self
     }
 
@@ -202,6 +211,16 @@ impl EntityQuery {
 
     pub fn range(mut self, range: EntityRange) -> Self {
         self.range = range;
+        self
+    }
+
+    pub fn first(mut self, first: u32) -> Self {
+        self.range.first = Some(first);
+        self
+    }
+
+    pub fn skip(mut self, skip: u32) -> Self {
+        self.range.skip = skip;
         self
     }
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -81,10 +81,20 @@ impl EntityFilter {
 }
 
 /// The order in which entities should be restored from a store.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EntityOrder {
     Ascending,
     Descending,
+}
+
+impl EntityOrder {
+    /// Return `"asc"` or `"desc"` as is used in SQL
+    pub fn to_sql(&self) -> &'static str {
+        match self {
+            EntityOrder::Ascending => "asc",
+            EntityOrder::Descending => "desc",
+        }
+    }
 }
 
 /// How many entities to return, how many to skip etc.

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use std::string::FromUtf8Error;
 
 use crate::components::store::StoreError;
+use crate::data::graphql::SerializableValue;
 use crate::data::subgraph::*;
 
 /// Error caused while executing a [Query](struct.Query.html).
@@ -54,6 +55,11 @@ pub enum QueryExecutionError {
     TooComplex(u64, u64), // (complexity, max_complexity)
     TooDeep(u8),          // max_depth
     UndefinedFragment(String),
+    // Using single query and prefetch resolution yield different results
+    IncorrectPrefetchResult {
+        single: q::Value,
+        prefetch: q::Value,
+    },
 }
 
 impl Error for QueryExecutionError {
@@ -194,6 +200,10 @@ impl fmt::Display for QueryExecutionError {
             }
             TooDeep(max_depth) => write!(f, "query has a depth that exceeds the limit of `{}`", max_depth),
             UndefinedFragment(frag_name) => write!(f, "fragment `{}` is not defined", frag_name),
+            IncorrectPrefetchResult{ .. } => write!(f, "Running query with prefetch \
+                           and single query resolution yielded different results. \
+                           This is a bug. Please open an issue at \
+                           https://github.com/graphprotocol/graph-node")
         }
     }
 }
@@ -285,7 +295,16 @@ impl Serialize for QueryError {
     {
         use self::QueryExecutionError::*;
 
-        let mut map = serializer.serialize_map(Some(1))?;
+        let entry_count =
+            if let QueryError::ExecutionError(QueryExecutionError::IncorrectPrefetchResult {
+                ..
+            }) = self
+            {
+                3
+            } else {
+                1
+            };
+        let mut map = serializer.serialize_map(Some(entry_count))?;
 
         let msg = match self {
             // Serialize parse errors with their location (line, column) to make it easier
@@ -339,6 +358,12 @@ impl Serialize for QueryError {
                 location.insert("line", pos.line);
                 location.insert("column", pos.column);
                 map.serialize_entry("locations", &vec![location])?;
+                format!("{}", self)
+            }
+            QueryError::ExecutionError(IncorrectPrefetchResult { single, prefetch }) => {
+                map.serialize_entry("incorrectPrefetch", &true)?;
+                map.serialize_entry("single", &SerializableValue(&single))?;
+                map.serialize_entry("prefetch", &SerializableValue(&prefetch))?;
                 format!("{}", self)
             }
             _ => format!("{}", self),

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -55,11 +55,8 @@ pub enum QueryExecutionError {
     TooComplex(u64, u64), // (complexity, max_complexity)
     TooDeep(u8),          // max_depth
     UndefinedFragment(String),
-    // Using single query and prefetch resolution yield different results
-    IncorrectPrefetchResult {
-        single: q::Value,
-        prefetch: q::Value,
-    },
+    // Using slow and prefetch query resolution yield different results
+    IncorrectPrefetchResult { slow: q::Value, prefetch: q::Value },
 }
 
 impl Error for QueryExecutionError {
@@ -201,7 +198,7 @@ impl fmt::Display for QueryExecutionError {
             TooDeep(max_depth) => write!(f, "query has a depth that exceeds the limit of `{}`", max_depth),
             UndefinedFragment(frag_name) => write!(f, "fragment `{}` is not defined", frag_name),
             IncorrectPrefetchResult{ .. } => write!(f, "Running query with prefetch \
-                           and single query resolution yielded different results. \
+                           and slow query resolution yielded different results. \
                            This is a bug. Please open an issue at \
                            https://github.com/graphprotocol/graph-node")
         }
@@ -360,9 +357,9 @@ impl Serialize for QueryError {
                 map.serialize_entry("locations", &vec![location])?;
                 format!("{}", self)
             }
-            QueryError::ExecutionError(IncorrectPrefetchResult { single, prefetch }) => {
+            QueryError::ExecutionError(IncorrectPrefetchResult { slow, prefetch }) => {
                 map.serialize_entry("incorrectPrefetch", &true)?;
-                map.serialize_entry("single", &SerializableValue(&single))?;
+                map.serialize_entry("single", &SerializableValue(&slow))?;
                 map.serialize_entry("prefetch", &SerializableValue(&prefetch))?;
                 format!("{}", self)
             }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -371,9 +371,12 @@ impl From<u64> for Value {
     }
 }
 
-impl From<Vec<Value>> for Value {
-    fn from(list: Vec<Value>) -> Value {
-        Value::List(list)
+impl<T> From<Vec<T>> for Value
+where
+    Value: From<T>,
+{
+    fn from(list: Vec<T>) -> Value {
+        Value::List(list.into_iter().map(Value::from).collect::<Vec<_>>())
     }
 }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -204,6 +204,14 @@ impl Value {
         }
     }
 
+    pub fn as_str(&self) -> Option<&str> {
+        if let Value::String(s) = self {
+            Some(s.as_str())
+        } else {
+            None
+        }
+    }
+
     pub fn is_string(&self) -> bool {
         match self {
             Value::String(_) => true,
@@ -484,13 +492,19 @@ impl DerefMut for Entity {
     }
 }
 
-impl Into<query::Value> for Entity {
-    fn into(self) -> query::Value {
+impl Into<BTreeMap<String, query::Value>> for Entity {
+    fn into(self) -> BTreeMap<String, query::Value> {
         let mut fields = BTreeMap::new();
         for (attr, value) in self.iter() {
             fields.insert(attr.to_string(), value.clone().into());
         }
-        query::Value::Object(fields)
+        fields
+    }
+}
+
+impl Into<query::Value> for Entity {
+    fn into(self) -> query::Value {
+        query::Value::Object(self.into())
     }
 }
 

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -48,7 +48,7 @@ pub trait TypedEntity {
             first: None,
             skip: 0,
         };
-        EntityQuery::new(SUBGRAPHS_ID.clone(), vec![Self::TYPENAME.to_owned()], range)
+        EntityQuery::new(SUBGRAPHS_ID.clone(), vec![Self::TYPENAME.to_owned()]).range(range)
     }
 
     fn subgraph_entity_pair() -> SubgraphEntityPair {

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -24,8 +24,8 @@ use web3::types::*;
 use super::SubgraphDeploymentId;
 use crate::components::ethereum::EthereumBlockPointer;
 use crate::components::store::{
-    AttributeIndexDefinition, EntityFilter, EntityKey, EntityOperation, EntityQuery, EntityRange,
-    MetadataOperation,
+    AttributeIndexDefinition, EntityCollection, EntityFilter, EntityKey, EntityOperation,
+    EntityQuery, EntityRange, MetadataOperation,
 };
 use crate::data::graphql::{TryFromValue, ValueMap};
 use crate::data::store::{Entity, NodeId, SubgraphEntityPair, Value, ValueType};
@@ -48,7 +48,11 @@ pub trait TypedEntity {
             first: None,
             skip: 0,
         };
-        EntityQuery::new(SUBGRAPHS_ID.clone(), vec![Self::TYPENAME.to_owned()]).range(range)
+        EntityQuery::new(
+            SUBGRAPHS_ID.clone(),
+            EntityCollection::All(vec![Self::TYPENAME.to_owned()]),
+        )
+        .range(range)
     }
 
     fn subgraph_entity_pair() -> SubgraphEntityPair {

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -63,9 +63,10 @@ pub mod prelude {
     pub use crate::components::server::subscription::SubscriptionServer;
     pub use crate::components::store::{
         AttributeIndexDefinition, ChainStore, EntityCache, EntityChange, EntityChangeOperation,
-        EntityFilter, EntityKey, EntityModification, EntityOperation, EntityOrder, EntityQuery,
-        EntityRange, EthereumCallCache, MetadataOperation, Store, StoreError, StoreEvent,
-        StoreEventStream, StoreEventStreamBox, SubgraphDeploymentStore, TransactionAbortError,
+        EntityCollection, EntityFilter, EntityKey, EntityLink, EntityModification, EntityOperation,
+        EntityOrder, EntityQuery, EntityRange, EntityWindow, EthereumCallCache, MetadataOperation,
+        ParentLink, Store, StoreError, StoreEvent, StoreEventStream, StoreEventStreamBox,
+        SubgraphDeploymentStore, TransactionAbortError, WindowAttribute,
         SUBSCRIPTION_THROTTLE_INTERVAL,
     };
     pub use crate::components::subgraph::{

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -303,7 +303,6 @@ where
 pub fn execute_root_selection_set<'a, R>(
     ctx: &ExecutionContext<'a, R>,
     selection_set: &'a q::SelectionSet,
-    initial_value: &Option<q::Value>,
 ) -> Result<q::Value, Vec<QueryExecutionError>>
 where
     R: Resolver,
@@ -343,18 +342,18 @@ where
     // Execute the root selection set against the root query type
     if data_set.items.is_empty() {
         // Only introspection
-        execute_selection_set(&ictx, &intro_set, introspection_query_type, initial_value)
+        execute_selection_set(&ictx, &intro_set, introspection_query_type, &None)
     } else if intro_set.items.is_empty() {
         // Only data
-        execute_selection_set(&ctx, &data_set, query_type, initial_value)
+        execute_selection_set(&ctx, &data_set, query_type, &None)
     } else {
         // Both introspection and data
-        let mut values = execute_selection_set_to_map(&ctx, &data_set, query_type, initial_value)?;
+        let mut values = execute_selection_set_to_map(&ctx, &data_set, query_type, &None)?;
         values.extend(execute_selection_set_to_map(
             &ictx,
             &intro_set,
             introspection_query_type,
-            initial_value,
+            &None,
         )?);
         Ok(q::Value::Object(values))
     }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -747,7 +747,7 @@ where
                     .resolver
                     .resolve_objects(
                         object_value,
-                        &field.name,
+                        field,
                         field_definition,
                         t.into(),
                         argument_values,
@@ -780,7 +780,7 @@ where
                     .resolver
                     .resolve_objects(
                         object_value,
-                        &field.name,
+                        field,
                         field_definition,
                         t.into(),
                         argument_values,

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -339,16 +339,23 @@ where
         }
     }
 
+    // If we are getting 'normal' data, prefetch it from the database
+    let initial_data = if data_set.items.is_empty() {
+        None
+    } else {
+        ctx.resolver.prefetch(&ctx, &data_set)?
+    };
+
     // Execute the root selection set against the root query type
     if data_set.items.is_empty() {
         // Only introspection
         execute_selection_set(&ictx, &intro_set, introspection_query_type, &None)
     } else if intro_set.items.is_empty() {
         // Only data
-        execute_selection_set(&ctx, &data_set, query_type, &None)
+        execute_selection_set(&ctx, &data_set, query_type, &initial_data)
     } else {
         // Both introspection and data
-        let mut values = execute_selection_set_to_map(&ctx, &data_set, query_type, &None)?;
+        let mut values = execute_selection_set_to_map(&ctx, &data_set, query_type, &initial_data)?;
         values.extend(execute_selection_set_to_map(
             &ictx,
             &intro_set,

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -327,7 +327,7 @@ where
 
     let ictx = ctx.as_introspection_context();
     let introspection_query_type = sast::get_root_query_type(&ictx.schema.document).unwrap();
-    for (_, fields) in collect_fields(ctx.clone(), query_type, selection_set, None) {
+    for (_, fields) in collect_fields(ctx, query_type, selection_set, None) {
         let name = fields[0].name.clone();
         let selections = fields.into_iter().map(|f| q::Selection::Field(f.clone()));
         // See if this is an introspection or data field. We don't worry about
@@ -393,7 +393,7 @@ where
     let mut result_map: BTreeMap<String, q::Value> = BTreeMap::new();
 
     // Group fields with the same response key, so we can execute them together
-    let grouped_field_set = collect_fields(ctx.clone(), object_type, selection_set, None);
+    let grouped_field_set = collect_fields(ctx, object_type, selection_set, None);
 
     // Process all field groups in order
     for (response_key, fields) in grouped_field_set {
@@ -441,7 +441,7 @@ where
 
 /// Collects fields of a selection set.
 pub fn collect_fields<'a, R>(
-    ctx: ExecutionContext<'a, R>,
+    ctx: &ExecutionContext<'a, R>,
     object_type: &s::ObjectType,
     selection_set: &'a q::SelectionSet,
     visited_fragments: Option<HashSet<&'a q::Name>>,
@@ -498,7 +498,7 @@ where
                             // We have a fragment that applies to the current object type,
                             // collect its fields into response key groups
                             let fragment_grouped_field_set = collect_fields(
-                                ctx.clone(),
+                                ctx,
                                 object_type,
                                 &fragment.selection_set,
                                 Some(visited_fragments.clone()),
@@ -524,7 +524,7 @@ where
 
                 if applies {
                     let fragment_grouped_field_set = collect_fields(
-                        ctx.clone(),
+                        ctx,
                         object_type,
                         &fragment.selection_set,
                         Some(visited_fragments.clone()),

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -369,7 +369,7 @@ where
             let single_values = execute_selection_set_to_map(&ctx, &data_set, query_type, &None)?;
             if values != single_values {
                 return Err(vec![QueryExecutionError::IncorrectPrefetchResult {
-                    single: q::Value::Object(single_values),
+                    slow: q::Value::Object(single_values),
                     prefetch: q::Value::Object(values),
                 }]);
             }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -963,7 +963,7 @@ where
 }
 
 /// Merges the selection sets of several fields into a single selection set.
-fn merge_selection_sets(fields: Vec<&q::Field>) -> q::SelectionSet {
+pub fn merge_selection_sets(fields: Vec<&q::Field>) -> q::SelectionSet {
     let (span, items) = fields
         .iter()
         .fold((None, vec![]), |(span, mut items), field| {

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -44,6 +44,10 @@ impl<'a> ObjectOrInterface<'a> {
             ObjectOrInterface::Interface(interface) => &interface.fields,
         }
     }
+
+    pub fn field(&self, name: &s::Name) -> Option<&s::Field> {
+        self.fields().iter().find(|field| &field.name == name)
+    }
 }
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use crate::prelude::*;
 use crate::schema::ast::get_named_type;
-use graph::prelude::{QueryExecutionError, StoreEventStreamBox};
+use graph::prelude::{QueryExecutionError, Schema, StoreEventStreamBox};
 
 #[derive(Copy, Clone, Debug)]
 pub enum ObjectOrInterface<'a> {
@@ -47,6 +47,16 @@ impl<'a> ObjectOrInterface<'a> {
 
     pub fn field(&self, name: &s::Name) -> Option<&s::Field> {
         self.fields().iter().find(|field| &field.name == name)
+    }
+
+    pub fn object_types(&'a self, schema: &'a Schema) -> Option<Vec<&'a s::ObjectType>> {
+        match self {
+            ObjectOrInterface::Object(object) => Some(vec![object]),
+            ObjectOrInterface::Interface(interface) => schema
+                .types_for_interface()
+                .get(&interface.name)
+                .map(|object_types| object_types.iter().collect()),
+        }
     }
 }
 

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -52,7 +52,7 @@ pub trait Resolver: Clone + Send + Sync {
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,
-        field: &q::Name,
+        field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -57,7 +57,7 @@ pub trait Resolver: Clone + Send + Sync {
         &self,
         ctx: &ExecutionContext<'a, Self>,
         selection_set: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, QueryExecutionError>;
+    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>>;
 
     /// Resolves entities referenced by a parent object.
     fn resolve_objects(

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -48,6 +48,13 @@ impl<'a> ObjectOrInterface<'a> {
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
 pub trait Resolver: Clone + Send + Sync {
+    /// Prepare for executing a query by prefetching as much data as possible
+    fn prefetch<'a>(
+        &self,
+        ctx: &ExecutionContext<'a, Self>,
+        selection_set: &q::SelectionSet,
+    ) -> Result<Option<q::Value>, QueryExecutionError>;
+
     /// Resolves entities referenced by a parent object.
     fn resolve_objects(
         &self,

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -459,7 +459,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         &self,
         _: &ExecutionContext<'r, Self>,
         _: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, QueryExecutionError> {
+    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
         Ok(None)
     }
 

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -455,6 +455,14 @@ impl<'a> IntrospectionResolver<'a> {
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
 impl<'a> Resolver for IntrospectionResolver<'a> {
+    fn prefetch<'r>(
+        &self,
+        _: &ExecutionContext<'r, Self>,
+        _: &q::SelectionSet,
+    ) -> Result<Option<q::Value>, QueryExecutionError> {
+        Ok(None)
+    }
+
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -458,14 +458,14 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,
-        field: &q::Name,
+        field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
         _max_first: u32,
     ) -> Result<q::Value, QueryExecutionError> {
-        match field.as_str() {
+        match field.name.as_str() {
             "possibleTypes" => {
                 let type_names = object_field(parent, "possibleTypes")
                     .and_then(|value| match value {
@@ -489,7 +489,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
                     Ok(q::Value::Null)
                 }
             }
-            _ => object_field(parent, field.as_str())
+            _ => object_field(parent, field.name.as_str())
                 .map_or(Ok(q::Value::Null), |value| Ok(value.clone())),
         }
     }

--- a/graphql/src/query/ext.rs
+++ b/graphql/src/query/ext.rs
@@ -1,0 +1,26 @@
+//! Extension traits for graphql_parser::query structs
+
+use graphql_parser::query as q;
+
+use std::collections::BTreeMap;
+
+pub trait ValueExt {
+    fn as_object(&self) -> &BTreeMap<q::Name, q::Value>;
+    fn as_string(&self) -> &str;
+}
+
+impl ValueExt for q::Value {
+    fn as_object(&self) -> &BTreeMap<q::Name, q::Value> {
+        match self {
+            q::Value::Object(object) => object,
+            _ => panic!("expected a Value::Object"),
+        }
+    }
+
+    fn as_string(&self) -> &str {
+        match self {
+            q::Value::String(string) => string,
+            _ => panic!("expected a Value::String"),
+        }
+    }
+}

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -61,6 +61,16 @@ where
             Err(errors) => return QueryResult::from(errors),
         };
 
+    let mode = if let q::OperationDefinition::Query(query) = operation {
+        if query.directives.iter().any(|dir| dir.name == "verify") {
+            ExecutionMode::Verify
+        } else {
+            ExecutionMode::Prefetch
+        }
+    } else {
+        ExecutionMode::Prefetch
+    };
+
     // Create a fresh execution context
     let ctx = ExecutionContext {
         logger: query_logger.clone(),
@@ -71,6 +81,7 @@ where
         variable_values: Arc::new(coerced_variable_values),
         deadline: options.deadline,
         max_first: options.max_first,
+        mode,
     };
 
     let result = match operation {

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -98,7 +98,7 @@ where
                         max_complexity,
                     )])
                 }
-                (Ok(_), _) => execute_root_selection_set(&ctx, selection_set, &None),
+                (Ok(_), _) => execute_root_selection_set(&ctx, selection_set),
             }
         }
         // Everything else (e.g. mutations) is unsupported

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -10,6 +10,9 @@ use crate::schema::ast as sast;
 /// Utilities for working with GraphQL query ASTs.
 pub mod ast;
 
+/// Extension traits
+pub mod ext;
+
 /// Options available for query execution.
 pub struct QueryExecutionOptions<R>
 where

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -566,7 +566,7 @@ fn entity_validation() {
         thing.set("name", name);
         thing.set("stuff", "less");
         thing.set("favorite_color", "red");
-        thing.set("things", vec![]);
+        thing.set("things", store::Value::List(vec![]));
         thing
     }
 
@@ -619,10 +619,7 @@ fn entity_validation() {
     }
 
     let mut thing = make_thing("t1");
-    thing.set(
-        "things",
-        store::Value::from(vec!["thing1".into(), "thing2".into()]),
-    );
+    thing.set("things", store::Value::from(vec!["thing1", "thing2"]));
     check(thing, "");
 
     let thing = make_thing("t2");

--- a/graphql/src/schema/ext.rs
+++ b/graphql/src/schema/ext.rs
@@ -1,0 +1,17 @@
+use graphql_parser::schema as s;
+
+pub trait ObjectTypeExt {
+    fn field(&self, name: &s::Name) -> Option<&s::Field>;
+}
+
+impl ObjectTypeExt for s::ObjectType {
+    fn field(&self, name: &s::Name) -> Option<&s::Field> {
+        self.fields.iter().find(|field| &field.name == name)
+    }
+}
+
+impl ObjectTypeExt for s::InterfaceType {
+    fn field(&self, name: &s::Name) -> Option<&s::Field> {
+        self.fields.iter().find(|field| &field.name == name)
+    }
+}

--- a/graphql/src/schema/mod.rs
+++ b/graphql/src/schema/mod.rs
@@ -5,3 +5,5 @@ pub mod api;
 pub mod ast;
 
 pub use self::api::{api_schema, APISchemaError};
+
+pub mod ext;

--- a/graphql/src/store/mod.rs
+++ b/graphql/src/store/mod.rs
@@ -1,3 +1,4 @@
+mod prefetch;
 mod query;
 mod resolver;
 

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -155,7 +155,7 @@ impl From<Node> for q::Value {
         let mut map: BTreeMap<_, _> = node.entity.into();
         map.insert(PREFETCH_KEY.to_owned(), q::Value::Boolean(true));
         for (key, nodes) in node.children.into_iter() {
-            map.insert(format!("r:{}", key), node_list_as_value(nodes));
+            map.insert(format!("prefetch:{}", key), node_list_as_value(nodes));
         }
         q::Value::Object(map)
     }
@@ -465,7 +465,7 @@ where
         q::Value::Object(nodes.into_iter().fold(map, |mut map, node| {
             // For root nodes, we only care about the children
             for (key, nodes) in node.children.into_iter() {
-                map.insert(format!("r:{}", key), node_list_as_value(nodes));
+                map.insert(format!("prefetch:{}", key), node_list_as_value(nodes));
             }
             map
         }))

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -322,7 +322,7 @@ pub fn run<'a, R, S>(
     ctx: &ExecutionContext<'a, R>,
     selection_set: &q::SelectionSet,
     store: Arc<S>,
-) -> Result<q::Value, QueryExecutionError>
+) -> Result<q::Value, Vec<QueryExecutionError>>
 where
     R: Resolver,
     S: Store,
@@ -345,7 +345,7 @@ fn execute_root_selection_set<'a, R, S>(
     ctx: &ExecutionContext<'a, R>,
     store: &S,
     selection_set: &'a q::SelectionSet,
-) -> Result<Vec<Node>, QueryExecutionError>
+) -> Result<Vec<Node>, Vec<QueryExecutionError>>
 where
     R: Resolver,
     S: Store,
@@ -353,7 +353,7 @@ where
     // Obtain the root Query type and fail if there isn't one
     let query_type = match sast::get_root_query_type(&ctx.schema.document) {
         Some(t) => t,
-        None => return Err(QueryExecutionError::NoRootQueryObjectType),
+        None => return Err(vec![QueryExecutionError::NoRootQueryObjectType]),
     };
 
     // Split the toplevel fields into introspection fields and
@@ -383,7 +383,6 @@ where
 
     // Execute the root selection set against the root query type
     execute_selection_set(&ctx, store, make_root_node(), &data_set, &query_type.into())
-        .map_err(|mut e| e.pop().unwrap())
 }
 
 fn object_or_interface_from_type<'a>(

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -753,8 +753,11 @@ fn fetch<S: Store>(
         };
         query.filter = Some(filter.and_maybe(query.filter));
         // Apply order by/range conditions to each batch of children, grouped
-        // by parent
-        query.window = Some(join.child_field.to_owned());
+        // by parent, but only if we have more than one parent, as the
+        // queries without a window are simpler
+        if parents.len() > 1 {
+            query.window = Some(join.child_field.to_owned());
+        }
     }
 
     store

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -340,8 +340,8 @@ impl<'a> Join<'a> {
                 child.typename()
             )) {
                 match child
-                    .get("parent_id")
-                    .expect("the query that produces 'child' ensures there is always a parent_id")
+                    .get("g$parent_id")
+                    .expect("the query that produces 'child' ensures there is always a g$parent_id")
                 {
                     StoreValue::String(key) => grouped
                         .entry((cond.parent_type, key))

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -1,0 +1,763 @@
+//! Run a GraphQL query and fetch all the entitied needed to build the
+//! final result
+
+use graphql_parser::query as q;
+use graphql_parser::schema as s;
+use lazy_static::lazy_static;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::ops::Deref;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Instant;
+
+use graph::prelude::{Entity, EntityFilter, QueryExecutionError, Store, Value as StoreValue};
+
+use crate::execution::{ExecutionContext, ObjectOrInterface, Resolver};
+use crate::query::ast as qast;
+use crate::schema::ast as sast;
+use crate::store::build_query;
+
+lazy_static! {
+    static ref ARG_FIRST: String = String::from("first");
+    static ref ARG_SKIP: String = String::from("skip");
+    static ref ARG_ID: String = String::from("id");
+}
+
+pub const PREFETCH_KEY: &str = ":prefetch";
+
+/// Similar to the TypeCondition from graphql_parser, but with
+/// derives that make it possible to use it as the key in a HashMap
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum TypeCondition {
+    Any,
+    On(q::Name),
+}
+
+impl TypeCondition {
+    /// Return a `TypeCondition` that matches when `self` and `other` match
+    /// simultaneously. If the two conditions can never match at the same time,
+    /// return `None`
+    fn and(&self, other: &Self) -> Option<Self> {
+        use TypeCondition::*;
+        match (self, other) {
+            (Any, _) => Some(other.clone()),
+            (_, Any) => Some(self.clone()),
+            (On(name1), On(name2)) if name1 == name2 => Some(self.clone()),
+            _ => None,
+        }
+    }
+
+    /// Return `true` if any of the entities matches this type condition
+    fn matches(&self, entities: &Vec<Node>) -> bool {
+        use TypeCondition::*;
+        match self {
+            Any => true,
+            On(name) => entities.iter().any(|entity| entity.typename() == name),
+        }
+    }
+
+    /// Return the type that matches this condition; for `Any`, use `object_type`
+    fn matching_type<'a>(
+        &self,
+        schema: &'a s::Document,
+        object_type: &'a ObjectOrInterface<'a>,
+    ) -> Option<ObjectOrInterface<'a>> {
+        use TypeCondition::*;
+
+        match self {
+            Any => Some(object_type.to_owned()),
+            On(name) => object_or_interface_by_name(schema, name),
+        }
+    }
+}
+
+impl From<Option<q::TypeCondition>> for TypeCondition {
+    fn from(cond: Option<q::TypeCondition>) -> Self {
+        match cond {
+            None => TypeCondition::Any,
+            Some(q::TypeCondition::On(name)) => TypeCondition::On(name),
+        }
+    }
+}
+
+/// Intermediate data structure to hold the results of prefetching entities
+/// and their nested associations. For each association of `entity`, `children`
+/// has an entry mapping the response key to the list of nodes.
+#[derive(Debug, Clone)]
+struct Node {
+    entity: Entity,
+    /// We are using an `Rc` here for two reasons: it allows us to defer
+    /// copying objects until the end, when converting to `q::Value` forces
+    /// us to copy any child that is referenced by multiple parents. It also
+    /// makes it possible to avoid unnecessary copying of a child that is
+    /// referenced by only one parent - without the `Rc` we would have to copy
+    /// since we do not know that only one parent uses it.
+    children: BTreeMap<String, Vec<Rc<Node>>>,
+}
+
+impl From<Entity> for Node {
+    fn from(entity: Entity) -> Self {
+        Node {
+            entity,
+            children: BTreeMap::default(),
+        }
+    }
+}
+
+/// Convert a list of nodes into a `q::Value::List` where each node has also
+/// been converted to a `q::Value`
+fn node_list_as_value(nodes: Vec<Rc<Node>>) -> q::Value {
+    q::Value::List(
+        nodes
+            .into_iter()
+            .map(|node| Rc::try_unwrap(node).unwrap_or_else(|rc| rc.as_ref().clone()))
+            .map(|node| node.into())
+            .collect(),
+    )
+}
+
+/// We pass the root node of the result around as a vec of nodes, not as
+/// a single node so that we can use the same functions on interior node
+/// lists which are the result of querying the database. The root list
+/// consists of exactly one entry, and that entry has an empty
+/// (not even a `__typename`) entity.
+///
+/// That distinguishes it from both the result of a query that matches
+/// nothing (an empty `Vec`), and a result that finds just one entity
+/// (the entity is not completely empty)
+fn is_root_node(nodes: &Vec<Node>) -> bool {
+    if let Some(node) = nodes.iter().next() {
+        node.entity.is_empty()
+    } else {
+        false
+    }
+}
+
+fn make_root_node() -> Vec<Node> {
+    vec![Node {
+        entity: Entity::new(),
+        children: BTreeMap::default(),
+    }]
+}
+
+/// Recursively convert a `Node` into the corresponding `q::Value`, which is
+/// always a `q::Value::Object`. The entity's associations are mapped to
+/// entries `r:{response_key}` as that name is guaranteed to not conflict
+/// with any field of the entity. Also add an entry `:prefetch` so that
+/// the resolver can later tell whether the `q::Value` was produced by prefetch
+/// and should therefore have `r:{response_key}` entries.
+impl From<Node> for q::Value {
+    fn from(node: Node) -> Self {
+        let mut map: BTreeMap<_, _> = node.entity.into();
+        map.insert(PREFETCH_KEY.to_owned(), q::Value::Boolean(true));
+        for (key, nodes) in node.children.into_iter() {
+            map.insert(format!("r:{}", key), node_list_as_value(nodes));
+        }
+        q::Value::Object(map)
+    }
+}
+
+impl Deref for Node {
+    type Target = Entity;
+
+    fn deref(&self) -> &Self::Target {
+        &self.entity
+    }
+}
+
+impl Node {
+    fn typename(&self) -> &str {
+        self.get("__typename")
+            .expect("all entities have a __typename")
+            .as_str()
+            .expect("__typename must be a string")
+    }
+}
+
+/// Encapsulate how we should join a list of parent entities with a list of
+/// child entities.
+#[derive(Debug)]
+struct Join<'a> {
+    /// The object type of the child entities
+    child_type: ObjectOrInterface<'a>,
+    /// The name of the field in the parent type
+    parent_field: &'a str,
+    /// Whether the parent field is a list or scalar
+    parent_is_list: bool,
+    /// The name of the field in the child type
+    child_field: &'a str,
+    /// Whether the child field is a list or a scalar
+    child_is_list: bool,
+}
+
+impl<'a> Join<'a> {
+    /// Construct a `Join` based on the parent field pointing to the child
+    fn new(schema: &'a s::Document, field: &'a s::Field) -> Self {
+        let child_type = object_or_interface_from_type(&schema, &field.field_type)
+            .expect("we only collect fields that are objects or interfaces");
+
+        let (parent_field, parent_is_list, child_field, child_is_list) =
+            if let Some(derived_from_field) = sast::get_derived_from_field(child_type, field) {
+                let is_list = sast::is_list_or_non_null_list_field(derived_from_field);
+                ("id", false, derived_from_field.name.as_str(), is_list)
+            } else {
+                let is_list = sast::is_list_or_non_null_list_field(field);
+                (field.name.as_str(), is_list, "id", false)
+            };
+        Join {
+            child_type,
+            parent_field,
+            parent_is_list,
+            child_field,
+            child_is_list,
+        }
+    }
+
+    /// Perform the join. The child nodes are distributed into the parent nodes
+    /// according to the join condition, and are stored in the `response_key`
+    /// entry in each parent's `children` map.
+    ///
+    /// The `children` must contain the nodes in the correct order for each
+    /// parent; we simply pick out matching children for each parent but
+    /// otherwise maintain the order in `children`
+    fn perform(&self, parents: &mut Vec<Node>, children: Vec<Node>, response_key: &str) {
+        let children: Vec<_> = children.into_iter().map(|child| Rc::new(child)).collect();
+
+        if is_root_node(parents) {
+            let root = parents
+                .first_mut()
+                .expect("is_root_node checked that we have a node");
+            root.children.insert(response_key.to_owned(), children);
+            return;
+        }
+
+        // Build a map child_key -> Vec<child> for joining by grouping
+        // children by their child_field
+        let mut grouped: BTreeMap<&str, Vec<Rc<Node>>> = BTreeMap::default();
+        for child in children.iter() {
+            match child
+                .get(self.child_field)
+                .expect("the query that produces 'child' ensures there is always an entry")
+            {
+                StoreValue::String(key) => grouped.entry(key).or_default().push(child.clone()),
+                StoreValue::List(list) => {
+                    for key in list {
+                        match key {
+                            StoreValue::String(key) => {
+                                grouped.entry(key).or_default().push(child.clone())
+                            }
+                            _ => unreachable!("a list of join keys contains only strings"),
+                        }
+                    }
+                }
+                _ => unreachable!("join fields are strings or lists"),
+            }
+        }
+
+        // Add appropriate children using grouped map
+        for parent in parents.iter_mut() {
+            // Set the `response_key` field in `parent`. Make sure that even
+            // if `parent` has no matching `children`, the field gets set (to
+            // an empty `Vec`)
+            // This is complicated by the fact that, if there was a type
+            // condition, we should only change parents that meet the type
+            // condition; we set it for all parents regardless, as that does
+            // not cause problems in later processing, but make sure that we
+            // do not clobber an entry under this `response_key` that might
+            // have been set by a previous join by appending values rather
+            // than using straight insert into the parent
+            let mut values = parent
+                .get(self.parent_field)
+                .and_then(|key| match key {
+                    StoreValue::String(key) => {
+                        grouped.get(key.as_str()).map(|values| values.clone())
+                    }
+                    StoreValue::List(keys) => {
+                        // Note that each `grouped.get` returns a vec with
+                        // at most one element, and since `key` is the id
+                        // of that element, the resulting `values` will not
+                        // contain duplicates
+                        Some(
+                            keys.iter()
+                                .filter_map(|key| key.as_str())
+                                .filter_map(|key| grouped.get(key))
+                                .flatten()
+                                .map(|rc| rc.clone())
+                                .collect::<Vec<_>>(),
+                        )
+                    }
+                    StoreValue::Null => None,
+                    _ => unreachable!("join fields must be strings or lists of strings"),
+                })
+                .unwrap_or(vec![]);
+            parent
+                .children
+                .entry(response_key.to_owned())
+                .or_default()
+                .append(&mut values);
+        }
+    }
+}
+
+/// Run the query in `ctx` in such a manner that we only perform one query
+/// per 'level' in the query. A query like `musicians { id bands { id } }`
+/// will perform two queries: one for musicians, and one for bands, regardless
+/// of how many musicians there are.
+///
+/// The returned value contains a `q::Value::Object` that contains a tree of
+/// all the entities (converted into objects) in the form in which they need
+/// to be returned. Nested object fields appear under the key `r:response_key`
+/// in these objects, and are always `q::Value::List` of objects. In addition,
+/// each entity has a property `:prefetch` set so that the resolver can
+/// tell whether the `r:response_key` associations should be there.
+///
+/// For the above example, the returned object would have one entry under
+/// `r:musicians`, which is a list of all the musicians; each musician has an
+/// entry `r:bands` that contains a list of the bands for that musician. Note
+/// that even for single-object fields, we return a list so that we can spot
+/// cases where the store contains data that violates the data model by having
+/// multiple values for what should be a relationship to a single object in
+/// @derivedFrom fields
+pub fn run<'a, R, S>(
+    ctx: &ExecutionContext<'a, R>,
+    selection_set: &q::SelectionSet,
+    store: Arc<S>,
+) -> Result<q::Value, QueryExecutionError>
+where
+    R: Resolver,
+    S: Store,
+{
+    execute_root_selection_set(ctx, store.as_ref(), selection_set).map(|nodes| {
+        let mut map = BTreeMap::default();
+        map.insert(PREFETCH_KEY.to_owned(), q::Value::Boolean(true));
+        q::Value::Object(nodes.into_iter().fold(map, |mut map, node| {
+            // For root nodes, we only care about the children
+            for (key, nodes) in node.children.into_iter() {
+                map.insert(format!("r:{}", key), node_list_as_value(nodes));
+            }
+            map
+        }))
+    })
+}
+
+/// Executes the root selection set of a query.
+fn execute_root_selection_set<'a, R, S>(
+    ctx: &ExecutionContext<'a, R>,
+    store: &S,
+    selection_set: &'a q::SelectionSet,
+) -> Result<Vec<Node>, QueryExecutionError>
+where
+    R: Resolver,
+    S: Store,
+{
+    // Obtain the root Query type and fail if there isn't one
+    let query_type = match sast::get_root_query_type(&ctx.schema.document) {
+        Some(t) => t,
+        None => return Err(QueryExecutionError::NoRootQueryObjectType),
+    };
+
+    // Split the toplevel fields into introspection fields and
+    // 'normal' data fields
+    let mut data_set = q::SelectionSet {
+        span: selection_set.span.clone(),
+        items: Vec::new(),
+    };
+
+    for (_, type_fields) in collect_fields(ctx, &query_type.into(), selection_set, None) {
+        let fields = match type_fields.get(&TypeCondition::Any) {
+            None => return Ok(vec![]),
+            Some(fields) => fields,
+        };
+
+        let name = fields[0].name.clone();
+        let selections = fields
+            .into_iter()
+            .map(|f| q::Selection::Field((*f).clone()));
+        // See if this is an introspection or data field. We don't worry about
+        // nonexistant fields; those will cause an error later when we execute
+        // the query in `execution::execute_root_selection_set`
+        if sast::get_field(query_type, &name).is_some() {
+            data_set.items.extend(selections)
+        }
+    }
+
+    // Execute the root selection set against the root query type
+    execute_selection_set(&ctx, store, make_root_node(), &data_set, &query_type.into())
+        .map_err(|mut e| e.pop().unwrap())
+}
+
+fn object_or_interface_from_type<'a>(
+    schema: &'a s::Document,
+    field_type: &'a s::Type,
+) -> Option<ObjectOrInterface<'a>> {
+    match field_type {
+        s::Type::NonNullType(inner_type) => object_or_interface_from_type(schema, inner_type),
+        s::Type::ListType(inner_type) => object_or_interface_from_type(schema, inner_type),
+        s::Type::NamedType(name) => object_or_interface_by_name(schema, name),
+    }
+}
+
+fn object_or_interface_by_name<'a>(
+    schema: &'a s::Document,
+    name: &s::Name,
+) -> Option<ObjectOrInterface<'a>> {
+    match sast::get_named_type(schema, name) {
+        Some(s::TypeDefinition::Object(t)) => Some(t.into()),
+        Some(s::TypeDefinition::Interface(t)) => Some(t.into()),
+        _ => None,
+    }
+}
+
+fn execute_selection_set<'a, R, S>(
+    ctx: &ExecutionContext<'a, R>,
+    store: &S,
+    mut parents: Vec<Node>,
+    selection_set: &'a q::SelectionSet,
+    object_type: &ObjectOrInterface,
+) -> Result<Vec<Node>, Vec<QueryExecutionError>>
+where
+    R: Resolver,
+    S: Store,
+{
+    let mut errors: Vec<QueryExecutionError> = Vec::new();
+
+    // Group fields with the same response key, so we can execute them together
+    let grouped_field_set = collect_fields(ctx, object_type, selection_set, None);
+
+    // Process all field groups in order
+    for (response_key, type_map) in grouped_field_set {
+        match ctx.deadline {
+            Some(deadline) if deadline < Instant::now() => {
+                errors.push(QueryExecutionError::Timeout);
+                break;
+            }
+            _ => (),
+        }
+
+        for (type_cond, fields) in type_map {
+            if !type_cond.matches(&parents) {
+                continue;
+            }
+
+            let concrete_type = type_cond
+                .matching_type(&ctx.schema.document, object_type)
+                .expect("collect_fields does not create type conditions for nonexistent types");
+
+            if let Some(ref field) = concrete_type.field(&fields[0].name) {
+                let ctx = ctx.for_field(&fields[0]);
+                let join = Join::new(&ctx.schema.document, field);
+
+                match execute_field(
+                    &ctx,
+                    store,
+                    &concrete_type,
+                    &parents,
+                    &join,
+                    &fields[0],
+                    field,
+                ) {
+                    Ok(children) => {
+                        let child_selection_set = crate::execution::merge_selection_sets(fields);
+                        let child_object_type =
+                            object_or_interface_from_type(&ctx.schema.document, &field.field_type)
+                                .expect("type of child field is object or interface");
+                        match execute_selection_set(
+                            &ctx,
+                            store,
+                            children,
+                            &child_selection_set,
+                            &child_object_type,
+                        ) {
+                            Ok(children) => join.perform(&mut parents, children, response_key),
+                            Err(mut e) => errors.append(&mut e),
+                        }
+                    }
+                    Err(mut e) => {
+                        errors.append(&mut e);
+                    }
+                };
+            } else {
+                errors.push(QueryExecutionError::UnknownField(
+                    fields[0].position,
+                    object_type.name().to_owned(),
+                    fields[0].name.clone(),
+                ))
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(parents)
+    } else {
+        if errors.is_empty() {
+            errors.push(QueryExecutionError::EmptySelectionSet(
+                object_type.name().to_owned(),
+            ));
+        }
+        Err(errors)
+    }
+}
+
+/// Collects fields of a selection set. The resulting map indicates for each
+/// response key from which types to fetch what fields to express the effect
+/// of fragment spreads
+fn collect_fields<'a, R>(
+    ctx: &ExecutionContext<'a, R>,
+    object_type: &ObjectOrInterface,
+    selection_set: &'a q::SelectionSet,
+    visited_fragments: Option<HashSet<&'a q::Name>>,
+) -> HashMap<&'a String, HashMap<TypeCondition, Vec<&'a q::Field>>>
+where
+    R: Resolver,
+{
+    let mut visited_fragments = visited_fragments.unwrap_or_default();
+    let mut grouped_fields: HashMap<_, HashMap<_, Vec<_>>> = HashMap::new();
+
+    // Only consider selections that are not skipped and should be included
+    let selections: Vec<_> = selection_set
+        .items
+        .iter()
+        .filter(|selection| !qast::skip_selection(selection, ctx.variable_values.deref()))
+        .filter(|selection| qast::include_selection(selection, ctx.variable_values.deref()))
+        .collect();
+
+    fn is_reference_field(
+        schema: &s::Document,
+        object_type: &ObjectOrInterface,
+        field: &q::Field,
+    ) -> bool {
+        object_type
+            .field(&field.name)
+            .map(|field_def| sast::get_type_definition_from_field(schema, field_def))
+            .unwrap_or(None)
+            .map(|type_def| match type_def {
+                s::TypeDefinition::Interface(_) | s::TypeDefinition::Object(_) => true,
+                _ => false,
+            })
+            .unwrap_or(false)
+    }
+
+    for selection in selections {
+        match selection {
+            q::Selection::Field(ref field) => {
+                // Only consider fields that point to objects or interfaces, and
+                // ignore nonexistent fields
+                if is_reference_field(&ctx.schema.document, object_type, field) {
+                    let response_key = qast::get_response_key(field);
+
+                    // Create a field group for this response key and add the field
+                    // with no type condition
+                    grouped_fields
+                        .entry(response_key)
+                        .or_default()
+                        .entry(TypeCondition::Any)
+                        .or_default()
+                        .push(field);
+                }
+            }
+
+            q::Selection::FragmentSpread(spread) => {
+                // Only consider the fragment if it hasn't already been included,
+                // as would be the case if the same fragment spread ...Foo appeared
+                // twice in the same selection set
+                if !visited_fragments.contains(&spread.fragment_name) {
+                    visited_fragments.insert(&spread.fragment_name);
+
+                    qast::get_fragment(&ctx.document, &spread.fragment_name).map(|fragment| {
+                        let fragment_grouped_field_set = collect_fields(
+                            ctx,
+                            object_type,
+                            &fragment.selection_set,
+                            Some(visited_fragments.clone()),
+                        );
+
+                        // Add all items from each fragments group to the field group
+                        // with the corresponding response key
+                        let fragment_cond =
+                            TypeCondition::from(Some(fragment.type_condition.clone()));
+                        for (response_key, type_fields) in fragment_grouped_field_set {
+                            for (type_cond, mut group) in type_fields {
+                                if let Some(cond) = fragment_cond.and(&type_cond) {
+                                    grouped_fields
+                                        .entry(response_key)
+                                        .or_default()
+                                        .entry(cond)
+                                        .or_default()
+                                        .append(&mut group);
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+
+            q::Selection::InlineFragment(fragment) => {
+                let fragment_cond = TypeCondition::from(fragment.type_condition.clone());
+                // Fields for this fragment need to be looked up in the type
+                // mentioned in the condition
+                let fragment_type = fragment_cond.matching_type(&ctx.schema.document, object_type);
+
+                // The `None` case here indicates an error where the type condition
+                // mentions a nonexistent type; the overall query execution logic will catch
+                // that
+                if let Some(fragment_type) = fragment_type {
+                    let fragment_grouped_field_set = collect_fields(
+                        ctx,
+                        &fragment_type,
+                        &fragment.selection_set,
+                        Some(visited_fragments.clone()),
+                    );
+
+                    for (response_key, type_fields) in fragment_grouped_field_set {
+                        for (type_cond, mut group) in type_fields {
+                            if let Some(cond) = fragment_cond.and(&type_cond) {
+                                grouped_fields
+                                    .entry(response_key)
+                                    .or_default()
+                                    .entry(cond)
+                                    .or_default()
+                                    .append(&mut group);
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    grouped_fields
+}
+
+/// Executes a field.
+fn execute_field<'a, R, S>(
+    ctx: &ExecutionContext<'a, R>,
+    store: &S,
+    object_type: &ObjectOrInterface<'_>,
+    parents: &Vec<Node>,
+    join: &Join<'a>,
+    field: &'a q::Field,
+    field_definition: &'a s::Field,
+) -> Result<Vec<Node>, Vec<QueryExecutionError>>
+where
+    R: Resolver,
+    S: Store,
+{
+    let mut argument_values = match object_type {
+        ObjectOrInterface::Object(object_type) => {
+            crate::execution::coerce_argument_values(ctx, object_type, field)
+        }
+        ObjectOrInterface::Interface(interface_type) => {
+            // This assumes that all implementations of the interface accept
+            // the same arguments for this field
+            match ctx
+                .schema
+                .types_for_interface
+                .get(&interface_type.name)
+                .expect("interface type exists")
+                .first()
+            {
+                Some(object_type) => {
+                    crate::execution::coerce_argument_values(ctx, &object_type, field)
+                }
+                None => {
+                    // Nobody is implementing this interface
+                    return Ok(vec![]);
+                }
+            }
+        }
+    }?;
+
+    if !argument_values.contains_key(&*ARG_FIRST) {
+        let first = if sast::is_list_or_non_null_list_field(field_definition) {
+            // This makes `build_range` use the default, 100
+            q::Value::Null
+        } else {
+            // For non-list fields, get up to 2 entries so we can spot
+            // ambiguous references that should only have one entry
+            q::Value::Int(2.into())
+        };
+        argument_values.insert(&*ARG_FIRST, first);
+    }
+
+    if !argument_values.contains_key(&*ARG_SKIP) {
+        // Use the default in build_range
+        argument_values.insert(&*ARG_SKIP, q::Value::Null);
+    }
+
+    fetch(
+        store,
+        &parents,
+        &join,
+        &argument_values,
+        ctx.schema.types_for_interface(),
+        ctx.max_first,
+    )
+    .map_err(|e| vec![e])
+}
+
+/// Query child entities for `parents` from the store. The `join` indicates
+/// in which child field to look for the parent's id/join field
+fn fetch<S: Store>(
+    store: &S,
+    parents: &Vec<Node>,
+    join: &Join<'_>,
+    arguments: &HashMap<&q::Name, q::Value>,
+    types_for_interface: &BTreeMap<s::Name, Vec<s::ObjectType>>,
+    max_first: u32,
+) -> Result<Vec<Node>, QueryExecutionError> {
+    let mut query = build_query(join.child_type, arguments, types_for_interface, max_first)?;
+
+    if let Some(q::Value::String(id)) = arguments.get(&*ARG_ID) {
+        query.filter = Some(
+            EntityFilter::Equal(ARG_ID.to_owned(), StoreValue::from(id.to_owned()))
+                .and_maybe(query.filter),
+        );
+    }
+
+    if !is_root_node(parents) {
+        // For anything but the root node, restrict the children we select
+        // by the parent list
+        let mut ids = if join.parent_is_list {
+            parents
+                .iter()
+                .filter_map(|entity| entity.get(join.parent_field))
+                .flat_map(|list| match list {
+                    StoreValue::List(values) => values.iter().filter_map(|value| value.as_str()),
+                    _ => unreachable!("parent_field is not a list of strings"),
+                })
+                .collect::<Vec<_>>()
+        } else {
+            parents
+                .iter()
+                .filter_map(|entity| entity.get(join.parent_field))
+                .filter_map(|value| match value {
+                    StoreValue::String(s) => Some(s.as_str()),
+                    StoreValue::Null => None,
+                    _ => unreachable!("parent_field must be a string or null"),
+                })
+                .collect::<Vec<_>>()
+        };
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+        ids.sort_unstable();
+        ids.dedup();
+        let ids = ids.into_iter().map(|id| StoreValue::from(id)).collect();
+        // We want to find all children that point to one of the parent `ids`
+        // If `child_field` is a list that is any child that has one of the
+        // parent `ids` in its `child_field`, hence the intersection
+        let filter = if join.child_is_list {
+            EntityFilter::Intersects(join.child_field.to_owned(), ids)
+        } else {
+            EntityFilter::In(join.child_field.to_owned(), ids)
+        };
+        query.filter = Some(filter.and_maybe(query.filter));
+        // Apply order by/range conditions to each batch of children, grouped
+        // by parent
+        query.window = Some(join.child_field.to_owned());
+    }
+
+    store
+        .find(query)
+        .map(|entities| entities.into_iter().map(|entity| entity.into()).collect())
+}

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -24,15 +24,18 @@ pub fn build_query<'a>(
             .map(|o| o.name.clone())
             .collect(),
     };
-    Ok(EntityQuery {
-        subgraph_id: parse_subgraph_id(entity)?,
-        entity_types,
-        range: build_range(arguments, max_first)?,
-        filter: build_filter(entity, arguments)?,
-        order_by: build_order_by(entity, arguments)?,
-        order_direction: build_order_direction(arguments)?,
-        window: None,
-    })
+    let mut query = EntityQuery::new(parse_subgraph_id(entity)?, entity_types)
+        .range(build_range(arguments, max_first)?);
+    if let Some(filter) = build_filter(entity, arguments)? {
+        query = query.filter(filter);
+    }
+    if let Some(order_by) = build_order_by(entity, arguments)? {
+        query = query.order_by_attribute(order_by);
+    }
+    if let Some(direction) = build_order_direction(arguments)? {
+        query = query.order_direction(direction);
+    }
+    Ok(query)
 }
 
 /// Parses GraphQL arguments into a EntityRange, if present.

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -31,6 +31,7 @@ pub fn build_query<'a>(
         filter: build_filter(entity, arguments)?,
         order_by: build_order_by(entity, arguments)?,
         order_direction: build_order_direction(arguments)?,
+        window: None,
     })
 }
 

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -17,13 +17,13 @@ pub fn build_query<'a>(
     max_first: u32,
 ) -> Result<EntityQuery, QueryExecutionError> {
     let entity = entity.into();
-    let entity_types = match &entity {
+    let entity_types = EntityCollection::All(match &entity {
         ObjectOrInterface::Object(object) => vec![object.name.clone()],
         ObjectOrInterface::Interface(interface) => types_for_interface[&interface.name]
             .iter()
             .map(|o| o.name.clone())
             .collect(),
-    };
+    });
     let mut query = EntityQuery::new(parse_subgraph_id(entity)?, entity_types)
         .range(build_range(arguments, max_first)?);
     if let Some(filter) = build_filter(entity, arguments)? {
@@ -375,8 +375,8 @@ mod tests {
                 std::u32::MAX
             )
             .unwrap()
-            .entity_types,
-            vec!["Entity1".to_string()]
+            .collection,
+            EntityCollection::All(vec!["Entity1".to_string()])
         );
         assert_eq!(
             build_query(
@@ -386,8 +386,8 @@ mod tests {
                 std::u32::MAX
             )
             .unwrap()
-            .entity_types,
-            vec!["Entity2".to_string()]
+            .collection,
+            EntityCollection::All(vec!["Entity2".to_string()])
         );
     }
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -327,8 +327,11 @@ where
                         .map(|o| o.name.clone())
                         .collect();
                     let range = EntityRange::first(1);
-                    let mut query =
-                        EntityQuery::new(subgraph_id_for_resolve_object, entity_types).range(range);
+                    let mut query = EntityQuery::new(
+                        subgraph_id_for_resolve_object,
+                        EntityCollection::All(entity_types),
+                    )
+                    .range(range);
                     query.filter = Some(EntityFilter::Equal(String::from("id"), Value::from(id)));
                     Ok(self.store.find(query)?.into_iter().next())
                 }

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -243,7 +243,7 @@ where
         &self,
         ctx: &ExecutionContext<'r, Self>,
         selection_set: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, QueryExecutionError> {
+    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
         super::prefetch::run(ctx, selection_set, self.store.clone()).map(|value| Some(value))
     }
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -160,6 +160,14 @@ impl<S> Resolver for StoreResolver<S>
 where
     S: Store,
 {
+    fn prefetch<'r>(
+        &self,
+        _: &ExecutionContext<'r, Self>,
+        _: &q::SelectionSet,
+    ) -> Result<Option<q::Value>, QueryExecutionError> {
+        Ok(None)
+    }
+
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -328,7 +328,7 @@ where
                         .collect();
                     let range = EntityRange::first(1);
                     let mut query =
-                        EntityQuery::new(subgraph_id_for_resolve_object, entity_types, range);
+                        EntityQuery::new(subgraph_id_for_resolve_object, entity_types).range(range);
                     query.filter = Some(EntityFilter::Equal(String::from("id"), Value::from(id)));
                     Ok(self.store.find(query)?.into_iter().next())
                 }

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -203,19 +203,15 @@ where
         if let Some(q::Value::List(children)) = Self::get_child(parent, field) {
             if children.len() > 1 {
                 let derived_from_field =
-                    sast::get_derived_from_field(object_type, field_definition);
+                    sast::get_derived_from_field(object_type, field_definition)
+                        .expect("only derived fields can lead to multiple children here");
 
-                match derived_from_field {
-                    Some(derived_from_field) => {
-                        return Err(QueryExecutionError::AmbiguousDerivedFromResult(
-                            field.position.clone(),
-                            field.name.to_owned(),
-                            object_type.name().to_owned(),
-                            derived_from_field.name.to_owned(),
-                        ));
-                    }
-                    None => return Ok(q::Value::Null),
-                }
+                return Err(QueryExecutionError::AmbiguousDerivedFromResult(
+                    field.position.clone(),
+                    field.name.to_owned(),
+                    object_type.name().to_owned(),
+                    derived_from_field.name.to_owned(),
+                ));
             } else {
                 return Ok(children
                     .into_iter()

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -157,7 +157,10 @@ where
             .unwrap_or(true)
     }
 
-    fn get_child<'a>(parent: &'a Option<q::Value>, field: &q::Field) -> Option<&'a q::Value> {
+    fn get_prefetched_child<'a>(
+        parent: &'a Option<q::Value>,
+        field: &q::Field,
+    ) -> Option<&'a q::Value> {
         match parent {
             Some(q::Value::Object(map)) => {
                 let key = format!("r:{}", qast::get_response_key(field));
@@ -180,7 +183,7 @@ where
         field: &q::Field,
         object_type: ObjectOrInterface<'_>,
     ) -> Result<q::Value, QueryExecutionError> {
-        if let Some(child) = Self::get_child(parent, field) {
+        if let Some(child) = Self::get_prefetched_child(parent, field) {
             Ok(child.clone())
         } else {
             Err(QueryExecutionError::ResolveEntitiesError(format!(
@@ -200,7 +203,7 @@ where
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
     ) -> Result<q::Value, QueryExecutionError> {
-        if let Some(q::Value::List(children)) = Self::get_child(parent, field) {
+        if let Some(q::Value::List(children)) = Self::get_prefetched_child(parent, field) {
             if children.len() > 1 {
                 let derived_from_field =
                     sast::get_derived_from_field(object_type, field_definition)

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -163,7 +163,7 @@ where
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,
-        _field: &q::Name,
+        _field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -163,7 +163,7 @@ where
     ) -> Option<&'a q::Value> {
         match parent {
             Some(q::Value::Object(map)) => {
-                let key = format!("r:{}", qast::get_response_key(field));
+                let key = format!("prefetch:{}", qast::get_response_key(field));
                 map.get(&key)
             }
             _ => None,

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -63,6 +63,7 @@ where
         variable_values: Arc::new(coerced_variable_values),
         deadline: None,
         max_first: options.max_first,
+        mode: ExecutionMode::Prefetch,
     };
 
     match operation {
@@ -221,6 +222,7 @@ where
         variable_values,
         deadline: timeout.map(|t| Instant::now() + t),
         max_first,
+        mode: ExecutionMode::Prefetch,
     };
 
     // We have established that this exists earlier in the subscription execution

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -120,7 +120,7 @@ where
     let subscription_type = sast::get_root_subscription_type(&ctx.schema.document)
         .ok_or(QueryExecutionError::NoRootSubscriptionObjectType)?;
 
-    let grouped_field_set = collect_fields(ctx.clone(), &subscription_type, &selection_set, None);
+    let grouped_field_set = collect_fields(ctx, &subscription_type, &selection_set, None);
 
     if grouped_field_set.is_empty() {
         return Err(SubscriptionError::from(QueryExecutionError::EmptyQuery));

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -15,7 +15,7 @@ impl Resolver for MockResolver {
     fn resolve_objects<'a>(
         &self,
         _parent: &Option<q::Value>,
-        _field: &q::Name,
+        _field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -12,6 +12,14 @@ use graph_graphql::prelude::*;
 pub struct MockResolver;
 
 impl Resolver for MockResolver {
+    fn prefetch<'r>(
+        &self,
+        _: &ExecutionContext<'r, Self>,
+        _: &q::SelectionSet,
+    ) -> Result<Option<q::Value>, QueryExecutionError> {
+        Ok(None)
+    }
+
     fn resolve_objects<'a>(
         &self,
         _parent: &Option<q::Value>,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -16,7 +16,7 @@ impl Resolver for MockResolver {
         &self,
         _: &ExecutionContext<'r, Self>,
         _: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, QueryExecutionError> {
+    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
         Ok(None)
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -106,6 +106,7 @@ impl MockStore {
             order_direction,
             range: _,
             window: _,
+            ..
         } = query;
 
         // List all entities with correct type

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -96,19 +96,26 @@ impl MockStore {
     fn execute_query(
         &self,
         entities: &HashMap<SubgraphDeploymentId, HashMap<String, HashMap<String, Entity>>>,
-        query: EntityQuery,
+        mut query: EntityQuery,
     ) -> Result<Vec<Entity>, QueryExecutionError> {
+        query = query.simplify();
+
         let EntityQuery {
             subgraph_id,
-            entity_types,
+            collection,
             filter,
             order_by,
             order_direction,
             range: _,
-            window: _,
             ..
         } = query;
 
+        let entity_types = match collection {
+            EntityCollection::All(entities) => entities,
+            EntityCollection::Window(_) => {
+                unimplemented!("the mock store does not support windowing")
+            }
+        };
         // List all entities with correct type
         let empty1 = HashMap::default();
         let empty2 = HashMap::default();

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -105,6 +105,7 @@ impl MockStore {
             order_by,
             order_direction,
             range: _,
+            window: _,
         } = query;
 
         // List all entities with correct type

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -222,6 +222,7 @@ impl Store for MockStore {
                     } else {
                         let mut new_entity = data;
                         new_entity.insert("id".to_owned(), key.entity_id.clone().into());
+                        new_entity.insert("__typename".to_owned(), key.entity_type.clone().into());
                         new_entity.retain(|_k, v| *v != Value::Null);
                         entities_of_type.insert(key.entity_id.clone(), new_entity);
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -68,7 +68,7 @@ where
         let service = self.clone();
 
         // Ask for two to find out if there is more than one
-        let entity_query = SubgraphEntity::query().range(EntityRange::first(2));
+        let entity_query = SubgraphEntity::query().first(2);
 
         Box::new(
             future::result(self.store.find(entity_query))

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -4,8 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use graph::data::graphql::{TryFromValue, ValueList, ValueMap};
 use graph::data::subgraph::schema::SUBGRAPHS_ID;
 use graph::prelude::*;
-use graph_graphql::prelude::{object_value, ObjectOrInterface, Resolver};
-
+use graph_graphql::prelude::{object_value, ExecutionContext, ObjectOrInterface, Resolver};
 use web3::types::H256;
 
 /// Resolver for the index node GraphQL API.
@@ -501,6 +500,14 @@ where
     R: GraphQlRunner,
     S: Store + SubgraphDeploymentStore,
 {
+    fn prefetch<'r>(
+        &self,
+        _: &ExecutionContext<'r, Self>,
+        _: &q::SelectionSet,
+    ) -> Result<Option<q::Value>, QueryExecutionError> {
+        Ok(None)
+    }
+
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -504,7 +504,7 @@ where
         &self,
         _: &ExecutionContext<'r, Self>,
         _: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, QueryExecutionError> {
+    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
         Ok(None)
     }
 

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -504,14 +504,14 @@ where
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,
-        field: &q::Name,
+        field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
         _max_first: u32,
     ) -> Result<q::Value, QueryExecutionError> {
-        match (parent, object_type.name(), field.as_str()) {
+        match (parent, object_type.name(), field.name.as_str()) {
             // The top-level `indexingStatuses` field
             (None, "SubgraphIndexingStatus", "indexingStatuses") => {
                 self.resolve_indexing_statuses(arguments)

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -81,14 +81,16 @@ impl ToSql<Range<Integer>, Pg> for BlockRange {
 /// Generate the clause that checks whether `block` is in the block range
 /// of an entity
 #[derive(Constructor)]
-pub struct BlockRangeContainsClause {
+pub struct BlockRangeContainsClause<'a> {
+    table_prefix: &'a str,
     block: BlockNumber,
 }
 
-impl QueryFragment<Pg> for BlockRangeContainsClause {
+impl<'a> QueryFragment<Pg> for BlockRangeContainsClause<'a> {
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
 
+        out.push_sql(self.table_prefix);
         out.push_identifier(BLOCK_RANGE_COLUMN)?;
         out.push_sql(" @> ");
         out.push_bind_param::<Integer, _>(&self.block)

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -43,8 +43,8 @@ use graph::data::schema::Schema as SubgraphSchema;
 use graph::data::subgraph::schema::SUBGRAPHS_ID;
 use graph::prelude::{
     debug, format_err, info, serde_json, warn, AttributeIndexDefinition, Entity, EntityChange,
-    EntityChangeOperation, EntityFilter, EntityKey, EntityModification, EntityOrder, Error,
-    EthereumBlockPointer, Logger, QueryExecutionError, StoreError, StoreEvent,
+    EntityChangeOperation, EntityFilter, EntityKey, EntityModification, EntityOrder, EntityRange,
+    Error, EthereumBlockPointer, Logger, QueryExecutionError, StoreError, StoreEvent,
     SubgraphDeploymentId, SubgraphDeploymentStore, ValueType,
 };
 
@@ -450,14 +450,13 @@ impl Connection {
         entity_types: Vec<String>,
         filter: Option<EntityFilter>,
         order: Option<(String, ValueType, EntityOrder)>,
-        first: Option<u32>,
-        skip: u32,
+        range: EntityRange,
         block: BlockNumber,
     ) -> Result<Vec<Entity>, QueryExecutionError> {
         match &*self.storage {
-            Storage::Json(json) => json.query(&self.conn, entity_types, filter, order, first, skip),
+            Storage::Json(json) => json.query(&self.conn, entity_types, filter, order, range),
             Storage::Relational(layout) => {
-                layout.query(&self.conn, entity_types, filter, order, first, skip, block)
+                layout.query(&self.conn, entity_types, filter, order, range, block)
             }
         }
     }
@@ -907,10 +906,9 @@ impl JsonStorage {
         entity_types: Vec<String>,
         filter: Option<EntityFilter>,
         order: Option<(String, ValueType, EntityOrder)>,
-        first: Option<u32>,
-        skip: u32,
+        range: EntityRange,
     ) -> Result<Vec<Entity>, QueryExecutionError> {
-        let query = FilterQuery::new(&self.table, entity_types, filter, order, first, skip)?;
+        let query = FilterQuery::new(&self.table, entity_types, filter, order, range)?;
 
         let query_debug_info = debug_query(&query).to_string();
 

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -43,7 +43,7 @@ use graph::data::schema::Schema as SubgraphSchema;
 use graph::data::subgraph::schema::SUBGRAPHS_ID;
 use graph::prelude::{
     debug, format_err, info, serde_json, warn, AttributeIndexDefinition, Entity, EntityChange,
-    EntityChangeOperation, EntityFilter, EntityKey, EntityModification, Error,
+    EntityChangeOperation, EntityFilter, EntityKey, EntityModification, EntityOrder, Error,
     EthereumBlockPointer, Logger, QueryExecutionError, StoreError, StoreEvent,
     SubgraphDeploymentId, SubgraphDeploymentStore, ValueType,
 };
@@ -449,7 +449,7 @@ impl Connection {
         &self,
         entity_types: Vec<String>,
         filter: Option<EntityFilter>,
-        order: Option<(String, ValueType, &str)>,
+        order: Option<(String, ValueType, EntityOrder)>,
         first: Option<u32>,
         skip: u32,
         block: BlockNumber,
@@ -906,7 +906,7 @@ impl JsonStorage {
         conn: &PgConnection,
         entity_types: Vec<String>,
         filter: Option<EntityFilter>,
-        order: Option<(String, ValueType, &str)>,
+        order: Option<(String, ValueType, EntityOrder)>,
         first: Option<u32>,
         skip: u32,
     ) -> Result<Vec<Entity>, QueryExecutionError> {

--- a/store/postgres/src/jsonb_queries.rs
+++ b/store/postgres/src/jsonb_queries.rs
@@ -1,0 +1,171 @@
+///! This module generates queries for the JSONB storage scheme.
+///
+///  We really only need that for supporting `EntityQuery`
+use diesel::pg::Pg;
+use diesel::prelude::BoxableExpression;
+use diesel::query_builder::{AstPass, Query, QueryFragment, QueryId};
+use diesel::query_dsl::RunQueryDsl;
+use diesel::result::QueryResult;
+use diesel::sql_types::{Array, Bool, Jsonb, Text};
+
+use graph::prelude::{EntityFilter, QueryExecutionError, ValueType};
+
+use crate::entities::{EntityTable, STRING_PREFIX_SIZE};
+use crate::filter::build_filter;
+use crate::relational::PRIMARY_KEY_COLUMN;
+
+pub struct OrderDetails {
+    attribute: String,
+    cast: &'static str,
+    prefix_only: bool,
+    direction: &'static str,
+}
+
+pub struct FilterQuery<'a> {
+    table: &'a EntityTable,
+    entity_types: Vec<String>,
+    filter: Option<Box<dyn BoxableExpression<EntityTable, Pg, SqlType = Bool>>>,
+    order: Option<OrderDetails>,
+    first: Option<u32>,
+    skip: u32,
+}
+
+impl<'a> FilterQuery<'a> {
+    pub fn new(
+        table: &'a EntityTable,
+        entity_types: Vec<String>,
+        filter: Option<EntityFilter>,
+        order: Option<(String, ValueType, &str)>,
+        first: Option<u32>,
+        skip: u32,
+    ) -> Result<Self, QueryExecutionError> {
+        let order = if let Some((attribute, value_type, direction)) = order {
+            let cast = match value_type {
+                ValueType::BigInt | ValueType::BigDecimal => "::numeric",
+                ValueType::Boolean => "::boolean",
+                ValueType::Bytes => "",
+                ValueType::ID => "",
+                ValueType::Int => "::bigint",
+                ValueType::String => "",
+                ValueType::List => {
+                    return Err(QueryExecutionError::OrderByNotSupportedForType(
+                        "List".to_string(),
+                    ));
+                }
+            };
+
+            let direction = if direction.eq_ignore_ascii_case("asc") {
+                "asc"
+            } else if direction.eq_ignore_ascii_case("desc") {
+                "desc"
+            } else {
+                unreachable!("GraphQL validation makes sure we only get asc or desc")
+            };
+
+            let prefix_only = &attribute != PRIMARY_KEY_COLUMN && value_type == ValueType::String;
+            Some(OrderDetails {
+                attribute,
+                cast,
+                prefix_only,
+                direction,
+            })
+        } else {
+            None
+        };
+        let filter = if let Some(filter) = filter {
+            Some(build_filter(filter).map_err(|e| {
+                QueryExecutionError::FilterNotSupportedError(format!("{}", e.value), e.filter)
+            })?)
+        } else {
+            None
+        };
+        Ok(FilterQuery {
+            table,
+            entity_types,
+            filter,
+            order,
+            first,
+            skip,
+        })
+    }
+
+    fn order_by(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql("\n order by ");
+        if let Some(order) = &self.order {
+            if order.prefix_only {
+                out.push_sql("left(data ->");
+                out.push_bind_param::<Text, _>(&order.attribute)?;
+                out.push_sql("->> 'data', ");
+                out.push_sql(&STRING_PREFIX_SIZE.to_string());
+                out.push_sql(") ");
+            } else {
+                if &order.attribute == PRIMARY_KEY_COLUMN {
+                    out.push_identifier(PRIMARY_KEY_COLUMN)?;
+                } else {
+                    out.push_sql("(data ->");
+                    out.push_bind_param::<Text, _>(&order.attribute)?;
+                    out.push_sql("->> 'data')");
+                    out.push_sql(&order.cast);
+                }
+                out.push_sql(" ");
+            }
+            out.push_sql(&order.direction);
+            out.push_sql(" nulls last, ");
+        }
+        out.push_identifier(PRIMARY_KEY_COLUMN)
+    }
+
+    fn limit(&self, out: &mut AstPass<Pg>) {
+        if let Some(first) = &self.first {
+            out.push_sql("\n limit ");
+            out.push_sql(&first.to_string());
+        }
+        if self.skip > 0 {
+            out.push_sql("\noffset ");
+            out.push_sql(&self.skip.to_string());
+        }
+    }
+}
+
+impl<'a> QueryFragment<Pg> for FilterQuery<'a> {
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+        out.push_sql("select data, entity\n  from ");
+        self.table.walk_ast(out.reborrow())?;
+        out.push_sql(" \n where ");
+        if self.entity_types.len() == 1 {
+            // If there is only one entity_type, which is the case in all
+            // queries that do not involve interfaces, leaving out `any`
+            // lets Postgres use the primary key index on the entities table
+            let entity_type = self
+                .entity_types
+                .first()
+                .expect("we checked that there is exactly one entity_type");
+            out.push_sql("entity = ");
+            out.push_bind_param::<Text, _>(&entity_type)?;
+        } else {
+            out.push_sql("entity = any(");
+            out.push_bind_param::<Array<Text>, _>(&self.entity_types)?;
+            out.push_sql(")")
+        }
+        if let Some(filter) = &self.filter {
+            out.push_sql(" and ");
+            filter.walk_ast(out.reborrow())?;
+        }
+        self.order_by(&mut out)?;
+        self.limit(&mut out);
+        Ok(())
+    }
+}
+
+impl<'a> QueryId for FilterQuery<'a> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a> Query for FilterQuery<'a> {
+    type SqlType = (Jsonb, Text);
+}
+
+impl<'a, Conn> RunQueryDsl<Conn> for FilterQuery<'a> {}

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -29,6 +29,7 @@ mod filter;
 mod functions;
 mod history_event;
 mod jsonb;
+mod jsonb_queries;
 mod notification_listener;
 pub mod relational;
 mod relational_queries;

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -21,7 +21,7 @@ use crate::relational_queries::{
     InsertQuery, QueryFilter, RevertClampQuery, RevertRemoveQuery,
 };
 use graph::prelude::{
-    format_err, Entity, EntityChange, EntityChangeOperation, EntityFilter, EntityKey,
+    format_err, Entity, EntityChange, EntityChangeOperation, EntityFilter, EntityKey, EntityOrder,
     QueryExecutionError, StoreError, StoreEvent, SubgraphDeploymentId, ValueType,
 };
 
@@ -390,7 +390,7 @@ impl Layout {
         conn: &PgConnection,
         entity_types: Vec<String>,
         filter: Option<EntityFilter>,
-        order: Option<(String, ValueType, &str)>,
+        order: Option<(String, ValueType, EntityOrder)>,
         first: Option<u32>,
         skip: u32,
         block: BlockNumber,

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -17,8 +17,8 @@ use std::str::FromStr;
 
 use graph::data::store::scalar;
 use graph::prelude::{
-    format_err, serde_json, Attribute, Entity, EntityFilter, EntityKey, EntityOrder, StoreError,
-    Value,
+    format_err, serde_json, Attribute, Entity, EntityFilter, EntityKey, EntityOrder, EntityRange,
+    StoreError, Value,
 };
 
 use crate::block_range::{
@@ -1007,8 +1007,7 @@ pub struct FilterQuery<'a> {
     schema: &'a str,
     table_filter_pairs: Vec<(&'a Table, Option<QueryFilter<'a>>)>,
     order: Option<(&'a SqlName, EntityOrder)>,
-    first: Option<String>,
-    skip: Option<String>,
+    range: EntityRange,
     block: BlockNumber,
 }
 
@@ -1040,13 +1039,13 @@ impl<'a> FilterQuery<'a> {
     }
 
     fn limit(&self, out: &mut AstPass<Pg>) {
-        if let Some(first) = &self.first {
+        if let Some(first) = &self.range.first {
             out.push_sql("\n limit ");
-            out.push_sql(first);
+            out.push_sql(&first.to_string());
         }
-        if let Some(skip) = &self.skip {
+        if self.range.skip > 0 {
             out.push_sql("\noffset ");
-            out.push_sql(skip);
+            out.push_sql(&self.range.skip.to_string());
         }
     }
 

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1246,7 +1246,7 @@ impl<'a> FilterCollection<'a> {
     }
 }
 
-/// Convebience to pass the name of the column to order by around. If `name`
+/// Convenience to pass the name of the column to order by around. If `name`
 /// is `None`, the sort key should be ignored
 #[derive(Debug, Clone)]
 pub struct SortKey {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -17,7 +17,8 @@ use std::str::FromStr;
 
 use graph::data::store::scalar;
 use graph::prelude::{
-    format_err, serde_json, Attribute, Entity, EntityFilter, EntityKey, StoreError, Value,
+    format_err, serde_json, Attribute, Entity, EntityFilter, EntityKey, EntityOrder, StoreError,
+    Value,
 };
 
 use crate::block_range::{
@@ -1005,7 +1006,7 @@ impl<'a, Conn> RunQueryDsl<Conn> for ConflictingEntityQuery<'a> {}
 pub struct FilterQuery<'a> {
     schema: &'a str,
     table_filter_pairs: Vec<(&'a Table, Option<QueryFilter<'a>>)>,
-    order: Option<(&'a SqlName, &'a str)>,
+    order: Option<(&'a SqlName, EntityOrder)>,
     first: Option<String>,
     skip: Option<String>,
     block: BlockNumber,
@@ -1017,7 +1018,7 @@ impl<'a> FilterQuery<'a> {
         if let Some((name, direction)) = &self.order {
             out.push_identifier(name.as_str())?;
             out.push_sql(" ");
-            out.push_sql(direction);
+            out.push_sql(direction.to_sql());
             if name.as_str() != PRIMARY_KEY_COLUMN {
                 out.push_sql(", ");
                 out.push_identifier(PRIMARY_KEY_COLUMN)?;

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -11,14 +11,15 @@ use diesel::query_dsl::{LoadQuery, RunQueryDsl};
 use diesel::result::QueryResult;
 use diesel::sql_types::{Array, Binary, Bool, Integer, Jsonb, Numeric, Range, Text};
 use diesel::Connection;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::convert::TryFrom;
 use std::str::FromStr;
 
 use graph::data::store::scalar;
 use graph::prelude::{
-    format_err, serde_json, Attribute, Entity, EntityFilter, EntityKey, EntityOrder, EntityRange,
-    StoreError, Value,
+    format_err, serde_json, Attribute, Entity, EntityCollection, EntityFilter, EntityKey,
+    EntityLink, EntityOrder, EntityRange, EntityWindow, QueryExecutionError, StoreError, Value,
+    ValueType,
 };
 
 use crate::block_range::{
@@ -141,7 +142,10 @@ impl EntityData {
                     // Simply ignore keys that do not have an underlying table
                     // column; those will be things like the block_range that
                     // is used internally for versioning
-                    if let Some(column) = table.column(&SqlName::from_snake_case(key)).ok() {
+                    if key == "parent_id" {
+                        let value = Self::value_from_json(&ColumnType::String, json)?;
+                        entity.insert("parent_id".to_owned(), value);
+                    } else if let Some(column) = table.column(&SqlName::from_snake_case(key)).ok() {
                         let value = Self::value_from_json(&column.column_type, json)?;
                         if value != Value::Null {
                             entity.insert(column.field.clone(), value);
@@ -770,7 +774,7 @@ impl<'a> QueryFragment<Pg> for FindQuery<'a> {
         out.push_sql(" = ");
         out.push_bind_param::<Text, _>(&self.id)?;
         out.push_sql(" and ");
-        BlockRangeContainsClause::new(self.block).walk_ast(out)
+        BlockRangeContainsClause::new("e.", self.block).walk_ast(out)
     }
 }
 
@@ -818,15 +822,13 @@ impl<'a> QueryFragment<Pg> for FindManyQuery<'a> {
             out.push_bind_param::<Text, _>(&table.object)?;
             out.push_sql(" as entity, to_jsonb(e.*) as data\n");
             out.push_sql("  from ");
-            out.push_identifier(self.schema)?;
-            out.push_sql(".");
-            out.push_identifier(table.name.as_str())?;
+            out.push_sql(table.qualified_name.as_str());
             out.push_sql(" e\n where ");
             out.push_identifier(PRIMARY_KEY_COLUMN)?;
             out.push_sql(" = any(");
             out.push_bind_param::<Array<Text>, _>(&self.ids_for_type[table.object.as_str()])?;
             out.push_sql(") and ");
-            BlockRangeContainsClause::new(self.block).walk_ast(out.reborrow())?;
+            BlockRangeContainsClause::new("e.", self.block).walk_ast(out.reborrow())?;
         }
         Ok(())
     }
@@ -992,26 +994,286 @@ impl<'a> LoadQuery<PgConnection, ConflictingEntityData> for ConflictingEntityQue
 
 impl<'a, Conn> RunQueryDsl<Conn> for ConflictingEntityQuery<'a> {}
 
-#[derive(Debug, Clone, Constructor)]
-pub struct FilterQuery<'a> {
-    table_filter_pairs: Vec<(&'a Table, Option<QueryFilter<'a>>)>,
-    order: Option<(&'a SqlName, EntityOrder)>,
-    range: EntityRange,
-    window: Option<&'a SqlName>,
-    block: BlockNumber,
+/// A `ParentLink` where we've resolved the entity type and attribute to the
+/// corresponding table and column
+#[derive(Debug, Clone)]
+struct ParentColumn<'a> {
+    table: &'a Table,
+    column: &'a Column,
 }
 
-// The queries are a little tricky because we need to defer generating
-// JSONB until we actually know which rows we really need to make these
-// queries fast; otherwise, Postgres spends too much time generating
-// JSONB, most of which will never get used
-impl<'a> FilterQuery<'a> {
+/// An `EntityLink` where we've resolved the entity type and attribute to the
+/// corresponding table and column
+#[derive(Debug, Clone)]
+enum TableLink<'a> {
+    Direct(&'a Column),
+    Parent(ParentColumn<'a>),
+}
+
+impl<'a> TableLink<'a> {
+    fn new(
+        layout: &'a Layout,
+        child_table: &'a Table,
+        link: EntityLink,
+    ) -> Result<Self, QueryExecutionError> {
+        match link {
+            EntityLink::Direct(attribute) => {
+                let column = child_table.column_for_field(attribute.name())?;
+                Ok(TableLink::Direct(column))
+            }
+            EntityLink::Parent(relation) => {
+                let table = layout.table_for_entity(&relation.parent_type)?;
+                let column = table.column_for_field(relation.child_field.name())?;
+                Ok(TableLink::Parent(ParentColumn { table, column }))
+            }
+        }
+    }
+}
+
+/// This is the parallel to `EntityWindow`, with names translated to
+/// the relational layout, and checked against it
+#[derive(Debug, Clone)]
+pub struct FilterWindow<'a> {
+    /// The table from which we take entities
+    table: &'a Table,
+    /// The overall filter for the entire query
+    query_filter: Option<QueryFilter<'a>>,
+    /// The parent ids we are interested in
+    ids: Vec<String>,
+    /// How to filter by a set of parents
+    link: TableLink<'a>,
+}
+
+impl<'a> FilterWindow<'a> {
+    fn new(
+        layout: &'a Layout,
+        window: EntityWindow,
+        query_filter: Option<&'a EntityFilter>,
+    ) -> Result<Self, QueryExecutionError> {
+        let EntityWindow {
+            child_type,
+            ids,
+            link,
+        } = window;
+        let table = layout.table_for_entity(&child_type).map(|rc| rc.as_ref())?;
+        let query_filter = query_filter
+            .map(|filter| QueryFilter::new(filter, table))
+            .transpose()?;
+        let link = TableLink::new(layout, table, link)?;
+        Ok(FilterWindow {
+            table,
+            query_filter,
+            ids,
+            link,
+        })
+    }
+
+    fn from_clause(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql("\n from ");
+        out.push_sql(self.table.qualified_name.as_str());
+        out.push_sql(" c");
+        match &self.link {
+            TableLink::Direct(column) => {
+                if column.is_list() {
+                    out.push_sql(" join lateral unnest(c.");
+                    out.push_identifier(column.name.as_str())?;
+                    out.push_sql(") as parent_id on true");
+                }
+            }
+            TableLink::Parent(parent) => {
+                out.push_sql(" inner join ");
+                out.push_sql(parent.table.qualified_name.as_str());
+                out.push_sql(" p on (c.id = ");
+                if parent.column.is_list() {
+                    out.push_sql("any(p.");
+                    out.push_identifier(parent.column.name.as_str())?;
+                    out.push_sql(")");
+                } else {
+                    out.push_sql("p.");
+                    out.push_identifier(parent.column.name.as_str())?;
+                }
+                out.push_sql(")");
+            }
+        }
+        Ok(())
+    }
+
+    fn where_clause(&self, block: BlockNumber, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        match &self.link {
+            TableLink::Direct(column) => {
+                if column.is_list() {
+                    out.push_sql("parent_id");
+                } else {
+                    out.push_sql("c.");
+                    out.push_identifier(column.name.as_str())?;
+                }
+                out.push_sql(" = any(");
+                out.push_bind_param::<Array<Text>, _>(&self.ids)?;
+                out.push_sql(")\n   and ");
+                BlockRangeContainsClause::new("c.", block).walk_ast(out.reborrow())?;
+            }
+            TableLink::Parent(_) => {
+                out.push_sql("p.id = any(");
+                out.push_bind_param::<Array<Text>, _>(&self.ids)?;
+                out.push_sql(")\n   and ");
+                BlockRangeContainsClause::new("c.", block).walk_ast(out.reborrow())?;
+                out.push_sql("\n   and ");
+                BlockRangeContainsClause::new("p.", block).walk_ast(out.reborrow())?;
+            }
+        }
+        Ok(())
+    }
+
+    fn parent_id(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        match self.link {
+            TableLink::Direct(column) => {
+                if column.is_list() {
+                    out.push_sql("parent_id");
+                } else {
+                    out.push_sql("c.");
+                    out.push_identifier(column.name.as_str())?;
+                    out.push_sql(" as parent_id");
+                }
+            }
+            TableLink::Parent(_) => {
+                out.push_sql("p.id as parent_id");
+            }
+        }
+        Ok(())
+    }
+
+    /// Select all children matching this window. The query returns all
+    /// the columns of `self.table` and a `parent_id` column
+    fn children_detailed(&self, block: BlockNumber, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql("select c.*, ");
+        self.parent_id(out)?;
+        self.from_clause(out)?;
+        out.push_sql("\n where ");
+        self.where_clause(block, out)?;
+        if let Some(filter) = &self.query_filter {
+            out.push_sql("\n   and ");
+            filter.walk_ast(out.reborrow())?
+        }
+        Ok(())
+    }
+
+    /// Select a basic subset of columns from the child table for use in
+    /// the `matches` CTE of queries that need to retrieve entities of
+    /// different types or entities that link differently to their parents
+    fn children_uniform(
+        &self,
+        sort_key: &SortKey,
+        block: BlockNumber,
+        out: &mut AstPass<Pg>,
+    ) -> QueryResult<()> {
+        out.push_sql("select '");
+        out.push_sql(self.table.object.as_str());
+        out.push_sql("' as entity, c.id, c.vid, ");
+        self.parent_id(out)?;
+        sort_key.select(out)?;
+        self.from_clause(out)?;
+        out.push_sql("\n where ");
+        self.where_clause(block, out)?;
+        if let Some(filter) = &self.query_filter {
+            out.push_sql("\n   and ");
+            filter.walk_ast(out.reborrow())?
+        }
+        Ok(())
+    }
+}
+
+/// This is a parallel to `EntityCollection`, but with entity type names
+/// and filters translated in a form ready for SQL generation
+#[derive(Debug, Clone)]
+pub enum FilterCollection<'a> {
+    /// Collection made from all entities in a table; each entry is the table
+    /// and the filter to apply to it, checked and bound to that table
+    All(Vec<(&'a Table, Option<QueryFilter<'a>>)>),
+    /// Collection made from windows of the same or different entity types
+    Window(Vec<FilterWindow<'a>>),
+}
+
+impl<'a> FilterCollection<'a> {
+    fn new(
+        layout: &'a Layout,
+        collection: EntityCollection,
+        filter: Option<&'a EntityFilter>,
+    ) -> Result<Self, QueryExecutionError> {
+        match collection {
+            EntityCollection::All(entities) => {
+                // This is a little ugly since we need to propagate errors
+                // from the inner closures. We turn each entity type name
+                // into the corresponding table, and check and bind the filter
+                // to it
+                let entities = entities
+                    .into_iter()
+                    .map(|entity| {
+                        layout
+                            .table_for_entity(&entity)
+                            .map(|rc| rc.as_ref())
+                            .and_then(|table| {
+                                filter
+                                    .map(|filter| QueryFilter::new(filter, table))
+                                    .transpose()
+                                    .map(|filter| (table, filter))
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(FilterCollection::All(entities))
+            }
+            EntityCollection::Window(windows) => {
+                let windows = windows
+                    .into_iter()
+                    .map(|window| FilterWindow::new(layout, window, filter))
+                    .collect::<Result<_, _>>()?;
+                Ok(FilterCollection::Window(windows))
+            }
+        }
+    }
+
+    fn first_table(&self) -> Option<&Table> {
+        match self {
+            FilterCollection::All(entities) => entities.first().map(|pair| pair.0),
+            FilterCollection::Window(windows) => windows.first().map(|window| window.table),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            FilterCollection::All(entities) => entities.is_empty(),
+            FilterCollection::Window(windows) => windows.is_empty(),
+        }
+    }
+}
+
+/// Convebience to pass the name of the column to order by around. If `name`
+/// is `None`, the sort key should be ignored
+#[derive(Debug, Clone)]
+pub struct SortKey {
+    name: Option<SqlName>,
+    direction: EntityOrder,
+}
+
+impl SortKey {
+    /// Generate selecting the sort key if it is needed
+    fn select(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        if let Some(name) = &self.name {
+            if name.as_str() != PRIMARY_KEY_COLUMN {
+                out.push_sql(", c.");
+                out.push_identifier(name.as_str())?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Generate
+    ///   order by [name direction,] id
     fn order_by(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
         out.push_sql("order by ");
-        if let Some((name, direction)) = &self.order {
+        if let Some(name) = &self.name {
             out.push_identifier(name.as_str())?;
             out.push_sql(" ");
-            out.push_sql(direction.to_sql());
+            out.push_sql(self.direction.to_sql());
             out.push_sql(" nulls last");
             if name.as_str() != PRIMARY_KEY_COLUMN {
                 out.push_sql(", ");
@@ -1022,22 +1284,61 @@ impl<'a> FilterQuery<'a> {
             out.push_identifier(PRIMARY_KEY_COLUMN)
         }
     }
+}
 
-    fn select_sort_key_and_window(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
-        if let Some(window) = self.window {
-            out.push_sql(", e.");
-            out.push_identifier(window.as_str())?;
-        }
+/// The parallel to `EntityQuery`.
+///
+/// Details of how query generation for `FilterQuery` works can be found
+/// in `docs/implementation/query-prefetching.md`
+#[derive(Debug, Clone)]
+pub struct FilterQuery<'a> {
+    collection: FilterCollection<'a>,
+    sort_key: SortKey,
+    range: EntityRange,
+    block: BlockNumber,
+}
 
-        if let Some((name, _)) = self.order {
-            if name.as_str() != PRIMARY_KEY_COLUMN && Some(name) != self.window {
-                out.push_sql(", e.");
-                out.push_identifier(name.as_str())?;
+impl<'a> FilterQuery<'a> {
+    pub fn new(
+        layout: &'a Layout,
+        collection: EntityCollection,
+        filter: Option<&'a EntityFilter>,
+        order: Option<(String, ValueType, EntityOrder)>,
+        range: EntityRange,
+        block: BlockNumber,
+    ) -> Result<Self, QueryExecutionError> {
+        let collection = FilterCollection::new(layout, collection, filter)?;
+
+        // Get the name of the column we order by; if there is more than one
+        // table, we are querying an interface, and the order is on an attribute
+        // in that interface so that all tables have a column for that. It is
+        // therefore enough to just look at the first table to get the name
+        let first_table = collection
+            .first_table()
+            .expect("an entity query always contains at least one entity type/table");
+        let sort_key = match order {
+            Some((ref attribute, _, direction)) => {
+                let column = first_table.column_for_field(&attribute)?;
+                SortKey {
+                    name: Some(column.name.clone()),
+                    direction,
+                }
             }
-        }
-        Ok(())
+            None => SortKey {
+                name: None,
+                direction: EntityOrder::Ascending,
+            },
+        };
+
+        Ok(FilterQuery {
+            collection,
+            sort_key,
+            range,
+            block,
+        })
     }
 
+    /// Generate `[limit {first}] [offset {skip}]
     fn limit(&self, out: &mut AstPass<Pg>) {
         if let Some(first) = &self.range.first {
             out.push_sql("\n limit ");
@@ -1049,61 +1350,50 @@ impl<'a> FilterQuery<'a> {
         }
     }
 
-    fn rank_window(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
-        if let Some(window) = self.window {
-            out.push_sql(", rank() over (partition by ");
-            out.push_identifier(window.as_str())?;
-            out.push_sql(" ");
-            self.order_by(out)?;
-            out.push_sql(") as pos");
-        }
-        Ok(())
-    }
-
     // Generate (taking optionality of either clause into account)
     //    where {pos} > {order.skip} and {pos} <= {order.first + order.skip}
-    //  `pos` must be the name of the column we order by and 'conj' must be
+    // `pos` must be the name of the column we order by and 'conj' must be
     // either 'and ' or 'where ' depending on where we add this clause
     fn limit_per_window(&self, pos: &str, conj: &str, out: &mut AstPass<Pg>) {
-        if self.window.is_some() {
-            let have_first = self.range.first.is_some();
-            let have_skip = self.range.skip > 0;
-            if have_first || have_skip {
-                out.push_sql("\n ");
-                out.push_sql(conj);
+        let have_first = self.range.first.is_some();
+        let have_skip = self.range.skip > 0;
+        if have_first || have_skip {
+            out.push_sql("\n ");
+            out.push_sql(conj);
+        }
+        if have_skip {
+            out.push_sql(pos);
+            out.push_sql(" > ");
+            out.push_sql(&self.range.skip.to_string());
+            if self.range.first.is_some() {
+                out.push_sql(" and ");
             }
-            if have_skip {
-                out.push_sql(pos);
-                out.push_sql(" > ");
-                out.push_sql(&self.range.skip.to_string());
-                if self.range.first.is_some() {
-                    out.push_sql(" and ");
-                }
-            }
-            if let Some(first) = self.range.first {
-                out.push_sql(pos);
-                out.push_sql(" <= ");
-                out.push_sql(&(first + self.range.skip).to_string());
-            }
+        }
+        if let Some(first) = self.range.first {
+            out.push_sql(pos);
+            out.push_sql(" <= ");
+            out.push_sql(&(first + self.range.skip).to_string());
         }
     }
 
+    /// Generate
+    ///     from schema.table c
+    ///    where block_range @> $block
+    ///      and query_filter
+    /// Only used when the query is against a `FilterCollection::All`, i.e.
+    /// when we do not need to window
     fn filtered_rows(
         &self,
         table: &Table,
-        filter: &Option<QueryFilter<'a>>,
+        table_filter: &Option<QueryFilter<'a>>,
         mut out: AstPass<Pg>,
     ) -> QueryResult<()> {
-        // Generate
-        //     from schema.table e
-        //    where block_range @> $block
-        //      and query_filter
         out.push_sql("\n  from ");
         out.push_sql(table.qualified_name.as_str());
-        out.push_sql(" e");
+        out.push_sql(" c");
         out.push_sql("\n where ");
-        BlockRangeContainsClause::new(self.block).walk_ast(out.reborrow())?;
-        if let Some(filter) = filter {
+        BlockRangeContainsClause::new("c.", self.block).walk_ast(out.reborrow())?;
+        if let Some(filter) = table_filter {
             out.push_sql(" and ");
             filter.walk_ast(out.reborrow())?;
         }
@@ -1111,68 +1401,29 @@ impl<'a> FilterQuery<'a> {
         Ok(())
     }
 
-    fn select_entity_and_data(table: &Table, out: &mut AstPass<Pg>) -> QueryResult<()> {
-        out.push_sql("select ");
-        out.push_bind_param::<Text, _>(&table.object)?;
-        out.push_sql(" as entity, to_jsonb(e.*) as data");
-        Ok(())
+    fn select_entity_and_data(table: &Table, out: &mut AstPass<Pg>) {
+        out.push_sql("select '");
+        out.push_sql(&table.object);
+        out.push_sql("' as entity, to_jsonb(c.*) as data");
     }
 
-    /// Generate the `matches` CTE for `query_window` and `query_no_window`
-    /// When there is no window, we can already order and limit the results
-    /// of this `union all` query
-    fn select_matches(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
-        for (i, (table, filter)) in self.table_filter_pairs.iter().enumerate() {
-            if i > 0 {
-                out.push_sql("\nunion all\n");
-            }
-            out.push_sql("select ");
-            out.push_bind_param::<Text, _>(&table.object)?;
-            out.push_sql(" as entity, e.id, e.vid");
-            self.select_sort_key_and_window(out)?;
-            self.filtered_rows(table, filter, out.reborrow())?;
-        }
-        out.push_sql("\n ");
-        if self.window.is_none() {
-            self.order_by(out)?;
-            self.limit(out);
-        }
-        Ok(())
-    }
-
-    fn matches_to_json(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
-        for (i, (table, _)) in self.table_filter_pairs.iter().enumerate() {
-            if i > 0 {
-                out.push_sql("\nunion all\n");
-            }
-            out.push_sql("select m.entity, to_jsonb(e.*) as data, e.id");
-            self.select_sort_key_and_window(out)?;
-            out.push_sql("\n  from ");
-            out.push_sql(table.qualified_name.as_str());
-            out.push_sql(" e,");
-            out.push_sql(" matches m");
-            out.push_sql("\n where e.vid = m.vid and m.entity = ");
-            out.push_bind_param::<Text, _>(&table.object)?;
-            self.limit_per_window("m.pos", "\n   and ", out);
-        }
-        out.push_sql("\n ");
-        Ok(())
-    }
     /// Only one table/filter pair, and no window
     ///
     /// Generate a query
     ///   select '..' as entity, to_jsonb(e.*) as data
-    ///     from table e
-    ///    where filter
+    ///     from table c
+    ///    where block_range @> $block
+    ///      and filter
     ///    order by .. limit .. skip ..
-    fn query_no_window_one_entity(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
-        let (table, filter) = self
-            .table_filter_pairs
-            .first()
-            .expect("we already checked that there is exactly one table");
-        Self::select_entity_and_data(table, &mut out)?;
+    fn query_no_window_one_entity(
+        &self,
+        table: &Table,
+        filter: &Option<QueryFilter>,
+        mut out: AstPass<Pg>,
+    ) -> QueryResult<()> {
+        Self::select_entity_and_data(table, &mut out);
         self.filtered_rows(table, filter, out.reborrow())?;
-        self.order_by(&mut out)?;
+        self.sort_key.order_by(&mut out)?;
         self.limit(&mut out);
         Ok(())
     }
@@ -1181,28 +1432,35 @@ impl<'a> FilterQuery<'a> {
     ///
     /// Generate a query
     ///   select '..' as entity, to_jsonb(e.*) as data
-    ///     from (select *, rank() over (partition by window order by ..) as pos
-    ///             from table e
-    ///            where filter) e
-    ///     where e.pos > skip and e.pos <= first + skip
-    ///     order by ..
-    fn query_window_one_entity(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
-        let (table, filter) = self
-            .table_filter_pairs
-            .first()
-            .expect("we already checked that there is exactly one table");
-        Self::select_entity_and_data(table, &mut out)?;
+    ///     from (
+    ///       select c.*,
+    ///              rank() over (partition by c.parent_id order by ..) as pos
+    ///         from ({window.children_detailed(block)}) c) c
+    ///     where c.pos > skip and c.pos <= first + skip
+    ///     order by c.parent_id, c.pos
+    fn query_window_one_entity(
+        &self,
+        window: &FilterWindow,
+        mut out: AstPass<Pg>,
+    ) -> QueryResult<()> {
+        Self::select_entity_and_data(&window.table, &mut out);
         out.push_sql(" from (\n");
-        out.push_sql("select *");
-        self.rank_window(&mut out)?;
-        self.filtered_rows(table, filter, out.reborrow())?;
-        out.push_sql(") e");
-        self.limit_per_window("e.pos", "where ", &mut out);
-        out.push_sql("\n ");
-        self.order_by(&mut out)
+        out.push_sql("select c.*, rank() over (partition by c.parent_id ");
+        self.sort_key.order_by(&mut out)?;
+        out.push_sql(") as pos\n  from (");
+        window.children_detailed(self.block, &mut out)?;
+        out.push_sql(") c) c");
+        self.limit_per_window("c.pos", "where ", &mut out);
+        out.push_sql("\n order by c.parent_id, c.pos");
+        Ok(())
     }
 
-    fn query_no_window(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+    /// No windowing, but multiple entity types
+    fn query_no_window(
+        &self,
+        entities: &Vec<(&Table, Option<QueryFilter>)>,
+        mut out: AstPass<Pg>,
+    ) -> QueryResult<()> {
         // We have multiple tables which might have different schemas since
         // the entity_types come from implementing the same interface. We
         // need to do the query in two steps: first we build a CTE with the
@@ -1213,44 +1471,63 @@ impl<'a> FilterQuery<'a> {
         // Overall, we generate a query
         //
         // with matches as (
-        //   select '...' as entity, id, vid
-        //     from table1
-        //    where entity_filter
+        //   select '...' as entity, id, vid, {sort_key}
+        //     from {table} c
+        //    where {query_filter}
         //    union all
         //    ...
-        //    order by ...
+        //    order by {sort_key}
         //    limit n offset m)
-        // select m.entity, to_jsonb(e.*) as data, sort_key, id
-        //   from table1 e, matches m
-        //  where e.vid = matches.vid and m.entity = '...'
+        // select m.entity, to_jsonb(c.*) as data, c.id, c.{sort_key}
+        //   from {table} c, matches m
+        //  where c.vid = m.vid and m.entity = '...'
         //  union all
         //  ...
-        //  order by ...
-        //
-        // If we have a window, we change the `matches` in the outer
-        // select to
-        //   (select *, rank() over (partition by {window} order by {order}) as pos
-        //    from matches m)
-        // We also do not do order by/limit inside the `matches` CTE, and
-        // replace the order by/limit on the outer query with
-        //    and m.pos > {skip} and m.pos <= {range.first + range.skip}
+        //  order by c.{sort_key}
 
         // Step 1: build matches CTE
         out.push_sql("with matches as (");
-        self.select_matches(&mut out)?;
+        for (i, (table, filter)) in entities.iter().enumerate() {
+            if i > 0 {
+                out.push_sql("\nunion all\n");
+            }
+            // select '..' as entity,
+            //        c.id,
+            //        c.vid,
+            //        c.${sort_key}
+            out.push_sql("select '");
+            out.push_sql(&table.object);
+            out.push_sql("' as entity, c.id, c.vid");
+            self.sort_key.select(&mut out)?;
+            self.filtered_rows(table, filter, out.reborrow())?;
+        }
+        out.push_sql("\n ");
+        self.sort_key.order_by(&mut out)?;
+        self.limit(&mut out);
+
         out.push_sql(")\n");
 
         // Step 2: convert to JSONB
-        self.matches_to_json(&mut out)?;
-        self.order_by(&mut out)?;
+        for (i, (table, _)) in entities.iter().enumerate() {
+            if i > 0 {
+                out.push_sql("\nunion all\n");
+            }
+            out.push_sql("select m.entity, to_jsonb(c.*) as data, c.id");
+            self.sort_key.select(&mut out)?;
+            out.push_sql("\n  from ");
+            out.push_sql(table.qualified_name.as_str());
+            out.push_sql(" c,");
+            out.push_sql(" matches m");
+            out.push_sql("\n where c.vid = m.vid and m.entity = ");
+            out.push_bind_param::<Text, _>(&table.object)?;
+        }
+        out.push_sql("\n ");
+        self.sort_key.order_by(&mut out)?;
         Ok(())
     }
 
-    fn query_window(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
-        // This is almost the same as `query_no_window`, except that we need to
-        // rank results in the `matches` CTE, and use `matches.pos` to restrict
-        // the rows that we return rather than use an `order by`
-        //
+    /// Multiple windows
+    fn query_window(&self, windows: &Vec<FilterWindow>, mut out: AstPass<Pg>) -> QueryResult<()> {
         // Note that a CTE is an optimization fence, and since we use
         // `matches` multiple times, we actually want to materialize it first
         // before we fill in JSON data in the main query. As a consequence, we
@@ -1261,56 +1538,112 @@ impl<'a> FilterQuery<'a> {
         // Overall, we generate a query
         //
         // with matches as (
-        //   -- limit the matches in each window
-        //   select e.*
+        //   -- Limit the matches for each parent
+        //   select c.*
         //     from (
-        //       -- rank matches in the overall set of matching rows
-        //       select e.*,
-        //              rank() over (partition by window order by ..)
-        //         from (
-        //           -- find matching rows across all entity types
-        //           select '...' as entity, id, vid
-        //             from table1
-        //            where entity_filter
-        //            union all
-        //                  ...) e) e
-        //    where e.pos > skip and e.pos <= first + skip)
-        // select m.entity, to_jsonb(e.*) as data, sort_key, id
-        //   from table1 e, matches m
-        //  where e.vid = matches.vid and m.entity = '...'
+        //       -- Rank matching children for each parent
+        //       select c.*,
+        //              rank() over (partition by c.parent_id order by ..) as pos
+        //         from ({window.children_uniform(sort_key, block)}) c
+        //               union all
+        //                 ...) c) c
+        //    where c.pos > {skip} and c.pos <= {first + skip})
+        // select m.entity, to_jsonb(e.*) as data, m.parent_id, m.pos
+        //   from {window.child_table} c, matches m
+        //  where c.vid = m.vid and m.entity = '{window.child_type}'
         //  union all
         //  ...
-        //  order by ...
+        //  order by parent_id, pos
 
         // Step 1: build matches CTE
         out.push_sql("with matches as (");
-        out.push_sql("select e.* from (");
-        out.push_sql("select e.*");
-        self.rank_window(&mut out)?;
+        out.push_sql("select c.* from (");
+
+        out.push_sql("select c.*, rank() over (partition by c.parent_id ");
+        self.sort_key.order_by(&mut out)?;
+        out.push_sql(") as pos");
+
         out.push_sql("\n from (");
-        self.select_matches(&mut out)?;
-        out.push_sql(") e) e\n");
-        self.limit_per_window("e.pos", " where ", &mut out);
+
+        for (i, window) in windows.iter().enumerate() {
+            if i > 0 {
+                out.push_sql("\nunion all\n");
+            }
+            window.children_uniform(&self.sort_key, self.block, &mut out)?;
+        }
+        out.push_sql("\n ");
+
+        out.push_sql(") c) c\n");
+        self.limit_per_window("c.pos", " where ", &mut out);
         out.push_sql(")\n");
         // Step 2: convert to JSONB
-        self.matches_to_json(&mut out)?;
-        out.push_sql("\n ");
-        self.order_by(&mut out)
+        // If the parent is an interface, each implementation might store its
+        // relationship to the children in different ways, leading to multiple
+        // windows that use the same table for the children. We need to make
+        // sure each table only appears once in the 'union all' otherwise we'll
+        // duplicate entities in the result
+        // We only use a table's qualified name and object to save ourselves
+        // the hassle of making `Table` hashable
+        let unique_child_tables = windows
+            .iter()
+            .map(|window| (&window.table.qualified_name, &window.table.object))
+            .collect::<HashSet<_>>();
+        for (i, (table_name, object)) in unique_child_tables.into_iter().enumerate() {
+            if i > 0 {
+                out.push_sql("\nunion all\n");
+            }
+            out.push_sql(
+                "select m.entity, \
+                 to_jsonb(c.*) || jsonb_build_object('parent_id', m.parent_id) as data, \
+                 m.parent_id, m.pos",
+            );
+            out.push_sql("\n  from ");
+            out.push_sql(table_name.as_str());
+            out.push_sql(" c, matches m\n where c.vid = m.vid and m.entity = '");
+            out.push_sql(object);
+            out.push_sql("'");
+        }
+        out.push_sql("\n order by parent_id, pos");
+        Ok(())
     }
 }
 
 impl<'a> QueryFragment<Pg> for FilterQuery<'a> {
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
-        if self.table_filter_pairs.is_empty() {
+        if self.collection.is_empty() {
             return Ok(());
         }
 
-        match (self.table_filter_pairs.len(), self.window) {
-            (1, None) => self.query_no_window_one_entity(out),
-            (1, Some(_)) => self.query_window_one_entity(out),
-            (_, None) => self.query_no_window(out),
-            (_, Some(_)) => self.query_window(out),
+        // We generate four different kinds of queries, depending on whether
+        // we need to window and whether we query just one or multiple entity
+        // types/windows; the most complex situation is windowing with multiple
+        // entity types. The other cases let us simplify the generated SQL
+        // considerably and produces faster queries
+        //
+        // Details of how all this works can be found in
+        // `docs/implementation/query-prefetching.md`
+        match &self.collection {
+            FilterCollection::All(entities) => {
+                if entities.len() == 1 {
+                    let (table, filter) = entities
+                        .first()
+                        .expect("a query always uses at least one table");
+                    self.query_no_window_one_entity(table, filter, out)
+                } else {
+                    self.query_no_window(entities, out)
+                }
+            }
+            FilterCollection::Window(windows) => {
+                if windows.len() == 1 {
+                    let window = windows
+                        .first()
+                        .expect("a query always uses at least one table");
+                    self.query_window_one_entity(window, out)
+                } else {
+                    self.query_window(windows, out)
+                }
+            }
         }
     }
 }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -363,6 +363,7 @@ impl Store {
             query.filter,
             order,
             query.range,
+            query.window,
             BLOCK_NUMBER_MAX,
         )
     }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -351,13 +351,7 @@ impl Store {
         // Add order by filters to query
         let order = match query.order_by {
             Some((attribute, value_type)) => {
-                let direction = query
-                    .order_direction
-                    .map(|direction| match direction {
-                        EntityOrder::Ascending => "ASC",
-                        EntityOrder::Descending => "DESC",
-                    })
-                    .unwrap_or("ASC");
+                let direction = query.order_direction.unwrap_or(EntityOrder::Ascending);
                 Some((attribute, value_type, direction))
             }
             None => None,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -362,8 +362,7 @@ impl Store {
             query.entity_types,
             query.filter,
             order,
-            query.range.first,
-            query.range.skip,
+            query.range,
             BLOCK_NUMBER_MAX,
         )
     }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -359,11 +359,10 @@ impl Store {
 
         // Process results; deserialize JSON data
         conn.query(
-            query.entity_types,
+            query.collection,
             query.filter,
             order,
             query.range,
-            query.window,
             BLOCK_NUMBER_MAX,
         )
     }

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -554,35 +554,25 @@ fn find_interface() {
 
     test_find(
         vec!["pluto", "garfield"],
-        query(vec!["Cat", "Dog"]).order_by(
-            ("name".to_owned(), ValueType::String),
-            EntityOrder::Descending,
-        ),
+        query(vec!["Cat", "Dog"]).order_by("name", ValueType::String, EntityOrder::Descending),
     );
 
     test_find(
         vec!["garfield"],
         query(vec!["Cat", "Dog"])
             .filter(EntityFilter::StartsWith("name".into(), Value::from("Gar")))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     );
 
     // Test that we can order by id
     test_find(
         vec!["pluto", "garfield"],
-        query(vec!["Cat", "Dog"]).order_by(
-            ("id".to_owned(), ValueType::String),
-            EntityOrder::Descending,
-        ),
+        query(vec!["Cat", "Dog"]).order_by("id", ValueType::String, EntityOrder::Descending),
     );
 
     test_find(
         vec!["garfield", "pluto"],
-        query(vec!["Cat", "Dog"])
-            .order_by(("id".to_owned(), ValueType::String), EntityOrder::Ascending),
+        query(vec!["Cat", "Dog"]).order_by("id", ValueType::String, EntityOrder::Ascending),
     );
 }
 
@@ -630,10 +620,7 @@ fn find_string_equal() {
                 "name".to_owned(),
                 "Cindini".into(),
             )]))
-            .order_by(
-                ("id".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("id", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -646,10 +633,7 @@ fn find_string_not_equal() {
                 "name".to_owned(),
                 "Cindini".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -673,10 +657,7 @@ fn find_string_less_than_order_by_asc() {
                 "name".to_owned(),
                 "Kundi".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -689,10 +670,7 @@ fn find_string_less_than_order_by_desc() {
                 "name".to_owned(),
                 "Kundi".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -705,10 +683,7 @@ fn find_string_less_than_range() {
                 "name".to_owned(),
                 "ZZZ".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(1)
             .skip(1),
     )
@@ -723,10 +698,7 @@ fn find_string_multiple_and() {
                 EntityFilter::LessThan("name".to_owned(), "Cz".into()),
                 EntityFilter::Equal("name".to_owned(), "Cindini".into()),
             ]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -739,10 +711,7 @@ fn find_string_ends_with() {
                 "name".to_owned(),
                 "ini".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -755,10 +724,7 @@ fn find_string_not_ends_with() {
                 "name".to_owned(),
                 "ini".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -771,10 +737,7 @@ fn find_string_in() {
                 "name".to_owned(),
                 vec!["Johnton".into(), "Nobody".into(), "Still nobody".into()],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -787,10 +750,7 @@ fn find_string_not_in() {
                 "name".to_owned(),
                 vec!["Shaqueeena".into()],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -814,10 +774,7 @@ fn find_float_not_equal() {
                 "weight".to_owned(),
                 Value::BigDecimal(184.4.into()),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -841,10 +798,7 @@ fn find_float_less_than() {
                 "weight".to_owned(),
                 Value::BigDecimal(160.0.into()),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -857,10 +811,7 @@ fn find_float_less_than_order_by_desc() {
                 "weight".to_owned(),
                 Value::BigDecimal(160.0.into()),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -873,10 +824,7 @@ fn find_float_less_than_range() {
                 "weight".to_owned(),
                 Value::BigDecimal(161.0.into()),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(1)
             .skip(1),
     )
@@ -894,10 +842,7 @@ fn find_float_in() {
                     Value::BigDecimal(111.7.into()),
                 ],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
 }
@@ -914,10 +859,7 @@ fn find_float_not_in() {
                     Value::BigDecimal(111.7.into()),
                 ],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
 }
@@ -931,10 +873,7 @@ fn find_int_equal() {
                 "age".to_owned(),
                 Value::Int(67 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -947,10 +886,7 @@ fn find_int_not_equal() {
                 "age".to_owned(),
                 Value::Int(67 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -974,10 +910,7 @@ fn find_int_greater_or_equal() {
                 "age".to_owned(),
                 Value::Int(43 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -990,10 +923,7 @@ fn find_int_less_than() {
                 "age".to_owned(),
                 Value::Int(50 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -1006,10 +936,7 @@ fn find_int_less_or_equal() {
                 "age".to_owned(),
                 Value::Int(43 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -1022,10 +949,7 @@ fn find_int_less_than_order_by_desc() {
                 "age".to_owned(),
                 Value::Int(50 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -1038,10 +962,7 @@ fn find_int_less_than_range() {
                 "age".to_owned(),
                 Value::Int(67 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(1)
             .skip(1),
     )
@@ -1056,10 +977,7 @@ fn find_int_in() {
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
 }
@@ -1073,10 +991,7 @@ fn find_int_not_in() {
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
 }
@@ -1090,10 +1005,7 @@ fn find_bool_equal() {
                 "coffee".to_owned(),
                 Value::Bool(true),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -1106,10 +1018,7 @@ fn find_bool_not_equal() {
                 "coffee".to_owned(),
                 Value::Bool(true),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -1122,10 +1031,7 @@ fn find_bool_in() {
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
 }
@@ -1139,10 +1045,7 @@ fn find_bool_not_in() {
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
 }
@@ -1156,10 +1059,7 @@ fn find_bytes_equal() {
                 "bin_name".to_owned(),
                 Value::Bytes("Johnton".as_bytes().into()),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -1172,10 +1072,7 @@ fn find_null_equal() {
                 "favorite_color".to_owned(),
                 Value::Null,
             ))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -1185,10 +1082,7 @@ fn find_null_not_equal() {
         vec!["1", "2"],
         user_query()
             .filter(EntityFilter::Not("favorite_color".to_owned(), Value::Null))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -1201,10 +1095,7 @@ fn find_null_not_in() {
                 "favorite_color".to_owned(),
                 vec![Value::Null],
             ))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     );
 
     test_find(
@@ -1214,10 +1105,7 @@ fn find_null_not_in() {
                 "favorite_color".to_owned(),
                 vec!["red".into(), Value::Null],
             ))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     );
 }
 
@@ -1225,17 +1113,11 @@ fn find_null_not_in() {
 fn find_order_by_float() {
     test_find(
         vec!["3", "2", "1"],
-        user_query().order_by(
-            ("weight".to_owned(), ValueType::BigDecimal),
-            EntityOrder::Ascending,
-        ),
+        user_query().order_by("weight", ValueType::BigDecimal, EntityOrder::Ascending),
     );
     test_find(
         vec!["1", "2", "3"],
-        user_query().order_by(
-            ("weight".to_owned(), ValueType::BigDecimal),
-            EntityOrder::Descending,
-        ),
+        user_query().order_by("weight", ValueType::BigDecimal, EntityOrder::Descending),
     );
 }
 
@@ -1243,11 +1125,11 @@ fn find_order_by_float() {
 fn find_order_by_id() {
     test_find(
         vec!["1", "2", "3"],
-        user_query().order_by(("id".to_owned(), ValueType::ID), EntityOrder::Ascending),
+        user_query().order_by("id", ValueType::ID, EntityOrder::Ascending),
     );
     test_find(
         vec!["3", "2", "1"],
-        user_query().order_by(("id".to_owned(), ValueType::ID), EntityOrder::Descending),
+        user_query().order_by("id", ValueType::ID, EntityOrder::Descending),
     );
 }
 
@@ -1255,11 +1137,11 @@ fn find_order_by_id() {
 fn find_order_by_int() {
     test_find(
         vec!["3", "2", "1"],
-        user_query().order_by(("age".to_owned(), ValueType::Int), EntityOrder::Ascending),
+        user_query().order_by("age", ValueType::Int, EntityOrder::Ascending),
     );
     test_find(
         vec!["1", "2", "3"],
-        user_query().order_by(("age".to_owned(), ValueType::Int), EntityOrder::Descending),
+        user_query().order_by("age", ValueType::Int, EntityOrder::Descending),
     );
 }
 
@@ -1267,17 +1149,11 @@ fn find_order_by_int() {
 fn find_order_by_string() {
     test_find(
         vec!["2", "1", "3"],
-        user_query().order_by(
-            ("name".to_owned(), ValueType::String),
-            EntityOrder::Ascending,
-        ),
+        user_query().order_by("name", ValueType::String, EntityOrder::Ascending),
     );
     test_find(
         vec!["3", "1", "2"],
-        user_query().order_by(
-            ("name".to_owned(), ValueType::String),
-            EntityOrder::Descending,
-        ),
+        user_query().order_by("name", ValueType::String, EntityOrder::Descending),
     );
 }
 
@@ -1290,7 +1166,7 @@ fn find_where_nested_and_or() {
                 EntityFilter::Equal("id".to_owned(), Value::from("1")),
                 EntityFilter::Equal("id".to_owned(), Value::from("2")),
             ])]))
-            .order_by(("id".to_owned(), ValueType::String), EntityOrder::Ascending),
+            .order_by("id", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -1303,10 +1179,7 @@ fn find_enum_equal() {
                 "favorite_color".to_owned(),
                 "red".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -1319,10 +1192,7 @@ fn find_enum_not_equal() {
                 "favorite_color".to_owned(),
                 "red".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -1335,10 +1205,7 @@ fn find_enum_in() {
                 "favorite_color".to_owned(),
                 vec!["red".into()],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
 }
@@ -1352,10 +1219,7 @@ fn find_enum_not_in() {
                 "favorite_color".to_owned(),
                 vec!["red".into()],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
 }
@@ -1387,9 +1251,11 @@ fn text_find(expected_entity_ids: Vec<&str>, filter: EntityFilter) {
         insert_pet(conn, layout, "Ferret", "a2b", &a2b);
         insert_pet(conn, layout, "Ferret", "a3", &a3);
 
-        let query = query(vec!["Ferret"])
-            .filter(filter)
-            .order_by(("id".to_owned(), ValueType::String), EntityOrder::Ascending);
+        let query = query(vec!["Ferret"]).filter(filter).order_by(
+            "id",
+            ValueType::String,
+            EntityOrder::Ascending,
+        );
 
         let order = match query.order_by {
             Some((attribute, value_type)) => {

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -580,10 +580,7 @@ fn find_interface() {
 fn find_string_contains() {
     test_find(
         vec!["2"],
-        user_query().filter(EntityFilter::And(vec![EntityFilter::Contains(
-            "name".into(),
-            "ind".into(),
-        )])),
+        user_query().filter(EntityFilter::Contains("name".into(), "ind".into())),
     )
 }
 
@@ -606,20 +603,14 @@ fn find_list_contains() {
 fn find_string_equal() {
     test_find(
         vec!["2"],
-        user_query().filter(EntityFilter::And(vec![EntityFilter::Equal(
-            "name".to_owned(),
-            "Cindini".into(),
-        )])),
+        user_query().filter(EntityFilter::Equal("name".to_owned(), "Cindini".into())),
     );
 
     // Test that we can order by id
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Equal(
-                "name".to_owned(),
-                "Cindini".into(),
-            )]))
+            .filter(EntityFilter::Equal("name".to_owned(), "Cindini".into()))
             .order_by("id", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -629,10 +620,7 @@ fn find_string_not_equal() {
     test_find(
         vec!["1", "3"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Not(
-                "name".to_owned(),
-                "Cindini".into(),
-            )]))
+            .filter(EntityFilter::Not("name".to_owned(), "Cindini".into()))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -641,10 +629,7 @@ fn find_string_not_equal() {
 fn find_string_greater_than() {
     test_find(
         vec!["3"],
-        user_query().filter(EntityFilter::And(vec![EntityFilter::GreaterThan(
-            "name".to_owned(),
-            "Kundi".into(),
-        )])),
+        user_query().filter(EntityFilter::GreaterThan("name".to_owned(), "Kundi".into())),
     )
 }
 
@@ -653,10 +638,7 @@ fn find_string_less_than_order_by_asc() {
     test_find(
         vec!["2", "1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
-                "name".to_owned(),
-                "Kundi".into(),
-            )]))
+            .filter(EntityFilter::LessThan("name".to_owned(), "Kundi".into()))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -666,10 +648,7 @@ fn find_string_less_than_order_by_desc() {
     test_find(
         vec!["1", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
-                "name".to_owned(),
-                "Kundi".into(),
-            )]))
+            .filter(EntityFilter::LessThan("name".to_owned(), "Kundi".into()))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -679,10 +658,7 @@ fn find_string_less_than_range() {
     test_find(
         vec!["1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
-                "name".to_owned(),
-                "ZZZ".into(),
-            )]))
+            .filter(EntityFilter::LessThan("name".to_owned(), "ZZZ".into()))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(1)
             .skip(1),
@@ -707,10 +683,7 @@ fn find_string_ends_with() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::EndsWith(
-                "name".to_owned(),
-                "ini".into(),
-            )]))
+            .filter(EntityFilter::EndsWith("name".to_owned(), "ini".into()))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -720,10 +693,7 @@ fn find_string_not_ends_with() {
     test_find(
         vec!["3", "1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::NotEndsWith(
-                "name".to_owned(),
-                "ini".into(),
-            )]))
+            .filter(EntityFilter::NotEndsWith("name".to_owned(), "ini".into()))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -733,10 +703,10 @@ fn find_string_in() {
     test_find(
         vec!["1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::In(
+            .filter(EntityFilter::In(
                 "name".to_owned(),
                 vec!["Johnton".into(), "Nobody".into(), "Still nobody".into()],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -746,10 +716,10 @@ fn find_string_not_in() {
     test_find(
         vec!["1", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
+            .filter(EntityFilter::NotIn(
                 "name".to_owned(),
                 vec!["Shaqueeena".into()],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -758,10 +728,10 @@ fn find_string_not_in() {
 fn find_float_equal() {
     test_find(
         vec!["1"],
-        user_query().filter(EntityFilter::And(vec![EntityFilter::Equal(
+        user_query().filter(EntityFilter::Equal(
             "weight".to_owned(),
             Value::BigDecimal(184.4.into()),
-        )])),
+        )),
     )
 }
 
@@ -770,10 +740,10 @@ fn find_float_not_equal() {
     test_find(
         vec!["3", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Not(
+            .filter(EntityFilter::Not(
                 "weight".to_owned(),
                 Value::BigDecimal(184.4.into()),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -782,10 +752,10 @@ fn find_float_not_equal() {
 fn find_float_greater_than() {
     test_find(
         vec!["1"],
-        user_query().filter(EntityFilter::And(vec![EntityFilter::GreaterThan(
+        user_query().filter(EntityFilter::GreaterThan(
             "weight".to_owned(),
             Value::BigDecimal(160.0.into()),
-        )])),
+        )),
     )
 }
 
@@ -794,10 +764,10 @@ fn find_float_less_than() {
     test_find(
         vec!["2", "3"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
+            .filter(EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::BigDecimal(160.0.into()),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -807,10 +777,10 @@ fn find_float_less_than_order_by_desc() {
     test_find(
         vec!["3", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
+            .filter(EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::BigDecimal(160.0.into()),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -820,10 +790,10 @@ fn find_float_less_than_range() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
+            .filter(EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::BigDecimal(161.0.into()),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(1)
             .skip(1),
@@ -835,13 +805,13 @@ fn find_float_in() {
     test_find(
         vec!["3", "1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::In(
+            .filter(EntityFilter::In(
                 "weight".to_owned(),
                 vec![
                     Value::BigDecimal(184.4.into()),
                     Value::BigDecimal(111.7.into()),
                 ],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
@@ -852,13 +822,13 @@ fn find_float_not_in() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
+            .filter(EntityFilter::NotIn(
                 "weight".to_owned(),
                 vec![
                     Value::BigDecimal(184.4.into()),
                     Value::BigDecimal(111.7.into()),
                 ],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
@@ -869,10 +839,7 @@ fn find_int_equal() {
     test_find(
         vec!["1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Equal(
-                "age".to_owned(),
-                Value::Int(67 as i32),
-            )]))
+            .filter(EntityFilter::Equal("age".to_owned(), Value::Int(67 as i32)))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -882,10 +849,7 @@ fn find_int_not_equal() {
     test_find(
         vec!["3", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Not(
-                "age".to_owned(),
-                Value::Int(67 as i32),
-            )]))
+            .filter(EntityFilter::Not("age".to_owned(), Value::Int(67 as i32)))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -894,10 +858,10 @@ fn find_int_not_equal() {
 fn find_int_greater_than() {
     test_find(
         vec!["1"],
-        user_query().filter(EntityFilter::And(vec![EntityFilter::GreaterThan(
+        user_query().filter(EntityFilter::GreaterThan(
             "age".to_owned(),
             Value::Int(43 as i32),
-        )])),
+        )),
     )
 }
 
@@ -906,10 +870,10 @@ fn find_int_greater_or_equal() {
     test_find(
         vec!["2", "1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::GreaterOrEqual(
+            .filter(EntityFilter::GreaterOrEqual(
                 "age".to_owned(),
                 Value::Int(43 as i32),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -919,10 +883,10 @@ fn find_int_less_than() {
     test_find(
         vec!["2", "3"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
+            .filter(EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(50 as i32),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -932,10 +896,10 @@ fn find_int_less_or_equal() {
     test_find(
         vec!["2", "3"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessOrEqual(
+            .filter(EntityFilter::LessOrEqual(
                 "age".to_owned(),
                 Value::Int(43 as i32),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -945,10 +909,10 @@ fn find_int_less_than_order_by_desc() {
     test_find(
         vec!["3", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
+            .filter(EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(50 as i32),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -958,10 +922,10 @@ fn find_int_less_than_range() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
+            .filter(EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(67 as i32),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(1)
             .skip(1),
@@ -973,10 +937,10 @@ fn find_int_in() {
     test_find(
         vec!["1", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::In(
+            .filter(EntityFilter::In(
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
@@ -987,10 +951,10 @@ fn find_int_not_in() {
     test_find(
         vec!["3"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
+            .filter(EntityFilter::NotIn(
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
@@ -1001,10 +965,7 @@ fn find_bool_equal() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Equal(
-                "coffee".to_owned(),
-                Value::Bool(true),
-            )]))
+            .filter(EntityFilter::Equal("coffee".to_owned(), Value::Bool(true)))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -1014,10 +975,7 @@ fn find_bool_not_equal() {
     test_find(
         vec!["1", "3"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Not(
-                "coffee".to_owned(),
-                Value::Bool(true),
-            )]))
+            .filter(EntityFilter::Not("coffee".to_owned(), Value::Bool(true)))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -1027,10 +985,10 @@ fn find_bool_in() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::In(
+            .filter(EntityFilter::In(
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
@@ -1041,10 +999,10 @@ fn find_bool_not_in() {
     test_find(
         vec!["3", "1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
+            .filter(EntityFilter::NotIn(
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
@@ -1055,10 +1013,10 @@ fn find_bytes_equal() {
     test_find(
         vec!["1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Equal(
+            .filter(EntityFilter::Equal(
                 "bin_name".to_owned(),
                 Value::Bytes("Johnton".as_bytes().into()),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -1175,10 +1133,10 @@ fn find_enum_equal() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Equal(
+            .filter(EntityFilter::Equal(
                 "favorite_color".to_owned(),
                 "red".into(),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -1188,10 +1146,7 @@ fn find_enum_not_equal() {
     test_find(
         vec!["1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Not(
-                "favorite_color".to_owned(),
-                "red".into(),
-            )]))
+            .filter(EntityFilter::Not("favorite_color".to_owned(), "red".into()))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -1201,10 +1156,10 @@ fn find_enum_in() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::In(
+            .filter(EntityFilter::In(
                 "favorite_color".to_owned(),
                 vec!["red".into()],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )
@@ -1215,10 +1170,10 @@ fn find_enum_not_in() {
     test_find(
         vec!["1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
+            .filter(EntityFilter::NotIn(
                 "favorite_color".to_owned(),
                 vec!["red".into()],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .first(5),
     )

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -426,6 +426,7 @@ fn count_scalar_entities(conn: &PgConnection, layout: &Layout) -> usize {
                 first: None,
                 skip: 0,
             },
+            None,
             BLOCK_NUMBER_MAX,
         )
         .expect("Count query failed")
@@ -516,6 +517,7 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
                 query.filter,
                 order,
                 query.range,
+                None,
                 BLOCK_NUMBER_MAX,
             )
             .expect("layout.query failed to execute query");
@@ -1654,6 +1656,7 @@ fn text_find(expected_entity_ids: Vec<&str>, filter: EntityFilter) {
                 query.filter,
                 order,
                 query.range,
+                None,
                 BLOCK_NUMBER_MAX,
             )
             .expect("layout.query failed to execute query");

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -537,72 +537,52 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
     })
 }
 
+fn query(entity_types: Vec<&str>) -> EntityQuery {
+    EntityQuery::new(
+        THINGS_SUBGRAPH_ID.clone(),
+        entity_types.into_iter().map(|s| s.to_owned()).collect(),
+    )
+}
+
+fn user_query() -> EntityQuery {
+    query(vec!["User"])
+}
+
 #[test]
 fn find_interface() {
-    test_find(
-        vec!["garfield", "pluto"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["Cat".to_owned(), "Dog".to_owned()],
-            filter: None,
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
-    );
+    test_find(vec!["garfield", "pluto"], query(vec!["Cat", "Dog"]));
 
     test_find(
         vec!["pluto", "garfield"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["Cat".to_owned(), "Dog".to_owned()],
-            filter: None,
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        query(vec!["Cat", "Dog"]).order_by(
+            ("name".to_owned(), ValueType::String),
+            EntityOrder::Descending,
+        ),
     );
 
     test_find(
         vec!["garfield"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["Cat".to_owned(), "Dog".to_owned()],
-            filter: Some(EntityFilter::StartsWith("name".into(), Value::from("Gar"))),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        query(vec!["Cat", "Dog"])
+            .filter(EntityFilter::StartsWith("name".into(), Value::from("Gar")))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     );
 
     // Test that we can order by id
     test_find(
         vec!["pluto", "garfield"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["Cat".to_owned(), "Dog".to_owned()],
-            filter: None,
-            order_by: Some(("id".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        query(vec!["Cat", "Dog"]).order_by(
+            ("id".to_owned(), ValueType::String),
+            EntityOrder::Descending,
+        ),
     );
 
     test_find(
         vec!["garfield", "pluto"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["Cat".to_owned(), "Dog".to_owned()],
-            filter: None,
-            order_by: Some(("id".to_owned(), ValueType::String)),
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        query(vec!["Cat", "Dog"])
+            .order_by(("id".to_owned(), ValueType::String), EntityOrder::Ascending),
     );
 }
 
@@ -610,18 +590,10 @@ fn find_interface() {
 fn find_string_contains() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Contains(
-                "name".into(),
-                "ind".into(),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::Contains(
+            "name".into(),
+            "ind".into(),
+        )])),
     )
 }
 
@@ -629,16 +601,7 @@ fn find_string_contains() {
 fn find_list_contains() {
     fn query(v: Vec<&str>) -> EntityQuery {
         let drinks: Option<Value> = Some(v.into());
-        let filter = Some(EntityFilter::Contains("drinks".into(), drinks.into()));
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter,
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        }
+        user_query().filter(EntityFilter::Contains("drinks".into(), drinks.into()))
     }
 
     test_find(vec!["2"], query(vec!["beer"]));
@@ -653,35 +616,24 @@ fn find_list_contains() {
 fn find_string_equal() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
-                "name".to_owned(),
-                "Cindini".into(),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::Equal(
+            "name".to_owned(),
+            "Cindini".into(),
+        )])),
     );
 
     // Test that we can order by id
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Equal(
                 "name".to_owned(),
                 "Cindini".into(),
-            )])),
-            order_by: Some(("id".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("id".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -689,18 +641,15 @@ fn find_string_equal() {
 fn find_string_not_equal() {
     test_find(
         vec!["1", "3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Not(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Not(
                 "name".to_owned(),
                 "Cindini".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -708,18 +657,10 @@ fn find_string_not_equal() {
 fn find_string_greater_than() {
     test_find(
         vec!["3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
-                "name".to_owned(),
-                "Kundi".into(),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::GreaterThan(
+            "name".to_owned(),
+            "Kundi".into(),
+        )])),
     )
 }
 
@@ -727,18 +668,15 @@ fn find_string_greater_than() {
 fn find_string_less_than_order_by_asc() {
     test_find(
         vec!["2", "1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "name".to_owned(),
                 "Kundi".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -746,18 +684,15 @@ fn find_string_less_than_order_by_asc() {
 fn find_string_less_than_order_by_desc() {
     test_find(
         vec!["1", "2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "name".to_owned(),
                 "Kundi".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -765,21 +700,17 @@ fn find_string_less_than_order_by_desc() {
 fn find_string_less_than_range() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "name".to_owned(),
                 "ZZZ".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange {
-                first: Some(1),
-                skip: 1,
-            },
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .first(1)
+            .skip(1),
     )
 }
 
@@ -787,18 +718,15 @@ fn find_string_less_than_range() {
 fn find_string_multiple_and() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![
+        user_query()
+            .filter(EntityFilter::And(vec![
                 EntityFilter::LessThan("name".to_owned(), "Cz".into()),
                 EntityFilter::Equal("name".to_owned(), "Cindini".into()),
-            ])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            ]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -806,18 +734,15 @@ fn find_string_multiple_and() {
 fn find_string_ends_with() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::EndsWith(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::EndsWith(
                 "name".to_owned(),
                 "ini".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -825,18 +750,15 @@ fn find_string_ends_with() {
 fn find_string_not_ends_with() {
     test_find(
         vec!["3", "1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::NotEndsWith(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::NotEndsWith(
                 "name".to_owned(),
                 "ini".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -844,18 +766,15 @@ fn find_string_not_ends_with() {
 fn find_string_in() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::In(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::In(
                 "name".to_owned(),
                 vec!["Johnton".into(), "Nobody".into(), "Still nobody".into()],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -863,18 +782,15 @@ fn find_string_in() {
 fn find_string_not_in() {
     test_find(
         vec!["1", "2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
                 "name".to_owned(),
                 vec!["Shaqueeena".into()],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -882,18 +798,10 @@ fn find_string_not_in() {
 fn find_float_equal() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
-                "weight".to_owned(),
-                Value::BigDecimal(184.4.into()),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::Equal(
+            "weight".to_owned(),
+            Value::BigDecimal(184.4.into()),
+        )])),
     )
 }
 
@@ -901,18 +809,15 @@ fn find_float_equal() {
 fn find_float_not_equal() {
     test_find(
         vec!["3", "2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Not(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Not(
                 "weight".to_owned(),
                 Value::BigDecimal(184.4.into()),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -920,18 +825,10 @@ fn find_float_not_equal() {
 fn find_float_greater_than() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
-                "weight".to_owned(),
-                Value::BigDecimal(160.0.into()),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::GreaterThan(
+            "weight".to_owned(),
+            Value::BigDecimal(160.0.into()),
+        )])),
     )
 }
 
@@ -939,18 +836,15 @@ fn find_float_greater_than() {
 fn find_float_less_than() {
     test_find(
         vec!["2", "3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::BigDecimal(160.0.into()),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -958,18 +852,15 @@ fn find_float_less_than() {
 fn find_float_less_than_order_by_desc() {
     test_find(
         vec!["3", "2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::BigDecimal(160.0.into()),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -977,21 +868,17 @@ fn find_float_less_than_order_by_desc() {
 fn find_float_less_than_range() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::BigDecimal(161.0.into()),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange {
-                first: Some(1),
-                skip: 1,
-            },
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .first(1)
+            .skip(1),
     )
 }
 
@@ -999,21 +886,19 @@ fn find_float_less_than_range() {
 fn find_float_in() {
     test_find(
         vec!["3", "1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::In(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::In(
                 "weight".to_owned(),
                 vec![
                     Value::BigDecimal(184.4.into()),
                     Value::BigDecimal(111.7.into()),
                 ],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .first(5),
     )
 }
 
@@ -1021,21 +906,19 @@ fn find_float_in() {
 fn find_float_not_in() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
                 "weight".to_owned(),
                 vec![
                     Value::BigDecimal(184.4.into()),
                     Value::BigDecimal(111.7.into()),
                 ],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .first(5),
     )
 }
 
@@ -1043,18 +926,15 @@ fn find_float_not_in() {
 fn find_int_equal() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Equal(
                 "age".to_owned(),
                 Value::Int(67 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1062,18 +942,15 @@ fn find_int_equal() {
 fn find_int_not_equal() {
     test_find(
         vec!["3", "2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Not(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Not(
                 "age".to_owned(),
                 Value::Int(67 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1081,18 +958,10 @@ fn find_int_not_equal() {
 fn find_int_greater_than() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
-                "age".to_owned(),
-                Value::Int(43 as i32),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::GreaterThan(
+            "age".to_owned(),
+            Value::Int(43 as i32),
+        )])),
     )
 }
 
@@ -1100,18 +969,15 @@ fn find_int_greater_than() {
 fn find_int_greater_or_equal() {
     test_find(
         vec!["2", "1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::GreaterOrEqual(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::GreaterOrEqual(
                 "age".to_owned(),
                 Value::Int(43 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -1119,18 +985,15 @@ fn find_int_greater_or_equal() {
 fn find_int_less_than() {
     test_find(
         vec!["2", "3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(50 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -1138,18 +1001,15 @@ fn find_int_less_than() {
 fn find_int_less_or_equal() {
     test_find(
         vec!["2", "3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessOrEqual(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessOrEqual(
                 "age".to_owned(),
                 Value::Int(43 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -1157,18 +1017,15 @@ fn find_int_less_or_equal() {
 fn find_int_less_than_order_by_desc() {
     test_find(
         vec!["3", "2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(50 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1176,21 +1033,17 @@ fn find_int_less_than_order_by_desc() {
 fn find_int_less_than_range() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(67 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange {
-                first: Some(1),
-                skip: 1,
-            },
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .first(1)
+            .skip(1),
     )
 }
 
@@ -1198,18 +1051,16 @@ fn find_int_less_than_range() {
 fn find_int_in() {
     test_find(
         vec!["1", "2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::In(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::In(
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .first(5),
     )
 }
 
@@ -1217,18 +1068,16 @@ fn find_int_in() {
 fn find_int_not_in() {
     test_find(
         vec!["3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .first(5),
     )
 }
 
@@ -1236,18 +1085,15 @@ fn find_int_not_in() {
 fn find_bool_equal() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Equal(
                 "coffee".to_owned(),
                 Value::Bool(true),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1255,18 +1101,15 @@ fn find_bool_equal() {
 fn find_bool_not_equal() {
     test_find(
         vec!["1", "3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Not(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Not(
                 "coffee".to_owned(),
                 Value::Bool(true),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -1274,18 +1117,16 @@ fn find_bool_not_equal() {
 fn find_bool_in() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::In(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::In(
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .first(5),
     )
 }
 
@@ -1293,18 +1134,16 @@ fn find_bool_in() {
 fn find_bool_not_in() {
     test_find(
         vec!["3", "1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .first(5),
     )
 }
 
@@ -1312,18 +1151,15 @@ fn find_bool_not_in() {
 fn find_bytes_equal() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Equal(
                 "bin_name".to_owned(),
                 Value::Bytes("Johnton".as_bytes().into()),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1331,18 +1167,15 @@ fn find_bytes_equal() {
 fn find_null_equal() {
     test_find(
         vec!["3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::Equal(
+        user_query()
+            .filter(EntityFilter::Equal(
                 "favorite_color".to_owned(),
                 Value::Null,
-            )),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            ))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1350,15 +1183,12 @@ fn find_null_equal() {
 fn find_null_not_equal() {
     test_find(
         vec!["1", "2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::Not("favorite_color".to_owned(), Value::Null)),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query()
+            .filter(EntityFilter::Not("favorite_color".to_owned(), Value::Null))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1366,34 +1196,28 @@ fn find_null_not_equal() {
 fn find_null_not_in() {
     test_find(
         vec!["1", "2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::NotIn(
+        user_query()
+            .filter(EntityFilter::NotIn(
                 "favorite_color".to_owned(),
                 vec![Value::Null],
-            )),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            ))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     );
 
     test_find(
         vec!["1", "2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::NotIn(
+        user_query()
+            .filter(EntityFilter::NotIn(
                 "favorite_color".to_owned(),
                 vec!["red".into(), Value::Null],
-            )),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            ))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     );
 }
 
@@ -1401,27 +1225,17 @@ fn find_null_not_in() {
 fn find_order_by_float() {
     test_find(
         vec!["3", "2", "1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: None,
-            order_by: Some(("weight".to_owned(), ValueType::BigDecimal)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(
+            ("weight".to_owned(), ValueType::BigDecimal),
+            EntityOrder::Ascending,
+        ),
     );
     test_find(
         vec!["1", "2", "3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: None,
-            order_by: Some(("weight".to_owned(), ValueType::BigDecimal)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(
+            ("weight".to_owned(), ValueType::BigDecimal),
+            EntityOrder::Descending,
+        ),
     );
 }
 
@@ -1429,27 +1243,11 @@ fn find_order_by_float() {
 fn find_order_by_id() {
     test_find(
         vec!["1", "2", "3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: None,
-            order_by: Some(("id".to_owned(), ValueType::ID)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(("id".to_owned(), ValueType::ID), EntityOrder::Ascending),
     );
     test_find(
         vec!["3", "2", "1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: None,
-            order_by: Some(("id".to_owned(), ValueType::ID)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(("id".to_owned(), ValueType::ID), EntityOrder::Descending),
     );
 }
 
@@ -1457,27 +1255,11 @@ fn find_order_by_id() {
 fn find_order_by_int() {
     test_find(
         vec!["3", "2", "1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: None,
-            order_by: Some(("age".to_owned(), ValueType::Int)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(("age".to_owned(), ValueType::Int), EntityOrder::Ascending),
     );
     test_find(
         vec!["1", "2", "3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: None,
-            order_by: Some(("age".to_owned(), ValueType::Int)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(("age".to_owned(), ValueType::Int), EntityOrder::Descending),
     );
 }
 
@@ -1485,27 +1267,17 @@ fn find_order_by_int() {
 fn find_order_by_string() {
     test_find(
         vec!["2", "1", "3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: None,
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(
+            ("name".to_owned(), ValueType::String),
+            EntityOrder::Ascending,
+        ),
     );
     test_find(
         vec!["3", "1", "2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: None,
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(
+            ("name".to_owned(), ValueType::String),
+            EntityOrder::Descending,
+        ),
     );
 }
 
@@ -1513,18 +1285,12 @@ fn find_order_by_string() {
 fn find_where_nested_and_or() {
     test_find(
         vec!["1", "2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Or(vec![
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Or(vec![
                 EntityFilter::Equal("id".to_owned(), Value::from("1")),
                 EntityFilter::Equal("id".to_owned(), Value::from("2")),
-            ])])),
-            order_by: Some(("id".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            ])]))
+            .order_by(("id".to_owned(), ValueType::String), EntityOrder::Ascending),
     )
 }
 
@@ -1532,18 +1298,15 @@ fn find_where_nested_and_or() {
 fn find_enum_equal() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Equal(
                 "favorite_color".to_owned(),
                 "red".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1551,18 +1314,15 @@ fn find_enum_equal() {
 fn find_enum_not_equal() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Not(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Not(
                 "favorite_color".to_owned(),
                 "red".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -1570,18 +1330,16 @@ fn find_enum_not_equal() {
 fn find_enum_in() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::In(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::In(
                 "favorite_color".to_owned(),
                 vec!["red".into()],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .first(5),
     )
 }
 
@@ -1589,18 +1347,16 @@ fn find_enum_in() {
 fn find_enum_not_in() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
                 "favorite_color".to_owned(),
                 vec!["red".into()],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .first(5),
     )
 }
 
@@ -1631,15 +1387,9 @@ fn text_find(expected_entity_ids: Vec<&str>, filter: EntityFilter) {
         insert_pet(conn, layout, "Ferret", "a2b", &a2b);
         insert_pet(conn, layout, "Ferret", "a3", &a3);
 
-        let query = EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["Ferret".to_owned()],
-            filter: Some(filter),
-            order_by: Some(("id".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        };
+        let query = query(vec!["Ferret"])
+            .filter(filter)
+            .order_by(("id".to_owned(), ValueType::String), EntityOrder::Ascending);
 
         let order = match query.order_by {
             Some((attribute, value_type)) => {
@@ -1799,28 +1549,12 @@ fn find_empty_and_or() {
     // An empty 'or' is 'false'
     test_find(
         vec![],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Or(vec![])])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::Or(vec![])])),
     );
 
     // An empty 'and' is 'true'
     test_find(
         vec!["1", "2", "3"],
-        EntityQuery {
-            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
-            entity_types: vec!["User".to_owned()],
-            filter: Some(EntityFilter::Or(vec![EntityFilter::And(vec![])])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::Or(vec![EntityFilter::And(vec![])])),
     )
 }

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -10,8 +10,8 @@ use std::str::FromStr;
 
 use graph::data::store::scalar::{BigDecimal, BigInt, Bytes};
 use graph::prelude::{
-    bigdecimal::One, web3::types::H256, Entity, EntityFilter, EntityKey, EntityOrder, EntityQuery,
-    EntityRange, Schema, SubgraphDeploymentId, Value, ValueType,
+    bigdecimal::One, web3::types::H256, Entity, EntityCollection, EntityFilter, EntityKey,
+    EntityOrder, EntityQuery, EntityRange, Schema, SubgraphDeploymentId, Value, ValueType,
 };
 use graph_store_postgres::layout_for_tests::{Layout, BLOCK_NUMBER_MAX, STRING_PREFIX_SIZE};
 
@@ -416,17 +416,17 @@ fn count_scalar_entities(conn: &PgConnection, layout: &Layout) -> usize {
         EntityFilter::Equal("bool".into(), true.into()),
         EntityFilter::Equal("bool".into(), false.into()),
     ]);
+    let collection = EntityCollection::All(vec!["Scalar".to_owned()]);
     layout
         .query(
             &conn,
-            vec!["Scalar".to_owned()],
+            collection,
             Some(filter),
             None,
             EntityRange {
                 first: None,
                 skip: 0,
             },
-            None,
             BLOCK_NUMBER_MAX,
         )
         .expect("Count query failed")
@@ -513,11 +513,10 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
         let entities = layout
             .query(
                 conn,
-                query.entity_types,
+                query.collection,
                 query.filter,
                 order,
                 query.range,
-                None,
                 BLOCK_NUMBER_MAX,
             )
             .expect("layout.query failed to execute query");
@@ -540,7 +539,7 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
 fn query(entity_types: Vec<&str>) -> EntityQuery {
     EntityQuery::new(
         THINGS_SUBGRAPH_ID.clone(),
-        entity_types.into_iter().map(|s| s.to_owned()).collect(),
+        EntityCollection::All(entity_types.into_iter().map(|s| s.to_owned()).collect()),
     )
 }
 
@@ -1223,11 +1222,10 @@ fn text_find(expected_entity_ids: Vec<&str>, filter: EntityFilter) {
         let entities = layout
             .query(
                 conn,
-                query.entity_types,
+                query.collection,
                 query.filter,
                 order,
                 query.range,
-                None,
                 BLOCK_NUMBER_MAX,
             )
             .expect("layout.query failed to execute query");

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -546,6 +546,7 @@ fn find_interface() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -558,6 +559,7 @@ fn find_interface() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -570,6 +572,7 @@ fn find_interface() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -583,6 +586,7 @@ fn find_interface() {
             order_by: Some(("id".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -595,6 +599,7 @@ fn find_interface() {
             order_by: Some(("id".to_owned(), ValueType::String)),
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -613,6 +618,7 @@ fn find_string_contains() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -629,6 +635,7 @@ fn find_list_contains() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         }
     }
 
@@ -654,6 +661,7 @@ fn find_string_equal() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -670,6 +678,7 @@ fn find_string_equal() {
             order_by: Some(("id".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -688,6 +697,7 @@ fn find_string_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -706,6 +716,7 @@ fn find_string_greater_than() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -724,6 +735,7 @@ fn find_string_less_than_order_by_asc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -742,6 +754,7 @@ fn find_string_less_than_order_by_desc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -763,6 +776,7 @@ fn find_string_less_than_range() {
                 first: Some(1),
                 skip: 1,
             },
+            window: None,
         },
     )
 }
@@ -781,6 +795,7 @@ fn find_string_multiple_and() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -799,6 +814,7 @@ fn find_string_ends_with() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -817,6 +833,7 @@ fn find_string_not_ends_with() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -835,6 +852,7 @@ fn find_string_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -853,6 +871,7 @@ fn find_string_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -871,6 +890,7 @@ fn find_float_equal() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -889,6 +909,7 @@ fn find_float_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -907,6 +928,7 @@ fn find_float_greater_than() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -925,6 +947,7 @@ fn find_float_less_than() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -943,6 +966,7 @@ fn find_float_less_than_order_by_desc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -964,6 +988,7 @@ fn find_float_less_than_range() {
                 first: Some(1),
                 skip: 1,
             },
+            window: None,
         },
     )
 }
@@ -985,6 +1010,7 @@ fn find_float_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1006,6 +1032,7 @@ fn find_float_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1024,6 +1051,7 @@ fn find_int_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1042,6 +1070,7 @@ fn find_int_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1060,6 +1089,7 @@ fn find_int_greater_than() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1078,6 +1108,7 @@ fn find_int_greater_or_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1096,6 +1127,7 @@ fn find_int_less_than() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1114,6 +1146,7 @@ fn find_int_less_or_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1132,6 +1165,7 @@ fn find_int_less_than_order_by_desc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1153,6 +1187,7 @@ fn find_int_less_than_range() {
                 first: Some(1),
                 skip: 1,
             },
+            window: None,
         },
     )
 }
@@ -1171,6 +1206,7 @@ fn find_int_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1189,6 +1225,7 @@ fn find_int_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1207,6 +1244,7 @@ fn find_bool_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1225,6 +1263,7 @@ fn find_bool_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1243,6 +1282,7 @@ fn find_bool_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1261,6 +1301,7 @@ fn find_bool_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1279,6 +1320,7 @@ fn find_bytes_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1297,6 +1339,7 @@ fn find_null_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1312,6 +1355,7 @@ fn find_null_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1330,6 +1374,7 @@ fn find_null_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -1345,6 +1390,7 @@ fn find_null_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1360,6 +1406,7 @@ fn find_order_by_float() {
             order_by: Some(("weight".to_owned(), ValueType::BigDecimal)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1371,6 +1418,7 @@ fn find_order_by_float() {
             order_by: Some(("weight".to_owned(), ValueType::BigDecimal)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1386,6 +1434,7 @@ fn find_order_by_id() {
             order_by: Some(("id".to_owned(), ValueType::ID)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1397,6 +1446,7 @@ fn find_order_by_id() {
             order_by: Some(("id".to_owned(), ValueType::ID)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1412,6 +1462,7 @@ fn find_order_by_int() {
             order_by: Some(("age".to_owned(), ValueType::Int)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1423,6 +1474,7 @@ fn find_order_by_int() {
             order_by: Some(("age".to_owned(), ValueType::Int)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1438,6 +1490,7 @@ fn find_order_by_string() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1449,6 +1502,7 @@ fn find_order_by_string() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1467,6 +1521,7 @@ fn find_where_nested_and_or() {
             order_by: Some(("id".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1485,6 +1540,7 @@ fn find_enum_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1503,6 +1559,7 @@ fn find_enum_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1521,6 +1578,7 @@ fn find_enum_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1539,6 +1597,7 @@ fn find_enum_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1577,6 +1636,7 @@ fn text_find(expected_entity_ids: Vec<&str>, filter: EntityFilter) {
             order_by: Some(("id".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         };
 
         let order = match query.order_by {
@@ -1743,6 +1803,7 @@ fn find_empty_and_or() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     );
 
@@ -1756,6 +1817,7 @@ fn find_empty_and_or() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -501,13 +501,7 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
 
         let order = match query.order_by {
             Some((attribute, value_type)) => {
-                let direction = query
-                    .order_direction
-                    .map(|direction| match direction {
-                        EntityOrder::Ascending => "ASC",
-                        EntityOrder::Descending => "DESC",
-                    })
-                    .unwrap_or("ASC");
+                let direction = query.order_direction.unwrap_or(EntityOrder::Ascending);
                 Some((attribute, value_type, direction))
             }
             None => None,
@@ -1586,13 +1580,7 @@ fn text_find(expected_entity_ids: Vec<&str>, filter: EntityFilter) {
 
         let order = match query.order_by {
             Some((attribute, value_type)) => {
-                let direction = query
-                    .order_direction
-                    .map(|direction| match direction {
-                        EntityOrder::Ascending => "ASC",
-                        EntityOrder::Descending => "DESC",
-                    })
-                    .unwrap_or("ASC");
+                let direction = query.order_direction.unwrap_or(EntityOrder::Ascending);
                 Some((attribute, value_type, direction))
             }
             None => None,

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -169,14 +169,7 @@ fn insert_user_entity(
             .unwrap_or(Value::Null),
     );
     if let Some(drinks) = drinks {
-        user.insert(
-            "drinks".to_owned(),
-            drinks
-                .into_iter()
-                .map(|drink| drink.into())
-                .collect::<Vec<_>>()
-                .into(),
-        );
+        user.insert("drinks".to_owned(), drinks.into());
     }
 
     insert_entity(conn, layout, entity_type, user);
@@ -632,12 +625,7 @@ fn find_string_contains() {
 #[test]
 fn find_list_contains() {
     fn query(v: Vec<&str>) -> EntityQuery {
-        let drinks: Option<Value> = Some(
-            v.into_iter()
-                .map(|drink| drink.into())
-                .collect::<Vec<_>>()
-                .into(),
-        );
+        let drinks: Option<Value> = Some(v.into());
         let filter = Some(EntityFilter::Contains("drinks".into(), drinks.into()));
         EntityQuery {
             subgraph_id: THINGS_SUBGRAPH_ID.clone(),

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -422,8 +422,10 @@ fn count_scalar_entities(conn: &PgConnection, layout: &Layout) -> usize {
             vec!["Scalar".to_owned()],
             Some(filter),
             None,
-            None,
-            0,
+            EntityRange {
+                first: None,
+                skip: 0,
+            },
             BLOCK_NUMBER_MAX,
         )
         .expect("Count query failed")
@@ -513,8 +515,7 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
                 query.entity_types,
                 query.filter,
                 order,
-                query.range.first,
-                query.range.skip,
+                query.range,
                 BLOCK_NUMBER_MAX,
             )
             .expect("layout.query failed to execute query");
@@ -1592,8 +1593,7 @@ fn text_find(expected_entity_ids: Vec<&str>, filter: EntityFilter) {
                 query.entity_types,
                 query.filter,
                 order,
-                query.range.first,
-                query.range.skip,
+                query.range,
                 BLOCK_NUMBER_MAX,
             )
             .expect("layout.query failed to execute query");

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use test_store::*;
 
-use graph::components::store::{EntityFilter, EntityKey, EntityOrder, EntityQuery, EntityRange};
+use graph::components::store::{EntityFilter, EntityKey, EntityOrder, EntityQuery};
 use graph::data::store::scalar;
 use graph::data::subgraph::schema::*;
 use graph::data::subgraph::*;
@@ -636,10 +636,8 @@ fn find_string_less_than_range() {
         user_query()
             .filter(EntityFilter::LessThan("name".to_owned(), "ZZZ".into()))
             .order_by("name", ValueType::String, EntityOrder::Descending)
-            .range(EntityRange {
-                first: Some(1),
-                skip: 1,
-            }),
+            .first(1)
+            .skip(1),
     )
 }
 
@@ -770,10 +768,8 @@ fn find_float_less_than_range() {
                 Value::BigDecimal(161.0.into()),
             ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
-            .range(EntityRange {
-                first: Some(1),
-                skip: 1,
-            }),
+            .first(1)
+            .skip(1),
     )
 }
 
@@ -790,7 +786,7 @@ fn find_float_in() {
                 ],
             ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
-            .range(EntityRange::first(5)),
+            .first(5),
     )
 }
 
@@ -807,7 +803,7 @@ fn find_float_not_in() {
                 ],
             ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
-            .range(EntityRange::first(5)),
+            .first(5),
     )
 }
 
@@ -904,10 +900,8 @@ fn find_int_less_than_range() {
                 Value::Int(67 as i32),
             ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
-            .range(EntityRange {
-                first: Some(1),
-                skip: 1,
-            }),
+            .first(1)
+            .skip(1),
     )
 }
 
@@ -921,7 +915,7 @@ fn find_int_in() {
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
             ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
-            .range(EntityRange::first(5)),
+            .first(5),
     )
 }
 
@@ -935,7 +929,7 @@ fn find_int_not_in() {
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
             ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
-            .range(EntityRange::first(5)),
+            .first(5),
     )
 }
 
@@ -969,7 +963,7 @@ fn find_bool_in() {
                 vec![Value::Bool(true)],
             ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
-            .range(EntityRange::first(5)),
+            .first(5),
     )
 }
 
@@ -983,7 +977,7 @@ fn find_bool_not_in() {
                 vec![Value::Bool(true)],
             ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
-            .range(EntityRange::first(5)),
+            .first(5),
     )
 }
 
@@ -1955,7 +1949,7 @@ fn handle_large_string_with_index() {
             .expect("Failed to insert large text");
 
         let query = user_query()
-            .range(EntityRange::first(5))
+            .first(5)
             .filter(EntityFilter::Equal(
                 NAME.to_owned(),
                 long_text.clone().into(),
@@ -1976,7 +1970,7 @@ fn handle_large_string_with_index() {
         let mut prefix = long_text.clone();
         prefix.truncate(STRING_PREFIX_SIZE);
         let query = user_query()
-            .range(EntityRange::first(5))
+            .first(5)
             .filter(EntityFilter::LessOrEqual(NAME.to_owned(), prefix.into()))
             .order_by(NAME, ValueType::String, EntityOrder::Ascending);
 
@@ -2003,14 +1997,14 @@ impl WindowQuery {
         WindowQuery(
             user_query()
                 .filter(EntityFilter::GreaterThan("age".into(), Value::from(0)))
-                .range(EntityRange::first(10))
+                .first(10)
                 .window_by("favorite_color".to_owned()),
             store.clone(),
         )
     }
 
     fn first(self, first: u32) -> Self {
-        WindowQuery(self.0.range(EntityRange::first(first)), self.1)
+        WindowQuery(self.0.first(first), self.1)
     }
 
     fn skip(self, skip: u32) -> Self {

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -572,6 +572,7 @@ fn find_string_contains() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -590,6 +591,7 @@ fn find_string_equal() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -608,6 +610,7 @@ fn find_string_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -626,6 +629,7 @@ fn find_string_greater_than() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -644,6 +648,7 @@ fn find_string_less_than_order_by_asc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -662,6 +667,7 @@ fn find_string_less_than_order_by_desc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -683,6 +689,7 @@ fn find_string_less_than_range() {
                 first: Some(1),
                 skip: 1,
             },
+            window: None,
         },
     )
 }
@@ -701,6 +708,7 @@ fn find_string_multiple_and() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -719,6 +727,7 @@ fn find_string_ends_with() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -737,6 +746,7 @@ fn find_string_not_ends_with() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -755,6 +765,7 @@ fn find_string_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -773,6 +784,7 @@ fn find_string_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -791,6 +803,7 @@ fn find_float_equal() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -809,6 +822,7 @@ fn find_float_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -827,6 +841,7 @@ fn find_float_greater_than() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -845,6 +860,7 @@ fn find_float_less_than() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -863,6 +879,7 @@ fn find_float_less_than_order_by_desc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -884,6 +901,7 @@ fn find_float_less_than_range() {
                 first: Some(1),
                 skip: 1,
             },
+            window: None,
         },
     )
 }
@@ -905,6 +923,7 @@ fn find_float_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -926,6 +945,7 @@ fn find_float_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -944,6 +964,7 @@ fn find_int_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -962,6 +983,7 @@ fn find_int_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -980,6 +1002,7 @@ fn find_int_greater_than() {
             order_by: None,
             order_direction: None,
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -998,6 +1021,7 @@ fn find_int_greater_or_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1016,6 +1040,7 @@ fn find_int_less_than() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1034,6 +1059,7 @@ fn find_int_less_or_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1052,6 +1078,7 @@ fn find_int_less_than_order_by_desc() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1073,6 +1100,7 @@ fn find_int_less_than_range() {
                 first: Some(1),
                 skip: 1,
             },
+            window: None,
         },
     )
 }
@@ -1091,6 +1119,7 @@ fn find_int_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1109,6 +1138,7 @@ fn find_int_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1127,6 +1157,7 @@ fn find_bool_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1145,6 +1176,7 @@ fn find_bool_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1163,6 +1195,7 @@ fn find_bool_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1181,6 +1214,7 @@ fn find_bool_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(5),
+            window: None,
         },
     )
 }
@@ -1199,6 +1233,7 @@ fn find_bytes_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1217,6 +1252,7 @@ fn find_null_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1232,6 +1268,7 @@ fn find_null_not_equal() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1250,6 +1287,7 @@ fn find_null_not_in() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1265,6 +1303,7 @@ fn find_order_by_float() {
             order_by: Some(("weight".to_owned(), ValueType::BigDecimal)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1276,6 +1315,7 @@ fn find_order_by_float() {
             order_by: Some(("weight".to_owned(), ValueType::BigDecimal)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1291,6 +1331,7 @@ fn find_order_by_id() {
             order_by: Some(("id".to_owned(), ValueType::ID)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1302,6 +1343,7 @@ fn find_order_by_id() {
             order_by: Some(("id".to_owned(), ValueType::ID)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1317,6 +1359,7 @@ fn find_order_by_int() {
             order_by: Some(("age".to_owned(), ValueType::Int)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1328,6 +1371,7 @@ fn find_order_by_int() {
             order_by: Some(("age".to_owned(), ValueType::Int)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1343,6 +1387,7 @@ fn find_order_by_string() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
     test_find(
@@ -1354,6 +1399,7 @@ fn find_order_by_string() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         },
     );
 }
@@ -1372,6 +1418,7 @@ fn find_where_nested_and_or() {
             order_by: Some(("id".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Ascending),
             range: EntityRange::first(100),
+            window: None,
         },
     )
 }
@@ -1497,6 +1544,7 @@ fn check_basic_revert(
         order_by: Some(("name".to_owned(), ValueType::String)),
         order_direction: Some(EntityOrder::Descending),
         range: EntityRange::first(100),
+        window: None,
     };
 
     let subscription = subscribe_and_consume(store.clone(), subgraph_id, entity_type);
@@ -1569,6 +1617,7 @@ fn revert_block_with_delete() {
             order_by: Some(("name".to_owned(), ValueType::String)),
             order_direction: Some(EntityOrder::Descending),
             range: EntityRange::first(100),
+            window: None,
         };
 
         // Delete entity with id=2

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -571,22 +571,18 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
     })
 }
 
+fn user_query() -> EntityQuery {
+    EntityQuery::new(TEST_SUBGRAPH_ID.clone(), vec![USER.to_owned()])
+}
+
 #[test]
 fn find_string_contains() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Contains(
-                "name".into(),
-                "ind".into(),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::Contains(
+            "name".into(),
+            "ind".into(),
+        )])),
     )
 }
 
@@ -594,18 +590,10 @@ fn find_string_contains() {
 fn find_string_equal() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
-                "name".to_owned(),
-                "Cindini".into(),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::Equal(
+            "name".to_owned(),
+            "Cindini".into(),
+        )])),
     )
 }
 
@@ -613,18 +601,15 @@ fn find_string_equal() {
 fn find_string_not_equal() {
     test_find(
         vec!["1", "3"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Not(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Not(
                 "name".to_owned(),
                 "Cindini".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -632,18 +617,10 @@ fn find_string_not_equal() {
 fn find_string_greater_than() {
     test_find(
         vec!["3"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
-                "name".to_owned(),
-                "Kundi".into(),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::GreaterThan(
+            "name".to_owned(),
+            "Kundi".into(),
+        )])),
     )
 }
 
@@ -651,18 +628,15 @@ fn find_string_greater_than() {
 fn find_string_less_than_order_by_asc() {
     test_find(
         vec!["2", "1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "name".to_owned(),
                 "Kundi".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -670,18 +644,15 @@ fn find_string_less_than_order_by_asc() {
 fn find_string_less_than_order_by_desc() {
     test_find(
         vec!["1", "2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "name".to_owned(),
                 "Kundi".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -689,21 +660,19 @@ fn find_string_less_than_order_by_desc() {
 fn find_string_less_than_range() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "name".to_owned(),
                 "ZZZ".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange {
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .range(EntityRange {
                 first: Some(1),
                 skip: 1,
-            },
-            window: None,
-        },
+            }),
     )
 }
 
@@ -711,18 +680,15 @@ fn find_string_less_than_range() {
 fn find_string_multiple_and() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![
+        user_query()
+            .filter(EntityFilter::And(vec![
                 EntityFilter::LessThan("name".to_owned(), "Cz".into()),
                 EntityFilter::Equal("name".to_owned(), "Cindini".into()),
-            ])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            ]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -730,18 +696,15 @@ fn find_string_multiple_and() {
 fn find_string_ends_with() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::EndsWith(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::EndsWith(
                 "name".to_owned(),
                 "ini".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -749,18 +712,15 @@ fn find_string_ends_with() {
 fn find_string_not_ends_with() {
     test_find(
         vec!["3", "1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::NotEndsWith(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::NotEndsWith(
                 "name".to_owned(),
                 "ini".into(),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -768,18 +728,15 @@ fn find_string_not_ends_with() {
 fn find_string_in() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::In(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::In(
                 "name".to_owned(),
                 vec!["Johnton".into()],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -787,18 +744,15 @@ fn find_string_in() {
 fn find_string_not_in() {
     test_find(
         vec!["1", "2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
                 "name".to_owned(),
                 vec!["Shaqueeena".into()],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -806,18 +760,10 @@ fn find_string_not_in() {
 fn find_float_equal() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
-                "weight".to_owned(),
-                Value::BigDecimal(184.4.into()),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::Equal(
+            "weight".to_owned(),
+            Value::BigDecimal(184.4.into()),
+        )])),
     )
 }
 
@@ -825,18 +771,15 @@ fn find_float_equal() {
 fn find_float_not_equal() {
     test_find(
         vec!["3", "2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Not(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Not(
                 "weight".to_owned(),
                 Value::BigDecimal(184.4.into()),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -844,18 +787,10 @@ fn find_float_not_equal() {
 fn find_float_greater_than() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
-                "weight".to_owned(),
-                Value::BigDecimal(160.0.into()),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::GreaterThan(
+            "weight".to_owned(),
+            Value::BigDecimal(160.0.into()),
+        )])),
     )
 }
 
@@ -863,18 +798,15 @@ fn find_float_greater_than() {
 fn find_float_less_than() {
     test_find(
         vec!["2", "3"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::BigDecimal(160.0.into()),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -882,18 +814,15 @@ fn find_float_less_than() {
 fn find_float_less_than_order_by_desc() {
     test_find(
         vec!["3", "2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::BigDecimal(160.0.into()),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -901,21 +830,19 @@ fn find_float_less_than_order_by_desc() {
 fn find_float_less_than_range() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::BigDecimal(161.0.into()),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange {
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .range(EntityRange {
                 first: Some(1),
                 skip: 1,
-            },
-            window: None,
-        },
+            }),
     )
 }
 
@@ -923,21 +850,19 @@ fn find_float_less_than_range() {
 fn find_float_in() {
     test_find(
         vec!["3", "1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::In(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::In(
                 "weight".to_owned(),
                 vec![
                     Value::BigDecimal(184.4.into()),
                     Value::BigDecimal(111.7.into()),
                 ],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .range(EntityRange::first(5)),
     )
 }
 
@@ -945,21 +870,19 @@ fn find_float_in() {
 fn find_float_not_in() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
                 "weight".to_owned(),
                 vec![
                     Value::BigDecimal(184.4.into()),
                     Value::BigDecimal(111.7.into()),
                 ],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .range(EntityRange::first(5)),
     )
 }
 
@@ -967,18 +890,15 @@ fn find_float_not_in() {
 fn find_int_equal() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Equal(
                 "age".to_owned(),
                 Value::Int(67 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -986,18 +906,15 @@ fn find_int_equal() {
 fn find_int_not_equal() {
     test_find(
         vec!["3", "2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Not(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Not(
                 "age".to_owned(),
                 Value::Int(67 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1005,18 +922,10 @@ fn find_int_not_equal() {
 fn find_int_greater_than() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::GreaterThan(
-                "age".to_owned(),
-                Value::Int(43 as i32),
-            )])),
-            order_by: None,
-            order_direction: None,
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().filter(EntityFilter::And(vec![EntityFilter::GreaterThan(
+            "age".to_owned(),
+            Value::Int(43 as i32),
+        )])),
     )
 }
 
@@ -1024,18 +933,15 @@ fn find_int_greater_than() {
 fn find_int_greater_or_equal() {
     test_find(
         vec!["2", "1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::GreaterOrEqual(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::GreaterOrEqual(
                 "age".to_owned(),
                 Value::Int(43 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -1043,18 +949,15 @@ fn find_int_greater_or_equal() {
 fn find_int_less_than() {
     test_find(
         vec!["2", "3"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(50 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -1062,18 +965,15 @@ fn find_int_less_than() {
 fn find_int_less_or_equal() {
     test_find(
         vec!["2", "3"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessOrEqual(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessOrEqual(
                 "age".to_owned(),
                 Value::Int(43 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -1081,18 +981,15 @@ fn find_int_less_or_equal() {
 fn find_int_less_than_order_by_desc() {
     test_find(
         vec!["3", "2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(50 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1100,21 +997,19 @@ fn find_int_less_than_order_by_desc() {
 fn find_int_less_than_range() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::LessThan(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(67 as i32),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange {
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .range(EntityRange {
                 first: Some(1),
                 skip: 1,
-            },
-            window: None,
-        },
+            }),
     )
 }
 
@@ -1122,18 +1017,16 @@ fn find_int_less_than_range() {
 fn find_int_in() {
     test_find(
         vec!["1", "2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::In(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::In(
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .range(EntityRange::first(5)),
     )
 }
 
@@ -1141,18 +1034,16 @@ fn find_int_in() {
 fn find_int_not_in() {
     test_find(
         vec!["3"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .range(EntityRange::first(5)),
     )
 }
 
@@ -1160,18 +1051,15 @@ fn find_int_not_in() {
 fn find_bool_equal() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Equal(
                 "coffee".to_owned(),
                 Value::Bool(true),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1179,18 +1067,15 @@ fn find_bool_equal() {
 fn find_bool_not_equal() {
     test_find(
         vec!["1", "3"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Not(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Not(
                 "coffee".to_owned(),
                 Value::Bool(true),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Ascending,
+            ),
     )
 }
 
@@ -1198,18 +1083,16 @@ fn find_bool_not_equal() {
 fn find_bool_in() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::In(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::In(
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .range(EntityRange::first(5)),
     )
 }
 
@@ -1217,18 +1100,16 @@ fn find_bool_in() {
 fn find_bool_not_in() {
     test_find(
         vec!["3", "1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::NotIn(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(5),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            )
+            .range(EntityRange::first(5)),
     )
 }
 
@@ -1236,18 +1117,15 @@ fn find_bool_not_in() {
 fn find_bytes_equal() {
     test_find(
         vec!["1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Equal(
                 "bin_name".to_owned(),
                 Value::Bytes("Johnton".as_bytes().into()),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1255,18 +1133,15 @@ fn find_bytes_equal() {
 fn find_null_equal() {
     test_find(
         vec!["3", "1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::Equal(
+        user_query()
+            .filter(EntityFilter::Equal(
                 "favorite_color".to_owned(),
                 Value::Null,
-            )),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            ))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1274,15 +1149,12 @@ fn find_null_equal() {
 fn find_null_not_equal() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::Not("favorite_color".to_owned(), Value::Null)),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query()
+            .filter(EntityFilter::Not("favorite_color".to_owned(), Value::Null))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1290,18 +1162,15 @@ fn find_null_not_equal() {
 fn find_null_not_in() {
     test_find(
         vec!["2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::NotIn(
+        user_query()
+            .filter(EntityFilter::NotIn(
                 "favorite_color".to_owned(),
                 vec![Value::Null],
-            )),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            ))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            ),
     )
 }
 
@@ -1309,27 +1178,17 @@ fn find_null_not_in() {
 fn find_order_by_float() {
     test_find(
         vec!["3", "2", "1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: None,
-            order_by: Some(("weight".to_owned(), ValueType::BigDecimal)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(
+            ("weight".to_owned(), ValueType::BigDecimal),
+            EntityOrder::Ascending,
+        ),
     );
     test_find(
         vec!["1", "2", "3"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: None,
-            order_by: Some(("weight".to_owned(), ValueType::BigDecimal)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(
+            ("weight".to_owned(), ValueType::BigDecimal),
+            EntityOrder::Descending,
+        ),
     );
 }
 
@@ -1337,27 +1196,11 @@ fn find_order_by_float() {
 fn find_order_by_id() {
     test_find(
         vec!["1", "2", "3"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: None,
-            order_by: Some(("id".to_owned(), ValueType::ID)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(("id".to_owned(), ValueType::ID), EntityOrder::Ascending),
     );
     test_find(
         vec!["3", "2", "1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: None,
-            order_by: Some(("id".to_owned(), ValueType::ID)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(("id".to_owned(), ValueType::ID), EntityOrder::Descending),
     );
 }
 
@@ -1365,27 +1208,11 @@ fn find_order_by_id() {
 fn find_order_by_int() {
     test_find(
         vec!["3", "2", "1"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: None,
-            order_by: Some(("age".to_owned(), ValueType::Int)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(("age".to_owned(), ValueType::Int), EntityOrder::Ascending),
     );
     test_find(
         vec!["1", "2", "3"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: None,
-            order_by: Some(("age".to_owned(), ValueType::Int)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(("age".to_owned(), ValueType::Int), EntityOrder::Descending),
     );
 }
 
@@ -1393,27 +1220,17 @@ fn find_order_by_int() {
 fn find_order_by_string() {
     test_find(
         vec!["2", "1", "3"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: None,
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(
+            ("name".to_owned(), ValueType::String),
+            EntityOrder::Ascending,
+        ),
     );
     test_find(
         vec!["3", "1", "2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: None,
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+        user_query().order_by(
+            ("name".to_owned(), ValueType::String),
+            EntityOrder::Descending,
+        ),
     );
 }
 
@@ -1421,18 +1238,12 @@ fn find_order_by_string() {
 fn find_where_nested_and_or() {
     test_find(
         vec!["1", "2"],
-        EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Or(vec![
+        user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Or(vec![
                 EntityFilter::Equal("id".to_owned(), Value::from("1")),
                 EntityFilter::Equal("id".to_owned(), Value::from("2")),
-            ])])),
-            order_by: Some(("id".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Ascending),
-            range: EntityRange::first(100),
-            window: None,
-        },
+            ])]))
+            .order_by(("id".to_owned(), ValueType::String), EntityOrder::Ascending),
     )
 }
 
@@ -1547,18 +1358,15 @@ fn check_basic_revert(
     subgraph_id: &SubgraphDeploymentId,
     entity_type: &str,
 ) -> impl Future<Item = (), Error = tokio_timer::timeout::Error<()>> {
-    let this_query = EntityQuery {
-        subgraph_id: TEST_SUBGRAPH_ID.clone(),
-        entity_types: vec![USER.to_owned()],
-        filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
+    let this_query = user_query()
+        .filter(EntityFilter::And(vec![EntityFilter::Equal(
             "name".to_owned(),
             Value::String("Shaqueeena".to_owned()),
-        )])),
-        order_by: Some(("name".to_owned(), ValueType::String)),
-        order_direction: Some(EntityOrder::Descending),
-        range: EntityRange::first(100),
-        window: None,
-    };
+        )]))
+        .order_by(
+            ("name".to_owned(), ValueType::String),
+            EntityOrder::Descending,
+        );
 
     let subscription = subscribe_and_consume(store.clone(), subgraph_id, entity_type);
 
@@ -1620,18 +1428,15 @@ fn revert_block_basic_subgraphs() {
 #[test]
 fn revert_block_with_delete() {
     run_test(|store| {
-        let this_query = EntityQuery {
-            subgraph_id: TEST_SUBGRAPH_ID.clone(),
-            entity_types: vec![USER.to_owned()],
-            filter: Some(EntityFilter::And(vec![EntityFilter::Equal(
+        let this_query = user_query()
+            .filter(EntityFilter::And(vec![EntityFilter::Equal(
                 "name".to_owned(),
                 Value::String("Cindini".to_owned()),
-            )])),
-            order_by: Some(("name".to_owned(), ValueType::String)),
-            order_direction: Some(EntityOrder::Descending),
-            range: EntityRange::first(100),
-            window: None,
-        };
+            )]))
+            .order_by(
+                ("name".to_owned(), ValueType::String),
+                EntityOrder::Descending,
+            );
 
         // Delete entity with id=2
         let del_key = EntityKey {
@@ -2305,16 +2110,13 @@ fn handle_large_string_with_index() {
             )
             .expect("Failed to insert large text");
 
-        let query = EntityQuery::new(
-            TEST_SUBGRAPH_ID.clone(),
-            vec![USER.to_owned()],
-            EntityRange::first(5),
-        )
-        .filter(EntityFilter::Equal(
-            NAME.to_owned(),
-            long_text.clone().into(),
-        ))
-        .order_by((NAME.to_owned(), ValueType::String), EntityOrder::Ascending);
+        let query = user_query()
+            .range(EntityRange::first(5))
+            .filter(EntityFilter::Equal(
+                NAME.to_owned(),
+                long_text.clone().into(),
+            ))
+            .order_by((NAME.to_owned(), ValueType::String), EntityOrder::Ascending);
 
         let ids = store
             .find(query)
@@ -2329,13 +2131,10 @@ fn handle_large_string_with_index() {
         // Make sure we check the full string and not just a prefix
         let mut prefix = long_text.clone();
         prefix.truncate(STRING_PREFIX_SIZE);
-        let query = EntityQuery::new(
-            TEST_SUBGRAPH_ID.clone(),
-            vec![USER.to_owned()],
-            EntityRange::first(5),
-        )
-        .filter(EntityFilter::LessOrEqual(NAME.to_owned(), prefix.into()))
-        .order_by((NAME.to_owned(), ValueType::String), EntityOrder::Ascending);
+        let query = user_query()
+            .range(EntityRange::first(5))
+            .filter(EntityFilter::LessOrEqual(NAME.to_owned(), prefix.into()))
+            .order_by((NAME.to_owned(), ValueType::String), EntityOrder::Ascending);
 
         let ids = store
             .find(query)
@@ -2358,71 +2157,41 @@ struct WindowQuery(EntityQuery, Arc<DieselStore>);
 impl WindowQuery {
     fn new(store: &Arc<DieselStore>) -> Self {
         WindowQuery(
-            EntityQuery {
-                subgraph_id: TEST_SUBGRAPH_ID.clone(),
-                entity_types: vec![USER.to_owned()],
-                filter: Some(EntityFilter::GreaterThan("age".into(), Value::from(0))),
-                order_by: None,
-                order_direction: None,
-                range: EntityRange::first(10),
-                window: Some("favorite_color".to_owned()),
-            },
+            user_query()
+                .filter(EntityFilter::GreaterThan("age".into(), Value::from(0)))
+                .range(EntityRange::first(10))
+                .window_by("favorite_color".to_owned()),
             store.clone(),
         )
     }
 
     fn first(self, first: u32) -> Self {
-        WindowQuery(
-            EntityQuery {
-                range: EntityRange::first(first),
-                ..self.0
-            },
-            self.1,
-        )
+        WindowQuery(self.0.range(EntityRange::first(first)), self.1)
     }
 
     fn skip(self, skip: u32) -> Self {
-        WindowQuery(
-            EntityQuery {
-                range: EntityRange {
-                    first: self.0.range.first,
-                    skip,
-                },
-                ..self.0
-            },
-            self.1,
-        )
+        WindowQuery(self.0.skip(skip), self.1)
     }
 
     fn order(self, attr: &str, dir: EntityOrder) -> Self {
         WindowQuery(
-            EntityQuery {
-                order_by: Some((attr.to_owned(), ValueType::String)),
-                order_direction: Some(dir),
-                ..self.0
-            },
+            self.0.order_by((attr.to_owned(), ValueType::String), dir),
             self.1,
         )
     }
 
     fn above(self, age: i32) -> Self {
         WindowQuery(
-            EntityQuery {
-                filter: Some(EntityFilter::GreaterThan("age".into(), Value::from(age))),
-                ..self.0
-            },
+            self.0
+                .filter(EntityFilter::GreaterThan("age".into(), Value::from(age))),
             self.1,
         )
     }
 
     fn against_color_and_age(self) -> Self {
-        WindowQuery(
-            EntityQuery {
-                entity_types: vec![USER.to_owned(), "Person".to_owned()],
-                ..self.0
-            },
-            self.1,
-        )
+        let mut query = self.0;
+        query.entity_types = vec![USER.to_owned(), "Person".to_owned()];
+        WindowQuery(query, self.1)
     }
 
     fn expect(&self, expected_ids: Vec<&str>, qid: &str) {

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -579,10 +579,7 @@ fn user_query() -> EntityQuery {
 fn find_string_contains() {
     test_find(
         vec!["2"],
-        user_query().filter(EntityFilter::And(vec![EntityFilter::Contains(
-            "name".into(),
-            "ind".into(),
-        )])),
+        user_query().filter(EntityFilter::Contains("name".into(), "ind".into())),
     )
 }
 
@@ -590,10 +587,7 @@ fn find_string_contains() {
 fn find_string_equal() {
     test_find(
         vec!["2"],
-        user_query().filter(EntityFilter::And(vec![EntityFilter::Equal(
-            "name".to_owned(),
-            "Cindini".into(),
-        )])),
+        user_query().filter(EntityFilter::Equal("name".to_owned(), "Cindini".into())),
     )
 }
 
@@ -602,10 +596,7 @@ fn find_string_not_equal() {
     test_find(
         vec!["1", "3"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Not(
-                "name".to_owned(),
-                "Cindini".into(),
-            )]))
+            .filter(EntityFilter::Not("name".to_owned(), "Cindini".into()))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -614,10 +605,7 @@ fn find_string_not_equal() {
 fn find_string_greater_than() {
     test_find(
         vec!["3"],
-        user_query().filter(EntityFilter::And(vec![EntityFilter::GreaterThan(
-            "name".to_owned(),
-            "Kundi".into(),
-        )])),
+        user_query().filter(EntityFilter::GreaterThan("name".to_owned(), "Kundi".into())),
     )
 }
 
@@ -626,10 +614,7 @@ fn find_string_less_than_order_by_asc() {
     test_find(
         vec!["2", "1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
-                "name".to_owned(),
-                "Kundi".into(),
-            )]))
+            .filter(EntityFilter::LessThan("name".to_owned(), "Kundi".into()))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -639,10 +624,7 @@ fn find_string_less_than_order_by_desc() {
     test_find(
         vec!["1", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
-                "name".to_owned(),
-                "Kundi".into(),
-            )]))
+            .filter(EntityFilter::LessThan("name".to_owned(), "Kundi".into()))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -652,10 +634,7 @@ fn find_string_less_than_range() {
     test_find(
         vec!["1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
-                "name".to_owned(),
-                "ZZZ".into(),
-            )]))
+            .filter(EntityFilter::LessThan("name".to_owned(), "ZZZ".into()))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange {
                 first: Some(1),
@@ -682,10 +661,7 @@ fn find_string_ends_with() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::EndsWith(
-                "name".to_owned(),
-                "ini".into(),
-            )]))
+            .filter(EntityFilter::EndsWith("name".to_owned(), "ini".into()))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -695,10 +671,7 @@ fn find_string_not_ends_with() {
     test_find(
         vec!["3", "1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::NotEndsWith(
-                "name".to_owned(),
-                "ini".into(),
-            )]))
+            .filter(EntityFilter::NotEndsWith("name".to_owned(), "ini".into()))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -708,10 +681,7 @@ fn find_string_in() {
     test_find(
         vec!["1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::In(
-                "name".to_owned(),
-                vec!["Johnton".into()],
-            )]))
+            .filter(EntityFilter::In("name".to_owned(), vec!["Johnton".into()]))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -721,10 +691,10 @@ fn find_string_not_in() {
     test_find(
         vec!["1", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
+            .filter(EntityFilter::NotIn(
                 "name".to_owned(),
                 vec!["Shaqueeena".into()],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -733,10 +703,10 @@ fn find_string_not_in() {
 fn find_float_equal() {
     test_find(
         vec!["1"],
-        user_query().filter(EntityFilter::And(vec![EntityFilter::Equal(
+        user_query().filter(EntityFilter::Equal(
             "weight".to_owned(),
             Value::BigDecimal(184.4.into()),
-        )])),
+        )),
     )
 }
 
@@ -745,10 +715,10 @@ fn find_float_not_equal() {
     test_find(
         vec!["3", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Not(
+            .filter(EntityFilter::Not(
                 "weight".to_owned(),
                 Value::BigDecimal(184.4.into()),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -757,10 +727,10 @@ fn find_float_not_equal() {
 fn find_float_greater_than() {
     test_find(
         vec!["1"],
-        user_query().filter(EntityFilter::And(vec![EntityFilter::GreaterThan(
+        user_query().filter(EntityFilter::GreaterThan(
             "weight".to_owned(),
             Value::BigDecimal(160.0.into()),
-        )])),
+        )),
     )
 }
 
@@ -769,10 +739,10 @@ fn find_float_less_than() {
     test_find(
         vec!["2", "3"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
+            .filter(EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::BigDecimal(160.0.into()),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -782,10 +752,10 @@ fn find_float_less_than_order_by_desc() {
     test_find(
         vec!["3", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
+            .filter(EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::BigDecimal(160.0.into()),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -795,10 +765,10 @@ fn find_float_less_than_range() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
+            .filter(EntityFilter::LessThan(
                 "weight".to_owned(),
                 Value::BigDecimal(161.0.into()),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange {
                 first: Some(1),
@@ -812,13 +782,13 @@ fn find_float_in() {
     test_find(
         vec!["3", "1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::In(
+            .filter(EntityFilter::In(
                 "weight".to_owned(),
                 vec![
                     Value::BigDecimal(184.4.into()),
                     Value::BigDecimal(111.7.into()),
                 ],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange::first(5)),
     )
@@ -829,13 +799,13 @@ fn find_float_not_in() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
+            .filter(EntityFilter::NotIn(
                 "weight".to_owned(),
                 vec![
                     Value::BigDecimal(184.4.into()),
                     Value::BigDecimal(111.7.into()),
                 ],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange::first(5)),
     )
@@ -846,10 +816,7 @@ fn find_int_equal() {
     test_find(
         vec!["1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Equal(
-                "age".to_owned(),
-                Value::Int(67 as i32),
-            )]))
+            .filter(EntityFilter::Equal("age".to_owned(), Value::Int(67 as i32)))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -859,10 +826,7 @@ fn find_int_not_equal() {
     test_find(
         vec!["3", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Not(
-                "age".to_owned(),
-                Value::Int(67 as i32),
-            )]))
+            .filter(EntityFilter::Not("age".to_owned(), Value::Int(67 as i32)))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -871,10 +835,10 @@ fn find_int_not_equal() {
 fn find_int_greater_than() {
     test_find(
         vec!["1"],
-        user_query().filter(EntityFilter::And(vec![EntityFilter::GreaterThan(
+        user_query().filter(EntityFilter::GreaterThan(
             "age".to_owned(),
             Value::Int(43 as i32),
-        )])),
+        )),
     )
 }
 
@@ -883,10 +847,10 @@ fn find_int_greater_or_equal() {
     test_find(
         vec!["2", "1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::GreaterOrEqual(
+            .filter(EntityFilter::GreaterOrEqual(
                 "age".to_owned(),
                 Value::Int(43 as i32),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -896,10 +860,10 @@ fn find_int_less_than() {
     test_find(
         vec!["2", "3"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
+            .filter(EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(50 as i32),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -909,10 +873,10 @@ fn find_int_less_or_equal() {
     test_find(
         vec!["2", "3"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessOrEqual(
+            .filter(EntityFilter::LessOrEqual(
                 "age".to_owned(),
                 Value::Int(43 as i32),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -922,10 +886,10 @@ fn find_int_less_than_order_by_desc() {
     test_find(
         vec!["3", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
+            .filter(EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(50 as i32),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -935,10 +899,10 @@ fn find_int_less_than_range() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::LessThan(
+            .filter(EntityFilter::LessThan(
                 "age".to_owned(),
                 Value::Int(67 as i32),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange {
                 first: Some(1),
@@ -952,10 +916,10 @@ fn find_int_in() {
     test_find(
         vec!["1", "2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::In(
+            .filter(EntityFilter::In(
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange::first(5)),
     )
@@ -966,10 +930,10 @@ fn find_int_not_in() {
     test_find(
         vec!["3"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
+            .filter(EntityFilter::NotIn(
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange::first(5)),
     )
@@ -980,10 +944,7 @@ fn find_bool_equal() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Equal(
-                "coffee".to_owned(),
-                Value::Bool(true),
-            )]))
+            .filter(EntityFilter::Equal("coffee".to_owned(), Value::Bool(true)))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -993,10 +954,7 @@ fn find_bool_not_equal() {
     test_find(
         vec!["1", "3"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Not(
-                "coffee".to_owned(),
-                Value::Bool(true),
-            )]))
+            .filter(EntityFilter::Not("coffee".to_owned(), Value::Bool(true)))
             .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
@@ -1006,10 +964,10 @@ fn find_bool_in() {
     test_find(
         vec!["2"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::In(
+            .filter(EntityFilter::In(
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange::first(5)),
     )
@@ -1020,10 +978,10 @@ fn find_bool_not_in() {
     test_find(
         vec!["3", "1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::NotIn(
+            .filter(EntityFilter::NotIn(
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange::first(5)),
     )
@@ -1034,10 +992,10 @@ fn find_bytes_equal() {
     test_find(
         vec!["1"],
         user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Equal(
+            .filter(EntityFilter::Equal(
                 "bin_name".to_owned(),
                 Value::Bytes("Johnton".as_bytes().into()),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
@@ -1251,10 +1209,10 @@ fn check_basic_revert(
     entity_type: &str,
 ) -> impl Future<Item = (), Error = tokio_timer::timeout::Error<()>> {
     let this_query = user_query()
-        .filter(EntityFilter::And(vec![EntityFilter::Equal(
+        .filter(EntityFilter::Equal(
             "name".to_owned(),
             Value::String("Shaqueeena".to_owned()),
-        )]))
+        ))
         .order_by("name", ValueType::String, EntityOrder::Descending);
 
     let subscription = subscribe_and_consume(store.clone(), subgraph_id, entity_type);
@@ -1318,10 +1276,10 @@ fn revert_block_basic_subgraphs() {
 fn revert_block_with_delete() {
     run_test(|store| {
         let this_query = user_query()
-            .filter(EntityFilter::And(vec![EntityFilter::Equal(
+            .filter(EntityFilter::Equal(
                 "name".to_owned(),
                 Value::String("Cindini".to_owned()),
-            )]))
+            ))
             .order_by("name", ValueType::String, EntityOrder::Descending);
 
         // Delete entity with id=2

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -606,10 +606,7 @@ fn find_string_not_equal() {
                 "name".to_owned(),
                 "Cindini".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -633,10 +630,7 @@ fn find_string_less_than_order_by_asc() {
                 "name".to_owned(),
                 "Kundi".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -649,10 +643,7 @@ fn find_string_less_than_order_by_desc() {
                 "name".to_owned(),
                 "Kundi".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -665,10 +656,7 @@ fn find_string_less_than_range() {
                 "name".to_owned(),
                 "ZZZ".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange {
                 first: Some(1),
                 skip: 1,
@@ -685,10 +673,7 @@ fn find_string_multiple_and() {
                 EntityFilter::LessThan("name".to_owned(), "Cz".into()),
                 EntityFilter::Equal("name".to_owned(), "Cindini".into()),
             ]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -701,10 +686,7 @@ fn find_string_ends_with() {
                 "name".to_owned(),
                 "ini".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -717,10 +699,7 @@ fn find_string_not_ends_with() {
                 "name".to_owned(),
                 "ini".into(),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -733,10 +712,7 @@ fn find_string_in() {
                 "name".to_owned(),
                 vec!["Johnton".into()],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -749,10 +725,7 @@ fn find_string_not_in() {
                 "name".to_owned(),
                 vec!["Shaqueeena".into()],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -776,10 +749,7 @@ fn find_float_not_equal() {
                 "weight".to_owned(),
                 Value::BigDecimal(184.4.into()),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -803,10 +773,7 @@ fn find_float_less_than() {
                 "weight".to_owned(),
                 Value::BigDecimal(160.0.into()),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -819,10 +786,7 @@ fn find_float_less_than_order_by_desc() {
                 "weight".to_owned(),
                 Value::BigDecimal(160.0.into()),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -835,10 +799,7 @@ fn find_float_less_than_range() {
                 "weight".to_owned(),
                 Value::BigDecimal(161.0.into()),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange {
                 first: Some(1),
                 skip: 1,
@@ -858,10 +819,7 @@ fn find_float_in() {
                     Value::BigDecimal(111.7.into()),
                 ],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange::first(5)),
     )
 }
@@ -878,10 +836,7 @@ fn find_float_not_in() {
                     Value::BigDecimal(111.7.into()),
                 ],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange::first(5)),
     )
 }
@@ -895,10 +850,7 @@ fn find_int_equal() {
                 "age".to_owned(),
                 Value::Int(67 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -911,10 +863,7 @@ fn find_int_not_equal() {
                 "age".to_owned(),
                 Value::Int(67 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -938,10 +887,7 @@ fn find_int_greater_or_equal() {
                 "age".to_owned(),
                 Value::Int(43 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -954,10 +900,7 @@ fn find_int_less_than() {
                 "age".to_owned(),
                 Value::Int(50 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -970,10 +913,7 @@ fn find_int_less_or_equal() {
                 "age".to_owned(),
                 Value::Int(43 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -986,10 +926,7 @@ fn find_int_less_than_order_by_desc() {
                 "age".to_owned(),
                 Value::Int(50 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -1002,10 +939,7 @@ fn find_int_less_than_range() {
                 "age".to_owned(),
                 Value::Int(67 as i32),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange {
                 first: Some(1),
                 skip: 1,
@@ -1022,10 +956,7 @@ fn find_int_in() {
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange::first(5)),
     )
 }
@@ -1039,10 +970,7 @@ fn find_int_not_in() {
                 "age".to_owned(),
                 vec![Value::Int(67 as i32), Value::Int(43 as i32)],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange::first(5)),
     )
 }
@@ -1056,10 +984,7 @@ fn find_bool_equal() {
                 "coffee".to_owned(),
                 Value::Bool(true),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -1072,10 +997,7 @@ fn find_bool_not_equal() {
                 "coffee".to_owned(),
                 Value::Bool(true),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Ascending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -1088,10 +1010,7 @@ fn find_bool_in() {
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange::first(5)),
     )
 }
@@ -1105,10 +1024,7 @@ fn find_bool_not_in() {
                 "coffee".to_owned(),
                 vec![Value::Bool(true)],
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            )
+            .order_by("name", ValueType::String, EntityOrder::Descending)
             .range(EntityRange::first(5)),
     )
 }
@@ -1122,10 +1038,7 @@ fn find_bytes_equal() {
                 "bin_name".to_owned(),
                 Value::Bytes("Johnton".as_bytes().into()),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -1138,10 +1051,7 @@ fn find_null_equal() {
                 "favorite_color".to_owned(),
                 Value::Null,
             ))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -1151,10 +1061,7 @@ fn find_null_not_equal() {
         vec!["2"],
         user_query()
             .filter(EntityFilter::Not("favorite_color".to_owned(), Value::Null))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -1167,10 +1074,7 @@ fn find_null_not_in() {
                 "favorite_color".to_owned(),
                 vec![Value::Null],
             ))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            ),
+            .order_by("name", ValueType::String, EntityOrder::Descending),
     )
 }
 
@@ -1178,17 +1082,11 @@ fn find_null_not_in() {
 fn find_order_by_float() {
     test_find(
         vec!["3", "2", "1"],
-        user_query().order_by(
-            ("weight".to_owned(), ValueType::BigDecimal),
-            EntityOrder::Ascending,
-        ),
+        user_query().order_by("weight", ValueType::BigDecimal, EntityOrder::Ascending),
     );
     test_find(
         vec!["1", "2", "3"],
-        user_query().order_by(
-            ("weight".to_owned(), ValueType::BigDecimal),
-            EntityOrder::Descending,
-        ),
+        user_query().order_by("weight", ValueType::BigDecimal, EntityOrder::Descending),
     );
 }
 
@@ -1196,11 +1094,11 @@ fn find_order_by_float() {
 fn find_order_by_id() {
     test_find(
         vec!["1", "2", "3"],
-        user_query().order_by(("id".to_owned(), ValueType::ID), EntityOrder::Ascending),
+        user_query().order_by("id", ValueType::ID, EntityOrder::Ascending),
     );
     test_find(
         vec!["3", "2", "1"],
-        user_query().order_by(("id".to_owned(), ValueType::ID), EntityOrder::Descending),
+        user_query().order_by("id", ValueType::ID, EntityOrder::Descending),
     );
 }
 
@@ -1208,11 +1106,11 @@ fn find_order_by_id() {
 fn find_order_by_int() {
     test_find(
         vec!["3", "2", "1"],
-        user_query().order_by(("age".to_owned(), ValueType::Int), EntityOrder::Ascending),
+        user_query().order_by("age", ValueType::Int, EntityOrder::Ascending),
     );
     test_find(
         vec!["1", "2", "3"],
-        user_query().order_by(("age".to_owned(), ValueType::Int), EntityOrder::Descending),
+        user_query().order_by("age", ValueType::Int, EntityOrder::Descending),
     );
 }
 
@@ -1220,17 +1118,11 @@ fn find_order_by_int() {
 fn find_order_by_string() {
     test_find(
         vec!["2", "1", "3"],
-        user_query().order_by(
-            ("name".to_owned(), ValueType::String),
-            EntityOrder::Ascending,
-        ),
+        user_query().order_by("name", ValueType::String, EntityOrder::Ascending),
     );
     test_find(
         vec!["3", "1", "2"],
-        user_query().order_by(
-            ("name".to_owned(), ValueType::String),
-            EntityOrder::Descending,
-        ),
+        user_query().order_by("name", ValueType::String, EntityOrder::Descending),
     );
 }
 
@@ -1243,7 +1135,7 @@ fn find_where_nested_and_or() {
                 EntityFilter::Equal("id".to_owned(), Value::from("1")),
                 EntityFilter::Equal("id".to_owned(), Value::from("2")),
             ])]))
-            .order_by(("id".to_owned(), ValueType::String), EntityOrder::Ascending),
+            .order_by("id", ValueType::String, EntityOrder::Ascending),
     )
 }
 
@@ -1363,10 +1255,7 @@ fn check_basic_revert(
             "name".to_owned(),
             Value::String("Shaqueeena".to_owned()),
         )]))
-        .order_by(
-            ("name".to_owned(), ValueType::String),
-            EntityOrder::Descending,
-        );
+        .order_by("name", ValueType::String, EntityOrder::Descending);
 
     let subscription = subscribe_and_consume(store.clone(), subgraph_id, entity_type);
 
@@ -1433,10 +1322,7 @@ fn revert_block_with_delete() {
                 "name".to_owned(),
                 Value::String("Cindini".to_owned()),
             )]))
-            .order_by(
-                ("name".to_owned(), ValueType::String),
-                EntityOrder::Descending,
-            );
+            .order_by("name", ValueType::String, EntityOrder::Descending);
 
         // Delete entity with id=2
         let del_key = EntityKey {
@@ -2116,7 +2002,7 @@ fn handle_large_string_with_index() {
                 NAME.to_owned(),
                 long_text.clone().into(),
             ))
-            .order_by((NAME.to_owned(), ValueType::String), EntityOrder::Ascending);
+            .order_by(NAME, ValueType::String, EntityOrder::Ascending);
 
         let ids = store
             .find(query)
@@ -2134,7 +2020,7 @@ fn handle_large_string_with_index() {
         let query = user_query()
             .range(EntityRange::first(5))
             .filter(EntityFilter::LessOrEqual(NAME.to_owned(), prefix.into()))
-            .order_by((NAME.to_owned(), ValueType::String), EntityOrder::Ascending);
+            .order_by(NAME, ValueType::String, EntityOrder::Ascending);
 
         let ids = store
             .find(query)
@@ -2174,10 +2060,7 @@ impl WindowQuery {
     }
 
     fn order(self, attr: &str, dir: EntityOrder) -> Self {
-        WindowQuery(
-            self.0.order_by((attr.to_owned(), ValueType::String), dir),
-            self.1,
-        )
+        WindowQuery(self.0.order_by(attr, ValueType::String, dir), self.1)
     }
 
     fn above(self, age: i32) -> Self {


### PR DESCRIPTION
For a query like `parents { id children { id } }` we used to run `1 + number(parents)` queries, one to get the parents, and then one query to get the children of each parent. The more deeply a query was nested, the more this effect compounded.

With this PR, we will now run 2 queries: one to get the parents, and one to get all children for the parents. Details of how this is done can be found in [this document](https://github.com/graphprotocol/graph-node/blob/dfefdf775b68db202e8fdf2672a9e909f0b21e59/docs/implementation/query-prefetching.md)

It is possible to have `graph-node` compare the results of execution with and without prefetching by adding a `@verify` directive to the query, as in `query stuff @verify { .. }` (this must use the form with an explicit `query` keyword) In this mode, the query will be executed in the old and the new way; if the two results differ, the query returns an error that contains both result for manual comparison.

It is also possible to completely turn off prefetching by setting the environment variable `GRAPH_GRAPHQL_NO_PREFETCH`; if that variable is set to anything at all, query execution behaves like it did before this PR. (see #1340)

Supersedes PR #1341