### PR TITLE
Fix entities updated after remove

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 **/*.idea
 **/*.DS_STORE
 
+# IDE files
+.vscode/
+
 # Ignore data files created by running the Docker Compose setup locally
 /docker/data/
 /docker/parity/chains/

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -13,7 +13,7 @@ pub struct DataSourceTemplateInfo {
     pub context: Option<DataSourceContext>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct BlockState {
     pub entity_cache: EntityCache,
     pub created_data_sources: Vec<DataSourceTemplateInfo>,
@@ -21,9 +21,9 @@ pub struct BlockState {
 }
 
 impl BlockState {
-    pub fn with_cache(lfu_cache: LfuCache<EntityKey, Option<Entity>>) -> Self {
+    pub fn new(store: Arc<dyn Store>, lfu_cache: LfuCache<EntityKey, Option<Entity>>) -> Self {
         BlockState {
-            entity_cache: EntityCache::with_current(lfu_cache),
+            entity_cache: EntityCache::with_current(store, lfu_cache),
             created_data_sources: Vec::new(),
             proof_of_indexing: Default::default(),
         }

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -145,7 +145,7 @@ impl MappingContext {
             logger: self.logger.clone(),
             host_exports: self.host_exports.clone(),
             block: self.block.clone(),
-            state: BlockState::default(),
+            state: BlockState::new(self.state.entity_cache.store.clone(), Default::default()),
         }
     }
 }

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -635,7 +635,8 @@ impl WasmiModule {
                         self.ctx
                             .state
                             .entity_cache
-                            .extend(output_state.entity_cache);
+                            .extend(output_state.entity_cache)
+                            .map_err(|e| HostExportError(e.to_string()))?;
                         self.ctx
                             .state
                             .created_data_sources

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -165,8 +165,8 @@ fn mock_context(
     MappingContext {
         logger: test_store::LOGGER.clone(),
         block: Default::default(),
-        host_exports: Arc::new(mock_host_exports(subgraph_id, data_source, store)),
-        state: BlockState::default(),
+        host_exports: Arc::new(mock_host_exports(subgraph_id, data_source, store.clone())),
+        state: BlockState::new(store, Default::default()),
     }
 }
 
@@ -908,7 +908,7 @@ fn entity_store() {
     }
 
     // Load, set, save cycle for a new entity with fulltext API
-    module.ctx.state.entity_cache = EntityCache::new();
+    module.ctx.state.entity_cache = EntityCache::new(store.clone());
     load_and_set_user_name(&mut module, "herobrine", "Brine-O");
     let mut fulltext_entities = BTreeMap::new();
     let mut fulltext_fields = BTreeMap::new();

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -136,8 +136,8 @@ pub fn transact_entity_operations(
     block_ptr_to: EthereumBlockPointer,
     ops: Vec<EntityOperation>,
 ) -> Result<bool, StoreError> {
-    let mut entity_cache = EntityCache::new();
-    entity_cache.append(ops);
+    let mut entity_cache = EntityCache::new(store.clone());
+    entity_cache.append(ops)?;
     let mods = entity_cache
         .as_modifications(store.as_ref())
         .expect("failed to convert to modifications")

--- a/tests/integration-tests/remove-then-update/abis/Contract.abi
+++ b/tests/integration-tests/remove-then-update/abis/Contract.abi
@@ -1,0 +1,1 @@
+[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint16","name":"x","type":"uint16"}],"name":"Trigger","type":"event"},{"inputs":[{"internalType":"uint16","name":"x","type":"uint16"}],"name":"emitTrigger","outputs":[],"stateMutability":"nonpayable","type":"function"}]

--- a/tests/integration-tests/remove-then-update/contracts/Contract.sol
+++ b/tests/integration-tests/remove-then-update/contracts/Contract.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.6.1;
+
+
+contract Contract {
+    event Trigger(uint16 x);
+
+    constructor() public {
+        emit Trigger(0);
+    }
+
+    function emitTrigger(uint16 x) public {
+        emit Trigger(x);
+    }
+}

--- a/tests/integration-tests/remove-then-update/contracts/Migrations.sol
+++ b/tests/integration-tests/remove-then-update/contracts/Migrations.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.6.1;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) public restricted {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}

--- a/tests/integration-tests/remove-then-update/migrations/1_initial_migration.js
+++ b/tests/integration-tests/remove-then-update/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+var Migrations = artifacts.require('./Migrations.sol')
+
+module.exports = function(deployer) {
+  deployer.deploy(Migrations)
+}

--- a/tests/integration-tests/remove-then-update/migrations/2_deploy_contracts.js
+++ b/tests/integration-tests/remove-then-update/migrations/2_deploy_contracts.js
@@ -1,0 +1,5 @@
+const Contract = artifacts.require('./Contract.sol')
+
+module.exports = async function(deployer) {
+  await deployer.deploy(Contract)
+}

--- a/tests/integration-tests/remove-then-update/package.json
+++ b/tests/integration-tests/remove-then-update/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "remove-then-update",
+  "version": "0.1.0",
+  "scripts": {
+    "build-contracts": "rm -rf abis bin && solcjs contracts/Contract.sol --abi -o abis && mv abis/*Contract.abi abis/Contract.abi && solcjs contracts/Contract.sol --bin -o bin && mv bin/*Contract.bin bin/Contract.bin",
+    "codegen": "graph codegen",
+    "test": "yarn build-contracts && truffle test --network test",
+    "create:test": "graph create test/remove-then-update --node http://localhost:18020/",
+    "deploy:test": "graph deploy test/remove-then-update --ipfs http://localhost:15001/ --node http://localhost:18020/"
+  },
+  "devDependencies": {
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "solc": "^0.6.1"
+  },
+  "dependencies": {
+    "apollo-fetch": "^0.7.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-register": "^6.26.0",
+    "gluegun": "^3.2.1",
+    "truffle": "^5.0.4",
+    "truffle-contract": "^4.0.5",
+    "truffle-hdwallet-provider": "^1.0.4"
+  }
+}

--- a/tests/integration-tests/remove-then-update/schema.graphql
+++ b/tests/integration-tests/remove-then-update/schema.graphql
@@ -1,0 +1,5 @@
+type Foo @entity {
+  id: ID!
+  value: String
+  removed: Boolean!
+}

--- a/tests/integration-tests/remove-then-update/src/mapping.ts
+++ b/tests/integration-tests/remove-then-update/src/mapping.ts
@@ -1,0 +1,25 @@
+import { BigInt, Bytes, store } from "@graphprotocol/graph-ts";
+import { Trigger } from "../generated/Contract/Contract";
+import { Foo } from "../generated/schema";
+
+export function handleTrigger(event: Trigger): void {
+  if (event.params.x == 0) {
+    create();
+  } else if (event.params.x == 1) {
+    store.remove("Foo", "0");
+
+    let obj = new Foo("0");
+    obj.removed = true;
+    obj.save();
+
+    obj = Foo.load("0") as Foo;
+    assert(obj.value == null);
+  }
+}
+
+function create(): void {
+  let obj = new Foo("0");
+  obj.value = "bla";
+  obj.removed = false;
+  obj.save();
+}

--- a/tests/integration-tests/remove-then-update/subgraph.yaml
+++ b/tests/integration-tests/remove-then-update/subgraph.yaml
@@ -1,0 +1,23 @@
+specVersion: 0.0.2
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: Contract
+    network: test
+    source:
+      address: "0xCfEB869F69431e42cdB54A4F4f105C19C080A601"
+      abi: Contract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      abis:
+        - name: Contract
+          file: ./abis/Contract.abi
+      entities:
+        - Call
+      eventHandlers:
+        - event: Trigger(uint16)
+          handler: handleTrigger
+      file: ./src/mapping.ts

--- a/tests/integration-tests/remove-then-update/test/test.js
+++ b/tests/integration-tests/remove-then-update/test/test.js
@@ -1,0 +1,96 @@
+const path = require("path");
+const execSync = require("child_process").execSync;
+const { system, patching } = require("gluegun");
+const { createApolloFetch } = require("apollo-fetch");
+
+const Contract = artifacts.require("./Contract.sol");
+
+const srcDir = path.join(__dirname, "..");
+
+const fetchSubgraphs = createApolloFetch({
+  uri: "http://localhost:18030/graphql",
+});
+const fetchSubgraph = createApolloFetch({
+  uri: "http://localhost:18000/subgraphs/name/test/remove-then-update",
+});
+
+const exec = (cmd) => {
+  try {
+    return execSync(cmd, { cwd: srcDir, stdio: "inherit" });
+  } catch (e) {
+    throw new Error(`Failed to run command \`${cmd}\``);
+  }
+};
+
+const waitForSubgraphToBeSynced = async () =>
+  new Promise((resolve, reject) => {
+    // Wait for 5s
+    let deadline = Date.now() + 5 * 1000;
+
+    // Function to check if the subgraph is synced
+    const checkSubgraphSynced = async () => {
+      try {
+        let result = await fetchSubgraphs({
+          query: `{ indexingStatuses { synced, failed } }`,
+        });
+
+        if (result.data.indexingStatuses[0].synced) {
+          resolve();
+        } else if (result.data.indexingStatuses[0].failed) {
+          reject(new Error("Subgraph failed"));
+        } else {
+          throw new Error("reject or retry");
+        }
+      } catch (e) {
+        if (Date.now() > deadline) {
+          reject(new Error(`Timed out waiting for the subgraph to sync`));
+        } else {
+          setTimeout(checkSubgraphSynced, 500);
+        }
+      }
+    };
+
+    // Periodically check whether the subgraph has synced
+    setTimeout(checkSubgraphSynced, 0);
+  });
+
+contract("Contract", (accounts) => {
+  // Deploy the subgraph once before all tests
+  before(async () => {
+    // Deploy the contract
+    const contract = await Contract.deployed();
+    await contract.emitTrigger(1);
+
+    // Insert its address into subgraph manifest
+    await patching.replace(
+      path.join(srcDir, "subgraph.yaml"),
+      "0x0000000000000000000000000000000000000000",
+      contract.address
+    );
+
+    // Create and deploy the subgraph
+    exec(`yarn codegen`);
+    exec(`yarn create:test`);
+    exec(`yarn deploy:test`);
+
+    // Wait for the subgraph to be indexed
+    await waitForSubgraphToBeSynced();
+  });
+
+  it("all overloads of the contract function are called", async () => {
+    let result = await fetchSubgraph({
+      query: `{ foos(orderBy: id) { id value removed } }`,
+    });
+
+    expect(result.errors).to.be.undefined;
+    expect(result.data).to.deep.equal({
+      foos: [
+        {
+          id: "0",
+          removed: true,
+          value: null,
+        },
+      ],
+    });
+  });
+});

--- a/tests/integration-tests/remove-then-update/truffle.js
+++ b/tests/integration-tests/remove-then-update/truffle.js
@@ -1,0 +1,19 @@
+require("babel-register");
+require("babel-polyfill");
+
+module.exports = {
+  networks: {
+    test: {
+      host: "localhost",
+      port: 18545,
+      network_id: "*",
+      gas: "100000000000",
+      gasPrice: "1"
+    }
+  },
+  compilers: {
+    solc: {
+      version: "0.6.1"
+    }
+  }
+};

--- a/tests/tests/tests.rs
+++ b/tests/tests/tests.rs
@@ -86,3 +86,9 @@ fn ganache_reverts() {
     let _m = TEST_MUTEX.lock();
     run_test("ganache-reverts")
 }
+
+#[test]
+fn remove_then_update() {
+    let _m = TEST_MUTEX.lock();
+    run_test("remove-then-update");
+}


### PR DESCRIPTION
Previously we'd ignore the removal, merging the update with the version in the store.

The fix required changing the structure of `EntityCache` to explicitly keep track of entities which were removed at some point.

Resolves #1598. Includes integration test.