### PR TITLE
Kill unresponsive node

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -99,3 +99,4 @@ triggers in each request (defaults to 100000).
   [here](https://docs.rs/env_logger/0.6.0/env_logger/)
 - `THEGRAPH_STORE_POSTGRES_DIESEL_URL`: postgres instance used when running
   tests. Set to `postgresql://<DBUSER>:<DBPASSWORD>@<DBHOST>:<DBPORT>/<DBNAME>`
+- `GRAPH_KILL_IF_UNRESPONSIVE`: If set, the process will be killed if unresponsive.

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -750,6 +750,10 @@ async fn main() {
                                      "code" => LogCode::TokioContention);
             if timeout < Duration::from_secs(10) {
                 timeout *= 10;
+            } else if std::env::var_os("GRAPH_KILL_IF_UNRESPONSIVE").is_some() {
+                // The node is unresponsive, kill it in hopes it will be restarted.
+                crit!(contention_logger, "Node is unresponsive, killing process");
+                std::process::exit(1)
             }
         }
     });


### PR DESCRIPTION
So kubernetes has a chance to restart it. If `GRAPH_ALLOW_UNRESPONSIVE` is set, then this will be disabled.