### PR TITLE
Fix regression in LinkResolver retry feature

### DIFF
--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -43,6 +43,7 @@ pub trait LinkResolver: Send + Sync + 'static {
     /// separately.
     fn json_stream<'a>(
         &'a self,
+        logger: &'a Logger,
         link: &'a Link,
     ) -> Pin<Box<dyn Future<Output = Result<JsonValueStream, failure::Error>> + Send + 'a>>;
 }

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -421,8 +421,10 @@ impl HostExports {
         let logger = ctx.logger.new(o!("ipfs_map" => link.clone()));
 
         let result = block_on03(async move {
-            let mut stream: JsonValueStream =
-                self.link_resolver.json_stream(&Link { link: link }).await?;
+            let mut stream: JsonValueStream = self
+                .link_resolver
+                .json_stream(&logger, &Link { link: link })
+                .await?;
             let mut v = Vec::new();
             while let Some(sv) = stream.next().await {
                 let sv = sv?;

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -390,10 +390,8 @@ async fn ipfs_map() {
     assert!(errmsg.contains("JSON value is not a string."));
 
     // Bad IPFS hash.
-    let errmsg = run_ipfs_map(BAD_IPFS_HASH.to_string())
-        .unwrap_err()
-        .to_string();
-    assert!(errmsg.contains("api returned error"))
+    let errmsg = dbg!(run_ipfs_map(BAD_IPFS_HASH.to_string()).unwrap_err()).to_string();
+    assert!(dbg!(errmsg).contains("ApiError"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
The first commit messages sum it up well:

> Adding support for multiple IPFS clients added a non-retrying `object.stat` into the mix, which unfortunately breaks the retry feature of `LinkResolver`. We added this retry feature to work around intermittent IPFS issues when starting subgraphs (e.g. retry when hitting an IPFS rate limit or temporary DNS error), reducing the chances of subgraphs failing to start at all.

This PR wraps the entire `LinkResolver::cat` body in a retry future. Initially I thought it would be best to simply add a retry future around identifying a suitable IPFS client, so we'd have two separate retries (for finding a client and for retrieving the file). However, that can lead to problems.

The second commit therefore wraps the entire body in a single retry future. From the commit message:

> This makes the retry logic easier to follow and means we are retrying whenever one of the two steps (identify the best IPFS client, retrieve the file) fails. Otherwise we might run into situations where we find an IPFS client but by the time we try to retrieve the file, that client is no longer suitable, e.g. because it no longer has the file.

Tested as follows:

1. Run IPFS, graph-node etc. locally.
2. Deploy an example subgraph locally. It starts indexing fine.
3. Stop graph-node.
4. Run `rm -rf ~/.ipfs && ipfs init && ipfs daemon --offline` to reset IPFS. Now the subgraph files are gone.
5. Start graph-node again.

Before the fix: graph-node would fail starting the subgraph immediately with a `ResolveError` (`merkledag: not found`).

After the fix: graph-node retries resolving subgraph files indefinitely, as expected:
```
Mar 04 15:11:05.471 DEBG Trying again after object.stat + ipfs.cat failed (attempt #50) with result Err(Api(ApiError { message: "merkledag: not found", code: 0 })), subgraph_id: QmcGseoFNsK98KFxeucCHJaRD4zEbqUPM2uieT9jthRr8P, component: SubgraphAssignmentProvider
```