### PR TITLE
Create a coredump on panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "coredump"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1261,7 @@ version = "0.17.1"
 dependencies = [
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "coredump 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4379,6 +4388,7 @@ dependencies = [
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
+"checksum coredump 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0816fc72f742f9e2937664d93cfea6b41acdc20fac0b41726ac665605b3b5f7"
 "checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
 "checksum crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad4c7ea749d9fb09e23c5cb17e3b70650860553a0e2744e38446b1803bf7db94"
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -13,6 +13,7 @@ futures = { version = "0.3.1", features = ["compat"] }
 ipfs-api = { version = "0.6.0-rc", features = ["hyper-tls"] }
 lazy_static = "1.2.0"
 url = "1.7.1"
+coredump = "0.1.0"
 crossbeam-channel = "0.4.0"
 graph = { path = "../graph" }
 graph-core = { path = "../core" }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -757,7 +757,7 @@ async fn main() {
             } else if std::env::var_os("GRAPH_KILL_IF_UNRESPONSIVE").is_some() {
                 // The node is unresponsive, kill it in hopes it will be restarted.
                 crit!(contention_logger, "Node is unresponsive, killing process");
-                std::process::exit(1)
+                panic!("Node unresponsive, killing process");
             }
         }
     });

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{App, Arg};
+use coredump::register_panic_handler;
 use git_testament::{git_testament, render_testament};
 use ipfs_api::IpfsClient;
 use lazy_static::lazy_static;
@@ -57,6 +58,9 @@ enum ConnectionType {
 #[tokio::main]
 async fn main() {
     env_logger::init();
+
+    // Dump core on panic
+    register_panic_handler().expect("Failed to register coredump panic handler");
 
     // Setup CLI using Clap, provide general info and capture postgres url
     let matches = App::new("graph-node")


### PR DESCRIPTION
Use the [coredump](https://crates.io/crates/coredump) crate so that any panic will cause a core dump (the crate does that by sending `SIGQUIT` to itself)

Also change the behavior when we detect that the node is unresponsive: if `GRAPH_KILL_IF_UNRESPONSIVE` is set, panic so we dump core instead of calling `exit(1)`