### PR TITLE
Create views that simulate relational storage of subgraph metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,7 @@ name = "graph-store-postgres"
 version = "0.17.1"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -26,6 +26,7 @@ serde = "1.0"
 uuid = { version = "0.8.1", features = ["v4"] }
 
 [dev-dependencies]
+clap = "2.33.0"
 graphql-parser = "0.2.3"
 hex = "0.4.0"
 parity-wasm = "0.40"

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -1,0 +1,115 @@
+extern crate clap;
+extern crate graph_store_postgres;
+
+use clap::App;
+use graphql_parser::parse_schema;
+use std::fs;
+use std::process::exit;
+
+use graph::prelude::SubgraphDeploymentId;
+use graph_store_postgres::relational::{IdType, Layout};
+
+pub fn usage(msg: &str) -> ! {
+    println!("layout: {}", msg);
+    println!("Try 'layout --help' for more information.");
+    std::process::exit(1);
+}
+
+pub fn ensure<T, E: std::fmt::Display>(res: Result<T, E>, msg: &str) -> T {
+    match res {
+        Ok(ok) => ok,
+        Err(err) => {
+            eprintln!("{}:\n    {}", msg, err);
+            exit(1)
+        }
+    }
+}
+
+fn print_migration(layout: &Layout) {
+    for table in layout.tables.values() {
+        print!("insert into\n  {}(", table.qualified_name);
+        for column in &table.columns {
+            print!("{}, ", column.name.as_str());
+        }
+        print!("block_range)\nselect ");
+        for (i, column) in table.columns.iter().enumerate() {
+            if i > 0 {
+                print!("       ");
+            }
+            if column.is_list() {
+                print!(
+                    "array(select (x->>'data')::{} from jsonb_array_elements(data->'{}'->'data') x)",
+                    column.column_type.sql_type(),
+                    column.field
+                );
+            } else {
+                if column.name.as_str() == "id" {
+                    print!("id");
+                } else {
+                    print!(
+                        "(data->'{}'->>'data')::{}",
+                        column.field,
+                        column.column_type.sql_type()
+                    );
+                }
+            }
+            println!(",");
+        }
+        println!("      block_range");
+        println!("  from history_data");
+        println!(" where entity = '{}';\n", table.object);
+    }
+}
+
+fn print_drop(layout: &Layout) {
+    for table in layout.tables.values() {
+        println!("drop table {};", table.qualified_name);
+    }
+}
+
+fn print_delete_all(layout: &Layout) {
+    for table in layout.tables.values() {
+        println!("delete from {};", table.qualified_name);
+    }
+}
+
+fn print_ddl(layout: &Layout) {
+    let ddl = ensure(layout.as_ddl(), "Failed to generate DDL");
+    println!("{}", ddl);
+}
+
+pub fn main() {
+    let args = App::new("layout")
+    .version("1.0")
+    .about("Information about the database schema for a GraphQL schema")
+    .args_from_usage(
+        "-g, --generate=[KIND] 'what kind of SQL to generate. Can be ddl (the default), migrate, delete, or drop'
+        <schema>
+        [db_schema]"
+    )
+    .get_matches();
+
+    let schema = args.value_of("schema").unwrap();
+    let db_schema = args.value_of("db_schema").unwrap_or("rel");
+    let kind = args.value_of("generate").unwrap_or("ddl");
+
+    let schema = ensure(fs::read_to_string(schema), "Can not read schema file");
+    let schema = ensure(parse_schema(&schema), "Failed to parse schema");
+    let subgraph = SubgraphDeploymentId::new("Qmasubgraph").unwrap();
+    let layout = ensure(
+        Layout::new(&schema, IdType::String, subgraph, db_schema),
+        "Failed to construct Mapping",
+    );
+    match kind {
+        "migrate" => {
+            print_ddl(&layout);
+            print_migration(&layout);
+        }
+        "drop" => print_drop(&layout),
+        "delete" => print_delete_all(&layout),
+        "ddl" => print_ddl(&layout),
+        _ => {
+            usage(&format!("illegal value {} for --generate", kind));
+        }
+    }
+}

--- a/store/postgres/migrations/2020-01-14-235608_relational_metadata_views/down.sql
+++ b/store/postgres/migrations/2020-01-14-235608_relational_metadata_views/down.sql
@@ -1,0 +1,22 @@
+--
+-- Generated with
+--   cargo run --example layout -- -g drop-views \
+--     ./store/postgres/src/subgraphs.graphql subgraphs
+--
+
+drop view if exists "subgraphs"."ethereum_contract_data_source_template";
+drop view if exists "subgraphs"."ethereum_contract_data_source_template_source";
+drop view if exists "subgraphs"."ethereum_contract_source";
+drop view if exists "subgraphs"."subgraph_deployment_assignment";
+drop view if exists "subgraphs"."subgraph";
+drop view if exists "subgraphs"."dynamic_ethereum_contract_data_source";
+drop view if exists "subgraphs"."subgraph_deployment";
+drop view if exists "subgraphs"."subgraph_version";
+drop view if exists "subgraphs"."ethereum_block_handler_entity";
+drop view if exists "subgraphs"."ethereum_contract_abi";
+drop view if exists "subgraphs"."ethereum_call_handler_entity";
+drop view if exists "subgraphs"."ethereum_contract_data_source";
+drop view if exists "subgraphs"."ethereum_contract_mapping";
+drop view if exists "subgraphs"."subgraph_manifest";
+drop view if exists "subgraphs"."ethereum_block_handler_filter_entity";
+drop view if exists "subgraphs"."ethereum_contract_event_handler";

--- a/store/postgres/migrations/2020-01-14-235608_relational_metadata_views/up.sql
+++ b/store/postgres/migrations/2020-01-14-235608_relational_metadata_views/up.sql
@@ -1,0 +1,154 @@
+--
+-- Generated with
+--   cargo run --example layout -- -g views \
+--     ./store/postgres/src/subgraphs.graphql subgraphs
+--
+
+create view "subgraphs"."ethereum_contract_data_source_template" as
+select id as id,
+       (data->'kind'->>'data')::text as kind,
+       (data->'name'->>'data')::text as name,
+       (data->'network'->>'data')::text as network,
+       (data->'source'->>'data')::text as source,
+       (data->'mapping'->>'data')::text as mapping
+  from subgraphs.entities
+ where entity = 'EthereumContractDataSourceTemplate';
+
+create view "subgraphs"."subgraph" as
+select id as id,
+       (data->'name'->>'data')::text as name,
+       (data->'currentVersion'->>'data')::text as current_version,
+       (data->'pendingVersion'->>'data')::text as pending_version,
+       (data->'createdAt'->>'data')::numeric as created_at
+  from subgraphs.entities
+ where entity = 'Subgraph';
+
+create view "subgraphs"."subgraph_version" as
+select id as id,
+       (data->'subgraph'->>'data')::text as subgraph,
+       (data->'deployment'->>'data')::text as deployment,
+       (data->'createdAt'->>'data')::numeric as created_at
+  from subgraphs.entities
+ where entity = 'SubgraphVersion';
+
+create view "subgraphs"."ethereum_contract_data_source" as
+select id as id,
+       (data->'kind'->>'data')::text as kind,
+       (data->'name'->>'data')::text as name,
+       (data->'network'->>'data')::text as network,
+       (data->'source'->>'data')::text as source,
+       (data->'mapping'->>'data')::text as mapping,
+       array(select (x->>'data')::text from jsonb_array_elements(data->'templates'->'data') x) as templates
+  from subgraphs.entities
+ where entity = 'EthereumContractDataSource';
+
+create view "subgraphs"."dynamic_ethereum_contract_data_source" as
+select id as id,
+       (data->'kind'->>'data')::text as kind,
+       (data->'name'->>'data')::text as name,
+       (data->'network'->>'data')::text as network,
+       (data->'source'->>'data')::text as source,
+       (data->'mapping'->>'data')::text as mapping,
+       array(select (x->>'data')::text from jsonb_array_elements(data->'templates'->'data') x) as templates,
+       (data->'ethereumBlockHash'->>'data')::bytea as ethereum_block_hash,
+       (data->'ethereumBlockNumber'->>'data')::numeric as ethereum_block_number,
+       (data->'deployment'->>'data')::text as deployment
+  from subgraphs.entities
+ where entity = 'DynamicEthereumContractDataSource';
+
+create view "subgraphs"."ethereum_call_handler_entity" as
+select id as id,
+       (data->'function'->>'data')::text as function,
+       (data->'handler'->>'data')::text as handler
+  from subgraphs.entities
+ where entity = 'EthereumCallHandlerEntity';
+
+create view "subgraphs"."ethereum_block_handler_filter_entity" as
+select id as id,
+       (data->'kind'->>'data')::text as kind
+  from subgraphs.entities
+ where entity = 'EthereumBlockHandlerFilterEntity';
+
+create view "subgraphs"."ethereum_contract_event_handler" as
+select id as id,
+       (data->'event'->>'data')::text as event,
+       (data->'topic0'->>'data')::bytea as topic_0,
+       (data->'handler'->>'data')::text as handler
+  from subgraphs.entities
+ where entity = 'EthereumContractEventHandler';
+
+create view "subgraphs"."subgraph_deployment_assignment" as
+select id as id,
+       (data->'nodeId'->>'data')::text as node_id,
+       (data->'cost'->>'data')::numeric as cost
+  from subgraphs.entities
+ where entity = 'SubgraphDeploymentAssignment';
+
+create view "subgraphs"."ethereum_block_handler_entity" as
+select id as id,
+       (data->'handler'->>'data')::text as handler,
+       (data->'filter'->>'data')::text as filter
+  from subgraphs.entities
+ where entity = 'EthereumBlockHandlerEntity';
+
+create view "subgraphs"."subgraph_deployment" as
+select id as id,
+       (data->'manifest'->>'data')::text as manifest,
+       (data->'failed'->>'data')::boolean as failed,
+       (data->'synced'->>'data')::boolean as synced,
+       (data->'earliestEthereumBlockHash'->>'data')::bytea as earliest_ethereum_block_hash,
+       (data->'earliestEthereumBlockNumber'->>'data')::numeric as earliest_ethereum_block_number,
+       (data->'latestEthereumBlockHash'->>'data')::bytea as latest_ethereum_block_hash,
+       (data->'latestEthereumBlockNumber'->>'data')::numeric as latest_ethereum_block_number,
+       (data->'ethereumHeadBlockNumber'->>'data')::numeric as ethereum_head_block_number,
+       (data->'ethereumHeadBlockHash'->>'data')::bytea as ethereum_head_block_hash,
+       (data->'totalEthereumBlocksCount'->>'data')::numeric as total_ethereum_blocks_count,
+       (data->'entityCount'->>'data')::numeric as entity_count
+  from subgraphs.entities
+ where entity = 'SubgraphDeployment';
+
+create view "subgraphs"."subgraph_manifest" as
+select id as id,
+       (data->'specVersion'->>'data')::text as spec_version,
+       (data->'description'->>'data')::text as description,
+       (data->'repository'->>'data')::text as repository,
+       (data->'schema'->>'data')::text as schema,
+       array(select (x->>'data')::text from jsonb_array_elements(data->'dataSources'->'data') x) as data_sources,
+       array(select (x->>'data')::text from jsonb_array_elements(data->'templates'->'data') x) as templates
+  from subgraphs.entities
+ where entity = 'SubgraphManifest';
+
+create view "subgraphs"."ethereum_contract_mapping" as
+select id as id,
+       (data->'kind'->>'data')::text as kind,
+       (data->'apiVersion'->>'data')::text as api_version,
+       (data->'language'->>'data')::text as language,
+       (data->'file'->>'data')::text as file,
+       array(select (x->>'data')::text from jsonb_array_elements(data->'entities'->'data') x) as entities,
+       array(select (x->>'data')::text from jsonb_array_elements(data->'abis'->'data') x) as abis,
+       array(select (x->>'data')::text from jsonb_array_elements(data->'blockHandlers'->'data') x) as block_handlers,
+       array(select (x->>'data')::text from jsonb_array_elements(data->'callHandlers'->'data') x) as call_handlers,
+       array(select (x->>'data')::text from jsonb_array_elements(data->'eventHandlers'->'data') x) as event_handlers
+  from subgraphs.entities
+ where entity = 'EthereumContractMapping';
+
+create view "subgraphs"."ethereum_contract_source" as
+select id as id,
+       (data->'address'->>'data')::text as address,
+       (data->'abi'->>'data')::text as abi,
+       (data->'startBlock'->>'data')::numeric as start_block
+  from subgraphs.entities
+ where entity = 'EthereumContractSource';
+
+create view "subgraphs"."ethereum_contract_abi" as
+select id as id,
+       (data->'name'->>'data')::text as name,
+       (data->'file'->>'data')::text as file
+  from subgraphs.entities
+ where entity = 'EthereumContractAbi';
+
+create view "subgraphs"."ethereum_contract_data_source_template_source" as
+select id as id,
+       (data->'abi'->>'data')::text as abi
+  from subgraphs.entities
+ where entity = 'EthereumContractDataSourceTemplateSource';

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -559,7 +559,7 @@ impl ColumnType {
         }
     }
 
-    fn sql_type(&self) -> &str {
+    pub fn sql_type(&self) -> &str {
         match self {
             ColumnType::Boolean => "boolean",
             ColumnType::BigDecimal => "numeric",

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -96,15 +96,18 @@ type EthereumContractAbi @entity {
 }
 
 type EthereumBlockHandlerEntity @entity {
+    id: ID!
     handler: String!
     filter: EthereumBlockHandlerFilterEntity
 }
 
 type EthereumBlockHandlerFilterEntity @entity {
-     kind: String!
+    id: ID!
+    kind: String!
 }
 
 type EthereumCallHandlerEntity @entity {
+    id: ID!
     function: String!
     handler: String!
 }


### PR DESCRIPTION
This PR does not change any of the `graph-node` logic, it merely puts views in place that have the same structure as the tables that we will use for the relational storage of subgraph metadata. Having these views while we still use JSONB storage makes it possible to update various bits of tooling that currently query `subgraphs.entities` without having them break once we do the actual update.

It would be good to get this merged and rolled out as quickly as possible so we can start updating the things that will be affected by the change in storage for subgraph metadata.