### PR TITLE
Create metrics to track block ingestion and GraphQL query execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,7 @@ dependencies = [
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph 0.16.1",
+ "graph-chain-ethereum 0.16.1",
  "graph-graphql 0.16.1",
  "graph-mock 0.16.1",
  "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -47,18 +47,15 @@ impl<S> BlockIngestor<S>
 where
     S: ChainStore,
 {
-    pub fn new<M>(
+    pub fn new(
         chain_store: Arc<S>,
         eth_adapter: Arc<dyn EthereumAdapter>,
         ancestor_count: u64,
         network_name: String,
         logger_factory: &LoggerFactory,
         polling_interval: Duration,
-        registry: Arc<M>,
-    ) -> Result<BlockIngestor<S>, Error>
-    where
-        M: MetricsRegistry,
-    {
+        registry: Arc<impl MetricsRegistry>,
+    ) -> Result<BlockIngestor<S>, Error> {
         let logger = logger_factory.component_logger(
             "BlockIngestor",
             Some(ComponentLoggerConfig {

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -39,7 +39,6 @@ where
     ancestor_count: u64,
     network_name: String,
     logger: Logger,
-    ingestor_metrics: Arc<BlockIngestorMetrics>,
     polling_interval: Duration,
 }
 
@@ -54,7 +53,6 @@ where
         network_name: String,
         logger_factory: &LoggerFactory,
         polling_interval: Duration,
-        registry: Arc<impl MetricsRegistry>,
     ) -> Result<BlockIngestor<S>, Error> {
         let logger = logger_factory.component_logger(
             "BlockIngestor",
@@ -64,7 +62,6 @@ where
                 }),
             }),
         );
-        let ingestor_metrics = Arc::new(BlockIngestorMetrics::new(registry.clone()));
 
         Ok(BlockIngestor {
             chain_store,
@@ -72,7 +69,6 @@ where
             ancestor_count,
             network_name,
             logger,
-            ingestor_metrics,
             polling_interval,
         })
     }
@@ -144,10 +140,6 @@ where
                                     LogCode::BlockIngestionStatus
                                 };
                                 if distance > 0 {
-                                    self.ingestor_metrics.observe_blocks_synced(
-                                        &network_name,
-                                        latest_number,
-                                    );
                                     info!(
                                         self.logger,
                                         "Syncing {} blocks from Ethereum.",

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -6,16 +6,16 @@ use graph::prelude::*;
 use web3::types::*;
 
 pub struct BlockIngestorMetrics {
-    pub block_number: Box<GaugeVec>,
+    chain_head_number: Box<GaugeVec>,
 }
 
 impl BlockIngestorMetrics {
-    pub fn new<M: MetricsRegistry>(registry: Arc<M>) -> Self {
+    pub fn new(registry: Arc<dyn MetricsRegistry>) -> Self {
         Self {
-            block_number: registry
+            chain_head_number: registry
                 .new_gauge_vec(
-                    String::from("ethereum_block_number"),
-                    String::from("Records the number of the most recent block synced on the Ethereum network"),
+                    String::from("ethereum_chain_head_number"),
+                    String::from("Block number of the most recent block synced from Ethereum"),
                     HashMap::new(),
                     vec![String::from("network")],
                 )
@@ -23,10 +23,10 @@ impl BlockIngestorMetrics {
         }
     }
 
-    pub fn observe_blocks_synced(&self, network_name: &str, latest_block_number: i64) {
-        self.block_number
+    pub fn set_chain_head_number(&self, network_name: &str, chain_head_number: i64) {
+        self.chain_head_number
             .with_label_values(vec![network_name].as_slice())
-            .set(latest_block_number as f64);
+            .set(chain_head_number as f64);
     }
 }
 

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -10,7 +10,7 @@ mod block_stream;
 mod ethereum_adapter;
 mod transport;
 
-pub use self::block_ingestor::BlockIngestor;
+pub use self::block_ingestor::{BlockIngestor, BlockIngestorMetrics};
 pub use self::block_stream::{BlockStream, BlockStreamBuilder};
 pub use self::ethereum_adapter::EthereumAdapter;
 pub use self::transport::{EventLoopHandle, Transport};

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -64,7 +64,7 @@ struct SubgraphInstanceManagerMetrics {
 }
 
 impl SubgraphInstanceManagerMetrics {
-    pub fn new<M: MetricsRegistry>(registry: Arc<M>) -> Self {
+    pub fn new(registry: Arc<impl MetricsRegistry>) -> Self {
         let subgraph_count = registry
             .new_gauge(
                 String::from("subgraph_count"),
@@ -103,7 +103,7 @@ struct SubgraphInstanceMetrics {
 }
 
 impl SubgraphInstanceMetrics {
-    pub fn new<M: MetricsRegistry>(registry: Arc<M>, subgraph_hash: String) -> Self {
+    pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: String) -> Self {
         let block_trigger_count = registry
             .new_histogram(
                 format!("subgraph_block_trigger_count_{}", subgraph_hash),

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -488,7 +488,7 @@ pub struct ProviderEthRpcMetrics {
 }
 
 impl ProviderEthRpcMetrics {
-    pub fn new<M: MetricsRegistry>(registry: Arc<M>) -> Self {
+    pub fn new(registry: Arc<impl MetricsRegistry>) -> Self {
         let request_duration = registry
             .new_histogram_vec(
                 String::from("eth_rpc_request_duration"),
@@ -530,7 +530,7 @@ pub struct SubgraphEthRpcMetrics {
 }
 
 impl SubgraphEthRpcMetrics {
-    pub fn new<M: MetricsRegistry>(registry: Arc<M>, subgraph_hash: String) -> Self {
+    pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: String) -> Self {
         let request_duration = registry
             .new_gauge_vec(
                 format!("subgraph_eth_rpc_request_duration_{}", subgraph_hash),
@@ -573,8 +573,8 @@ pub struct BlockStreamMetrics {
 }
 
 impl BlockStreamMetrics {
-    pub fn new<M: MetricsRegistry>(
-        registry: Arc<M>,
+    pub fn new(
+        registry: Arc<impl MetricsRegistry>,
         ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
         deployment_id: SubgraphDeploymentId,
         stopwatch: StopwatchMetrics,

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -64,8 +64,8 @@ impl fmt::Debug for HostMetrics {
 }
 
 impl HostMetrics {
-    pub fn new<M: MetricsRegistry>(
-        registry: Arc<M>,
+    pub fn new(
+        registry: Arc<impl MetricsRegistry>,
         subgraph_hash: String,
         stopwatch: StopwatchMetrics,
     ) -> Self {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -576,6 +576,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                         network_name.to_string(),
                         &logger_factory,
                         block_polling_interval,
+                        metrics_registry.clone(),
                     )
                     .expect("failed to create Ethereum block ingestor");
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -578,7 +578,6 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                         network_name.to_string(),
                         &logger_factory,
                         block_polling_interval,
-                        metrics_registry.clone(),
                     )
                     .expect("failed to create Ethereum block ingestor");
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -488,6 +488,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
         create_connection_pool(postgres_url.clone(), store_conn_pool_size, &logger);
 
     let stores_metrics_registry = metrics_registry.clone();
+    let graphql_metrics_registry = metrics_registry.clone();
     let stores_logger = logger.clone();
     let stores_error_logger = logger.clone();
     let stores_eth_adapters = eth_adapters.clone();
@@ -541,6 +542,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
             ));
             let mut graphql_server = GraphQLQueryServer::new(
                 &logger_factory,
+                graphql_metrics_registry,
                 graphql_runner.clone(),
                 generic_store.clone(),
                 node_id.clone(),

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -44,7 +44,7 @@ impl GraphQLServiceMetrics {
                 vec![String::from("subgraph_deployment")],
                 vec![0.1, 0.5, 1.0, 10.0, 100.0],
             )
-            .expect("failed to create `subgraph_query_execution_time` histogram");
+            .expect("failed to create `subgraph_failed_query_execution_time` histogram");
 
         Self {
             query_execution_time,

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -24,7 +24,7 @@ impl fmt::Debug for GraphQLServiceMetrics {
 }
 
 impl GraphQLServiceMetrics {
-    pub fn new<M: MetricsRegistry>(registry: Arc<M>) -> Self {
+    pub fn new(registry: Arc<impl MetricsRegistry>) -> Self {
         let query_execution_time = registry
             .new_histogram_vec(
                 format!("subgraph_query_execution_time"),

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -74,7 +74,7 @@ impl GraphQlRunner for TestGraphQlRunner {
 #[cfg(test)]
 mod test {
     use super::*;
-    use graph_mock::MockStore;
+    use graph_mock::{MockMetricsRegistry, MockStore};
     use web3::types::H256;
 
     fn mock_store(id: SubgraphDeploymentId) -> Arc<MockStore> {
@@ -117,11 +117,12 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
                 let logger_factory = LoggerFactory::new(logger, None);
+                let metrics_registry = Arc::new(MockMetricsRegistry::new());
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server = HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
+                let mut server = HyperGraphQLServer::new(&logger_factory, metrics_registry, query_runner, store, node_id);
                 let http_server = server
                     .serve(8001, 8002)
                     .expect("Failed to start GraphQL server");
@@ -167,12 +168,18 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
                 let logger_factory = LoggerFactory::new(logger, None);
+                let metrics_registry = Arc::new(MockMetricsRegistry::new());
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server =
-                    HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
+                let mut server = HyperGraphQLServer::new(
+                    &logger_factory,
+                    metrics_registry,
+                    query_runner,
+                    store,
+                    node_id,
+                );
                 let http_server = server
                     .serve(8002, 8003)
                     .expect("Failed to start GraphQL server");
@@ -252,12 +259,18 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
                 let logger_factory = LoggerFactory::new(logger, None);
+                let metrics_registry = Arc::new(MockMetricsRegistry::new());
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server =
-                    HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
+                let mut server = HyperGraphQLServer::new(
+                    &logger_factory,
+                    metrics_registry,
+                    query_runner,
+                    store,
+                    node_id,
+                );
                 let http_server = server
                     .serve(8003, 8004)
                     .expect("Failed to start GraphQL server");
@@ -302,13 +315,19 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
                 let logger_factory = LoggerFactory::new(logger, None);
+                let metrics_registry = Arc::new(MockMetricsRegistry::new());
 
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server =
-                    HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
+                let mut server = HyperGraphQLServer::new(
+                    &logger_factory,
+                    metrics_registry,
+                    query_runner,
+                    store,
+                    node_id,
+                );
                 let http_server = server
                     .serve(8005, 8006)
                     .expect("Failed to start GraphQL server");

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -15,6 +15,7 @@ failure = "0.1.6"
 fallible-iterator = "0.1.4"
 futures = "0.1.21"
 graph = { path = "../../graph" }
+graph-chain-ethereum = { path = "../../chain/ethereum" }
 graph-graphql = { path = "../../graphql" }
 graphql-parser = "0.2.3"
 Inflector = "0.11.3"

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -68,6 +68,9 @@ impl ChainHeadUpdateListener {
                                 notification.payload
                             )
                         });
+
+                    // Observe the latest chain_head_number for each network in order to monitor
+                    // block ingestion
                     metrics.set_chain_head_number(
                         &update.network_name,
                         *&update.head_block_number as i64,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -27,6 +27,7 @@ use graph::prelude::{
     SubgraphAssignmentProviderError, SubgraphDeploymentId, SubgraphDeploymentStore,
     SubgraphEntityPair, TransactionAbortError, Value, BLOCK_NUMBER_MAX,
 };
+use graph_chain_ethereum::BlockIngestorMetrics;
 use graph_graphql::prelude::api_schema;
 use tokio::timer::Interval;
 use web3::types::H256;
@@ -163,6 +164,7 @@ impl Store {
         let store_events = listener
             .take_event_stream()
             .expect("Failed to listen to entity change events in Postgres");
+        let block_ingestor_metrics = Arc::new(BlockIngestorMetrics::new(registry.clone()));
 
         // Create the store
         let mut store = Store {
@@ -171,6 +173,7 @@ impl Store {
             listener,
             chain_head_update_listener: ChainHeadUpdateListener::new(
                 &logger,
+                block_ingestor_metrics,
                 config.postgres_url,
                 config.network_name.clone(),
             ),


### PR DESCRIPTION
This PR creates two new metrics structs for instrumenting the Block Ingestor and the GraphQL server. 

1. `BlockIngestorMetrics` with a gauge vec to track the number of blocks being synced from Ethereum, labeled by networks name. 

2. `GraphQLServiceMetrics` which includes a histogram vec for tracking query execution time of successful queries, labeled by subgraph deployment id. 