### PR TITLE
Simplify logs fetching

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -12,12 +12,12 @@ those.
 
 - `ETHEREUM_POLLING_INTERVAL`: how often to poll Ethereum for new blocks (in ms,
   defaults to 500ms)
-- `ETHEREUM_RPC_MAX_PARALLEL_REQUESTS`: how many RPC connections to start in
-  parallel for block retrieval (defaults to 64)
+- `ETHEREUM_RPC_MAX_PARALLEL_REQUESTS`: Maximum number of concurrent HTTP
+  requests to an Ethereum RPC endpoint (defaults to 64).
 - `GRAPH_ETHEREUM_TARGET_TRIGGERS_PER_BLOCK_RANGE`: The ideal amount of triggers
-to be processed in a batch. If this is too small it may cause too many requests
-to the ethereum node, if it is too large it may cause unreasonably expensive
-calls to the ethereum node and excessive memory usage (defaults to 100).
+  to be processed in a batch. If this is too small it may cause too many requests
+  to the ethereum node, if it is too large it may cause unreasonably expensive
+  calls to the ethereum node and excessive memory usage (defaults to 100).
 - `ETHEREUM_TRACE_STREAM_STEP_SIZE`: `graph-node` queries traces for a given
   block range when a subgraph defines call handlers or block handlers with a
   call filter. The value of this variable controls the number of blocks to scan
@@ -27,9 +27,7 @@ calls to the ethereum node and excessive memory usage (defaults to 100).
 - `ETHEREUM_BLOCK_BATCH_SIZE`: number of Ethereum blocks to request in parallel
   (defaults to 50)
 - `GRAPH_ETHEREUM_MAX_BLOCK_RANGE_SIZE`: Maximum number of blocks to scan for
-triggers in each request (defaults to 100000).
-- `ETHEREUM_PARALLEL_BLOCK_RANGES`: Maximum number of parallel `eth_getLogs`
-  calls to make when scanning logs for a subgraph. Defaults to 100.
+  triggers in each request (defaults to 100000).
 - `GRAPH_ETHEREUM_MAX_EVENT_ONLY_RANGE`: Maximum range size for `eth.getLogs`
   requests that dont filter on contract address, only event signature.
 - `GRAPH_ETHEREUM_JSON_RPC_TIMEOUT`: Timeout for Ethereum JSON-RPC requests.

--- a/graph/src/cheap_clone.rs
+++ b/graph/src/cheap_clone.rs
@@ -1,0 +1,14 @@
+use slog::Logger;
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// Things that, in the context of an application such as Graph Node, are fast to clone.
+pub trait CheapClone: Clone {
+    fn cheap_clone(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl<T: ?Sized> CheapClone for Rc<T> {}
+impl<T: ?Sized> CheapClone for Arc<T> {}
+impl CheapClone for Logger {}

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -739,7 +739,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         from: u64,
         to: u64,
         log_filter: EthereumLogFilter,
-    ) -> Box<dyn std::future::Future<Output = Result<Vec<Log>, Error>> + Send + Unpin>;
+    ) -> DynTryFuture<'static, Vec<Log>, Error>;
 
     fn calls_in_block_range(
         &self,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -13,6 +13,9 @@ pub mod ext;
 /// Logging utilities
 pub mod log;
 
+/// `CheapClone` trait.
+pub mod cheap_clone;
+
 /// Module with mocks for different parts of the system.
 pub mod mock {
     pub use crate::components::ethereum::MockEthereumAdapter;
@@ -99,6 +102,7 @@ pub mod prelude {
     };
     pub use crate::components::{EventConsumer, EventProducer};
 
+    pub use crate::cheap_clone::CheapClone;
     pub use crate::data::graphql::{SerializableValue, TryFromValue, ValueMap};
     pub use crate::data::query::{
         Query, QueryError, QueryExecutionError, QueryResult, QueryVariables,


### PR DESCRIPTION
This PR simplifies how fetch logs so it's more robust and so can better reason about how many requests are made when.

First, the `log_stream` function no longer makes requests in parallel if the first request fails. This used to be important for performance before we started splitting the `eth_getLogs` requests, but those are split up now in `logs_in_block_range` so we already have a good level of parallelism. This is also hard on the Ethereum service, since we only make requests in parallel if we detect the node considered the original request too heavy so the range is split up, but if the original request was overloading the service it's possible that requesting the logs in parallel will also overload it, doing sequential requests gives the service a better chance to cope. This should help with the recent issues we've had with our Rinkeby service being rate limited due to these parallel requests.

The other usage of the `ETHEREUM_PARALLEL_BLOCK_RANGES` env var was to limit the parallel eth_getLogs requests in `logs_in_block_range`. Only complex subgraphs would have enough requests to hit a limit here, and limiting parallelism at this level will hurt performance for those complex subgraphs. We already have `ETHEREUM_RPC_MAX_PARALLEL_REQUESTS` to limit the total amount of parallel requests a node can make to an Ethereum endpoint, so in the spirit of having less but more meaningful configuration I removed that env var completely.

The code around this was refactored a bit to use futures 0.3 and async/await.

I tested on the Moloch subgraph that syncing was done correctly.