### PR TITLE
store: Lower the threshold for a notification to be large to 128 bytes

### DIFF
--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -218,8 +218,10 @@ pub struct JsonNotification {
     pub payload: serde_json::Value,
 }
 
-// Any payload bigger than this is considered large.
-static LARGE_NOTIFICATION_THRESHOLD: usize = 7800;
+// Any payload bigger than this is considered large. Any notification larger
+// than this will be put into the `large_notifications` table, and only
+// its id in the table will be sent via `notify`
+static LARGE_NOTIFICATION_THRESHOLD: usize = 128;
 
 impl JsonNotification {
     pub fn parse(


### PR DESCRIPTION
We are seeing a lot of commits taking 300ms or so in production; when that happens lots of commits pile up and it looks like they are all waiting for a lock on Postgres' internal notification queue. Forcing more notifications to be bounced through the `large_notifications` table should reduce the amount of work Postgres has to do for each notification internally during commit, and the hope is that this will reduce the contention on the notification queue.