### PR TITLE
Allow using `Bytes` for `ID` and switch block explorer to that

### DIFF
--- a/chain/ethereum/src/network_indexer/ethereum.graphql
+++ b/chain/ethereum/src/network_indexer/ethereum.graphql
@@ -1,6 +1,6 @@
 """ Block is an Ethereum block."""
 type Block @entity {
-  id: ID!
+  id: Bytes!
 
   """The number of this block, starting at 0 for the genesis block."""
   number: BigInt!

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -109,7 +109,6 @@ pub enum ValueType {
     BigInt,
     Bytes,
     BigDecimal,
-    ID,
     Int,
     String,
     List,
@@ -124,9 +123,8 @@ impl FromStr for ValueType {
             "BigInt" => Ok(ValueType::BigInt),
             "Bytes" => Ok(ValueType::Bytes),
             "BigDecimal" => Ok(ValueType::BigDecimal),
-            "ID" => Ok(ValueType::ID),
             "Int" => Ok(ValueType::Int),
-            "String" => Ok(ValueType::String),
+            "String" | "ID" => Ok(ValueType::String),
             "List" => Ok(ValueType::List),
             s => Err(format_err!("Type not available in this context: {}", s)),
         }
@@ -143,7 +141,6 @@ impl ValueType {
                 | ValueType::BigDecimal
                 | ValueType::BigInt
                 | ValueType::Bytes
-                | ValueType::ID
                 | ValueType::Int
                 | ValueType::String => true,
             })

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -1350,8 +1350,9 @@ fn inner_type_name(field_type: &Type, definitions: &[Definition]) -> Result<Valu
     match field_type {
         Type::NamedType(ref name) => ValueType::from_str(&name).or_else(|e| {
             if is_entity(name, definitions) {
-                // The field is a reference to another type and therefore of type ID
-                Ok(ValueType::ID)
+                // The field is a reference to another type and therefore
+                // of type `String`
+                Ok(ValueType::String)
             } else {
                 Err(e)
             }

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -438,9 +438,7 @@ fn scalar_value_type(schema: &Document, field_type: &Type) -> ValueType {
     match field_type {
         Type::NamedType(name) => {
             ValueType::from_str(&name).unwrap_or_else(|_| match get_named_type(schema, name) {
-                Some(t::Object(_)) => ValueType::ID,
-                Some(t::Interface(_)) => ValueType::ID,
-                Some(t::Enum(_)) => ValueType::String,
+                Some(t::Object(_)) | Some(t::Interface(_)) | Some(t::Enum(_)) => ValueType::String,
                 Some(t::Scalar(_)) => unreachable!("user-defined scalars are not used"),
                 Some(t::Union(_)) => unreachable!("unions are not used"),
                 Some(t::InputObject(_)) => unreachable!("inputObjects are not used"),
@@ -463,7 +461,6 @@ fn is_list(field_type: &Type) -> bool {
 fn is_assignable(value: &store::Value, scalar_type: &ValueType, is_list: bool) -> bool {
     match (value, scalar_type) {
         (store::Value::String(_), ValueType::String)
-        | (store::Value::String(_), ValueType::ID)
         | (store::Value::BigDecimal(_), ValueType::BigDecimal)
         | (store::Value::BigInt(_), ValueType::BigInt)
         | (store::Value::Bool(_), ValueType::Boolean)

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -2,11 +2,10 @@ extern crate clap;
 extern crate graph_store_postgres;
 
 use clap::App;
-use graphql_parser::parse_schema;
 use std::fs;
 use std::process::exit;
 
-use graph::prelude::SubgraphDeploymentId;
+use graph::prelude::{Schema, SubgraphDeploymentId};
 use graph_store_postgres::relational::{Column, ColumnType, Layout};
 
 pub fn usage(msg: &str) -> ! {
@@ -317,11 +316,12 @@ pub fn main() {
     let db_schema = args.value_of("db_schema").unwrap_or("rel");
     let kind = args.value_of("generate").unwrap_or("ddl");
 
-    let schema = ensure(fs::read_to_string(schema), "Can not read schema file");
-    let schema = ensure(parse_schema(&schema), "Failed to parse schema");
     let subgraph = SubgraphDeploymentId::new("Qmasubgraph").unwrap();
+    let schema = ensure(fs::read_to_string(schema), "Can not read schema file");
+    let schema = ensure(Schema::parse(&schema, subgraph), "Failed to parse schema");
+
     let layout = ensure(
-        Layout::new(&schema, subgraph, db_schema, false),
+        Layout::new(&schema, db_schema, false),
         "Failed to construct Mapping",
     );
     match kind {

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::process::exit;
 
 use graph::prelude::SubgraphDeploymentId;
-use graph_store_postgres::relational::{Column, ColumnType, IdType, Layout};
+use graph_store_postgres::relational::{Column, ColumnType, Layout};
 
 pub fn usage(msg: &str) -> ! {
     println!("layout: {}", msg);
@@ -321,7 +321,7 @@ pub fn main() {
     let schema = ensure(parse_schema(&schema), "Failed to parse schema");
     let subgraph = SubgraphDeploymentId::new("Qmasubgraph").unwrap();
     let layout = ensure(
-        Layout::new(&schema, IdType::String, subgraph, db_schema, false),
+        Layout::new(&schema, subgraph, db_schema, false),
         "Failed to construct Mapping",
     );
     match kind {

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -200,7 +200,7 @@ fn print_diesel_tables(layout: &Layout) {
         let mut dsl_type = match column.column_type {
             ColumnType::Boolean => "Bool",
             ColumnType::BigDecimal | ColumnType::BigInt => "Numeric",
-            ColumnType::Bytes => "Binary",
+            ColumnType::Bytes | ColumnType::BytesId => "Binary",
             ColumnType::Int => "Integer",
             ColumnType::String | ColumnType::Enum(_) | ColumnType::TSVector(_) => "Text",
         }
@@ -219,7 +219,7 @@ fn print_diesel_tables(layout: &Layout) {
         let mut dsl_type = match column.column_type {
             ColumnType::Boolean => "bool",
             ColumnType::BigDecimal | ColumnType::BigInt => "BigDecimal",
-            ColumnType::Bytes => "Vec<u8>",
+            ColumnType::Bytes | ColumnType::BytesId => "Vec<u8>",
             ColumnType::Int => "i32",
             ColumnType::String | ColumnType::Enum(_) | ColumnType::TSVector(_) => "String",
         }

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -843,12 +843,7 @@ impl Connection<'_> {
 
         match *GRAPH_STORAGE_SCHEME {
             v::Relational => {
-                let layout = Layout::create_relational_schema(
-                    &self.conn,
-                    &schema_name,
-                    schema.id.clone(),
-                    &schema.document,
-                )?;
+                let layout = Layout::create_relational_schema(&self.conn, schema, schema_name)?;
                 // See if we are grafting and check that the graft is permissible
                 if let Some((base, _)) = metadata::deployment_graft(&self.conn, &schema.id)? {
                     match Storage::new(&self.conn, &base)? {
@@ -1408,12 +1403,7 @@ impl Storage {
             V::Relational => {
                 let subgraph_schema = metadata::subgraph_schema(conn, subgraph.to_owned())?;
                 let has_poi = supports_proof_of_indexing(conn, subgraph, &schema.name)?;
-                let layout = Layout::new(
-                    &subgraph_schema.document,
-                    subgraph.clone(),
-                    schema.name,
-                    has_poi,
-                )?;
+                let layout = Layout::new(&subgraph_schema, &schema.name, has_poi)?;
                 Storage::Relational(layout)
             }
         };

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -55,7 +55,7 @@ use crate::history_event::HistoryEvent;
 use crate::jsonb_queries::FilterQuery;
 use crate::metadata;
 use crate::notification_listener::JsonNotification;
-use crate::relational::{IdType, Layout};
+use crate::relational::Layout;
 
 lazy_static! {
     // We allow overriding the default storage scheme with the environment
@@ -1410,7 +1410,6 @@ impl Storage {
                 let has_poi = supports_proof_of_indexing(conn, subgraph, &schema.name)?;
                 let layout = Layout::new(
                     &subgraph_schema.document,
-                    IdType::String,
                     subgraph.clone(),
                     schema.name,
                     has_poi,

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -1224,7 +1224,6 @@ impl JsonStorage {
             | ValueType::BigInt
             | ValueType::Bytes
             | ValueType::BigDecimal
-            | ValueType::ID
             | ValueType::Int
             | ValueType::String => (String::from("btree"), String::from(""), "->>"),
             ValueType::List => (String::from("gin"), String::from("jsonb_path_ops"), "->"),

--- a/store/postgres/src/jsonb_queries.rs
+++ b/store/postgres/src/jsonb_queries.rs
@@ -46,7 +46,6 @@ impl<'a> FilterQuery<'a> {
                 ValueType::BigInt | ValueType::BigDecimal => "::numeric",
                 ValueType::Boolean => "::boolean",
                 ValueType::Bytes => "",
-                ValueType::ID => "",
                 ValueType::Int => "::bigint",
                 ValueType::String => "",
                 ValueType::List => {

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -125,9 +125,8 @@ impl fmt::Display for SqlName {
 /// The SQL type to use for GraphQL ID properties. We support
 /// strings and byte arrays
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum IdType {
+pub(crate) enum IdType {
     String,
-    #[allow(dead_code)]
     Bytes,
 }
 
@@ -135,8 +134,6 @@ type EnumMap = BTreeMap<String, Arc<BTreeSet<String>>>;
 
 #[derive(Debug, Clone)]
 pub struct Layout {
-    /// The SQL type for columns with GraphQL type `ID`
-    id_type: IdType,
     /// Maps the GraphQL name of a type to the relational table
     pub tables: HashMap<String, Arc<Table>>,
     /// The subgraph id
@@ -158,7 +155,6 @@ impl Layout {
     /// is in `schema`.
     pub fn new(
         document: &s::Document,
-        id_type: IdType,
         subgraph: SubgraphDeploymentId,
         schema: impl Into<String>,
         create_proof_of_indexing: bool,
@@ -220,7 +216,6 @@ impl Layout {
                         &schema,
                         Schema::entity_fulltext_definitions(&obj_type.name, document),
                         &enums,
-                        id_type,
                         tables.len() as u32,
                     )?);
                 }
@@ -265,7 +260,6 @@ impl Layout {
             });
 
         Ok(Layout {
-            id_type,
             subgraph,
             schema,
             tables,
@@ -280,8 +274,7 @@ impl Layout {
         subgraph: SubgraphDeploymentId,
         document: &s::Document,
     ) -> Result<Layout, StoreError> {
-        let layout =
-            crate::relational::Layout::new(document, IdType::String, subgraph, schema_name, true)?;
+        let layout = Self::new(document, subgraph, schema_name, true)?;
         let sql = layout
             .as_ddl()
             .map_err(|_| StoreError::Unknown(format_err!("failed to generate DDL for layout")))?;
@@ -802,7 +795,6 @@ impl ColumnType {
         field_type: &q::Type,
         schema: &str,
         enums: &EnumMap,
-        id_type: IdType,
     ) -> Result<ColumnType, StoreError> {
         let name = named_type(field_type);
 
@@ -827,8 +819,7 @@ impl ColumnType {
             ValueType::BigInt => Ok(ColumnType::BigInt),
             ValueType::Bytes => Ok(ColumnType::Bytes),
             ValueType::Int => Ok(ColumnType::Int),
-            ValueType::String => Ok(ColumnType::String),
-            ValueType::ID => Ok(ColumnType::from(id_type)),
+            ValueType::String | ValueType::ID => Ok(ColumnType::String),
             ValueType::List => Err(StoreError::Unknown(format_err!(
                 "can not convert ValueType::List to ColumnType"
             ))),
@@ -860,12 +851,7 @@ pub struct Column {
 }
 
 impl Column {
-    fn new(
-        field: &s::Field,
-        schema: &str,
-        enums: &EnumMap,
-        id_type: IdType,
-    ) -> Result<Column, StoreError> {
+    fn new(field: &s::Field, schema: &str, enums: &EnumMap) -> Result<Column, StoreError> {
         SqlName::check_valid_identifier(&*field.name, "attribute")?;
 
         let sql_name = SqlName::from(&*field.name);
@@ -875,7 +861,7 @@ impl Column {
         Ok(Column {
             name: sql_name,
             field: field.name.clone(),
-            column_type: ColumnType::from_field_type(&field.field_type, schema, enums, id_type)?,
+            column_type: ColumnType::from_field_type(&field.field_type, schema, enums)?,
             field_type: field.field_type.clone(),
             fulltext_fields: None,
             is_reference,
@@ -1028,7 +1014,6 @@ impl Table {
         schema: &str,
         fulltexts: Vec<FulltextDefinition>,
         enums: &EnumMap,
-        id_type: IdType,
         position: u32,
     ) -> Result<Table, StoreError> {
         SqlName::check_valid_identifier(&*defn.name, "object")?;
@@ -1038,7 +1023,7 @@ impl Table {
             .fields
             .iter()
             .filter(|field| !derived_column(field))
-            .map(|field| Column::new(field, schema, enums, id_type))
+            .map(|field| Column::new(field, schema, enums))
             .chain(fulltexts.iter().map(|def| Column::new_fulltext(def)))
             .collect::<Result<Vec<Column>, StoreError>>()?;
 
@@ -1195,8 +1180,7 @@ mod tests {
     fn test_layout(gql: &str) -> Layout {
         let schema = parse_schema(gql).expect("Test schema invalid");
         let subgraph = SubgraphDeploymentId::new("subgraph").unwrap();
-        Layout::new(&schema, IdType::String, subgraph, "rel", false)
-            .expect("Failed to construct Layout")
+        Layout::new(&schema, subgraph, "rel", false).expect("Failed to construct Layout")
     }
 
     #[test]

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -149,7 +149,7 @@ impl TryFrom<&s::Type> for IdType {
         let name = named_type(field_type);
 
         match ValueType::from_str(name)? {
-            ValueType::String | ValueType::ID => Ok(IdType::String),
+            ValueType::String => Ok(IdType::String),
             ValueType::Bytes => Ok(IdType::Bytes),
             _ => Err(format_err!(
                 "The `id` field has type `{}` but only `String`, `Bytes`, and `ID` are allowed",
@@ -911,7 +911,7 @@ impl ColumnType {
             ValueType::BigInt => Ok(ColumnType::BigInt),
             ValueType::Bytes => Ok(ColumnType::Bytes),
             ValueType::Int => Ok(ColumnType::Int),
-            ValueType::String | ValueType::ID => Ok(ColumnType::String),
+            ValueType::String => Ok(ColumnType::String),
             ValueType::List => Err(StoreError::Unknown(format_err!(
                 "can not convert ValueType::List to ColumnType"
             ))),
@@ -1290,8 +1290,7 @@ fn derived_column(field: &s::Field) -> bool {
 fn is_object_type(field_type: &q::Type, enums: &EnumMap) -> bool {
     let name = named_type(field_type);
 
-    !enums.contains_key(&*name)
-        && ValueType::from_str(name).unwrap_or(ValueType::ID) == ValueType::ID
+    !enums.contains_key(&*name) && !ValueType::is_scalar(name)
 }
 
 #[cfg(test)]

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -231,7 +231,7 @@ impl Layout {
                     if types.len() > 1 {
                         Err(format_err!(
                             "The implementations of interface \
-                            {} use different types for the `id` field",
+                            `{}` use different types for the `id` field",
                             interface
                         )
                         .into())

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -14,7 +14,7 @@ use graphql_parser::query as q;
 use graphql_parser::schema as s;
 use inflector::Inflector;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::convert::{From, TryInto};
+use std::convert::{From, TryFrom, TryInto};
 use std::fmt::{self, Write};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -25,6 +25,7 @@ use crate::relational_queries::{
     DeleteDynamicDataSourcesQuery, DeleteQuery, EntityData, FilterCollection, FilterQuery,
     FindManyQuery, FindQuery, InsertQuery, RevertClampQuery, RevertRemoveQuery, UpdateQuery,
 };
+use graph::data::graphql::ext::ObjectTypeExt;
 use graph::data::schema::{FulltextConfig, FulltextDefinition, Schema, SCHEMA_TYPE_NAME};
 use graph::data::subgraph::schema::{
     DynamicEthereumContractDataSourceEntity, POI_OBJECT, POI_TABLE,
@@ -124,11 +125,42 @@ impl fmt::Display for SqlName {
 
 /// The SQL type to use for GraphQL ID properties. We support
 /// strings and byte arrays
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) enum IdType {
     String,
     Bytes,
 }
+
+impl TryFrom<&s::ObjectType> for IdType {
+    type Error = StoreError;
+
+    fn try_from(obj_type: &s::ObjectType) -> Result<Self, Self::Error> {
+        let pk = obj_type
+            .field(&PRIMARY_KEY_COLUMN.to_owned())
+            .expect("Each ObjectType has an `id` field");
+        Self::try_from(&pk.field_type)
+    }
+}
+
+impl TryFrom<&s::Type> for IdType {
+    type Error = StoreError;
+
+    fn try_from(field_type: &s::Type) -> Result<Self, Self::Error> {
+        let name = named_type(field_type);
+
+        match ValueType::from_str(name)? {
+            ValueType::String | ValueType::ID => Ok(IdType::String),
+            ValueType::Bytes => Ok(IdType::Bytes),
+            _ => Err(format_err!(
+                "The `id` field has type `{}` but only `String`, `Bytes`, and `ID` are allowed",
+                &name
+            )
+            .into()),
+        }
+    }
+}
+
+type IdTypeMap = HashMap<String, IdType>;
 
 type EnumMap = BTreeMap<String, Arc<BTreeSet<String>>>;
 
@@ -149,93 +181,111 @@ pub struct Layout {
 
 impl Layout {
     /// Generate a layout for a relational schema for entities in the
-    /// GraphQL schema `document`. Attributes of type `ID` will use the
-    /// SQL type `id_type`. The subgraph ID is passed in `subgraph`, and
-    /// the name of the database schema in which the subgraph's tables live
-    /// is in `schema`.
+    /// GraphQL schema `schema`. The name of the database schema in which
+    /// the subgraph's tables live is in `schema`.
     pub fn new(
-        document: &s::Document,
-        subgraph: SubgraphDeploymentId,
-        schema: impl Into<String>,
+        schema: &Schema,
+        schema_name: &str,
         create_proof_of_indexing: bool,
-    ) -> Result<Layout, StoreError> {
+    ) -> Result<Self, StoreError> {
         use s::Definition::*;
         use s::TypeDefinition::*;
 
-        let schema = schema.into();
-        SqlName::check_valid_identifier(&schema, "database schema")?;
+        SqlName::check_valid_identifier(schema_name, "database schema")?;
 
-        // Extract interfaces and tables
-        let mut tables = Vec::new();
-        let mut enums = EnumMap::new();
-
-        let table_name = SqlName::verbatim(POI_TABLE.to_owned());
-
-        if create_proof_of_indexing {
-            let poi_table = Table {
-                object: POI_OBJECT.to_owned(),
-                qualified_name: SqlName::qualified_name(&schema, &table_name),
-                name: table_name,
-                columns: vec![
-                    Column {
-                        name: SqlName::from("digest"),
-                        field: "digest".to_owned(),
-                        field_type: q::Type::NonNullType(Box::new(q::Type::NamedType(
-                            "String".to_owned(),
-                        ))),
-                        column_type: ColumnType::String,
-                        fulltext_fields: None,
-                        is_reference: false,
-                    },
-                    Column {
-                        name: SqlName::from(PRIMARY_KEY_COLUMN),
-                        field: PRIMARY_KEY_COLUMN.to_owned(),
-                        field_type: q::Type::NonNullType(Box::new(q::Type::NamedType(
-                            "String".to_owned(),
-                        ))),
-                        column_type: ColumnType::String,
-                        fulltext_fields: None,
-                        is_reference: false,
-                    },
-                ],
-                /// The position of this table in all the tables for this layout; this
-                /// is really only needed for the tests to make the names of indexes
-                /// predictable
-                position: tables.len() as u32,
-            };
-            tables.push(poi_table);
-        }
-
-        for definition in &document.definitions {
-            match definition {
-                // Do not create a table for the _Schema_ type
-                TypeDefinition(Object(obj_type)) if obj_type.name.eq(SCHEMA_TYPE_NAME) => {}
-                TypeDefinition(Object(obj_type)) => {
-                    tables.push(Table::new(
-                        obj_type,
-                        &schema,
-                        Schema::entity_fulltext_definitions(&obj_type.name, document),
-                        &enums,
-                        tables.len() as u32,
-                    )?);
+        // Extract enum types
+        let enums: EnumMap = schema
+            .document
+            .definitions
+            .iter()
+            .filter_map(|defn| {
+                if let TypeDefinition(Enum(enum_type)) = defn {
+                    Some(enum_type)
+                } else {
+                    None
                 }
-                TypeDefinition(Interface(_)) => { /* we do not care about interfaces */ }
-                TypeDefinition(Enum(enum_type)) => {
+            })
+            .map(
+                |enum_type| -> Result<(String, Arc<BTreeSet<String>>), StoreError> {
                     SqlName::check_valid_identifier(&enum_type.name, "enum")?;
-                    let values: BTreeSet<_> = enum_type
-                        .values
-                        .iter()
-                        .map(|value| value.name.to_owned())
-                        .collect();
-                    enums.insert(enum_type.name.clone(), Arc::new(values));
+                    Ok((
+                        enum_type.name.clone(),
+                        Arc::new(
+                            enum_type
+                                .values
+                                .iter()
+                                .map(|value| value.name.to_owned())
+                                .collect::<BTreeSet<_>>(),
+                        ),
+                    ))
+                },
+            )
+            .collect::<Result<_, _>>()?;
+
+        // List of all object types that are not __SCHEMA__
+        let object_types = schema
+            .document
+            .definitions
+            .iter()
+            .filter_map(|defn| {
+                if let TypeDefinition(Object(obj_type)) = defn {
+                    Some(obj_type)
+                } else {
+                    None
                 }
-                other => {
-                    return Err(StoreError::Unknown(format_err!(
-                        "can not handle {:?}",
-                        other
-                    )))
-                }
-            }
+            })
+            .filter(|obj_type| obj_type.name != SCHEMA_TYPE_NAME)
+            .collect::<Vec<_>>();
+
+        // For interfaces, check that all implementors use the same IdType
+        // and build a list of name/IdType pairs
+        let id_types_for_interface = schema.types_for_interface.iter().map(|(interface, types)| {
+            types
+                .iter()
+                .map(|obj_type| IdType::try_from(obj_type))
+                .collect::<Result<HashSet<_>, _>>()
+                .and_then(move |types| {
+                    if types.len() > 1 {
+                        Err(format_err!(
+                            "The implementations of interface \
+                            {} use different types for the `id` field",
+                            interface
+                        )
+                        .into())
+                    } else {
+                        // For interfaces that are not implemented at all, pretend
+                        // they have a String `id` field
+                        let id_type = types.iter().next().cloned().unwrap_or(IdType::String);
+                        Ok((interface.to_owned(), id_type))
+                    }
+                })
+        });
+
+        // Map of type name to the type of the ID column for the object_types
+        // and interfaces in the schema
+        let id_types = object_types
+            .iter()
+            .map(|obj_type| IdType::try_from(*obj_type).map(|t| (obj_type.name.to_owned(), t)))
+            .chain(id_types_for_interface)
+            .collect::<Result<IdTypeMap, _>>()?;
+
+        // Construct a Table struct for each ObjectType
+        let mut tables = object_types
+            .iter()
+            .enumerate()
+            .map(|(i, obj_type)| {
+                Table::new(
+                    obj_type,
+                    &schema_name,
+                    Schema::entity_fulltext_definitions(&obj_type.name, &schema.document),
+                    &enums,
+                    &id_types,
+                    i as u32,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if create_proof_of_indexing {
+            tables.push(Self::make_poi_table(&schema_name, tables.len()))
         }
 
         let tables: Vec<_> = tables.into_iter().map(|table| Arc::new(table)).collect();
@@ -245,7 +295,7 @@ impl Layout {
             .map(|table| {
                 format!(
                     "select count(*) from \"{}\".\"{}\" where upper_inf(block_range)",
-                    schema, table.name
+                    schema_name, table.name
                 )
             })
             .collect::<Vec<_>>()
@@ -260,21 +310,55 @@ impl Layout {
             });
 
         Ok(Layout {
-            subgraph,
-            schema,
+            subgraph: schema.id.clone(),
+            schema: schema_name.to_owned(),
             tables,
             enums,
             count_query,
         })
     }
 
+    fn make_poi_table(schema_name: &str, position: usize) -> Table {
+        let table_name = SqlName::verbatim(POI_TABLE.to_owned());
+        Table {
+            object: POI_OBJECT.to_owned(),
+            qualified_name: SqlName::qualified_name(schema_name, &table_name),
+            name: table_name,
+            columns: vec![
+                Column {
+                    name: SqlName::from("digest"),
+                    field: "digest".to_owned(),
+                    field_type: q::Type::NonNullType(Box::new(q::Type::NamedType(
+                        "String".to_owned(),
+                    ))),
+                    column_type: ColumnType::String,
+                    fulltext_fields: None,
+                    is_reference: false,
+                },
+                Column {
+                    name: SqlName::from(PRIMARY_KEY_COLUMN),
+                    field: PRIMARY_KEY_COLUMN.to_owned(),
+                    field_type: q::Type::NonNullType(Box::new(q::Type::NamedType(
+                        "String".to_owned(),
+                    ))),
+                    column_type: ColumnType::String,
+                    fulltext_fields: None,
+                    is_reference: false,
+                },
+            ],
+            /// The position of this table in all the tables for this layout; this
+            /// is really only needed for the tests to make the names of indexes
+            /// predictable
+            position: position as u32,
+        }
+    }
+
     pub fn create_relational_schema(
         conn: &PgConnection,
+        schema: &Schema,
         schema_name: &str,
-        subgraph: SubgraphDeploymentId,
-        document: &s::Document,
     ) -> Result<Layout, StoreError> {
-        let layout = Self::new(document, subgraph, schema_name, true)?;
+        let layout = Self::new(schema, schema_name, true)?;
         let sql = layout
             .as_ddl()
             .map_err(|_| StoreError::Unknown(format_err!("failed to generate DDL for layout")))?;
@@ -798,8 +882,14 @@ impl ColumnType {
         field_type: &q::Type,
         schema: &str,
         enums: &EnumMap,
+        id_types: &IdTypeMap,
     ) -> Result<ColumnType, StoreError> {
         let name = named_type(field_type);
+
+        // See if its an object type defined in the schema
+        if let Some(id_type) = id_types.get(name) {
+            return Ok(id_type.clone().into());
+        }
 
         // Check if it's an enum, and if it is, return an appropriate
         // ColumnType::Enum
@@ -813,10 +903,9 @@ impl ColumnType {
             }));
         }
 
-        // It is not an enum, and therefore one of our builtin primitive types
-        // or a reference to another type. For the latter, we use `ValueType::ID`
-        // as the underlying type
-        match ValueType::from_str(name).unwrap_or(ValueType::ID) {
+        // It is not an object type or an enum, and therefore one of our
+        // builtin primitive types
+        match ValueType::from_str(name)? {
             ValueType::Boolean => Ok(ColumnType::Boolean),
             ValueType::BigDecimal => Ok(ColumnType::BigDecimal),
             ValueType::BigInt => Ok(ColumnType::BigInt),
@@ -849,7 +938,10 @@ impl ColumnType {
         match self {
             ColumnType::String => IdType::String,
             ColumnType::BytesId => IdType::Bytes,
-            _ => unreachable!("only String and Bytes are allowed as primary keys"),
+            _ => unreachable!(
+                "only String and BytesId are allowed as primary keys but not {:?}",
+                self
+            ),
         }
     }
 }
@@ -865,17 +957,27 @@ pub struct Column {
 }
 
 impl Column {
-    fn new(field: &s::Field, schema: &str, enums: &EnumMap) -> Result<Column, StoreError> {
+    fn new(
+        field: &s::Field,
+        schema: &str,
+        enums: &EnumMap,
+        id_types: &IdTypeMap,
+    ) -> Result<Column, StoreError> {
         SqlName::check_valid_identifier(&*field.name, "attribute")?;
 
         let sql_name = SqlName::from(&*field.name);
         let is_reference =
             sql_name.as_str() != PRIMARY_KEY_COLUMN && is_object_type(&field.field_type, enums);
 
+        let column_type = if sql_name.as_str() == PRIMARY_KEY_COLUMN {
+            IdType::try_from(&field.field_type)?.into()
+        } else {
+            ColumnType::from_field_type(&field.field_type, schema, enums, id_types)?
+        };
         Ok(Column {
             name: sql_name,
             field: field.name.clone(),
-            column_type: ColumnType::from_field_type(&field.field_type, schema, enums)?,
+            column_type,
             field_type: field.field_type.clone(),
             fulltext_fields: None,
             is_reference,
@@ -1028,6 +1130,7 @@ impl Table {
         schema: &str,
         fulltexts: Vec<FulltextDefinition>,
         enums: &EnumMap,
+        id_types: &IdTypeMap,
         position: u32,
     ) -> Result<Table, StoreError> {
         SqlName::check_valid_identifier(&*defn.name, "object")?;
@@ -1037,7 +1140,7 @@ impl Table {
             .fields
             .iter()
             .filter(|field| !derived_column(field))
-            .map(|field| Column::new(field, schema, enums))
+            .map(|field| Column::new(field, schema, enums, id_types))
             .chain(fulltexts.iter().map(|def| Column::new_fulltext(def)))
             .collect::<Result<Vec<Column>, StoreError>>()?;
 
@@ -1194,14 +1297,13 @@ fn is_object_type(field_type: &q::Type, enums: &EnumMap) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use graphql_parser::parse_schema;
 
     const ID_TYPE: ColumnType = ColumnType::String;
 
     fn test_layout(gql: &str) -> Layout {
-        let schema = parse_schema(gql).expect("Test schema invalid");
         let subgraph = SubgraphDeploymentId::new("subgraph").unwrap();
-        Layout::new(&schema, subgraph, "rel", false).expect("Failed to construct Layout")
+        let schema = Schema::parse(gql, subgraph).expect("Test schema invalid");
+        Layout::new(&schema, "rel", false).expect("Failed to construct Layout")
     }
 
     #[test]

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2041,7 +2041,7 @@ pub struct RevertEntityData {
 impl RevertEntityData {
     /// Convert primary key ids from Postgres' internal form to the format we
     /// use by stripping `\\x` off the front of bytes strings
-    fn convert(table: &Table, mut data: Vec<RevertEntityData>) -> Vec<RevertEntityData> {
+    fn bytes_as_str(table: &Table, mut data: Vec<RevertEntityData>) -> Vec<RevertEntityData> {
         match table.primary_key().column_type.id_type() {
             IdType::String => data,
             IdType::Bytes => {
@@ -2092,7 +2092,7 @@ impl<'a> QueryId for RevertRemoveQuery<'a> {
 impl<'a> LoadQuery<PgConnection, RevertEntityData> for RevertRemoveQuery<'a> {
     fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
         conn.query_by_name(&self)
-            .map(|data| RevertEntityData::convert(&self.table, data))
+            .map(|data| RevertEntityData::bytes_as_str(&self.table, data))
     }
 }
 
@@ -2144,7 +2144,7 @@ impl<'a> QueryId for RevertClampQuery<'a> {
 impl<'a> LoadQuery<PgConnection, RevertEntityData> for RevertClampQuery<'a> {
     fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
         conn.query_by_name(&self)
-            .map(|data| RevertEntityData::convert(&self.table, data))
+            .map(|data| RevertEntityData::bytes_as_str(&self.table, data))
     }
 }
 
@@ -2236,7 +2236,7 @@ impl<'a> QueryId for DeleteByPrefixQuery<'a> {
 impl<'a> LoadQuery<PgConnection, RevertEntityData> for DeleteByPrefixQuery<'a> {
     fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
         conn.query_by_name(&self)
-            .map(|data| RevertEntityData::convert(&self.table, data))
+            .map(|data| RevertEntityData::bytes_as_str(&self.table, data))
     }
 }
 

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -8,7 +8,7 @@
 use diesel::pg::{Pg, PgConnection};
 use diesel::query_builder::{AstPass, QueryFragment, QueryId};
 use diesel::query_dsl::{LoadQuery, RunQueryDsl};
-use diesel::result::QueryResult;
+use diesel::result::{Error as DieselError, QueryResult};
 use diesel::sql_types::{Array, Binary, Bool, Integer, Jsonb, Numeric, Range, Text};
 use diesel::Connection;
 use std::collections::{BTreeMap, HashSet};
@@ -28,8 +28,55 @@ use crate::block_range::{
 };
 use crate::entities::STRING_PREFIX_SIZE;
 use crate::filter::UnsupportedFilter;
-use crate::relational::{Column, ColumnType, Layout, SqlName, Table, PRIMARY_KEY_COLUMN};
+use crate::relational::{Column, ColumnType, IdType, Layout, SqlName, Table, PRIMARY_KEY_COLUMN};
 use crate::sql_value::SqlValue;
+
+fn str_as_bytes(id: &str) -> QueryResult<scalar::Bytes> {
+    scalar::Bytes::from_str(&id).map_err(|e| DieselError::SerializationError(Box::new(e)))
+}
+
+/// Convert Postgres string representation of bytes "\xdeadbeef"
+/// to ours of just "deadbeef".
+fn bytes_as_str(id: &str) -> String {
+    id.trim_start_matches("\\x").to_owned()
+}
+
+/// Conveniences for handling primary keys depending on whether we are using
+/// `IdType::Bytes` or `IdType::String` as the primary key
+struct PrimaryKey {}
+
+impl PrimaryKey {
+    fn eq(table: &Table, id: &str, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        let pk = table.primary_key();
+
+        out.push_sql(pk.name.as_str());
+        out.push_sql(" = ");
+        match pk.column_type.id_type() {
+            IdType::String => out.push_bind_param::<Text, _>(&id),
+            IdType::Bytes => out.push_bind_param::<Binary, _>(&str_as_bytes(&id)?.as_slice()),
+        }
+    }
+
+    fn is_in(table: &Table, ids: &Vec<&str>, out: &mut AstPass<Pg>) -> QueryResult<()> {
+        let pk = table.primary_key();
+
+        out.push_sql(pk.name.as_str());
+        out.push_sql(" = any(");
+        match pk.column_type.id_type() {
+            IdType::String => out.push_bind_param::<Array<Text>, _>(ids)?,
+            IdType::Bytes => {
+                let ids = ids
+                    .into_iter()
+                    .map(|id| str_as_bytes(id))
+                    .collect::<Result<Vec<scalar::Bytes>, _>>()?;
+                let id_slices = ids.iter().map(|id| id.as_slice()).collect::<Vec<_>>();
+                out.push_bind_param::<Array<Binary>, _>(&id_slices)?;
+            }
+        }
+        out.push_sql(")");
+        Ok(())
+    }
+}
 
 /// Helper struct for retrieving entities from the database. With diesel, we
 /// can only run queries that return columns whose number and type are known
@@ -105,6 +152,7 @@ impl EntityData {
                         StoreError::Unknown(format_err!("failed to convert {} to Bytes: {}", s, e))
                     })
             }
+            (j::String(s), ColumnType::BytesId) => Ok(g::String(bytes_as_str(&s))),
             (j::String(s), column_type) => Err(StoreError::Unknown(format_err!(
                 "can not convert string {} to {:?}",
                 s,
@@ -186,6 +234,11 @@ impl<'a> QueryFragment<Pg> for QueryValue<'a> {
                     out.push_sql(")");
                     Ok(())
                 }
+                ColumnType::Bytes | ColumnType::BytesId => {
+                    let bytes = scalar::Bytes::from_str(&s)
+                        .map_err(|e| DieselError::SerializationError(Box::new(e)))?;
+                    out.push_bind_param::<Binary, _>(&bytes.as_slice())
+                }
                 _ => unreachable!(
                     "only string, enum and tsvector columns have values of type string"
                 ),
@@ -237,6 +290,7 @@ impl<'a> QueryFragment<Pg> for QueryValue<'a> {
                         out.push_sql("))");
                         Ok(())
                     }
+                    ColumnType::BytesId => out.push_bind_param::<Array<Binary>, _>(&values),
                 }
             }
             Value::Null => {
@@ -810,9 +864,7 @@ impl<'a> QueryFragment<Pg> for FindQuery<'a> {
         out.push_sql("  from ");
         out.push_sql(self.table.qualified_name.as_str());
         out.push_sql(" e\n where ");
-        out.push_identifier(PRIMARY_KEY_COLUMN)?;
-        out.push_sql(" = ");
-        out.push_bind_param::<Text, _>(&self.id)?;
+        PrimaryKey::eq(&self.table, &self.id, &mut out)?;
         out.push_sql(" and ");
         BlockRangeContainsClause::new("e.", self.block).walk_ast(out)
     }
@@ -864,10 +916,8 @@ impl<'a> QueryFragment<Pg> for FindManyQuery<'a> {
             out.push_sql("  from ");
             out.push_sql(table.qualified_name.as_str());
             out.push_sql(" e\n where ");
-            out.push_identifier(PRIMARY_KEY_COLUMN)?;
-            out.push_sql(" = any(");
-            out.push_bind_param::<Array<Text>, _>(&self.ids_for_type[table.object.as_str()])?;
-            out.push_sql(") and ");
+            PrimaryKey::is_in(table, &self.ids_for_type[table.object.as_str()], &mut out)?;
+            out.push_sql(" and ");
             BlockRangeContainsClause::new("e.", self.block).walk_ast(out.reborrow())?;
         }
         Ok(())
@@ -1013,7 +1063,7 @@ impl<'a> QueryFragment<Pg> for UpdateQuery<'a> {
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
 
-        let updateable = { |column: &Column| column.name.as_str() != PRIMARY_KEY_COLUMN };
+        let updateable = { |column: &Column| !column.is_primary_key() };
 
         // Construct a query
         //   update schema.table1
@@ -1050,9 +1100,7 @@ impl<'a> QueryFragment<Pg> for UpdateQuery<'a> {
             QueryValue(value, &column.column_type).walk_ast(out.reborrow())?;
         }
         out.push_sql("\n where ");
-        out.push_identifier(PRIMARY_KEY_COLUMN)?;
-        out.push_sql(" = ");
-        out.push_bind_param::<Text, _>(&self.key.entity_id)?;
+        PrimaryKey::eq(&self.table, &self.key.entity_id, &mut out)?;
         Ok(())
     }
 }
@@ -1079,13 +1127,10 @@ impl<'a> QueryFragment<Pg> for DeleteQuery<'a> {
         // Construct a query
         //   delete from table
         //    where id = $key.entity_id
-        //   returning id
         out.push_sql("delete from ");
         out.push_sql(self.table.qualified_name.as_str());
         out.push_sql("\n where ");
-        out.push_identifier(PRIMARY_KEY_COLUMN)?;
-        out.push_sql(" = ");
-        out.push_bind_param::<Text, _>(&self.key.entity_id)
+        PrimaryKey::eq(&self.table, &self.key.entity_id, &mut out)
     }
 }
 
@@ -1520,7 +1565,7 @@ impl<'a> SortKey<'a> {
     fn select(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
         if let Some(column) = self.column {
             let name = column.name.as_str();
-            if name != PRIMARY_KEY_COLUMN {
+            if !column.is_primary_key() {
                 out.push_sql(", c.");
                 out.push_identifier(name)?;
             }
@@ -1969,9 +2014,7 @@ impl<'a> QueryFragment<Pg> for ClampRangeQuery<'a> {
         out.push_sql("), ");
         out.push_bind_param::<Integer, _>(&self.block)?;
         out.push_sql(")\n where ");
-        out.push_identifier(PRIMARY_KEY_COLUMN)?;
-        out.push_sql(" = ");
-        out.push_bind_param::<Text, _>(&self.key.entity_id)?;
+        PrimaryKey::eq(&self.table, &self.key.entity_id, &mut out)?;
         out.push_sql(" and (");
         out.push_sql(BLOCK_RANGE_CURRENT);
         out.push_sql(")");
@@ -1995,8 +2038,24 @@ pub struct RevertEntityData {
     pub id: String,
 }
 
+impl RevertEntityData {
+    /// Convert primary key ids from Postgres' internal form to the format we
+    /// use by stripping `\\x` off the front of bytes strings
+    fn convert(table: &Table, mut data: Vec<RevertEntityData>) -> Vec<RevertEntityData> {
+        match table.primary_key().column_type.id_type() {
+            IdType::String => data,
+            IdType::Bytes => {
+                for entry in data.iter_mut() {
+                    entry.id = bytes_as_str(&entry.id);
+                }
+                data
+            }
+        }
+    }
+}
+
 /// A query that removes all versions whose block range lies entirely
-/// beyond `block`
+/// beyond `block`.
 #[derive(Debug, Clone, Constructor)]
 pub struct RevertRemoveQuery<'a> {
     table: &'a Table,
@@ -2018,7 +2077,9 @@ impl<'a> QueryFragment<Pg> for RevertRemoveQuery<'a> {
         out.push_sql(") >= ");
         out.push_bind_param::<Integer, _>(&self.block)?;
         out.push_sql("\nreturning ");
-        out.push_identifier(PRIMARY_KEY_COLUMN)
+        out.push_sql(PRIMARY_KEY_COLUMN);
+        out.push_sql("::text");
+        Ok(())
     }
 }
 
@@ -2031,13 +2092,14 @@ impl<'a> QueryId for RevertRemoveQuery<'a> {
 impl<'a> LoadQuery<PgConnection, RevertEntityData> for RevertRemoveQuery<'a> {
     fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
         conn.query_by_name(&self)
+            .map(|data| RevertEntityData::convert(&self.table, data))
     }
 }
 
 impl<'a, Conn> RunQueryDsl<Conn> for RevertRemoveQuery<'a> {}
 
 /// A query that unclamps the block range of all versions that contain
-/// `block` by setting the upper bound of the block range to infinity
+/// `block` by setting the upper bound of the block range to infinity.
 #[derive(Debug, Clone, Constructor)]
 pub struct RevertClampQuery<'a> {
     table: &'a Table,
@@ -2067,7 +2129,9 @@ impl<'a> QueryFragment<Pg> for RevertClampQuery<'a> {
         out.push_sql(" and not ");
         out.push_sql(BLOCK_RANGE_CURRENT);
         out.push_sql("\nreturning ");
-        out.push_identifier(PRIMARY_KEY_COLUMN)
+        out.push_sql(PRIMARY_KEY_COLUMN);
+        out.push_sql("::text");
+        Ok(())
     }
 }
 
@@ -2080,6 +2144,7 @@ impl<'a> QueryId for RevertClampQuery<'a> {
 impl<'a> LoadQuery<PgConnection, RevertEntityData> for RevertClampQuery<'a> {
     fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
         conn.query_by_name(&self)
+            .map(|data| RevertEntityData::convert(&self.table, data))
     }
 }
 
@@ -2156,7 +2221,9 @@ impl<'a> QueryFragment<Pg> for DeleteByPrefixQuery<'a> {
         out.push_sql(") = any(");
         out.push_bind_param::<Array<Text>, _>(&self.prefixes)?;
         out.push_sql(")\nreturning ");
-        out.push_identifier(PRIMARY_KEY_COLUMN)
+        out.push_sql(PRIMARY_KEY_COLUMN);
+        out.push_sql("::text");
+        Ok(())
     }
 }
 
@@ -2169,6 +2236,7 @@ impl<'a> QueryId for DeleteByPrefixQuery<'a> {
 impl<'a> LoadQuery<PgConnection, RevertEntityData> for DeleteByPrefixQuery<'a> {
     fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
         conn.query_by_name(&self)
+            .map(|data| RevertEntityData::convert(&self.table, data))
     }
 }
 

--- a/store/postgres/src/sql_value.rs
+++ b/store/postgres/src/sql_value.rs
@@ -2,8 +2,9 @@ use diesel::pg::Pg;
 use diesel::serialize::{self, Output, ToSql};
 use diesel::sql_types::{Binary, Bool, Integer, Numeric, Text};
 use std::io::Write;
+use std::str::FromStr;
 
-use graph::data::store::Value;
+use graph::data::store::{scalar, Value};
 
 #[derive(Clone, Debug, PartialEq, AsExpression)]
 pub struct SqlValue(Value);
@@ -58,6 +59,9 @@ impl ToSql<Binary, Pg> for SqlValue {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
         match self.0 {
             Value::Bytes(ref h) => <_ as ToSql<Binary, Pg>>::to_sql(&h.as_slice(), out),
+            Value::String(ref s) => {
+                <_ as ToSql<Binary, Pg>>::to_sql(scalar::Bytes::from_str(s)?.as_slice(), out)
+            }
             _ => panic!("Failed to convert attribute value to Bytes in SQL"),
         }
     }

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -1183,11 +1183,11 @@ fn find_order_by_float() {
 fn find_order_by_id() {
     test_find(
         vec!["1", "2", "3"],
-        user_query().order_by("id", ValueType::ID, EntityOrder::Ascending),
+        user_query().order_by("id", ValueType::String, EntityOrder::Ascending),
     );
     test_find(
         vec!["3", "2", "1"],
-        user_query().order_by("id", ValueType::ID, EntityOrder::Descending),
+        user_query().order_by("id", ValueType::String, EntityOrder::Descending),
     );
 }
 

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -300,15 +300,8 @@ fn insert_test_data(conn: &PgConnection) -> Layout {
     let query = format!("create schema {}", SCHEMA_NAME);
     conn.batch_execute(&*query).unwrap();
 
-    let layout = Layout::create_relational_schema(
-        &conn,
-        SCHEMA_NAME,
-        THINGS_SUBGRAPH_ID.clone(),
-        &schema.document,
-    )
-    .expect("Failed to create relational schema");
-
-    layout
+    Layout::create_relational_schema(&conn, &schema, SCHEMA_NAME)
+        .expect("Failed to create relational schema")
 }
 
 fn scrub(entity: &Entity) -> Entity {

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -82,15 +82,8 @@ fn create_schema(conn: &PgConnection) -> Layout {
     let query = format!("create schema {}", SCHEMA_NAME);
     conn.batch_execute(&*query).unwrap();
 
-    let layout = Layout::create_relational_schema(
-        &conn,
-        SCHEMA_NAME,
-        THINGS_SUBGRAPH_ID.clone(),
-        &schema.document,
-    )
-    .expect("Failed to create relational schema");
-
-    layout
+    Layout::create_relational_schema(&conn, &schema, SCHEMA_NAME)
+        .expect("Failed to create relational schema")
 }
 
 fn scrub(entity: &Entity) -> Entity {
@@ -181,7 +174,7 @@ fn bad_id() {
         let res = layout.find(conn, "Thing", "\\xbadd", BLOCK_NUMBER_MAX);
         assert!(res.is_err());
         assert_eq!(
-            "store error: Invalid character \'\\\' at position 0",
+            "store error: Invalid character \'\\\\\' at position 0",
             res.err().unwrap().to_string()
         );
 

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -26,6 +26,21 @@ const THINGS_GQL: &str = "
 
 const SCHEMA_NAME: &str = "layout";
 
+macro_rules! entity {
+    ($($name:ident: $value:expr,)*) => {
+        {
+            let mut result = ::graph::prelude::Entity::new();
+            $(
+                result.insert(stringify!($name).to_string(), Value::from($value));
+            )*
+            result
+        }
+    };
+    ($($name:ident: $value:expr),*) => {
+        entity! {$($name: $value,)*}
+    };
+}
+
 lazy_static! {
     static ref THINGS_SUBGRAPH_ID: SubgraphDeploymentId =
         SubgraphDeploymentId::new("things").unwrap();
@@ -41,12 +56,10 @@ lazy_static! {
     static ref BYTES_VALUE3: H256 = H256::from(hex!(
         "977c084229c72a0fa377cae304eda9099b6a2cb5d83b25cdf0f0969b69874255"
     ));
-    static ref BEEF_ENTITY: Entity = {
-        let mut entity = Entity::new();
-        entity.set("id", "deadbeef");
-        entity.set("name", "Beef");
-        entity.set("__typename", "Thing");
-        entity
+    static ref BEEF_ENTITY: Entity = entity! {
+        id: "deadbeef",
+        name: "Beef",
+        __typename: "Thing"
     };
 }
 
@@ -68,12 +81,15 @@ fn insert_entity(conn: &PgConnection, layout: &Layout, entity_type: &str, entity
 }
 
 fn insert_thing(conn: &PgConnection, layout: &Layout, id: &str, name: &str) {
-    let mut thing = Entity::new();
-
-    thing.insert("id".to_owned(), Value::String(id.to_owned()));
-    thing.insert("name".to_owned(), Value::String(name.to_owned()));
-
-    insert_entity(conn, layout, "Thing", thing);
+    insert_entity(
+        conn,
+        layout,
+        "Thing",
+        entity! {
+            id: id,
+            name: name
+        },
+    );
 }
 
 fn create_schema(conn: &PgConnection) -> Layout {

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -1,0 +1,310 @@
+//! Test relational schemas that use `Bytes` to store ids
+use diesel::connection::SimpleConnection as _;
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+use futures::future::IntoFuture;
+use hex_literal::hex;
+use lazy_static::lazy_static;
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+use graph::data::store::scalar::{BigDecimal, BigInt};
+use graph::prelude::{
+    bigdecimal::One, web3::types::H256, Entity, EntityKey, Future01CompatExt, Schema,
+    SubgraphDeploymentId, Value, BLOCK_NUMBER_MAX,
+};
+use graph_store_postgres::layout_for_tests::Layout;
+
+use test_store::*;
+
+const THINGS_GQL: &str = "
+    type Thing @entity {
+        id: Bytes!
+        name: String!
+    }
+";
+
+const SCHEMA_NAME: &str = "layout";
+
+lazy_static! {
+    static ref THINGS_SUBGRAPH_ID: SubgraphDeploymentId =
+        SubgraphDeploymentId::new("things").unwrap();
+    static ref LARGE_INT: BigInt = BigInt::from(std::i64::MAX).pow(17);
+    static ref LARGE_DECIMAL: BigDecimal =
+        BigDecimal::one() / LARGE_INT.clone().to_big_decimal(BigInt::from(1));
+    static ref BYTES_VALUE: H256 = H256::from(hex!(
+        "e8b3b02b936c4a4a331ac691ac9a86e197fb7731f14e3108602c87d4dac55160"
+    ));
+    static ref BYTES_VALUE2: H256 = H256::from(hex!(
+        "b98fb783b49de5652097a989414c767824dff7e7fd765a63b493772511db81c1"
+    ));
+    static ref BYTES_VALUE3: H256 = H256::from(hex!(
+        "977c084229c72a0fa377cae304eda9099b6a2cb5d83b25cdf0f0969b69874255"
+    ));
+    static ref BEEF_ENTITY: Entity = {
+        let mut entity = Entity::new();
+        entity.set("id", "deadbeef");
+        entity.set("name", "Beef");
+        entity.set("__typename", "Thing");
+        entity
+    };
+}
+
+/// Removes test data from the database behind the store.
+fn remove_test_data(conn: &PgConnection) {
+    let query = format!("drop schema if exists {} cascade", SCHEMA_NAME);
+    conn.batch_execute(&query)
+        .expect("Failed to drop test schema");
+}
+
+fn insert_entity(conn: &PgConnection, layout: &Layout, entity_type: &str, entity: Entity) {
+    let key = EntityKey {
+        subgraph_id: THINGS_SUBGRAPH_ID.clone(),
+        entity_type: entity_type.to_owned(),
+        entity_id: entity.id().unwrap(),
+    };
+    let errmsg = format!("Failed to insert entity {}[{}]", entity_type, key.entity_id);
+    layout.insert(&conn, &key, entity, 0).expect(&errmsg);
+}
+
+fn insert_thing(conn: &PgConnection, layout: &Layout, id: &str, name: &str) {
+    let mut thing = Entity::new();
+
+    thing.insert("id".to_owned(), Value::String(id.to_owned()));
+    thing.insert("name".to_owned(), Value::String(name.to_owned()));
+
+    insert_entity(conn, layout, "Thing", thing);
+}
+
+fn create_schema(conn: &PgConnection) -> Layout {
+    let schema = Schema::parse(THINGS_GQL, THINGS_SUBGRAPH_ID.clone()).unwrap();
+
+    let query = format!("create schema {}", SCHEMA_NAME);
+    conn.batch_execute(&*query).unwrap();
+
+    let layout = Layout::create_relational_schema(
+        &conn,
+        SCHEMA_NAME,
+        THINGS_SUBGRAPH_ID.clone(),
+        &schema.document,
+    )
+    .expect("Failed to create relational schema");
+
+    layout
+}
+
+fn scrub(entity: &Entity) -> Entity {
+    let mut scrubbed = Entity::new();
+    // merge has the sideffect of removing any attribute
+    // that is Value::Null
+    scrubbed.merge(entity.clone());
+    scrubbed
+}
+
+macro_rules! assert_entity_eq {
+    ($left:expr, $right:expr) => {{
+        let (left, right) = (&($left), &($right));
+        let mut pass = true;
+
+        for (key, left_value) in left.iter() {
+            match right.get(key) {
+                None => {
+                    pass = false;
+                    println!("key '{}' missing from right", key);
+                }
+                Some(right_value) => {
+                    if left_value != right_value {
+                        pass = false;
+                        println!(
+                            "values for '{}' differ:\n     left: {:?}\n    right: {:?}",
+                            key, left_value, right_value
+                        );
+                    }
+                }
+            }
+        }
+        for key in right.keys() {
+            if left.get(key).is_none() {
+                pass = false;
+                println!("key '{}' missing from left", key);
+            }
+        }
+        assert!(pass, "left and right entities are different");
+    }};
+}
+
+/// Test harness for running database integration tests.
+fn run_test<R, F>(test: F)
+where
+    F: FnOnce(&PgConnection, &Layout) -> R + Send + 'static,
+    R: IntoFuture<Item = ()> + Send + 'static,
+    R::Error: Send + Debug,
+    R::Future: Send,
+{
+    let url = postgres_test_url();
+    let conn = PgConnection::establish(url.as_str()).expect("Failed to connect to Postgres");
+
+    // Lock regardless of poisoning. This also forces sequential test execution.
+    let mut runtime = match STORE_RUNTIME.lock() {
+        Ok(guard) => guard,
+        Err(err) => err.into_inner(),
+    };
+
+    runtime
+        .block_on(async {
+            // Reset state before starting
+            remove_test_data(&conn);
+
+            // Seed database with test data
+            let layout = create_schema(&conn);
+
+            // Run test
+            test(&conn, &layout).into_future().compat().await
+        })
+        .expect("Failed to run ChainHead test");
+}
+
+#[test]
+fn bad_id() {
+    run_test(|conn, layout| -> Result<(), ()> {
+        // We test that we get errors for various strings that are not
+        // valid 'Bytes' strings; we use `find` to force the conversion
+        // from String -> Bytes internally
+        let res = layout.find(conn, "Thing", "bad", BLOCK_NUMBER_MAX);
+        assert!(res.is_err());
+        assert_eq!(
+            "store error: Odd number of digits",
+            res.err().unwrap().to_string()
+        );
+
+        // We do not allow the `\x` prefix that Postgres uses
+        let res = layout.find(conn, "Thing", "\\xbadd", BLOCK_NUMBER_MAX);
+        assert!(res.is_err());
+        assert_eq!(
+            "store error: Invalid character \'\\\' at position 0",
+            res.err().unwrap().to_string()
+        );
+
+        // Having the '0x' prefix is ok
+        let res = layout.find(conn, "Thing", "0xbadd", BLOCK_NUMBER_MAX);
+        assert!(res.is_ok());
+
+        // Using non-hex characters is also bad
+        let res = layout.find(conn, "Thing", "nope", BLOCK_NUMBER_MAX);
+        assert!(res.is_err());
+        assert_eq!(
+            "store error: Invalid character \'n\' at position 0",
+            res.err().unwrap().to_string()
+        );
+
+        Ok(())
+    });
+}
+
+#[test]
+fn find() {
+    run_test(|conn, layout| -> Result<(), ()> {
+        const ID: &str = "deadbeef";
+        const NAME: &str = "Beef";
+        insert_thing(&conn, &layout, ID, NAME);
+
+        // Happy path: find existing entity
+        let entity = layout
+            .find(conn, "Thing", ID, BLOCK_NUMBER_MAX)
+            .expect("Failed to read Thing[deadbeef]")
+            .unwrap();
+        assert_entity_eq!(scrub(&*BEEF_ENTITY), entity);
+
+        // Find non-existing entity
+        let entity = layout
+            .find(conn, "Thing", "badd", BLOCK_NUMBER_MAX)
+            .expect("Failed to read Thing[badd]");
+        assert!(entity.is_none());
+        Ok(())
+    });
+}
+
+#[test]
+fn find_many() {
+    run_test(|conn, layout| -> Result<(), ()> {
+        const ID: &str = "deadbeef";
+        const NAME: &str = "Beef";
+        const ID2: &str = "deadbeef02";
+        const NAME2: &str = "Moo";
+        insert_thing(&conn, &layout, ID, NAME);
+        insert_thing(&conn, &layout, ID2, NAME2);
+
+        let mut id_map: BTreeMap<&str, Vec<&str>> = BTreeMap::default();
+        id_map.insert("Thing", vec![ID, ID2, "badd"]);
+
+        let entities = layout
+            .find_many(conn, id_map, BLOCK_NUMBER_MAX)
+            .expect("Failed to read many things");
+        assert_eq!(1, entities.len());
+
+        let ids = entities
+            .get("Thing")
+            .expect("We got some things")
+            .iter()
+            .map(|thing| thing.id().unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(2, ids.len());
+        assert!(ids.contains(&ID.to_owned()), "Missing ID");
+        assert!(ids.contains(&ID2.to_owned()), "Missing ID2");
+        Ok(())
+    });
+}
+
+#[test]
+fn update() {
+    run_test(|conn, layout| -> Result<(), ()> {
+        insert_entity(&conn, &layout, "Thing", BEEF_ENTITY.clone());
+
+        // Update the entity
+        let mut entity = BEEF_ENTITY.clone();
+        entity.set("name", "Moo");
+        let key = EntityKey {
+            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
+            entity_type: "Thing".to_owned(),
+            entity_id: entity.id().unwrap().clone(),
+        };
+        layout
+            .update(&conn, &key, entity.clone(), 1)
+            .expect("Failed to update");
+
+        let actual = layout
+            .find(conn, "Thing", &entity.id().unwrap(), BLOCK_NUMBER_MAX)
+            .expect("Failed to read Thing[deadbeef]")
+            .unwrap();
+        assert_entity_eq!(scrub(&entity), actual);
+        Ok(())
+    });
+}
+
+#[test]
+fn delete() {
+    run_test(|conn, layout| -> Result<(), ()> {
+        const TWO_ID: &str = "deadbeef02";
+
+        insert_entity(&conn, &layout, "Thing", BEEF_ENTITY.clone());
+        let mut two = BEEF_ENTITY.clone();
+        two.set("id", TWO_ID);
+        insert_entity(&conn, &layout, "Thing", two);
+
+        // Delete where nothing is getting deleted
+        let mut key = EntityKey {
+            subgraph_id: THINGS_SUBGRAPH_ID.clone(),
+            entity_type: "Thing".to_owned(),
+            entity_id: "ffff".to_owned(),
+        };
+        let count = layout.delete(&conn, &key, 1).expect("Failed to delete");
+        assert_eq!(0, count);
+
+        // Delete entity two
+        key.entity_id = TWO_ID.to_owned();
+        let count = layout.delete(&conn, &key, 1).expect("Failed to delete");
+        assert_eq!(1, count);
+        Ok(())
+    });
+}

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1051,11 +1051,11 @@ fn find_order_by_float() {
 fn find_order_by_id() {
     test_find(
         vec!["1", "2", "3"],
-        user_query().order_by("id", ValueType::ID, EntityOrder::Ascending),
+        user_query().order_by("id", ValueType::String, EntityOrder::Ascending),
     );
     test_find(
         vec!["3", "2", "1"],
-        user_query().order_by("id", ValueType::ID, EntityOrder::Descending),
+        user_query().order_by("id", ValueType::String, EntityOrder::Descending),
     );
 }
 


### PR DESCRIPTION
These changes make it so that the `id` field of an entity can either be of type `String` or of type `Bytes` in the subgraph's GraphQL schema. For backwards compatibility, the type `ID` can also be used, though it is now officially a synonym for `String`.

The distinction between `Bytes` and `String` only affects how the `id` of entities is stored in the database, either in a `bytea` or a `text` column. The rest of the code (e.g., `Entity`) uses strings always.

Fixes #1414 

(Replaces PR #1445 as the code had changed a lot since that PR was opened)