### PR TITLE
graph, graphql: Log variables passed into GraphQL query with query

### DIFF
--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -87,6 +87,22 @@ impl DerefMut for QueryVariables {
     }
 }
 
+impl serde::ser::Serialize for QueryVariables {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        use crate::data::graphql::SerializableValue;
+        use serde::ser::SerializeMap;
+
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        for (k, v) in &self.0 {
+            map.serialize_entry(k, &SerializableValue(v))?;
+        }
+        map.end()
+    }
+}
+
 /// A GraphQL query as submitted by a client, either directly or through a subscription.
 #[derive(Clone, Debug)]
 pub struct Query {

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -111,6 +111,7 @@ where
                 query_logger,
                 "Execute query";
                 "query" => query.document.format(&Style::default().indent(0)).replace('\n', " "),
+                "variables" => serde_json::to_string(&query.variables).unwrap_or_default(),
                 "query_time_ms" => start.elapsed().as_millis(),
             );
             result


### PR DESCRIPTION
For some queries, there is huge variation in the time a query takes depending on the values of the variables passed in. Log GraphQL variables together with the query to make it easier to understand why a certain query is slow.