### PR TITLE
Allow using `Bytes` for `ID` and switch block explorer to that

### DIFF
--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -88,8 +88,12 @@ fn create_subgraph(
         spec_version: String::from("0.0.1"),
         description: None,
         repository: None,
-        schema: Schema::parse(include_str!("./ethereum.graphql"), subgraph_id.clone())
-            .expect("valid Ethereum network subgraph schema"),
+        schema: Schema::parse(
+            include_str!("./ethereum.graphql"),
+            subgraph_id.clone(),
+            IdType::String,
+        )
+        .expect("valid Ethereum network subgraph schema"),
         data_sources: vec![],
         templates: vec![],
     };

--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -91,7 +91,7 @@ fn create_subgraph(
         schema: Schema::parse(
             include_str!("./ethereum.graphql"),
             subgraph_id.clone(),
-            IdType::String,
+            IdType::Bytes,
         )
         .expect("valid Ethereum network subgraph schema"),
         data_sources: vec![],

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -11,7 +11,7 @@ fn insert_and_query(
     entities: Vec<(Entity, &str)>,
     query: &str,
 ) -> Result<QueryResult, StoreError> {
-    create_test_subgraph(subgraph_id, schema);
+    create_test_subgraph(subgraph_id, schema, IdType::String);
     let subgraph_id = SubgraphDeploymentId::new(subgraph_id).unwrap();
 
     let insert_ops = entities

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -778,6 +778,19 @@ pub enum TransactionAbortError {
     Other(String),
 }
 
+/// The SQL type to use for the GraphQL ID type for a subgraph. The store
+/// will always expect and return id's as strings, but the store will store
+/// them differently depending on which variant was used when the subgraph
+/// was created
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum IdType {
+    /// The 'id' attribute of entities can be any string
+    String,
+    /// The 'id' attribute of entities will only contain hex strings
+    /// of the form '0xdeadbeef'
+    Bytes,
+}
+
 /// Common trait for store implementations.
 #[automock]
 pub trait Store: Send + Sync + 'static {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -16,7 +16,7 @@ use tokio::prelude::*;
 use web3::types::{Address, H256};
 
 use crate::components::link_resolver::LinkResolver;
-use crate::components::store::StoreError;
+use crate::components::store::{IdType, StoreError};
 use crate::data::query::QueryExecutionError;
 use crate::data::schema::Schema;
 use crate::data::subgraph::schema::{
@@ -380,9 +380,9 @@ impl SchemaData {
     ) -> impl Future<Item = Schema, Error = failure::Error> + Send {
         info!(logger, "Resolve schema"; "link" => &self.file.link);
 
-        resolver
-            .cat(&logger, &self.file)
-            .and_then(|schema_bytes| Schema::parse(&String::from_utf8(schema_bytes)?, id))
+        resolver.cat(&logger, &self.file).and_then(|schema_bytes| {
+            Schema::parse(&String::from_utf8(schema_bytes)?, id, IdType::String)
+        })
     }
 }
 

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -72,7 +72,7 @@ pub mod prelude {
         AttributeIndexDefinition, BlockNumber, ChainStore, EntityCache, EntityChange,
         EntityChangeOperation, EntityCollection, EntityFilter, EntityKey, EntityLink,
         EntityModification, EntityOperation, EntityOrder, EntityQuery, EntityRange, EntityWindow,
-        EthereumCallCache, MetadataOperation, ParentLink, Store, StoreError, StoreEvent,
+        EthereumCallCache, IdType, MetadataOperation, ParentLink, Store, StoreError, StoreEvent,
         StoreEventStream, StoreEventStreamBox, SubgraphDeploymentStore, TransactionAbortError,
         WindowAttribute, BLOCK_NUMBER_MAX, SUBSCRIPTION_THROTTLE_INTERVAL,
     };

--- a/graphql/src/introspection/schema.rs
+++ b/graphql/src/introspection/schema.rs
@@ -1,5 +1,6 @@
 use graphql_parser::{self, schema::Document};
 
+use graph::components::store::IdType;
 use graph::data::schema::Schema;
 use graph::data::subgraph::SubgraphDeploymentId;
 use lazy_static::lazy_static;
@@ -116,5 +117,5 @@ lazy_static! {
 }
 
 pub fn introspection_schema(id: SubgraphDeploymentId) -> Schema {
-    Schema::new(id, INTROSPECTION_DOCUMENT.clone())
+    Schema::new(id, IdType::String, INTROSPECTION_DOCUMENT.clone())
 }

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -589,8 +589,8 @@ fn entity_validation() {
           cruft: Cruft! @derivedFrom(field: \"thing\")
       }";
         let subgraph = SubgraphDeploymentId::new("doesntmatter").unwrap();
-        let schema =
-            graph::prelude::Schema::parse(DOCUMENT, subgraph).expect("Failed to parse test schema");
+        let schema = graph::prelude::Schema::parse(DOCUMENT, subgraph, IdType::String)
+            .expect("Failed to parse test schema");
         let id = thing.id().unwrap_or("none".to_owned());
         let key = EntityKey {
             subgraph_id: SubgraphDeploymentId::new("doesntmatter").unwrap(),

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -98,6 +98,7 @@ fn mock_schema() -> Schema {
              }
              ",
         SubgraphDeploymentId::new("mockschema").unwrap(),
+        IdType::String,
     )
     .unwrap()
 }
@@ -1116,6 +1117,7 @@ fn successfully_runs_introspection_query_against_complex_schema() {
     let mut schema = Schema::parse(
         COMPLEX_SCHEMA,
         SubgraphDeploymentId::new("complexschema").unwrap(),
+        IdType::String,
     )
     .unwrap();
     schema.document = api_schema(&schema.document).unwrap();
@@ -1225,6 +1227,7 @@ fn introspection_possible_types() {
     let mut schema = Schema::parse(
         COMPLEX_SCHEMA,
         SubgraphDeploymentId::new("complexschema").unwrap(),
+        IdType::String,
     )
     .unwrap();
     schema.document = api_schema(&schema.document).unwrap();

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -58,6 +58,7 @@ fn test_schema(id: SubgraphDeploymentId) -> Schema {
             }
             ",
         id,
+        IdType::String,
     )
     .expect("Test schema invalid")
 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -157,8 +157,12 @@ pub fn mock_store_with_users_subgraph() -> (Arc<MockStore>, SubgraphDeploymentId
                 }
             ";
 
-            let mut schema = Schema::parse(USERS_SCHEMA, subgraph_id_for_api_schema.clone())
-                .expect("failed to parse users schema");
+            let mut schema = Schema::parse(
+                USERS_SCHEMA,
+                subgraph_id_for_api_schema.clone(),
+                IdType::String,
+            )
+            .expect("failed to parse users schema");
             schema.document =
                 api_schema(&schema.document).expect("failed to generate users API schema");
             Ok(Arc::new(schema))

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -50,6 +50,7 @@ fn test_valid_module_and_store(
             value: String,
             extra: String
         }",
+        IdType::String,
     );
     let deployment_id = SubgraphDeploymentId::new(subgraph_id).unwrap();
     let stopwatch_metrics = StopwatchMetrics::new(

--- a/server/http/src/request.rs
+++ b/server/http/src/request.rs
@@ -85,18 +85,25 @@ mod tests {
 
     const EXAMPLE_SCHEMA: &'static str = "type Query @entity { users: [User!] }";
 
+    fn example_schema() -> Schema {
+        Schema::parse(
+            EXAMPLE_SCHEMA,
+            SubgraphDeploymentId::new("test").unwrap(),
+            IdType::String,
+        )
+        .unwrap()
+    }
+
     #[test]
     fn rejects_invalid_json() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = GraphQLRequest::new(hyper::Chunk::from("!@#)%"), Arc::new(schema));
         request.wait().expect_err("Should reject invalid JSON");
     }
 
     #[test]
     fn rejects_json_without_query_field() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = GraphQLRequest::new(hyper::Chunk::from("{}"), Arc::new(schema));
         request
             .wait()
@@ -105,8 +112,7 @@ mod tests {
 
     #[test]
     fn rejects_json_with_non_string_query_field() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = GraphQLRequest::new(hyper::Chunk::from("{\"query\": 5}"), Arc::new(schema));
         request
             .wait()
@@ -115,8 +121,7 @@ mod tests {
 
     #[test]
     fn rejects_broken_queries() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request =
             GraphQLRequest::new(hyper::Chunk::from("{\"query\": \"foo\"}"), Arc::new(schema));
         request.wait().expect_err("Should reject broken queries");
@@ -124,8 +129,7 @@ mod tests {
 
     #[test]
     fn accepts_valid_queries() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = GraphQLRequest::new(
             hyper::Chunk::from("{\"query\": \"{ user { name } }\"}"),
             Arc::new(schema),
@@ -139,8 +143,7 @@ mod tests {
 
     #[test]
     fn accepts_null_variables() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = GraphQLRequest::new(
             hyper::Chunk::from(
                 "\
@@ -160,8 +163,7 @@ mod tests {
 
     #[test]
     fn rejects_non_map_variables() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = GraphQLRequest::new(
             hyper::Chunk::from(
                 "\
@@ -177,8 +179,7 @@ mod tests {
 
     #[test]
     fn parses_variables() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = GraphQLRequest::new(
             hyper::Chunk::from(
                 "\

--- a/server/index-node/src/request.rs
+++ b/server/index-node/src/request.rs
@@ -86,18 +86,25 @@ mod tests {
 
     const EXAMPLE_SCHEMA: &'static str = "type Query @entity { users: [User!] }";
 
+    fn example_schema() -> Schema {
+        Schema::parse(
+            EXAMPLE_SCHEMA,
+            SubgraphDeploymentId::new("test").unwrap(),
+            IdType::String,
+        )
+        .unwrap()
+    }
+
     #[test]
     fn rejects_invalid_json() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = IndexNodeRequest::new(hyper::Chunk::from("!@#)%"), Arc::new(schema));
         request.wait().expect_err("Should reject invalid JSON");
     }
 
     #[test]
     fn rejects_json_without_query_field() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = IndexNodeRequest::new(hyper::Chunk::from("{}"), Arc::new(schema));
         request
             .wait()
@@ -106,8 +113,7 @@ mod tests {
 
     #[test]
     fn rejects_json_with_non_string_query_field() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = IndexNodeRequest::new(hyper::Chunk::from("{\"query\": 5}"), Arc::new(schema));
         request
             .wait()
@@ -116,8 +122,7 @@ mod tests {
 
     #[test]
     fn rejects_broken_queries() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request =
             IndexNodeRequest::new(hyper::Chunk::from("{\"query\": \"foo\"}"), Arc::new(schema));
         request.wait().expect_err("Should reject broken queries");
@@ -125,8 +130,7 @@ mod tests {
 
     #[test]
     fn accepts_valid_queries() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = IndexNodeRequest::new(
             hyper::Chunk::from("{\"query\": \"{ user { name } }\"}"),
             Arc::new(schema),
@@ -140,8 +144,7 @@ mod tests {
 
     #[test]
     fn accepts_null_variables() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = IndexNodeRequest::new(
             hyper::Chunk::from(
                 "\
@@ -161,8 +164,7 @@ mod tests {
 
     #[test]
     fn rejects_non_map_variables() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = IndexNodeRequest::new(
             hyper::Chunk::from(
                 "\
@@ -178,8 +180,7 @@ mod tests {
 
     #[test]
     fn parses_variables() {
-        let schema =
-            Schema::parse(EXAMPLE_SCHEMA, SubgraphDeploymentId::new("test").unwrap()).unwrap();
+        let schema = example_schema();
         let request = IndexNodeRequest::new(
             hyper::Chunk::from(
                 "\

--- a/server/index-node/src/schema.rs
+++ b/server/index-node/src/schema.rs
@@ -11,6 +11,7 @@ lazy_static! {
 
         Arc::new(Schema {
             id: SubgraphDeploymentId::new("indexnode").unwrap(),
+            id_type: IdType::String,
             document: document,
             interfaces_for_type,
             types_for_interface,

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -914,6 +914,10 @@ pub fn id_type(conn: &PgConnection, subgraph: &SubgraphDeploymentId) -> Result<I
     use self::public::columns;
     use self::public::deployment_schemas as ds;
 
+    if subgraph.is_meta() {
+        return Ok(IdType::String);
+    }
+
     let (data_type, schema_name): (String, String) = columns::table
         .select((columns::data_type, columns::table_schema))
         .inner_join(ds::table.on(ds::name.eq(columns::table_schema)))

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -44,7 +44,7 @@ use graph::data::subgraph::schema::SUBGRAPHS_ID;
 use graph::prelude::{
     debug, format_err, info, serde_json, warn, AttributeIndexDefinition, BlockNumber, Entity,
     EntityChange, EntityChangeOperation, EntityCollection, EntityFilter, EntityKey,
-    EntityModification, EntityOrder, EntityRange, Error, EthereumBlockPointer, Logger,
+    EntityModification, EntityOrder, EntityRange, Error, EthereumBlockPointer, IdType, Logger,
     QueryExecutionError, StoreError, StoreEvent, SubgraphDeploymentId, SubgraphDeploymentStore,
     ValueType, BLOCK_NUMBER_MAX,
 };
@@ -54,7 +54,7 @@ use crate::history_event::HistoryEvent;
 use crate::jsonb::PgJsonbExpressionMethods as _;
 use crate::jsonb_queries::FilterQuery;
 use crate::notification_listener::JsonNotification;
-use crate::relational::{IdType, Layout};
+use crate::relational::Layout;
 use crate::store::Store;
 
 lazy_static! {

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -861,7 +861,7 @@ impl Connection {
             v::Relational => Layout::create_relational_schema(
                 &self.conn,
                 &schema_name,
-                IdType::String,
+                schema.id_type,
                 schema.id.clone(),
                 &schema.document,
             )

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -915,7 +915,7 @@ pub fn id_type(conn: &PgConnection, subgraph: &SubgraphDeploymentId) -> Result<I
     use self::public::deployment_schemas as ds;
 
     let (data_type, schema_name): (String, String) = columns::table
-        .select((columns::data_type, columns::column_name))
+        .select((columns::data_type, columns::table_schema))
         .inner_join(ds::table.on(ds::name.eq(columns::table_schema)))
         .filter(columns::column_name.eq("id"))
         .filter(ds::subgraph.eq(subgraph.as_str()))
@@ -925,9 +925,10 @@ pub fn id_type(conn: &PgConnection, subgraph: &SubgraphDeploymentId) -> Result<I
         "bytea" => IdType::Bytes,
         _ => {
             return Err(StoreError::Unknown(format_err!(
-                "unsupported type `{}` for primary key column in schema {}",
+                "unsupported type `{}` for primary key column in schema {}(`{}`)",
                 data_type,
-                schema_name
+                schema_name,
+                subgraph.as_str()
             )))
         }
     };

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -848,6 +848,7 @@ impl Connection {
             v::Relational => Layout::create_relational_schema(
                 &self.conn,
                 &schema_name,
+                IdType::String,
                 schema.id.clone(),
                 &schema.document,
             )

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -918,8 +918,12 @@ pub fn id_type(conn: &PgConnection, subgraph: &SubgraphDeploymentId) -> Result<I
         return Ok(IdType::String);
     }
 
-    let (data_type, schema_name): (String, String) = columns::table
-        .select((columns::data_type, columns::table_schema))
+    let (data_type, schema_name, table_name): (String, String, String) = columns::table
+        .select((
+            columns::data_type,
+            columns::table_schema,
+            columns::table_name,
+        ))
         .inner_join(ds::table.on(ds::name.eq(columns::table_schema)))
         .filter(columns::column_name.eq("id"))
         .filter(ds::subgraph.eq(subgraph.as_str()))
@@ -929,8 +933,9 @@ pub fn id_type(conn: &PgConnection, subgraph: &SubgraphDeploymentId) -> Result<I
         "bytea" => IdType::Bytes,
         _ => {
             return Err(StoreError::Unknown(format_err!(
-                "unsupported type `{}` for primary key column in schema {}(`{}`)",
+                "unsupported type `{}` for primary key column in table {} in schema {}(`{}`)",
                 data_type,
+                table_name,
                 schema_name,
                 subgraph.as_str()
             )))

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -46,7 +46,7 @@ pub mod db_schema_for_tests {
 #[cfg(debug_assertions)]
 pub mod layout_for_tests {
     pub use crate::block_range::*;
-    pub use crate::entities::STRING_PREFIX_SIZE;
+    pub use crate::entities::{id_type, STRING_PREFIX_SIZE};
     pub use crate::relational::*;
 }
 

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -22,8 +22,8 @@ use crate::relational_queries::{
 };
 use graph::prelude::{
     format_err, BlockNumber, Entity, EntityChange, EntityChangeOperation, EntityCollection,
-    EntityFilter, EntityKey, EntityOrder, EntityRange, QueryExecutionError, StoreError, StoreEvent,
-    SubgraphDeploymentId, ValueType,
+    EntityFilter, EntityKey, EntityOrder, EntityRange, IdType, QueryExecutionError, StoreError,
+    StoreEvent, SubgraphDeploymentId, ValueType,
 };
 
 use crate::block_range::BLOCK_RANGE_COLUMN;
@@ -111,15 +111,6 @@ impl fmt::Display for SqlName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
-}
-
-/// The SQL type to use for GraphQL ID properties. We support
-/// strings and byte arrays
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum IdType {
-    String,
-    #[allow(dead_code)]
-    Bytes,
 }
 
 type EnumMap = BTreeMap<String, Vec<String>>;

--- a/store/postgres/src/sql_value.rs
+++ b/store/postgres/src/sql_value.rs
@@ -2,8 +2,9 @@ use diesel::pg::Pg;
 use diesel::serialize::{self, Output, ToSql};
 use diesel::sql_types::{Binary, Bool, Integer, Numeric, Text};
 use std::io::Write;
+use std::str::FromStr;
 
-use graph::data::store::Value;
+use graph::data::store::{scalar, Value};
 
 #[derive(Clone, Debug, PartialEq, AsExpression)]
 pub struct SqlValue(Value);
@@ -58,6 +59,9 @@ impl ToSql<Binary, Pg> for SqlValue {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
         match self.0 {
             Value::Bytes(ref h) => <_ as ToSql<Binary, Pg>>::to_sql(&h.as_slice(), out),
+            Value::String(ref s) => {
+                <_ as ToSql<Binary, Pg>>::to_sql(scalar::Bytes::from_str(s)?.as_slice(), out)
+            }
             _ => panic!("Failed to convert attribute value to Bytes in SQL"),
         }
     }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -728,7 +728,7 @@ impl Store {
         };
 
         // Parse the schema and add @subgraphId directives
-        let input_schema = Schema::parse(&input_schema, subgraph_id.clone())?;
+        let input_schema = Schema::parse(&input_schema, subgraph_id.clone(), IdType::String)?;
         let mut schema = input_schema.clone();
 
         // Generate an API schema for the subgraph and make sure all types in the

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -21,7 +21,7 @@ use graph::prelude::{
     web3, AttributeIndexDefinition, BigInt, BlockNumber, ChainHeadUpdateListener as _,
     ChainHeadUpdateStream, ChainStore, Entity, EntityKey, EntityModification, EntityOrder,
     EntityQuery, EntityRange, Error, EthereumBlock, EthereumBlockPointer, EthereumCallCache,
-    EthereumNetworkIdentifier, EventProducer as _, Future, LightEthereumBlock, Logger,
+    EthereumNetworkIdentifier, EventProducer as _, Future, IdType, LightEthereumBlock, Logger,
     MetadataOperation, MetricsRegistry, QueryExecutionError, Schema, Sink as _, StopwatchMetrics,
     StoreError, StoreEvent, StoreEventStream, StoreEventStreamBox, Stream,
     SubgraphAssignmentProviderError, SubgraphDeploymentId, SubgraphDeploymentStore,

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -14,7 +14,7 @@ use graph::prelude::{
     EntityOrder, EntityQuery, EntityRange, Schema, SubgraphDeploymentId, Value, ValueType,
     BLOCK_NUMBER_MAX,
 };
-use graph_store_postgres::layout_for_tests::{Layout, STRING_PREFIX_SIZE};
+use graph_store_postgres::layout_for_tests::{IdType, Layout, STRING_PREFIX_SIZE};
 
 use test_store::*;
 
@@ -239,6 +239,7 @@ fn insert_test_data(conn: &PgConnection) -> Layout {
     let layout = Layout::create_relational_schema(
         &conn,
         SCHEMA_NAME,
+        IdType::String,
         THINGS_SUBGRAPH_ID.clone(),
         &schema.document,
     )

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -11,10 +11,10 @@ use std::str::FromStr;
 use graph::data::store::scalar::{BigDecimal, BigInt, Bytes};
 use graph::prelude::{
     bigdecimal::One, web3::types::H256, Entity, EntityCollection, EntityFilter, EntityKey,
-    EntityOrder, EntityQuery, EntityRange, Schema, SubgraphDeploymentId, Value, ValueType,
+    EntityOrder, EntityQuery, EntityRange, IdType, Schema, SubgraphDeploymentId, Value, ValueType,
     BLOCK_NUMBER_MAX,
 };
-use graph_store_postgres::layout_for_tests::{IdType, Layout, STRING_PREFIX_SIZE};
+use graph_store_postgres::layout_for_tests::{Layout, STRING_PREFIX_SIZE};
 
 use test_store::*;
 

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -231,7 +231,7 @@ fn insert_pets(conn: &PgConnection, layout: &Layout) {
 }
 
 fn insert_test_data(conn: &PgConnection) -> Layout {
-    let schema = Schema::parse(THINGS_GQL, THINGS_SUBGRAPH_ID.clone()).unwrap();
+    let schema = Schema::parse(THINGS_GQL, THINGS_SUBGRAPH_ID.clone(), IdType::String).unwrap();
 
     let query = format!("create schema {}", SCHEMA_NAME);
     conn.batch_execute(&*query).unwrap();

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -10,10 +10,10 @@ use std::fmt::Debug;
 
 use graph::data::store::scalar::{BigDecimal, BigInt};
 use graph::prelude::{
-    bigdecimal::One, web3::types::H256, Entity, EntityKey, Schema, SubgraphDeploymentId, Value,
-    BLOCK_NUMBER_MAX,
+    bigdecimal::One, web3::types::H256, Entity, EntityKey, IdType, Schema, SubgraphDeploymentId,
+    Value, BLOCK_NUMBER_MAX,
 };
-use graph_store_postgres::layout_for_tests::{IdType, Layout};
+use graph_store_postgres::layout_for_tests::Layout;
 
 use test_store::*;
 

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -77,7 +77,7 @@ fn insert_thing(conn: &PgConnection, layout: &Layout, id: &str, name: &str) {
 }
 
 fn create_schema(conn: &PgConnection) -> Layout {
-    let schema = Schema::parse(THINGS_GQL, THINGS_SUBGRAPH_ID.clone()).unwrap();
+    let schema = Schema::parse(THINGS_GQL, THINGS_SUBGRAPH_ID.clone(), IdType::Bytes).unwrap();
 
     let query = format!("create schema {}", SCHEMA_NAME);
     conn.batch_execute(&*query).unwrap();
@@ -85,7 +85,7 @@ fn create_schema(conn: &PgConnection) -> Layout {
     let layout = Layout::create_relational_schema(
         &conn,
         SCHEMA_NAME,
-        IdType::Bytes,
+        schema.id_type,
         THINGS_SUBGRAPH_ID.clone(),
         &schema.document,
     )

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -1,0 +1,311 @@
+//! Test relational schemas that use `Bytes` to store ids
+use diesel::connection::SimpleConnection as _;
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+use futures::future::{self, IntoFuture};
+use hex_literal::hex;
+use lazy_static::lazy_static;
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+use graph::data::store::scalar::{BigDecimal, BigInt};
+use graph::prelude::{
+    bigdecimal::One, web3::types::H256, Entity, EntityKey, Schema, SubgraphDeploymentId, Value,
+    BLOCK_NUMBER_MAX,
+};
+use graph_store_postgres::layout_for_tests::{IdType, Layout};
+
+use test_store::*;
+
+const THINGS_GQL: &str = "
+    type Thing @entity {
+        id: ID!
+        name: String!
+    }
+";
+
+const SCHEMA_NAME: &str = "layout";
+
+lazy_static! {
+    static ref THINGS_SUBGRAPH_ID: SubgraphDeploymentId =
+        SubgraphDeploymentId::new("things").unwrap();
+    static ref LARGE_INT: BigInt = BigInt::from(std::i64::MAX).pow(17);
+    static ref LARGE_DECIMAL: BigDecimal =
+        BigDecimal::one() / LARGE_INT.clone().to_big_decimal(BigInt::from(1));
+    static ref BYTES_VALUE: H256 = H256::from(hex!(
+        "e8b3b02b936c4a4a331ac691ac9a86e197fb7731f14e3108602c87d4dac55160"
+    ));
+    static ref BYTES_VALUE2: H256 = H256::from(hex!(
+        "b98fb783b49de5652097a989414c767824dff7e7fd765a63b493772511db81c1"
+    ));
+    static ref BYTES_VALUE3: H256 = H256::from(hex!(
+        "977c084229c72a0fa377cae304eda9099b6a2cb5d83b25cdf0f0969b69874255"
+    ));
+    static ref BEEF_ENTITY: Entity = {
+        let mut entity = Entity::new();
+        entity.set("id", "deadbeef");
+        entity.set("name", "Beef");
+        entity.set("__typename", "Thing");
+        entity
+    };
+}
+
+/// Removes test data from the database behind the store.
+fn remove_test_data(conn: &PgConnection) {
+    let query = format!("drop schema if exists {} cascade", SCHEMA_NAME);
+    conn.batch_execute(&query)
+        .expect("Failed to drop test schema");
+}
+
+fn insert_entity(conn: &PgConnection, layout: &Layout, entity_type: &str, entity: Entity) {
+    let key = EntityKey {
+        subgraph_id: THINGS_SUBGRAPH_ID.clone(),
+        entity_type: entity_type.to_owned(),
+        entity_id: entity.id().unwrap(),
+    };
+    let errmsg = format!("Failed to insert entity {}[{}]", entity_type, key.entity_id);
+    layout.insert(&conn, &key, &entity, 0).expect(&errmsg);
+}
+
+fn insert_thing(conn: &PgConnection, layout: &Layout, id: &str, name: &str) {
+    let mut thing = Entity::new();
+
+    thing.insert("id".to_owned(), Value::String(id.to_owned()));
+    thing.insert("name".to_owned(), Value::String(name.to_owned()));
+
+    insert_entity(conn, layout, "Thing", thing);
+}
+
+fn create_schema(conn: &PgConnection) -> Layout {
+    let schema = Schema::parse(THINGS_GQL, THINGS_SUBGRAPH_ID.clone()).unwrap();
+
+    let query = format!("create schema {}", SCHEMA_NAME);
+    conn.batch_execute(&*query).unwrap();
+
+    let layout = Layout::create_relational_schema(
+        &conn,
+        SCHEMA_NAME,
+        IdType::Bytes,
+        THINGS_SUBGRAPH_ID.clone(),
+        &schema.document,
+    )
+    .expect("Failed to create relational schema");
+
+    layout
+}
+
+fn scrub(entity: &Entity) -> Entity {
+    let mut scrubbed = Entity::new();
+    // merge has the sideffect of removing any attribute
+    // that is Value::Null
+    scrubbed.merge(entity.clone());
+    scrubbed
+}
+
+macro_rules! assert_entity_eq {
+    ($left:expr, $right:expr) => {{
+        let (left, right) = (&($left), &($right));
+        let mut pass = true;
+
+        for (key, left_value) in left.iter() {
+            match right.get(key) {
+                None => {
+                    pass = false;
+                    println!("key '{}' missing from right", key);
+                }
+                Some(right_value) => {
+                    if left_value != right_value {
+                        pass = false;
+                        println!(
+                            "values for '{}' differ:\n     left: {:?}\n    right: {:?}",
+                            key, left_value, right_value
+                        );
+                    }
+                }
+            }
+        }
+        for key in right.keys() {
+            if left.get(key).is_none() {
+                pass = false;
+                println!("key '{}' missing from left", key);
+            }
+        }
+        assert!(pass, "left and right entities are different");
+    }};
+}
+
+/// Test harness for running database integration tests.
+fn run_test<R, F>(test: F)
+where
+    F: FnOnce(&PgConnection, &Layout) -> R + Send + 'static,
+    R: IntoFuture<Item = ()> + Send + 'static,
+    R::Error: Send + Debug,
+    R::Future: Send,
+{
+    let url = postgres_test_url();
+    let conn = PgConnection::establish(url.as_str()).expect("Failed to connect to Postgres");
+
+    // Lock regardless of poisoning. This also forces sequential test execution.
+    let mut runtime = match STORE_RUNTIME.lock() {
+        Ok(guard) => guard,
+        Err(err) => err.into_inner(),
+    };
+
+    runtime
+        .block_on(future::lazy(move || {
+            // Reset state before starting
+            remove_test_data(&conn);
+
+            // Seed database with test data
+            let layout = create_schema(&conn);
+
+            // Run test
+            test(&conn, &layout)
+        }))
+        .expect("Failed to run ChainHead test");
+}
+
+#[test]
+fn bad_id() {
+    run_test(|conn, layout| -> Result<(), ()> {
+        // We test that we get errors for various strings that are not
+        // valid 'Bytes' strings; we use `find` to force the conversion
+        // from String -> Bytes internally
+        let res = layout.find(conn, "Thing", "bad", BLOCK_NUMBER_MAX);
+        assert!(res.is_err());
+        assert_eq!(
+            "store error: Odd number of digits",
+            res.err().unwrap().to_string()
+        );
+
+        // We do not allow the `\x` prefix that Postgres uses
+        let res = layout.find(conn, "Thing", "\\xbadd", BLOCK_NUMBER_MAX);
+        assert!(res.is_err());
+        assert_eq!(
+            "store error: Invalid character \'\\\' at position 0",
+            res.err().unwrap().to_string()
+        );
+
+        // Having the '0x' prefix is ok
+        let res = layout.find(conn, "Thing", "0xbadd", BLOCK_NUMBER_MAX);
+        assert!(res.is_ok());
+
+        // Using non-hex characters is also bad
+        let res = layout.find(conn, "Thing", "nope", BLOCK_NUMBER_MAX);
+        assert!(res.is_err());
+        assert_eq!(
+            "store error: Invalid character \'n\' at position 0",
+            res.err().unwrap().to_string()
+        );
+
+        Ok(())
+    });
+}
+
+#[test]
+fn find() {
+    run_test(|conn, layout| -> Result<(), ()> {
+        const ID: &str = "deadbeef";
+        const NAME: &str = "Beef";
+        insert_thing(&conn, &layout, ID, NAME);
+
+        // Happy path: find existing entity
+        let entity = layout
+            .find(conn, "Thing", ID, BLOCK_NUMBER_MAX)
+            .expect("Failed to read Thing[deadbeef]")
+            .unwrap();
+        assert_entity_eq!(scrub(&*BEEF_ENTITY), entity);
+
+        // Find non-existing entity
+        let entity = layout
+            .find(conn, "Thing", "badd", BLOCK_NUMBER_MAX)
+            .expect("Failed to read Thing[badd]");
+        assert!(entity.is_none());
+        Ok(())
+    });
+}
+
+#[test]
+fn find_many() {
+    run_test(|conn, layout| -> Result<(), ()> {
+        const ID: &str = "deadbeef";
+        const NAME: &str = "Beef";
+        const ID2: &str = "deadbeef02";
+        const NAME2: &str = "Moo";
+        insert_thing(&conn, &layout, ID, NAME);
+        insert_thing(&conn, &layout, ID2, NAME2);
+
+        let mut id_map: BTreeMap<&str, Vec<&str>> = BTreeMap::default();
+        id_map.insert("Thing", vec![ID, ID2, "badd"]);
+
+        let entities = layout
+            .find_many(conn, id_map, BLOCK_NUMBER_MAX)
+            .expect("Failed to read many things");
+        assert_eq!(1, entities.len());
+
+        let ids = entities
+            .get("Thing")
+            .expect("We got some things")
+            .iter()
+            .map(|thing| thing.id().unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(2, ids.len());
+        assert!(ids.contains(&ID.to_owned()), "Missing ID");
+        assert!(ids.contains(&ID2.to_owned()), "Missing ID2");
+        Ok(())
+    });
+}
+
+#[test]
+fn update() {
+    run_test(|conn, layout| -> Result<(), ()> {
+        insert_entity(&conn, &layout, "Thing", BEEF_ENTITY.clone());
+
+        // Update the entity
+        let mut entity = BEEF_ENTITY.clone();
+        entity.set("name", "Moo");
+        let key = EntityKey {
+            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
+            entity_type: "Thing".to_owned(),
+            entity_id: entity.id().unwrap().clone(),
+        };
+        layout
+            .update(&conn, &key, &entity, 1)
+            .expect("Failed to update");
+
+        let actual = layout
+            .find(conn, "Thing", &entity.id().unwrap(), BLOCK_NUMBER_MAX)
+            .expect("Failed to read Thing[deadbeef]")
+            .unwrap();
+        assert_entity_eq!(scrub(&entity), actual);
+        Ok(())
+    });
+}
+
+#[test]
+fn delete() {
+    run_test(|conn, layout| -> Result<(), ()> {
+        const TWO_ID: &str = "deadbeef02";
+
+        insert_entity(&conn, &layout, "Thing", BEEF_ENTITY.clone());
+        let mut two = BEEF_ENTITY.clone();
+        two.set("id", TWO_ID);
+        insert_entity(&conn, &layout, "Thing", two);
+
+        // Delete where nothing is getting deleted
+        let mut key = EntityKey {
+            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
+            entity_type: "Thing".to_owned(),
+            entity_id: "ffff".to_owned(),
+        };
+        let count = layout.delete(&conn, &key, 1).expect("Failed to delete");
+        assert_eq!(0, count);
+
+        // Delete entity two
+        key.entity_id = TWO_ID.to_owned();
+        let count = layout.delete(&conn, &key, 1).expect("Failed to delete");
+        assert_eq!(1, count);
+        Ok(())
+    });
+}

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -57,7 +57,8 @@ lazy_static! {
     static ref TEST_SUBGRAPH_ID: SubgraphDeploymentId =
         SubgraphDeploymentId::new(TEST_SUBGRAPH_ID_STRING.as_str()).unwrap();
     static ref TEST_SUBGRAPH_SCHEMA: Schema =
-        Schema::parse(USER_GQL, TEST_SUBGRAPH_ID.clone()).expect("Failed to parse user schema");
+        Schema::parse(USER_GQL, TEST_SUBGRAPH_ID.clone(), IdType::String)
+            .expect("Failed to parse user schema");
     static ref TEST_BLOCK_0_PTR: EthereumBlockPointer = (
         H256::from(hex!(
             "bd34884280958002c51d3f7b5f853e6febeba33de0f40d15b0363006533c924f"
@@ -1595,8 +1596,8 @@ fn revert_block_with_dynamic_data_source_operations() {
 fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
     run_test(|store| {
         let subgraph_id = SubgraphDeploymentId::new("EntityChangeTestSubgraph").unwrap();
-        let schema =
-            Schema::parse(USER_GQL, subgraph_id.clone()).expect("Failed to parse user schema");
+        let schema = Schema::parse(USER_GQL, subgraph_id.clone(), IdType::String)
+            .expect("Failed to parse user schema");
         let manifest = SubgraphManifest {
             id: subgraph_id.clone(),
             location: "/ipfs/test".to_owned(),

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -2259,6 +2259,9 @@ fn determine_id_type() {
             assert_eq!(IdType::String, id_type(&conn, &bytes_subgraph).unwrap());
         }
 
+        // The metadata subgraph is special, and uses 'IdType::String', always
+        assert_eq!(IdType::String, id_type(&conn, &*SUBGRAPHS_ID).unwrap());
+
         Ok(())
     })
 }

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -74,9 +74,9 @@ lazy_static! {
     ).into();
 }
 
-pub fn create_test_subgraph(subgraph_id: &str, schema: &str) {
+pub fn create_test_subgraph(subgraph_id: &str, schema: &str, id_type: IdType) {
     let subgraph_id = SubgraphDeploymentId::new(subgraph_id).unwrap();
-    let schema = Schema::parse(schema, subgraph_id.clone()).unwrap();
+    let schema = Schema::parse(schema, subgraph_id.clone(), id_type).unwrap();
 
     let manifest = SubgraphManifest {
         id: subgraph_id.clone(),


### PR DESCRIPTION
Map between strings that represent bytes and `bytea` in the database; the difference between subgraphs that use `Bytes` for `ID` and those that use `String` is transparent to subgraph users. The only exception is that when an entity is stored with an id `0xdeadbeef` it will be returned as the string `deadbeef` stripping the `0x` prefix.

Currently, this is only used for network indexing; all user-supplied subgraphs still use `String` as their `ID` and there is no way for users to switch to `Bytes`.

Fixes https://github.com/graphprotocol/graph-node/issues/1414