### PR TITLE
Use monomorphic result type for fulltext searches

### DIFF
--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -1,4 +1,4 @@
-use graphql_parser::schema::{Name, UnionType, Value, *};
+use graphql_parser::schema::{Name, Value, *};
 use graphql_parser::Pos;
 use inflector::Inflector;
 
@@ -34,80 +34,12 @@ pub fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
     add_builtin_scalar_types(&mut schema)?;
     add_order_direction_enum(&mut schema);
     add_block_height_type(&mut schema);
-    add_fulltext_unions(&mut schema, &object_types);
     add_types_for_object_types(&mut schema, &object_types)?;
     add_types_for_interface_types(&mut schema, &interface_types)?;
     add_field_arguments(&mut schema, &input_schema)?;
     add_query_type(&mut schema, &object_types, &interface_types)?;
     add_subscription_type(&mut schema, &object_types, &interface_types)?;
     Ok(schema)
-}
-
-fn add_fulltext_unions(schema: &mut Document, object_types: &Vec<&ObjectType>) {
-    // Collect the fulltext directives from the _Schema_ type
-    object_types
-        .iter()
-        .find(|obj| obj.name.eq(SCHEMA_TYPE_NAME))
-        .map(|schema_type| {
-            schema_type
-                .directives
-                .iter()
-                .filter(|directive| directive.name.eq("fulltext"))
-                .collect::<Vec<&Directive>>()
-        })
-        .unwrap_or(vec![])
-        .iter()
-        .for_each(|fulltext| {
-            // For each fulltext directive:
-            //   1. Transform @fulltext.name by uppercasing the first character, prepending Fulltext, and appending Entity
-            //   2. Collect the entities names included in the search from @fulltext.include[i].entity
-            //   3. Construct a UnionType using the derived name and the collection of entities
-
-            let mut original_name = fulltext
-                .arguments
-                .iter()
-                .find(|(name, _)| name.eq("name"))
-                .map(|(_, value)| {
-                    match value {
-                        Value::String(name) => name.clone(),
-                        // This is unreachable because of deploy validation
-                        _ => unreachable!(),
-                    }
-                })
-                .unwrap();
-            let (first_character, remaining_characters) = original_name.split_at_mut(1);
-            first_character.make_ascii_uppercase();
-            remaining_characters.make_ascii_lowercase();
-            let union_name =
-                vec!["_Fulltext", first_character, remaining_characters, "Entity"].join("");
-
-            if let Some((_, Value::List(includes))) = fulltext
-                .arguments
-                .iter()
-                .find(|(name, _)| name.eq("include"))
-            {
-                let entity_names = includes
-                    .into_iter()
-                    .filter_map(|include| match include {
-                        Value::Object(include) => match include.get("entity") {
-                            Some(Value::String(entity)) => Some(entity.clone()),
-                            _ => None,
-                        },
-                        _ => None,
-                    })
-                    .collect();
-
-                let fulltext_union = Definition::TypeDefinition(TypeDefinition::Union(UnionType {
-                    position: Pos::default(),
-                    description: None,
-                    name: union_name,
-                    directives: vec![],
-                    types: entity_names,
-                }));
-
-                schema.definitions.push(fulltext_union);
-            }
-        })
 }
 
 /// Adds built-in GraphQL scalar types (`Int`, `String` etc.) to the schema.
@@ -556,7 +488,6 @@ fn add_query_type(
 }
 
 fn query_field_for_fulltext(fulltext: &Directive) -> Option<Field> {
-    // let name = ;
     let original_name = fulltext
         .arguments
         .iter()
@@ -569,12 +500,22 @@ fn query_field_for_fulltext(fulltext: &Directive) -> Option<Field> {
             }
         })
         .unwrap();
-    let mut original_name_clone = original_name.clone();
-    let (first_character, remaining_characters) = original_name_clone.split_at_mut(1);
-    first_character.make_ascii_uppercase();
-    remaining_characters.make_ascii_lowercase();
-    let union_type_name =
-        vec!["_Fulltext", first_character, remaining_characters, "Entity"].join("");
+
+    let entity_name = fulltext
+        .arguments
+        .iter()
+        .find(|(name, _)| &name[..] == "include")
+        .and_then(|(_, value)| match value {
+            Value::List(includes) => includes.iter().next().and_then(|value| match value {
+                Value::Object(include) => match include.get("entity") {
+                    Some(Value::String(entity)) => Some(entity),
+                    _ => None,
+                },
+                _ => None,
+            }),
+            _ => None,
+        })?;
+
     let arguments = vec![
         // text: String
         InputValue {
@@ -618,7 +559,9 @@ fn query_field_for_fulltext(fulltext: &Directive) -> Option<Field> {
         description: None,
         name: original_name, // fulltext.name
         arguments: arguments,
-        field_type: Type::NamedType(union_type_name), // search enum name
+        field_type: Type::NonNullType(Box::new(Type::ListType(Box::new(Type::NonNullType(
+            Box::new(Type::NamedType(entity_name.clone())),
+        ))))), // included entity type name
         directives: vec![fulltext.clone()],
     })
 }


### PR DESCRIPTION
The initial implementation of fulltext search queries only supports the inclusion of one entity type, so the result type for a fulltext query is the type of the entity included. 