### PR TITLE
Normalize BigDecimal values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,6 +1199,7 @@ dependencies = [
  "bytes 0.5.4",
  "chrono",
  "diesel",
+ "diesel_derives",
  "ethabi 10.0.0",
  "failure",
  "futures 0.1.29",

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -8,6 +8,7 @@ async-trait = "0.1.29"
 bigdecimal = { version = "0.1.0", features = ["serde"] }
 bytes = "0.5"
 diesel = { version = "1.4.3", features = ["postgres", "serde_json", "numeric", "r2d2"] }
+diesel_derives = "1.4"
 chrono = "0.4"
 Inflector = "0.11.3"
 isatty = "0.1"

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -177,7 +177,7 @@ impl StableHash for Value {
                 "Int"
             }
             BigDecimal(inner) => {
-                scalar::big_decimal_stable_hash(inner, sequence_number.next_child(), state);
+                inner.stable_hash(sequence_number.next_child(), state);
                 "BigDecimal"
             }
             Bool(inner) => {

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -65,10 +65,10 @@ impl BigDecimal {
         }
         let (bigint, exp) = self.0.as_bigint_and_exponent();
         let (sign, mut digits) = bigint.to_radix_be(10);
-        let trailing_count = digits.iter().rev().take_while(|i| **i == 0).count() as i64;
-        digits.truncate(digits.len() - trailing_count as usize);
+        let trailing_count = digits.iter().rev().take_while(|i| **i == 0).count();
+        digits.truncate(digits.len() - trailing_count);
         let int_val = num_bigint::BigInt::from_radix_be(sign, &digits, 10).unwrap();
-        let scale = exp - trailing_count;
+        let scale = exp - trailing_count as i64;
         BigDecimal(bigdecimal::BigDecimal::new(int_val.into(), scale))
     }
 }

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -1,6 +1,5 @@
 use diesel::deserialize::FromSql;
-use diesel::serialize::ToSql;
-use diesel_derives::{AsExpression, FromSqlRow};
+use diesel_derives::FromSqlRow;
 use failure::Fail;
 use hex;
 use num_bigint;
@@ -13,7 +12,6 @@ use stable_hash::{
 };
 use std::convert::{TryFrom, TryInto};
 use std::fmt::{self, Display, Formatter};
-use std::io::Write;
 use std::ops::{Add, Div, Mul, Rem, Sub};
 use std::str::FromStr;
 
@@ -23,11 +21,8 @@ pub use num_bigint::Sign as BigIntSign;
 // Caveat: The exponent is currently an i64 and may overflow. See
 // https://github.com/akubera/bigdecimal-rs/issues/54.
 // Using `#[serde(from = "BigDecimal"]` makes sure deserialization calls `BigDecimal::new()`.
-#[derive(
-    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, AsExpression, FromSqlRow,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, FromSqlRow)]
 #[serde(from = "bigdecimal::BigDecimal")]
-#[sql_type = "diesel::sql_types::Numeric"]
 pub struct BigDecimal(bigdecimal::BigDecimal);
 
 impl From<bigdecimal::BigDecimal> for BigDecimal {
@@ -144,15 +139,6 @@ impl Div for BigDecimal {
         }
 
         Self::from(self.0.div(other.0))
-    }
-}
-
-impl ToSql<diesel::sql_types::Numeric, diesel::pg::Pg> for BigDecimal {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut diesel::serialize::Output<W, diesel::pg::Pg>,
-    ) -> diesel::serialize::Result {
-        <_ as ToSql<diesel::sql_types::Numeric, _>>::to_sql(&self.0, out)
     }
 }
 

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -295,19 +295,6 @@ impl BigInt {
         U256::from_little_endian(&bytes)
     }
 
-    pub fn to_big_decimal(self, exp: BigInt) -> BigDecimal {
-        let bytes = exp.to_signed_bytes_le();
-
-        // The hope here is that bigdecimal switches to BigInt exponents. Until
-        // then, a panic is fine since this is only used in mappings.
-        if bytes.len() > 8 {
-            panic!("big decimal exponent does not fit in i64")
-        }
-        let mut byte_array = if exp >= 0.into() { [0; 8] } else { [255; 8] };
-        byte_array[..bytes.len()].copy_from_slice(&bytes);
-        BigDecimal::new(self, i64::from_le_bytes(byte_array))
-    }
-
     pub fn pow(self, exponent: u8) -> Self {
         use num_traits::pow::Pow;
 

--- a/runtime/wasm/src/asc_abi/mod.rs
+++ b/runtime/wasm/src/asc_abi/mod.rs
@@ -52,6 +52,14 @@ pub trait AscHeap: Sized {
     {
         T::from_asc_obj(asc_ptr.read_ptr(self), self)
     }
+
+    fn try_asc_get<T, C>(&self, asc_ptr: AscPtr<C>) -> Result<T, graph::prelude::Error>
+    where
+        C: AscType,
+        T: TryFromAscObj<C>,
+    {
+        T::try_from_asc_obj(asc_ptr.read_ptr(self), self)
+    }
 }
 
 /// Type that can be converted to an Asc object of class `C`.
@@ -62,6 +70,10 @@ pub trait ToAscObj<C: AscType> {
 /// Type that can be converted from an Asc object of class `C`.
 pub trait FromAscObj<C: AscType> {
     fn from_asc_obj<H: AscHeap>(obj: C, heap: &H) -> Self;
+}
+
+pub trait TryFromAscObj<C: AscType>: Sized {
+    fn try_from_asc_obj<H: AscHeap>(obj: C, heap: &H) -> Result<Self, graph::prelude::Error>;
 }
 
 // `AscType` is not really public, implementors should live inside the `class` module.

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -420,7 +420,7 @@ impl WasmiModule {
         }
         let entity = self.asc_get(entity_ptr);
         let id = self.asc_get(id_ptr);
-        let data = self.asc_get(data_ptr);
+        let data = self.try_asc_get(data_ptr).map_err(HostExportError::from)?;
         self.ctx
             .host_exports
             .store_set(&self.ctx.logger, &mut self.ctx.state, entity, id, data)?;
@@ -612,7 +612,7 @@ impl WasmiModule {
     ) -> Result<Option<RuntimeValue>, Trap> {
         let link: String = self.asc_get(link_ptr);
         let callback: String = self.asc_get(callback);
-        let user_data: store::Value = self.asc_get(user_data);
+        let user_data: store::Value = self.try_asc_get(user_data).map_err(HostExportError::from)?;
 
         let flags = self.asc_get(flags);
         let start_time = Instant::now();
@@ -768,7 +768,7 @@ impl WasmiModule {
         let result = self
             .ctx
             .host_exports
-            .big_decimal_divided_by(x, self.asc_get(y_ptr))?;
+            .big_decimal_divided_by(x, self.try_asc_get(y_ptr).map_err(HostExportError::from)?)?;
         Ok(Some(RuntimeValue::from(self.asc_new(&result))))
     }
 
@@ -815,10 +815,10 @@ impl WasmiModule {
         &mut self,
         big_decimal_ptr: AscPtr<AscBigDecimal>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let result = self
-            .ctx
-            .host_exports
-            .big_decimal_to_string(self.asc_get(big_decimal_ptr));
+        let result = self.ctx.host_exports.big_decimal_to_string(
+            self.try_asc_get(big_decimal_ptr)
+                .map_err(HostExportError::from)?,
+        );
         Ok(Some(RuntimeValue::from(self.asc_new(&result))))
     }
 
@@ -840,10 +840,10 @@ impl WasmiModule {
         x_ptr: AscPtr<AscBigDecimal>,
         y_ptr: AscPtr<AscBigDecimal>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let result = self
-            .ctx
-            .host_exports
-            .big_decimal_plus(self.asc_get(x_ptr), self.asc_get(y_ptr));
+        let result = self.ctx.host_exports.big_decimal_plus(
+            self.try_asc_get(x_ptr).map_err(HostExportError::from)?,
+            self.try_asc_get(y_ptr).map_err(HostExportError::from)?,
+        );
         Ok(Some(RuntimeValue::from(self.asc_new(&result))))
     }
 
@@ -853,10 +853,10 @@ impl WasmiModule {
         x_ptr: AscPtr<AscBigDecimal>,
         y_ptr: AscPtr<AscBigDecimal>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let result = self
-            .ctx
-            .host_exports
-            .big_decimal_minus(self.asc_get(x_ptr), self.asc_get(y_ptr));
+        let result = self.ctx.host_exports.big_decimal_minus(
+            self.try_asc_get(x_ptr).map_err(HostExportError::from)?,
+            self.try_asc_get(y_ptr).map_err(HostExportError::from)?,
+        );
         Ok(Some(RuntimeValue::from(self.asc_new(&result))))
     }
 
@@ -866,10 +866,10 @@ impl WasmiModule {
         x_ptr: AscPtr<AscBigDecimal>,
         y_ptr: AscPtr<AscBigDecimal>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let result = self
-            .ctx
-            .host_exports
-            .big_decimal_times(self.asc_get(x_ptr), self.asc_get(y_ptr));
+        let result = self.ctx.host_exports.big_decimal_times(
+            self.try_asc_get(x_ptr).map_err(HostExportError::from)?,
+            self.try_asc_get(y_ptr).map_err(HostExportError::from)?,
+        );
         Ok(Some(RuntimeValue::from(self.asc_new(&result))))
     }
 
@@ -879,10 +879,10 @@ impl WasmiModule {
         x_ptr: AscPtr<AscBigDecimal>,
         y_ptr: AscPtr<AscBigDecimal>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let result = self
-            .ctx
-            .host_exports
-            .big_decimal_divided_by(self.asc_get(x_ptr), self.asc_get(y_ptr))?;
+        let result = self.ctx.host_exports.big_decimal_divided_by(
+            self.try_asc_get(x_ptr).map_err(HostExportError::from)?,
+            self.try_asc_get(y_ptr).map_err(HostExportError::from)?,
+        )?;
         Ok(Some(RuntimeValue::from(self.asc_new(&result))))
     }
 
@@ -892,10 +892,10 @@ impl WasmiModule {
         x_ptr: AscPtr<AscBigDecimal>,
         y_ptr: AscPtr<AscBigDecimal>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let equals = self
-            .ctx
-            .host_exports
-            .big_decimal_equals(self.asc_get(x_ptr), self.asc_get(y_ptr));
+        let equals = self.ctx.host_exports.big_decimal_equals(
+            self.try_asc_get(x_ptr).map_err(HostExportError::from)?,
+            self.try_asc_get(y_ptr).map_err(HostExportError::from)?,
+        );
         Ok(Some(RuntimeValue::I32(if equals { 1 } else { 0 })))
     }
 
@@ -926,7 +926,9 @@ impl WasmiModule {
     ) -> Result<Option<RuntimeValue>, Trap> {
         let name: String = self.asc_get(name_ptr);
         let params: Vec<String> = self.asc_get(params_ptr);
-        let context: HashMap<_, _> = self.asc_get(context_ptr);
+        let context: HashMap<_, _> = self
+            .try_asc_get(context_ptr)
+            .map_err(HostExportError::from)?;
         self.ctx.host_exports.data_source_create(
             &self.ctx.logger,
             &mut self.ctx.state,

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -764,7 +764,7 @@ impl WasmiModule {
         x_ptr: AscPtr<AscBigInt>,
         y_ptr: AscPtr<AscBigDecimal>,
     ) -> Result<Option<RuntimeValue>, Trap> {
-        let x = self.asc_get::<BigInt, _>(x_ptr).to_big_decimal(0.into());
+        let x = BigDecimal::new(self.asc_get::<BigInt, _>(x_ptr), 0);
         let result = self
             .ctx
             .host_exports

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -873,7 +873,9 @@ fn entity_store() {
             None
         } else {
             Some(Entity::from(
-                module.asc_get::<HashMap<String, Value>, _>(entity_ptr),
+                module
+                    .try_asc_get::<HashMap<String, Value>, _>(entity_ptr)
+                    .unwrap(),
             ))
         }
     };

--- a/runtime/wasm/src/module/test/abi.rs
+++ b/runtime/wasm/src/module/test/abi.rs
@@ -227,33 +227,33 @@ fn abi_store_value() {
         .expect("call returned nothing")
         .try_into()
         .expect("call did not return ptr");
-    let null_value: Value = module.asc_get(null_value_ptr);
+    let null_value: Value = module.try_asc_get(null_value_ptr).unwrap();
     assert_eq!(null_value, Value::Null);
 
     // Value::String
     let string = "some string";
     let string_ptr = module.asc_new(string);
     let new_value_ptr = module.takes_ptr_returns_ptr("value_from_string", string_ptr);
-    let new_value: Value = module.asc_get(new_value_ptr);
+    let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::from(string));
 
     // Value::Int
     let int = i32::min_value();
     let new_value_ptr = module.takes_val_returns_ptr("value_from_int", RuntimeValue::from(int));
-    let new_value: Value = module.asc_get(new_value_ptr);
+    let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::Int(int));
 
     // Value::BigDecimal
     let big_decimal = BigDecimal::from_str("3.14159001").unwrap();
     let big_decimal_ptr = module.asc_new(&big_decimal);
     let new_value_ptr = module.takes_ptr_returns_ptr("value_from_big_decimal", big_decimal_ptr);
-    let new_value: Value = module.asc_get(new_value_ptr);
+    let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::BigDecimal(big_decimal));
 
     let big_decimal = BigDecimal::new(10.into(), 5);
     let big_decimal_ptr = module.asc_new(&big_decimal);
     let new_value_ptr = module.takes_ptr_returns_ptr("value_from_big_decimal", big_decimal_ptr);
-    let new_value: Value = module.asc_get(new_value_ptr);
+    let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::BigDecimal(1_000_000.into()));
 
     // Value::Bool
@@ -262,7 +262,7 @@ fn abi_store_value() {
         "value_from_bool",
         RuntimeValue::I32(if boolean { 1 } else { 0 }),
     );
-    let new_value: Value = module.asc_get(new_value_ptr);
+    let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::Bool(boolean));
 
     // Value::List
@@ -281,7 +281,7 @@ fn abi_store_value() {
         .expect("call returned nothing")
         .try_into()
         .expect("call did not return ptr");
-    let new_value: Value = module.asc_get(new_value_ptr);
+    let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(
         new_value,
         Value::List(vec![Value::from(string), Value::Int(int)])
@@ -293,7 +293,7 @@ fn abi_store_value() {
     ];
     let array_ptr = module.asc_new(array);
     let new_value_ptr = module.takes_ptr_returns_ptr("value_from_array", array_ptr);
-    let new_value: Value = module.asc_get(new_value_ptr);
+    let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(
         new_value,
         Value::List(vec![
@@ -306,14 +306,14 @@ fn abi_store_value() {
     let bytes: &[u8] = &[0, 2, 5];
     let bytes_ptr: AscPtr<Bytes> = module.asc_new(bytes);
     let new_value_ptr = module.takes_ptr_returns_ptr("value_from_bytes", bytes_ptr);
-    let new_value: Value = module.asc_get(new_value_ptr);
+    let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::Bytes(bytes.into()));
 
     // Value::BigInt
     let bytes: &[u8] = &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
     let bytes_ptr: AscPtr<Uint8Array> = module.asc_new(bytes);
     let new_value_ptr = module.takes_ptr_returns_ptr("value_from_bigint", bytes_ptr);
-    let new_value: Value = module.asc_get(new_value_ptr);
+    let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(
         new_value,
         Value::BigInt(::graph::data::store::scalar::BigInt::from_unsigned_bytes_le(bytes))
@@ -406,5 +406,5 @@ fn invalid_discriminant() {
         .expect("call returned nothing")
         .try_into()
         .expect("call did not return ptr");
-    let _value: Value = module.asc_get(value_ptr);
+    let _value: Value = module.try_asc_get(value_ptr).unwrap();
 }

--- a/runtime/wasm/src/module/test/abi.rs
+++ b/runtime/wasm/src/module/test/abi.rs
@@ -250,7 +250,7 @@ fn abi_store_value() {
     let new_value: Value = module.asc_get(new_value_ptr);
     assert_eq!(new_value, Value::BigDecimal(big_decimal));
 
-    let big_decimal = BigDecimal::new(10.into(), -5);
+    let big_decimal = BigDecimal::new(10.into(), 5);
     let big_decimal_ptr = module.asc_new(&big_decimal);
     let new_value_ptr = module.takes_ptr_returns_ptr("value_from_big_decimal", big_decimal_ptr);
     let new_value: Value = module.asc_get(new_value_ptr);

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -2,10 +2,9 @@ use diesel::dsl::{self, sql};
 use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::serialize::ToSql;
-use diesel::sql_types::{Array, Bool, Double, HasSqlType, Integer, Numeric, Text};
+use diesel::sql_types::{Array, Bool, Double, HasSqlType, Integer, Text};
 use std::error::Error as StdError;
 use std::fmt::{self, Display};
-use std::str::FromStr;
 
 use graph::components::store::EntityFilter;
 use graph::data::store::*;
@@ -121,10 +120,8 @@ impl<QS> IntoFilter<QS> for BigInt {
                 .bind::<Text, _>(attribute)
                 .sql("->> 'data')::numeric")
                 .sql(op)
-                // Using `BigDecimal::new(query_value.0, 0)` results in a
-                // mismatch of `bignum` versions, go through the string
-                // representation to work around that.
-                .bind::<Numeric, _>(BigDecimal::from_str(&self.to_string()).unwrap()),
+                .bind::<Text, _>(self.to_string())
+                .sql("::numeric"),
         ) as FilterExpression<QS>
     }
 }
@@ -136,7 +133,8 @@ impl<QS> IntoFilter<QS> for BigDecimal {
                 .bind::<Text, _>(attribute)
                 .sql("->> 'data')::numeric")
                 .sql(op)
-                .bind::<Numeric, _>(self),
+                .bind::<Text, _>(self.to_string())
+                .sql("::numeric"),
         ) as FilterExpression<QS>
     }
 }
@@ -347,8 +345,10 @@ where
             let op = " = ANY ";
 
             match values[0] {
-                Value::BigInt(_) | Value::BigDecimal(_) => Ok(SqlValue::new_array(values)
-                    .into_array_filter::<Numeric>(attribute, op, "::numeric")),
+                Value::BigInt(_) | Value::BigDecimal(_) => Err(UnsupportedFilter {
+                    filter: "JSONB is deprecated, this subgraph needs to be redeployed".to_string(),
+                    value: Value::Null,
+                }),
                 Value::Bool(_) => Ok(SqlValue::new_array(values).into_array_filter::<Bool>(
                     attribute,
                     op,

--- a/store/postgres/src/filter.rs
+++ b/store/postgres/src/filter.rs
@@ -5,7 +5,6 @@ use diesel::serialize::ToSql;
 use diesel::sql_types::{Array, Bool, Double, HasSqlType, Integer, Numeric, Text};
 use std::error::Error as StdError;
 use std::fmt::{self, Display};
-use std::str::FromStr;
 
 use graph::components::store::EntityFilter;
 use graph::data::store::*;
@@ -121,10 +120,8 @@ impl<QS> IntoFilter<QS> for BigInt {
                 .bind::<Text, _>(attribute)
                 .sql("->> 'data')::numeric")
                 .sql(op)
-                // Using `BigDecimal::new(query_value.0, 0)` results in a
-                // mismatch of `bignum` versions, go through the string
-                // representation to work around that.
-                .bind::<Numeric, _>(BigDecimal::from_str(&self.to_string()).unwrap()),
+                .bind::<Text, _>(self.to_string())
+                .sql("::numeric"),
         ) as FilterExpression<QS>
     }
 }
@@ -136,7 +133,8 @@ impl<QS> IntoFilter<QS> for BigDecimal {
                 .bind::<Text, _>(attribute)
                 .sql("->> 'data')::numeric")
                 .sql(op)
-                .bind::<Numeric, _>(self),
+                .bind::<Text, _>(self.to_string())
+                .sql("::numeric"),
         ) as FilterExpression<QS>
     }
 }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -337,19 +337,7 @@ impl<'a> QueryFragment<Pg> for QueryValue<'a> {
                 ),
             },
             Value::Int(i) => out.push_bind_param::<Integer, _>(i),
-            Value::BigDecimal(d) => {
-                // If a BigDecimal with negative scale gets sent to Diesel (and then Postgres)
-                // Postgres will complain with 'invalid scale in external "numeric" value'
-                let (_, scale) = d.as_bigint_and_exponent();
-                if scale < 0 {
-                    // This is safe since we are effectively multiplying the
-                    // integer part of d with 10^(-scale), an integer
-                    let d = d.with_scale(0);
-                    out.push_bind_param::<Numeric, _>(&d)
-                } else {
-                    out.push_bind_param::<Numeric, _>(d)
-                }
-            }
+            Value::BigDecimal(d) => out.push_bind_param::<Numeric, _>(d),
             Value::Bool(b) => out.push_bind_param::<Bool, _>(b),
             Value::List(values) => {
                 let values = SqlValue::new_array(values.clone());

--- a/store/postgres/src/sql_value.rs
+++ b/store/postgres/src/sql_value.rs
@@ -1,6 +1,6 @@
 use diesel::pg::Pg;
 use diesel::serialize::{self, Output, ToSql};
-use diesel::sql_types::{Binary, Bool, Integer, Text};
+use diesel::sql_types::{Binary, Bool, Integer, Numeric, Text};
 use std::io::Write;
 use std::str::FromStr;
 
@@ -29,6 +29,19 @@ impl ToSql<Integer, Pg> for SqlValue {
         match self.0 {
             Value::Int(ref i) => <i32 as ToSql<Integer, Pg>>::to_sql(&i, out),
             _ => panic!("Failed to convert non-int attribute value to int in SQL"),
+        }
+    }
+}
+
+// Used only for JSONB support
+impl ToSql<Numeric, Pg> for SqlValue {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+        match &self.0 {
+            Value::BigDecimal(d) => <_ as ToSql<Numeric, Pg>>::to_sql(&d, out),
+            Value::BigInt(number) => {
+                <_ as ToSql<Numeric, Pg>>::to_sql(&scalar::BigDecimal::new(number.clone(), 0), out)
+            }
+            _ => panic!("Failed to convert attribute value to bigint in SQL"),
         }
     }
 }

--- a/store/postgres/src/sql_value.rs
+++ b/store/postgres/src/sql_value.rs
@@ -1,6 +1,6 @@
 use diesel::pg::Pg;
 use diesel::serialize::{self, Output, ToSql};
-use diesel::sql_types::{Binary, Bool, Integer, Numeric, Text};
+use diesel::sql_types::{Binary, Bool, Integer, Text};
 use std::io::Write;
 use std::str::FromStr;
 
@@ -29,18 +29,6 @@ impl ToSql<Integer, Pg> for SqlValue {
         match self.0 {
             Value::Int(ref i) => <i32 as ToSql<Integer, Pg>>::to_sql(&i, out),
             _ => panic!("Failed to convert non-int attribute value to int in SQL"),
-        }
-    }
-}
-
-impl ToSql<Numeric, Pg> for SqlValue {
-    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
-        match &self.0 {
-            Value::BigDecimal(d) => <_ as ToSql<Numeric, Pg>>::to_sql(&d, out),
-            Value::BigInt(number) => {
-                <_ as ToSql<Numeric, Pg>>::to_sql(&number.clone().to_big_decimal(0.into()), out)
-            }
-            _ => panic!("Failed to convert attribute value to bigint in SQL"),
         }
     }
 }

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -96,7 +96,7 @@ lazy_static! {
         SubgraphDeploymentId::new("things").unwrap();
     static ref LARGE_INT: BigInt = BigInt::from(std::i64::MAX).pow(17);
     static ref LARGE_DECIMAL: BigDecimal =
-        BigDecimal::from(1) / LARGE_INT.clone().to_big_decimal(BigInt::from(1));
+        BigDecimal::from(1) / BigDecimal::new(LARGE_INT.clone(), 1);
     static ref BYTES_VALUE: H256 = H256::from(hex!(
         "e8b3b02b936c4a4a331ac691ac9a86e197fb7731f14e3108602c87d4dac55160"
     ));

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -45,11 +45,13 @@ const THINGS_GQL: &str = r#"
         bool: Boolean,
         int: Int,
         bigDecimal: BigDecimal,
+        bigDecimalArray: [BigDecimal!]!
         string: String,
         strings: [String!],
         bytes: Bytes,
         byteArray: [Bytes!],
         bigInt: BigInt,
+        bigIntArray: [BigInt!]!
         color: Color,
     }
 
@@ -121,12 +123,22 @@ lazy_static! {
         entity.set("id", "one");
         entity.set("bool", true);
         entity.set("int", std::i32::MAX);
-        entity.set("bigDecimal", (*LARGE_DECIMAL).clone());
+        let decimal = (*LARGE_DECIMAL).clone();
+        entity.set("bigDecimal", decimal.clone());
+        entity.set(
+            "bigDecimalArray",
+            vec![decimal.clone(), (decimal + 1.into()).clone()],
+        );
         entity.set("string", "scalar");
         entity.set("strings", strings);
         entity.set("bytes", (*BYTES_VALUE).clone());
         entity.set("byteArray", byte_array);
-        entity.set("bigInt", (*LARGE_INT).clone());
+        let big_int = (*LARGE_INT).clone();
+        entity.set("bigInt", big_int.clone());
+        entity.set(
+            "bigIntArray",
+            vec![big_int.clone(), (big_int + 1.into()).clone()],
+        );
         entity.set("color", "yellow");
         entity.set("__typename", "Scalar");
         entity

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -10,9 +10,9 @@ use std::fmt::Debug;
 
 use graph::data::store::scalar::{BigDecimal, BigInt};
 use graph::prelude::{
-    bigdecimal::One, web3::types::H256, Entity, EntityCollection, EntityKey, EntityLink,
-    EntityRange, EntityWindow, Future01CompatExt, ParentLink, Schema, SubgraphDeploymentId, Value,
-    WindowAttribute, BLOCK_NUMBER_MAX,
+    web3::types::H256, Entity, EntityCollection, EntityKey, EntityLink, EntityRange, EntityWindow,
+    Future01CompatExt, ParentLink, Schema, SubgraphDeploymentId, Value, WindowAttribute,
+    BLOCK_NUMBER_MAX,
 };
 use graph_store_postgres::layout_for_tests::Layout;
 
@@ -50,7 +50,7 @@ lazy_static! {
         SubgraphDeploymentId::new("things").unwrap();
     static ref LARGE_INT: BigInt = BigInt::from(std::i64::MAX).pow(17);
     static ref LARGE_DECIMAL: BigDecimal =
-        BigDecimal::one() / LARGE_INT.clone().to_big_decimal(BigInt::from(1));
+        BigDecimal::from(1) / LARGE_INT.clone().to_big_decimal(BigInt::from(1));
     static ref BYTES_VALUE: H256 = H256::from(hex!(
         "e8b3b02b936c4a4a331ac691ac9a86e197fb7731f14e3108602c87d4dac55160"
     ));

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -50,7 +50,7 @@ lazy_static! {
         SubgraphDeploymentId::new("things").unwrap();
     static ref LARGE_INT: BigInt = BigInt::from(std::i64::MAX).pow(17);
     static ref LARGE_DECIMAL: BigDecimal =
-        BigDecimal::from(1) / LARGE_INT.clone().to_big_decimal(BigInt::from(1));
+        BigDecimal::from(1) / BigDecimal::new(LARGE_INT.clone(), 1);
     static ref BYTES_VALUE: H256 = H256::from(hex!(
         "e8b3b02b936c4a4a331ac691ac9a86e197fb7731f14e3108602c87d4dac55160"
     ));

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -780,6 +780,10 @@ fn find_float_less_than_range() {
 
 #[test]
 fn find_float_in() {
+    // This filter is no longer supported on JSONB.
+    if !*test_store::USING_RELATIONAL_STORAGE {
+        return;
+    }
     test_find(
         vec!["3", "1"],
         user_query()

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -780,10 +780,6 @@ fn find_float_less_than_range() {
 
 #[test]
 fn find_float_in() {
-    // This filter is no longer supported on JSONB.
-    if !*test_store::USING_RELATIONAL_STORAGE {
-        return;
-    }
     test_find(
         vec!["3", "1"],
         user_query()


### PR DESCRIPTION
By putting any trailing zeros in the scale. This solves determinism issues because when an entity makes a roundtrip through the store it gets normalized by postgres anyways, at least in some cases.

This is mostly just plumbing through the impls for the `BigDecimal` newtype.

One strange consequence is that the workaround in https://github.com/graphprotocol/graph-node/pull/1182 is no longer necessary. It seems that issue only manifested in non-normalized BigDecimals.