### PR TITLE
Add `User-Agent` to CORS allowed headers

### DIFF
--- a/server/http/src/response.rs
+++ b/server/http/src/response.rs
@@ -60,7 +60,7 @@ impl Future for GraphQLResponse {
         let response = Response::builder()
             .status(status_code)
             .header("Access-Control-Allow-Origin", "*")
-            .header("Access-Control-Allow-Headers", "Content-Type")
+            .header("Access-Control-Allow-Headers", "Content-Type, User-Agent")
             .header("Access-Control-Allow-Methods", "GET, OPTIONS, POST")
             .header("Content-Type", "application/json")
             .body(Body::from(json))

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -308,7 +308,7 @@ where
             Ok(Response::builder()
                 .status(200)
                 .header("Access-Control-Allow-Origin", "*")
-                .header("Access-Control-Allow-Headers", "Content-Type")
+                .header("Access-Control-Allow-Headers", "Content-Type, User-Agent")
                 .header("Access-Control-Allow-Methods", "GET, OPTIONS, POST")
                 .body(Body::from(""))
                 .unwrap())

--- a/server/index-node/src/response.rs
+++ b/server/index-node/src/response.rs
@@ -62,7 +62,7 @@ impl Future for IndexNodeResponse {
         let response = Response::builder()
             .status(status_code)
             .header("Access-Control-Allow-Origin", "*")
-            .header("Access-Control-Allow-Headers", "Content-Type")
+            .header("Access-Control-Allow-Headers", "Content-Type, User-Agent")
             .header("Access-Control-Allow-Methods", "GET, OPTIONS, POST")
             .header("Content-Type", "application/json")
             .body(Body::from(json))

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -152,7 +152,7 @@ where
             Ok(Response::builder()
                 .status(200)
                 .header("Access-Control-Allow-Origin", "*")
-                .header("Access-Control-Allow-Headers", "Content-Type")
+                .header("Access-Control-Allow-Headers", "Content-Type, User-Agent")
                 .header("Access-Control-Allow-Methods", "GET, OPTIONS, POST")
                 .body(Body::from(""))
                 .unwrap())


### PR DESCRIPTION
This is required on Firefox if `User-Agent` is passed in the request `Access-Control-Request-Headers` header.