### PR TITLE
Moar Async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
 name = "graph-core"
 version = "0.17.1"
 dependencies = [
+ "async-trait",
  "bytes 0.5.4",
  "futures 0.1.29",
  "futures 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,7 @@ dependencies = [
 name = "graph-runtime-wasm"
 version = "0.17.1"
 dependencies = [
+ "async-trait",
  "bs58",
  "ethabi 10.0.0",
  "futures 0.1.29",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.17.1"
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1.25"
 bytes = "0.5"
 futures01 = { package="futures", version="0.1.29" }
 futures = { version="0.3.4", features=["compat"] }

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -112,8 +112,7 @@ where
             .await?;
 
             let data_sources = loader
-                .load_dynamic_data_sources(id, logger.clone())
-                .compat()
+                .load_dynamic_data_sources(id.clone(), logger.clone())
                 .map_err(SubgraphAssignmentProviderError::DynamicDataSourcesError)
                 .await?;
 

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -376,18 +376,11 @@ async fn handle_assignment_event(
         AssignmentEvent::Remove {
             subgraph_id,
             node_id: _,
-        } => {
-            provider
-                .stop(subgraph_id)
-                .then(|result| match result {
-                    Ok(()) => Ok(()),
-                    Err(SubgraphAssignmentProviderError::NotRunning(_)) => Ok(()),
-                    Err(e) => Err(e),
-                })
-                .map_err(CancelableError::Error)
-                .compat()
-                .await
-        }
+        } => match provider.stop(subgraph_id).await {
+            Ok(()) => Ok(()),
+            Err(SubgraphAssignmentProviderError::NotRunning(_)) => Ok(()),
+            Err(e) => Err(CancelableError::Error(e)),
+        },
     }
 }
 

--- a/graph/src/components/subgraph/loader.rs
+++ b/graph/src/components/subgraph/loader.rs
@@ -1,9 +1,12 @@
+use async_trait::async_trait;
+
 use crate::prelude::*;
 
+#[async_trait]
 pub trait DataSourceLoader {
-    fn load_dynamic_data_sources(
-        self: Arc<Self>,
-        id: &SubgraphDeploymentId,
+    async fn load_dynamic_data_sources(
+        &self,
+        id: SubgraphDeploymentId,
         logger: Logger,
-    ) -> Box<dyn Future<Item = Vec<DataSource>, Error = Error> + Send>;
+    ) -> Result<Vec<DataSource>, Error>;
 }

--- a/graph/src/components/subgraph/provider.rs
+++ b/graph/src/components/subgraph/provider.rs
@@ -1,20 +1,13 @@
+use async_trait::async_trait;
+
 use crate::prelude::*;
 
 /// Common trait for subgraph providers.
+#[async_trait]
 pub trait SubgraphAssignmentProvider:
     EventProducer<SubgraphAssignmentProviderEvent> + Send + Sync + 'static
 {
-    fn start<'a>(
-        &'a self,
-        id: &'a SubgraphDeploymentId,
-    ) -> Pin<
-        Box<
-            dyn futures03::Future<Output = Result<(), SubgraphAssignmentProviderError>> + Send + 'a,
-        >,
-    >;
-
-    fn stop(
-        &self,
-        id: SubgraphDeploymentId,
-    ) -> Box<dyn Future<Item = (), Error = SubgraphAssignmentProviderError> + Send + 'static>;
+    async fn start(&self, id: &SubgraphDeploymentId)
+        -> Result<(), SubgraphAssignmentProviderError>;
+    async fn stop(&self, id: SubgraphDeploymentId) -> Result<(), SubgraphAssignmentProviderError>;
 }

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+
 use crate::prelude::*;
 
 #[derive(Clone, Copy, Debug)]
@@ -16,28 +18,26 @@ impl SubgraphVersionSwitchingMode {
     }
 }
 
-/// Common trait for named subgraph providers.
+/// Common trait for subgraph registrars.
+#[async_trait]
 pub trait SubgraphRegistrar: Send + Sync + 'static {
-    fn create_subgraph(
+    async fn create_subgraph(
         &self,
         name: SubgraphName,
-    ) -> Box<dyn Future<Item = CreateSubgraphResult, Error = SubgraphRegistrarError> + Send + 'static>;
+    ) -> Result<CreateSubgraphResult, SubgraphRegistrarError>;
 
-    fn create_subgraph_version<'a>(
-        &'a self,
+    async fn create_subgraph_version(
+        &self,
         name: SubgraphName,
         hash: SubgraphDeploymentId,
         assignment_node_id: NodeId,
-    ) -> DynTryFuture<'a, (), SubgraphRegistrarError>;
+    ) -> Result<(), SubgraphRegistrarError>;
 
-    fn remove_subgraph(
-        &self,
-        name: SubgraphName,
-    ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
+    async fn remove_subgraph(&self, name: SubgraphName) -> Result<(), SubgraphRegistrarError>;
 
-    fn reassign_subgraph(
+    async fn reassign_subgraph(
         &self,
         hash: SubgraphDeploymentId,
         node_id: NodeId,
-    ) -> Box<dyn Future<Item = (), Error = SubgraphRegistrarError> + Send + 'static>;
+    ) -> Result<(), SubgraphRegistrarError>;
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -693,10 +693,7 @@ async fn main() {
 
                 graph::spawn(
                     async move {
-                        subgraph_registrar
-                            .create_subgraph(name.clone())
-                            .compat()
-                            .await?;
+                        subgraph_registrar.create_subgraph(name.clone()).await?;
                         subgraph_registrar
                             .create_subgraph_version(name, subgraph_id, node_id)
                             .await

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.17.1"
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1.25"
 ethabi = { git = "https://github.com/graphprotocol/ethabi.git", branch = "master" }
 futures = "0.1.21"
 hex = "0.4.2"


### PR DESCRIPTION
While I was going through our code in preparation of multi-blockchain planning, I thought I'd take the opportunity to convert more code to async. This converts the following traits (and implementations) to use async/await more (primarily in the trait methods):

- `DataSourceLoader`
- `LinkResolver`
- `RuntimeHost`
- `SubgraphAssignmentProvider`
- `SubgraphRegistrar`
- `SubgraphInstance`