### PR TITLE
Fix error in GraphQL execution caused by overly aggressive assertion in prefetch

### DIFF
--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -372,10 +372,16 @@ impl<'a> Join<'a> {
 
         // Add appropriate children using grouped map
         for parent in parents.iter_mut() {
-            for cond in conds_by_parent.get(parent.typename()).expect(&format!(
-                "query results only contain known types: parent {}",
-                parent.typename()
-            )) {
+            // It is possible that we do not have a join condition for some
+            // parent types. That can happen, for example, if the parents
+            // were the result of querying for an interface type, and we
+            // have to get children for some of the parents, but not others.
+            // If a parent type is not mentioned in any join conditions,
+            // we skip it by looping over an empty vector.
+            //
+            // See the test interface_inline_fragment_with_subquery in
+            // core/tests/interfaces.rs for an example.
+            for cond in conds_by_parent.get(parent.typename()).unwrap_or(&vec![]) {
                 // Set the `response_key` field in `parent`. Make sure that even
                 // if `parent` has no matching `children`, the field gets set (to
                 // an empty `Vec`)


### PR DESCRIPTION
The assertion in `prefetch.rs` that this PR removes was too aggressive, as there is no reason for it to be true in the situation created by the test `interface_inline_fragment_with_subquery` in `core/tests/interfaces.rs`

This change simply replaces that assertion by skipping the attempt to add children to a parent whose type is not mentioned in any join condition. The queries did the right thing already.

The reverse assertion on line 338 in `prefetch.rs` is still valid: if a child type is not mentioned in a join condition, that join condition should not even be there, which would indicate some logic error somewhere else in the code.