### PR TITLE
Use cached block for number -> hash mapping if that is unambiguous

### DIFF
--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -346,6 +346,7 @@ where
                             ctx.eth_adapter.is_on_main_chain(
                                 &ctx.logger,
                                 ctx.metrics.ethrpc_metrics.clone(),
+                                ctx.chain_store.clone(),
                                 ptr,
                             )
                         },

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -835,10 +835,11 @@ where
     fn block_pointer_from_number(
         &self,
         logger: &Logger,
+        chain_store: Arc<dyn ChainStore>,
         block_number: u64,
     ) -> Box<dyn Future<Item = EthereumBlockPointer, Error = EthereumAdapterError> + Send> {
         Box::new(
-            self.block_hash_by_block_number(logger, block_number)
+            self.block_hash_by_block_number(logger, chain_store.clone(), block_number)
                 .and_then(move |block_hash_opt| {
                     block_hash_opt.ok_or_else(|| {
                         format_err!(
@@ -858,6 +859,7 @@ where
     fn block_hash_by_block_number(
         &self,
         logger: &Logger,
+        _chain_store: Arc<dyn ChainStore>,
         block_number: u64,
     ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send> {
         let web3 = self.web3.clone();
@@ -925,10 +927,11 @@ where
         &self,
         logger: &Logger,
         _: Arc<SubgraphEthRpcMetrics>,
+        chain_store: Arc<dyn ChainStore>,
         block_ptr: EthereumBlockPointer,
     ) -> Box<dyn Future<Item = bool, Error = Error> + Send> {
         Box::new(
-            self.block_hash_by_block_number(&logger, block_ptr.number)
+            self.block_hash_by_block_number(&logger, chain_store, block_ptr.number)
                 .and_then(move |block_hash_opt| {
                     block_hash_opt
                         .ok_or_else(|| {

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -534,7 +534,7 @@ fn resolve_subgraph_chain_blocks(
             0 => Box::new(future::ok(None)) as Box<dyn Future<Item = _, Error = _> + Send>,
             min_start_block => Box::new(
                 ethereum_adapter
-                    .block_pointer_from_number(logger, min_start_block - 1)
+                    .block_pointer_from_number(logger, chain_store.clone(), min_start_block - 1)
                     .map(Some)
                     .map_err(move |_| {
                         SubgraphRegistrarError::ManifestValidationError(vec![

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1265,6 +1265,10 @@ pub trait ChainStore: Send + Sync + 'static {
 
     /// Return the hashes of all blocks with the given number
     fn block_hashes_by_block_number(&self, number: u64) -> Result<Vec<H256>, Error>;
+
+    /// Confirm that block number `number` has hash `hash` and that the store
+    /// may purge any other blocks with that number
+    fn confirm_block_hash(&self, number: u64, hash: &H256) -> Result<usize, Error>;
 }
 
 pub trait EthereumCallCache: Send + Sync + 'static {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1262,6 +1262,9 @@ pub trait ChainStore: Send + Sync + 'static {
     /// We will never remove blocks that are within `ancestor_count` of
     /// the chain head.
     fn cleanup_cached_blocks(&self, ancestor_count: u64) -> Result<(BlockNumber, usize), Error>;
+
+    /// Return the hashes of all blocks with the given number
+    fn block_hashes_by_block_number(&self, number: u64) -> Result<Vec<H256>, Error>;
 }
 
 pub trait EthereumCallCache: Send + Sync + 'static {

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -119,6 +119,8 @@ mock! {
         ) -> Result<Option<EthereumBlock>, Error>;
 
         fn cleanup_cached_blocks(&self, ancestor_count: u64) -> Result<(BlockNumber, usize), Error>;
+
+        fn block_hashes_by_block_number(&self, number: u64) -> Result<Vec<H256>, Error>;
     }
 }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -121,6 +121,8 @@ mock! {
         fn cleanup_cached_blocks(&self, ancestor_count: u64) -> Result<(BlockNumber, usize), Error>;
 
         fn block_hashes_by_block_number(&self, number: u64) -> Result<Vec<H256>, Error>;
+
+        fn confirm_block_hash(&self, number: u64, hash: &H256) -> Result<usize, Error>;
     }
 }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1328,6 +1328,21 @@ impl ChainStore for Store {
             .unwrap_or(Ok((0, 0)))
             .map_err(|e| e.into())
     }
+
+    fn block_hashes_by_block_number(&self, number: u64) -> Result<Vec<H256>, Error> {
+        use crate::db_schema::ethereum_blocks::dsl;
+
+        let conn = self.get_conn()?;
+        dsl::ethereum_blocks
+            .select(dsl::hash)
+            .filter(dsl::network_name.eq(&self.network_name))
+            .filter(dsl::number.eq(number as i64))
+            .get_results::<String>(&conn)?
+            .into_iter()
+            .map(|h| h.parse())
+            .collect::<Result<Vec<H256>, _>>()
+            .map_err(Error::from)
+    }
 }
 
 impl EthereumCallCache for Store {

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1343,6 +1343,18 @@ impl ChainStore for Store {
             .collect::<Result<Vec<H256>, _>>()
             .map_err(Error::from)
     }
+
+    fn confirm_block_hash(&self, number: u64, hash: &H256) -> Result<usize, Error> {
+        use crate::db_schema::ethereum_blocks::dsl;
+
+        let conn = self.get_conn()?;
+        diesel::delete(dsl::ethereum_blocks)
+            .filter(dsl::network_name.eq(&self.network_name))
+            .filter(dsl::number.eq(number as i64))
+            .filter(dsl::hash.ne(&format!("{:x}", hash)))
+            .execute(&conn)
+            .map_err(Error::from)
+    }
 }
 
 impl EthereumCallCache for Store {

--- a/store/postgres/tests/chain_head.rs
+++ b/store/postgres/tests/chain_head.rs
@@ -195,6 +195,28 @@ fn block_hashes_by_number() {
 
         let hashes = store.block_hashes_by_block_number(127).unwrap();
         assert_eq!(0, hashes.len());
+
+        let deleted = store
+            .confirm_block_hash(1, &BLOCK_ONE.block_hash())
+            .unwrap();
+        assert_eq!(0, deleted);
+
+        let deleted = store
+            .confirm_block_hash(2, &BLOCK_TWO.block_hash())
+            .unwrap();
+        assert_eq!(1, deleted);
+
+        // Make sure that we do not delete anything for a nonexistent block
+        let deleted = store
+            .confirm_block_hash(127, &GENESIS_BLOCK.block_hash())
+            .unwrap();
+        assert_eq!(0, deleted);
+
+        let hashes = store.block_hashes_by_block_number(1).unwrap();
+        assert_eq!(vec![BLOCK_ONE.block_hash()], hashes);
+
+        let hashes = store.block_hashes_by_block_number(2).unwrap();
+        assert_eq!(vec![BLOCK_TWO.block_hash()], hashes);
         Ok(())
     })
 }

--- a/store/postgres/tests/chain_head.rs
+++ b/store/postgres/tests/chain_head.rs
@@ -175,3 +175,26 @@ fn block_number() {
         Ok(())
     })
 }
+
+#[test]
+fn block_hashes_by_number() {
+    let chain = vec![
+        &*GENESIS_BLOCK,
+        &*BLOCK_ONE,
+        &*BLOCK_TWO,
+        &*BLOCK_TWO_NO_PARENT,
+    ];
+    run_test(chain, move |store| -> Result<(), ()> {
+        let hashes = store.block_hashes_by_block_number(1).unwrap();
+        assert_eq!(vec![BLOCK_ONE.block_hash()], hashes);
+
+        let hashes = store.block_hashes_by_block_number(2).unwrap();
+        assert_eq!(2, hashes.len());
+        assert!(hashes.contains(&BLOCK_TWO.block_hash()));
+        assert!(hashes.contains(&BLOCK_TWO_NO_PARENT.block_hash()));
+
+        let hashes = store.block_hashes_by_block_number(127).unwrap();
+        assert_eq!(0, hashes.len());
+        Ok(())
+    })
+}


### PR DESCRIPTION
One thing I am unsure about with this is whether it will interfere with reverts, since during a revert, we'll have multiple blocks with the same number in the database. If doing the revert requires that the orphaned block remains in the database, this code could cause problems.