### PR TITLE
Report the block at which a query was run in the response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,6 +1294,7 @@ name = "graph-graphql"
 version = "0.18.0"
 dependencies = [
  "Inflector",
+ "futures 0.1.29",
  "graph",
  "graphql-parser",
  "indexmap",
@@ -1330,6 +1331,7 @@ dependencies = [
  "graph-chain-arweave",
  "graph-chain-ethereum",
  "graph-core",
+ "graph-graphql",
  "graph-mock",
  "graph-runtime-wasm",
  "graph-server-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3718,6 +3718,7 @@ version = "0.18.0"
 dependencies = [
  "diesel",
  "graph",
+ "graph-graphql",
  "graph-mock",
  "graph-store-postgres",
  "hex-literal",

--- a/core/src/graphql/mod.rs
+++ b/core/src/graphql/mod.rs
@@ -1,3 +1,0 @@
-mod runner;
-
-pub use self::runner::GraphQlRunner;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,10 +1,8 @@
-mod graphql;
 mod link_resolver;
 mod metrics;
 mod subgraph;
 pub mod three_box;
 
-pub use crate::graphql::GraphQlRunner;
 pub use crate::link_resolver::LinkResolver;
 pub use crate::metrics::MetricsRegistry;
 pub use crate::subgraph::{

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -1,7 +1,6 @@
 // Tests for graphql interfaces.
 
 use graph::prelude::*;
-use graph_graphql::prelude::{execute_query, QueryExecutionOptions, StoreResolver};
 use test_store::*;
 
 // `entities` is `(entity, type)`.
@@ -32,20 +31,9 @@ fn insert_and_query(
         insert_ops.collect::<Vec<_>>(),
     )?;
 
-    let logger = Logger::root(slog::Discard, o!());
-    let resolver = StoreResolver::new(&logger, STORE.clone());
-
-    let options = QueryExecutionOptions {
-        logger,
-        resolver,
-        deadline: None,
-        max_complexity: None,
-        max_depth: 100,
-        max_first: std::u32::MAX,
-    };
     let document = graphql_parser::parse_query(query).unwrap();
     let query = Query::new(STORE.api_schema(&subgraph_id).unwrap(), document, None);
-    Ok(execute_query(query, options))
+    Ok(execute_subgraph_query(query))
 }
 
 #[test]

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -60,6 +60,7 @@ pub enum QueryExecutionError {
     Panic(String),
     EventStreamError,
     FulltextQueryRequiresFilter,
+    InconsistentBlockConstraints,
 }
 
 impl Error for QueryExecutionError {
@@ -207,6 +208,7 @@ impl fmt::Display for QueryExecutionError {
             Panic(msg) => write!(f, "panic processing query: {}", msg),
             EventStreamError => write!(f, "error in the subscription event stream"),
             FulltextQueryRequiresFilter => write!(f, "fulltext search queries can only use EntityFilter::Equal"),
+            InconsistentBlockConstraints => write!(f, "when a query has multiple top level fields, they all must have the same block constraint")
         }
     }
 }

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -21,11 +21,24 @@ pub struct QueryResult {
     pub data: Option<q::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub errors: Option<Vec<QueryError>>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_data"
+    )]
+    pub extensions: Option<q::Value>,
 }
 
 impl QueryResult {
     pub fn new(data: Option<q::Value>) -> Self {
-        QueryResult { data, errors: None }
+        QueryResult {
+            data,
+            errors: None,
+            extensions: None,
+        }
+    }
+    pub fn with_extensions(mut self, extensions: q::Value) -> Self {
+        self.extensions = Some(extensions);
+        self
     }
 }
 
@@ -42,6 +55,7 @@ impl From<Vec<QueryExecutionError>> for QueryResult {
         QueryResult {
             data: None,
             errors: Some(e.into_iter().map(QueryError::from).collect()),
+            extensions: None,
         }
     }
 }

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -3,6 +3,7 @@ use crate::data::graphql::SerializableValue;
 use graphql_parser::query as q;
 use serde::ser::*;
 use serde::Serialize;
+use std::collections::BTreeMap;
 
 fn serialize_data<S>(data: &Option<q::Value>, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -36,8 +37,8 @@ impl QueryResult {
             extensions: None,
         }
     }
-    pub fn with_extensions(mut self, extensions: q::Value) -> Self {
-        self.extensions = Some(extensions);
+    pub fn with_extensions(mut self, extensions: BTreeMap<q::Name, q::Value>) -> Self {
+        self.extensions = Some(q::Value::Object(extensions));
         self
     }
 }

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -45,3 +45,12 @@ impl From<Vec<QueryExecutionError>> for QueryResult {
         }
     }
 }
+
+impl From<Result<q::Value, Vec<QueryExecutionError>>> for QueryResult {
+    fn from(result: Result<q::Value, Vec<QueryExecutionError>>) -> Self {
+        match result {
+            Ok(v) => QueryResult::new(Some(v)),
+            Err(errors) => QueryResult::from(errors),
+        }
+    }
+}

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.18.0"
 edition = "2018"
 
 [dependencies]
+futures01 = { package="futures", version="0.1.29" }
 graph = { path = "../graph" }
 graphql-parser = "0.2.3"
 indexmap = "1.3"

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -486,7 +486,6 @@ fn resolve_field_value_for_named_type(
             t.into(),
             argument_values,
             ctx.query.schema.types_for_interface(),
-            ctx.block,
         ),
 
         // Let the resolver decide how values in the resolved object value
@@ -528,7 +527,6 @@ fn resolve_field_value_for_named_type(
             i.into(),
             argument_values,
             ctx.query.schema.types_for_interface(),
-            ctx.block,
         ),
 
         s::TypeDefinition::Union(_) => Err(QueryExecutionError::Unimplemented("unions".to_owned())),
@@ -575,7 +573,6 @@ fn resolve_field_value_for_list_type(
                         t.into(),
                         argument_values,
                         ctx.query.schema.types_for_interface(),
-                        ctx.block,
                         ctx.max_first,
                     )
                     .map_err(|e| vec![e]),
@@ -609,7 +606,6 @@ fn resolve_field_value_for_list_type(
                         t.into(),
                         argument_values,
                         ctx.query.schema.types_for_interface(),
-                        ctx.block,
                         ctx.max_first,
                     )
                     .map_err(|e| vec![e]),

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -50,10 +50,6 @@ where
     /// Max value for `first`.
     pub max_first: u32,
 
-    /// The block at which we should execute the query. Initialize this
-    /// with `BLOCK_NUMBER_MAX` to get the latest data
-    pub block: BlockNumber,
-
     pub mode: ExecutionMode,
 }
 
@@ -99,7 +95,6 @@ where
             fields: vec![],
             deadline: self.deadline,
             max_first: std::u32::MAX,
-            block: self.block,
             mode: ExecutionMode::Prefetch,
         }
     }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -13,7 +13,6 @@ use crate::introspection::{
 };
 use crate::prelude::*;
 use crate::query::ast as qast;
-use crate::query::ext::FieldExt as _;
 use crate::schema::ast as sast;
 use crate::values::coercion;
 
@@ -84,16 +83,9 @@ where
     R: Resolver,
 {
     /// Creates a derived context for a new field (added to the top of the field stack).
-    pub fn for_field<'a>(
-        &self,
-        field: &q::Field,
-        object_type: impl Into<ObjectOrInterface<'a>>,
-    ) -> Result<Self, QueryExecutionError> {
+    pub fn for_field<'a>(&self, field: &q::Field) -> Result<Self, QueryExecutionError> {
         let mut ctx = self.clone();
         ctx.fields.push(field.clone());
-        if let Some(bc) = field.block_constraint(object_type)? {
-            ctx.block = self.resolver.locate_block(&bc)?;
-        }
         Ok(ctx)
     }
 
@@ -235,7 +227,7 @@ fn execute_selection_set_to_map(
         // If the field exists on the object, execute it and add its result to the result map
         if let Some(ref field) = sast::get_field(object_type, &fields[0].name) {
             // Push the new field onto the context's field stack
-            match ctx.for_field(&fields[0], object_type) {
+            match ctx.for_field(&fields[0]) {
                 Ok(ctx) => {
                     match execute_field(&ctx, object_type, object_value, &fields[0], field, fields)
                     {

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -111,8 +111,6 @@ impl Query {
     /// syntactically, each toplevel field can have its own block constraint,
     /// we check that they are all identical and report an error otherwise
     pub fn block_constraint(&self) -> Result<Option<BlockConstraint>, Vec<QueryExecutionError>> {
-        let root_type = sast::get_root_query_type(&self.schema.document).unwrap();
-
         let mut bcs = HashSet::new();
         let mut errors = Vec::new();
 
@@ -120,7 +118,7 @@ impl Query {
             q::Selection::Field(f) => Some(f),
             _ => None,
         }) {
-            match field.block_constraint(root_type) {
+            match field.block_constraint() {
                 Ok(bc) => {
                     bcs.insert(bc);
                 }

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -110,7 +110,7 @@ impl Query {
     /// Return the block constraint for the toplevel query field(s) Since,
     /// syntactically, each toplevel field can have its own block constraint,
     /// we check that they are all identical and report an error otherwise
-    pub fn block_constraint(&self) -> Result<Option<BlockConstraint>, Vec<QueryExecutionError>> {
+    pub fn block_constraint(&self) -> Result<BlockConstraint, Vec<QueryExecutionError>> {
         let mut bcs = HashSet::new();
         let mut errors = Vec::new();
 
@@ -131,7 +131,10 @@ impl Query {
         if !errors.is_empty() {
             Err(errors)
         } else {
-            Ok(bcs.into_iter().next().flatten())
+            Ok(bcs
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| BlockConstraint::default()))
         }
     }
 

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -2,11 +2,8 @@ use graphql_parser::{query as q, schema as s};
 use std::collections::{BTreeMap, HashMap};
 
 use crate::prelude::*;
-use crate::query::ext::BlockConstraint;
 use crate::schema::ast::get_named_type;
-use graph::prelude::{
-    BlockNumber, QueryExecutionError, Schema, StoreEventStreamBox, SubgraphDeploymentId,
-};
+use graph::prelude::{QueryExecutionError, Schema, StoreEventStreamBox};
 
 #[derive(Copy, Clone, Debug)]
 pub enum ObjectOrInterface<'a> {
@@ -72,15 +69,6 @@ pub trait Resolver: Clone + Send + Sync {
         selection_set: &q::SelectionSet,
     ) -> Result<Option<q::Value>, Vec<QueryExecutionError>>;
 
-    /// Locate the block for the given constraint and return its block number.
-    /// That number will later be passed into `resolve_object` and
-    /// `resolve_objects`
-    fn locate_block(
-        &self,
-        block_constraint: BlockConstraint,
-        subgraph: &SubgraphDeploymentId,
-    ) -> Result<BlockNumber, QueryExecutionError>;
-
     /// Resolves entities referenced by a parent object.
     fn resolve_objects(
         &self,
@@ -90,7 +78,6 @@ pub trait Resolver: Clone + Send + Sync {
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
-        block: BlockNumber,
         max_first: u32,
     ) -> Result<q::Value, QueryExecutionError>;
 
@@ -103,7 +90,6 @@ pub trait Resolver: Clone + Send + Sync {
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
-        block: BlockNumber,
     ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an enum value for a given enum type.

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -4,7 +4,9 @@ use std::collections::{BTreeMap, HashMap};
 use crate::prelude::*;
 use crate::query::ext::BlockConstraint;
 use crate::schema::ast::get_named_type;
-use graph::prelude::{BlockNumber, QueryExecutionError, Schema, StoreEventStreamBox};
+use graph::prelude::{
+    BlockNumber, QueryExecutionError, Schema, StoreEventStreamBox, SubgraphDeploymentId,
+};
 
 #[derive(Copy, Clone, Debug)]
 pub enum ObjectOrInterface<'a> {
@@ -75,7 +77,8 @@ pub trait Resolver: Clone + Send + Sync {
     /// `resolve_objects`
     fn locate_block(
         &self,
-        block_constraint: &BlockConstraint,
+        block_constraint: BlockConstraint,
+        subgraph: &SubgraphDeploymentId,
     ) -> Result<BlockNumber, QueryExecutionError>;
 
     /// Resolves entities referenced by a parent object.

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -367,7 +367,11 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         Ok(None)
     }
 
-    fn locate_block(&self, _: &BlockConstraint) -> Result<BlockNumber, QueryExecutionError> {
+    fn locate_block(
+        &self,
+        _: BlockConstraint,
+        _: &SubgraphDeploymentId,
+    ) -> Result<BlockNumber, QueryExecutionError> {
         Ok(BLOCK_NUMBER_MAX)
     }
 

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -4,7 +4,6 @@ use std::collections::{BTreeMap, HashMap};
 use graph::prelude::*;
 
 use crate::prelude::*;
-use crate::query::ext::BlockConstraint;
 use crate::schema::ast as sast;
 
 type TypeObjectsMap = BTreeMap<String, q::Value>;
@@ -367,14 +366,6 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         Ok(None)
     }
 
-    fn locate_block(
-        &self,
-        _: BlockConstraint,
-        _: &SubgraphDeploymentId,
-    ) -> Result<BlockNumber, QueryExecutionError> {
-        Ok(BLOCK_NUMBER_MAX)
-    }
-
     fn resolve_objects(
         &self,
         parent: &Option<q::Value>,
@@ -383,7 +374,6 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
-        _block: BlockNumber,
         _max_first: u32,
     ) -> Result<q::Value, QueryExecutionError> {
         match field.name.as_str() {
@@ -423,7 +413,6 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
         _object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         _: &BTreeMap<Name, Vec<ObjectType>>,
-        _: BlockNumber,
     ) -> Result<q::Value, QueryExecutionError> {
         let object = match field.name.as_str() {
             "__schema" => self.schema_object(),

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -30,7 +30,7 @@ mod runner;
 pub mod prelude {
     pub use super::execution::{ExecutionContext, ObjectOrInterface, Query, Resolver};
     pub use super::introspection::{introspection_schema, IntrospectionResolver};
-    pub use super::query::{execute_prepared_query, ext::BlockConstraint, QueryExecutionOptions};
+    pub use super::query::{execute_query, ext::BlockConstraint, QueryExecutionOptions};
     pub use super::schema::{api_schema, ast::validate_entity, APISchemaError};
     pub use super::store::{build_query, StoreResolver};
     pub use super::subscription::{execute_subscription, SubscriptionExecutionOptions};

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -28,9 +28,9 @@ mod runner;
 
 /// Prelude that exports the most important traits and types.
 pub mod prelude {
-    pub use super::execution::{ExecutionContext, ObjectOrInterface, Resolver};
+    pub use super::execution::{ExecutionContext, ObjectOrInterface, Query, Resolver};
     pub use super::introspection::{introspection_schema, IntrospectionResolver};
-    pub use super::query::{execute_query, ext::BlockConstraint, QueryExecutionOptions};
+    pub use super::query::{execute_prepared_query, ext::BlockConstraint, QueryExecutionOptions};
     pub use super::schema::{api_schema, ast::validate_entity, APISchemaError};
     pub use super::store::{build_query, StoreResolver};
     pub use super::subscription::{execute_subscription, SubscriptionExecutionOptions};

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -23,6 +23,9 @@ mod values;
 /// Utilities for querying `Store` components.
 mod store;
 
+/// The external interface for actually running queries
+mod runner;
+
 /// Prelude that exports the most important traits and types.
 pub mod prelude {
     pub use super::execution::{ExecutionContext, ObjectOrInterface, Resolver};
@@ -34,5 +37,7 @@ pub mod prelude {
     pub use super::values::{object_value, IntoValue, MaybeCoercible};
 
     pub use super::graphql_parser::{query::Name, schema::ObjectType};
+    pub use super::runner::GraphQlRunner;
+
     pub use crate::object;
 }

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -27,9 +27,7 @@ mod store;
 pub mod prelude {
     pub use super::execution::{ExecutionContext, ObjectOrInterface, Resolver};
     pub use super::introspection::{introspection_schema, IntrospectionResolver};
-    pub use super::query::{
-        execute_query, ext::BlockConstraint, ext::BlockLocator, QueryExecutionOptions,
-    };
+    pub use super::query::{execute_query, ext::BlockConstraint, QueryExecutionOptions};
     pub use super::schema::{api_schema, ast::validate_entity, APISchemaError};
     pub use super::store::{build_query, StoreResolver};
     pub use super::subscription::{execute_subscription, SubscriptionExecutionOptions};

--- a/graphql/src/query/ext.rs
+++ b/graphql/src/query/ext.rs
@@ -35,11 +35,13 @@ impl ValueExt for q::Value {
     }
 }
 
+#[derive(PartialEq, Eq, Hash)]
 pub enum BlockLocator {
     Hash(H256),
     Number(BlockNumber),
 }
 
+#[derive(PartialEq, Eq, Hash)]
 pub struct BlockConstraint {
     pub subgraph: SubgraphDeploymentId,
     pub block: BlockLocator,

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -69,8 +69,6 @@ where
         ExecutionMode::Prefetch
     };
 
-    let block = 0;
-
     // Create a fresh execution context
     let ctx = ExecutionContext {
         logger: query_logger.clone(),
@@ -79,7 +77,6 @@ where
         fields: vec![],
         deadline: options.deadline,
         max_first: options.max_first,
-        block,
         mode,
     };
 

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -82,7 +82,7 @@ where
 
     let block = query
         .block_constraint()?
-        .map(|bc| options.resolver.locate_block(&bc))
+        .map(|bc| options.resolver.locate_block(bc, &query.schema.id))
         .transpose()?
         .unwrap_or(BLOCK_NUMBER_MAX);
 

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,4 +1,4 @@
-use graph::prelude::{info, o, Logger, Query as GraphDataQuery, QueryExecutionError, QueryResult};
+use graph::prelude::{info, o, Logger, QueryExecutionError};
 use graphql_parser::query as q;
 use std::sync::Arc;
 use std::time::Instant;
@@ -37,20 +37,7 @@ where
 }
 
 /// Executes a query and returns a result.
-pub fn execute_query<R>(query: GraphDataQuery, options: QueryExecutionOptions<R>) -> QueryResult
-where
-    R: Resolver,
-{
-    let query = match Query::new(query, options.max_complexity, options.max_depth) {
-        Ok(query) => query,
-        Err(e) => return QueryResult::from(e),
-    };
-
-    QueryResult::from(execute_prepared_query(query, options))
-}
-
-/// Executes a query and returns a result.
-pub(crate) fn execute_prepared_query<R>(
+pub fn execute_prepared_query<R>(
     query: Arc<Query>,
     options: QueryExecutionOptions<R>,
 ) -> Result<q::Value, Vec<QueryExecutionError>>

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -80,6 +80,12 @@ where
         ExecutionMode::Prefetch
     };
 
+    let block = query
+        .block_constraint()?
+        .map(|bc| options.resolver.locate_block(&bc))
+        .transpose()?
+        .unwrap_or(BLOCK_NUMBER_MAX);
+
     // Create a fresh execution context
     let ctx = ExecutionContext {
         logger: query_logger.clone(),
@@ -88,7 +94,7 @@ where
         fields: vec![],
         deadline: options.deadline,
         max_first: options.max_first,
-        block: BLOCK_NUMBER_MAX,
+        block,
         mode,
     };
 

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -37,7 +37,7 @@ where
 }
 
 /// Executes a query and returns a result.
-pub fn execute_prepared_query<R>(
+pub fn execute_query<R>(
     query: Arc<Query>,
     options: QueryExecutionOptions<R>,
 ) -> Result<q::Value, Vec<QueryExecutionError>>

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -69,8 +69,7 @@ where
         ExecutionMode::Prefetch
     };
 
-    let bc = query.block_constraint()?;
-    let block = options.resolver.locate_block(bc, &query.schema.id)?;
+    let block = 0;
 
     // Create a fresh execution context
     let ctx = ExecutionContext {

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,5 +1,5 @@
 use graph::prelude::{Query as GraphDataQuery, *};
-use graphql_parser::{query as q, Style};
+use graphql_parser::query as q;
 use std::time::Instant;
 use uuid::Uuid;
 
@@ -60,18 +60,6 @@ where
         "query_id" => query_id
     ));
 
-    let (query_text, variables_text) = if *graph::log::LOG_GQL_TIMING {
-        (
-            query
-                .document
-                .format(&Style::default().indent(0))
-                .replace('\n', " "),
-            serde_json::to_string(&query.variables).unwrap_or_default(),
-        )
-    } else {
-        ("".to_owned(), "".to_owned())
-    };
-
     let query = crate::execution::Query::new(query, options.max_complexity, options.max_depth)?;
 
     let mode = if query.verify {
@@ -108,8 +96,8 @@ where
         info!(
             query_logger,
             "Query timing (GraphQL)";
-            "query" => query_text,
-            "variables" => variables_text,
+            "query" => &query.query_text,
+            "variables" => &query.variables_text,
             "query_time_ms" => start.elapsed().as_millis(),
         );
     }

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -26,12 +26,6 @@ where
     /// Time at which the query times out.
     pub deadline: Option<Instant>,
 
-    /// Maximum complexity for a query.
-    pub max_complexity: Option<u64>,
-
-    /// Maximum depth for a query.
-    pub max_depth: u8,
-
     /// Maximum value for the `first` argument.
     pub max_first: u32,
 }

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -80,11 +80,8 @@ where
         ExecutionMode::Prefetch
     };
 
-    let block = query
-        .block_constraint()?
-        .map(|bc| options.resolver.locate_block(bc, &query.schema.id))
-        .transpose()?
-        .unwrap_or(BLOCK_NUMBER_MAX);
+    let bc = query.block_constraint()?;
+    let block = options.resolver.locate_block(bc, &query.schema.id)?;
 
     // Create a fresh execution context
     let ctx = ExecutionContext {

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use crate::prelude::{
     object, object_value, QueryExecutionOptions, StoreResolver, SubscriptionExecutionOptions,
 };
-use crate::query::execute_prepared_query;
+use crate::query::execute_query;
 use crate::subscription::execute_prepared_subscription;
 use graph::prelude::{
     o, EthereumBlockPointer, GraphQlRunner as GraphQlRunnerTrait, Logger, Query,
@@ -101,7 +101,7 @@ where
         let (resolver, block_ptr) =
             StoreResolver::at_block(&self.logger, self.store.clone(), bc, &query.schema.id)?;
         let exts = self.make_extensions(&query.schema.id, &block_ptr)?;
-        execute_prepared_query(
+        execute_query(
             query,
             QueryExecutionOptions {
                 logger: self.logger.clone(),

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -107,8 +107,6 @@ where
                 logger: self.logger.clone(),
                 resolver,
                 deadline: GRAPHQL_QUERY_TIMEOUT.map(|t| Instant::now() + t),
-                max_complexity: max_complexity,
-                max_depth: max_depth,
                 max_first: max_first.unwrap_or(*GRAPHQL_MAX_FIRST),
             },
         )

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -62,7 +62,7 @@ where
         let max_depth = max_depth.unwrap_or(*GRAPHQL_MAX_DEPTH);
         let query = crate::execution::Query::new(query, max_complexity, max_depth)?;
         let bc = query.block_constraint()?;
-        let resolver =
+        let (resolver, block_ptr) =
             StoreResolver::at_block(&self.logger, self.store.clone(), bc, &query.schema.id)?;
         execute_prepared_query(
             query,

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -3,8 +3,8 @@ use std::env;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
 
+use crate::prelude::*;
 use graph::prelude::{GraphQlRunner as GraphQlRunnerTrait, *};
-use graph_graphql::prelude::*;
 
 use lazy_static::lazy_static;
 

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -1,5 +1,6 @@
 use futures01::future;
 use graphql_parser::query as q;
+use std::collections::BTreeMap;
 use std::env;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -65,7 +66,7 @@ where
         &self,
         subgraph: &SubgraphDeploymentId,
         block_ptr: &EthereumBlockPointer,
-    ) -> Result<q::Value, Vec<QueryExecutionError>> {
+    ) -> Result<BTreeMap<q::Name, q::Value>, Vec<QueryExecutionError>> {
         let network = self
             .store
             .network_name(subgraph)
@@ -90,12 +91,15 @@ where
             // the block where the query happened
             object_value(vec![(network.as_str(), object_value(vec![]))])
         };
-        Ok(object! {
-            subgraph: object! {
+        let mut exts = BTreeMap::new();
+        exts.insert(
+            "subgraph".to_owned(),
+            object! {
                 id: subgraph.to_string(),
                 blocks: vec![network_info]
-            }
-        })
+            },
+        );
+        Ok(exts)
     }
 
     fn execute(

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -2,12 +2,16 @@ use futures01::future;
 use graphql_parser::query as q;
 use std::env;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::prelude::*;
+use crate::prelude::{object, QueryExecutionOptions, StoreResolver, SubscriptionExecutionOptions};
 use crate::query::execute_prepared_query;
 use crate::subscription::execute_prepared_subscription;
-use graph::prelude::{GraphQlRunner as GraphQlRunnerTrait, *};
+use graph::prelude::{
+    o, GraphQlRunner as GraphQlRunnerTrait, Logger, Query, QueryExecutionError, QueryResult,
+    QueryResultFuture, Store, Subscription, SubscriptionResultFuture,
+};
 
 use lazy_static::lazy_static;
 

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -61,11 +61,14 @@ where
     ) -> Result<q::Value, Vec<QueryExecutionError>> {
         let max_depth = max_depth.unwrap_or(*GRAPHQL_MAX_DEPTH);
         let query = crate::execution::Query::new(query, max_complexity, max_depth)?;
+        let bc = query.block_constraint()?;
+        let resolver =
+            StoreResolver::at_block(&self.logger, self.store.clone(), bc, &query.schema.id)?;
         execute_prepared_query(
             query,
             QueryExecutionOptions {
                 logger: self.logger.clone(),
-                resolver: StoreResolver::new(&self.logger, self.store.clone()),
+                resolver,
                 deadline: GRAPHQL_QUERY_TIMEOUT.map(|t| Instant::now() + t),
                 max_complexity: max_complexity,
                 max_depth: max_depth,

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -570,7 +570,7 @@ fn execute_selection_set(
                 .expect("collect_fields does not create type conditions for nonexistent types");
 
             if let Some(ref field) = concrete_type.field(&fields[0].name) {
-                match ctx.for_field(&fields[0], concrete_type.clone()) {
+                match ctx.for_field(&fields[0]) {
                     Ok(ctx) => {
                         let child_type = object_or_interface_from_type(
                             &ctx.query.schema.document,

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -284,6 +284,14 @@ where
                         )
                     })
                 }),
+            BlockConstraint::Latest => self
+                .store
+                .block_ptr(subgraph.clone())
+                .map_err(|e| StoreError::from(e).into())
+                .and_then(|ptr| {
+                    let ptr = ptr.expect("we should have already checked that the subgraph exists");
+                    Ok(ptr.number as i32)
+                }),
         }
     }
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -16,8 +16,8 @@ use crate::store::query::{collect_entities_from_query_field, parse_subgraph_id};
 /// A resolver that fetches entities from a `Store`.
 pub struct StoreResolver<S> {
     logger: Logger,
-    store: Arc<S>,
-    block: BlockNumber,
+    pub(crate) store: Arc<S>,
+    pub(crate) block: BlockNumber,
 }
 
 impl<S> Clone for StoreResolver<S>
@@ -315,7 +315,7 @@ where
         ctx: &ExecutionContext<Self>,
         selection_set: &q::SelectionSet,
     ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
-        super::prefetch::run(ctx, selection_set, self.store.clone()).map(|value| Some(value))
+        super::prefetch::run(&self, ctx, selection_set).map(|value| Some(value))
     }
 
     fn resolve_objects(

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -82,7 +82,6 @@ where
         fields: vec![],
         deadline: None,
         max_first: options.max_first,
-        block: BLOCK_NUMBER_MAX,
         mode: ExecutionMode::Prefetch,
     };
 
@@ -195,7 +194,6 @@ async fn execute_subscription_event(
         fields: vec![],
         deadline: timeout.map(|t| Instant::now() + t),
         max_first,
-        block: BLOCK_NUMBER_MAX,
         mode: ExecutionMode::Prefetch,
     };
 

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -1,10 +1,11 @@
 use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 use std::result::Result;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::Semaphore;
 
 use graph::prelude::*;
+use tokio::sync::Semaphore;
 
 use crate::execution::*;
 use crate::schema::ast as sast;
@@ -63,7 +64,16 @@ where
         options.max_complexity,
         options.max_depth,
     )?;
+    execute_prepared_subscription(query, options)
+}
 
+pub(crate) fn execute_prepared_subscription<R>(
+    query: Arc<crate::execution::Query>,
+    options: SubscriptionExecutionOptions<R>,
+) -> Result<SubscriptionResult, SubscriptionError>
+where
+    R: Resolver + 'static,
+{
     // Create a fresh execution context
     let ctx = ExecutionContext {
         logger: options.logger,

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -1,4 +1,4 @@
-use graphql_parser::{query as q, schema as s, Style};
+use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 use std::result::Result;
 use std::time::{Duration, Instant};
@@ -58,12 +58,6 @@ pub fn execute_subscription<R>(
 where
     R: Resolver + 'static,
 {
-    let query_text = subscription
-        .query
-        .document
-        .format(&Style::default().indent(0))
-        .replace('\n', " ");
-
     let query = crate::execution::Query::new(
         subscription.query,
         options.max_complexity,
@@ -91,7 +85,7 @@ where
     info!(
         ctx.logger,
         "Execute subscription";
-        "query" => query_text,
+        "query" => &query.query_text,
     );
 
     let source_stream = create_source_event_stream(&ctx)?;

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -20,7 +20,11 @@ impl Resolver for MockResolver {
         Ok(None)
     }
 
-    fn locate_block(&self, _: &BlockConstraint) -> Result<BlockNumber, QueryExecutionError> {
+    fn locate_block(
+        &self,
+        _: BlockConstraint,
+        _: &SubgraphDeploymentId,
+    ) -> Result<BlockNumber, QueryExecutionError> {
         Ok(BLOCK_NUMBER_MAX)
     }
 

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -3,9 +3,15 @@ extern crate pretty_assertions;
 
 use graphql_parser::{query as q, schema as s};
 use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
 
-use graph::prelude::*;
-use graph_graphql::prelude::*;
+use graph::prelude::{
+    o, slog, Logger, Query, QueryExecutionError, QueryResult, Schema, SubgraphDeploymentId,
+};
+use graph_graphql::prelude::{
+    api_schema, execute_query, object, object_value, ExecutionContext, ObjectOrInterface,
+    QueryExecutionOptions, Resolver,
+};
 
 /// Mock resolver used in tests that don't need a resolver.
 #[derive(Clone)]
@@ -27,7 +33,7 @@ impl Resolver for MockResolver {
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
-        _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
+        _types_for_interface: &BTreeMap<q::Name, Vec<s::ObjectType>>,
         _max_first: u32,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
@@ -40,7 +46,7 @@ impl Resolver for MockResolver {
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
-        _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
+        _types_for_interface: &BTreeMap<q::Name, Vec<s::ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -20,14 +20,6 @@ impl Resolver for MockResolver {
         Ok(None)
     }
 
-    fn locate_block(
-        &self,
-        _: BlockConstraint,
-        _: &SubgraphDeploymentId,
-    ) -> Result<BlockNumber, QueryExecutionError> {
-        Ok(BLOCK_NUMBER_MAX)
-    }
-
     fn resolve_objects<'a>(
         &self,
         _parent: &Option<q::Value>,
@@ -36,7 +28,6 @@ impl Resolver for MockResolver {
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
-        _block: BlockNumber,
         _max_first: u32,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
@@ -50,7 +41,6 @@ impl Resolver for MockResolver {
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
-        _block: BlockNumber,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -560,8 +560,6 @@ fn introspection_query(schema: Schema, query: &str) -> QueryResult {
         logger: Logger::root(slog::Discard, o!()),
         resolver: MockResolver,
         deadline: None,
-        max_complexity: None,
-        max_depth: 100,
         max_first: std::u32::MAX,
     };
 

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -9,7 +9,7 @@ use graph::prelude::{
     o, slog, Logger, Query, QueryExecutionError, QueryResult, Schema, SubgraphDeploymentId,
 };
 use graph_graphql::prelude::{
-    api_schema, execute_prepared_query, object, object_value, ExecutionContext, ObjectOrInterface,
+    api_schema, execute_query, object, object_value, ExecutionContext, ObjectOrInterface,
     Query as PreparedQuery, QueryExecutionOptions, Resolver,
 };
 
@@ -565,8 +565,8 @@ fn introspection_query(schema: Schema, query: &str) -> QueryResult {
         max_first: std::u32::MAX,
     };
 
-    let result = PreparedQuery::new(query, None, 100)
-        .and_then(|query| execute_prepared_query(query, options));
+    let result =
+        PreparedQuery::new(query, None, 100).and_then(|query| execute_query(query, options));
     QueryResult::from(result)
 }
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -4,9 +4,17 @@ extern crate pretty_assertions;
 use graphql_parser::{query as q, Pos};
 use lazy_static::lazy_static;
 use std::collections::HashMap;
+use std::iter::FromIterator;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use graph::prelude::*;
+use graph::prelude::{
+    futures03::stream::StreamExt, futures03::FutureExt, futures03::TryFutureExt, o, slog, tokio,
+    Entity, EntityKey, EntityOperation, EthereumBlockPointer, FutureExtension, Logger, Query,
+    QueryError, QueryExecutionError, QueryResult, QueryVariables, Schema, Store,
+    SubgraphDeploymentEntity, SubgraphDeploymentId, SubgraphDeploymentStore, SubgraphManifest,
+    Subscription, SubscriptionError, Value,
+};
 use graph_graphql::prelude::*;
 use test_store::{transact_entity_operations, BLOCK_ONE, GENESIS_PTR, STORE};
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,6 +18,7 @@ graph = { path = "../graph" }
 graph-core = { path = "../core" }
 graph-chain-ethereum = { path = "../chain/ethereum" }
 graph-chain-arweave = { path = "../chain/arweave" }
+graph-graphql = { path = "../graphql" }
 graph-mock = { path = "../mock" }
 graph-runtime-wasm = { path = "../runtime/wasm" }
 graph-server-http = { path = "../server/http" }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -22,6 +22,7 @@ use graph_core::{
     SubgraphAssignmentProvider as IpfsSubgraphAssignmentProvider, SubgraphInstanceManager,
     SubgraphRegistrar as IpfsSubgraphRegistrar,
 };
+use graph_graphql::prelude::GraphQlRunner;
 use graph_runtime_wasm::RuntimeHostBuilder as WASMRuntimeHostBuilder;
 use graph_server_http::GraphQLServer as GraphQLQueryServer;
 use graph_server_index_node::IndexNodeServer;
@@ -533,10 +534,7 @@ async fn main() {
         .and_then(move |stores| {
             let generic_store = stores.values().next().expect("error creating stores");
 
-            let graphql_runner = Arc::new(graph_core::GraphQlRunner::new(
-                &logger,
-                generic_store.clone(),
-            ));
+            let graphql_runner = Arc::new(GraphQlRunner::new(&logger, generic_store.clone()));
             let mut graphql_server = GraphQLQueryServer::new(
                 &logger_factory,
                 graphql_metrics_registry,

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -4,9 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use graph::data::graphql::{TryFromValue, ValueList, ValueMap};
 use graph::data::subgraph::schema::SUBGRAPHS_ID;
 use graph::prelude::*;
-use graph_graphql::prelude::{
-    object, BlockConstraint, ExecutionContext, IntoValue, ObjectOrInterface, Resolver,
-};
+use graph_graphql::prelude::{object, ExecutionContext, IntoValue, ObjectOrInterface, Resolver};
 use std::convert::TryInto;
 use web3::types::H256;
 
@@ -518,14 +516,6 @@ where
         Ok(None)
     }
 
-    fn locate_block(
-        &self,
-        _: BlockConstraint,
-        _: &SubgraphDeploymentId,
-    ) -> Result<BlockNumber, QueryExecutionError> {
-        Ok(BLOCK_NUMBER_MAX)
-    }
-
     /// Resolves a scalar value for a given scalar type.
     fn resolve_scalar_value(
         &self,
@@ -559,7 +549,6 @@ where
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
-        _block: BlockNumber,
         _max_first: u32,
     ) -> Result<q::Value, QueryExecutionError> {
         match (parent, object_type.name(), field.name.as_str()) {
@@ -606,7 +595,6 @@ where
         object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
         _types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
-        _block: BlockNumber,
     ) -> Result<q::Value, QueryExecutionError> {
         match (parent, object_type.name(), field.name.as_str()) {
             (Some(status), "EthereumBlock", "chainHeadBlock") => Ok(status

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -518,7 +518,11 @@ where
         Ok(None)
     }
 
-    fn locate_block(&self, _: &BlockConstraint) -> Result<BlockNumber, QueryExecutionError> {
+    fn locate_block(
+        &self,
+        _: BlockConstraint,
+        _: &SubgraphDeploymentId,
+    ) -> Result<BlockNumber, QueryExecutionError> {
         Ok(BLOCK_NUMBER_MAX)
     }
 

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -116,13 +116,10 @@ where
                         logger: logger.clone(),
                         resolver: IndexNodeResolver::new(&logger, graphql_runner, store),
                         deadline: None,
-                        max_complexity: None,
-                        max_depth: 100,
                         max_first: std::u32::MAX,
                     };
-                    let result =
-                        PreparedQuery::new(query, options.max_complexity, options.max_depth)
-                            .and_then(|query| execute_query(query, options));
+                    let result = PreparedQuery::new(query, None, 100)
+                        .and_then(|query| execute_query(query, options));
 
                     futures03::future::ok(QueryResult::from(result))
                 })

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -7,9 +7,7 @@ use std::time::Instant;
 
 use graph::components::server::query::GraphQLServerError;
 use graph::prelude::*;
-use graph_graphql::prelude::{
-    execute_prepared_query, Query as PreparedQuery, QueryExecutionOptions,
-};
+use graph_graphql::prelude::{execute_query, Query as PreparedQuery, QueryExecutionOptions};
 
 use crate::request::IndexNodeRequest;
 use crate::resolver::IndexNodeResolver;
@@ -124,7 +122,7 @@ where
                     };
                     let result =
                         PreparedQuery::new(query, options.max_complexity, options.max_depth)
-                            .and_then(|query| execute_prepared_query(query, options));
+                            .and_then(|query| execute_query(query, options));
 
                     futures03::future::ok(QueryResult::from(result))
                 })

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "Provides static store instance for tests."
 
 [dependencies]
+graph-graphql = { path = "../../graphql" }
 graph-mock = { path = "../../mock" }
 graph = { path = "../../graph" }
 graph-store-postgres = { path = "../postgres" }

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -378,8 +378,6 @@ fn execute_subgraph_query_internal(
         logger,
         resolver,
         deadline,
-        max_complexity,
-        max_depth: 100,
         max_first: std::u32::MAX,
     };
     QueryResult::from(execute_query(query, options))

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -5,7 +5,7 @@ use crate::tokio::runtime::{Builder, Runtime};
 use graph::log;
 use graph::prelude::{Store as _, *};
 use graph_graphql::prelude::{
-    execute_prepared_query, Query as PreparedQuery, QueryExecutionOptions, StoreResolver,
+    execute_query, Query as PreparedQuery, QueryExecutionOptions, StoreResolver,
 };
 use graph_mock::MockMetricsRegistry;
 use graph_store_postgres::connection_pool::create_connection_pool;
@@ -382,5 +382,5 @@ fn execute_subgraph_query_internal(
         max_depth: 100,
         max_first: std::u32::MAX,
     };
-    QueryResult::from(execute_prepared_query(query, options))
+    QueryResult::from(execute_query(query, options))
 }


### PR DESCRIPTION
With this PR, GraphQL query responses will now include information about the bock at which they were run. This PR also makes sure that GraphQL queries that do not explicitly specify a block are run in their entirety against a fixed block (the latest block of a subgraph)

The response will now contain
```json
{
  "data" : "...",
  "extensions": {
    "subgraph": {
      "blocks": [ {
          "ethereum/mainnet": {
            "hash": "ea3bc37eb909f29c897d7a3fe3de30abd86baa58619403941e14a9797063a479",
            "number": 9892879 }
      } ],
      "id": "QmZo35amfokYndPeuRd91bSzF6EusfBKMuDQCvaq25FVUX"
   }
}
```

Note that when the query constrains blocks by number, the hash will always be reported as "000..000" since we can not guarantee that the block is in our database cache (though we can still execute the query), plus we don't want people to use this API to turn block numbers into hashes.