### PR TITLE
Lower target triggers per range

### DIFF
--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -21,7 +21,7 @@ lazy_static! {
 
     /// Ideal number of triggers in a range. The range size will adapt to try to meet this.
     static ref TARGET_TRIGGERS_PER_BLOCK_RANGE: u64 = std::env::var("GRAPH_ETHEREUM_TARGET_TRIGGERS_PER_BLOCK_RANGE")
-        .unwrap_or("1000".into())
+        .unwrap_or("100".into())
         .parse::<u64>()
         .expect("invalid GRAPH_ETHEREUM_TARGET_TRIGGERS_PER_BLOCK_RANGE");
 }


### PR DESCRIPTION
The Ethereum node provider for the hosted service reported that there were many `eth_getLogs` requests being made with unreasonably large responses due to the amount of contracts being queried and the size of the range, and the recommended way to make the calls cheaper is to shorten the request range. Changing this configuration is the simplest way we have to reduce the range for requests with large payloads, and 1000 does seem too aggressive.