### PR TITLE
Log block and full transaction hash when handler fails

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -823,6 +823,7 @@ where
         .fold((ctx, block_state), move |(ctx, block_state), trigger| {
             let logger = logger.clone();
             let block = block.clone();
+            let block_ptr = EthereumBlockPointer::from(block.as_ref());
             let subgraph_metrics = ctx.subgraph_metrics.clone();
             let trigger_type = match trigger {
                 EthereumTrigger::Log(_) => TriggerType::Event,
@@ -845,7 +846,8 @@ where
                 })
                 .map_err(move |e| match transaction_id {
                     Some(tx_hash) => format_err!(
-                        "Failed to process trigger in transaction {}: {}",
+                        "Failed to process trigger in block {}, transaction {:x}: {}",
+                        block_ptr,
                         tx_hash,
                         e
                     ),


### PR DESCRIPTION
Right now, we're logging this:
```
Subgraph instance failed to run: Failed to process trigger in transaction
0x4843…999b: Failed to handle Ethereum event with handler "handleTokenPurchase":
attempted to divide BigDecimal `252446073566483947580.0000000000000000000000000000000000000000000000000000000000000000000000000000000`
by zero, code: SubgraphSyncingFailure, id: QmPtYS7sxvpaw5pzV7QGJzkLHqK7AHgPqanA7ZKiHK9FcD
```
when it would be better to log this:
```
Subgraph instance failed to run: Failed to process trigger in block #123123123
(1231241acbacbacbacb23), transaction 0x484abcbacbacbacbacbacbacbac999b: Failed to
handle Ethereum event with handler "handleTokenPurchase": attempted to divide BigDecimal
`252446073566483947580.0000000000000000000000000000000000000000000000000000000000000000000000000000000`
by zero, code: SubgraphSyncingFailure, id: QmPtYS7sxvpaw5pzV7QGJzkLHqK7AHgPqanA7ZKiHK9FcD
```

This is what this PR does. 