### PR TITLE
Add logging of DB connection contention back in

### DIFF
--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -58,12 +58,12 @@ impl HandleEvent for EventHandler {
         self.gauge.inc();
         if event.duration() > Duration::from_millis(CONTENTION_LOG_THRESHOLD) {
             warn!(self.logger, "Excessive wait time on checkout";
-            "wait_ms" => event.duration().as_millis())
+                  "wait_ms" => event.duration().as_millis())
         }
     }
     fn handle_timeout(&self, event: e::TimeoutEvent) {
         error!(self.logger, "Connection checkout timed out";
-            "wait_ms" => event.timeout().as_millis())
+               "wait_ms" => event.timeout().as_millis())
     }
     fn handle_checkin(&self, _: e::CheckinEvent) {
         self.gauge.dec();


### PR DESCRIPTION
I was too hasty when I said we don't need to log about excessive waits when getting a connection from the database pool. Turns out when a node is going sideways it's useful to see when contention starts.

This PR adds logging about that back in, but done as a r2d2 event handler, and with a threshold of 100ms instead of 10ms. It also adds a Prometheus gauge that reports the number of currently checked-out connections.