### PR TITLE
Batch load entites when applying the entity cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,6 +1031,7 @@ dependencies = [
  "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "test-store 0.1.0",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2811,6 +2812,7 @@ dependencies = [
 name = "test-store"
 version = "0.1.0"
 dependencies = [
+ "diesel 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.16.1",
  "graph-mock 0.16.1",
  "graph-store-postgres 0.16.1",

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -11,28 +11,8 @@ fn insert_and_query(
     entities: Vec<(Entity, &str)>,
     query: &str,
 ) -> Result<QueryResult, StoreError> {
+    create_test_subgraph(subgraph_id, schema);
     let subgraph_id = SubgraphDeploymentId::new(subgraph_id).unwrap();
-    let schema = Schema::parse(schema, subgraph_id.clone()).unwrap();
-
-    let manifest = SubgraphManifest {
-        id: subgraph_id.clone(),
-        location: String::new(),
-        spec_version: "1".to_owned(),
-        description: None,
-        repository: None,
-        schema: schema.clone(),
-        data_sources: vec![],
-        templates: vec![],
-    };
-
-    let logger = Logger::root(slog::Discard, o!());
-
-    let ops = SubgraphDeploymentEntity::new(&manifest, false, false, None, None)
-        .create_operations_replace(&subgraph_id)
-        .into_iter()
-        .map(|op| op.into())
-        .collect();
-    STORE.create_subgraph_deployment(&schema, ops).unwrap();
 
     let insert_ops = entities
         .into_iter()
@@ -52,6 +32,7 @@ fn insert_and_query(
         insert_ops.collect::<Vec<_>>(),
     )?;
 
+    let logger = Logger::root(slog::Discard, o!());
     let resolver = StoreResolver::new(&logger, STORE.clone());
 
     let options = QueryExecutionOptions {

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -1,8 +1,8 @@
 use futures::sync::mpsc;
 use rand::rngs::OsRng;
 use rand::seq::SliceRandom;
-use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Mutex;
 
 use graph::components::store::*;
@@ -163,6 +163,14 @@ impl Store for MockStore {
             .map(|entity| entity.to_owned()))
     }
 
+    fn get_many(
+        &self,
+        _subgraph_id: &SubgraphDeploymentId,
+        _ids_for_type: BTreeMap<&str, Vec<&str>>,
+    ) -> Result<BTreeMap<String, Vec<Entity>>, StoreError> {
+        unimplemented!("get_many unimplemented")
+    }
+
     fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
         self.execute_query(&self.entities.lock().unwrap(), query)
     }
@@ -171,12 +179,8 @@ impl Store for MockStore {
         Ok(self.find(query)?.pop())
     }
 
-    fn find_ens_name(&self, hash: &str) -> Result<Option<String>, QueryExecutionError> {
-        let s1 = "dealdrafts".to_string();
-        match hash {
-            "0x7f0c1b04d1a4926f9c635a030eeb611d4c26e5e73291b32a1c7a4ac56935b5b3" => Ok(Some(s1)),
-            _ => Ok(None),
-        }
+    fn find_ens_name(&self, _: &str) -> Result<Option<String>, QueryExecutionError> {
+        unimplemented!("find_ens_name unimplemented")
     }
 
     fn block_ptr(&self, _: SubgraphDeploymentId) -> Result<Option<EthereumBlockPointer>, Error> {
@@ -463,6 +467,14 @@ impl Store for FakeStore {
         Ok(None)
     }
 
+    fn get_many(
+        &self,
+        _: &SubgraphDeploymentId,
+        _: BTreeMap<&str, Vec<&str>>,
+    ) -> Result<BTreeMap<String, Vec<Entity>>, StoreError> {
+        unimplemented!()
+    }
+
     fn find(&self, _: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
         unimplemented!();
     }
@@ -471,12 +483,8 @@ impl Store for FakeStore {
         unimplemented!();
     }
 
-    fn find_ens_name(&self, hash: &str) -> Result<Option<String>, QueryExecutionError> {
-        let s1 = "dealdrafts".to_string();
-        match hash {
-            "0x7f0c1b04d1a4926f9c635a030eeb611d4c26e5e73291b32a1c7a4ac56935b5b3" => Ok(Some(s1)),
-            _ => Ok(None),
-        }
+    fn find_ens_name(&self, _: &str) -> Result<Option<String>, QueryExecutionError> {
+        unimplemented!("find_ens_name unimplemented")
     }
 
     fn block_ptr(&self, _: SubgraphDeploymentId) -> Result<Option<EthereumBlockPointer>, Error> {

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -22,6 +22,7 @@ uuid = { version = "0.8.1", features = ["v4"] }
 graphql-parser = "0.2.3"
 graph-core = { path = "../../core" }
 graph-mock = { path = "../../mock" }
+test-store = { path = "../../store/test-store" }
 # We're using the latest ipfs-api for the HTTPS support that was merged in
 # https://github.com/ferristseng/rust-ipfs-api/commit/55902e98d868dcce047863859caf596a629d10ec
 # but has not been released yet.

--- a/runtime/wasm/src/module/test/abi.rs
+++ b/runtime/wasm/src/module/test/abi.rs
@@ -4,7 +4,10 @@ use super::*;
 fn unbounded_loop() {
     // Set handler timeout to 3 seconds.
     env::set_var(crate::host::TIMEOUT_ENV_VAR, "3");
-    let mut module = test_module(mock_data_source("wasm_test/non_terminating.wasm"));
+    let mut module = test_module(
+        "unboundedLoop",
+        mock_data_source("wasm_test/non_terminating.wasm"),
+    );
     module.start_time = Instant::now();
     let err = module
         .module
@@ -19,7 +22,10 @@ fn unbounded_loop() {
 
 #[test]
 fn unbounded_recursion() {
-    let mut module = test_module(mock_data_source("wasm_test/non_terminating.wasm"));
+    let mut module = test_module(
+        "unboundedRecursion",
+        mock_data_source("wasm_test/non_terminating.wasm"),
+    );
     let err = module
         .module
         .clone()
@@ -30,7 +36,7 @@ fn unbounded_recursion() {
 
 #[test]
 fn abi_array() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let mut module = test_module("abiArray", mock_data_source("wasm_test/abi_classes.wasm"));
 
     let vec = vec![
         "1".to_owned(),
@@ -58,7 +64,10 @@ fn abi_array() {
 
 #[test]
 fn abi_subarray() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let mut module = test_module(
+        "abiSubarray",
+        mock_data_source("wasm_test/abi_classes.wasm"),
+    );
 
     let vec: Vec<u8> = vec![1, 2, 3, 4];
     let vec_obj: AscPtr<TypedArray<u8>> = module.asc_new(&*vec);
@@ -72,7 +81,10 @@ fn abi_subarray() {
 
 #[test]
 fn abi_bytes_and_fixed_bytes() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let mut module = test_module(
+        "abiBytesAndFixedBytes",
+        mock_data_source("wasm_test/abi_classes.wasm"),
+    );
     let bytes1: Vec<u8> = vec![42, 45, 7, 245, 45];
     let bytes2: Vec<u8> = vec![3, 12, 0, 1, 255];
 
@@ -93,7 +105,10 @@ fn abi_bytes_and_fixed_bytes() {
 /// and assert the final token is the same as the starting one.
 #[test]
 fn abi_ethabi_token_identity() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_token.wasm"));
+    let mut module = test_module(
+        "abiEthabiTokenIdentity",
+        mock_data_source("wasm_test/abi_token.wasm"),
+    );
 
     // Token::Address
     let address = H160([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
@@ -198,7 +213,10 @@ fn abi_ethabi_token_identity() {
 fn abi_store_value() {
     use graph::data::store::Value;
 
-    let mut module = test_module(mock_data_source("wasm_test/abi_store_value.wasm"));
+    let mut module = test_module(
+        "abiStoreValue",
+        mock_data_source("wasm_test/abi_store_value.wasm"),
+    );
 
     // Value::Null
     let null_value_ptr: AscPtr<AscEnum<StoreValueKind>> = module
@@ -304,7 +322,7 @@ fn abi_store_value() {
 
 #[test]
 fn abi_h160() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let mut module = test_module("abiH160", mock_data_source("wasm_test/abi_classes.wasm"));
     let address = H160::zero();
 
     // As an `Uint8Array`
@@ -323,7 +341,7 @@ fn abi_h160() {
 
 #[test]
 fn string() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let mut module = test_module("string", mock_data_source("wasm_test/abi_classes.wasm"));
     let string = "    漢字Double_Me🇧🇷  ";
     let trimmed_string_ptr = module.asc_new(string);
     let trimmed_string_obj: AscPtr<AscString> =
@@ -334,7 +352,7 @@ fn string() {
 
 #[test]
 fn abi_big_int() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_classes.wasm"));
+    let mut module = test_module("abiBigInt", mock_data_source("wasm_test/abi_classes.wasm"));
 
     // Test passing in 0 and increment it by 1
     let old_uint = U256::zero();
@@ -357,7 +375,10 @@ fn abi_big_int() {
 
 #[test]
 fn big_int_to_string() {
-    let mut module = test_module(mock_data_source("wasm_test/big_int_to_string.wasm"));
+    let mut module = test_module(
+        "bigIntToString",
+        mock_data_source("wasm_test/big_int_to_string.wasm"),
+    );
 
     let big_int_str = "30145144166666665000000000000000000";
     let big_int = BigInt::from_str(big_int_str).unwrap();
@@ -372,7 +393,10 @@ fn big_int_to_string() {
 #[test]
 #[should_panic]
 fn invalid_discriminant() {
-    let mut module = test_module(mock_data_source("wasm_test/abi_store_value.wasm"));
+    let mut module = test_module(
+        "invalidDiscriminant",
+        mock_data_source("wasm_test/abi_store_value.wasm"),
+    );
 
     let value_ptr = module
         .module

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -11,3 +11,4 @@ graph = { path = "../../graph" }
 graph-store-postgres = { path = "../postgres" }
 lazy_static = "1.1"
 hex-literal = "0.2"
+diesel = { version = "1.4.3", features = ["postgres", "serde_json", "numeric", "r2d2"] }


### PR DESCRIPTION
Part of #1381. Local benchmark with erc20:

![Captura de Tela 2019-11-30 às 10 53 39](https://user-images.githubusercontent.com/9885558/69901516-873e8b80-1361-11ea-81f0-840866310b13.png)

Most of the `store_set` work got moved into `as_modifications`. Now `store_set` doesn't show up in the top categories anymore, and `as_modifications` is barely there, so we can claim this combined with #1384 really did improve things, I'd say we got at least a 2x speedup at fetching entites for merging. My local sync got to block 4844255 vs 4729000 previously, which signals than things got overall faster.

I still need to check that it really works with JSON storage, but this is ready for review. I also switched the runtime tests to use the test-store so we could get test coverage for this.