### PR TITLE
node: Fix --version not reporting the current version (#967)

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -60,7 +60,7 @@ async fn main() {
 
     // Setup CLI using Clap, provide general info and capture postgres url
     let matches = App::new("graph-node")
-        .version("0.1.0")
+        .version(render_testament!(TESTAMENT).as_str())
         .author("Graph Protocol, Inc.")
         .about("Scalable queries for a decentralized future")
         .arg(


### PR DESCRIPTION
A small fix for #967 that uses the testament not just for logging it but also for `--version`.

Before:
```sh
$ graph-node --version
graph-node 0.1.0
```

After:
```sh
$ graph-node --version
graph-node v0.17.1+261 (2bc03399f 2020-03-30) dirty 2 modifications
```