### PR TITLE
Fix format of 'extensions' field in GraphQL responses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+### Feature: Include Block in Query Responses
+
+Responses to GraphQL queries now include the block at which the query was
+executed. The response now contains an `extensions` field of the following
+form:
+
+```json
+{
+  "data" : "...",
+  "extensions": {
+    "subgraph": {
+      "blocks": {
+        "ethereum/mainnet": {
+          "hash": "ea3bc37eb909f29c897d7a3fe3de30abd86baa58619403941e14a9797063a479",
+          "number": 9892879
+        }
+      },
+      "id": "QmZo35amfokYndPeuRd91bSzF6EusfBKMuDQCvaq25FVUX"
+    }
+  }
+}
+```
+
+The key in the `blocks` object indicate the Ethereum network that the
+subgraph indexes, such as `ethereum/mainnet` or `ethereum/kovan`. What
+exactly gets reported has `hash` and `number` depends on the query:
+
+- for time-travel queries with a block constraint of the form `block: {
+hash: "deadbeef" }`, that hash and the number of the corresponding block
+will appear in the response
+- for time-travel queries with a block constraint of the form `block: {
+number: 123456 }`, the `hash` will be all zeroes, and the number will be
+the number given in the query
+- for queries without any block constraint, the query will be run against
+  the latest block that subgraph has processed, the hash and number of that
+  block will be reported in the response
+
 ### Misc
 
 - Fix loading more than 200 dynamic data sources (#1596).

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -96,13 +96,13 @@ where
             "subgraph".to_owned(),
             object! {
                 id: subgraph.to_string(),
-                blocks: vec![network_info]
+                blocks: network_info
             },
         );
         Ok(exts)
     }
 
-    fn execute(
+    pub fn execute(
         &self,
         query: Query,
         max_complexity: Option<u64>,

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -350,6 +350,7 @@ pub fn execute_subgraph_query_with_deadline(
 
 /// Like `try!`, but we return the contents of an `Err`, not the
 /// whole `Result`
+#[macro_export]
 macro_rules! return_err {
     ( $ expr : expr ) => {
         match $expr {


### PR DESCRIPTION
While adding a description of how we indicate the block at which a query ran to the release notes, I noticed a small inconsistency. Fixed that and added a test to check the output format.