### PR TITLE
Block Ingestor Metrics - tracking block syncing events

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -576,6 +576,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                         network_name.to_string(),
                         &logger_factory,
                         block_polling_interval,
+                        metrics_registry.clone(),
                     )
                     .expect("failed to create Ethereum block ingestor");
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -488,6 +488,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
         create_connection_pool(postgres_url.clone(), store_conn_pool_size, &logger);
 
     let stores_metrics_registry = metrics_registry.clone();
+    let graphql_metrics_registry = metrics_registry.clone();
     let stores_logger = logger.clone();
     let stores_error_logger = logger.clone();
     let stores_eth_adapters = eth_adapters.clone();
@@ -541,6 +542,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
             ));
             let mut graphql_server = GraphQLQueryServer::new(
                 &logger_factory,
+                graphql_metrics_registry,
                 graphql_runner.clone(),
                 generic_store.clone(),
                 node_id.clone(),

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -74,7 +74,7 @@ impl GraphQlRunner for TestGraphQlRunner {
 #[cfg(test)]
 mod test {
     use super::*;
-    use graph_mock::MockStore;
+    use graph_mock::{MockMetricsRegistry, MockStore};
     use web3::types::H256;
 
     fn mock_store(id: SubgraphDeploymentId) -> Arc<MockStore> {
@@ -117,11 +117,12 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
                 let logger_factory = LoggerFactory::new(logger, None);
+                let metrics_registry = Arc::new(MockMetricsRegistry::new());
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server = HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
+                let mut server = HyperGraphQLServer::new(&logger_factory, metrics_registry, query_runner, store, node_id);
                 let http_server = server
                     .serve(8001, 8002)
                     .expect("Failed to start GraphQL server");
@@ -167,12 +168,18 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
                 let logger_factory = LoggerFactory::new(logger, None);
+                let metrics_registry = Arc::new(MockMetricsRegistry::new());
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server =
-                    HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
+                let mut server = HyperGraphQLServer::new(
+                    &logger_factory,
+                    metrics_registry,
+                    query_runner,
+                    store,
+                    node_id,
+                );
                 let http_server = server
                     .serve(8002, 8003)
                     .expect("Failed to start GraphQL server");
@@ -252,12 +259,18 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
                 let logger_factory = LoggerFactory::new(logger, None);
+                let metrics_registry = Arc::new(MockMetricsRegistry::new());
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server =
-                    HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
+                let mut server = HyperGraphQLServer::new(
+                    &logger_factory,
+                    metrics_registry,
+                    query_runner,
+                    store,
+                    node_id,
+                );
                 let http_server = server
                     .serve(8003, 8004)
                     .expect("Failed to start GraphQL server");
@@ -302,13 +315,19 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
                 let logger_factory = LoggerFactory::new(logger, None);
+                let metrics_registry = Arc::new(MockMetricsRegistry::new());
 
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server =
-                    HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
+                let mut server = HyperGraphQLServer::new(
+                    &logger_factory,
+                    metrics_registry,
+                    query_runner,
+                    store,
+                    node_id,
+                );
                 let http_server = server
                     .serve(8005, 8006)
                     .expect("Failed to start GraphQL server");


### PR DESCRIPTION
Adds a gauge to track blocks being synced by the different Ethereum networks.   The gauge will be used to create robust block syncing tracking and alerts. 

>  Note: Not yet tested on a local Prometheus/Grafana setup. 