### PR TITLE
server: Fixed deploy suppressing error

### DIFF
--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -390,8 +390,10 @@ async fn ipfs_map() {
     assert!(errmsg.contains("JSON value is not a string."));
 
     // Bad IPFS hash.
-    let errmsg = dbg!(run_ipfs_map(BAD_IPFS_HASH.to_string()).unwrap_err()).to_string();
-    assert!(dbg!(errmsg).contains("ApiError"));
+    let errmsg = run_ipfs_map(BAD_IPFS_HASH.to_string())
+        .unwrap_err()
+        .to_string();
+    assert!(errmsg.contains("ApiError"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR fixes a regression that caused error messages to be suppressed when deploying a subgraph