### PR TITLE
docker: Increase startup timeouts (Postgres, IPFS) to 120s

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,10 +57,10 @@ RUN apt-get install gawk
 CMD wait-for-it.sh \
       $(echo $ipfs | \
         gawk 'match($0, /^([a-z]+:\/\/)?([^\/:]+)(:([0-9]+))?.*$/, m) { print m[2]":"(m[4] ? m[4] : (m[1] == "https://" ? 443 : 80)) }') \
-      -t 30 \
+      -t 120 \
     && wait-for-it.sh \
          $(echo $postgres_host | \
            gawk 'match($0, /^([a-z]+:\/\/)?([^\/:]+)(:([0-9]+))?.*$/, m) { print m[2]":"(m[4] ? m[4] : 5432) }') \
-         -t 30 \
+         -t 120 \
     && sleep 5 \
     && start-node


### PR DESCRIPTION
We've been running into this a few times now that graph-node timed out waiting for Postgres on the first run of the Docker Compose setup and that you had to start it a second time to get past that. Postgres always comes up but sometimes it takes longer than 30s to initialize.

A timeout of 30s seems short, 60s might work but maybe not everywhere, 120s should get rid of this problem everywhere.