### PR TITLE
Don't return `__typename` to mappings

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1717,7 +1717,11 @@ impl LfuCache<EntityKey, Option<Entity>> {
     ) -> Result<Option<Entity>, QueryExecutionError> {
         match self.get(&key) {
             None => {
-                let entity = store.get(key.clone())?;
+                let mut entity = store.get(key.clone())?;
+                if let Some(entity) = &mut entity {
+                    // `__typename` is for queries not for mappings.
+                    entity.remove("__typename");
+                }
                 self.insert(key.clone(), entity.clone());
                 Ok(entity)
             }


### PR DESCRIPTION
We didn't mean for that to happen, and also causes a difference between entities that are set and then returned from cache vs entities returned from the store.

Also the `ipfs_map` test was causing trouble for me locally, and refactoring it a bit fixed it.