### PR TITLE
Fix setting fields to null being ignored in certain cases

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -2,6 +2,8 @@ use failure::Error;
 use futures::stream::poll_fn;
 use futures::{Async, Future, Poll, Stream};
 use lazy_static::lazy_static;
+use mockall::predicate::*;
+use mockall::*;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
@@ -776,6 +778,7 @@ pub enum TransactionAbortError {
 }
 
 /// Common trait for store implementations.
+#[automock]
 pub trait Store: Send + Sync + 'static {
     /// Get a pointer to the most recently processed block in the subgraph.
     fn block_ptr(
@@ -788,10 +791,10 @@ pub trait Store: Send + Sync + 'static {
 
     /// Look up multiple entities as of the latest block. Returns a map of
     /// entities by type.
-    fn get_many(
+    fn get_many<'a>(
         &self,
         subgraph_id: &SubgraphDeploymentId,
-        ids_for_type: BTreeMap<&str, Vec<&str>>,
+        ids_for_type: BTreeMap<&'a str, Vec<&'a str>>,
     ) -> Result<BTreeMap<String, Vec<Entity>>, StoreError>;
 
     /// Queries the store for entities that match the store query.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1446,13 +1446,13 @@ impl EntityCache {
                 (None, Some(updates)) => {
                     // Merging with an empty entity removes null fields.
                     let mut data = Entity::new();
-                    data.merge(updates);
+                    data.merge_remove_null_fields(updates);
                     Some(Insert { key, data })
                 }
                 // Entity may have been changed
                 (Some(current), Some(updates)) => {
                     let mut data = current.clone();
-                    data.merge(updates);
+                    data.merge_remove_null_fields(updates);
                     if current != data {
                         Some(Overwrite { key, data })
                     } else {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1276,7 +1276,7 @@ pub trait EthereumCallCache: Send + Sync + 'static {
 /// An entity operation that can be transacted into the store; as opposed to
 /// `EntityOperation`, we already know whether a `Set` should be an `Insert`
 /// or `Update`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EntityModification {
     /// Insert the entity
     Insert { key: EntityKey, data: Entity },

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -132,7 +132,7 @@ impl FromStr for ValueType {
 }
 
 /// An attribute value is represented as an enum with variants for all supported value types.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(tag = "type", content = "data")]
 pub enum Value {
     String(String),
@@ -414,7 +414,7 @@ where
 }
 
 /// An entity is represented as a map of attribute names to values.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 pub struct Entity(HashMap<Attribute, Value>);
 impl Entity {
     /// Creates a new entity with no attributes set.

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -440,8 +440,19 @@ impl Entity {
     ///
     /// If a key exists in both entities, the value from `update` is chosen.
     /// If a key only exists on one entity, the value from that entity is chosen.
-    /// If a key is set to `Value::Null` in `update`, the key/value pair is removed.
+    /// If a key is set to `Value::Null` in `update`, the key/value pair is set to `Value::Null`.
     pub fn merge(&mut self, update: Entity) {
+        for (key, value) in update.0.into_iter() {
+            self.insert(key, value);
+        }
+    }
+
+    /// Merges an entity update `update` into this entity, removing `Value::Null` values.
+    ///
+    /// If a key exists in both entities, the value from `update` is chosen.
+    /// If a key only exists on one entity, the value from that entity is chosen.
+    /// If a key is set to `Value::Null` in `update`, the key/value pair is removed.
+    pub fn merge_remove_null_fields(&mut self, update: Entity) {
         for (key, value) in update.0.into_iter() {
             match value {
                 Value::Null => self.remove(&key),

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -16,6 +16,7 @@ pub mod log;
 /// Module with mocks for different parts of the system.
 pub mod mock {
     pub use crate::components::ethereum::MockEthereumAdapter;
+    pub use crate::components::store::MockStore;
 }
 
 /// A prelude that makes all system component traits and data types available.

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1270,7 +1270,7 @@ fn query_at_block() {
             .collect();
         let expected = Some(object_value(vec![("musicians", q::Value::List(ids))]));
 
-        let result = dbg!(execute_query_document(query));
+        let result = execute_query_document(query);
 
         if STORE.uses_relational_schema(&*TEST_SUBGRAPH_ID).unwrap() {
             assert!(result.errors.is_none(), "unexpected error: {}", qid);

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -223,7 +223,7 @@ impl Store for MockStore {
 
                     if entities_of_type.contains_key(&key.entity_id) {
                         let existing_entity = entities_of_type.get_mut(&key.entity_id).unwrap();
-                        existing_entity.merge(data);
+                        existing_entity.merge_remove_null_fields(data);
 
                         entity_changes
                             .push(EntityChange::from_key(key, EntityChangeOperation::Set));
@@ -248,7 +248,7 @@ impl Store for MockStore {
 
                     if entities_of_type.contains_key(&key.entity_id) {
                         let existing_entity = entities_of_type.get_mut(&key.entity_id).unwrap();
-                        existing_entity.merge(data);
+                        existing_entity.merge_remove_null_fields(data);
 
                         entity_changes
                             .push(EntityChange::from_key(key, EntityChangeOperation::Set));

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -444,14 +444,14 @@ impl Store {
                 // merge the changes into the entity.
                 let result = match entity {
                     Some(mut entity) => {
-                        entity.merge(data);
+                        entity.merge_remove_null_fields(data);
                         conn.update(&key, &entity, None).map(|_| 0)
                     }
                     None => {
                         // Merge with a new entity since that removes values that
                         // were set to Value::Null
                         let mut entity = Entity::new();
-                        entity.merge(data);
+                        entity.merge_remove_null_fields(data);
                         conn.insert(&key, &entity, None).map(|_| 1)
                     }
                 };

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -249,9 +249,9 @@ fn insert_test_data(conn: &PgConnection) -> Layout {
 
 fn scrub(entity: &Entity) -> Entity {
     let mut scrubbed = Entity::new();
-    // merge has the sideffect of removing any attribute
+    // merge_remove_null_fields has the side-effect of removing any attribute
     // that is Value::Null
-    scrubbed.merge(entity.clone());
+    scrubbed.merge_remove_null_fields(entity.clone());
     scrubbed
 }
 


### PR DESCRIPTION
This fixes a bug in `EntityCache` where setting an entity field to `Value::Null` would not take effect when there were two changes to the same entity, with any number of changes in-between, where the first change would set the field to a non-null value and the later change would set the field to `Value::Null`.

The problem was caused by `EntityCache` merging entities twice: all in-flight changes were merged together with `Entity::merge`, dropping all `Value::Null` fields. The combined changes were later merged into the original entity from the store using the same merge algorithm; except that now all fields that should be set to `Value::Null` were already removed from the combined changes and it was as if they had never happened.

This PR renames the existing `Entity::merge` method to `Entity::merge_remove_null_fields` to make obvious what it does. In addition, a new `Entity::merge` method is added that preserves `Value::Null` fields.

The `EntityCache` uses the new `Entity::merge` method to merge in-flight changes, preserving requests to set fields to `Value::Null`. It then uses the `Entity::merge_remove_null_fields` method to merge these changes into the original entity, so that any null fields are removed from the final entity, as expected.

All places using the old `Entity::merge` method are updated to use `Entity::merge_remove_null_fields`.

Basic tests are added for `EntityCache`. These would've caught the bug (I verified this by making `merge` and `merge_remove_null_fields` behave the same).