### PR TITLE
Revamp how we build containers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 # by running something like the following
 #   docker build --target STAGE -f docker/Dockerfile .
 
-FROM rust:alpine as graph-node-bld
+FROM rust:latest as graph-node-bld
 
 ARG COMMIT_SHA=unknown
 ARG REPO_NAME=unknown
@@ -13,12 +13,8 @@ ARG TAG_NAME=unknown
 
 ADD . /graph-node
 
-# See https://github.com/rust-lang/cargo/issues/7563 for why we use -crt-static
-# in the RUSTFLAGS
-RUN apk update \
- && apk add musl-dev openssl-dev postgresql-dev git \
- && cd /graph-node \
- && RUSTFLAGS="-g -C target-feature=-crt-static" cargo install --locked --path node \
+RUN cd /graph-node \
+ && RUSTFLAGS="-g" cargo install --locked --path node \
  && cargo clean \
  && objcopy --only-keep-debug /usr/local/cargo/bin/graph-node /usr/local/cargo/bin/graph-node.debug \
  && strip -g /usr/local/cargo/bin/graph-node \
@@ -32,7 +28,7 @@ RUN apk update \
  && echo "RUST_VERSION='$(rustc --version)'" >> /etc/image-info
 
 # The graph-node runtime image with only the executable
-FROM alpine:latest as graph-node
+FROM debian:buster-slim as graph-node
 ENV RUST_LOG ""
 ENV GRAPH_LOG ""
 ENV EARLY_LOG_CHUNK_SIZE ""
@@ -61,7 +57,8 @@ EXPOSE 8001
 # JSON-RPC port
 EXPOSE 8020
 
-RUN apk add libgcc libssl1.1 libcrypto1.1 postgresql-libs bash
+RUN apt-get update \
+ && apt-get install -y libpq-dev ca-certificates
 
 ADD docker/wait_for docker/start /usr/local/bin/
 COPY --from=graph-node-bld /usr/local/cargo/bin/graph-node /usr/local/bin
@@ -71,8 +68,8 @@ CMD start
 
 # Debug image to access core dumps
 FROM graph-node-bld as graph-node-dbg
-RUN apk add gdb postgresql-client bash curl
-ADD docker/debug /usr/local/bin
-COPY --from=graph-node-bld /etc/image-info /etc/image-info
+RUN apt-get update \
+ && apt-get install -y curl gdb postgresql-client
+
 COPY docker/Dockerfile /Dockerfile
-COPY bin/* /usr/local/bin
+COPY docker/bin/* /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,8 @@ ENV ethereum ""
 # The role the node should have, one of index-node, query-node, or
 # combined-node
 ENV node_role "combined-node"
+# The name of this node
+ENV node_id "default"
 
 # HTTP port
 EXPOSE 8000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,11 @@
 
 FROM rust:alpine as graph-node-bld
 
+ARG COMMIT_SHA=unknown
+ARG REPO_NAME=unknown
+ARG BRANCH_NAME=unknown
+ARG TAG_NAME=unknown
+
 ADD . /graph-node
 
 # See https://github.com/rust-lang/cargo/issues/7563 for why we use -crt-static
@@ -19,10 +24,12 @@ RUN apk update \
  && strip -g /usr/local/cargo/bin/graph-node \
  && cd /usr/local/cargo/bin \
  && objcopy --add-gnu-debuglink=graph-node.debug graph-node \
- && echo "repo: $(git config --get remote.origin.url)" > /image-info \
- && echo "commit: $(git describe --always)" >> /image-info \
- && echo "cargo: $(cargo --version)" >> /image-info \
- && echo "rust: $(rustc --version)" >> /image-info
+ && echo "repo:   $REPO_NAME" > /image-info \
+ && echo "tag:    $TAG_NAME" >> /image-info \
+ && echo "branch: $BRANCH_NAME" >> /image-info \
+ && echo "commit: $COMMIT_SHA" >> /image-info \
+ && echo "cargo:  $(cargo --version)" >> /image-info \
+ && echo "rust:   $(rustc --version)" >> /image-info
 
 # The graph-node runtime image with only the executable
 FROM alpine:latest as graph-node-run

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,8 @@ CMD start
 
 # Debug image to access core dumps
 FROM graph-node-bld as graph-node-dbg
-RUN apk add gdb
+RUN apk add gdb postgresql-client bash curl
 ADD docker/debug /usr/local/bin
 COPY --from=graph-node-bld /etc/image-info /etc/image-info
 COPY docker/Dockerfile /Dockerfile
+COPY bin/* /usr/local/bin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,23 +1,23 @@
 # Full build with debuginfo for graph-node
 FROM rust:alpine as graph-node-bld
 
-# Replace this with the graph-node branch you want to build the image from;
-# Note: Docker Hub substitutes this automatically using our hooks/post_checkout script.
-ENV SOURCE_BRANCH "master"
+ADD . /graph-node
 
 # See https://github.com/rust-lang/cargo/issues/7563 for why we use -crt-static
 # in the RUSTFLAGS
 RUN apk update \
  && apk add musl-dev openssl-dev postgresql-dev git \
- && git clone https://github.com/lutter/graph-node /graph-node \
  && cd /graph-node \
- && git checkout "$SOURCE_BRANCH" \
  && RUSTFLAGS="-g -C target-feature=-crt-static" cargo install --locked --path node \
  && cargo clean \
  && objcopy --only-keep-debug /usr/local/cargo/bin/graph-node /usr/local/cargo/bin/graph-node.debug \
  && strip -g /usr/local/cargo/bin/graph-node \
  && cd /usr/local/cargo/bin \
- && objcopy --add-gnu-debuglink=graph-node.debug graph-node
+ && objcopy --add-gnu-debuglink=graph-node.debug graph-node \
+ && echo "repo: $(git config --get remote.origin.url)" > /image-info \
+ && echo "commit: $(git describe --always)" >> /image-info \
+ && echo "cargo: $(cargo --version)" >> /image-info \
+ && echo "rust: $(rustc --version)" >> /image-info
 
 # The graph-node runtime image with only the executable
 FROM alpine:latest as graph-node-run

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,9 @@
 # Full build with debuginfo for graph-node
+#
+# The expectation if that the docker build uses the parent directory as PWD
+# by running something like the following
+#   docker build --target STAGE -f docker/Dockerfile .
+
 FROM rust:alpine as graph-node-bld
 
 ADD . /graph-node
@@ -45,8 +50,10 @@ EXPOSE 8020
 
 RUN apk add libgcc libssl1.1 libcrypto1.1 postgresql-libs bash
 
-ADD wait_for start /usr/local/bin
+ADD docker/wait_for docker/start /usr/local/bin/
 COPY --from=graph-node-bld /usr/local/cargo/bin/graph-node /usr/local/bin
+COPY --from=graph-node-bld /image-info /image-info
+COPY docker/Dockerfile /Dockerfile
 
 # The query-node image
 FROM graph-node-run as query-node
@@ -63,4 +70,6 @@ CMD start combined-node
 # Debug image to access core dumps
 FROM graph-node-bld as graph-node-dbg
 RUN apk add gdb
-ADD debug /usr/local/bin
+ADD docker/debug /usr/local/bin
+COPY --from=graph-node-bld /image-info /image-info
+COPY docker/Dockerfile /Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,12 +24,12 @@ RUN apk update \
  && strip -g /usr/local/cargo/bin/graph-node \
  && cd /usr/local/cargo/bin \
  && objcopy --add-gnu-debuglink=graph-node.debug graph-node \
- && echo "repo:   $REPO_NAME" > /image-info \
- && echo "tag:    $TAG_NAME" >> /image-info \
- && echo "branch: $BRANCH_NAME" >> /image-info \
- && echo "commit: $COMMIT_SHA" >> /image-info \
- && echo "cargo:  $(cargo --version)" >> /image-info \
- && echo "rust:   $(rustc --version)" >> /image-info
+ && echo "REPO_NAME='$REPO_NAME'" > /etc/image-info \
+ && echo "TAG_NAME='$TAG_NAME'" >> /etc/image-info \
+ && echo "BRANCH_NAME='$BRANCH_NAME'" >> /etc/image-info \
+ && echo "COMMIT_SHA='$COMMIT_SHA'" >> /etc/image-info \
+ && echo "CARGO_VERSION='$(cargo --version)'" >> /etc/image-info \
+ && echo "RUST_VERSION='$(rustc --version)'" >> /etc/image-info
 
 # The graph-node runtime image with only the executable
 FROM alpine:latest as graph-node
@@ -63,7 +63,7 @@ RUN apk add libgcc libssl1.1 libcrypto1.1 postgresql-libs bash
 
 ADD docker/wait_for docker/start /usr/local/bin/
 COPY --from=graph-node-bld /usr/local/cargo/bin/graph-node /usr/local/bin
-COPY --from=graph-node-bld /image-info /image-info
+COPY --from=graph-node-bld /etc/image-info /etc/image-info
 COPY docker/Dockerfile /Dockerfile
 CMD start
 
@@ -71,5 +71,5 @@ CMD start
 FROM graph-node-bld as graph-node-dbg
 RUN apk add gdb
 ADD docker/debug /usr/local/bin
-COPY --from=graph-node-bld /image-info /image-info
+COPY --from=graph-node-bld /etc/image-info /etc/image-info
 COPY docker/Dockerfile /Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,7 @@ ENV postgres_host ""
 ENV postgres_user ""
 ENV postgres_pass ""
 ENV postgres_db ""
+# The full URL to the IPFS node
 ENV ipfs ""
 # The etherum network(s) to connect to. Set this to a space-separated
 # list of the networks where each entry has the form NAME:URL

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN apk update \
  && echo "rust:   $(rustc --version)" >> /image-info
 
 # The graph-node runtime image with only the executable
-FROM alpine:latest as graph-node-run
+FROM alpine:latest as graph-node
 ENV RUST_LOG ""
 ENV GRAPH_LOG ""
 ENV EARLY_LOG_CHUNK_SIZE ""
@@ -47,6 +47,9 @@ ENV ipfs ""
 # The etherum network(s) to connect to. Set this to a space-separated
 # list of the networks where each entry has the form NAME:URL
 ENV ethereum ""
+# The role the node should have, one of index-node, query-node, or
+# combined-node
+ENV node_role "combined-node"
 
 # HTTP port
 EXPOSE 8000
@@ -61,18 +64,7 @@ ADD docker/wait_for docker/start /usr/local/bin/
 COPY --from=graph-node-bld /usr/local/cargo/bin/graph-node /usr/local/bin
 COPY --from=graph-node-bld /image-info /image-info
 COPY docker/Dockerfile /Dockerfile
-
-# The query-node image
-FROM graph-node-run as query-node
-CMD start query-node
-
-# The index-node image
-FROM graph-node-run as index-node
-CMD start index-node
-
-# The combined-node image used for the public docker compose setup
-FROM graph-node-run as graph-node
-CMD start combined-node
+CMD start
 
 # Debug image to access core dumps
 FROM graph-node-bld as graph-node-dbg

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,27 +1,26 @@
-FROM rust:latest
+# Full build with debuginfo for graph-node
+FROM rust:alpine as graph-node-bld
 
 # Replace this with the graph-node branch you want to build the image from;
 # Note: Docker Hub substitutes this automatically using our hooks/post_checkout script.
 ENV SOURCE_BRANCH "master"
 
-# Install clang (required for dependencies)
-RUN apt-get update \
-    && apt-get install -y clang libclang-dev
+# See https://github.com/rust-lang/cargo/issues/7563 for why we use -crt-static
+# in the RUSTFLAGS
+RUN apk update \
+ && apk add musl-dev openssl-dev postgresql-dev git \
+ && git clone https://github.com/lutter/graph-node /graph-node \
+ && cd /graph-node \
+ && git checkout "$SOURCE_BRANCH" \
+ && RUSTFLAGS="-g -C target-feature=-crt-static" cargo install --locked --path node \
+ && cargo clean \
+ && objcopy --only-keep-debug /usr/local/cargo/bin/graph-node /usr/local/cargo/bin/graph-node.debug \
+ && strip -g /usr/local/cargo/bin/graph-node \
+ && cd /usr/local/cargo/bin \
+ && objcopy --add-gnu-debuglink=graph-node.debug graph-node
 
-# Clone and build the graph-node repository
-RUN git clone https://github.com/graphprotocol/graph-node \
-    && cd graph-node \
-    && git checkout "$SOURCE_BRANCH" \
-    && cargo install --locked --path node \
-    && cd .. \
-    && rm -rf graph-node
-
-# Clone and install wait-for-it
-RUN git clone https://github.com/vishnubob/wait-for-it \
-    && cp wait-for-it/wait-for-it.sh /usr/local/bin \
-    && chmod +x /usr/local/bin/wait-for-it.sh \
-    && rm -rf wait-for-it
-
+# The graph-node runtime image with only the executable
+FROM alpine:latest as graph-node-run
 ENV RUST_LOG ""
 ENV GRAPH_LOG ""
 ENV EARLY_LOG_CHUNK_SIZE ""
@@ -33,34 +32,35 @@ ENV postgres_user ""
 ENV postgres_pass ""
 ENV postgres_db ""
 ENV ipfs ""
+# The etherum network(s) to connect to. Set this to a space-separated
+# list of the networks where each entry has the form NAME:URL
 ENV ethereum ""
 
 # HTTP port
 EXPOSE 8000
-
 # WebSocket port
 EXPOSE 8001
-
 # JSON-RPC port
 EXPOSE 8020
 
-# Start everything on startup
-ADD start-node /usr/local/bin
+RUN apk add libgcc libssl1.1 libcrypto1.1 postgresql-libs bash
 
-RUN apt-get install gawk
+ADD wait_for start /usr/local/bin
+COPY --from=graph-node-bld /usr/local/cargo/bin/graph-node /usr/local/bin
 
-# Wait for IPFS and Postgres to start up.
-#
-# The awk commands below take the IPFS and Postgres and extract
-# hostname:port from them. The IPFS port defaults to 443 for HTTPS
-# and 80 for HTTP. The Postgres port defaults to 5432.
-CMD wait-for-it.sh \
-      $(echo $ipfs | \
-        gawk 'match($0, /^([a-z]+:\/\/)?([^\/:]+)(:([0-9]+))?.*$/, m) { print m[2]":"(m[4] ? m[4] : (m[1] == "https://" ? 443 : 80)) }') \
-      -t 120 \
-    && wait-for-it.sh \
-         $(echo $postgres_host | \
-           gawk 'match($0, /^([a-z]+:\/\/)?([^\/:]+)(:([0-9]+))?.*$/, m) { print m[2]":"(m[4] ? m[4] : 5432) }') \
-         -t 120 \
-    && sleep 5 \
-    && start-node
+# The query-node image
+FROM graph-node-run as query-node
+CMD start query-node
+
+# The index-node image
+FROM graph-node-run as index-node
+CMD start index-node
+
+# The combined-node image used for the public docker compose setup
+FROM graph-node-run as graph-node
+CMD start combined-node
+
+# Debug image to access core dumps
+FROM graph-node-bld as graph-node-dbg
+RUN apk add gdb
+ADD debug /usr/local/bin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 # by running something like the following
 #   docker build --target STAGE -f docker/Dockerfile .
 
-FROM rust:latest as graph-node-bld
+FROM rust:latest as graph-node-build
 
 ARG COMMIT_SHA=unknown
 ARG REPO_NAME=unknown
@@ -61,13 +61,13 @@ RUN apt-get update \
  && apt-get install -y libpq-dev ca-certificates
 
 ADD docker/wait_for docker/start /usr/local/bin/
-COPY --from=graph-node-bld /usr/local/cargo/bin/graph-node /usr/local/bin
-COPY --from=graph-node-bld /etc/image-info /etc/image-info
+COPY --from=graph-node-build /usr/local/cargo/bin/graph-node /usr/local/bin
+COPY --from=graph-node-build /etc/image-info /etc/image-info
 COPY docker/Dockerfile /Dockerfile
 CMD start
 
 # Debug image to access core dumps
-FROM graph-node-bld as graph-node-dbg
+FROM graph-node-build as graph-node-debug
 RUN apt-get update \
  && apt-get install -y curl gdb postgresql-client
 

--- a/docker/bin/create
+++ b/docker/bin/create
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+if [ $# != 1 ]; then
+    echo "usage: create <name>"
+    exit 1
+fi
+
+api="http://index-node.default/"
+
+data=$(printf '{"jsonrpc": "2.0", "method": "subgraph_create", "params": {"name":"%s"}, "id":"1"}' "$1")
+curl -H "content-type: application/json" --data "$data" "$api"

--- a/docker/bin/debug
+++ b/docker/bin/debug
@@ -2,7 +2,7 @@
 
 if [ -f "$1" ]
 then
-    exec gdb -c "$1" /usr/local/bin/graph-node
+    exec rust-gdb -c "$1" /usr/local/cargo/bin/graph-node
 else
     echo "usage: debug <core-file>"
     exit 1

--- a/docker/bin/deploy
+++ b/docker/bin/deploy
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ $# != 3 ]; then
+    echo "usage: deploy <name> <ipfs_hash> <node>"
+    exit 1
+fi
+
+api="http://index-node.default/"
+
+echo "Deploying $1 (deployment $2)"
+data=$(printf '{"jsonrpc": "2.0", "method": "subgraph_deploy", "params": {"name":"%s", "ipfs_hash":"%s", "node_id":"%s"}, "id":"1"}' "$1" "$2" "$3")
+curl -H "content-type: application/json" --data "$data" "$api"

--- a/docker/bin/reassign
+++ b/docker/bin/reassign
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ $# -lt 3 ]; then
+    echo "usage: reassign <name> <ipfs_hash> <node>"
+    exit 1
+fi
+
+api="http://index-node.default/"
+
+echo Assigning to "$3"
+data=$(printf '{"jsonrpc": "2.0", "method": "subgraph_reassign", "params": {"name":"%s", "ipfs_hash":"%s", "node_id":"%s"}, "id":"1"}' "$1" "$2" "$3")
+curl -H "content-type: application/json" --data "$data" "$api"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -9,9 +9,6 @@ type -p podman > /dev/null && docker=podman || docker=docker
 cd $(dirname $0)/..
 
 for stage in graph-node-bld \
-                 graph-node-run \
-                 query-node \
-                 index-node \
                  graph-node \
                  graph-node-dbg
 do

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -8,9 +8,7 @@ type -p podman > /dev/null && docker=podman || docker=docker
 
 cd $(dirname $0)/..
 
-for stage in graph-node-bld \
-                 graph-node \
-                 graph-node-dbg
+for stage in graph-node-build graph-node graph-node-debug
 do
     $docker build -t $stage --target $stage -f docker/Dockerfile .
 done

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -6,11 +6,14 @@
 
 type -p podman > /dev/null && docker=podman || docker=docker
 
+cd $(dirname $0)/..
+
 for stage in graph-node-bld \
                  graph-node-run \
                  query-node \
                  index-node \
+                 graph-node \
                  graph-node-dbg
 do
-    $docker build -t $stage --target $stage .
+    $docker build -t $stage --target $stage -f docker/Dockerfile .
 done

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+# This file is only here to ease testing/development. The commands in this
+# file should ultimately be moved to the corresponding commands for Cloud Build
+# in the cloudbuild.*.yaml files
+
+type -p podman > /dev/null && docker=podman || docker=docker
+
+for stage in graph-node-bld \
+                 graph-node-run \
+                 query-node \
+                 index-node \
+                 graph-node-dbg
+do
+    $docker build -t $stage --target $stage .
+done

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -11,19 +11,10 @@ steps:
          '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-bld:$SHORT_SHA',
          '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'graph-node-run', '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-run:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'query-node', '-t', 'gcr.io/$PROJECT_ID/alp-query-node:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'index-node', '-t', 'gcr.io/$PROJECT_ID/alp-index-node:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
-- name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--target', 'graph-node', '-t', 'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--target', 'graph-node-dbg', '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-dbg:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
 images:
   - 'gcr.io/$PROJECT_ID/alp-graph-node-bld:$SHORT_SHA'
-  - 'gcr.io/$PROJECT_ID/alp-graph-node-run:$SHORT_SHA'
-  - 'gcr.io/$PROJECT_ID/alp-query-node:$SHORT_SHA'
-  - 'gcr.io/$PROJECT_ID/alp-index-node:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/alp-graph-node-dbg:$SHORT_SHA'

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -1,0 +1,23 @@
+options:
+  machineType: "N1_HIGHCPU_32"
+timeout: 1800s
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--target', 'graph-node-bld', '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-bld:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--target', 'graph-node-run', '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-run:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--target', 'query-node', '-t', 'gcr.io/$PROJECT_ID/alp-query-node:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--target', 'index-node', '-t', 'gcr.io/$PROJECT_ID/alp-index-node:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--target', 'graph-node', '-t', 'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--target', 'graph-node-dbg', '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-dbg:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
+images:
+  - 'gcr.io/$PROJECT_ID/alp-graph-node-bld:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/alp-graph-node-run:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/alp-query-node:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/alp-index-node:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/alp-graph-node-dbg:$SHORT_SHA'

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
          '--build-arg', 'REPO_NAME=$REPO_NAME',
          '--build-arg', 'BRANCH_NAME=$BRANCH_NAME',
          '--build-arg', 'TAG_NAME=$TAG_NAME',
-         '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-build:$SHORT_SHA',
+         '-t', 'gcr.io/$PROJECT_ID/graph-node-build:$SHORT_SHA',
          '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--target', 'graph-node',
@@ -20,7 +20,7 @@ steps:
          '--build-arg', 'REPO_NAME=$REPO_NAME',
          '--build-arg', 'BRANCH_NAME=$BRANCH_NAME',
          '--build-arg', 'TAG_NAME=$TAG_NAME',
-         '-t', 'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA',
+         '-t', 'gcr.io/$PROJECT_ID/graph-node:$SHORT_SHA',
          '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--target', 'graph-node-debug',
@@ -28,18 +28,24 @@ steps:
          '--build-arg', 'REPO_NAME=$REPO_NAME',
          '--build-arg', 'BRANCH_NAME=$BRANCH_NAME',
          '--build-arg', 'TAG_NAME=$TAG_NAME',
-         '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-debug:$SHORT_SHA',
+         '-t', 'gcr.io/$PROJECT_ID/graph-node-debug:$SHORT_SHA',
          '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['tag',
-         'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA',
-         'lutter/alp-graph-node:$SHORT_SHA']
+         'gcr.io/$PROJECT_ID/graph-node:$SHORT_SHA',
+         'lutter/graph-node:$SHORT_SHA']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'lutter/alp-graph-node:$SHORT_SHA']
+  entrypoint: 'bash'
+  args: ['docker/tag.sh']
+  secretEnv: ['PASSWORD']
+  env:
+    - 'SHORT_SHA=$SHORT_SHA'
+    - 'TAG_NAME=$TAG_NAME'
+    - 'PROJECT_ID=$PROJECT_ID'
 images:
-  - 'gcr.io/$PROJECT_ID/alp-graph-node-build:$SHORT_SHA'
-  - 'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA'
-  - 'gcr.io/$PROJECT_ID/alp-graph-node-debug:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/graph-node-build:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/graph-node:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/graph-node-debug:$SHORT_SHA'
 secrets:
  - kmsKeyName: projects/the-graph-staging/locations/global/keyRings/docker/cryptoKeys/docker-hub-push
    secretEnv:

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -3,7 +3,13 @@ options:
 timeout: 1800s
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'graph-node-bld', '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-bld:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
+  args: ['build', '--target', 'graph-node-bld',
+         '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
+         '--build-arg', 'REPO_NAME=$REPO_NAME',
+         '--build-arg', 'BRANCH_NAME=$BRANCH_NAME',
+         '--build-arg', 'TAG_NAME=$TAG_NAME',
+         '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-bld:$SHORT_SHA',
+         '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--target', 'graph-node-run', '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-run:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -11,9 +11,21 @@ steps:
          '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-bld:$SHORT_SHA',
          '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'graph-node', '-t', 'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
+  args: ['build', '--target', 'graph-node',
+         '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
+         '--build-arg', 'REPO_NAME=$REPO_NAME',
+         '--build-arg', 'BRANCH_NAME=$BRANCH_NAME',
+         '--build-arg', 'TAG_NAME=$TAG_NAME',
+         '-t', 'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA',
+         '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'graph-node-dbg', '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-dbg:$SHORT_SHA', '-f', 'docker/Dockerfile', '.']
+  args: ['build', '--target', 'graph-node-dbg',
+         '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
+         '--build-arg', 'REPO_NAME=$REPO_NAME',
+         '--build-arg', 'BRANCH_NAME=$BRANCH_NAME',
+         '--build-arg', 'TAG_NAME=$TAG_NAME',
+         '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-dbg:$SHORT_SHA',
+         '-f', 'docker/Dockerfile', '.']
 images:
   - 'gcr.io/$PROJECT_ID/alp-graph-node-bld:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA'

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -3,6 +3,10 @@ options:
 timeout: 1800s
 steps:
 - name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', 'docker login --username=lutter --password=$$PASSWORD']
+  secretEnv: ['PASSWORD']
+- name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--target', 'graph-node-bld',
          '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
          '--build-arg', 'REPO_NAME=$REPO_NAME',
@@ -26,7 +30,17 @@ steps:
          '--build-arg', 'TAG_NAME=$TAG_NAME',
          '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-dbg:$SHORT_SHA',
          '-f', 'docker/Dockerfile', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['tag',
+         'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA',
+         'lutter/alp-graph-node:$SHORT_SHA']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', 'lutter/alp-graph-node:$SHORT_SHA']
 images:
   - 'gcr.io/$PROJECT_ID/alp-graph-node-bld:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/alp-graph-node-dbg:$SHORT_SHA'
+secrets:
+ - kmsKeyName: projects/the-graph-staging/locations/global/keyRings/docker/cryptoKeys/docker-hub-push
+   secretEnv:
+     PASSWORD: 'CiQAdfFldbmUiHgGP1lPq6bAOfd+VQ/dFwyohB1IQwiwQg03ZE8STQDvWKpv6eJHVUN1YoFC5FcooJrH+Stvx9oMD7jBjgxEH5ngIiAysWP3E4Pgxt/73xnaanbM1EQ94eVFKCiY0GaEKFNu0BJx22vCYmU4'

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -7,12 +7,12 @@ steps:
   args: ['-c', 'docker login --username=lutter --password=$$PASSWORD']
   secretEnv: ['PASSWORD']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'graph-node-bld',
+  args: ['build', '--target', 'graph-node-build',
          '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
          '--build-arg', 'REPO_NAME=$REPO_NAME',
          '--build-arg', 'BRANCH_NAME=$BRANCH_NAME',
          '--build-arg', 'TAG_NAME=$TAG_NAME',
-         '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-bld:$SHORT_SHA',
+         '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-build:$SHORT_SHA',
          '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--target', 'graph-node',
@@ -23,12 +23,12 @@ steps:
          '-t', 'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA',
          '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'graph-node-dbg',
+  args: ['build', '--target', 'graph-node-debug',
          '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
          '--build-arg', 'REPO_NAME=$REPO_NAME',
          '--build-arg', 'BRANCH_NAME=$BRANCH_NAME',
          '--build-arg', 'TAG_NAME=$TAG_NAME',
-         '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-dbg:$SHORT_SHA',
+         '-t', 'gcr.io/$PROJECT_ID/alp-graph-node-debug:$SHORT_SHA',
          '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['tag',
@@ -37,9 +37,9 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'lutter/alp-graph-node:$SHORT_SHA']
 images:
-  - 'gcr.io/$PROJECT_ID/alp-graph-node-bld:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/alp-graph-node-build:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/alp-graph-node:$SHORT_SHA'
-  - 'gcr.io/$PROJECT_ID/alp-graph-node-dbg:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/alp-graph-node-debug:$SHORT_SHA'
 secrets:
  - kmsKeyName: projects/the-graph-staging/locations/global/keyRings/docker/cryptoKeys/docker-hub-push
    secretEnv:

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -3,10 +3,6 @@ options:
 timeout: 1800s
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  entrypoint: 'bash'
-  args: ['-c', 'docker login --username=lutter --password=$$PASSWORD']
-  secretEnv: ['PASSWORD']
-- name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--target', 'graph-node-build',
          '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
          '--build-arg', 'REPO_NAME=$REPO_NAME',
@@ -42,10 +38,14 @@ steps:
     - 'SHORT_SHA=$SHORT_SHA'
     - 'TAG_NAME=$TAG_NAME'
     - 'PROJECT_ID=$PROJECT_ID'
+    - 'DOCKER_HUB_USER=$_DOCKER_HUB_USER'
 images:
   - 'gcr.io/$PROJECT_ID/graph-node-build:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/graph-node:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/graph-node-debug:$SHORT_SHA'
+substitutions:
+  # The owner of the access token whose encrypted value is in PASSWORD
+  _DOCKER_HUB_USER: "lutter"
 secrets:
  - kmsKeyName: projects/the-graph-staging/locations/global/keyRings/docker/cryptoKeys/docker-hub-push
    secretEnv:

--- a/docker/debug
+++ b/docker/debug
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+if [ -f "$1" ]
+then
+    exec gdb -c "$1" /usr/local/bin/graph-node
+else
+    echo "usage: debug <core-file>"
+    exit 1
+fi

--- a/docker/start
+++ b/docker/start
@@ -58,12 +58,12 @@ start_query_node() {
 start_index_node() {
     # Only the index node with the name set in BLOCK_INGESTOR should ingest
     # blocks
-    if [[ ${pod_name} != "${BLOCK_INGESTOR}" ]]; then
+    if [[ ${node_id} != "${BLOCK_INGESTOR}" ]]; then
         export DISABLE_BLOCK_INGESTOR=true
     fi
 
     graph-node \
-	    --node-id "${pod_name//-/_}" \
+	    --node-id "${node_id//-/_}" \
 	    --postgres-url "$postgres_url" \
 	    --ethereum-rpc $ethereum \
 	    --ipfs "$ipfs"
@@ -84,7 +84,7 @@ sleep 5
 
 trap save_coredumps EXIT
 
-export PGAPPNAME="${pod_name-$HOSTNAME}"
+export PGAPPNAME="${node_id-$HOSTNAME}"
 
 case "${node_role-combined-node}" in
     query-node)

--- a/docker/start
+++ b/docker/start
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 save_coredumps() {
-    core_dir=/var/lib/graph/cores
+    graph_dir=/var/lib/graph
     datestamp=$(date +"%Y-%m-%dT%H:%M:%S")
     ls /core.* >& /dev/null && have_cores=yes || have_cores=no
-    if [ -d "$core_dir" -a "$have_cores" = yes ]
+    if [ -d "$graph_dir" -a "$have_cores" = yes ]
     then
+        core_dir=$graph_dir/cores
+        mkdir -p $core_dir
         exec >> "$core_dir"/messages 2>&1
         echo "${HOSTNAME##*-} Saving core dump on ${HOSTNAME} at ${datestamp}"
 

--- a/docker/start
+++ b/docker/start
@@ -13,6 +13,8 @@ save_coredumps() {
         mkdir "$dst"
         cp /usr/local/cargo/bin/graph-node "$dst"
         cp /proc/loadavg "$dst"
+        [ -f /Dockerfile ] && cp /Dockerfile "$dst"
+        tar czf "$dst/etc.tgz" /etc/
         dmesg -e > "$dst/dmesg"
         # Capture environment variables, but filter out passwords
         env | sort | sed -r -e 's/^(postgres_pass|ELASTICSEARCH_PASSWORD)=.*$/\1=REDACTED/' > "$dst/env"

--- a/docker/start
+++ b/docker/start
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+save_coredumps() {
+    core_dir=/var/lib/graph/cores
+    datestamp=$(date +"%Y-%m-%dT%H:%M:%S")
+    ls /core.* >& /dev/null && have_cores=yes || have_cores=no
+    if [ -d "$core_dir" -a "$have_cores" = yes ]
+    then
+        exec >> "$core_dir"/messages 2>&1
+        echo "${HOSTNAME##*-} Saving core dump on ${HOSTNAME} at ${datestamp}"
+
+        dst="$core_dir/$datestamp-${HOSTNAME}"
+        mkdir "$dst"
+        cp /usr/local/cargo/bin/graph-node "$dst"
+        cp /proc/loadavg "$dst"
+        dmesg -e > "$dst/dmesg"
+        # Capture environment variables, but filter out passwords
+        env | sort | sed -r -e 's/^(postgres_pass|ELASTICSEARCH_PASSWORD)=.*$/\1=REDACTED/' > "$dst/env"
+
+        for f in /core.*
+        do
+            echo "${HOSTNAME##*-} Found core dump $f"
+            mv "$f" "$dst"
+        done
+        echo "${HOSTNAME##*-} Saving done"
+    fi
+}
+
+start_query_node() {
+    export DISABLE_BLOCK_INGESTOR=true
+    graph-node \
+        --postgres-url "$postgres_url" \
+        --ethereum-rpc $ethereum \
+        --ipfs "$ipfs"
+}
+
+start_index_node() {
+    POD_INDEX=${pod_name##*-}
+
+    # FIXME: Users should just pass this in or something
+    # Only enable block ingestion for `index-node-<network>-0`;
+    # disable it for all tracing and production nodes
+    if [[ ${pod_name} != *"block-ingestor"* ]]; then
+        export DISABLE_BLOCK_INGESTOR=true
+    fi
+
+    if [ -z $MULTIPLE_ETHEREUM_NETWORKS ]; then
+        graph-node \
+	        --node-id "${pod_name//-/_}" \
+	        --postgres-url "$postgres_url" \
+	        --ethereum-rpc "$ETHEREUM_NETWORK" \
+	        --ipfs "$ipfs"
+    else
+        graph-node \
+	        --node-id "${pod_name//-/_}" \
+	        --postgres-url "$postgres_url" \
+	        --ethereum-rpc $ethereum \
+	        --ipfs "$ipfs"
+    fi
+}
+
+start_combined_node() {
+    graph-node \
+        --postgres-url "$postgres_url" \
+        --ethereum-rpc $ethereum \
+        --ipfs "$ipfs"
+}
+
+postgres_url="postgresql://$postgres_user:$postgres_pass@$postgres_host/$postgres_db"
+
+wait_for "$ipfs" -t 120
+wait_for "$postgres_host:5432" -t 120
+sleep 5
+
+trap save_coredumps EXIT
+
+case "$1" in
+    query-node)
+        start_query_node
+        ;;
+    index-node)
+        start_index_node
+        ;;
+    combined-node)
+        start_combined_node
+        ;;
+    *)
+        echo "Unknown mode for start-node: $1"
+        echo "usage: start-node (query-node|index-node)"
+        exit 1
+esac

--- a/docker/start
+++ b/docker/start
@@ -26,6 +26,25 @@ save_coredumps() {
     fi
 }
 
+wait_for_ipfs() {
+    # Take the IPFS URL in $1 apart and extract host and port. If no explicit
+    # host is given, use 443 for https, and 80 otherwise
+    if [[ "$1" =~ ^((https?)://)?([^:/]+)(:([0-9]+))? ]]
+    then
+        proto=${BASH_REMATCH[2]:-http}
+        host=${BASH_REMATCH[3]}
+        port=${BASH_REMATCH[5]}
+        if [ -z "$port" ]
+        then
+            [ "$proto" = "https" ] && port=443 || port=80
+        fi
+        wait_for "$host:$port" -t 120
+    else
+        echo "invalid IPFS URL: $1"
+        exit 1
+    fi
+}
+
 start_query_node() {
     export DISABLE_BLOCK_INGESTOR=true
     graph-node \
@@ -57,8 +76,8 @@ start_combined_node() {
 
 postgres_url="postgresql://$postgres_user:$postgres_pass@$postgres_host/$postgres_db"
 
-wait_for "$ipfs" -t 120
-wait_for "$postgres_host:5432" -t 120
+wait_for_ipfs "$ipfs"
+wait_for "$postgres_host:5432" -t 30
 sleep 5
 
 trap save_coredumps EXIT

--- a/docker/start
+++ b/docker/start
@@ -13,7 +13,7 @@ save_coredumps() {
 
         dst="$core_dir/$datestamp-${HOSTNAME}"
         mkdir "$dst"
-        cp /usr/local/cargo/bin/graph-node "$dst"
+        cp /usr/local/bin/graph-node "$dst"
         cp /proc/loadavg "$dst"
         [ -f /Dockerfile ] && cp /Dockerfile "$dst"
         tar czf "$dst/etc.tgz" /etc/

--- a/docker/start
+++ b/docker/start
@@ -35,28 +35,17 @@ start_query_node() {
 }
 
 start_index_node() {
-    POD_INDEX=${pod_name##*-}
-
-    # FIXME: Users should just pass this in or something
-    # Only enable block ingestion for `index-node-<network>-0`;
-    # disable it for all tracing and production nodes
-    if [[ ${pod_name} != *"block-ingestor"* ]]; then
+    # Only the index node with the name set in BLOCK_INGESTOR should ingest
+    # blocks
+    if [[ ${pod_name} != "${BLOCK_INGESTOR}" ]]; then
         export DISABLE_BLOCK_INGESTOR=true
     fi
 
-    if [ -z $MULTIPLE_ETHEREUM_NETWORKS ]; then
-        graph-node \
-	        --node-id "${pod_name//-/_}" \
-	        --postgres-url "$postgres_url" \
-	        --ethereum-rpc "$ETHEREUM_NETWORK" \
-	        --ipfs "$ipfs"
-    else
-        graph-node \
-	        --node-id "${pod_name//-/_}" \
-	        --postgres-url "$postgres_url" \
-	        --ethereum-rpc $ethereum \
-	        --ipfs "$ipfs"
-    fi
+    graph-node \
+	    --node-id "${pod_name//-/_}" \
+	    --postgres-url "$postgres_url" \
+	    --ethereum-rpc $ethereum \
+	    --ipfs "$ipfs"
 }
 
 start_combined_node() {
@@ -73,6 +62,8 @@ wait_for "$postgres_host:5432" -t 120
 sleep 5
 
 trap save_coredumps EXIT
+
+[ -z "$pod_name" ] && export PGAPPNAME="$HOSTNAME" || export PGAPPNAME="$pod_name"
 
 case "$1" in
     query-node)

--- a/docker/start
+++ b/docker/start
@@ -81,7 +81,7 @@ start_combined_node() {
 postgres_url="postgresql://$postgres_user:$postgres_pass@$postgres_host/$postgres_db"
 
 wait_for_ipfs "$ipfs"
-wait_for "$postgres_host:5432" -t 30
+wait_for "$postgres_host:5432" -t 120
 sleep 5
 
 trap save_coredumps EXIT
@@ -100,6 +100,6 @@ case "${node_role-combined-node}" in
         ;;
     *)
         echo "Unknown mode for start-node: $1"
-        echo "usage: start-node (query-node|index-node)"
+        echo "usage: start (combined-node|query-node|index-node)"
         exit 1
 esac

--- a/docker/start
+++ b/docker/start
@@ -63,9 +63,9 @@ sleep 5
 
 trap save_coredumps EXIT
 
-[ -z "$pod_name" ] && export PGAPPNAME="$HOSTNAME" || export PGAPPNAME="$pod_name"
+export PGAPPNAME="${pod_name-$HOSTNAME}"
 
-case "$1" in
+case "${node_role-combined-node}" in
     query-node)
         start_query_node
         ;;

--- a/docker/start-node
+++ b/docker/start-node
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-set -x
-
-graph-node \
-  --postgres-url "postgresql://$postgres_user:$postgres_pass@$postgres_host/$postgres_db" \
-  --ethereum-rpc $(echo $ethereum) \
-  --ipfs "$ipfs"

--- a/docker/tag.sh
+++ b/docker/tag.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+# This script is used by cloud build to push Docker images into Docker hub
+
+tag_and_push() {
+    tag=$1
+    docker tag gcr.io/$PROJECT_ID/graph-node:$SHORT_SHA \
+           lutter/graph-node:$tag
+    docker push lutter/graph-node:$tag
+
+    docker tag gcr.io/$PROJECT_ID/graph-node-debug:$SHORT_SHA \
+           lutter/graph-node-debug:$tag
+    docker push lutter/graph-node-debug:$tag
+}
+
+echo "Logging into Docker Hub"
+echo $PASSWORD | docker login --username=lutter --password-stdin
+
+set -x
+
+tag_and_push "$SHORT_SHA"
+tag_and_push latest
+
+if [ -n "$TAG_NAME" ]
+then
+    tag_and_push "$TAG_NAME"
+fi

--- a/docker/tag.sh
+++ b/docker/tag.sh
@@ -14,7 +14,7 @@ tag_and_push() {
 }
 
 echo "Logging into Docker Hub"
-echo $PASSWORD | docker login --username=lutter --password-stdin
+echo $PASSWORD | docker login --username="$DOCKER_HUB_USER" --password-stdin
 
 set -x
 

--- a/docker/wait_for
+++ b/docker/wait_for
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+# POSIX compatible clone of wait-for-it.sh
+# This copy is from https://github.com/eficode/wait-for/commits/master
+# at commit 8d9b4446
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"


### PR DESCRIPTION
These changes accomplish a few things:

* the `Dockerfile` produces three containers: a (very large) build container, a smaller `graph-ndoe` runtime container, and a `graph-node-dbg` debug container that can be used to investigate core dumps produced by the runtime container. The `docker/build.sh` script shows how to build the three containers using plain `docker` (resp `podman`) The `Dockerfile` expects that the current working directory for a build is the root of the repo
* the `start` script makes it possible to run an all-in-one `graph-node` (`ENV node_role=combined-node`, the default), or separate `query-node` or `index-node` containers. For `index-node`, it is possible to select which instance of such a container runs a block ingestor
* the `start` script will capture a core dump and other useful debugging information if the main process aborts for any reason as long as the directory `/var/lib/graph` exists. When starting a container, map that directory to a persistent directory on the host or via NFS to enable this feature
* the `graph-node-dbg` container also contains utility scripts that make it possible to create/deploy/reassign subgraphs that are already present on the IPFS server
* there is a `cloudbuild.yaml` that can be used to build containers in Google Cloud Build; in the future, we should also fix up the support for building images in Docker Hub (I'll need access to our account there to set that up)

The PR starts out by moving the container build to Alpine, but because of [this issue](https://andygrove.io/2020/05/why-musl-extremely-slow/) that causes Rust programs to run very slow under Alpine, a later commit moves the build back to Debian buster. The slowness was clearly observable both during container builds and in test environments indexing simple subgraphs.

