### PR TITLE
runtime: Remove logging of time for store.get

### DIFF
--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -187,12 +187,10 @@ impl HostExports {
 
     pub(crate) fn store_get(
         &self,
-        logger: &Logger,
         state: &mut BlockState,
         entity_type: String,
         entity_id: String,
     ) -> Result<Option<Entity>, HostExportError<impl ExportError>> {
-        let start_time = Instant::now();
         let store_key = EntityKey {
             subgraph_id: self.subgraph_id.clone(),
             entity_type: entity_type.clone(),
@@ -205,10 +203,6 @@ impl HostExports {
             .map_err(HostExportError)
             .map(|ok| ok.to_owned());
 
-        debug!(logger, "Store get finished";
-               "type" => &entity_type,
-               "id" => &entity_id,
-               "time" => format!("{}ms", start_time.elapsed().as_millis()));
         result
     }
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -452,12 +452,10 @@ impl WasmiModule {
     ) -> Result<Option<RuntimeValue>, Trap> {
         let entity_ptr = self.asc_get(entity_ptr);
         let id_ptr = self.asc_get(id_ptr);
-        let entity_option = self.ctx.host_exports.store_get(
-            &self.ctx.logger,
-            &mut self.ctx.state,
-            entity_ptr,
-            id_ptr,
-        )?;
+        let entity_option =
+            self.ctx
+                .host_exports
+                .store_get(&mut self.ctx.state, entity_ptr, id_ptr)?;
 
         Ok(Some(match entity_option {
             Some(entity) => {


### PR DESCRIPTION
We are producing 5k - 20k of these messages _per minute_ in hosted, and I don't think they are particularly useful to anybody