### PR TITLE
Enable time-travel GraphQL queries

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -3,13 +3,16 @@ use futures::future;
 use futures::prelude::*;
 use lazy_static::lazy_static;
 use std::collections::HashSet;
+use std::iter::FromIterator;
 use std::sync::Arc;
 use std::time::Instant;
 
 use ethabi::ParamType;
 use graph::components::ethereum::{EthereumAdapter as EthereumAdapterTrait, *};
-use graph::prelude::*;
-use web3;
+use graph::prelude::{
+    debug, err_msg, error, ethabi, format_err, hex, info, retry, stream, tiny_keccak, tokio_timer,
+    trace, warn, web3, ChainStore, Error, EthereumCallCache, Logger,
+};
 use web3::api::Web3;
 use web3::transports::batch::Batch;
 use web3::types::{Filter, *};

--- a/core/src/graphql/runner.rs
+++ b/core/src/graphql/runner.rs
@@ -56,7 +56,7 @@ where
 {
     fn run_query(&self, query: Query) -> QueryResultFuture {
         let result = execute_query(
-            &query,
+            query,
             QueryExecutionOptions {
                 logger: self.logger.clone(),
                 resolver: StoreResolver::new(&self.logger, self.store.clone()),
@@ -77,7 +77,7 @@ where
         max_first: Option<u32>,
     ) -> QueryResultFuture {
         let result = execute_query(
-            &query,
+            query,
             QueryExecutionOptions {
                 logger: self.logger.clone(),
                 resolver: StoreResolver::new(&self.logger, self.store.clone()),

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -49,7 +49,7 @@ fn insert_and_query(
         document,
         variables: None,
     };
-    Ok(execute_query(&query, options))
+    Ok(execute_query(query, options))
 }
 
 #[test]

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -260,10 +260,14 @@ pub struct EntityQuery {
 }
 
 impl EntityQuery {
-    pub fn new(subgraph_id: SubgraphDeploymentId, collection: EntityCollection) -> Self {
+    pub fn new(
+        subgraph_id: SubgraphDeploymentId,
+        block: BlockNumber,
+        collection: EntityCollection,
+    ) -> Self {
         EntityQuery {
             subgraph_id,
-            block: BLOCK_NUMBER_MAX,
+            block,
             collection,
             filter: None,
             order_by: None,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1159,6 +1159,14 @@ pub trait Store: Send + Sync + 'static {
         subgraph_id: &SubgraphDeploymentId,
         block_ptr: &EthereumBlockPointer,
     );
+
+    /// Return the number of the block with the given hash for the given
+    /// subgraph
+    fn block_number(
+        &self,
+        subgraph_id: &SubgraphDeploymentId,
+        block_hash: H256,
+    ) -> Result<BlockNumber, StoreError>;
 }
 
 pub trait SubgraphDeploymentStore: Send + Sync + 'static {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -217,6 +217,12 @@ pub enum EntityCollection {
     /// column `b`; they will be grouped by using `A.a` and `B.b` as the keys
     Window(Vec<EntityWindow>),
 }
+/// The type we use for block numbers. This has to be a signed integer type
+/// since Postgres does not support unsigned integer types. But 2G ought to
+/// be enough for everybody
+pub type BlockNumber = i32;
+
+pub const BLOCK_NUMBER_MAX: BlockNumber = std::i32::MAX;
 
 /// A query for entities in a store.
 ///

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -233,6 +233,13 @@ pub struct EntityQuery {
     /// ID of the subgraph.
     pub subgraph_id: SubgraphDeploymentId,
 
+    /// The block height at which to execute the query. Set this to
+    /// `BLOCK_NUMBER_MAX` to run the query at the latest available block.
+    /// If the subgraph uses JSONB storage, anything but `BLOCK_NUMBER_MAX`
+    /// will cause an error as JSONB storage does not support querying anything
+    /// but the latest block
+    pub block: BlockNumber,
+
     /// The names of the entity types being queried. The result is the union
     /// (with repetition) of the query for each entity.
     pub collection: EntityCollection,
@@ -256,6 +263,7 @@ impl EntityQuery {
     pub fn new(subgraph_id: SubgraphDeploymentId, collection: EntityCollection) -> Self {
         EntityQuery {
             subgraph_id,
+            block: BLOCK_NUMBER_MAX,
             collection,
             filter: None,
             order_by: None,
@@ -771,10 +779,11 @@ pub trait Store: Send + Sync + 'static {
         subgraph_id: SubgraphDeploymentId,
     ) -> Result<Option<EthereumBlockPointer>, Error>;
 
-    /// Looks up an entity using the given store key.
+    /// Looks up an entity using the given store key at the latest block.
     fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError>;
 
-    /// Look up multiple entities. Returns a map of entities by type.
+    /// Look up multiple entities as of the latest block. Returns a map of
+    /// entities by type.
     fn get_many(
         &self,
         subgraph_id: &SubgraphDeploymentId,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1166,7 +1166,7 @@ pub trait Store: Send + Sync + 'static {
         &self,
         subgraph_id: &SubgraphDeploymentId,
         block_hash: H256,
-    ) -> Result<BlockNumber, StoreError>;
+    ) -> Result<Option<BlockNumber>, StoreError>;
 }
 
 pub trait SubgraphDeploymentStore: Send + Sync + 'static {

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -50,6 +50,7 @@ pub trait TypedEntity {
         };
         EntityQuery::new(
             SUBGRAPHS_ID.clone(),
+            BLOCK_NUMBER_MAX,
             EntityCollection::All(vec![Self::TYPENAME.to_owned()]),
         )
         .range(range)

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -62,12 +62,12 @@ pub mod prelude {
     pub use crate::components::server::query::GraphQLServer;
     pub use crate::components::server::subscription::SubscriptionServer;
     pub use crate::components::store::{
-        AttributeIndexDefinition, ChainStore, EntityCache, EntityChange, EntityChangeOperation,
-        EntityCollection, EntityFilter, EntityKey, EntityLink, EntityModification, EntityOperation,
-        EntityOrder, EntityQuery, EntityRange, EntityWindow, EthereumCallCache, MetadataOperation,
-        ParentLink, Store, StoreError, StoreEvent, StoreEventStream, StoreEventStreamBox,
-        SubgraphDeploymentStore, TransactionAbortError, WindowAttribute,
-        SUBSCRIPTION_THROTTLE_INTERVAL,
+        AttributeIndexDefinition, BlockNumber, ChainStore, EntityCache, EntityChange,
+        EntityChangeOperation, EntityCollection, EntityFilter, EntityKey, EntityLink,
+        EntityModification, EntityOperation, EntityOrder, EntityQuery, EntityRange, EntityWindow,
+        EthereumCallCache, MetadataOperation, ParentLink, Store, StoreError, StoreEvent,
+        StoreEventStream, StoreEventStreamBox, SubgraphDeploymentStore, TransactionAbortError,
+        WindowAttribute, BLOCK_NUMBER_MAX, SUBSCRIPTION_THROTTLE_INTERVAL,
     };
     pub use crate::components::subgraph::{
         BlockState, DataSourceLoader, DataSourceTemplateInfo, HostMetrics, RuntimeHost,

--- a/graphql/examples/schema.rs
+++ b/graphql/examples/schema.rs
@@ -1,0 +1,39 @@
+extern crate graph_graphql;
+
+use graphql_parser::parse_schema;
+use std::env;
+use std::fs;
+use std::process::exit;
+
+use graph_graphql::schema::api::api_schema;
+
+pub fn usage(msg: &str) -> ! {
+    println!("{}", msg);
+    println!("usage: schema schema.graphql");
+    println!("\nPrint the API schema we derive from the given input schema");
+    std::process::exit(1);
+}
+
+pub fn ensure<T, E: std::fmt::Display>(res: Result<T, E>, msg: &str) -> T {
+    match res {
+        Ok(ok) => ok,
+        Err(err) => {
+            eprintln!("{}:\n    {}", msg, err);
+            exit(1)
+        }
+    }
+}
+
+pub fn main() {
+    let args: Vec<String> = env::args().collect();
+    let schema = match args.len() {
+        0 | 1 => usage("please provide a GraphQL schema"),
+        2 => args[1].clone(),
+        _ => usage("too many arguments"),
+    };
+    let schema = ensure(fs::read_to_string(schema), "Can not read schema file");
+    let schema = ensure(parse_schema(&schema), "Failed to parse schema");
+    let schema = ensure(api_schema(&schema), "Failed to convert to API schema");
+
+    println!("{}", schema);
+}

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -56,6 +56,10 @@ where
     /// Max value for `first`.
     pub max_first: u32,
 
+    /// The block at which we should execute the query. Initialize this
+    /// with `BLOCK_NUMBER_MAX` to get the latest data
+    pub block: BlockNumber,
+
     pub mode: ExecutionMode,
 }
 
@@ -113,6 +117,7 @@ where
             variable_values: self.variable_values.clone(),
             deadline: self.deadline,
             max_first: std::u32::MAX,
+            block: self.block,
             mode: ExecutionMode::Prefetch,
         }
     }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -717,6 +717,7 @@ where
             t.into(),
             argument_values,
             ctx.schema.types_for_interface(),
+            ctx.block,
         ),
 
         // Let the resolver decide how values in the resolved object value
@@ -746,6 +747,7 @@ where
             i.into(),
             argument_values,
             ctx.schema.types_for_interface(),
+            ctx.block,
         ),
 
         s::TypeDefinition::Union(_) => Err(QueryExecutionError::Unimplemented("unions".to_owned())),
@@ -795,6 +797,7 @@ where
                         t.into(),
                         argument_values,
                         ctx.schema.types_for_interface(),
+                        ctx.block,
                         ctx.max_first,
                     )
                     .map_err(|e| vec![e]),
@@ -828,6 +831,7 @@ where
                         t.into(),
                         argument_values,
                         ctx.schema.types_for_interface(),
+                        ctx.block,
                         ctx.max_first,
                     )
                     .map_err(|e| vec![e]),

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -13,6 +13,7 @@ use graph::prelude::*;
 use crate::introspection::INTROSPECTION_DOCUMENT;
 use crate::prelude::*;
 use crate::query::ast as qast;
+use crate::query::ext::FieldExt as _;
 use crate::schema::ast as sast;
 use crate::values::coercion;
 
@@ -96,10 +97,13 @@ where
     pub fn for_field(
         &self,
         field: &'a q::Field,
-        _object_type: impl Into<ObjectOrInterface<'a>>,
+        object_type: impl Into<ObjectOrInterface<'a>>,
     ) -> Result<Self, QueryExecutionError> {
         let mut ctx = self.clone();
         ctx.fields.push(field);
+        if let Some(bc) = field.block_constraint(object_type)? {
+            ctx.block = self.resolver.locate_block(&bc)?;
+        }
         Ok(ctx)
     }
 

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use crate::prelude::*;
 use crate::schema::ast::get_named_type;
-use graph::prelude::{QueryExecutionError, Schema, StoreEventStreamBox};
+use graph::prelude::{BlockNumber, QueryExecutionError, Schema, StoreEventStreamBox};
 
 #[derive(Copy, Clone, Debug)]
 pub enum ObjectOrInterface<'a> {
@@ -78,6 +78,7 @@ pub trait Resolver: Clone + Send + Sync {
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
+        block: BlockNumber,
         max_first: u32,
     ) -> Result<q::Value, QueryExecutionError>;
 
@@ -90,6 +91,7 @@ pub trait Resolver: Clone + Send + Sync {
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
+        block: BlockNumber,
     ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an enum value for a given enum type.

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -2,6 +2,7 @@ use graphql_parser::{query as q, schema as s};
 use std::collections::{BTreeMap, HashMap};
 
 use crate::prelude::*;
+use crate::query::ext::BlockConstraint;
 use crate::schema::ast::get_named_type;
 use graph::prelude::{BlockNumber, QueryExecutionError, Schema, StoreEventStreamBox};
 
@@ -68,6 +69,14 @@ pub trait Resolver: Clone + Send + Sync {
         ctx: &ExecutionContext<'a, Self>,
         selection_set: &q::SelectionSet,
     ) -> Result<Option<q::Value>, Vec<QueryExecutionError>>;
+
+    /// Locate the block for the given constraint and return its block number.
+    /// That number will later be passed into `resolve_object` and
+    /// `resolve_objects`
+    fn locate_block(
+        &self,
+        block_constraint: &BlockConstraint,
+    ) -> Result<BlockNumber, QueryExecutionError>;
 
     /// Resolves entities referenced by a parent object.
     fn resolve_objects(

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use graph::prelude::*;
 
 use crate::prelude::*;
+use crate::query::ext::BlockConstraint;
 use crate::schema::ast as sast;
 
 type TypeObjectsMap = BTreeMap<String, q::Value>;
@@ -461,6 +462,10 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         _: &q::SelectionSet,
     ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
         Ok(None)
+    }
+
+    fn locate_block(&self, _: &BlockConstraint) -> Result<BlockNumber, QueryExecutionError> {
+        Ok(BLOCK_NUMBER_MAX)
     }
 
     fn resolve_objects(

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -471,6 +471,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
+        _block: BlockNumber,
         _max_first: u32,
     ) -> Result<q::Value, QueryExecutionError> {
         match field.name.as_str() {
@@ -510,6 +511,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         _object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         _: &BTreeMap<Name, Vec<ObjectType>>,
+        _: BlockNumber,
     ) -> Result<q::Value, QueryExecutionError> {
         let object = match field.name.as_str() {
             "__schema" => self.schema_object(),

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -27,7 +27,9 @@ mod store;
 pub mod prelude {
     pub use super::execution::{ExecutionContext, ObjectOrInterface, Resolver};
     pub use super::introspection::{introspection_schema, IntrospectionResolver};
-    pub use super::query::{execute_query, QueryExecutionOptions};
+    pub use super::query::{
+        execute_query, ext::BlockConstraint, ext::BlockLocator, QueryExecutionOptions,
+    };
     pub use super::schema::{api_schema, ast::validate_entity, APISchemaError};
     pub use super::store::{build_query, StoreResolver};
     pub use super::subscription::{execute_subscription, SubscriptionExecutionOptions};

--- a/graphql/src/query/ext.rs
+++ b/graphql/src/query/ext.rs
@@ -3,6 +3,16 @@
 use graphql_parser::query as q;
 
 use std::collections::BTreeMap;
+use std::convert::TryFrom;
+
+use graph::data::graphql::TryFromValue;
+use graph::data::query::QueryExecutionError;
+use graph::data::subgraph::SubgraphDeploymentId;
+use graph::prelude::web3::types::H256;
+use graph::prelude::BlockNumber;
+
+use crate::execution::ObjectOrInterface;
+use crate::store::parse_subgraph_id;
 
 pub trait ValueExt {
     fn as_object(&self) -> &BTreeMap<q::Name, q::Value>;
@@ -21,6 +31,86 @@ impl ValueExt for q::Value {
         match self {
             q::Value::String(string) => string,
             _ => panic!("expected a Value::String"),
+        }
+    }
+}
+
+pub enum BlockLocator {
+    Hash(H256),
+    Number(BlockNumber),
+}
+
+pub struct BlockConstraint {
+    pub subgraph: SubgraphDeploymentId,
+    pub block: BlockLocator,
+}
+
+pub trait FieldExt {
+    fn block_constraint<'a>(
+        &self,
+        object_type: impl Into<ObjectOrInterface<'a>>,
+    ) -> Result<Option<BlockConstraint>, QueryExecutionError>;
+}
+
+impl FieldExt for q::Field {
+    fn block_constraint<'a>(
+        &self,
+        object_type: impl Into<ObjectOrInterface<'a>>,
+    ) -> Result<Option<BlockConstraint>, QueryExecutionError> {
+        fn invalid_argument(arg: &str, field: &q::Field, value: &q::Value) -> QueryExecutionError {
+            QueryExecutionError::InvalidArgumentError(
+                field.position.clone(),
+                arg.to_owned(),
+                value.clone(),
+            )
+        }
+
+        let value =
+            self.arguments.iter().find_map(
+                |(name, value)| {
+                    if name == "block" {
+                        Some(value)
+                    } else {
+                        None
+                    }
+                },
+            );
+        if let Some(value) = value {
+            if let q::Value::Object(map) = value {
+                if map.len() != 1 || !(map.contains_key("hash") || map.contains_key("number")) {
+                    return Err(invalid_argument("block", self, value));
+                }
+                let subgraph = parse_subgraph_id(object_type)?;
+                if let Some(hash) = map.get("hash") {
+                    TryFromValue::try_from_value(hash)
+                        .map_err(|_| invalid_argument("block.hash", self, value))
+                        .map(|hash| {
+                            Some(BlockConstraint {
+                                subgraph,
+                                block: BlockLocator::Hash(hash),
+                            })
+                        })
+                } else if let Some(number_value) = map.get("number") {
+                    TryFromValue::try_from_value(number_value)
+                        .map_err(|_| invalid_argument("block.number", self, number_value))
+                        .and_then(|number: u64| {
+                            TryFrom::try_from(number)
+                                .map_err(|_| invalid_argument("block.number", self, number_value))
+                        })
+                        .map(|number| {
+                            Some(BlockConstraint {
+                                subgraph,
+                                block: BlockLocator::Number(number),
+                            })
+                        })
+                } else {
+                    unreachable!("We already checked that there is a hash or number entry")
+                }
+            } else {
+                Err(invalid_argument("block", self, value))
+            }
+        } else {
+            Ok(None)
         }
     }
 }

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -81,6 +81,7 @@ where
         variable_values: Arc::new(coerced_variable_values),
         deadline: options.deadline,
         max_first: options.max_first,
+        block: BLOCK_NUMBER_MAX,
         mode,
     };
 

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -38,7 +38,7 @@ where
 }
 
 /// Executes a query and returns a result.
-pub fn execute_query<R>(query: &Query, options: QueryExecutionOptions<R>) -> QueryResult
+pub fn execute_query<R>(query: Query, options: QueryExecutionOptions<R>) -> QueryResult
 where
     R: Resolver,
 {

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -25,6 +25,7 @@ pub fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
 
     // Refactor: Don't clone the schema.
     let mut schema = input_schema.clone();
+    add_directives(&mut schema);
     add_builtin_scalar_types(&mut schema)?;
     add_order_direction_enum(&mut schema);
     add_types_for_object_types(&mut schema, &object_types)?;
@@ -63,6 +64,51 @@ fn add_builtin_scalar_types(schema: &mut Document) -> Result<(), APISchemaError>
         }
     }
     Ok(())
+}
+
+/// Add directive definitions for our custom directives
+fn add_directives(schema: &mut Document) {
+    let entity = Definition::DirectiveDefinition(DirectiveDefinition {
+        position: Pos::default(),
+        description: None,
+        name: "entity".to_owned(),
+        arguments: vec![],
+        locations: vec![DirectiveLocation::Object],
+    });
+
+    let derived_from = Definition::DirectiveDefinition(DirectiveDefinition {
+        position: Pos::default(),
+        description: None,
+        name: "derivedFrom".to_owned(),
+        arguments: vec![InputValue {
+            position: Pos::default(),
+            description: None,
+            name: "field".to_owned(),
+            value_type: Type::NamedType("String".to_owned()),
+            default_value: None,
+            directives: vec![],
+        }],
+        locations: vec![DirectiveLocation::FieldDefinition],
+    });
+
+    let subgraph_id = Definition::DirectiveDefinition(DirectiveDefinition {
+        position: Pos::default(),
+        description: None,
+        name: "subgraphId".to_owned(),
+        arguments: vec![InputValue {
+            position: Pos::default(),
+            description: None,
+            name: "id".to_owned(),
+            value_type: Type::NamedType("String".to_owned()),
+            default_value: None,
+            directives: vec![],
+        }],
+        locations: vec![DirectiveLocation::Object],
+    });
+
+    schema.definitions.push(entity);
+    schema.definitions.push(derived_from);
+    schema.definitions.push(subgraph_id);
 }
 
 /// Adds a global `OrderDirection` type to the schema.

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -500,13 +500,13 @@ fn add_subscription_type(
 fn block_argument() -> InputValue {
     InputValue {
         position: Pos::default(),
-        description: None, /*Some(
-                               "The block at which the query should be executed. \
-                                Can either be an `Int` containing the block number or a `Bytes` \
-                                value containing a block hash. Defaults to the latest block when \
-                                omitted."
-                                   .to_owned(),
-                           ), */
+        description: Some(
+            "The block at which the query should be executed. \
+             Can either be an `{ number: Int }` containing the block number \
+             or a `{ hash: Bytes }` value containing a block hash. Defaults \
+             to the latest block when omitted."
+                .to_owned(),
+        ),
         name: "block".to_string(),
         value_type: Type::NamedType(BLOCK_HEIGHT.to_owned()),
         default_value: None,

--- a/graphql/src/store/mod.rs
+++ b/graphql/src/store/mod.rs
@@ -2,5 +2,5 @@ mod prefetch;
 mod query;
 mod resolver;
 
-pub use self::query::build_query;
+pub use self::query::{build_query, parse_subgraph_id};
 pub use self::resolver::StoreResolver;

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use graph::prelude::{
-    Entity, EntityCollection, EntityFilter, EntityLink, EntityWindow, ParentLink,
+    BlockNumber, Entity, EntityCollection, EntityFilter, EntityLink, EntityWindow, ParentLink,
     QueryExecutionError, Schema, Store, Value as StoreValue, WindowAttribute,
 };
 
@@ -839,6 +839,7 @@ where
         &join,
         &argument_values,
         ctx.schema.types_for_interface(),
+        ctx.block,
         ctx.max_first,
     )
     .map_err(|e| vec![e])
@@ -852,9 +853,16 @@ fn fetch<S: Store>(
     join: &Join<'_>,
     arguments: &HashMap<&q::Name, q::Value>,
     types_for_interface: &BTreeMap<s::Name, Vec<s::ObjectType>>,
+    block: BlockNumber,
     max_first: u32,
 ) -> Result<Vec<Node>, QueryExecutionError> {
-    let mut query = build_query(join.child_type, arguments, types_for_interface, max_first)?;
+    let mut query = build_query(
+        join.child_type,
+        block,
+        arguments,
+        types_for_interface,
+        max_first,
+    )?;
 
     if let Some(q::Value::String(id)) = arguments.get(&*ARG_ID) {
         query.filter = Some(

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -24,7 +24,7 @@ pub fn build_query<'a>(
             .map(|o| o.name.clone())
             .collect(),
     });
-    let mut query = EntityQuery::new(parse_subgraph_id(entity)?, entity_types)
+    let mut query = EntityQuery::new(parse_subgraph_id(entity)?, BLOCK_NUMBER_MAX, entity_types)
         .range(build_range(arguments, max_first)?);
     if let Some(filter) = build_filter(entity, arguments)? {
         query = query.filter(filter);

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -12,6 +12,7 @@ use crate::schema::ast as sast;
 /// Panics if `entity` is not present in `schema`.
 pub fn build_query<'a>(
     entity: impl Into<ObjectOrInterface<'a>>,
+    block: BlockNumber,
     arguments: &HashMap<&q::Name, q::Value>,
     types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     max_first: u32,
@@ -24,7 +25,7 @@ pub fn build_query<'a>(
             .map(|o| o.name.clone())
             .collect(),
     });
-    let mut query = EntityQuery::new(parse_subgraph_id(entity)?, BLOCK_NUMBER_MAX, entity_types)
+    let mut query = EntityQuery::new(parse_subgraph_id(entity)?, block, entity_types)
         .range(build_range(arguments, max_first)?);
     if let Some(filter) = build_filter(entity, arguments)? {
         query = query.filter(filter);
@@ -370,6 +371,7 @@ mod tests {
         assert_eq!(
             build_query(
                 &object("Entity1"),
+                BLOCK_NUMBER_MAX,
                 &default_arguments(),
                 &BTreeMap::new(),
                 std::u32::MAX
@@ -381,6 +383,7 @@ mod tests {
         assert_eq!(
             build_query(
                 &object("Entity2"),
+                BLOCK_NUMBER_MAX,
                 &default_arguments(),
                 &BTreeMap::new(),
                 std::u32::MAX
@@ -396,6 +399,7 @@ mod tests {
         assert_eq!(
             build_query(
                 &default_object(),
+                BLOCK_NUMBER_MAX,
                 &default_arguments(),
                 &BTreeMap::new(),
                 std::u32::MAX
@@ -407,6 +411,7 @@ mod tests {
         assert_eq!(
             build_query(
                 &default_object(),
+                BLOCK_NUMBER_MAX,
                 &default_arguments(),
                 &BTreeMap::new(),
                 std::u32::MAX
@@ -423,18 +428,30 @@ mod tests {
         let mut args = default_arguments();
         args.insert(&order_by, q::Value::Enum("name".to_string()));
         assert_eq!(
-            build_query(&default_object(), &args, &BTreeMap::new(), std::u32::MAX)
-                .unwrap()
-                .order_by,
+            build_query(
+                &default_object(),
+                BLOCK_NUMBER_MAX,
+                &args,
+                &BTreeMap::new(),
+                std::u32::MAX
+            )
+            .unwrap()
+            .order_by,
             Some(("name".to_string(), ValueType::String))
         );
 
         let mut args = default_arguments();
         args.insert(&order_by, q::Value::Enum("email".to_string()));
         assert_eq!(
-            build_query(&default_object(), &args, &BTreeMap::new(), std::u32::MAX)
-                .unwrap()
-                .order_by,
+            build_query(
+                &default_object(),
+                BLOCK_NUMBER_MAX,
+                &args,
+                &BTreeMap::new(),
+                std::u32::MAX
+            )
+            .unwrap()
+            .order_by,
             Some(("email".to_string(), ValueType::String))
         );
     }
@@ -445,18 +462,30 @@ mod tests {
         let mut args = default_arguments();
         args.insert(&order_by, q::Value::String("name".to_string()));
         assert_eq!(
-            build_query(&default_object(), &args, &BTreeMap::new(), std::u32::MAX)
-                .unwrap()
-                .order_by,
+            build_query(
+                &default_object(),
+                BLOCK_NUMBER_MAX,
+                &args,
+                &BTreeMap::new(),
+                std::u32::MAX
+            )
+            .unwrap()
+            .order_by,
             None,
         );
 
         let mut args = default_arguments();
         args.insert(&order_by, q::Value::String("email".to_string()));
         assert_eq!(
-            build_query(&default_object(), &args, &BTreeMap::new(), std::u32::MAX)
-                .unwrap()
-                .order_by,
+            build_query(
+                &default_object(),
+                BLOCK_NUMBER_MAX,
+                &args,
+                &BTreeMap::new(),
+                std::u32::MAX
+            )
+            .unwrap()
+            .order_by,
             None,
         );
     }
@@ -467,27 +496,45 @@ mod tests {
         let mut args = default_arguments();
         args.insert(&order_direction, q::Value::Enum("asc".to_string()));
         assert_eq!(
-            build_query(&default_object(), &args, &BTreeMap::new(), std::u32::MAX)
-                .unwrap()
-                .order_direction,
+            build_query(
+                &default_object(),
+                BLOCK_NUMBER_MAX,
+                &args,
+                &BTreeMap::new(),
+                std::u32::MAX
+            )
+            .unwrap()
+            .order_direction,
             Some(EntityOrder::Ascending)
         );
 
         let mut args = default_arguments();
         args.insert(&order_direction, q::Value::Enum("desc".to_string()));
         assert_eq!(
-            build_query(&default_object(), &args, &BTreeMap::new(), std::u32::MAX)
-                .unwrap()
-                .order_direction,
+            build_query(
+                &default_object(),
+                BLOCK_NUMBER_MAX,
+                &args,
+                &BTreeMap::new(),
+                std::u32::MAX
+            )
+            .unwrap()
+            .order_direction,
             Some(EntityOrder::Descending)
         );
 
         let mut args = default_arguments();
         args.insert(&order_direction, q::Value::Enum("ascending...".to_string()));
         assert_eq!(
-            build_query(&default_object(), &args, &BTreeMap::new(), std::u32::MAX)
-                .unwrap()
-                .order_direction,
+            build_query(
+                &default_object(),
+                BLOCK_NUMBER_MAX,
+                &args,
+                &BTreeMap::new(),
+                std::u32::MAX
+            )
+            .unwrap()
+            .order_direction,
             None,
         );
     }
@@ -498,18 +545,30 @@ mod tests {
         let mut args = default_arguments();
         args.insert(&order_direction, q::Value::String("asc".to_string()));
         assert_eq!(
-            build_query(&default_object(), &args, &BTreeMap::new(), std::u32::MAX)
-                .unwrap()
-                .order_direction,
+            build_query(
+                &default_object(),
+                BLOCK_NUMBER_MAX,
+                &args,
+                &BTreeMap::new(),
+                std::u32::MAX
+            )
+            .unwrap()
+            .order_direction,
             None,
         );
 
         let mut args = default_arguments();
         args.insert(&order_direction, q::Value::String("desc".to_string()));
         assert_eq!(
-            build_query(&default_object(), &args, &BTreeMap::new(), std::u32::MAX)
-                .unwrap()
-                .order_direction,
+            build_query(
+                &default_object(),
+                BLOCK_NUMBER_MAX,
+                &args,
+                &BTreeMap::new(),
+                std::u32::MAX
+            )
+            .unwrap()
+            .order_direction,
             None,
         );
     }
@@ -519,6 +578,7 @@ mod tests {
         assert_eq!(
             build_query(
                 &default_object(),
+                BLOCK_NUMBER_MAX,
                 &default_arguments(),
                 &BTreeMap::new(),
                 std::u32::MAX
@@ -535,9 +595,15 @@ mod tests {
         let mut args = default_arguments();
         args.insert(&skip, q::Value::Int(q::Number::from(50)));
         assert_eq!(
-            build_query(&default_object(), &args, &BTreeMap::new(), std::u32::MAX)
-                .unwrap()
-                .range,
+            build_query(
+                &default_object(),
+                BLOCK_NUMBER_MAX,
+                &args,
+                &BTreeMap::new(),
+                std::u32::MAX
+            )
+            .unwrap()
+            .range,
             EntityRange {
                 first: Some(100),
                 skip: 50,
@@ -562,6 +628,7 @@ mod tests {
                     fields: vec![field("name", Type::NamedType("string".to_owned()))],
                     ..default_object()
                 },
+                BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
                 std::u32::MAX,

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -8,6 +8,7 @@ use graph::prelude::*;
 
 use crate::prelude::*;
 use crate::query::ast as qast;
+use crate::query::ext::BlockConstraint;
 use crate::schema::ast as sast;
 
 use crate::store::query::{collect_entities_from_query_field, parse_subgraph_id};
@@ -244,6 +245,10 @@ where
         selection_set: &q::SelectionSet,
     ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
         super::prefetch::run(ctx, selection_set, self.store.clone()).map(|value| Some(value))
+    }
+
+    fn locate_block(&self, _: &BlockConstraint) -> Result<BlockNumber, QueryExecutionError> {
+        Ok(BLOCK_NUMBER_MAX)
     }
 
     fn resolve_objects(

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -329,6 +329,7 @@ where
                     let range = EntityRange::first(1);
                     let mut query = EntityQuery::new(
                         subgraph_id_for_resolve_object,
+                        BLOCK_NUMBER_MAX,
                         EntityCollection::All(entity_types),
                     )
                     .range(range);

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -253,7 +253,15 @@ where
             BlockLocator::Hash(hash) => self
                 .store
                 .block_number(&bc.subgraph, hash)
-                .map_err(|e| e.into()),
+                .map_err(|e| e.into())
+                .and_then(|number| {
+                    number.ok_or_else(|| {
+                        QueryExecutionError::ValueParseError(
+                            "block.hash".to_owned(),
+                            "no block with that hash found".to_owned(),
+                        )
+                    })
+                }),
         }
     }
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -247,8 +247,14 @@ where
         super::prefetch::run(ctx, selection_set, self.store.clone()).map(|value| Some(value))
     }
 
-    fn locate_block(&self, _: &BlockConstraint) -> Result<BlockNumber, QueryExecutionError> {
-        Ok(BLOCK_NUMBER_MAX)
+    fn locate_block(&self, bc: &BlockConstraint) -> Result<BlockNumber, QueryExecutionError> {
+        match bc.block {
+            BlockLocator::Number(number) => Ok(number),
+            BlockLocator::Hash(hash) => self
+                .store
+                .block_number(&bc.subgraph, hash)
+                .map_err(|e| e.into()),
+        }
     }
 
     fn resolve_objects(

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -63,6 +63,7 @@ where
         variable_values: Arc::new(coerced_variable_values),
         deadline: None,
         max_first: options.max_first,
+        block: BLOCK_NUMBER_MAX,
         mode: ExecutionMode::Prefetch,
     };
 
@@ -222,6 +223,7 @@ where
         variable_values,
         deadline: timeout.map(|t| Instant::now() + t),
         max_first,
+        block: BLOCK_NUMBER_MAX,
         mode: ExecutionMode::Prefetch,
     };
 

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -20,6 +20,10 @@ impl Resolver for MockResolver {
         Ok(None)
     }
 
+    fn locate_block(&self, _: &BlockConstraint) -> Result<BlockNumber, QueryExecutionError> {
+        Ok(BLOCK_NUMBER_MAX)
+    }
+
     fn resolve_objects<'a>(
         &self,
         _parent: &Option<q::Value>,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -28,6 +28,7 @@ impl Resolver for MockResolver {
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
+        _block: BlockNumber,
         _max_first: u32,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
@@ -41,6 +42,7 @@ impl Resolver for MockResolver {
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
+        _block: BlockNumber,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -553,7 +553,7 @@ fn introspection_query(schema: Schema, query: &str) -> QueryResult {
 
     // Execute it
     execute_query(
-        &query,
+        query,
         QueryExecutionOptions {
             logger: Logger::root(slog::Discard, o!()),
             resolver: MockResolver,

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -221,7 +221,7 @@ fn execute_query_document_with_variables(
         max_first: std::u32::MAX,
     };
 
-    execute_query(&query, options)
+    execute_query(query, options)
 }
 
 #[test]
@@ -716,7 +716,7 @@ fn query_complexity() {
     };
 
     // This query is exactly at the maximum complexity.
-    let result = execute_query(&query, options);
+    let result = execute_query(query, options);
     assert!(result.errors.is_none());
 
     let query = Query {
@@ -753,7 +753,7 @@ fn query_complexity() {
     };
 
     // The extra introspection causes the complexity to go over.
-    let result = execute_query(&query, options);
+    let result = execute_query(query, options);
     match result.errors.unwrap()[0] {
         QueryError::ExecutionError(QueryExecutionError::TooComplex(1_010_200, _)) => (),
         _ => panic!("did not catch complexity"),
@@ -859,7 +859,7 @@ fn instant_timeout() {
         max_first: std::u32::MAX,
     };
 
-    match execute_query(&query, options).errors.unwrap()[0] {
+    match execute_query(query, options).errors.unwrap()[0] {
         QueryError::ExecutionError(QueryExecutionError::Timeout) => (), // Expected
         _ => panic!("did not time out"),
     };

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -374,6 +374,10 @@ impl Store for MockStore {
         self.apply_metadata_operations(ops)
     }
 
+    fn block_number(&self, _: &SubgraphDeploymentId, _: H256) -> Result<BlockNumber, StoreError> {
+        Ok(BLOCK_NUMBER_MAX)
+    }
+
     fn migrate_subgraph_deployment(
         &self,
         _: &Logger,
@@ -559,6 +563,10 @@ impl Store for FakeStore {
         _: &EthereumBlockPointer,
     ) {
         unimplemented!()
+    }
+
+    fn block_number(&self, _: &SubgraphDeploymentId, _: H256) -> Result<BlockNumber, StoreError> {
+        Ok(BLOCK_NUMBER_MAX)
     }
 }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -374,8 +374,12 @@ impl Store for MockStore {
         self.apply_metadata_operations(ops)
     }
 
-    fn block_number(&self, _: &SubgraphDeploymentId, _: H256) -> Result<BlockNumber, StoreError> {
-        Ok(BLOCK_NUMBER_MAX)
+    fn block_number(
+        &self,
+        _: &SubgraphDeploymentId,
+        _: H256,
+    ) -> Result<Option<BlockNumber>, StoreError> {
+        Ok(Some(BLOCK_NUMBER_MAX))
     }
 
     fn migrate_subgraph_deployment(
@@ -565,8 +569,12 @@ impl Store for FakeStore {
         unimplemented!()
     }
 
-    fn block_number(&self, _: &SubgraphDeploymentId, _: H256) -> Result<BlockNumber, StoreError> {
-        Ok(BLOCK_NUMBER_MAX)
+    fn block_number(
+        &self,
+        _: &SubgraphDeploymentId,
+        _: H256,
+    ) -> Result<Option<BlockNumber>, StoreError> {
+        Ok(Some(BLOCK_NUMBER_MAX))
     }
 }
 

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -4,7 +4,9 @@ use std::collections::{BTreeMap, HashMap};
 use graph::data::graphql::{TryFromValue, ValueList, ValueMap};
 use graph::data::subgraph::schema::SUBGRAPHS_ID;
 use graph::prelude::*;
-use graph_graphql::prelude::{object_value, ExecutionContext, ObjectOrInterface, Resolver};
+use graph_graphql::prelude::{
+    object_value, BlockConstraint, ExecutionContext, ObjectOrInterface, Resolver,
+};
 use web3::types::H256;
 
 /// Resolver for the index node GraphQL API.
@@ -506,6 +508,10 @@ where
         _: &q::SelectionSet,
     ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
         Ok(None)
+    }
+
+    fn locate_block(&self, _: &BlockConstraint) -> Result<BlockNumber, QueryExecutionError> {
+        Ok(BLOCK_NUMBER_MAX)
     }
 
     fn resolve_objects(

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -516,6 +516,7 @@ where
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
+        _block: BlockNumber,
         _max_first: u32,
     ) -> Result<q::Value, QueryExecutionError> {
         match (parent, object_type.name(), field.name.as_str()) {
@@ -562,6 +563,7 @@ where
         object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
+        _block: BlockNumber,
     ) -> Result<q::Value, QueryExecutionError> {
         match (parent, object_type.name(), field.name.as_str()) {
             (Some(status), "EthereumBlock", "chainHeadBlock") => Ok(status

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -109,7 +109,7 @@ where
 
                     // Run the query using the index node resolver
                     Box::new(future::ok(execute_query(
-                        &query,
+                        query,
                         QueryExecutionOptions {
                             logger: logger.clone(),
                             resolver: IndexNodeResolver::new(&logger, graphql_runner, store),

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -7,14 +7,9 @@ use diesel::sql_types::{Integer, Range};
 use std::io::Write;
 use std::ops::{Bound, RangeBounds, RangeFrom};
 
+use graph::prelude::BlockNumber;
+
 use crate::history_event::HistoryEvent;
-
-/// The type we use for block numbers. This has to be a signed integer type
-/// since Postgres does not support unsigned integer types. But 2G ought to
-/// be enough for everybody
-pub type BlockNumber = i32;
-
-pub const BLOCK_NUMBER_MAX: BlockNumber = std::i32::MAX;
 
 /// The name of the column in which we store the block range
 pub(crate) const BLOCK_RANGE_COLUMN: &str = "block_range";

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -42,13 +42,14 @@ use std::time::Instant;
 use graph::data::schema::Schema as SubgraphSchema;
 use graph::data::subgraph::schema::SUBGRAPHS_ID;
 use graph::prelude::{
-    debug, format_err, info, serde_json, warn, AttributeIndexDefinition, Entity, EntityChange,
-    EntityChangeOperation, EntityCollection, EntityFilter, EntityKey, EntityModification,
-    EntityOrder, EntityRange, Error, EthereumBlockPointer, Logger, QueryExecutionError, StoreError,
-    StoreEvent, SubgraphDeploymentId, SubgraphDeploymentStore, ValueType,
+    debug, format_err, info, serde_json, warn, AttributeIndexDefinition, BlockNumber, Entity,
+    EntityChange, EntityChangeOperation, EntityCollection, EntityFilter, EntityKey,
+    EntityModification, EntityOrder, EntityRange, Error, EthereumBlockPointer, Logger,
+    QueryExecutionError, StoreError, StoreEvent, SubgraphDeploymentId, SubgraphDeploymentStore,
+    ValueType,
 };
 
-use crate::block_range::{block_number, BlockNumber};
+use crate::block_range::block_number;
 use crate::history_event::HistoryEvent;
 use crate::jsonb::PgJsonbExpressionMethods as _;
 use crate::jsonb_queries::FilterQuery;

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -461,7 +461,7 @@ impl Connection {
                     return Err(StoreError::QueryExecutionError(
                         "This subgraph uses JSONB storage, which does not \
                          support querying at a specific block height. Redeploy \
-                         the subgraph to remove this error message."
+                         a new version of this subgraph to enable this feature."
                             .to_owned(),
                     )
                     .into());

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -21,12 +21,12 @@ use crate::relational_queries::{
     InsertQuery, RevertClampQuery, RevertRemoveQuery,
 };
 use graph::prelude::{
-    format_err, Entity, EntityChange, EntityChangeOperation, EntityCollection, EntityFilter,
-    EntityKey, EntityOrder, EntityRange, QueryExecutionError, StoreError, StoreEvent,
+    format_err, BlockNumber, Entity, EntityChange, EntityChangeOperation, EntityCollection,
+    EntityFilter, EntityKey, EntityOrder, EntityRange, QueryExecutionError, StoreError, StoreEvent,
     SubgraphDeploymentId, ValueType,
 };
 
-use crate::block_range::{BlockNumber, BLOCK_RANGE_COLUMN};
+use crate::block_range::BLOCK_RANGE_COLUMN;
 use crate::entities::STRING_PREFIX_SIZE;
 
 /// A string we use as a SQL name for a table or column. The important thing

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -17,13 +17,13 @@ use std::str::FromStr;
 
 use graph::data::store::scalar;
 use graph::prelude::{
-    format_err, serde_json, Attribute, Entity, EntityCollection, EntityFilter, EntityKey,
-    EntityLink, EntityOrder, EntityRange, EntityWindow, QueryExecutionError, StoreError, Value,
-    ValueType,
+    format_err, serde_json, Attribute, BlockNumber, Entity, EntityCollection, EntityFilter,
+    EntityKey, EntityLink, EntityOrder, EntityRange, EntityWindow, QueryExecutionError, StoreError,
+    Value, ValueType,
 };
 
 use crate::block_range::{
-    BlockNumber, BlockRange, BlockRangeContainsClause, BLOCK_RANGE_COLUMN, BLOCK_RANGE_CURRENT,
+    BlockRange, BlockRangeContainsClause, BLOCK_RANGE_COLUMN, BLOCK_RANGE_CURRENT,
 };
 use crate::entities::STRING_PREFIX_SIZE;
 use crate::filter::UnsupportedFilter;

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -374,7 +374,7 @@ impl Store {
             query.filter,
             order,
             query.range,
-            BLOCK_NUMBER_MAX,
+            query.block,
         )
     }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -18,14 +18,14 @@ use graph::data::subgraph::schema::{
 };
 use graph::prelude::{
     bail, debug, ethabi, format_err, info, o, serde_json, stream, tiny_keccak, tokio, trace, warn,
-    web3, AttributeIndexDefinition, BigInt, ChainHeadUpdateListener as _, ChainHeadUpdateStream,
-    ChainStore, Entity, EntityKey, EntityModification, EntityOrder, EntityQuery, EntityRange,
-    Error, EthereumBlock, EthereumBlockPointer, EthereumCallCache, EthereumNetworkIdentifier,
-    EventProducer as _, Future, LightEthereumBlock, Logger, MetadataOperation, MetricsRegistry,
-    QueryExecutionError, Schema, Sink as _, StopwatchMetrics, StoreError, StoreEvent,
-    StoreEventStream, StoreEventStreamBox, Stream, SubgraphAssignmentProviderError,
-    SubgraphDeploymentId, SubgraphDeploymentStore, SubgraphEntityPair, TransactionAbortError,
-    Value, BLOCK_NUMBER_MAX,
+    web3, AttributeIndexDefinition, BigInt, BlockNumber, ChainHeadUpdateListener as _,
+    ChainHeadUpdateStream, ChainStore, Entity, EntityKey, EntityModification, EntityOrder,
+    EntityQuery, EntityRange, Error, EthereumBlock, EthereumBlockPointer, EthereumCallCache,
+    EthereumNetworkIdentifier, EventProducer as _, Future, LightEthereumBlock, Logger,
+    MetadataOperation, MetricsRegistry, QueryExecutionError, Schema, Sink as _, StopwatchMetrics,
+    StoreError, StoreEvent, StoreEventStream, StoreEventStreamBox, Stream,
+    SubgraphAssignmentProviderError, SubgraphDeploymentId, SubgraphDeploymentStore,
+    SubgraphEntityPair, TransactionAbortError, Value, BLOCK_NUMBER_MAX,
 };
 use graph_graphql::prelude::api_schema;
 use tokio::timer::Interval;
@@ -1061,6 +1061,10 @@ impl StoreTrait for Store {
                             "error" => e.to_string(),
             );
         }
+    }
+
+    fn block_number(&self, _: &SubgraphDeploymentId, _: H256) -> Result<BlockNumber, StoreError> {
+        Ok(BLOCK_NUMBER_MAX)
     }
 }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -25,13 +25,12 @@ use graph::prelude::{
     QueryExecutionError, Schema, Sink as _, StopwatchMetrics, StoreError, StoreEvent,
     StoreEventStream, StoreEventStreamBox, Stream, SubgraphAssignmentProviderError,
     SubgraphDeploymentId, SubgraphDeploymentStore, SubgraphEntityPair, TransactionAbortError,
-    Value,
+    Value, BLOCK_NUMBER_MAX,
 };
 use graph_graphql::prelude::api_schema;
 use tokio::timer::Interval;
 use web3::types::H256;
 
-use crate::block_range::BLOCK_NUMBER_MAX;
 use crate::chain_head_listener::ChainHeadUpdateListener;
 use crate::entities as e;
 use crate::functions::{attempt_chain_head_update, lookup_ancestor_block};

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -7,14 +7,26 @@ use futures::sync::mpsc::{channel, Sender};
 use lru_time_cache::LruCache;
 use std::collections::{BTreeMap, HashMap};
 use std::convert::TryInto;
-use std::sync::{Mutex, RwLock};
+use std::iter::FromIterator;
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 use graph::components::store::Store as StoreTrait;
-use graph::data::subgraph::schema::*;
-use graph::prelude::serde_json;
-use graph::prelude::{ChainHeadUpdateListener as _, *};
+use graph::data::subgraph::schema::{
+    SubgraphDeploymentEntity, SubgraphManifestEntity, TypedEntity as _, SUBGRAPHS_ID,
+};
+use graph::prelude::{
+    bail, debug, ethabi, format_err, info, o, serde_json, stream, tiny_keccak, tokio, trace, warn,
+    web3, AttributeIndexDefinition, BigInt, ChainHeadUpdateListener as _, ChainHeadUpdateStream,
+    ChainStore, Entity, EntityKey, EntityModification, EntityOrder, EntityQuery, EntityRange,
+    Error, EthereumBlock, EthereumBlockPointer, EthereumCallCache, EthereumNetworkIdentifier,
+    EventProducer as _, Future, LightEthereumBlock, Logger, MetadataOperation, MetricsRegistry,
+    QueryExecutionError, Schema, Sink as _, StopwatchMetrics, StoreError, StoreEvent,
+    StoreEventStream, StoreEventStreamBox, Stream, SubgraphAssignmentProviderError,
+    SubgraphDeploymentId, SubgraphDeploymentStore, SubgraphEntityPair, TransactionAbortError,
+    Value,
+};
 use graph_graphql::prelude::api_schema;
 use tokio::timer::Interval;
 use web3::types::H256;

--- a/store/postgres/tests/chain_head.rs
+++ b/store/postgres/tests/chain_head.rs
@@ -1,140 +1,23 @@
 //! Test ChainStore implementation of Store, in particular, how
 //! the chain head pointer gets updated in various situations
 
-use diesel::prelude::*;
-use diesel::RunQueryDsl;
 use futures::future::{self, IntoFuture};
-use lazy_static::lazy_static;
 use std::fmt::Debug;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use graph::components::store::{ChainStore, Store as _};
-use graph::prelude::{serde_json, web3::types::H256, SubgraphDeploymentId};
-use graph_store_postgres::db_schema_for_tests as db_schema;
+use graph::prelude::SubgraphDeploymentId;
 use graph_store_postgres::Store as DieselStore;
 
+use test_store::block_store::{
+    Chain, FakeBlock, BLOCK_FIVE, BLOCK_FOUR, BLOCK_ONE, BLOCK_ONE_NO_PARENT, BLOCK_ONE_SIBLING,
+    BLOCK_THREE, BLOCK_THREE_NO_PARENT, BLOCK_TWO, BLOCK_TWO_NO_PARENT, GENESIS_BLOCK, NO_PARENT,
+};
 use test_store::*;
 
 // The ancestor count we use for chain head updates. We keep this very small
 // to make setting up the tests easier
 const ANCESTOR_COUNT: u64 = 3;
-
-/// The parts of an Ethereum block that are interesting for these tests:
-/// the block number, hash, and the hash of the parent block
-#[derive(Clone, Debug, PartialEq)]
-struct FakeBlock {
-    number: u64,
-    hash: String,
-    parent_hash: String,
-}
-
-impl FakeBlock {
-    fn make_child(&self, hash: &str) -> Self {
-        FakeBlock {
-            number: self.number + 1,
-            hash: hash.to_owned(),
-            parent_hash: self.hash.clone(),
-        }
-    }
-
-    fn make_no_parent(number: u64, hash: &str) -> Self {
-        FakeBlock {
-            number,
-            hash: hash.to_owned(),
-            parent_hash: NO_PARENT.clone(),
-        }
-    }
-
-    fn insert(&self, conn: &PgConnection) {
-        use db_schema::ethereum_blocks as b;
-
-        let data = serde_json::to_value(format!(
-            "{{\"hash\":\"{}\", \"number\":{}}}",
-            self.hash, self.number
-        ))
-        .expect("Failed to serialize block");
-
-        let errmsg = format!("Failed to insert block {} ({})", self.number, self.hash);
-        diesel::insert_into(b::table)
-            .values((
-                &b::number.eq(self.number as i64),
-                &b::hash.eq(&self.hash),
-                &b::parent_hash.eq(&self.parent_hash),
-                &b::network_name.eq(NETWORK_NAME),
-                &b::data.eq(data),
-            ))
-            .execute(conn)
-            .expect(&errmsg);
-    }
-
-    fn block_hash(&self) -> H256 {
-        H256::from_str(self.hash.as_str()).expect("invalid block hash")
-    }
-}
-
-type Chain = Vec<&'static FakeBlock>;
-
-lazy_static! {
-    // Hash indicating 'no parent'
-    static ref NO_PARENT: String =
-        "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
-    // Genesis block
-    static ref GENESIS_BLOCK: FakeBlock = FakeBlock {
-        number: GENESIS_PTR.number,
-        hash: format!("{:x}", GENESIS_PTR.hash),
-        parent_hash: NO_PARENT.clone()
-    };
-    static ref BLOCK_ONE: FakeBlock = GENESIS_BLOCK
-        .make_child("8511fa04b64657581e3f00e14543c1d522d5d7e771b54aa3060b662ade47da13");
-    static ref BLOCK_ONE_SIBLING: FakeBlock =
-        GENESIS_BLOCK.make_child("b98fb783b49de5652097a989414c767824dff7e7fd765a63b493772511db81c1");
-    static ref BLOCK_ONE_NO_PARENT: FakeBlock = FakeBlock::make_no_parent(
-        1,
-        "7205bdfcf4521874cf38ce38c879ff967bf3a069941286bfe267109ad275a63d"
-    );
-
-    static ref BLOCK_TWO: FakeBlock = BLOCK_ONE.make_child("f8ccbd3877eb98c958614f395dd351211afb9abba187bfc1fb4ac414b099c4a6");
-    static ref BLOCK_TWO_NO_PARENT: FakeBlock = FakeBlock::make_no_parent(2, "3b652b00bff5e168b1218ff47593d516123261c4487629c4175f642ee56113fe");
-    static ref BLOCK_THREE: FakeBlock = BLOCK_TWO.make_child("7347afe69254df06729e123610b00b8b11f15cfae3241f9366fb113aec07489c");
-    static ref BLOCK_THREE_NO_PARENT: FakeBlock = FakeBlock::make_no_parent(3, "fa9ebe3f74de4c56908b49f5c4044e85825f7350f3fa08a19151de82a82a7313");
-    static ref BLOCK_FOUR: FakeBlock = BLOCK_THREE.make_child("7cce080f5a49c2997a6cc65fc1cee9910fd8fc3721b7010c0b5d0873e2ac785e");
-    static ref BLOCK_FIVE: FakeBlock = BLOCK_FOUR.make_child("7b0ea919e258eb2b119eb32de56b85d12d50ac6a9f7c5909f843d6172c8ba196");
-    static ref BLOCK_SIX_NO_PARENT: FakeBlock = FakeBlock::make_no_parent(6, "6b834521bb753c132fdcf0e1034803ed9068e324112f8750ba93580b393a986b");
-}
-
-/// Removes test data from the database behind the store.
-fn remove_test_data() {
-    let url = postgres_test_url();
-    let conn = PgConnection::establish(url.as_str()).expect("Failed to connect to Postgres");
-
-    diesel::delete(db_schema::ethereum_blocks::table)
-        .execute(&conn)
-        .expect("Failed to delete ethereum_blocks");
-    diesel::delete(db_schema::ethereum_networks::table)
-        .execute(&conn)
-        .expect("Failed to delete ethereum_networks");
-}
-
-fn insert_test_data(_store: Arc<DieselStore>, chain: Chain) {
-    let url = postgres_test_url();
-    let conn = PgConnection::establish(url.as_str()).expect("Failed to connect to Postgres");
-
-    use db_schema::ethereum_networks as n;
-    let hash = format!("{:x}", GENESIS_PTR.hash);
-    diesel::insert_into(n::table)
-        .values((
-            &n::name.eq(NETWORK_NAME),
-            &n::genesis_block_hash.eq(&hash),
-            &n::net_version.eq(NETWORK_VERSION),
-        ))
-        .execute(&conn)
-        .expect("Failed to insert test network");
-
-    for block in chain {
-        block.insert(&conn);
-    }
-}
 
 /// Test harness for running database integration tests.
 fn run_test<R, F>(chain: Chain, test: F)
@@ -155,10 +38,10 @@ where
     runtime
         .block_on(future::lazy(move || {
             // Reset state before starting
-            remove_test_data();
+            block_store::remove();
 
             // Seed database with test data
-            insert_test_data(store.clone(), chain);
+            block_store::insert(chain, NETWORK_NAME);
 
             // Run test
             test(store)

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -12,8 +12,9 @@ use graph::data::store::scalar::{BigDecimal, BigInt, Bytes};
 use graph::prelude::{
     bigdecimal::One, web3::types::H256, Entity, EntityCollection, EntityFilter, EntityKey,
     EntityOrder, EntityQuery, EntityRange, Schema, SubgraphDeploymentId, Value, ValueType,
+    BLOCK_NUMBER_MAX,
 };
-use graph_store_postgres::layout_for_tests::{Layout, BLOCK_NUMBER_MAX, STRING_PREFIX_SIZE};
+use graph_store_postgres::layout_for_tests::{Layout, STRING_PREFIX_SIZE};
 
 use test_store::*;
 

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -540,6 +540,7 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
 fn query(entity_types: Vec<&str>) -> EntityQuery {
     EntityQuery::new(
         THINGS_SUBGRAPH_ID.clone(),
+        BLOCK_NUMBER_MAX,
         EntityCollection::All(entity_types.into_iter().map(|s| s.to_owned()).collect()),
     )
 }

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -2196,7 +2196,15 @@ fn find_at_block() {
         })
     }
 
-    shaqueeena_at_block(1, "queensha@email.com");
-    shaqueeena_at_block(2, "teeko@email.com");
-    shaqueeena_at_block(7000, "teeko@email.com");
+    // These tests only make sense with relational storage
+    let testing_relational_storage = std::env::var("GRAPH_STORAGE_SCHEME")
+        .unwrap_or_else(|_| "relational".to_owned())
+        .as_str()
+        == "relational";
+
+    if testing_relational_storage {
+        shaqueeena_at_block(1, "queensha@email.com");
+        shaqueeena_at_block(2, "teeko@email.com");
+        shaqueeena_at_block(7000, "teeko@email.com");
+    }
 }

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -2174,3 +2174,29 @@ fn window() {
         Ok(())
     });
 }
+
+#[test]
+fn find_at_block() {
+    fn shaqueeena_at_block(block: BlockNumber, email: &'static str) {
+        run_test(move |store| -> Result<(), ()> {
+            let mut query = user_query()
+                .filter(EntityFilter::Equal("name".to_owned(), "Shaqueeena".into()))
+                .order_by("name", ValueType::String, EntityOrder::Descending);
+            query.block = block;
+
+            let entities = store
+                .find(query)
+                .expect("store.find failed to execute query");
+
+            assert_eq!(1, entities.len());
+            let entity = entities.first().unwrap();
+            assert_eq!(Some(&Value::from(email)), entity.get("email"));
+
+            Ok(())
+        })
+    }
+
+    shaqueeena_at_block(1, "queensha@email.com");
+    shaqueeena_at_block(2, "teeko@email.com");
+    shaqueeena_at_block(7000, "teeko@email.com");
+}

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -574,6 +574,7 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
 fn user_query() -> EntityQuery {
     EntityQuery::new(
         TEST_SUBGRAPH_ID.clone(),
+        BLOCK_NUMBER_MAX,
         EntityCollection::All(vec![USER.to_owned()]),
     )
 }

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -160,3 +160,133 @@ pub fn insert_entities(
     )
     .map(|_| ())
 }
+
+pub mod block_store {
+    use diesel::prelude::*;
+    use std::str::FromStr;
+
+    use graph::prelude::{serde_json, web3::types::H256};
+    use graph_store_postgres::db_schema_for_tests as db_schema;
+    use lazy_static::lazy_static;
+
+    /// The parts of an Ethereum block that are interesting for these tests:
+    /// the block number, hash, and the hash of the parent block
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct FakeBlock {
+        pub number: u64,
+        pub hash: String,
+        pub parent_hash: String,
+    }
+
+    impl FakeBlock {
+        fn make_child(&self, hash: &str) -> Self {
+            FakeBlock {
+                number: self.number + 1,
+                hash: hash.to_owned(),
+                parent_hash: self.hash.clone(),
+            }
+        }
+
+        fn make_no_parent(number: u64, hash: &str) -> Self {
+            FakeBlock {
+                number,
+                hash: hash.to_owned(),
+                parent_hash: NO_PARENT.clone(),
+            }
+        }
+
+        fn insert(&self, conn: &PgConnection) {
+            use db_schema::ethereum_blocks as b;
+
+            let data = serde_json::to_value(format!(
+                "{{\"hash\":\"{}\", \"number\":{}}}",
+                self.hash, self.number
+            ))
+            .expect("Failed to serialize block");
+
+            let errmsg = format!("Failed to insert block {} ({})", self.number, self.hash);
+            diesel::insert_into(b::table)
+                .values((
+                    &b::number.eq(self.number as i64),
+                    &b::hash.eq(&self.hash),
+                    &b::parent_hash.eq(&self.parent_hash),
+                    &b::network_name.eq(super::NETWORK_NAME),
+                    &b::data.eq(data),
+                ))
+                .execute(conn)
+                .expect(&errmsg);
+        }
+
+        pub fn block_hash(&self) -> H256 {
+            H256::from_str(self.hash.as_str()).expect("invalid block hash")
+        }
+    }
+
+    pub type Chain = Vec<&'static FakeBlock>;
+
+    lazy_static! {
+        // Hash indicating 'no parent'
+        pub static ref NO_PARENT: String =
+            "0000000000000000000000000000000000000000000000000000000000000000".to_owned();
+        // Genesis block
+        pub static ref GENESIS_BLOCK: FakeBlock = FakeBlock {
+            number: super::GENESIS_PTR.number,
+            hash: format!("{:x}", super::GENESIS_PTR.hash),
+            parent_hash: NO_PARENT.clone()
+        };
+        pub static ref BLOCK_ONE: FakeBlock = GENESIS_BLOCK
+            .make_child("8511fa04b64657581e3f00e14543c1d522d5d7e771b54aa3060b662ade47da13");
+        pub static ref BLOCK_ONE_SIBLING: FakeBlock =
+            GENESIS_BLOCK.make_child("b98fb783b49de5652097a989414c767824dff7e7fd765a63b493772511db81c1");
+        pub static ref BLOCK_ONE_NO_PARENT: FakeBlock = FakeBlock::make_no_parent(
+            1,
+            "7205bdfcf4521874cf38ce38c879ff967bf3a069941286bfe267109ad275a63d"
+        );
+
+        pub static ref BLOCK_TWO: FakeBlock = BLOCK_ONE.make_child("f8ccbd3877eb98c958614f395dd351211afb9abba187bfc1fb4ac414b099c4a6");
+        pub static ref BLOCK_TWO_NO_PARENT: FakeBlock = FakeBlock::make_no_parent(2, "3b652b00bff5e168b1218ff47593d516123261c4487629c4175f642ee56113fe");
+        pub static ref BLOCK_THREE: FakeBlock = BLOCK_TWO.make_child("7347afe69254df06729e123610b00b8b11f15cfae3241f9366fb113aec07489c");
+        pub static ref BLOCK_THREE_NO_PARENT: FakeBlock = FakeBlock::make_no_parent(3, "fa9ebe3f74de4c56908b49f5c4044e85825f7350f3fa08a19151de82a82a7313");
+        pub static ref BLOCK_FOUR: FakeBlock = BLOCK_THREE.make_child("7cce080f5a49c2997a6cc65fc1cee9910fd8fc3721b7010c0b5d0873e2ac785e");
+        pub static ref BLOCK_FIVE: FakeBlock = BLOCK_FOUR.make_child("7b0ea919e258eb2b119eb32de56b85d12d50ac6a9f7c5909f843d6172c8ba196");
+        pub static ref BLOCK_SIX_NO_PARENT: FakeBlock = FakeBlock::make_no_parent(6, "6b834521bb753c132fdcf0e1034803ed9068e324112f8750ba93580b393a986b");
+    }
+
+    /// Removes all networks and blocks from the database
+    pub fn remove() {
+        use db_schema::ethereum_blocks as b;
+        use db_schema::ethereum_networks as n;
+
+        let url = super::postgres_test_url();
+        let conn = PgConnection::establish(url.as_str()).expect("Failed to connect to Postgres");
+
+        diesel::delete(b::table)
+            .execute(&conn)
+            .expect("Failed to delete ethereum_blocks");
+        diesel::delete(n::table)
+            .execute(&conn)
+            .expect("Failed to delete ethereum_networks");
+    }
+
+    // Store the given chain as the blocks for the `network` and set the
+    // network's genesis block to the hash of `GENESIS_BLOCK`
+    pub fn insert(chain: Chain, network: &str) {
+        let url = super::postgres_test_url();
+        let conn = PgConnection::establish(url.as_str()).expect("Failed to connect to Postgres");
+
+        use db_schema::ethereum_networks as n;
+        let hash = format!("{:x}", super::GENESIS_PTR.hash);
+        diesel::insert_into(n::table)
+            .values((
+                &n::name.eq(network),
+                &n::genesis_block_hash.eq(&hash),
+                &n::net_version.eq(super::NETWORK_VERSION),
+            ))
+            .execute(&conn)
+            .expect("Failed to insert test network");
+
+        for block in chain {
+            block.insert(&conn);
+        }
+    }
+}


### PR DESCRIPTION
With this PR, it is possible to run queries against the state of a subgraph at an arbitrary block height, and not just the latest block. So far, a query like `transactions { id }` would always return the data for the latest set of transactions, and rerunning it might return a different result if the subgraph had ingested more transactions in the mean time.

It is now possible to fix the block at which to query by passing an additional `block` argument to top-level fields: `transactions(block: { number: 7000 }) { id }` will return the transactions as of the block with that number, and `transactions(block: { hash: "0xdeadbeef" }) { id }` will return transactions as of that block hash. To make absolutely sure the query result is reproducible, the form with the `hash` should be used as which block is designated by `number` may change if the chain is reorganized (though using `number` far enough away from the chain head will be fine)

If a query does not explicitly specify a block, we continue to run it against the latest available data, so that the behavior for existing queries does not change.

Fixes #1329 
Fixes #813 

