### PR TITLE
Don't query for the start block of dynamic data sources

### DIFF
--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -53,7 +53,7 @@ where
                       network
                       name
                       context
-                      source { address abi startBlock }
+                      source { address abi }
                       mapping {
                         kind
                         apiVersion


### PR DESCRIPTION
Fixes a bug introduced in #1580.