### PR TITLE
tests: Update integration test to latest `graph test`

### DIFF
--- a/tests/integration-tests/overloaded-contract-functions/package.json
+++ b/tests/integration-tests/overloaded-contract-functions/package.json
@@ -5,8 +5,8 @@
     "build-contracts": "rm -rf abis bin && solcjs contracts/Contract.sol --abi -o abis && mv abis/*Contract.abi abis/Contract.abi && solcjs contracts/Contract.sol --bin -o bin && mv bin/*Contract.bin bin/Contract.bin",
     "codegen": "graph codegen",
     "test": "yarn build-contracts && truffle test --network test",
-    "create:local": "graph create test/overloaded-contract-functions --node http://localhost:8020/",
-    "deploy:local": "graph deploy test/overloaded-contract-functions --ipfs http://localhost:5001/ --node http://localhost:8020/"
+    "create:test": "graph create test/overloaded-contract-functions --node http://localhost:18020/",
+    "deploy:test": "graph deploy test/overloaded-contract-functions --ipfs http://localhost:15001/ --node http://localhost:18020/"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",

--- a/tests/integration-tests/overloaded-contract-functions/test/test.js
+++ b/tests/integration-tests/overloaded-contract-functions/test/test.js
@@ -8,10 +8,11 @@ const Contract = artifacts.require("./Contract.sol");
 const srcDir = path.join(__dirname, "..");
 
 const fetchSubgraphs = createApolloFetch({
-  uri: "http://localhost:8030/graphql"
+  uri: "http://localhost:18030/graphql"
 });
 const fetchSubgraph = createApolloFetch({
-  uri: "http://localhost:8000/subgraphs/name/test/overloaded-contract-functions"
+  uri:
+    "http://localhost:18000/subgraphs/name/test/overloaded-contract-functions"
 });
 
 const exec = cmd => {
@@ -70,8 +71,8 @@ contract("Contract", accounts => {
 
     // Create and deploy the subgraph
     exec(`yarn codegen`);
-    exec(`yarn create:local`);
-    exec(`yarn deploy:local`);
+    exec(`yarn create:test`);
+    exec(`yarn deploy:test`);
 
     // Wait for the subgraph to be indexed
     await waitForSubgraphToBeSynced();

--- a/tests/integration-tests/overloaded-contract-functions/truffle.js
+++ b/tests/integration-tests/overloaded-contract-functions/truffle.js
@@ -5,7 +5,7 @@ module.exports = {
   networks: {
     test: {
       host: "localhost",
-      port: 8545,
+      port: 18545,
       network_id: "*",
       gas: "100000000000",
       gasPrice: "1"

--- a/tests/integration-tests/overloaded-contract-functions/yarn.lock
+++ b/tests/integration-tests/overloaded-contract-functions/yarn.lock
@@ -27,7 +27,7 @@
 
 "@graphprotocol/graph-cli@https://github.com/graphprotocol/graph-cli#master":
   version "0.17.1"
-  resolved "https://github.com/graphprotocol/graph-cli#083c1a8e928dbd22a2bd1d9c301ff2118f3ed030"
+  resolved "https://github.com/graphprotocol/graph-cli#6e51b05387a7b80928fc9c945b6427b5bd154e6e"
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
     chalk "^3.0.0"


### PR DESCRIPTION
This bumps Graph CLI in the one integration test we have and updates the test environment ports from `8000` to `18000`, `8030` to `18030` and so on.