### PR TITLE
store: Make sure metadata gets reverted only for one subgraph

### DIFF
--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1996,3 +1996,92 @@ impl<'a> LoadQuery<PgConnection, RevertEntityData> for RevertClampQuery<'a> {
 }
 
 impl<'a, Conn> RunQueryDsl<Conn> for RevertClampQuery<'a> {}
+
+/// A query that removes all dynamic data sources for a given subgraph
+/// whose block range lies entirely beyond `block`. The query only deletes
+/// the data sources but not any related objects
+#[derive(Debug, Clone, Constructor)]
+pub struct DeleteDynamicDataSourcesQuery<'a> {
+    subgraph: &'a str,
+    block: BlockNumber,
+}
+
+impl<'a> QueryFragment<Pg> for DeleteDynamicDataSourcesQuery<'a> {
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+
+        // Construct a query
+        //   delete from subgraphs.dynamic_ethereum_contract_data_source
+        //    where lower(block_range) >= $block
+        //      and deployment = $subgraph
+        //   returning id
+        out.push_sql("delete from subgraphs.dynamic_ethereum_contract_data_source\n");
+        out.push_sql(" where lower(");
+        out.push_identifier(BLOCK_RANGE_COLUMN)?;
+        out.push_sql(") >= ");
+        out.push_bind_param::<Integer, _>(&self.block)?;
+        out.push_sql(" and deployment = ");
+        out.push_bind_param::<Text, _>(&self.subgraph)?;
+        out.push_sql("\nreturning ");
+        out.push_identifier(PRIMARY_KEY_COLUMN)
+    }
+}
+
+impl<'a> QueryId for DeleteDynamicDataSourcesQuery<'a> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a> LoadQuery<PgConnection, RevertEntityData> for DeleteDynamicDataSourcesQuery<'a> {
+    fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
+        conn.query_by_name(&self)
+    }
+}
+
+impl<'a, Conn> RunQueryDsl<Conn> for DeleteDynamicDataSourcesQuery<'a> {}
+
+/// Remove all entities from the given table whose id has a prefix that
+/// matches one of the given prefixes. This query is mostly useful to
+/// delete subgraph metadata that belongs to a certain dynamic data source
+#[derive(Debug, Clone, Constructor)]
+pub struct DeleteByPrefixQuery<'a> {
+    table: &'a Table,
+    prefixes: &'a Vec<String>,
+    prefix_len: i32,
+}
+
+impl<'a> QueryFragment<Pg> for DeleteByPrefixQuery<'a> {
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+
+        // Construct a query
+        //   delete from {table}
+        //    where left(id, {prefix_len}) = any({prefixes})
+        //   returning id
+        out.push_sql("delete from ");
+        out.push_sql(self.table.qualified_name.as_str());
+        out.push_sql("\n where left(");
+        out.push_sql(PRIMARY_KEY_COLUMN);
+        out.push_sql(",");
+        out.push_bind_param::<Integer, _>(&self.prefix_len)?;
+        out.push_sql(") = any(");
+        out.push_bind_param::<Array<Text>, _>(&self.prefixes)?;
+        out.push_sql(")\nreturning ");
+        out.push_identifier(PRIMARY_KEY_COLUMN)
+    }
+}
+
+impl<'a> QueryId for DeleteByPrefixQuery<'a> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a> LoadQuery<PgConnection, RevertEntityData> for DeleteByPrefixQuery<'a> {
+    fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
+        conn.query_by_name(&self)
+    }
+}
+
+impl<'a, Conn> RunQueryDsl<Conn> for DeleteByPrefixQuery<'a> {}


### PR DESCRIPTION
The way we used to revert metadata when a block was reverted was not
correct: the reversion would also revert metadata for unrelated subgraphs,
leading to potential loss of dynamic data sources.

This code now makes sure we only revert metadata for the subgraph for which
we are reverting a block.

