### PR TITLE
graph, runtime: Env variable to log PoI events deterministically

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -110,3 +110,5 @@ those.
   queries caused by subscriptions. Defaults to no logging.
 - `STORE_CONNECTION_POOL_SIZE`: How many simultaneous connections to allow to the store.
   Due to implementation details, this value may not be strictly adhered to. Defaults to 10. 
+- `GRAPH_LOG_POI_EVENTS`: Logs Proof of Indexing events deterministically.
+  This may be useful for debugging.

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -140,12 +140,14 @@ impl HostExports {
 
     pub(crate) fn store_set(
         &self,
+        logger: &Logger,
         state: &mut BlockState,
         entity_type: String,
         entity_id: String,
         mut data: HashMap<String, Value>,
     ) -> Result<(), HostExportError<impl ExportError>> {
         state.proof_of_indexing.write(
+            logger,
             &self.causality_region,
             &ProofOfIndexingEvent::SetEntity {
                 entity_type: &entity_type,
@@ -194,11 +196,13 @@ impl HostExports {
 
     pub(crate) fn store_remove(
         &self,
+        logger: &Logger,
         state: &mut BlockState,
         entity_type: String,
         entity_id: String,
     ) {
         state.proof_of_indexing.write(
+            logger,
             &self.causality_region,
             &ProofOfIndexingEvent::RemoveEntity {
                 entity_type: &entity_type,

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -423,7 +423,7 @@ impl WasmiModule {
         let data = self.asc_get(data_ptr);
         self.ctx
             .host_exports
-            .store_set(&mut self.ctx.state, entity, id, data)?;
+            .store_set(&self.ctx.logger, &mut self.ctx.state, entity, id, data)?;
         Ok(None)
     }
 
@@ -440,7 +440,7 @@ impl WasmiModule {
         let id = self.asc_get(id_ptr);
         self.ctx
             .host_exports
-            .store_remove(&mut self.ctx.state, entity, id);
+            .store_remove(&self.ctx.logger, &mut self.ctx.state, entity, id);
         Ok(None)
     }
 


### PR DESCRIPTION
This PR adds an environment variable `GRAPH_LOG_POI_EVENTS` which when set to `true` will log the PoI stream deterministically within a given subgraph for efficient log diffing.