### PR TITLE
store: Go back to higher LARGE_NOTIFICATION_THRESHOLD

### DIFF
--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -221,7 +221,7 @@ pub struct JsonNotification {
 // Any payload bigger than this is considered large. Any notification larger
 // than this will be put into the `large_notifications` table, and only
 // its id in the table will be sent via `notify`
-static LARGE_NOTIFICATION_THRESHOLD: usize = 128;
+static LARGE_NOTIFICATION_THRESHOLD: usize = 7800;
 
 impl JsonNotification {
     pub fn parse(


### PR DESCRIPTION
The lower threshold made things a lot worse in production (commits no hang
for almost a second sometimes when before it was more like 300ms)

This reverts commit 6ae99b55939c8b14f3ca6f8a3556f9de6856fb2d.

