### PR TITLE
Change how we select top n children for a set of parents

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -162,14 +162,17 @@ impl WindowAttribute {
     }
 }
 
-/// How to join with the parent table when the child table does not
+/// How to connect children to their parent when the child table does not
 /// store parent id's
 #[derive(Clone, Debug, PartialEq)]
-pub struct ParentLink {
-    /// Name of the parent entity (concrete type, not an interface)
-    pub parent_type: String,
-    /// Name of the attribute where parent stores child ids
-    pub child_field: WindowAttribute,
+pub enum ParentLink {
+    /// The parent stores a list of child ids. The ith entry in the outer
+    /// vector contains the id of the children for `EntityWindow.ids[i]`
+    List(Vec<Vec<String>>),
+    /// The parent stores the id of one child. The ith entry in the
+    /// vector contains the id of the child of the parent with id
+    /// `EntityWindow.ids[i]`
+    Scalar(Vec<String>),
 }
 
 /// How to select children for their parents depending on whether the

--- a/store/postgres/migrations/2020-01-24-065338_add_reduce_dim/down.sql
+++ b/store/postgres/migrations/2020-01-24-065338_add_reduce_dim/down.sql
@@ -1,0 +1,1 @@
+drop function reduce_dim(anyarray);

--- a/store/postgres/migrations/2020-01-24-065338_add_reduce_dim/up.sql
+++ b/store/postgres/migrations/2020-01-24-065338_add_reduce_dim/up.sql
@@ -1,0 +1,14 @@
+-- From https://wiki.postgresql.org/wiki/Unnest_multidimensional_array
+CREATE OR REPLACE FUNCTION public.reduce_dim(anyarray)
+RETURNS SETOF anyarray AS
+$function$
+DECLARE
+    s $1%TYPE;
+BEGIN
+    FOREACH s SLICE 1  IN ARRAY $1 LOOP
+        RETURN NEXT s;
+    END LOOP;
+    RETURN;
+END;
+$function$
+LANGUAGE plpgsql IMMUTABLE;

--- a/store/postgres/src/jsonb_queries.rs
+++ b/store/postgres/src/jsonb_queries.rs
@@ -8,9 +8,11 @@ use diesel::query_dsl::RunQueryDsl;
 use diesel::result::QueryResult;
 use diesel::sql_types::{Array, Bool, Jsonb, Text};
 use graph::prelude::{
-    EntityCollection, EntityFilter, EntityLink, EntityOrder, EntityRange, EntityWindow,
+    EntityCollection, EntityFilter, EntityLink, EntityOrder, EntityRange, EntityWindow, ParentLink,
     QueryExecutionError, ValueType, WindowAttribute,
 };
+use std::collections::HashSet;
+use std::iter::FromIterator;
 
 use crate::entities::{EntityTable, STRING_PREFIX_SIZE};
 use crate::filter::build_filter;
@@ -98,26 +100,40 @@ impl<'a> FilterQuery<'a> {
         Ok(())
     }
 
-    fn order_by(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
-        out.push_sql("\n order by ");
+    fn sort_key(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
         if let Some(order) = &self.order {
-            if order.prefix_only {
-                out.push_sql("left(data ->");
-                out.push_bind_param::<Text, _>(&order.attribute)?;
-                out.push_sql("->> 'data', ");
-                out.push_sql(&STRING_PREFIX_SIZE.to_string());
-                out.push_sql(") ");
-            } else {
-                if &order.attribute == PRIMARY_KEY_COLUMN {
-                    out.push_identifier(PRIMARY_KEY_COLUMN)?;
-                } else {
-                    out.push_sql("(data ->");
+            if &order.attribute != PRIMARY_KEY_COLUMN {
+                out.push_sql(", ");
+                if order.prefix_only {
+                    out.push_sql("left(data ->");
                     out.push_bind_param::<Text, _>(&order.attribute)?;
-                    out.push_sql("->> 'data')");
-                    out.push_sql(&order.cast);
+                    out.push_sql("->> 'data', ");
+                    out.push_sql(&STRING_PREFIX_SIZE.to_string());
+                    out.push_sql(")");
+                } else {
+                    if &order.attribute == PRIMARY_KEY_COLUMN {
+                        out.push_identifier(PRIMARY_KEY_COLUMN)?;
+                    } else {
+                        out.push_sql("(data ->");
+                        out.push_bind_param::<Text, _>(&order.attribute)?;
+                        out.push_sql("->> 'data')");
+                        out.push_sql(&order.cast);
+                    }
                 }
-                out.push_sql(" ");
+                out.push_sql(" as g$sort_key");
             }
+        }
+        Ok(())
+    }
+
+    fn order_by(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        if let Some(order) = &self.order {
+            if &order.attribute == PRIMARY_KEY_COLUMN {
+                out.push_identifier(PRIMARY_KEY_COLUMN)?;
+            } else {
+                out.push_sql("g$sort_key");
+            }
+            out.push_sql(" ");
             out.push_sql(order.direction.to_sql());
             out.push_sql(" nulls last, ");
         }
@@ -135,97 +151,6 @@ impl<'a> FilterQuery<'a> {
         }
     }
 
-    fn from_window_clause(&self, window: &EntityWindow, out: &mut AstPass<Pg>) -> QueryResult<()> {
-        match &window.link {
-            EntityLink::Direct(attribute) => {
-                match attribute {
-                    WindowAttribute::List(name) => {
-                        out.push_sql(" join lateral jsonb_array_elements(data->");
-                        out.push_bind_param::<Text, _>(name)?;
-                        out.push_sql("->'data') parent on parent->>'data' = any(");
-                        out.push_bind_param::<Array<Text>, _>(&window.ids)?;
-                        out.push_sql(")");
-                    }
-                    WindowAttribute::Scalar(_) => { /* handled in window_filter */ }
-                }
-            }
-            EntityLink::Parent(parent) => {
-                match &parent.child_field {
-                    WindowAttribute::Scalar(name) => {
-                        // inner join {table} p
-                        //   on (p.entity = '{object}'
-                        //       and c.id = p.data->{name}->>'data'
-                        out.push_sql(" inner join ");
-                        self.table.walk_ast(out.reborrow())?;
-                        out.push_sql(" p on (p.entity = '");
-                        out.push_sql(&parent.parent_type);
-                        out.push_sql("' and ");
-                        out.push_sql("c.id = p.data->");
-                        out.push_bind_param::<Text, _>(name)?;
-                        out.push_sql("->>'data'");
-                    }
-                    WindowAttribute::List(name) => {
-                        // p.data->name->'data' is an array where each entry
-                        // is a data/type pair. We dissolve that into a table
-                        // with only the 'data' values from each array entry
-                        //
-                        // inner join ({table} p
-                        //             join lateral jsonb_array_elements(p.data->{name}->'data') ary(elt) on true) p
-                        //   on (p.entity = '{object}'
-                        //       and c.id = p.elt->>'data'
-                        out.push_sql(" inner join (");
-                        self.table.walk_ast(out.reborrow())?;
-                        out.push_sql(" p join lateral jsonb_array_elements(p.data->");
-                        out.push_bind_param::<Text, _>(name)?;
-                        out.push_sql("->'data') ary(elt) on true) p on (p.entity = '");
-                        out.push_sql(&parent.parent_type);
-                        out.push_sql("' and c.id = p.elt->>'data'");
-                    }
-                }
-                out.push_sql(" and p.id = any(");
-                out.push_bind_param::<Array<Text>, _>(&window.ids)?;
-                out.push_sql("))");
-            }
-        }
-        Ok(())
-    }
-
-    fn parent_id(&self, window: &EntityWindow, out: &mut AstPass<Pg>) -> QueryResult<()> {
-        match &window.link {
-            EntityLink::Direct(attribute) => match attribute {
-                WindowAttribute::Scalar(name) => {
-                    out.push_sql("c.data->");
-                    out.push_bind_param::<Text, _>(&name)?;
-                    out.push_sql("->>'data' as g$parent_id");
-                }
-                WindowAttribute::List(_) => out.push_sql("parent->>'data' as g$parent_id"),
-            },
-            EntityLink::Parent(_) => {
-                out.push_sql("p.id as g$parent_id");
-            }
-        }
-        Ok(())
-    }
-
-    fn window_filter(&self, window: &EntityWindow, out: &mut AstPass<Pg>) -> QueryResult<()> {
-        match &window.link {
-            EntityLink::Direct(attribute) => {
-                match attribute {
-                    WindowAttribute::List(_) => { /* handled in from_window_clause */ }
-                    WindowAttribute::Scalar(name) => {
-                        out.push_sql("\n   and c.data->");
-                        out.push_bind_param::<Text, _>(name)?;
-                        out.push_sql("->>'data' = any(");
-                        out.push_bind_param::<Array<Text>, _>(&window.ids)?;
-                        out.push_sql(")");
-                    }
-                }
-            }
-            EntityLink::Parent(_) => { /* handled in from_window_clause */ }
-        }
-        Ok(())
-    }
-
     /// Generate the query when there is no window. This produces
     ///
     ///   select data, entity
@@ -237,6 +162,7 @@ impl<'a> FilterQuery<'a> {
     fn query_no_window(&self, entities: &Vec<String>, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         out.push_sql("select id, data, entity");
+        self.sort_key(&mut out)?;
         out.push_sql("\n  from ");
         self.table.walk_ast(out.reborrow())?;
         out.push_sql(" c\n where ");
@@ -246,8 +172,106 @@ impl<'a> FilterQuery<'a> {
             filter.walk_ast(out.reborrow())?;
         }
 
+        out.push_sql("\n order by ");
         self.order_by(&mut out)?;
         self.limit(&mut out);
+        Ok(())
+    }
+
+    // Produce a literal `array[array[..],..]` containing child_ids
+    fn matrix_literal(child_ids: &Vec<Vec<String>>, out: &mut AstPass<Pg>) {
+        let maxlen = child_ids.iter().map(|ids| ids.len()).max().unwrap_or(0);
+        // Diesel does not support arrays of arrays as bind variables, nor
+        // arrays containing nulls, so we have to manually serialize
+        // the child_ids
+        out.push_sql("array[");
+        for (i, ids) in child_ids.iter().enumerate() {
+            if i > 0 {
+                out.push_sql(", ");
+            }
+            out.push_sql("array[");
+            for (j, id) in ids.iter().enumerate() {
+                if j > 0 {
+                    out.push_sql(", ");
+                }
+                out.push_sql("'");
+                if id.contains('\'') {
+                    out.push_sql(&id.replace('\'', "''"));
+                } else {
+                    out.push_sql(&id);
+                }
+                out.push_sql("'");
+            }
+            // Pad individual arrays with 'null' since Postgres requires that
+            // in an array of arrays all rows have the same number of entries
+            for j in 0..(maxlen - ids.len()) {
+                if j > 0 || ids.len() > 0 {
+                    out.push_sql(", ");
+                }
+                out.push_sql("null");
+            }
+            out.push_sql("]");
+        }
+        out.push_sql("]");
+    }
+
+    fn expand_parents(&self, window: &EntityWindow, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        match &window.link {
+            EntityLink::Direct(_) => {
+                // Type A and B
+                // unnest($parent_ids) as p(id)
+                out.push_sql("unnest(");
+                out.push_bind_param::<Array<Text>, _>(&window.ids)?;
+                out.push_sql(") as p(id)");
+            }
+            EntityLink::Parent(ParentLink::List(child_ids)) => {
+                // Type C
+                // rows from (unnest($parent_ids), reduce_dim($child_id_matrix)) as p(id, child_ids)
+                out.push_sql("rows from (unnest(");
+                out.push_bind_param::<Array<Text>, _>(&window.ids)?;
+                out.push_sql("::text[]), reduce_dim(");
+                Self::matrix_literal(child_ids, out);
+                out.push_sql(")) as p(id, child_ids)");
+            }
+            EntityLink::Parent(ParentLink::Scalar(child_ids)) => {
+                // Type D
+                // unnest($parent_ids, $child_ids) as p(id, child_id)
+                out.push_sql("unnest(");
+                out.push_bind_param::<Array<Text>, _>(&window.ids)?;
+                out.push_sql(",");
+                out.push_bind_param::<Array<Text>, _>(&child_ids)?;
+                out.push_sql(") as p(id, child_id)");
+            }
+        }
+        Ok(())
+    }
+
+    fn linked_children(&self, window: &EntityWindow, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        match &window.link {
+            EntityLink::Direct(WindowAttribute::List(name)) => {
+                // Type A
+                // The `in (..)` part turns the id's stored in `name` into
+                // a list of parent ids
+                out.push_sql("p.id in (select ary->>'data' from jsonb_array_elements(c.data->");
+                out.push_bind_param::<Text, _>(name)?;
+                out.push_sql("->'data') ary)");
+            }
+            EntityLink::Direct(WindowAttribute::Scalar(name)) => {
+                // Type B
+                // p.id = c.data->{name}->>'data'
+                out.push_sql("p.id = c.data->");
+                out.push_bind_param::<Text, _>(name)?;
+                out.push_sql("->>'data'");
+            }
+            EntityLink::Parent(ParentLink::List(_)) => {
+                // Type C
+                out.push_sql("c.id = any(p.child_ids)");
+            }
+            EntityLink::Parent(ParentLink::Scalar(_)) => {
+                // Type D
+                out.push_sql("c.id = p.child_id");
+            }
+        }
         Ok(())
     }
 
@@ -259,71 +283,77 @@ impl<'a> FilterQuery<'a> {
     /// The query we produce is
     ///
     ///   select id, data, entity
-    ///     from (select id, data, entity,
-    ///                  rank() over (partition by g$parent_id order by {order}) as g$pos
-    ///              from {inner_query}) a
-    ///    where a.g$pos > {range.skip} and a.g$pos <= {range.skip} + {range.first}
-    ///    order by {order}
+    ///     from
+    ///       (select id from unnest({parent_ids}) as q(id))
+    ///       cross join lateral (
+    ///          {expand_parents} p
+    ///          cross join lateral
+    ///            (select id, data, entity
+    ///               from entities c
+    ///              where {linked_children}
+    ///                and p.id = q.id
+    ///                and c.entity = {child_type}
+    ///                and {filter})
+    ///          union all
+    ///          .. range over all windows ..
+    ///          order by {order}
+    ///          limit {first} skip {skip}))
     ///
-    /// And `inner_query` is
-    ///   select id, data, entity, {parent_id} as g$parent_id
-    ///     from {table}
-    ///          [join lateral jsonb_array_elements({window.attribute}) g$parent_id on g$parent_id = any({window.ids})]
-    ///    where entity = {entity_type}
-    ///      and [{window.attribute} = any({window.ids})]
-    ///      and {filter}
-    ///    union all
-    ///      ...
-    /// where we loop this over every entry in `self.window`
-    ///
-    /// The `join lateral` clause is only needed if the `window.attribute` is a list; if it is
-    /// a scalar, we use the `[{window.attribute} = any({window.ids})]` clause instead
+    #[allow(unreachable_code, unused_variables)]
     fn query_window(&self, windows: &Vec<EntityWindow>, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
-        out.push_sql(
-            "select id, data || jsonb_build_object('g$parent_id', jsonb_build_object('data', g$parent_id, 'type', 'String')), entity\n  from (",
-        );
 
-        out.push_sql("select id, data, entity, g$parent_id");
-        out.push_sql(", rank() over (partition by g$parent_id");
-        self.order_by(&mut out)?;
-        out.push_sql(") as g$pos");
-        out.push_sql("\n  from (");
-        // inner_query starts here
+        // Collect all the parent ids from all the windows
+        let parent_ids: HashSet<String> = HashSet::from_iter(
+            windows
+                .iter()
+                .map(|window| window.ids.iter().cloned())
+                .flatten(),
+        );
+        let parent_ids: Vec<String> = parent_ids.into_iter().collect();
+
+        out.push_sql("select c.id, c.data, c.entity from ");
+        out.push_sql("unnest(");
+        out.push_bind_param::<Array<Text>, _>(&parent_ids)?;
+        out.push_sql(") as q(id) cross join lateral (");
         for (index, window) in windows.iter().enumerate() {
             if index > 0 {
                 out.push_sql("\nunion all\n");
             }
-            out.push_sql("select c.id, c.data, c.entity, ");
-            self.parent_id(window, &mut out)?;
-            out.push_sql("\n  from ");
+            // we actually put the parent_id into the entity as g$parent_id
+            out.push_sql(
+                "select c.id, \
+                 c.data || \
+                   jsonb_build_object('g$parent_id', jsonb_build_object('data', p.id, 'type', 'String')) as data, \
+                 c.entity"
+            );
+            self.sort_key(&mut out)?;
+            out.push_sql(" from ");
+            self.expand_parents(window, &mut out)?;
+            out.push_sql(
+                " cross join lateral \
+                 (select c.id, c.data, c.entity",
+            );
+            self.sort_key(&mut out)?;
+            out.push_sql(" from ");
             self.table.walk_ast(out.reborrow())?;
             out.push_sql(" c");
-            self.from_window_clause(window, &mut out)?;
-            out.push_sql("\n where c.entity = ");
+            out.push_sql(" where ");
+            self.linked_children(window, &mut out)?;
+            out.push_sql(" and p.id = q.id");
+            out.push_sql(" and c.entity = ");
             out.push_bind_param::<Text, _>(&window.child_type)?;
-            self.window_filter(window, &mut out)?;
             if let Some(filter) = &self.filter {
-                out.push_sql("\n   and ");
+                out.push_sql(" and ");
                 filter.walk_ast(out.reborrow())?;
             }
+            out.push_sql(") c");
         }
-        // back to the outer query
-        out.push_sql(") a) a\n where ");
-        if self.range.skip > 0 {
-            out.push_sql("a.g$pos > ");
-            out.push_sql(&self.range.skip.to_string());
-            if self.range.first.is_some() {
-                out.push_sql(" and ");
-            }
-        }
-        if let Some(first) = self.range.first {
-            let pos = self.range.skip + first;
-            out.push_sql("a.g$pos <= ");
-            out.push_sql(&pos.to_string());
-        }
-        out.push_sql("\n order by a.g$parent_id, a.g$pos");
-        Ok(())
+        out.push_sql("\n order by ");
+        self.order_by(&mut out)?;
+        self.limit(&mut out);
+        out.push_sql(") c order by q.id, ");
+        self.order_by(&mut out)
     }
 }
 

--- a/store/postgres/src/jsonb_queries.rs
+++ b/store/postgres/src/jsonb_queries.rs
@@ -299,7 +299,6 @@ impl<'a> FilterQuery<'a> {
     ///          order by {order}
     ///          limit {first} skip {skip}))
     ///
-    #[allow(unreachable_code, unused_variables)]
     fn query_window(&self, windows: &Vec<EntityWindow>, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
 

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1202,9 +1202,6 @@ impl<'a> FilterWindow<'a> {
         Ok(())
     }
 
-    //  self.children(None, None, block, ParentFilter::Outer, out)
-    //  window.children(Some(&self.sort_key), Some(&self.range), self.block, ParentFilter::None, out.reborrow()
-
     fn children(
         &self,
         limit: ParentLimit<'_>,


### PR DESCRIPTION
Using the 'rank() over(..)' window function for ranking and selecting the top n children per parent turned out to be very slow in some cases. With  a 'join lateral' we are essentially encoding a for loop in the queries which seems to perform much better.
    
This also eases subgraph composition since we now never join two 'real' tables, and therefore do not need to worry about joins crossing subgraph boundaries
    
Fixes https://github.com/graphprotocol/graph-node/issues/1450