### PR TITLE
Print deprecation warning for JSONB subgraphs

### DIFF
--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1085,6 +1085,13 @@ impl StoreTrait for Store {
     ) -> Result<(), StoreError> {
         let econn = self.get_entity_conn(subgraph_id)?;
 
+        if !econn.uses_relational_schema() {
+            warn!(&self.logger, "This subgraph uses JSONB storage, which is \
+              deprecated and support for it will be removed in a future release. \
+              Please redeploy the subgraph to address this warning";
+              "subgraph" => subgraph_id.to_string());
+        }
+
         econn.transaction(|| {
             let event = self.apply_metadata_operations_with_conn(&econn, ops)?;
             econn.start_subgraph()?;


### PR DESCRIPTION
This change (besides a minor cleanup for relational schema code) makes it so that we print a deprecation warning for every JSONB subgraph that gets started.

The next release should include a note like

> JSONB storage is deprecated and will be removed in the next release. This only affects subgraphs that were deployed with a graph-node version before 0.16. Starting with this version, graph-node will print a warning for any subgraph that uses JSONB storage when that subgraph starts syncing. Please check your logs for this warning. You can remove the warning by redeploying the subgraph.

