### PR TITLE
store: Add explicit types to arguments of unnest() and reduce_dim()

### DIFF
--- a/store/postgres/src/jsonb_queries.rs
+++ b/store/postgres/src/jsonb_queries.rs
@@ -222,7 +222,7 @@ impl<'a> FilterQuery<'a> {
                 // unnest($parent_ids) as p(id)
                 out.push_sql("unnest(");
                 out.push_bind_param::<Array<Text>, _>(&window.ids)?;
-                out.push_sql(") as p(id)");
+                out.push_sql("::text[]) as p(id)");
             }
             EntityLink::Parent(ParentLink::List(child_ids)) => {
                 // Type C
@@ -231,16 +231,16 @@ impl<'a> FilterQuery<'a> {
                 out.push_bind_param::<Array<Text>, _>(&window.ids)?;
                 out.push_sql("::text[]), reduce_dim(");
                 Self::matrix_literal(child_ids, out);
-                out.push_sql(")) as p(id, child_ids)");
+                out.push_sql("::text[][])) as p(id, child_ids)");
             }
             EntityLink::Parent(ParentLink::Scalar(child_ids)) => {
                 // Type D
                 // unnest($parent_ids, $child_ids) as p(id, child_id)
                 out.push_sql("unnest(");
                 out.push_bind_param::<Array<Text>, _>(&window.ids)?;
-                out.push_sql(",");
+                out.push_sql("::text[],");
                 out.push_bind_param::<Array<Text>, _>(&child_ids)?;
-                out.push_sql(") as p(id, child_id)");
+                out.push_sql("::text[]) as p(id, child_id)");
             }
         }
         Ok(())
@@ -314,7 +314,7 @@ impl<'a> FilterQuery<'a> {
         out.push_sql("select c.id, c.data, c.entity from ");
         out.push_sql("unnest(");
         out.push_bind_param::<Array<Text>, _>(&parent_ids)?;
-        out.push_sql(") as q(id) cross join lateral (");
+        out.push_sql("::text[]) as q(id) cross join lateral (");
         for (index, window) in windows.iter().enumerate() {
             if index > 0 {
                 out.push_sql("\nunion all\n");

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1123,7 +1123,7 @@ impl<'a> FilterWindow<'a> {
                 // unnest($parent_ids) as p(id)
                 out.push_sql("unnest(");
                 out.push_bind_param::<Array<Text>, _>(&self.ids)?;
-                out.push_sql(") as p(id)");
+                out.push_sql("::text[]) as p(id)");
             }
             TableLink::Parent(ParentIds::List(child_ids)) => {
                 // Type C
@@ -1158,7 +1158,7 @@ impl<'a> FilterWindow<'a> {
                     }
                     out.push_sql("]");
                 }
-                out.push_sql("])) as p(id, child_ids)");
+                out.push_sql("]::text[][])) as p(id, child_ids)");
             }
             TableLink::Parent(ParentIds::Scalar(child_ids)) => {
                 // Type D
@@ -1631,7 +1631,7 @@ impl<'a> FilterQuery<'a> {
         out.push_sql("select c.* from ");
         out.push_sql("unnest(");
         out.push_bind_param::<Array<Text>, _>(parent_ids)?;
-        out.push_sql(") as q(id)\n");
+        out.push_sql("::text[]) as q(id)\n");
         out.push_sql(" cross join lateral (");
         for (i, window) in windows.iter().enumerate() {
             if i > 0 {


### PR DESCRIPTION
If we pass an empty array, Postgres can not determine the type of the array by itself, and fails because it can't select the right variant of unnest. Explicitly state that the argument to unnest is a 'text[]' and the
argument to reduce_dim is 'text[][]'

For review, the important thing is to make sure that all calls of the form `unnest(_)` have been changed to `unnest(_::text[])` and calls to `reduce_dim(_)` have been changed to `reduce_dim(_::text[][])` I _think_ I caught them all, and got the various brakcets and parens in the right places, but would appreciate a good check of those aspects.