### PR TITLE
Update Ethereum network indexer to include transactions and logs

### DIFF
--- a/chain/ethereum/src/network_indexer/convert.rs
+++ b/chain/ethereum/src/network_indexer/convert.rs
@@ -202,7 +202,6 @@ impl TryIntoEntity for &LoadedTransaction {
             ("value", transaction.value.into()),
             ("gasPrice", transaction.gas_price.into()),
             ("gas", transaction.gas.into()),
-            ("inputData", transaction.input.clone().into()),
             (
                 "block",
                 format!("{:x}", transaction.block_hash.unwrap()).into(),

--- a/chain/ethereum/src/network_indexer/ethereum.graphql
+++ b/chain/ethereum/src/network_indexer/ethereum.graphql
@@ -62,18 +62,18 @@ type Block @entity {
   """The number of ommers (AKA uncles) associated with this block."""
   ommerCount: Int!
 
-  # """
-  # A list of ommer (AKA uncle) blocks associated with this block.
-  # """
+  """
+  A list of ommer (AKA uncle) blocks associated with this block.
+  """
   ommers: [Block]!
 
   """The keccak256 hash of all the ommers (AKA uncles) associated with this block."""
   ommerHash: Bytes!
 
-  # """
-  # A list of transactions associated with this block.
-  # """
-  # transactions: [Transaction!]
+  """
+  A list of transactions associated with this block.
+  """
+  transactions: [Transaction!]
 
   # """The logs emitted in this block."""
   # logs: [Log!]!
@@ -83,4 +83,73 @@ type Block @entity {
 
   """Seal fields."""
   sealFields: [Bytes!]!
+}
+
+""" An Ethereum transaction. """
+type Transaction @entity {
+  id: ID!
+
+  """ The hash of this transaction. """
+  hash: Bytes!
+
+  """ The nonce of the account this transaction was generated with. """
+  nonce: BigInt!
+
+  """
+  The index of this transaction in the parent block.
+  This will be null if the transaction has not yet been mined.
+  """
+  index: BigInt
+
+  """ The account that sent this transaction - this will always be an externally owned account. """
+  from: Bytes!
+
+  """ The account the transaction was sent to. This is null for contract-creating transactions. """
+  to: Bytes
+
+  """ The value, in wei, sent along with this transaction. """
+  value: BigInt!
+
+  """ The price offered to miners for gas, in wei per unit. """
+  gasPrice: BigInt!
+
+  """ The maximum amount of gas this transaction can consume. """
+  gas: BigInt!
+
+  """ The data supplied to the target of the transaction. """
+  inputData: Bytes!
+
+  """ The block this transaction was mined in. This will be null if the transaction has not yet been mined. """
+  block: Block
+
+  #  """
+  #  Logs is a list of log entries emitted by this transaction.
+  #  If the transaction has not yet been mined, this field will be null.
+  #  """
+  #  logs: [Log!]
+
+  #  """
+  #  Status is the return status of the transaction.
+  #  This will be 1 if the transaction succeeded,
+  #  or 0 if it failed (due to a revert, or due to running out of gas).
+  #  If the transaction has not yet been mined, this field will be null.
+  #  """
+  # status: BigInt # From transaction receipt
+
+  #  """
+  #  GasUsed is the amount of gas that was used processing this transaction.
+  #  If the transaction has not yet been mined, this field will be null.
+  #  """
+  # gasUsed: BigInt # From transaction receipt
+
+  #  """
+  #  CumulativeGasUsed is the total gas used in the block up to and including this transaction.
+  #  If the transaction has not yet been mined, this field will be null.
+  #  """
+  # cumulativeGasUsed: BigInt # From transaction receipt
+
+  #  """ CreatedContract is the account that was created by a contract creation transaction.
+  #  If the transaction was not a contract creation transaction, or it has not yet been mined, this field will be null.
+  #  """
+  # createdContract: Account # From transaction receipt
 }

--- a/chain/ethereum/src/network_indexer/ethereum.graphql
+++ b/chain/ethereum/src/network_indexer/ethereum.graphql
@@ -75,6 +75,9 @@ type Block @entity {
   """
   transactions: [Transaction!]
 
+  """The number of logs emitted in this block."""
+  logCount: Int!
+
   """The logs emitted in this block."""
   logs: [Log!]
 
@@ -124,6 +127,12 @@ type Transaction @entity {
   This will be null if the transaction has not yet been mined.
   """
   block: Block
+
+  """ The number of the block this transaction was mined in. """
+  blockNumber: Int!
+
+  """The number of logs emitted in this transaction."""
+  logCount: Int!
 
   """
   A list of log entries emitted by this transaction.

--- a/chain/ethereum/src/network_indexer/ethereum.graphql
+++ b/chain/ethereum/src/network_indexer/ethereum.graphql
@@ -119,8 +119,8 @@ type Transaction @entity {
   """ The maximum amount of gas this transaction can consume. """
   gas: BigInt!
 
-  """ The data supplied to the target of the transaction. """
-  inputData: Bytes!
+  #  """ The data supplied to the target of the transaction. """
+  #  inputData: Bytes!
 
   """
   The block this transaction was mined in.

--- a/chain/ethereum/src/network_indexer/ethereum.graphql
+++ b/chain/ethereum/src/network_indexer/ethereum.graphql
@@ -119,39 +119,43 @@ type Transaction @entity {
   """ The data supplied to the target of the transaction. """
   inputData: Bytes!
 
-  """ The block this transaction was mined in. This will be null if the transaction has not yet been mined. """
+  """
+  The block this transaction was mined in.
+  This will be null if the transaction has not yet been mined.
+  """
   block: Block
 
-  #  """
-  #  Logs is a list of log entries emitted by this transaction.
-  #  If the transaction has not yet been mined, this field will be null.
-  #  """
-  #  logs: [Log!]
+  """
+  A list of log entries emitted by this transaction.
+  If the transaction has not yet been mined, this field will be null.
+  """
+  logs: [Log!]
 
-  #  """
-  #  Status is the return status of the transaction.
-  #  This will be 1 if the transaction succeeded,
-  #  or 0 if it failed (due to a revert, or due to running out of gas).
-  #  If the transaction has not yet been mined, this field will be null.
-  #  """
-  # status: BigInt # From transaction receipt
+  """
+  The return status of the transaction.
+  This will be 1 if the transaction succeeded,
+  or 0 if it failed (due to a revert, or due to running out of gas).
+  If the transaction has not yet been mined, this field will be null.
+  """
+  status: BigInt
 
-  #  """
-  #  GasUsed is the amount of gas that was used processing this transaction.
-  #  If the transaction has not yet been mined, this field will be null.
-  #  """
-  # gasUsed: BigInt # From transaction receipt
+  """
+  The amount of gas that was used processing this transaction.
+  If the transaction has not yet been mined, this field will be null.
+  """
+  gasUsed: BigInt
 
-  #  """
-  #  CumulativeGasUsed is the total gas used in the block up to and including this transaction.
-  #  If the transaction has not yet been mined, this field will be null.
-  #  """
-  # cumulativeGasUsed: BigInt # From transaction receipt
+  """
+  The total gas used in the block up to and including this transaction.
+  If the transaction has not yet been mined, this field will be null.
+  """
+  cumulativeGasUsed: BigInt
 
-  #  """ CreatedContract is the account that was created by a contract creation transaction.
-  #  If the transaction was not a contract creation transaction, or it has not yet been mined, this field will be null.
-  #  """
-  # createdContract: Account # From transaction receipt
+  """
+  The account that was created by a contract creation transaction.
+  If the transaction was not a contract creation transaction, or it has not yet been mined, this field will be null.
+  """
+  createdContract: Bytes
 }
 
 """ An Ethereum event log. """

--- a/chain/ethereum/src/network_indexer/ethereum.graphql
+++ b/chain/ethereum/src/network_indexer/ethereum.graphql
@@ -75,8 +75,8 @@ type Block @entity {
   """
   transactions: [Transaction!]
 
-  # """The logs emitted in this block."""
-  # logs: [Log!]!
+  """The logs emitted in this block."""
+  logs: [Log!]
 
   """Size of the block in bytes."""
   size: BigInt
@@ -152,4 +152,23 @@ type Transaction @entity {
   #  If the transaction was not a contract creation transaction, or it has not yet been mined, this field will be null.
   #  """
   # createdContract: Account # From transaction receipt
+}
+
+""" An Ethereum event log. """
+type Log @entity {
+  id: ID!
+  """ The index of this log in the block. """
+  index: Int!
+
+  """ The account which generated this log. """
+  account: Bytes!
+
+  """ A list of 0-4 indexed topics for the log. """
+  topics: [Bytes!]!
+
+  """ Unindexed data for this log. """
+  data: Bytes!
+
+  """ The transaction that generated this log entry. """
+  transaction: Transaction
 }

--- a/chain/ethereum/src/network_indexer/mod.rs
+++ b/chain/ethereum/src/network_indexer/mod.rs
@@ -1,7 +1,9 @@
 use graph::prelude::*;
 use std::fmt;
 use std::ops::Deref;
-use web3::types::{Block, Log as Web3Log, Transaction as Web3Transaction, H256};
+use web3::types::{
+    Block, Log as Web3Log, Transaction as Web3Transaction, TransactionReceipt, H256,
+};
 
 mod block_writer;
 mod convert;
@@ -85,19 +87,17 @@ impl fmt::Display for BlockWithOmmers {
 
 // Helper type to represent transactions.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct Transaction(Web3Transaction);
-
-impl From<Web3Transaction> for Transaction {
-    fn from(transaction: Web3Transaction) -> Self {
-        Self(transaction)
-    }
+pub struct LoadedTransaction {
+    pub transaction: Web3Transaction,
+    pub receipt: TransactionReceipt,
 }
 
-impl Deref for Transaction {
-    type Target = Web3Transaction;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl From<(Web3Transaction, TransactionReceipt)> for LoadedTransaction {
+    fn from(transaction_and_receipt: (Web3Transaction, TransactionReceipt)) -> Self {
+        Self {
+            transaction: transaction_and_receipt.0,
+            receipt: transaction_and_receipt.1,
+        }
     }
 }
 

--- a/chain/ethereum/src/network_indexer/mod.rs
+++ b/chain/ethereum/src/network_indexer/mod.rs
@@ -1,7 +1,7 @@
 use graph::prelude::*;
 use std::fmt;
 use std::ops::Deref;
-use web3::types::{Block, Transaction as Web3Transaction, H256};
+use web3::types::{Block, Log as Web3Log, Transaction as Web3Transaction, H256};
 
 mod block_writer;
 mod convert;
@@ -95,6 +95,24 @@ impl From<Web3Transaction> for Transaction {
 
 impl Deref for Transaction {
     type Target = Web3Transaction;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// Helper type to represent logs.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Log(Web3Log);
+
+impl From<Web3Log> for Log {
+    fn from(log: Web3Log) -> Self {
+        Self(log)
+    }
+}
+
+impl Deref for Log {
+    type Target = Web3Log;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/chain/ethereum/src/network_indexer/mod.rs
+++ b/chain/ethereum/src/network_indexer/mod.rs
@@ -1,7 +1,7 @@
 use graph::prelude::*;
 use std::fmt;
 use std::ops::Deref;
-use web3::types::{Block, H256};
+use web3::types::{Block, Transaction as Web3Transaction, H256};
 
 mod block_writer;
 mod convert;
@@ -80,6 +80,24 @@ impl BlockWithOmmers {
 impl fmt::Display for BlockWithOmmers {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.inner().format())
+    }
+}
+
+// Helper type to represent transactions.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Transaction(Web3Transaction);
+
+impl From<Web3Transaction> for Transaction {
+    fn from(transaction: Web3Transaction) -> Self {
+        Self(transaction)
+    }
+}
+
+impl Deref for Transaction {
+    type Target = Web3Transaction;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 


### PR DESCRIPTION
This PR updates the Ethereum network indexer to process transactions and transaction receipts from each block.  Additional entities have been created on the Ethereum subgraph to store the transactions, transaction logs and their relationship. 

Nested queries linking blocks, transactions and logs are now supported:
```graphql
query {
  blocks(orderBy:number orderDirection:desc where:{logs_not:[]}){
    id
    number
    transactionCount
    transactions {
      id 
      logs {
        id
      }
    }
    logs {
      id
      account
      data      
      transaction {
        id
      }
    }
  }
}
```
```graphql
query {
    logs {
      transaction {
        block {
          id
        }
      }
      id
      account
      data      
      transaction {
        id
      }
    }
  }

```