### PR TITLE
Proof of Indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,9 +990,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fragile"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f8140122fa0d5dcb9fc8627cfce2b37cc1500f752636d46ea28bc26785c2f9"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -1225,6 +1225,8 @@ dependencies = [
  "slog-envlogger",
  "slog-term",
  "stable-hash",
+ "strum",
+ "strum_macros",
  "test-store",
  "tiny-keccak",
  "tokio 0.2.18",
@@ -1400,7 +1402,7 @@ name = "graph-server-index-node"
 version = "0.18.0"
 dependencies = [
  "failure",
- "futures 0.1.29",
+ "futures 0.3.4",
  "graph",
  "graph-graphql",
  "graphql-parser",
@@ -1455,6 +1457,7 @@ name = "graph-store-postgres"
 version = "0.18.0"
 dependencies = [
  "Inflector",
+ "async-trait",
  "clap",
  "derive_more",
  "diesel",
@@ -1473,10 +1476,13 @@ dependencies = [
  "hex-literal",
  "lazy_static",
  "lru_time_cache",
+ "maybe-owned",
  "parity-wasm",
  "postgres",
  "serde",
+ "stable-hash",
  "test-store",
+ "twox-hash",
  "uuid 0.8.1",
 ]
 
@@ -2050,6 +2056,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006ac35c23dc00cd88083b27297224aedc893d628aff7374352b4f3d57315fa9"
+
+[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95a7e7cfbce0e99ebbf5356a085d3b5e320a7ef300f77cd50a7148aa362e7c2"
+checksum = "48c9eefc7768ee7a28a09d64e40203d57ad20af8525b7428d5f2f55d8c621984"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -2196,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a615a1ad92048ad5d9633251edb7492b8abc057d7a679a9898476aef173935"
+checksum = "447326d4e6d99ea272b6e5599cbbfc1e3407c23a856ccf1eb9427ad73267376f"
 dependencies = [
  "cfg-if",
  "proc-macro2 1.0.9",
@@ -3507,7 +3519,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "stable-hash"
 version = "0.1.0"
-source = "git+https://github.com/graphprotocol/stable-hash#f3d4be4fe57bff479e249d4e126c3f6c699fc732"
+source = "git+https://github.com/graphprotocol/stable-hash#75d7ed4f5d2adce4d194b7aac6d78ec315298690"
 dependencies = [
  "num-traits",
 ]

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -16,7 +16,7 @@ state_machine_future = "0.2"
 
 [dev-dependencies]
 diesel = { version = "1.4.2", features = ["postgres", "serde_json", "numeric", "r2d2"] }
-mockall = "0.6.0"
+mockall = "0.7.0"
 graph-core = { path = "../../core" }
 graph-store-postgres = { path = "../../store/postgres" }
 pretty_assertions = "0.6.1"

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -536,6 +536,8 @@ where
                                         block_filter.clone(),
                                         BlockFinality::NonFinal(block),
                                     )
+                                    .boxed()
+                                    .compat()
                                 })
                                 .map(move |block| {
                                     ReconciliationStep::ProcessDescendantBlocks(vec![block], 1)
@@ -758,13 +760,11 @@ where
 
             // Update subgraph entities to promote pending versions to current
             for subgraph in subgraphs_to_update {
-                let mut data = Entity::new();
-                data.set("id", subgraph.id().unwrap());
-                data.set("pendingVersion", Value::Null);
-                data.set(
-                    "currentVersion",
-                    subgraph.get("pendingVersion").unwrap().to_owned(),
-                );
+                let data = entity! {
+                    id: subgraph.id().unwrap(),
+                    pendingVersion: Value::Null,
+                    currentVersion: subgraph.get("pendingVersion").unwrap().to_owned(),
+                };
                 ops.push(MetadataOperation::Set {
                     entity: SubgraphEntity::TYPENAME.to_owned(),
                     id: subgraph.id().unwrap(),

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -108,3 +108,5 @@ those.
   additional SQL queries that get logged when `sql` is given. These are
   queries caused by mappings when processing blocks for a subgraph, and
   queries caused by subscriptions. Defaults to no logging.
+- `STORE_CONNECTION_POOL_SIZE`: How many simultaneous connections to allow to the store.
+  Due to implementation details, this value may not be strictly adhered to. Defaults to 10. 

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -26,7 +26,7 @@ ipfs-api = { version = "0.7.1", features = ["hyper-tls"] }
 parity-wasm = "0.40"
 failure = "0.1.7"
 lazy_static = "1.2.0"
-mockall = "0.6"
+mockall = "0.7"
 num-bigint = { version = "^0.2.6", features = ["serde"] }
 num-traits = "0.2"
 rand = "0.6.1"
@@ -37,6 +37,8 @@ serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 serde_yaml = "0.8"
 slog = { version = "2.5.2", features = ["release_max_level_trace", "max_level_trace"] }
 stable-hash = { git = "https://github.com/graphprotocol/stable-hash" }
+strum = "0.18.0"
+strum_macros = "0.18.0"
 twox-hash = "1.5.0"
 slog-async = "2.5.0"
 slog-envlogger = "2.1.0"

--- a/graph/src/cheap_clone.rs
+++ b/graph/src/cheap_clone.rs
@@ -22,4 +22,10 @@ pub trait CheapClone: Clone {
 
 impl<T: ?Sized> CheapClone for Rc<T> {}
 impl<T: ?Sized> CheapClone for Arc<T> {}
+impl<T: ?Sized + CheapClone> CheapClone for Box<T> {}
+impl<T: ?Sized + CheapClone> CheapClone for std::pin::Pin<T> {}
 impl CheapClone for Logger {}
+
+// Pool is implemented as a newtype over Arc,
+// So it is CheapClone.
+impl<M: diesel::r2d2::ManageConnection> CheapClone for diesel::r2d2::Pool<M> {}

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use web3::types::Log;
 
+use super::ProofOfIndexing;
 use crate::prelude::*;
 use crate::util::lfu_cache::LfuCache;
 
@@ -16,6 +17,7 @@ pub struct DataSourceTemplateInfo {
 pub struct BlockState {
     pub entity_cache: EntityCache,
     pub created_data_sources: Vec<DataSourceTemplateInfo>,
+    pub proof_of_indexing: ProofOfIndexing,
 }
 
 impl BlockState {
@@ -23,6 +25,7 @@ impl BlockState {
         BlockState {
             entity_cache: EntityCache::with_current(lfu_cache),
             created_data_sources: Vec::new(),
+            proof_of_indexing: Default::default(),
         }
     }
 }

--- a/graph/src/components/subgraph/mod.rs
+++ b/graph/src/components/subgraph/mod.rs
@@ -2,6 +2,7 @@ mod host;
 mod instance;
 mod instance_manager;
 mod loader;
+mod proof_of_indexing;
 mod provider;
 mod registrar;
 
@@ -11,5 +12,8 @@ pub use self::host::{HostMetrics, RuntimeHost, RuntimeHostBuilder};
 pub use self::instance::{BlockState, DataSourceTemplateInfo, SubgraphInstance};
 pub use self::instance_manager::SubgraphInstanceManager;
 pub use self::loader::DataSourceLoader;
+pub use self::proof_of_indexing::{
+    ProofOfIndexing, ProofOfIndexingDigest, ProofOfIndexingEvent, ProofOfIndexingStream,
+};
 pub use self::provider::SubgraphAssignmentProvider;
 pub use self::registrar::{SubgraphRegistrar, SubgraphVersionSwitchingMode};

--- a/graph/src/components/subgraph/proof_of_indexing.rs
+++ b/graph/src/components/subgraph/proof_of_indexing.rs
@@ -1,0 +1,142 @@
+use crate::prelude::Value;
+use stable_hash::{prelude::*, utils::StableHasherWrapper, SequenceNumberInt};
+use std::collections::HashMap;
+use std::fmt;
+use strum::AsStaticRef as _;
+use strum_macros::AsStaticStr;
+use twox_hash::XxHash64;
+
+#[derive(Debug)]
+pub struct ProofOfIndexingDigest(pub String);
+
+impl StableHash for ProofOfIndexingDigest {
+    fn stable_hash(&self, sequence_number: impl SequenceNumber, state: &mut impl StableHasher) {
+        self.0.stable_hash(sequence_number, state)
+    }
+}
+
+#[derive(AsStaticStr)]
+pub enum ProofOfIndexingEvent<'a> {
+    RemoveEntity {
+        entity_type: &'a str,
+        id: &'a str,
+    },
+    SetEntity {
+        entity_type: &'a str,
+        id: &'a str,
+        data: &'a HashMap<String, Value>,
+    },
+}
+
+impl StableHash for ProofOfIndexingEvent<'_> {
+    fn stable_hash(&self, mut sequence_number: impl SequenceNumber, state: &mut impl StableHasher) {
+        use ProofOfIndexingEvent::*;
+        match self {
+            RemoveEntity { entity_type, id } => {
+                entity_type.stable_hash(sequence_number.next_child(), state);
+                id.stable_hash(sequence_number.next_child(), state);
+            }
+            SetEntity {
+                entity_type,
+                id,
+                data,
+            } => {
+                entity_type.stable_hash(sequence_number.next_child(), state);
+                id.stable_hash(sequence_number.next_child(), state);
+                data.stable_hash(sequence_number.next_child(), state);
+            }
+        }
+        // Include the discriminant
+        self.as_static().stable_hash(sequence_number, state);
+    }
+}
+
+/// The POI is the StableHash of:
+/// (Vec<ProofOfIndexingEvent>, PreviousDigest)
+/// This struct contains the necessary state to construct that value in a streaming manner
+pub struct ProofOfIndexingStream {
+    previous_digest_sequence_number: SequenceNumberInt<u64>,
+    vec_sequence_number: SequenceNumberInt<u64>,
+    vec_length: usize,
+    digest: StableHasherWrapper<XxHash64>,
+}
+
+impl ProofOfIndexingStream {
+    fn new() -> Self {
+        let mut tuple_sequence_number = SequenceNumberInt::<u64>::root();
+        let vec_sequence_number = tuple_sequence_number.next_child();
+        let previous_digest_sequence_number = tuple_sequence_number.next_child();
+        Self {
+            previous_digest_sequence_number,
+            vec_sequence_number,
+            vec_length: 0,
+            digest: Default::default(),
+        }
+    }
+
+    fn write(&mut self, event: &ProofOfIndexingEvent) {
+        event.stable_hash(self.vec_sequence_number.next_child(), &mut self.digest);
+        self.vec_length += 1;
+    }
+
+    pub fn finish(self, previous: &Option<ProofOfIndexingDigest>) -> ProofOfIndexingDigest {
+        let Self {
+            previous_digest_sequence_number,
+            vec_sequence_number,
+            vec_length,
+            mut digest,
+        } = self;
+
+        // Finish out the vec digest
+        vec_length.stable_hash(vec_sequence_number, &mut digest);
+
+        // Add the previous digest to the end of the tuple
+        previous.stable_hash(previous_digest_sequence_number, &mut digest);
+
+        let hash = format!("{:x}", digest.finish());
+        ProofOfIndexingDigest(hash)
+    }
+}
+
+#[derive(Default)]
+pub struct ProofOfIndexing {
+    /// The POI is updated for each data source independently. This is necessary because
+    /// some data sources (eg: IPFS files) may be unreliable and therefore cannot mix
+    /// state with other data sources. This may also give us some freedom to change
+    /// the order of triggers in the future.
+    per_causality_region: HashMap<String, ProofOfIndexingStream>,
+}
+
+impl fmt::Debug for ProofOfIndexing {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ProofOfIndexing").field(&"...").finish()
+    }
+}
+
+impl ProofOfIndexing {
+    /// Adds an event to the digest of the ProofOfIndexingStream local to the DataSource
+    pub fn write(&mut self, causality_region: &str, event: &ProofOfIndexingEvent<'_>) {
+        // This may be better with the raw_entry API, once that is stabilized
+        if let Some(data_source) = self.per_causality_region.get_mut(causality_region) {
+            data_source.write(event);
+        } else {
+            let mut entry = ProofOfIndexingStream::new();
+            entry.write(event);
+            self.per_causality_region
+                .insert(causality_region.to_owned(), entry);
+        }
+    }
+
+    /// Swaps the internals out for an empty one
+    /// Returns None if there are no changes.
+    pub fn take(&mut self) -> Option<HashMap<String, ProofOfIndexingStream>> {
+        if self.per_causality_region.is_empty() {
+            None
+        } else {
+            Some(std::mem::replace(
+                &mut self.per_causality_region,
+                HashMap::new(),
+            ))
+        }
+    }
+}

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -169,7 +169,7 @@ pub enum Value {
 impl StableHash for Value {
     fn stable_hash(&self, mut sequence_number: impl SequenceNumber, state: &mut impl StableHasher) {
         use Value::*;
-        let discriminant = match self {
+        match self {
             Null => "", // This is the default.
             String(inner) => {
                 inner.stable_hash(sequence_number.next_child(), state);
@@ -199,8 +199,8 @@ impl StableHash for Value {
                 inner.stable_hash(sequence_number.next_child(), state);
                 "BigInt"
             }
-        };
-        discriminant.stable_hash(sequence_number, state);
+        }
+        .stable_hash(sequence_number, state);
     }
 }
 
@@ -483,6 +483,22 @@ impl StableHash for Entity {
     fn stable_hash(&self, mut sequence_number: impl SequenceNumber, state: &mut impl StableHasher) {
         self.0.stable_hash(sequence_number.next_child(), state);
     }
+}
+
+#[macro_export]
+macro_rules! entity {
+    ($($name:ident: $value:expr,)*) => {
+        {
+            let mut result = $crate::data::store::Entity::new();
+            $(
+                result.set(stringify!($name), $crate::data::store::Value::from($value));
+            )*
+            result
+        }
+    };
+    ($($name:ident: $value:expr),*) => {
+        entity! {$($name: $value,)*}
+    };
 }
 
 impl Entity {

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -26,6 +26,7 @@ pub mod mock {
 mod task_spawn;
 pub use task_spawn::{
     block_on_allow_panic, spawn, spawn_allow_panic, spawn_blocking, spawn_blocking_allow_panic,
+    spawn_blocking_async_allow_panic,
 };
 
 pub use bytes;
@@ -39,6 +40,7 @@ pub use url;
 /// use graph::prelude::*;
 /// ```
 pub mod prelude {
+    pub use super::entity;
     pub use async_trait::async_trait;
     pub use bigdecimal;
     pub use ethabi;
@@ -133,8 +135,8 @@ pub mod prelude {
         QueryResultStream, Subscription, SubscriptionError, SubscriptionResult,
     };
     pub use crate::ext::futures::{
-        CancelGuard, CancelHandle, CancelableError, FutureExtension, SharedCancelGuard,
-        StreamExtension,
+        CancelGuard, CancelHandle, CancelToken, CancelableError, FutureExtension,
+        SharedCancelGuard, StreamExtension,
     };
     pub use crate::log::codes::LogCode;
     pub use crate::log::elastic::{elastic_logger, ElasticDrainConfig, ElasticLoggingConfig};

--- a/graph/src/task_spawn.rs
+++ b/graph/src/task_spawn.rs
@@ -39,6 +39,13 @@ pub fn spawn_blocking_allow_panic<T: Send + 'static>(
     tokio::task::spawn_blocking(move || block_on(f))
 }
 
+/// Does not abort on panic
+pub async fn spawn_blocking_async_allow_panic<R: 'static + Send>(
+    f: impl 'static + FnOnce() -> R + Send,
+) -> R {
+    tokio::task::spawn_blocking(f).await.unwrap()
+}
+
 /// Panics if there is no current tokio::Runtime
 pub fn block_on_allow_panic<T>(f: impl Future03<Output = T> + Send) -> T {
     let rt = tokio::runtime::Handle::current();

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -38,7 +38,7 @@ fn insert_modifications() {
     // Return no entities from the store, forcing the cache to treat any `set`
     // operation as an insert.
     store
-        .expect_get_many()
+        .expect_get_many_mock()
         .returning(|_, _| Ok(BTreeMap::new()));
 
     let mut cache = EntityCache::new();
@@ -75,9 +75,9 @@ fn insert_modifications() {
 fn overwrite_modifications() {
     let mut store = MockStore::new();
 
-    // Prepopulate the store with entities so that the cache treats
+    // Pre-populate the store with entities so that the cache treats
     // every set operation as an overwrite.
-    store.expect_get_many().returning(|_, _| {
+    store.expect_get_many_mock().returning(|_, _| {
         let mut map = BTreeMap::new();
 
         map.insert(
@@ -141,9 +141,9 @@ fn overwrite_modifications() {
 fn consecutive_modifications() {
     let mut store = MockStore::new();
 
-    // Prepopulate the store with data so that we can test setting a field to
+    // Pre-populate the store with data so that we can test setting a field to
     // `Value::Null`.
-    store.expect_get_many().returning(|_, _| {
+    store.expect_get_many_mock().returning(|_, _| {
         let mut map = BTreeMap::new();
 
         map.insert(

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -689,7 +689,6 @@ fn resolve_field_value_for_named_type(
     // Try to resolve the type name into the actual type
     let named_type = sast::get_named_type(&ctx.schema.document, type_name)
         .ok_or_else(|| QueryExecutionError::NamedTypeError(type_name.to_string()))?;
-
     match named_type {
         // Let the resolver decide how the field (with the given object type)
         // is resolved into an entity based on the (potential) parent object
@@ -716,10 +715,22 @@ fn resolve_field_value_for_named_type(
         // Let the resolver decide how values in the resolved object value
         // map to values of GraphQL scalars
         s::TypeDefinition::Scalar(t) => match object_value {
-            Some(q::Value::Object(o)) => {
-                ctx.resolver
-                    .resolve_scalar_value(object_type, o, field, t, o.get(&field.name))
-            }
+            Some(q::Value::Object(o)) => ctx.resolver.resolve_scalar_value(
+                object_type,
+                o,
+                field,
+                t,
+                o.get(&field.name),
+                argument_values,
+            ),
+            None => ctx.resolver.resolve_scalar_value(
+                object_type,
+                &BTreeMap::new(),
+                field,
+                t,
+                None,
+                argument_values,
+            ),
             _ => Ok(q::Value::Null),
         },
 

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -121,7 +121,10 @@ pub trait Resolver: Clone + Send + Sync {
         _field: &q::Field,
         _scalar_type: &s::ScalarType,
         value: Option<&q::Value>,
+        _argument_values: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
+        // This code is duplicated.
+        // See also c2112309-44fd-4a84-92a0-5a651e6ed548
         Ok(value.cloned().unwrap_or(q::Value::Null))
     }
 

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -47,10 +47,10 @@ fn list_type_object(
     type_objects: &mut TypeObjectsMap,
     inner_type: &s::Type,
 ) -> q::Value {
-    object_value(vec![
-        ("kind", q::Value::Enum(String::from("LIST"))),
-        ("ofType", type_object(schema, type_objects, inner_type)),
-    ])
+    object! {
+        kind: q::Value::Enum(String::from("LIST")),
+        ofType: type_object(schema, type_objects, inner_type),
+    }
 }
 
 fn non_null_type_object(
@@ -58,10 +58,10 @@ fn non_null_type_object(
     type_objects: &mut TypeObjectsMap,
     inner_type: &s::Type,
 ) -> q::Value {
-    object_value(vec![
-        ("kind", q::Value::Enum(String::from("NON_NULL"))),
-        ("ofType", type_object(schema, type_objects, inner_type)),
-    ])
+    object! {
+        kind: q::Value::Enum(String::from("NON_NULL")),
+        ofType: type_object(schema, type_objects, inner_type),
+    }
 }
 
 fn type_definition_object(
@@ -93,18 +93,12 @@ fn type_definition_object(
 }
 
 fn enum_type_object(enum_type: &s::EnumType) -> q::Value {
-    object_value(vec![
-        ("kind", q::Value::Enum(String::from("ENUM"))),
-        ("name", q::Value::String(enum_type.name.to_owned())),
-        (
-            "description",
-            enum_type
-                .description
-                .as_ref()
-                .map_or(q::Value::Null, |s| q::Value::String(s.to_owned())),
-        ),
-        ("enumValues", enum_values(enum_type)),
-    ])
+    object! {
+        kind: q::Value::Enum(String::from("ENUM")),
+        name: enum_type.name.to_owned(),
+        description: enum_type.description.clone(),
+        enumValues: enum_values(enum_type),
+    }
 }
 
 fn enum_values(enum_type: &s::EnumType) -> q::Value {
@@ -112,18 +106,12 @@ fn enum_values(enum_type: &s::EnumType) -> q::Value {
 }
 
 fn enum_value(enum_value: &s::EnumValue) -> q::Value {
-    object_value(vec![
-        ("name", q::Value::String(enum_value.name.to_owned())),
-        (
-            "description",
-            enum_value
-                .description
-                .as_ref()
-                .map_or(q::Value::Null, |s| q::Value::String(s.to_owned())),
-        ),
-        ("isDeprecated", q::Value::Boolean(false)),
-        ("deprecationReason", q::Value::Null),
-    ])
+    object! {
+        name: enum_value.name.to_owned(),
+        description: enum_value.description.clone(),
+        isDeprecated: false,
+        deprecationReason: q::Value::Null,
+    }
 }
 
 fn input_object_type_object(
@@ -132,18 +120,12 @@ fn input_object_type_object(
     input_object_type: &s::InputObjectType,
 ) -> q::Value {
     let input_values = input_values(schema, type_objects, &input_object_type.fields);
-    object_value(vec![
-        ("name", q::Value::String(input_object_type.name.to_owned())),
-        ("kind", q::Value::Enum(String::from("INPUT_OBJECT"))),
-        (
-            "description",
-            input_object_type
-                .description
-                .as_ref()
-                .map_or(q::Value::Null, |s| q::Value::String(s.to_owned())),
-        ),
-        ("inputFields", q::Value::List(input_values)),
-    ])
+    object! {
+        name: input_object_type.name.to_owned(),
+        kind: q::Value::Enum(String::from("INPUT_OBJECT")),
+        description: input_object_type.description.clone(),
+        inputFields: input_values,
+    }
 }
 
 fn interface_type_object(
@@ -151,30 +133,17 @@ fn interface_type_object(
     type_objects: &mut TypeObjectsMap,
     interface_type: &s::InterfaceType,
 ) -> q::Value {
-    object_value(vec![
-        ("name", q::Value::String(interface_type.name.to_owned())),
-        ("kind", q::Value::Enum(String::from("INTERFACE"))),
-        (
-            "description",
-            interface_type
-                .description
-                .as_ref()
-                .map_or(q::Value::Null, |s| q::Value::String(s.to_owned())),
-        ),
-        (
-            "fields",
+    object! {
+        name: interface_type.name.to_owned(),
+        kind: q::Value::Enum(String::from("INTERFACE")),
+        description: interface_type.description.clone(),
+        fields:
             field_objects(schema, type_objects, &interface_type.fields),
-        ),
-        (
-            "possibleTypes",
-            q::Value::List(
-                schema.types_for_interface()[&interface_type.name]
-                    .iter()
-                    .map(|object_type| q::Value::String(object_type.name.to_owned()))
-                    .collect(),
-            ),
-        ),
-    ])
+        possibleTypes: schema.types_for_interface()[&interface_type.name]
+            .iter()
+            .map(|object_type| q::Value::String(object_type.name.to_owned()))
+            .collect::<Vec<_>>(),
+    }
 }
 
 fn object_type_object(
@@ -186,25 +155,13 @@ fn object_type_object(
         .get(&object_type.name)
         .cloned()
         .unwrap_or_else(|| {
-            let type_object = object_value(vec![
-                ("kind", q::Value::Enum(String::from("OBJECT"))),
-                ("name", q::Value::String(object_type.name.to_owned())),
-                (
-                    "description",
-                    object_type
-                        .description
-                        .as_ref()
-                        .map_or(q::Value::Null, |s| q::Value::String(s.to_owned())),
-                ),
-                (
-                    "fields",
-                    field_objects(schema, type_objects, &object_type.fields),
-                ),
-                (
-                    "interfaces",
-                    object_interfaces(schema, type_objects, object_type),
-                ),
-            ]);
+            let type_object = object! {
+                kind: q::Value::Enum(String::from("OBJECT")),
+                name: object_type.name.to_owned(),
+                description: object_type.description.clone(),
+                fields: field_objects(schema, type_objects, &object_type.fields),
+                interfaces: object_interfaces(schema, type_objects, object_type),
+            };
 
             type_objects.insert(object_type.name.to_owned(), type_object.clone());
             type_object
@@ -225,23 +182,14 @@ fn field_objects(
 }
 
 fn field_object(schema: &Schema, type_objects: &mut TypeObjectsMap, field: &s::Field) -> q::Value {
-    object_value(vec![
-        ("name", q::Value::String(field.name.to_owned())),
-        (
-            "description",
-            field
-                .description
-                .as_ref()
-                .map_or(q::Value::Null, |s| q::Value::String(s.to_owned())),
-        ),
-        (
-            "args",
-            q::Value::List(input_values(schema, type_objects, &field.arguments)),
-        ),
-        ("type", type_object(schema, type_objects, &field.field_type)),
-        ("isDeprecated", q::Value::Boolean(false)),
-        ("deprecationReason", q::Value::Null),
-    ])
+    object! {
+        name: field.name.to_owned(),
+        description: field.description.clone(),
+        args: input_values(schema, type_objects, &field.arguments),
+        type: type_object(schema, type_objects, &field.field_type),
+        isDeprecated: false,
+        deprecationReason: q::Value::Null,
+    }
 }
 
 fn object_interfaces(
@@ -260,48 +208,32 @@ fn object_interfaces(
 }
 
 fn scalar_type_object(scalar_type: &s::ScalarType) -> q::Value {
-    object_value(vec![
-        ("name", q::Value::String(scalar_type.name.to_owned())),
-        ("kind", q::Value::Enum(String::from("SCALAR"))),
-        (
-            "description",
-            scalar_type
-                .description
-                .as_ref()
-                .map_or(q::Value::Null, |s| q::Value::String(s.to_owned())),
-        ),
-        ("isDeprecated", q::Value::Boolean(false)),
-        ("deprecationReason", q::Value::Null),
-    ])
+    object! {
+        name: scalar_type.name.to_owned(),
+        kind: q::Value::Enum(String::from("SCALAR")),
+        description: scalar_type.description.clone(),
+        isDeprecated: false,
+        deprecationReason: q::Value::Null,
+    }
 }
 
 fn union_type_object(schema: &Schema, union_type: &s::UnionType) -> q::Value {
-    object_value(vec![
-        ("name", q::Value::String(union_type.name.to_owned())),
-        ("kind", q::Value::Enum(String::from("UNION"))),
-        (
-            "description",
-            union_type
-                .description
-                .as_ref()
-                .map_or(q::Value::Null, |s| q::Value::String(s.to_owned())),
-        ),
-        (
-            "possibleTypes",
-            q::Value::List(
-                sast::get_object_type_definitions(&schema.document)
-                    .iter()
-                    .filter(|object_type| {
-                        object_type
-                            .implements_interfaces
-                            .iter()
-                            .any(|implemented_name| implemented_name == &union_type.name)
-                    })
-                    .map(|object_type| q::Value::String(object_type.name.to_owned()))
-                    .collect(),
-            ),
-        ),
-    ])
+    object! {
+        name: union_type.name.to_owned(),
+        kind: q::Value::Enum(String::from("UNION")),
+        description: union_type.description.clone(),
+        possibleTypes:
+            sast::get_object_type_definitions(&schema.document)
+                .iter()
+                .filter(|object_type| {
+                    object_type
+                        .implements_interfaces
+                        .iter()
+                        .any(|implemented_name| implemented_name == &union_type.name)
+                })
+                .map(|object_type| q::Value::String(object_type.name.to_owned()))
+                .collect::<Vec<_>>(),
+    }
 }
 
 fn schema_directive_objects(schema: &Schema, type_objects: &mut TypeObjectsMap) -> q::Value {
@@ -324,21 +256,12 @@ fn directive_object(
     type_objects: &mut TypeObjectsMap,
     directive: &s::DirectiveDefinition,
 ) -> q::Value {
-    object_value(vec![
-        ("name", q::Value::String(directive.name.to_owned())),
-        (
-            "description",
-            directive
-                .description
-                .as_ref()
-                .map_or(q::Value::Null, |s| q::Value::String(s.to_owned())),
-        ),
-        ("locations", directive_locations(directive)),
-        (
-            "args",
-            q::Value::List(input_values(schema, type_objects, &directive.arguments)),
-        ),
-    ])
+    object! {
+        name: directive.name.to_owned(),
+        description: directive.description.clone(),
+        locations: directive_locations(directive),
+        args: input_values(schema, type_objects, &directive.arguments),
+    }
 }
 
 fn directive_locations(directive: &s::DirectiveDefinition) -> q::Value {
@@ -368,29 +291,18 @@ fn input_value(
     type_objects: &mut TypeObjectsMap,
     input_value: &s::InputValue,
 ) -> q::Value {
-    object_value(vec![
-        ("name", q::Value::String(input_value.name.to_owned())),
-        (
-            "description",
-            input_value
-                .description
-                .as_ref()
-                .map_or(q::Value::Null, |s| q::Value::String(s.to_owned())),
-        ),
-        (
-            "type",
-            type_object(schema, type_objects, &input_value.value_type),
-        ),
-        (
-            "defaultValue",
+    object! {
+        name: input_value.name.to_owned(),
+        description: input_value.description.clone(),
+        type: type_object(schema, type_objects, &input_value.value_type),
+        defaultValue:
             input_value
                 .default_value
                 .as_ref()
                 .map_or(q::Value::Null, |value| {
                     q::Value::String(format!("{}", value))
                 }),
-        ),
-    ])
+    }
 }
 
 #[derive(Clone)]
@@ -420,28 +332,19 @@ impl<'a> IntrospectionResolver<'a> {
     }
 
     fn schema_object(&self) -> q::Value {
-        object_value(vec![
-            (
-                "queryType",
+        object! {
+            queryType:
                 self.type_objects
                     .get(&String::from("Query"))
-                    .cloned()
-                    .unwrap_or(q::Value::Null),
-            ),
-            (
-                "subscriptionType",
+                    .cloned(),
+            subscriptionType:
                 self.type_objects
                     .get(&String::from("Subscription"))
-                    .cloned()
-                    .unwrap_or(q::Value::Null),
-            ),
-            ("mutationType", q::Value::Null),
-            (
-                "types",
-                q::Value::List(self.type_objects.values().cloned().collect::<Vec<_>>()),
-            ),
-            ("directives", self.directives.clone()),
-        ])
+                    .cloned(),
+            mutationType: q::Value::Null,
+            types: self.type_objects.values().cloned().collect::<Vec<_>>(),
+            directives: self.directives.clone(),
+        }
     }
 
     fn type_object(&self, name: &q::Value) -> q::Value {

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -33,7 +33,8 @@ pub mod prelude {
     pub use super::schema::{api_schema, ast::validate_entity, APISchemaError};
     pub use super::store::{build_query, StoreResolver};
     pub use super::subscription::{execute_subscription, SubscriptionExecutionOptions};
-    pub use super::values::{object_value, MaybeCoercible};
+    pub use super::values::{object_value, IntoValue, MaybeCoercible};
 
     pub use super::graphql_parser::{query::Name, schema::ObjectType};
+    pub use crate::object;
 }

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -15,8 +15,9 @@ use lazy_static::lazy_static;
 lazy_static! {
     static ref SUBSCRIPTION_QUERY_SEMAPHORE: Semaphore = {
         // This is duplicating the logic in main.rs to get the connection pool size, which is
-        // unfourtunate. But because this module has no share state otherwise, it's not simple to
+        // unfortunate. But because this module has no share state otherwise, it's not simple to
         // refactor so that the semaphore isn't a global.
+        // See also 82d5dad6-b633-4350-86d9-70c8b2e65805
         let db_conn_pool_size = std::env::var("STORE_CONNECTION_POOL_SIZE")
             .unwrap_or("10".into())
             .parse::<usize>()

--- a/graphql/src/values/coercion.rs
+++ b/graphql/src/values/coercion.rs
@@ -87,7 +87,7 @@ fn coerce_to_definition<'a>(
 
 /// Coerces an argument into a GraphQL value.
 ///
-/// `Ok(None)` happens when no value is found for a nullabe type.
+/// `Ok(None)` happens when no value is found for a nullable type.
 pub(crate) fn coerce_input_value<'a>(
     mut value: Option<Value>,
     def: &InputValue,
@@ -127,7 +127,6 @@ pub(crate) fn coerce_input_value<'a>(
     ))
 }
 
-/// `R` is a name resolver.
 pub(crate) fn coerce_value<'a>(
     value: &Value,
     ty: &Type,

--- a/graphql/src/values/mod.rs
+++ b/graphql/src/values/mod.rs
@@ -1,15 +1,84 @@
-use graphql_parser::query::Value;
+use graphql_parser::query::{Number, Value};
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
 
-/// Utilties for coercing GraphQL values based on GraphQL types.
+/// Utilities for coercing GraphQL values based on GraphQL types.
 pub mod coercion;
 
 pub use self::coercion::MaybeCoercible;
 
 /// Creates a `graphql_parser::query::Value::Object` from key/value pairs.
+/// If you don't need to determine which keys are included dynamically at runtime
+/// consider using the `object! {}` macro instead.
 pub fn object_value(data: Vec<(&str, Value)>) -> Value {
     Value::Object(BTreeMap::from_iter(
         data.into_iter().map(|(k, v)| (k.to_string(), v)),
     ))
+}
+
+pub trait IntoValue {
+    fn into_value(self) -> Value;
+}
+
+impl IntoValue for Value {
+    #[inline]
+    fn into_value(self) -> Value {
+        self
+    }
+}
+
+impl IntoValue for &'_ str {
+    #[inline]
+    fn into_value(self) -> Value {
+        self.to_owned().into_value()
+    }
+}
+
+impl<T: IntoValue> IntoValue for Option<T> {
+    #[inline]
+    fn into_value(self) -> Value {
+        match self {
+            Some(v) => v.into_value(),
+            None => Value::Null,
+        }
+    }
+}
+
+macro_rules! impl_into_values {
+    ($(($T:ty, $V:ident)),*) => {
+        $(
+            impl IntoValue for $T {
+                #[inline]
+                fn into_value(self) -> Value {
+                    Value::$V(self)
+                }
+            }
+        )+
+    };
+}
+
+impl_into_values![
+    (String, String),
+    (f64, Float),
+    (bool, Boolean),
+    (Vec<Value>, List),
+    (Number, Int)
+];
+
+/// Creates a `graphql_parser::query::Value::Object` from key/value pairs.
+#[macro_export]
+macro_rules! object {
+    ($($name:ident: $value:expr,)*) => {
+        {
+            let mut result = ::std::collections::BTreeMap::new();
+            $(
+                let value = $crate::prelude::IntoValue::into_value($value);
+                result.insert(stringify!($name).to_string(), value);
+            )*
+            ::graphql_parser::query::Value::Object(result)
+        }
+    };
+    ($($name:ident: $value:expr),*) => {
+        object! {$($name: $value,)*}
+    };
 }

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -105,76 +105,74 @@ fn mock_schema() -> Schema {
 /// Builds the expected result for GraphiQL's introspection query that we are
 /// using for testing.
 fn expected_mock_schema_introspection() -> q::Value {
-    let string_type = object_value(vec![
-        ("kind", q::Value::Enum("SCALAR".to_string())),
-        ("name", q::Value::String("String".to_string())),
-        ("description", q::Value::Null),
-        ("fields", q::Value::Null),
-        ("inputFields", q::Value::Null),
-        ("enumValues", q::Value::Null),
-        ("interfaces", q::Value::Null),
-        ("possibleTypes", q::Value::Null),
-    ]);
+    let string_type = object! {
+        kind: q::Value::Enum("SCALAR".to_string()),
+        name: "String",
+        description: q::Value::Null,
+        fields: q::Value::Null,
+        inputFields: q::Value::Null,
+        enumValues: q::Value::Null,
+        interfaces: q::Value::Null,
+        possibleTypes: q::Value::Null,
+    };
 
-    let id_type = object_value(vec![
-        ("kind", q::Value::Enum("SCALAR".to_string())),
-        ("name", q::Value::String("ID".to_string())),
-        ("description", q::Value::Null),
-        ("fields", q::Value::Null),
-        ("inputFields", q::Value::Null),
-        ("enumValues", q::Value::Null),
-        ("interfaces", q::Value::Null),
-        ("possibleTypes", q::Value::Null),
-    ]);
+    let id_type = object! {
+        kind: q::Value::Enum("SCALAR".to_string()),
+        name: "ID",
+        description: q::Value::Null,
+        fields: q::Value::Null,
+        inputFields: q::Value::Null,
+        enumValues: q::Value::Null,
+        interfaces: q::Value::Null,
+        possibleTypes: q::Value::Null,
+    };
 
-    let int_type = object_value(vec![
-        ("kind", q::Value::Enum("SCALAR".to_string())),
-        ("name", q::Value::String("Int".to_string())),
-        ("description", q::Value::Null),
-        ("fields", q::Value::Null),
-        ("inputFields", q::Value::Null),
-        ("enumValues", q::Value::Null),
-        ("interfaces", q::Value::Null),
-        ("possibleTypes", q::Value::Null),
-    ]);
+    let int_type = object! {
+        kind: q::Value::Enum("SCALAR".to_string()),
+        name: "Int",
+        description: q::Value::Null,
+        fields: q::Value::Null,
+        inputFields: q::Value::Null,
+        enumValues: q::Value::Null,
+        interfaces: q::Value::Null,
+        possibleTypes: q::Value::Null,
+    };
 
-    let boolean_type = object_value(vec![
-        ("kind", q::Value::Enum("SCALAR".to_string())),
-        ("name", q::Value::String("Boolean".to_string())),
-        ("description", q::Value::Null),
-        ("fields", q::Value::Null),
-        ("inputFields", q::Value::Null),
-        ("enumValues", q::Value::Null),
-        ("interfaces", q::Value::Null),
-        ("possibleTypes", q::Value::Null),
-    ]);
+    let boolean_type = object! {
+        kind: q::Value::Enum("SCALAR".to_string()),
+        name: "Boolean",
+        description: q::Value::Null,
+        fields: q::Value::Null,
+        inputFields: q::Value::Null,
+        enumValues: q::Value::Null,
+        interfaces: q::Value::Null,
+        possibleTypes: q::Value::Null,
+    };
 
-    let role_type = object_value(vec![
-        ("kind", q::Value::Enum("ENUM".to_string())),
-        ("name", q::Value::String("Role".to_string())),
-        ("description", q::Value::Null),
-        ("fields", q::Value::Null),
-        ("inputFields", q::Value::Null),
-        (
-            "enumValues",
+    let role_type = object! {
+        kind: q::Value::Enum("ENUM".to_string()),
+        name: "Role",
+        description: q::Value::Null,
+        fields: q::Value::Null,
+        inputFields: q::Value::Null,
+        enumValues:
             q::Value::List(vec![
-                object_value(vec![
-                    ("name", q::Value::String("USER".to_string())),
-                    ("description", q::Value::Null),
-                    ("isDeprecated", q::Value::Boolean(false)),
-                    ("deprecationReason", q::Value::Null),
-                ]),
-                object_value(vec![
-                    ("name", q::Value::String("ADMIN".to_string())),
-                    ("description", q::Value::Null),
-                    ("isDeprecated", q::Value::Boolean(false)),
-                    ("deprecationReason", q::Value::Null),
-                ]),
+                object! {
+                    name: "USER",
+                    description: q::Value::Null,
+                    isDeprecated: q::Value::Boolean(false),
+                    deprecationReason: q::Value::Null,
+                },
+                object! {
+                    name: "ADMIN",
+                    description: q::Value::Null,
+                    isDeprecated: false,
+                    deprecationReason: q::Value::Null,
+                },
             ]),
-        ),
-        ("interfaces", q::Value::Null),
-        ("possibleTypes", q::Value::Null),
-    ]);
+        interfaces: q::Value::Null,
+        possibleTypes: q::Value::Null,
+    };
 
     let node_type = object_value(vec![
         ("kind", q::Value::Enum("INTERFACE".to_string())),

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -9,5 +9,5 @@ futures = "0.1.21"
 graphql-parser = "0.2.3"
 graph = { path = "../graph" }
 graph-graphql = { path = "../graphql" }
-mockall = "0.6"
+mockall = "0.7"
 rand = "0.6.1"

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -3,87 +3,15 @@ use mockall::*;
 use std::collections::BTreeMap;
 
 use graph::components::store::*;
+use graph::components::subgraph::ProofOfIndexingDigest;
 use graph::data::subgraph::schema::*;
 use graph::prelude::*;
 use graph_graphql::prelude::api_schema;
 use web3::types::H256;
 
 mock! {
-    pub Store {}
-
-    trait Store: Send + Sync + 'static  {
-        fn block_ptr(
-            &self,
-            subgraph_id: SubgraphDeploymentId,
-        ) -> Result<Option<EthereumBlockPointer>, Error>;
-
-        fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError>;
-
-        fn get_many<'a>(
-            &self,
-            subgraph_id: &SubgraphDeploymentId,
-            ids_for_type: BTreeMap<&'a str, Vec<&'a str>>,
-        ) -> Result<BTreeMap<String, Vec<Entity>>, StoreError>;
-
-        fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError>;
-
-        fn find_one(&self, query: EntityQuery) -> Result<Option<Entity>, QueryExecutionError>;
-
-        fn find_ens_name(&self, _hash: &str) -> Result<Option<String>, QueryExecutionError>;
-
-        fn transact_block_operations(
-            &self,
-            subgraph_id: SubgraphDeploymentId,
-            block_ptr_to: EthereumBlockPointer,
-            mods: Vec<EntityModification>,
-            stopwatch: StopwatchMetrics,
-        ) -> Result<bool, StoreError>;
-
-        fn apply_metadata_operations(
-            &self,
-            operations: Vec<MetadataOperation>,
-        ) -> Result<(), StoreError>;
-
-        fn build_entity_attribute_indexes(
-            &self,
-            subgraph: &SubgraphDeploymentId,
-            indexes: Vec<AttributeIndexDefinition>,
-        ) -> Result<(), SubgraphAssignmentProviderError>;
-
-        fn revert_block_operations(
-            &self,
-            subgraph_id: SubgraphDeploymentId,
-            block_ptr_from: EthereumBlockPointer,
-            block_ptr_to: EthereumBlockPointer,
-        ) -> Result<(), StoreError>;
-
-        fn subscribe(&self, entities: Vec<SubgraphEntityPair>) -> StoreEventStreamBox;
-
-        fn create_subgraph_deployment(
-            &self,
-            schema: &Schema,
-            ops: Vec<MetadataOperation>,
-        ) -> Result<(), StoreError>;
-
-        fn start_subgraph_deployment(
-            &self,
-            logger: &Logger,
-            subgraph_id: &SubgraphDeploymentId,
-            ops: Vec<MetadataOperation>,
-        ) -> Result<(), StoreError>;
-
-        fn migrate_subgraph_deployment(
-            &self,
-            logger: &Logger,
-            subgraph_id: &SubgraphDeploymentId,
-            block_ptr: &EthereumBlockPointer,
-        );
-
-        fn block_number(
-            &self,
-            subgraph_id: &SubgraphDeploymentId,
-            block_hash: H256,
-        ) -> Result<Option<BlockNumber>, StoreError>;
+    pub Store {
+        fn get_mock(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError>;
     }
 
     trait SubgraphDeploymentStore: Send + Sync + 'static {
@@ -94,7 +22,7 @@ mock! {
         fn uses_relational_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<bool, Error>;
 
         fn network_name(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Option<String>, Error>;
-}
+    }
 
     trait ChainStore: Send + Sync + 'static {
         fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error>;
@@ -129,6 +57,126 @@ mock! {
     }
 }
 
+impl Store for MockStore {
+    fn block_ptr(
+        &self,
+        _subgraph_id: SubgraphDeploymentId,
+    ) -> Result<Option<EthereumBlockPointer>, Error> {
+        unimplemented!()
+    }
+
+    fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError> {
+        self.get_mock(key)
+    }
+
+    fn get_many(
+        &self,
+        _subgraph_id: &SubgraphDeploymentId,
+        _ids_for_type: BTreeMap<&str, Vec<&str>>,
+    ) -> Result<BTreeMap<String, Vec<Entity>>, StoreError> {
+        unimplemented!()
+    }
+
+    fn supports_proof_of_indexing<'a>(
+        &'a self,
+        _subgraph_id: &'a SubgraphDeploymentId,
+    ) -> DynTryFuture<'a, bool> {
+        unimplemented!()
+    }
+
+    fn get_proof_of_indexing<'a>(
+        &'a self,
+        _subgraph_id: &'a SubgraphDeploymentId,
+        _block_number: u64,
+    ) -> DynTryFuture<'a, Option<ProofOfIndexingDigest>> {
+        unimplemented!()
+    }
+
+    fn find(&self, _query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
+        unimplemented!()
+    }
+
+    fn find_one(&self, _query: EntityQuery) -> Result<Option<Entity>, QueryExecutionError> {
+        unimplemented!()
+    }
+
+    fn find_ens_name(&self, _hash: &str) -> Result<Option<String>, QueryExecutionError> {
+        unimplemented!()
+    }
+
+    fn transact_block_operations(
+        &self,
+        _subgraph_id: SubgraphDeploymentId,
+        _block_ptr_to: EthereumBlockPointer,
+        _mods: Vec<EntityModification>,
+        _stopwatch: StopwatchMetrics,
+    ) -> Result<bool, StoreError> {
+        unimplemented!()
+    }
+
+    fn apply_metadata_operations(
+        &self,
+        _operations: Vec<MetadataOperation>,
+    ) -> Result<(), StoreError> {
+        unimplemented!()
+    }
+
+    fn build_entity_attribute_indexes(
+        &self,
+        _subgraph: &SubgraphDeploymentId,
+        _indexes: Vec<AttributeIndexDefinition>,
+    ) -> Result<(), SubgraphAssignmentProviderError> {
+        unimplemented!()
+    }
+
+    fn revert_block_operations(
+        &self,
+        _subgraph_id: SubgraphDeploymentId,
+        _block_ptr_from: EthereumBlockPointer,
+        _block_ptr_to: EthereumBlockPointer,
+    ) -> Result<(), StoreError> {
+        unimplemented!()
+    }
+
+    fn subscribe(&self, _entities: Vec<SubgraphEntityPair>) -> StoreEventStreamBox {
+        unimplemented!()
+    }
+
+    fn create_subgraph_deployment(
+        &self,
+        _schema: &Schema,
+        _ops: Vec<MetadataOperation>,
+    ) -> Result<(), StoreError> {
+        unimplemented!()
+    }
+
+    fn start_subgraph_deployment(
+        &self,
+        _logger: &Logger,
+        _subgraph_id: &SubgraphDeploymentId,
+        _ops: Vec<MetadataOperation>,
+    ) -> Result<(), StoreError> {
+        unimplemented!()
+    }
+
+    fn migrate_subgraph_deployment(
+        &self,
+        _logger: &Logger,
+        _subgraph_id: &SubgraphDeploymentId,
+        _block_ptr: &EthereumBlockPointer,
+    ) {
+        unimplemented!()
+    }
+
+    fn block_number(
+        &self,
+        _subgraph_id: &SubgraphDeploymentId,
+        _block_hash: H256,
+    ) -> Result<Option<BlockNumber>, StoreError> {
+        unimplemented!()
+    }
+}
+
 pub fn mock_store_with_users_subgraph() -> (Arc<MockStore>, SubgraphDeploymentId) {
     let mut store = MockStore::new();
 
@@ -139,7 +187,7 @@ pub fn mock_store_with_users_subgraph() -> (Arc<MockStore>, SubgraphDeploymentId
 
     // Simulate that the "users" subgraph is deployed
     store
-        .expect_get()
+        .expect_get_mock()
         .withf(move |key| {
             key == &SubgraphDeploymentEntity::key(subgraph_id_for_deployment_entity.clone())
         })

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -217,6 +217,7 @@ async fn main() {
                 .default_value("false")
                 .help("Ensures that the block ingestor component does not execute"),
         )
+        // See also 82d5dad6-b633-4350-86d9-70c8b2e65805
         .arg(
             Arg::with_name("store-connection-pool-size")
                 .long("store-connection-pool-size")

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1.7"
-futures = "0.1.21"
+futures = "0.3.4"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
 graphql-parser = "0.2.3"

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -7,6 +7,7 @@ scalar String
 type Query {
   indexingStatusesForSubgraphName(subgraphName: String!): [SubgraphIndexingStatus!]!
   indexingStatuses(subgraphs: [String!]): [SubgraphIndexingStatus!]!
+  proofOfIndexing(subgraph: String!, blockNumber: BigInt!): Bytes
 }
 
 type SubgraphIndexingStatus {

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -1,7 +1,6 @@
 use http::header;
 use hyper::service::Service;
 use hyper::{Body, Method, Request, Response, StatusCode};
-use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Instant;
@@ -16,8 +15,7 @@ use crate::response::IndexNodeResponse;
 use crate::schema::SCHEMA;
 
 /// An asynchronous response to a GraphQL request.
-pub type IndexNodeServiceResponse =
-    Pin<Box<dyn std::future::Future<Output = Result<Response<Body>, GraphQLServerError>> + Send>>;
+pub type IndexNodeServiceResponse = DynTryFuture<'static, Response<Body>, GraphQLServerError>;
 
 /// A Hyper Service that serves GraphQL over a POST / endpoint.
 #[derive(Debug)]
@@ -81,12 +79,13 @@ where
     }
 
     fn index(&self) -> IndexNodeServiceResponse {
-        Box::pin(async {
+        async {
             Ok(Response::builder()
                 .status(200)
                 .body(Body::from("OK"))
                 .unwrap())
-        })
+        }
+        .boxed()
     }
 
     fn handle_graphiql(&self) -> IndexNodeServiceResponse {

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.18.0"
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1.27"
 derive_more = { version = "0.99.2" }
 diesel = { version = "1.4.3", features = ["postgres", "serde_json", "numeric", "r2d2"] }
 # We use diesel-dynamic-schema straight from git as the project has not
@@ -21,9 +22,12 @@ graphql-parser = "0.2.3"
 Inflector = "0.11.3"
 lazy_static = "1.1"
 lru_time_cache = "0.9"
+maybe-owned = "0.3.2"
 postgres = "0.15.2"
 serde = "1.0"
 uuid = { version = "0.8.1", features = ["v4"] }
+stable-hash = { git = "https://github.com/graphprotocol/stable-hash" }
+twox-hash = "1.5.0"
 
 [dev-dependencies]
 clap = "2.33.0"

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -321,7 +321,7 @@ pub fn main() {
     let schema = ensure(parse_schema(&schema), "Failed to parse schema");
     let subgraph = SubgraphDeploymentId::new("Qmasubgraph").unwrap();
     let layout = ensure(
-        Layout::new(&schema, IdType::String, subgraph, db_schema),
+        Layout::new(&schema, IdType::String, subgraph, db_schema, false),
         "Failed to construct Mapping",
     );
     match kind {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -146,7 +146,7 @@ impl EntityData {
                     if key == "g$parent_id" {
                         let value = Self::value_from_json(&ColumnType::String, json)?;
                         entity.insert("g$parent_id".to_owned(), value);
-                    } else if let Some(column) = table.column(&SqlName::from_snake_case(key)) {
+                    } else if let Some(column) = table.column(&SqlName::verbatim(key)) {
                         let value = Self::value_from_json(&column.column_type, json)?;
                         if value != Value::Null {
                             entity.insert(column.field.clone(), value);


### PR DESCRIPTION
### Proof of Indexing
This change adds much of the needed framework around the Proof of Indexing digest update and serving. Some of the database work is left for future work in order to integrate what changes have been marked. These are clearly marked.

Changes were made to the network RFC in order to work around limitations of GraphQL. In particular, interfaces cannot be used as inputs.

### Other new APIs
new `object!` macro - removes noise/boilerplate for graphql objects (`IntoValue` added to support this). Lib code has been migrated to use this, There are more than 100 places within tests to migrate later.
`Store::with_entity_connection` - Talk to the database without violating the futures API, allowing timeout, quicker transaction cancellation on future drop, and greater levels of concurrency
`TryFrom<BigInt> for u64` - fallible conversion with custom error
`trait CancelToken` - convenient `token.check_cancel()?` API.
More `CheapClone` impls
`spawn_blocking_async_allow_panic` to eventually replace futures based version

### Fixes
Call `resolve_scalar_value` when outside of an object for GraphQL
No 6 hour timeout for db connection in test means you get an error message when the connection fails

### And more
Various added documentation, migrating to async, and other cleanup
