### PR TITLE
Default to IPFS 0.4.23 in Docker Compose setup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       ethereum: 'mainnet:http://host.docker.internal:8545'
       RUST_LOG: info
   ipfs:
-    image: ipfs/go-ipfs
+    image: ipfs/go-ipfs:v0.4.23
     ports:
       - '5001:5001'
     volumes:


### PR DESCRIPTION
The IPFS docker tag `latest` has changed incompatibly, breaking everyone's setup. This hard-codes an IPFS version that works.