### PR TITLE
graph/schema: Fix validation step that checks includes fields are valid

### DIFF
--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -978,7 +978,7 @@ impl Schema {
                                 match BuiltInScalarType::try_from(
                                     field.field_type.get_base_type().as_ref(),
                                 ) {
-                                    Ok(BuiltInScalarType::String) if !field.name.eq(field_name) => {
+                                    Ok(BuiltInScalarType::String) if field.name.eq(field_name) => {
                                         true
                                     }
                                     _ => false,


### PR DESCRIPTION
Previously the step had a misplaced `!` that caused it to check for a string field that doesn't match the includes field name instead of validating that there is an entity field that _does_ match the includes field name. 