### PR TITLE
Use the correct network when resolving a block hash into a block number

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1191,6 +1191,10 @@ pub trait SubgraphDeploymentStore: Send + Sync + 'static {
     /// store internals that should really be hidden and should be used
     /// sparingly and only when absolutely needed
     fn uses_relational_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<bool, Error>;
+
+    /// Return the name of the network that the subgraph is indexing from. The
+    /// names returned are things like `mainnet` or `ropsten`
+    fn network_name(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Option<String>, Error>;
 }
 
 /// Common trait for blockchain store implementations.

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -91,7 +91,9 @@ mock! {
         fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error>;
 
         fn uses_relational_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<bool, Error>;
-    }
+
+        fn network_name(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Option<String>, Error>;
+}
 
     trait ChainStore: Send + Sync + 'static {
         fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error>;

--- a/store/postgres/tests/chain_head.rs
+++ b/store/postgres/tests/chain_head.rs
@@ -156,6 +156,9 @@ fn long_chain_with_uncles() {
 fn block_number() {
     let chain = vec![&*GENESIS_BLOCK, &*BLOCK_ONE, &*BLOCK_TWO];
     let subgraph = SubgraphDeploymentId::new("nonExistentSubgraph").unwrap();
+
+    create_test_subgraph(subgraph.as_str(), "type Dummy @entity { id: ID! }");
+
     run_test(chain, move |store| -> Result<(), ()> {
         let block = store
             .block_number(&subgraph, GENESIS_BLOCK.block_hash())


### PR DESCRIPTION
GraphQL queries that uses time-travel queries with a block hash would sometimes fail with an error of 'no block for this hash found' when that block clearly existed in the database. When we look up a block with a given hash, we look for a block with that hash and the store's network; that is wrong, as for queries the store's network and the subgraph's network might be different. Instead, we now determine the subgraph's network and use that when we check for the hash.