### PR TITLE
Add integration test for handling Ganache reverts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,15 @@
 ## Unreleased
 
 ### Misc
+
+- Fix loading more than 200 dynamic data sources (#1596).
+- Log warnings after 10 successive failed `eth_call` requests. This makes
+  it more visible when graph-node is not operating against an Ethereum
+  archive node (#1606).
 - Log all GraphQL and SQL queries performed by a node, controlled through
   the `GRAPH_LOG_QUERY_TIMING` [environment
-  variable](docs/environment-variables.md).
+  variable](docs/environment-variables.md) (#1595).
+- Add integration test for handling Ganache reverts (#1590).
 
 ## 0.18.0
 

--- a/tests/integration-tests/ganache-reverts/abis/Contract.abi
+++ b/tests/integration-tests/ganache-reverts/abis/Contract.abi
@@ -1,0 +1,1 @@
+[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[],"name":"Trigger","type":"event"},{"inputs":[{"internalType":"uint256","name":"value","type":"uint256"}],"name":"inc","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"pure","type":"function"}]

--- a/tests/integration-tests/ganache-reverts/contracts/Contract.sol
+++ b/tests/integration-tests/ganache-reverts/contracts/Contract.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.6.1;
+
+
+contract Contract {
+    event Trigger();
+
+    constructor() public {
+        emit Trigger();
+    }
+
+    function inc(uint256 value) public pure returns (uint256) {
+        require(value < 10, "can only handle values < 10");
+        return value + 1;
+    }
+}

--- a/tests/integration-tests/ganache-reverts/contracts/Migrations.sol
+++ b/tests/integration-tests/ganache-reverts/contracts/Migrations.sol
@@ -1,0 +1,24 @@
+pragma solidity ^0.6.1;
+
+
+contract Migrations {
+    address public owner;
+    uint256 public last_completed_migration;
+
+    constructor() public {
+        owner = msg.sender;
+    }
+
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
+
+    function setCompleted(uint256 completed) public restricted {
+        last_completed_migration = completed;
+    }
+
+    function upgrade(address new_address) public restricted {
+        Migrations upgraded = Migrations(new_address);
+        upgraded.setCompleted(last_completed_migration);
+    }
+}

--- a/tests/integration-tests/ganache-reverts/migrations/1_initial_migration.js
+++ b/tests/integration-tests/ganache-reverts/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+var Migrations = artifacts.require('./Migrations.sol')
+
+module.exports = function(deployer) {
+  deployer.deploy(Migrations)
+}

--- a/tests/integration-tests/ganache-reverts/migrations/2_deploy_contracts.js
+++ b/tests/integration-tests/ganache-reverts/migrations/2_deploy_contracts.js
@@ -1,0 +1,5 @@
+const Contract = artifacts.require('./Contract.sol')
+
+module.exports = async function(deployer) {
+  await deployer.deploy(Contract)
+}

--- a/tests/integration-tests/ganache-reverts/package.json
+++ b/tests/integration-tests/ganache-reverts/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ganache-reverts",
+  "version": "0.1.0",
+  "scripts": {
+    "build-contracts": "rm -rf abis bin && solcjs contracts/Contract.sol --abi -o abis && mv abis/*Contract.abi abis/Contract.abi && solcjs contracts/Contract.sol --bin -o bin && mv bin/*Contract.bin bin/Contract.bin",
+    "codegen": "graph codegen",
+    "test": "yarn build-contracts && truffle test --network test",
+    "create:test": "graph create test/ganache-reverts --node http://localhost:18020/",
+    "deploy:test": "graph deploy test/ganache-reverts --ipfs http://localhost:15001/ --node http://localhost:18020/"
+  },
+  "devDependencies": {
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "solc": "^0.6.1"
+  },
+  "dependencies": {
+    "apollo-fetch": "^0.7.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-register": "^6.26.0",
+    "gluegun": "^3.2.1",
+    "truffle": "^5.0.4",
+    "truffle-contract": "^4.0.5",
+    "truffle-hdwallet-provider": "^1.0.4"
+  }
+}

--- a/tests/integration-tests/ganache-reverts/schema.graphql
+++ b/tests/integration-tests/ganache-reverts/schema.graphql
@@ -1,0 +1,5 @@
+type Call @entity {
+  id: ID!
+  reverted: Boolean!
+  returnValue: BigInt
+}

--- a/tests/integration-tests/ganache-reverts/src/mapping.ts
+++ b/tests/integration-tests/ganache-reverts/src/mapping.ts
@@ -1,0 +1,30 @@
+import { BigInt, Bytes } from '@graphprotocol/graph-ts'
+import { Trigger, Contract } from '../generated/Contract/Contract'
+import { Call } from '../generated/schema'
+
+export function handleTrigger(event: Trigger): void {
+  let contract = Contract.bind(event.address)
+
+  // The contract can only handle numbers < 10, so this call
+  // should revert
+  let call1 = new Call('100')
+  let result1 = contract.try_inc(BigInt.fromI32(100))
+  if (result1.reverted) {
+    call1.reverted = true
+  } else {
+    call1.reverted = false
+    call1.returnValue = result1.value
+  }
+  call1.save()
+
+  // This call should no revert, as the value is < 10
+  let call2 = new Call('9')
+  let result2 = contract.try_inc(BigInt.fromI32(9))
+  if (result2.reverted) {
+    call2.reverted = true
+  } else {
+    call2.reverted = false
+    call2.returnValue = result2.value
+  }
+  call2.save()
+}

--- a/tests/integration-tests/ganache-reverts/subgraph.yaml
+++ b/tests/integration-tests/ganache-reverts/subgraph.yaml
@@ -1,0 +1,23 @@
+specVersion: 0.0.2
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: Contract
+    network: test
+    source:
+      address: "0xCfEB869F69431e42cdB54A4F4f105C19C080A601"
+      abi: Contract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      abis:
+        - name: Contract
+          file: ./abis/Contract.abi
+      entities:
+        - Call
+      eventHandlers:
+        - event: Trigger()
+          handler: handleTrigger
+      file: ./src/mapping.ts

--- a/tests/integration-tests/ganache-reverts/test/test.js
+++ b/tests/integration-tests/ganache-reverts/test/test.js
@@ -1,0 +1,101 @@
+const path = require('path')
+const execSync = require('child_process').execSync
+const { system, patching } = require('gluegun')
+const { createApolloFetch } = require('apollo-fetch')
+
+const Contract = artifacts.require('./Contract.sol')
+
+const srcDir = path.join(__dirname, '..')
+
+const fetchSubgraphs = createApolloFetch({
+  uri: 'http://localhost:18030/graphql'
+})
+const fetchSubgraph = createApolloFetch({
+  uri: 'http://localhost:18000/subgraphs/name/test/ganache-reverts'
+})
+
+const exec = cmd => {
+  try {
+    return execSync(cmd, { cwd: srcDir, stdio: 'inherit' })
+  } catch (e) {
+    throw new Error(`Failed to run command \`${cmd}\``)
+  }
+}
+
+const waitForSubgraphToBeSynced = async () =>
+  new Promise((resolve, reject) => {
+    // Wait for 5s
+    let deadline = Date.now() + 5 * 1000
+
+    // Function to check if the subgraph is synced
+    const checkSubgraphSynced = async () => {
+      try {
+        let result = await fetchSubgraphs({
+          query: `{ indexingStatuses { synced } }`
+        })
+
+        if (
+          JSON.stringify(result) ===
+          JSON.stringify({ data: { indexingStatuses: [{ synced: true }] } })
+        ) {
+          resolve()
+        } else {
+          throw new Error('reject or retry')
+        }
+      } catch (e) {
+        if (Date.now() > deadline) {
+          reject(new Error(`Timed out waiting for the subgraph to sync`))
+        } else {
+          setTimeout(checkSubgraphSynced, 500)
+        }
+      }
+    }
+
+    // Periodically check whether the subgraph has synced
+    setTimeout(checkSubgraphSynced, 0)
+  })
+
+contract('Contract', accounts => {
+  // Deploy the subgraph once before all tests
+  before(async () => {
+    // Deploy the contract
+    const contract = await Contract.deployed()
+
+    // Insert its address into subgraph manifest
+    await patching.replace(
+      path.join(srcDir, 'subgraph.yaml'),
+      '0x0000000000000000000000000000000000000000',
+      contract.address
+    )
+
+    // Create and deploy the subgraph
+    exec(`yarn codegen`)
+    exec(`yarn create:test`)
+    exec(`yarn deploy:test`)
+
+    // Wait for the subgraph to be indexed
+    await waitForSubgraphToBeSynced()
+  })
+
+  it('all overloads of the contract function are called', async () => {
+    let result = await fetchSubgraph({
+      query: `{ calls(orderBy: id) { id reverted returnValue } }`
+    })
+
+    expect(result.errors).to.be.undefined
+    expect(result.data).to.deep.equal({
+      calls: [
+        {
+          id: '100',
+          reverted: true,
+          returnValue: null
+        },
+        {
+          id: '9',
+          reverted: false,
+          returnValue: '10'
+        }
+      ]
+    })
+  })
+})

--- a/tests/integration-tests/ganache-reverts/truffle.js
+++ b/tests/integration-tests/ganache-reverts/truffle.js
@@ -1,0 +1,19 @@
+require("babel-register");
+require("babel-polyfill");
+
+module.exports = {
+  networks: {
+    test: {
+      host: "localhost",
+      port: 18545,
+      network_id: "*",
+      gas: "100000000000",
+      gasPrice: "1"
+    }
+  },
+  compilers: {
+    solc: {
+      version: "0.6.1"
+    }
+  }
+};

--- a/tests/tests/tests.rs
+++ b/tests/tests/tests.rs
@@ -80,3 +80,9 @@ fn arweave_and_3box() {
     let _m = TEST_MUTEX.lock();
     run_test("arweave-and-3box")
 }
+
+#[test]
+fn ganache_reverts() {
+    let _m = TEST_MUTEX.lock();
+    run_test("ganache-reverts")
+}


### PR DESCRIPTION
This tests that `try_` calls made against Ganache correctly catch reverts. The test makes two calls (one reverting, the other succeeding) and writes the reverted flag and return values into a `Call` entity. This entity is then queried after the subgraph has synced.

Run the test with:
```sh
cargo test ganache_reverts
```
from the root directory of this repo.
