### PR TITLE
server: Add test for canonical serialization of JSON responses

### DIFF
--- a/graphql/src/values/mod.rs
+++ b/graphql/src/values/mod.rs
@@ -34,6 +34,13 @@ impl IntoValue for &'_ str {
     }
 }
 
+impl IntoValue for i32 {
+    #[inline]
+    fn into_value(self) -> Value {
+        Value::Int(Number::from(self))
+    }
+}
+
 impl<T: IntoValue> IntoValue for Option<T> {
     #[inline]
     fn into_value(self) -> Value {
@@ -41,6 +48,13 @@ impl<T: IntoValue> IntoValue for Option<T> {
             Some(v) => v.into_value(),
             None => Value::Null,
         }
+    }
+}
+
+impl<T: IntoValue> IntoValue for Vec<T> {
+    #[inline]
+    fn into_value(self) -> Value {
+        Value::List(self.into_iter().map(|e| e.into_value()).collect::<Vec<_>>())
     }
 }
 
@@ -61,7 +75,6 @@ impl_into_values![
     (String, String),
     (f64, Float),
     (bool, Boolean),
-    (Vec<Value>, List),
     (Number, Int)
 ];
 

--- a/server/http/src/response.rs
+++ b/server/http/src/response.rs
@@ -75,7 +75,8 @@ mod tests {
     use futures::sync::oneshot;
     use graph::components::server::query::GraphQLServerError;
     use graph::prelude::*;
-    use graphql_parser;
+    use graph_graphql::object;
+    use graphql_parser::{self, query as q};
     use http::status::StatusCode;
     use std::collections::BTreeMap;
 
@@ -239,6 +240,72 @@ mod tests {
         assert_eq!(
             message,
             "GraphQL server error (internal error): Something went wrong"
+        );
+    }
+
+    #[test]
+    fn canonical_serialization() {
+        macro_rules! assert_resp {
+            ($exp: expr, $obj: expr) => {{
+                {
+                    // This match is solely there to make sure these tests
+                    // get amended if q::Value ever gets more variants
+                    // The order of the variants should be the same as the
+                    // order of the tests below
+                    use q::Value::*;
+                    let _ = match $obj {
+                        Variable(_) | Object(_) | List(_) | Enum(_) | Null | Int(_) | Float(_)
+                        | String(_) | Boolean(_) => (),
+                    };
+                }
+                let res = QueryResult::new(Some($obj));
+                let resp = GraphQLResponse::new(Ok(res));
+                assert_eq!($exp, serde_json::to_string(&resp).unwrap());
+            }};
+        }
+        assert_resp!(r#"{"data":{"id":"12345"}}"#, object! { id: "12345" });
+
+        // Value::Variable: nothing to check, not used in a response
+
+        // Value::Object: Insertion order of keys does not matter
+        let first_second = r#"{"data":{"first":"first","second":"second"}}"#;
+        assert_resp!(first_second, object! { first: "first", second: "second" });
+        assert_resp!(first_second, object! { second: "second", first: "first" });
+
+        // Value::List
+        assert_resp!(r#"{"data":{"ary":[1,2]}}"#, object! { ary: vec![1,2] });
+
+        // Value::Enum
+        assert_resp!(
+            r#"{"data":{"enum_field":"enum"}}"#,
+            object! { enum_field:  q::Value::Enum("enum".to_owned())}
+        );
+
+        // Value::Null
+        assert_resp!(
+            r#"{"data":{"nothing":null}}"#,
+            object! { nothing:  q::Value::Null}
+        );
+
+        // Value::Int
+        assert_resp!(
+            r#"{"data":{"int32":17,"neg32":-314}}"#,
+            object! { int32: 17, neg32: -314 }
+        );
+
+        // Value::Float
+        assert_resp!(r#"{"data":{"float":3.14159}}"#, object! { float: 3.14159 });
+
+        // Value::String
+        assert_resp!(
+            r#"{"data":{"text":"Ünïcödë with spaceß"}}"#,
+            object! { text: "Ünïcödë with spaceß" }
+        );
+
+        // Value::Boolean
+        assert_resp!(
+            r#"{"data":{"no":false,"yes":true}}"#,
+            object! { yes: true, no: false }
         );
     }
 }


### PR DESCRIPTION
The JSON that `serde_json` produces is already what we want. This adds tests that make sure that the serialization of responses remains what we expect, even if the underlying implementation changes.