### PR TITLE
Simplify passing around MetricsRegistry

### DIFF
--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -10,7 +10,7 @@ pub struct BlockIngestorMetrics {
 }
 
 impl BlockIngestorMetrics {
-    pub fn new<M: MetricsRegistry>(registry: Arc<M>) -> Self {
+    pub fn new(registry: Arc<impl MetricsRegistry>) -> Self {
         Self {
             block_number: registry
                 .new_gauge_vec(
@@ -47,18 +47,15 @@ impl<S> BlockIngestor<S>
 where
     S: ChainStore,
 {
-    pub fn new<M>(
+    pub fn new(
         chain_store: Arc<S>,
         eth_adapter: Arc<dyn EthereumAdapter>,
         ancestor_count: u64,
         network_name: String,
         logger_factory: &LoggerFactory,
         polling_interval: Duration,
-        registry: Arc<M>,
-    ) -> Result<BlockIngestor<S>, Error>
-    where
-        M: MetricsRegistry,
-    {
+        registry: Arc<impl MetricsRegistry>,
+    ) -> Result<BlockIngestor<S>, Error> {
         let logger = logger_factory.component_logger(
             "BlockIngestor",
             Some(ComponentLoggerConfig {

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -488,7 +488,7 @@ pub struct ProviderEthRpcMetrics {
 }
 
 impl ProviderEthRpcMetrics {
-    pub fn new<M: MetricsRegistry>(registry: Arc<M>) -> Self {
+    pub fn new(registry: Arc<impl MetricsRegistry>) -> Self {
         let request_duration = registry
             .new_histogram_vec(
                 String::from("eth_rpc_request_duration"),
@@ -530,7 +530,7 @@ pub struct SubgraphEthRpcMetrics {
 }
 
 impl SubgraphEthRpcMetrics {
-    pub fn new<M: MetricsRegistry>(registry: Arc<M>, subgraph_hash: String) -> Self {
+    pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: String) -> Self {
         let request_duration = registry
             .new_gauge_vec(
                 format!("subgraph_eth_rpc_request_duration_{}", subgraph_hash),
@@ -573,8 +573,8 @@ pub struct BlockStreamMetrics {
 }
 
 impl BlockStreamMetrics {
-    pub fn new<M: MetricsRegistry>(
-        registry: Arc<M>,
+    pub fn new(
+        registry: Arc<impl MetricsRegistry>,
         ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
         deployment_id: SubgraphDeploymentId,
         stopwatch: StopwatchMetrics,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -576,6 +576,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
                         network_name.to_string(),
                         &logger_factory,
                         block_polling_interval,
+                        metrics_registry.clone(),
                     )
                     .expect("failed to create Ethereum block ingestor");
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -488,6 +488,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
         create_connection_pool(postgres_url.clone(), store_conn_pool_size, &logger);
 
     let stores_metrics_registry = metrics_registry.clone();
+    let graphql_metrics_registry = metrics_registry.clone();
     let stores_logger = logger.clone();
     let stores_error_logger = logger.clone();
     let stores_eth_adapters = eth_adapters.clone();
@@ -541,6 +542,7 @@ fn async_main() -> impl Future<Item = (), Error = ()> + Send + 'static {
             ));
             let mut graphql_server = GraphQLQueryServer::new(
                 &logger_factory,
+                graphql_metrics_registry,
                 graphql_runner.clone(),
                 generic_store.clone(),
                 node_id.clone(),

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -24,7 +24,7 @@ impl fmt::Debug for GraphQLServiceMetrics {
 }
 
 impl GraphQLServiceMetrics {
-    pub fn new<M: MetricsRegistry>(registry: Arc<M>) -> Self {
+    pub fn new(registry: Arc<impl MetricsRegistry>) -> Self {
         let query_execution_time = registry
             .new_histogram_vec(
                 format!("subgraph_query_execution_time"),

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -74,7 +74,7 @@ impl GraphQlRunner for TestGraphQlRunner {
 #[cfg(test)]
 mod test {
     use super::*;
-    use graph_mock::MockStore;
+    use graph_mock::{MockMetricsRegistry, MockStore};
     use web3::types::H256;
 
     fn mock_store(id: SubgraphDeploymentId) -> Arc<MockStore> {
@@ -117,11 +117,12 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
                 let logger_factory = LoggerFactory::new(logger, None);
+                let metrics_registry = Arc::new(MockMetricsRegistry::new());
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server = HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
+                let mut server = HyperGraphQLServer::new(&logger_factory, metrics_registry, query_runner, store, node_id);
                 let http_server = server
                     .serve(8001, 8002)
                     .expect("Failed to start GraphQL server");
@@ -167,12 +168,18 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
                 let logger_factory = LoggerFactory::new(logger, None);
+                let metrics_registry = Arc::new(MockMetricsRegistry::new());
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server =
-                    HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
+                let mut server = HyperGraphQLServer::new(
+                    &logger_factory,
+                    metrics_registry,
+                    query_runner,
+                    store,
+                    node_id,
+                );
                 let http_server = server
                     .serve(8002, 8003)
                     .expect("Failed to start GraphQL server");
@@ -252,12 +259,18 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
                 let logger_factory = LoggerFactory::new(logger, None);
+                let metrics_registry = Arc::new(MockMetricsRegistry::new());
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server =
-                    HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
+                let mut server = HyperGraphQLServer::new(
+                    &logger_factory,
+                    metrics_registry,
+                    query_runner,
+                    store,
+                    node_id,
+                );
                 let http_server = server
                     .serve(8003, 8004)
                     .expect("Failed to start GraphQL server");
@@ -302,13 +315,19 @@ mod test {
             .block_on(futures::lazy(|| {
                 let logger = Logger::root(slog::Discard, o!());
                 let logger_factory = LoggerFactory::new(logger, None);
+                let metrics_registry = Arc::new(MockMetricsRegistry::new());
 
                 let id = SubgraphDeploymentId::new("testschema").unwrap();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let store = mock_store(id.clone());
                 let node_id = NodeId::new("test").unwrap();
-                let mut server =
-                    HyperGraphQLServer::new(&logger_factory, query_runner, store, node_id);
+                let mut server = HyperGraphQLServer::new(
+                    &logger_factory,
+                    metrics_registry,
+                    query_runner,
+                    store,
+                    node_id,
+                );
                 let http_server = server
                     .serve(8005, 8006)
                     .expect("Failed to start GraphQL server");


### PR DESCRIPTION
Simple changes to simplify all places where `MetricsRegistry` is passed around.