### PR TITLE
Fix loading dynamic data sources with topic0 event handlers

### DIFF
--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -50,7 +50,7 @@ where
                       network
                       name
                       context
-                      source { address abi }
+                      source { address abi startBlock }
                       mapping {
                         kind
                         apiVersion
@@ -60,7 +60,7 @@ where
                         abis { name file }
                         blockHandlers { handler filter }
                         callHandlers {  function handler }
-                        eventHandlers { event handler }
+                        eventHandlers { event handler topic0 }
                       }
                       templates {
                         kind
@@ -74,9 +74,9 @@ where
                           file
                           entities
                           abis { name file }
-                          blockHandlers { handler filter}
-                          callHandlers { function handler}
-                          eventHandlers { event handler }
+                          blockHandlers { handler filter }
+                          callHandlers { function handler }
+                          eventHandlers { event handler topic0 }
                         }
                       }
                     }


### PR DESCRIPTION
After restarting, graph-node was loading dynamic data sources incorrectly that had event handlers with `topic0` filters. It was loading them without the `topic0` value, meaning that events matching these `topic0` values would no longer be processed.

This commit fixes the issue by including the missing `topic0` field in the query that loads dynamic data sources and their templates.

