### PR TITLE
Refactor some of the GraphQL query execution

### DIFF
--- a/core/src/graphql/runner.rs
+++ b/core/src/graphql/runner.rs
@@ -92,7 +92,7 @@ where
 
     fn run_subscription(&self, subscription: Subscription) -> SubscriptionResultFuture {
         let result = execute_subscription(
-            &subscription,
+            subscription,
             SubscriptionExecutionOptions {
                 logger: self.logger.clone(),
                 resolver: StoreResolver::new(&self.logger, self.store.clone()),

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -42,60 +42,59 @@ where
         //
         // See also: ed42d219c6704a4aab57ce1ea66698e7.
         // Note: This query needs to be in sync with the metadata schema.
-        Ok(Query {
-            schema,
-            document: parse_query(
-                r#"
-                query deployment($id: ID!, $skip: Int!) {
-                  subgraphDeployment(id: $id) {
-                    dynamicDataSources(orderBy: id, skip: $skip) {
+        let document = parse_query(
+            r#"
+            query deployment($id: ID!, $skip: Int!) {
+              subgraphDeployment(id: $id) {
+                dynamicDataSources(orderBy: id, skip: $skip) {
+                  kind
+                  network
+                  name
+                  context
+                  source { address abi }
+                  mapping {
+                    kind
+                    apiVersion
+                    language
+                    file
+                    entities
+                    abis { name file }
+                    blockHandlers { handler filter }
+                    callHandlers {  function handler }
+                    eventHandlers { event handler topic0 }
+                  }
+                  templates {
+                    kind
+                    network
+                    name
+                    source { abi }
+                    mapping {
                       kind
-                      network
-                      name
-                      context
-                      source { address abi }
-                      mapping {
-                        kind
-                        apiVersion
-                        language
-                        file
-                        entities
-                        abis { name file }
-                        blockHandlers { handler filter }
-                        callHandlers {  function handler }
-                        eventHandlers { event handler topic0 }
-                      }
-                      templates {
-                        kind
-                        network
-                        name
-                        source { abi }
-                        mapping {
-                          kind
-                          apiVersion
-                          language
-                          file
-                          entities
-                          abis { name file }
-                          blockHandlers { handler filter }
-                          callHandlers { function handler }
-                          eventHandlers { event handler topic0 }
-                        }
-                      }
+                      apiVersion
+                      language
+                      file
+                      entities
+                      abis { name file }
+                      blockHandlers { handler filter }
+                      callHandlers { function handler }
+                      eventHandlers { event handler topic0 }
                     }
                   }
                 }
-                "#,
-            )
-            .expect("invalid query for dynamic data sources"),
-            variables: Some(QueryVariables::new(HashMap::from_iter(
-                vec![
-                    (String::from("id"), q::Value::String(deployment.to_string())),
-                    (String::from("skip"), q::Value::Int(skip.into())),
-                ]
-                .into_iter(),
-            ))),
-        })
+              }
+            }
+            "#,
+        )
+        .expect("invalid query for dynamic data sources");
+        let variables = Some(QueryVariables::new(HashMap::from_iter(
+            vec![
+                (String::from("id"), q::Value::String(deployment.to_string())),
+                (String::from("skip"), q::Value::Int(skip.into())),
+            ]
+            .into_iter(),
+        )));
+
+        Ok(Query::new(schema, document, variables))
     }
 
     async fn query_dynamic_data_sources(

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -44,11 +44,7 @@ fn insert_and_query(
         max_first: std::u32::MAX,
     };
     let document = graphql_parser::parse_query(query).unwrap();
-    let query = Query {
-        schema: STORE.api_schema(&subgraph_id).unwrap(),
-        document,
-        variables: None,
-    };
+    let query = Query::new(STORE.api_schema(&subgraph_id).unwrap(), document, None);
     Ok(execute_query(query, options))
 }
 

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -109,4 +109,20 @@ pub struct Query {
     pub schema: Arc<Schema>,
     pub document: q::Document,
     pub variables: Option<QueryVariables>,
+    _force_use_of_new: (),
+}
+
+impl Query {
+    pub fn new(
+        schema: Arc<Schema>,
+        document: q::Document,
+        variables: Option<QueryVariables>,
+    ) -> Self {
+        Query {
+            schema,
+            document,
+            variables,
+            _force_use_of_new: (),
+        }
+    }
 }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -39,7 +39,7 @@ where
     pub schema: Arc<Schema>,
 
     /// The query to execute.
-    pub document: q::Document,
+    pub query: Arc<crate::execution::Query>,
 
     /// The resolver to use.
     pub resolver: Arc<R>,
@@ -111,7 +111,7 @@ where
             logger: self.logger.clone(),
             resolver: Arc::new(introspection_resolver),
             schema: Arc::new(introspection_schema),
-            document: self.document.clone(),
+            query: self.query.clone(),
             fields: vec![],
             variable_values: self.variable_values.clone(),
             deadline: self.deadline,
@@ -310,7 +310,7 @@ pub fn collect_fields<'a>(
 
                     // Resolve the fragment using its name and, if it applies, collect
                     // fields for the fragment and group them
-                    qast::get_fragment(&ctx.document, &spread.fragment_name)
+                    qast::get_fragment(&ctx.query.document, &spread.fragment_name)
                         .and_then(|fragment| {
                             // We have a fragment, only pass it on if it applies to the
                             // current object type

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -306,7 +306,8 @@ pub fn collect_fields<'a>(
 
                     // Resolve the fragment using its name and, if it applies, collect
                     // fields for the fragment and group them
-                    qast::get_fragment(&ctx.query.document, &spread.fragment_name)
+                    ctx.query
+                        .get_fragment(&spread.fragment_name)
                         .and_then(|fragment| {
                             // We have a fragment, only pass it on if it applies to the
                             // current object type

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -113,7 +113,7 @@ where
             logger: self.logger.clone(),
             resolver: Arc::new(introspection_resolver),
             schema: Arc::new(introspection_schema),
-            query: self.query.clone(),
+            query: self.query.as_introspection_query(),
             fields: vec![],
             variable_values: self.variable_values.clone(),
             deadline: self.deadline,

--- a/graphql/src/execution/mod.rs
+++ b/graphql/src/execution/mod.rs
@@ -4,5 +4,8 @@ mod execution;
 /// Common trait for field resolvers used in the execution.
 mod resolver;
 
+mod query;
+
 pub use self::execution::*;
+pub use self::query::Query;
 pub use self::resolver::{ObjectOrInterface, Resolver};

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -28,8 +28,8 @@ impl Deref for Query {
 }
 
 impl Query {
-    pub fn new(query: GraphDataQuery) -> Self {
-        Self(query)
+    pub fn new(query: GraphDataQuery) -> Result<Self, QueryExecutionError> {
+        Ok(Self(query))
     }
 
     /// See https://developer.github.com/v4/guides/resource-limitations/.

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -27,12 +27,21 @@ enum Kind {
     Either,
 }
 
+/// A GraphQL query that has been preprocessed and checked and is ready
+/// for execution. Checking includes validating all query fields and, if
+/// desired, checking the query's complexity
 pub struct Query {
+    /// The schema against which to execute the query
     pub schema: Arc<Schema>,
+    /// The variables for the query, coerced into proper values
     pub variables: HashMap<q::Name, q::Value>,
+    /// The root selection set of the query
     pub selection_set: q::SelectionSet,
     fragments: HashMap<String, q::FragmentDefinition>,
     kind: Kind,
+    /// This is `true` if the query should run in both prefetch and slow
+    /// execution modes, and the results of the two executions should be
+    /// checked against each other
     pub verify: bool,
 }
 
@@ -98,6 +107,7 @@ impl Query {
         Ok(query)
     }
 
+    /// Return this query, but use the introspection schema as its schema
     pub fn as_introspection_query(&self) -> Arc<Self> {
         let introspection_schema = introspection_schema(self.schema.id.clone());
 
@@ -115,6 +125,8 @@ impl Query {
         self.fragments.get(name)
     }
 
+    /// Return `true` if this is a query, and not a subscription or
+    /// mutation
     pub fn is_query(&self) -> bool {
         match self.kind {
             Kind::Query | Kind::Either => true,
@@ -122,6 +134,7 @@ impl Query {
         }
     }
 
+    /// Return `true` if this is a subscription, not a query or a mutation
     pub fn is_subscription(&self) -> bool {
         match self.kind {
             Kind::Subscription => true,

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -1,0 +1,142 @@
+use graphql_parser::query as q;
+use graphql_parser::schema as s;
+use std::ops::Deref;
+
+use graph::data::graphql::ext::TypeExt;
+use graph::data::query::Query as GraphDataQuery;
+use graph::prelude::QueryExecutionError;
+
+use crate::execution::{get_field, get_named_type};
+use crate::query::ast as qast;
+use crate::schema::ast as sast;
+
+#[derive(Copy, Clone, Debug)]
+pub enum ComplexityError {
+    TooDeep,
+    Overflow,
+    Invalid,
+}
+
+pub struct Query(GraphDataQuery);
+
+impl Deref for Query {
+    type Target = graph::data::query::Query;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Query {
+    pub fn new(query: GraphDataQuery) -> Self {
+        Self(query)
+    }
+
+    /// See https://developer.github.com/v4/guides/resource-limitations/.
+    ///
+    /// If the query is invalid, returns `Ok(0)` so that execution proceeds and
+    /// gives a proper error.
+    pub fn complexity(
+        &self,
+        selection_set: &q::SelectionSet,
+        max_depth: u8,
+    ) -> Result<u64, QueryExecutionError> {
+        let root_type = sast::get_root_query_type_def(&self.schema.document).unwrap();
+
+        match self.complexity_inner(root_type, selection_set, max_depth, 0) {
+            Ok(complexity) => Ok(complexity),
+            Err(ComplexityError::Invalid) => Ok(0),
+            Err(ComplexityError::TooDeep) => Err(QueryExecutionError::TooDeep(max_depth)),
+            Err(ComplexityError::Overflow) => {
+                Err(QueryExecutionError::TooComplex(u64::max_value(), 0))
+            }
+        }
+    }
+
+    fn complexity_inner(
+        &self,
+        ty: &s::TypeDefinition,
+        selection_set: &q::SelectionSet,
+        max_depth: u8,
+        depth: u8,
+    ) -> Result<u64, ComplexityError> {
+        use ComplexityError::*;
+
+        if depth >= max_depth {
+            return Err(TooDeep);
+        }
+
+        selection_set
+            .items
+            .iter()
+            .try_fold(0, |total_complexity, selection| {
+                let schema = &self.schema.document;
+                match selection {
+                    q::Selection::Field(field) => {
+                        // Empty selection sets are the base case.
+                        if field.selection_set.items.is_empty() {
+                            return Ok(total_complexity);
+                        }
+
+                        // Get field type to determine if this is a collection query.
+                        let s_field = match ty {
+                            s::TypeDefinition::Object(t) => get_field(t, &field.name),
+                            s::TypeDefinition::Interface(t) => get_field(t, &field.name),
+
+                            // `Scalar` and `Enum` cannot have selection sets.
+                            // `InputObject` can't appear in a selection.
+                            // `Union` is not yet supported.
+                            s::TypeDefinition::Scalar(_)
+                            | s::TypeDefinition::Enum(_)
+                            | s::TypeDefinition::InputObject(_)
+                            | s::TypeDefinition::Union(_) => None,
+                        }
+                        .ok_or(Invalid)?;
+
+                        let field_complexity = self.complexity_inner(
+                            &get_named_type(schema, s_field.field_type.get_base_type())
+                                .ok_or(Invalid)?,
+                            &field.selection_set,
+                            max_depth,
+                            depth + 1,
+                        )?;
+
+                        // Non-collection queries pass through.
+                        if !sast::is_list_or_non_null_list_field(&s_field) {
+                            return Ok(total_complexity + field_complexity);
+                        }
+
+                        // For collection queries, check the `first` argument.
+                        let max_entities = qast::get_argument_value(&field.arguments, "first")
+                            .and_then(|arg| match arg {
+                                q::Value::Int(n) => Some(n.as_i64()? as u64),
+                                _ => None,
+                            })
+                            .unwrap_or(100);
+                        max_entities
+                            .checked_add(
+                                max_entities.checked_mul(field_complexity).ok_or(Overflow)?,
+                            )
+                            .ok_or(Overflow)
+                    }
+                    q::Selection::FragmentSpread(fragment) => {
+                        let def = qast::get_fragment(&self.document, &fragment.fragment_name)
+                            .ok_or(Invalid)?;
+                        let q::TypeCondition::On(type_name) = &def.type_condition;
+                        let ty = get_named_type(schema, &type_name).ok_or(Invalid)?;
+                        self.complexity_inner(&ty, &def.selection_set, max_depth, depth + 1)
+                    }
+                    q::Selection::InlineFragment(fragment) => {
+                        let ty = match &fragment.type_condition {
+                            Some(q::TypeCondition::On(type_name)) => {
+                                get_named_type(schema, &type_name).ok_or(Invalid)?
+                            }
+                            _ => ty.clone(),
+                        };
+                        self.complexity_inner(&ty, &fragment.selection_set, max_depth, depth + 1)
+                    }
+                }
+                .and_then(|complexity| total_complexity.checked_add(complexity).ok_or(Overflow))
+            })
+    }
+}

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -133,10 +133,16 @@ impl Query {
         }
     }
 
-    pub fn validate_fields(&self) -> Vec<QueryExecutionError> {
+    pub fn validate_fields(&self) -> Result<(), Vec<QueryExecutionError>> {
         let root_type = sast::get_root_query_type_def(&self.schema.document).unwrap();
 
-        self.validate_fields_inner(&"Query".to_owned(), root_type, &self.selection_set)
+        let errors =
+            self.validate_fields_inner(&"Query".to_owned(), root_type, &self.selection_set);
+        if errors.len() == 0 {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 
     // Checks for invalid selections.

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -24,7 +24,6 @@ pub enum ComplexityError {
 enum Kind {
     Query,
     Subscription,
-    Either,
 }
 
 /// A GraphQL query that has been preprocessed and checked and is ready
@@ -81,7 +80,8 @@ impl Query {
             q::OperationDefinition::Query(q::Query { selection_set, .. }) => {
                 (Kind::Query, selection_set)
             }
-            q::OperationDefinition::SelectionSet(selection_set) => (Kind::Either, selection_set),
+            // Queries can be run by just sending a selction set
+            q::OperationDefinition::SelectionSet(selection_set) => (Kind::Query, selection_set),
             q::OperationDefinition::Subscription(q::Subscription { selection_set, .. }) => {
                 (Kind::Subscription, selection_set)
             }
@@ -129,7 +129,7 @@ impl Query {
     /// mutation
     pub fn is_query(&self) -> bool {
         match self.kind {
-            Kind::Query | Kind::Either => true,
+            Kind::Query => true,
             Kind::Subscription => false,
         }
     }
@@ -138,7 +138,7 @@ impl Query {
     pub fn is_subscription(&self) -> bool {
         match self.kind {
             Kind::Subscription => true,
-            Kind::Query | Kind::Either => false,
+            Kind::Query => false,
         }
     }
 

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -120,14 +120,10 @@ impl Query {
     ///
     /// If the query is invalid, returns `Ok(0)` so that execution proceeds and
     /// gives a proper error.
-    pub fn complexity(
-        &self,
-        selection_set: &q::SelectionSet,
-        max_depth: u8,
-    ) -> Result<u64, QueryExecutionError> {
+    pub fn complexity(&self, max_depth: u8) -> Result<u64, QueryExecutionError> {
         let root_type = sast::get_root_query_type_def(&self.schema.document).unwrap();
 
-        match self.complexity_inner(root_type, selection_set, max_depth, 0) {
+        match self.complexity_inner(root_type, &self.selection_set, max_depth, 0) {
             Ok(complexity) => Ok(complexity),
             Err(ComplexityError::Invalid) => Ok(0),
             Err(ComplexityError::TooDeep) => Err(QueryExecutionError::TooDeep(max_depth)),
@@ -137,10 +133,10 @@ impl Query {
         }
     }
 
-    pub fn validate_fields(&self, selection_set: &q::SelectionSet) -> Vec<QueryExecutionError> {
+    pub fn validate_fields(&self) -> Vec<QueryExecutionError> {
         let root_type = sast::get_root_query_type_def(&self.schema.document).unwrap();
 
-        self.validate_fields_inner(&"Query".to_owned(), root_type, selection_set)
+        self.validate_fields_inner(&"Query".to_owned(), root_type, &self.selection_set)
     }
 
     // Checks for invalid selections.

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -21,7 +21,7 @@ pub enum ComplexityError {
 
 pub struct Query {
     pub schema: Arc<Schema>,
-    pub document: q::Document,
+    document: q::Document,
     pub variables: Option<QueryVariables>,
 }
 
@@ -42,6 +42,14 @@ impl Query {
             document: self.document.clone(),
             variables: self.variables.clone(),
         })
+    }
+
+    pub fn get_fragment(&self, name: &q::Name) -> Option<&q::FragmentDefinition> {
+        qast::get_fragment(&self.document, name)
+    }
+
+    pub fn get_operation(&self) -> Result<&q::OperationDefinition, QueryExecutionError> {
+        qast::get_operation(&self.document, None)
     }
 
     /// See https://developer.github.com/v4/guides/resource-limitations/.

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -25,12 +25,12 @@ pub struct Query {
 }
 
 impl Query {
-    pub fn new(query: GraphDataQuery) -> Result<Self, QueryExecutionError> {
-        Ok(Self {
+    pub fn new(query: GraphDataQuery) -> Result<Arc<Self>, QueryExecutionError> {
+        Ok(Arc::new(Self {
             schema: query.schema,
             document: query.document,
             variables: query.variables,
-        })
+        }))
     }
 
     /// See https://developer.github.com/v4/guides/resource-limitations/.

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -8,6 +8,7 @@ use graph::data::schema::Schema;
 use graph::prelude::QueryExecutionError;
 
 use crate::execution::{get_field, get_named_type};
+use crate::introspection::introspection_schema;
 use crate::query::ast as qast;
 use crate::schema::ast as sast;
 
@@ -31,6 +32,16 @@ impl Query {
             document: query.document,
             variables: query.variables,
         }))
+    }
+
+    pub fn as_introspection_query(&self) -> Arc<Self> {
+        let introspection_schema = introspection_schema(self.schema.id.clone());
+
+        Arc::new(Self {
+            schema: Arc::new(introspection_schema),
+            document: self.document.clone(),
+            variables: self.variables.clone(),
+        })
     }
 
     /// See https://developer.github.com/v4/guides/resource-limitations/.

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -1,9 +1,10 @@
 use graphql_parser::query as q;
 use graphql_parser::schema as s;
-use std::ops::Deref;
+use std::sync::Arc;
 
 use graph::data::graphql::ext::TypeExt;
-use graph::data::query::Query as GraphDataQuery;
+use graph::data::query::{Query as GraphDataQuery, QueryVariables};
+use graph::data::schema::Schema;
 use graph::prelude::QueryExecutionError;
 
 use crate::execution::{get_field, get_named_type};
@@ -17,19 +18,19 @@ pub enum ComplexityError {
     Invalid,
 }
 
-pub struct Query(GraphDataQuery);
-
-impl Deref for Query {
-    type Target = graph::data::query::Query;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+pub struct Query {
+    pub schema: Arc<Schema>,
+    pub document: q::Document,
+    pub variables: Option<QueryVariables>,
 }
 
 impl Query {
     pub fn new(query: GraphDataQuery) -> Result<Self, QueryExecutionError> {
-        Ok(Self(query))
+        Ok(Self {
+            schema: query.schema,
+            document: query.document,
+            variables: query.variables,
+        })
     }
 
     /// See https://developer.github.com/v4/guides/resource-limitations/.

--- a/graphql/src/introspection/mod.rs
+++ b/graphql/src/introspection/mod.rs
@@ -2,4 +2,6 @@ mod resolver;
 mod schema;
 
 pub use self::resolver::IntrospectionResolver;
-pub use self::schema::{introspection_schema, INTROSPECTION_DOCUMENT};
+pub use self::schema::{
+    introspection_schema, is_introspection_field, INTROSPECTION_DOCUMENT, INTROSPECTION_QUERY_TYPE,
+};

--- a/graphql/src/introspection/schema.rs
+++ b/graphql/src/introspection/schema.rs
@@ -1,8 +1,12 @@
-use graphql_parser::{self, schema::Document};
+use graphql_parser::{self, schema::Document, schema::Name, schema::ObjectType};
 
+use graph::data::graphql::ext::ObjectTypeExt;
 use graph::data::schema::Schema;
 use graph::data::subgraph::SubgraphDeploymentId;
+
 use lazy_static::lazy_static;
+
+use crate::schema::ast as sast;
 
 const INTROSPECTION_SCHEMA: &str = "
 scalar Boolean
@@ -113,8 +117,14 @@ enum __DirectiveLocation {
 lazy_static! {
     pub static ref INTROSPECTION_DOCUMENT: Document =
         graphql_parser::parse_schema(INTROSPECTION_SCHEMA).unwrap();
+    pub static ref INTROSPECTION_QUERY_TYPE: &'static ObjectType =
+        sast::get_root_query_type(&*INTROSPECTION_DOCUMENT).unwrap();
 }
 
 pub fn introspection_schema(id: SubgraphDeploymentId) -> Schema {
     Schema::new(id, INTROSPECTION_DOCUMENT.clone())
+}
+
+pub fn is_introspection_field(name: &Name) -> bool {
+    INTROSPECTION_QUERY_TYPE.field(name).is_some()
 }

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -80,7 +80,7 @@ where
         logger: query_logger.clone(),
         resolver: Arc::new(options.resolver),
         schema: query.schema.clone(),
-        document: query.document.clone(),
+        query: query.clone(),
         fields: vec![],
         variable_values: Arc::new(coerced_variable_values),
         deadline: options.deadline,

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -99,7 +99,6 @@ where
     }
 
     // Execute top-level `query { ... }` and `{ ... }` expressions.
-    query.validate_fields()?;
 
     let complexity = query.complexity(options.max_depth);
 

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -47,7 +47,10 @@ where
         "query_id" => query_id
     ));
 
-    let query = crate::execution::Query::new(query);
+    let query = match crate::execution::Query::new(query) {
+        Ok(query) => query,
+        Err(e) => return QueryResult::from(e),
+    };
 
     // Obtain the only operation of the query (fail if there is none or more than one)
     let operation = match qast::get_operation(&query.document, None) {

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -88,12 +88,12 @@ where
     }
 
     // Execute top-level `query { ... }` and `{ ... }` expressions.
-    let validation_errors = query.validate_fields(&query.selection_set);
+    let validation_errors = query.validate_fields();
     if !validation_errors.is_empty() {
         return QueryResult::from(validation_errors);
     }
 
-    let complexity = query.complexity(&query.selection_set, options.max_depth);
+    let complexity = query.complexity(options.max_depth);
 
     let start = Instant::now();
     let result = match (complexity, options.max_complexity) {

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -99,20 +99,10 @@ where
     }
 
     // Execute top-level `query { ... }` and `{ ... }` expressions.
-
-    let complexity = query.complexity(options.max_depth);
+    query.check_complexity(options.max_complexity, options.max_depth)?;
 
     let start = Instant::now();
-    let result = match (complexity, options.max_complexity) {
-        (Err(e), _) => Err(vec![e]),
-        (Ok(complexity), Some(max_complexity)) if complexity > max_complexity => {
-            Err(vec![QueryExecutionError::TooComplex(
-                complexity,
-                max_complexity,
-            )])
-        }
-        (Ok(_), _) => execute_root_selection_set(&ctx, &query.selection_set),
-    };
+    let result = execute_root_selection_set(&ctx, &query.selection_set);
     if *graph::log::LOG_GQL_TIMING {
         info!(
             query_logger,

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -5,7 +5,6 @@ use uuid::Uuid;
 
 use crate::execution::*;
 use crate::query::ast as qast;
-use crate::schema::ast as sast;
 
 /// Utilities for working with GraphQL query ASTs.
 pub mod ast;
@@ -91,9 +90,7 @@ where
         // Execute top-level `query { ... }` and `{ ... }` expressions.
         q::OperationDefinition::Query(q::Query { selection_set, .. })
         | q::OperationDefinition::SelectionSet(selection_set) => {
-            let root_type = sast::get_root_query_type_def(&ctx.schema.document).unwrap();
-            let validation_errors =
-                ctx.validate_fields(&"Query".to_owned(), root_type, selection_set);
+            let validation_errors = query.validate_fields(selection_set);
             if !validation_errors.is_empty() {
                 return QueryResult::from(validation_errors);
             }

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -72,7 +72,7 @@ where
         ("".to_owned(), "".to_owned())
     };
 
-    let query = crate::execution::Query::new(query)?;
+    let query = crate::execution::Query::new(query, options.max_complexity, options.max_depth)?;
 
     let mode = if query.verify {
         ExecutionMode::Verify
@@ -99,8 +99,6 @@ where
     }
 
     // Execute top-level `query { ... }` and `{ ... }` expressions.
-    query.check_complexity(options.max_complexity, options.max_depth)?;
-
     let start = Instant::now();
     let result = execute_root_selection_set(&ctx, &query.selection_set);
     if *graph::log::LOG_GQL_TIMING {

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -79,7 +79,6 @@ where
     let ctx = ExecutionContext {
         logger: query_logger.clone(),
         resolver: Arc::new(options.resolver),
-        schema: query.schema.clone(),
         query: query.clone(),
         fields: vec![],
         variable_values: Arc::new(coerced_variable_values),

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -704,31 +704,33 @@ fn collect_fields<'a>(
                 if !visited_fragments.contains(&spread.fragment_name) {
                     visited_fragments.insert(&spread.fragment_name);
 
-                    qast::get_fragment(&ctx.document, &spread.fragment_name).map(|fragment| {
-                        let fragment_grouped_field_set = collect_fields(
-                            ctx,
-                            object_type,
-                            &fragment.selection_set,
-                            Some(visited_fragments.clone()),
-                        );
+                    qast::get_fragment(&ctx.query.document, &spread.fragment_name).map(
+                        |fragment| {
+                            let fragment_grouped_field_set = collect_fields(
+                                ctx,
+                                object_type,
+                                &fragment.selection_set,
+                                Some(visited_fragments.clone()),
+                            );
 
-                        // Add all items from each fragments group to the field group
-                        // with the corresponding response key
-                        let fragment_cond =
-                            TypeCondition::from(Some(fragment.type_condition.clone()));
-                        for (response_key, type_fields) in fragment_grouped_field_set {
-                            for (type_cond, mut group) in type_fields {
-                                if let Some(cond) = fragment_cond.and(&type_cond) {
-                                    grouped_fields
-                                        .entry(response_key)
-                                        .or_default()
-                                        .entry(cond)
-                                        .or_default()
-                                        .append(&mut group);
+                            // Add all items from each fragments group to the field group
+                            // with the corresponding response key
+                            let fragment_cond =
+                                TypeCondition::from(Some(fragment.type_condition.clone()));
+                            for (response_key, type_fields) in fragment_grouped_field_set {
+                                for (type_cond, mut group) in type_fields {
+                                    if let Some(cond) = fragment_cond.and(&type_cond) {
+                                        grouped_fields
+                                            .entry(response_key)
+                                            .or_default()
+                                            .entry(cond)
+                                            .or_default()
+                                            .append(&mut group);
+                                    }
                                 }
                             }
-                        }
-                    });
+                        },
+                    );
                 }
             }
 

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -706,7 +706,7 @@ fn collect_fields<'a>(
                 if !visited_fragments.contains(&spread.fragment_name) {
                     visited_fragments.insert(&spread.fragment_name);
 
-                    qast::get_fragment(&ctx.query.document, &spread.fragment_name).map(
+                    ctx.query.get_fragment(&spread.fragment_name).map(
                         |fragment| {
                             let fragment_grouped_field_set = collect_fields(
                                 ctx,

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -64,7 +64,11 @@ where
         .format(&Style::default().indent(0))
         .replace('\n', " ");
 
-    let query = crate::execution::Query::new(subscription.query)?;
+    let query = crate::execution::Query::new(
+        subscription.query,
+        options.max_complexity,
+        options.max_depth,
+    )?;
 
     // Create a fresh execution context
     let ctx = ExecutionContext {
@@ -83,8 +87,6 @@ where
             "Only subscriptions are supported".to_string(),
         )));
     }
-
-    query.check_complexity(options.max_complexity, options.max_depth)?;
 
     info!(
         ctx.logger,

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -88,9 +88,7 @@ where
     match operation {
         // Execute top-level `subscription { ... }` expressions
         q::OperationDefinition::Subscription(q::Subscription { selection_set, .. }) => {
-            let root_type = sast::get_root_query_type_def(&ctx.schema.document).unwrap();
-            let validation_errors =
-                ctx.validate_fields(&"Query".to_owned(), root_type, selection_set);
+            let validation_errors = query.validate_fields(selection_set);
             if !validation_errors.is_empty() {
                 return Err(SubscriptionError::from(validation_errors));
             }

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -84,10 +84,7 @@ where
         )));
     }
 
-    let validation_errors = query.validate_fields();
-    if !validation_errors.is_empty() {
-        return Err(SubscriptionError::from(validation_errors));
-    }
+    query.validate_fields()?;
 
     let complexity = query.complexity(options.max_depth).map_err(|e| vec![e])?;
 

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -84,7 +84,6 @@ where
         )));
     }
 
-    query.validate_fields()?;
 
     let complexity = query.complexity(options.max_depth).map_err(|e| vec![e])?;
 

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -84,14 +84,12 @@ where
         )));
     }
 
-    let validation_errors = query.validate_fields(&query.selection_set);
+    let validation_errors = query.validate_fields();
     if !validation_errors.is_empty() {
         return Err(SubscriptionError::from(validation_errors));
     }
 
-    let complexity = query
-        .complexity(&query.selection_set, options.max_depth)
-        .map_err(|e| vec![e])?;
+    let complexity = query.complexity(options.max_depth).map_err(|e| vec![e])?;
 
     info!(
         ctx.logger,

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -76,7 +76,7 @@ where
         logger: options.logger,
         resolver: Arc::new(options.resolver),
         schema: query.schema.clone(),
-        document: query.document.clone(),
+        query: query.clone(),
         fields: vec![],
         variable_values: Arc::new(coerced_variable_values),
         deadline: None,
@@ -100,7 +100,7 @@ where
             info!(
                 ctx.logger,
                 "Execute subscription";
-                "query" => ctx.document.format(&Style::default().indent(0)).replace('\n', " "),
+                "query" => ctx.query.document.format(&Style::default().indent(0)).replace('\n', " "),
                 "complexity" => complexity,
             );
 
@@ -172,7 +172,7 @@ fn map_source_to_response_stream(
     let logger = ctx.logger.clone();
     let resolver = ctx.resolver.clone();
     let schema = ctx.schema.clone();
-    let document = ctx.document.clone();
+    let query = ctx.query.cheap_clone();
     let selection_set = selection_set.to_owned();
     let variable_values = ctx.variable_values.clone();
     let max_first = ctx.max_first;
@@ -198,7 +198,7 @@ fn map_source_to_response_stream(
                     logger.clone(),
                     resolver.clone(),
                     schema.clone(),
-                    document.clone(),
+                    query.clone(),
                     selection_set.clone(),
                     variable_values.clone(),
                     event,
@@ -214,7 +214,7 @@ async fn execute_subscription_event(
     logger: Logger,
     resolver: Arc<impl Resolver + 'static>,
     schema: Arc<Schema>,
-    document: q::Document,
+    query: Arc<crate::execution::Query>,
     selection_set: q::SelectionSet,
     variable_values: Arc<HashMap<q::Name, q::Value>>,
     event: StoreEvent,
@@ -228,7 +228,7 @@ async fn execute_subscription_event(
         logger,
         resolver,
         schema,
-        document,
+        query,
         fields: vec![],
         variable_values,
         deadline: timeout.map(|t| Instant::now() + t),

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -59,7 +59,7 @@ pub fn execute_subscription<R>(
 where
     R: Resolver + 'static,
 {
-    let query = crate::execution::Query::new(subscription.query);
+    let query = crate::execution::Query::new(subscription.query)?;
 
     // Obtain the only operation of the subscription (fail if there is none or more than one)
     let operation = qast::get_operation(&query.document, None)?;

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -549,11 +549,11 @@ fn expected_mock_schema_introspection() -> q::Value {
 /// Execute an introspection query.
 fn introspection_query(schema: Schema, query: &str) -> QueryResult {
     // Create the query
-    let query = Query {
-        schema: Arc::new(schema),
-        document: graphql_parser::parse_query(query).unwrap(),
-        variables: None,
-    };
+    let query = Query::new(
+        Arc::new(schema),
+        graphql_parser::parse_query(query).unwrap(),
+        None,
+    );
 
     // Execute it
     execute_query(

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -807,7 +807,7 @@ async fn query_complexity_subscriptions() {
 
     // This query is exactly at the maximum complexity.
     // FIXME: Not collecting the stream because that will hang the test.
-    let _ignore_stream = execute_subscription(&Subscription { query }, options).unwrap();
+    let _ignore_stream = execute_subscription(Subscription { query }, options).unwrap();
 
     let query = Query::new(
         Arc::new(api_test_schema()),
@@ -843,7 +843,7 @@ async fn query_complexity_subscriptions() {
     };
 
     // The extra introspection causes the complexity to go over.
-    let result = execute_subscription(&Subscription { query }, options);
+    let result = execute_subscription(Subscription { query }, options);
     match result {
         Err(SubscriptionError::GraphQLError(e)) => match e[0] {
             QueryExecutionError::TooComplex(1_010_200, _) => (), // Expected
@@ -1179,7 +1179,7 @@ async fn subscription_gets_result_even_without_events() {
 
     // Execute the subscription and expect at least one result to be
     // available in the result stream
-    let stream = execute_subscription(&Subscription { query }, options).unwrap();
+    let stream = execute_subscription(Subscription { query }, options).unwrap();
     let results: Vec<_> = stream
         .take(1)
         .collect()

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -219,11 +219,7 @@ fn execute_query_document_with_variables(
     query: q::Document,
     variables: Option<QueryVariables>,
 ) -> QueryResult {
-    let query = Query {
-        schema: Arc::new(api_test_schema()),
-        document: query,
-        variables,
-    };
+    let query = Query::new(Arc::new(api_test_schema()), query, variables);
 
     let logger = Logger::root(slog::Discard, o!());
     let store_resolver = StoreResolver::new(&logger, STORE.clone());
@@ -703,9 +699,9 @@ fn query_complexity() {
     let logger = Logger::root(slog::Discard, o!());
     let store_resolver = StoreResolver::new(&logger, STORE.clone());
 
-    let query = Query {
-        schema: Arc::new(api_test_schema()),
-        document: graphql_parser::parse_query(
+    let query = Query::new(
+        Arc::new(api_test_schema()),
+        graphql_parser::parse_query(
             "query {
                 musicians(orderBy: id) {
                     name
@@ -719,8 +715,8 @@ fn query_complexity() {
             }",
         )
         .unwrap(),
-        variables: None,
-    };
+        None,
+    );
     let max_complexity = Some(1_010_100);
     let options = QueryExecutionOptions {
         logger: logger.clone(),
@@ -735,9 +731,9 @@ fn query_complexity() {
     let result = execute_query(query, options);
     assert!(result.errors.is_none());
 
-    let query = Query {
-        schema: Arc::new(api_test_schema()),
-        document: graphql_parser::parse_query(
+    let query = Query::new(
+        Arc::new(api_test_schema()),
+        graphql_parser::parse_query(
             "query {
                 musicians(orderBy: id) {
                     name
@@ -756,8 +752,8 @@ fn query_complexity() {
             }",
         )
         .unwrap(),
-        variables: None,
-    };
+        None,
+    );
 
     let options = QueryExecutionOptions {
         logger,
@@ -781,9 +777,9 @@ async fn query_complexity_subscriptions() {
     let logger = Logger::root(slog::Discard, o!());
     let store_resolver = StoreResolver::new(&logger, STORE.clone());
 
-    let query = Query {
-        schema: Arc::new(api_test_schema()),
-        document: graphql_parser::parse_query(
+    let query = Query::new(
+        Arc::new(api_test_schema()),
+        graphql_parser::parse_query(
             "subscription {
                 musicians(orderBy: id) {
                     name
@@ -797,8 +793,8 @@ async fn query_complexity_subscriptions() {
             }",
         )
         .unwrap(),
-        variables: None,
-    };
+        None,
+    );
     let max_complexity = Some(1_010_100);
     let options = SubscriptionExecutionOptions {
         logger: logger.clone(),
@@ -813,9 +809,9 @@ async fn query_complexity_subscriptions() {
     // FIXME: Not collecting the stream because that will hang the test.
     let _ignore_stream = execute_subscription(&Subscription { query }, options).unwrap();
 
-    let query = Query {
-        schema: Arc::new(api_test_schema()),
-        document: graphql_parser::parse_query(
+    let query = Query::new(
+        Arc::new(api_test_schema()),
+        graphql_parser::parse_query(
             "subscription {
                 musicians(orderBy: id) {
                     name
@@ -834,8 +830,8 @@ async fn query_complexity_subscriptions() {
             }",
         )
         .unwrap(),
-        variables: None,
-    };
+        None,
+    );
 
     let options = SubscriptionExecutionOptions {
         logger,
@@ -859,11 +855,11 @@ async fn query_complexity_subscriptions() {
 
 #[test]
 fn instant_timeout() {
-    let query = Query {
-        schema: Arc::new(api_test_schema()),
-        document: graphql_parser::parse_query("query { musicians(first: 100) { name } }").unwrap(),
-        variables: None,
-    };
+    let query = Query::new(
+        Arc::new(api_test_schema()),
+        graphql_parser::parse_query("query { musicians(first: 100) { name } }").unwrap(),
+        None,
+    );
     let logger = Logger::root(slog::Discard, o!());
     let store_resolver = StoreResolver::new(&logger, STORE.clone());
 
@@ -1159,9 +1155,9 @@ async fn subscription_gets_result_even_without_events() {
     let logger = Logger::root(slog::Discard, o!());
     let store_resolver = StoreResolver::new(&logger, STORE.clone());
 
-    let query = Query {
-        schema: Arc::new(api_test_schema()),
-        document: graphql_parser::parse_query(
+    let query = Query::new(
+        Arc::new(api_test_schema()),
+        graphql_parser::parse_query(
             "subscription {
               musicians(orderBy: id, first: 2) {
                 name
@@ -1169,8 +1165,8 @@ async fn subscription_gets_result_even_without_events() {
             }",
         )
         .unwrap(),
-        variables: None,
-    };
+        None,
+    );
 
     let options = SubscriptionExecutionOptions {
         logger: logger.clone(),

--- a/server/http/src/request.rs
+++ b/server/http/src/request.rs
@@ -64,11 +64,7 @@ impl Future for GraphQLRequest {
             )),
         }?;
 
-        Ok(Async::Ready(Query {
-            document,
-            variables,
-            schema,
-        }))
+        Ok(Async::Ready(Query::new(schema, document, variables)))
     }
 }
 

--- a/server/index-node/src/request.rs
+++ b/server/index-node/src/request.rs
@@ -65,11 +65,7 @@ impl Future for IndexNodeRequest {
             )),
         }?;
 
-        Ok(Async::Ready(Query {
-            document,
-            variables,
-            schema,
-        }))
+        Ok(Async::Ready(Query::new(schema, document, variables)))
     }
 }
 

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -258,15 +258,13 @@ where
         };
 
         // Build a query for matching subgraph deployments
-        let query = Query {
+        let query = Query::new(
             // The query is against the subgraph of subgraphs
-            schema: self
-                .store
+            self.store
                 .api_schema(&SUBGRAPHS_ID)
                 .map_err(QueryExecutionError::StoreError)?,
-
             // We're querying all deployments that match the provided filter
-            document: q::parse_query(
+            q::parse_query(
                 r#"
                 query deployments(
                   $whereDeployments: SubgraphDeployment_filter!,
@@ -296,17 +294,16 @@ where
                 "#,
             )
             .unwrap(),
-
             // If the `subgraphs` argument was provided, build a suitable `where`
             // filter to match the IDs; otherwise leave the `where` filter empty
-            variables: Some(QueryVariables::new(HashMap::from_iter(
+            Some(QueryVariables::new(HashMap::from_iter(
                 vec![
                     ("whereDeployments".into(), where_filter.clone()),
                     ("whereAssignments".into(), where_filter),
                 ]
                 .into_iter(),
             ))),
-        };
+        );
 
         // Execute the query
         let result = self
@@ -352,15 +349,13 @@ where
         let where_filter = object! { name: subgraph_name.clone() };
 
         // Build a query for matching subgraph deployments
-        let query = Query {
+        let query = Query::new(
             // The query is against the subgraph of subgraphs
-            schema: self
-                .store
+            self.store
                 .api_schema(&SUBGRAPHS_ID)
                 .map_err(QueryExecutionError::StoreError)?,
-
             // We're querying all deployments that match the provided filter
-            document: q::parse_query(
+            q::parse_query(
                 r#"
                 query subgraphs($where: Subgraph_filter!) {
                   subgraphs(where: $where, first: 1000000) {
@@ -391,13 +386,12 @@ where
                 "#,
             )
             .unwrap(),
-
             // If the `subgraphs` argument was provided, build a suitable `where`
             // filter to match the IDs; otherwise leave the `where` filter empty
-            variables: Some(QueryVariables::new(HashMap::from_iter(
+            Some(QueryVariables::new(HashMap::from_iter(
                 vec![("where".into(), where_filter)].into_iter(),
             ))),
-        };
+        );
 
         // Execute the query
         let result = self

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -292,11 +292,7 @@ where
 
                     // Construct a subscription
                     let subscription = Subscription {
-                        query: Query {
-                            schema: schema.clone(),
-                            document: query,
-                            variables,
-                        },
+                        query: Query::new(schema.clone(), query, variables),
                     };
 
                     debug!(logger, "Start operation";


### PR DESCRIPTION
There was quite a bit of code in GraphQL execution that only depended on the query, and was run before we ever executed anything. Some of the execution code was made less clear by the fact that it had to simultaneously destructure the GraphQL AST and perform logic depending on the structure. Some logic was duplicated, with minor variations, across query and subscription execution.

This PR introduces a new `execution::Query` struct whose construction does as much work as can be done before actual query execution starts, in particular, it does things like variable coercion, field validation, and query complexity checking.

This PR solely refactors code, and should not change any behavior of the system. It's ultimately motivated by needing to access the block at which a query is run in a more convenient manner, which I'll do in another PR.