### PR TITLE
Less expensive block polling

### DIFF
--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -94,6 +94,8 @@ where
                 // Attempt to poll
                 static_self
                     .do_poll()
+                    .boxed()
+                    .compat()
                     .then(move |result| {
                         if let Err(err) = result {
                             // Some polls will fail due to transient issues
@@ -144,120 +146,109 @@ where
             })
     }
 
-    fn do_poll(&'static self) -> impl Future<Item = (), Error = EthereumAdapterError> + 'static {
+    async fn do_poll(&'static self) -> Result<(), EthereumAdapterError> {
         trace!(self.logger, "BlockIngestor::do_poll");
 
         // Get chain head ptr from store
-        future::result(self.chain_store.chain_head_ptr())
-            .from_err()
-            .and_then(move |head_block_ptr_opt| {
-                // Ask for latest block from Ethereum node
-                self.eth_adapter.latest_block(&self.logger)
-                    // Compare latest block with head ptr, alert user if far behind
-                    .and_then(move |latest_block: LightEthereumBlock| -> Box<dyn Future<Item=_, Error=_> + Send> {
-                        match head_block_ptr_opt {
-                            None => {
-                                info!(
-                                    self.logger,
-                                    "Downloading latest blocks from Ethereum. \
+        let head_block_ptr_opt = self.chain_store.chain_head_ptr()?;
+
+        // Ask for latest block from Ethereum node
+        let latest_block = self.eth_adapter.latest_block(&self.logger).compat().await?;
+
+        // If latest block matches head block in store, nothing needs to be done
+        if Some((&latest_block).into()) == head_block_ptr_opt {
+            return Ok(());
+        }
+
+        // Compare latest block with head ptr, alert user if far behind
+        match head_block_ptr_opt {
+            None => {
+                info!(
+                    self.logger,
+                    "Downloading latest blocks from Ethereum. \
                                     This may take a few minutes..."
-                                );
-                            }
-                            Some(head_block_ptr) => {
-                                let latest_number = latest_block.number.unwrap().as_u64() as i64;
-                                let head_number = head_block_ptr.number as i64;
-                                let distance = latest_number - head_number;
-                                let blocks_needed = (distance).min(self.ancestor_count as i64);
-                                let code = if distance >= 15 {
-                                    LogCode::BlockIngestionLagging
-                                } else {
-                                    LogCode::BlockIngestionStatus
-                                };
-                                if distance > 0 {
-                                    info!(
-                                        self.logger,
-                                        "Syncing {} blocks from Ethereum.",
-                                        blocks_needed;
-                                        "current_block_head" => head_number,
-                                        "latest_block_head" => latest_number,
-                                        "blocks_behind" => distance,
-                                        "blocks_needed" => blocks_needed,
-                                        "code" => code,
-                                    );
-                                }
-                            }
-                        }
+                );
+            }
+            Some(head_block_ptr) => {
+                let latest_number = latest_block.number.unwrap().as_u64() as i64;
+                let head_number = head_block_ptr.number as i64;
+                let distance = latest_number - head_number;
+                let blocks_needed = (distance).min(self.ancestor_count as i64);
+                let code = if distance >= 15 {
+                    LogCode::BlockIngestionLagging
+                } else {
+                    LogCode::BlockIngestionStatus
+                };
+                if distance > 0 {
+                    info!(
+                        self.logger,
+                        "Syncing {} blocks from Ethereum.",
+                        blocks_needed;
+                        "current_block_head" => head_number,
+                        "latest_block_head" => latest_number,
+                        "blocks_behind" => distance,
+                        "blocks_needed" => blocks_needed,
+                        "code" => code,
+                    );
+                }
+            }
+        }
 
-                        // If latest block matches head block in store
-                        if Some((&latest_block).into()) == head_block_ptr_opt {
-                            // We're done
-                            return Box::new(future::ok(()));
-                        }
+        let latest_block = self
+            .eth_adapter
+            .load_full_block(&self.logger, latest_block)
+            .compat()
+            .await?;
 
-                        Box::new(
-                            self.eth_adapter.load_full_block(&self.logger, latest_block)
-                            .and_then(move |latest_block: EthereumBlock| {
-                                // Store latest block in block store.
-                                // Might be a no-op if latest block is one that we have seen.
-                                // ingest_blocks will return a (potentially incomplete) list of blocks that are
-                                // missing.
-                                self.ingest_blocks(stream::once(Ok(latest_block)))
-                            }).and_then(move |missing_block_hashes| {
-                                // Repeatedly fetch missing parent blocks, and ingest them.
-                                // ingest_blocks will continue to tell us about more missing parent
-                                // blocks until we have filled in all missing pieces of the
-                                // blockchain in the block number range we care about.
-                                //
-                                // Loop will terminate because:
-                                // - The number of blocks in the ChainStore in the block number
-                                //   range [latest - ancestor_count, latest] is finite.
-                                // - The missing parents in the first iteration have at most block
-                                //   number latest-1.
-                                // - Each iteration loads parents of all blocks in the range whose
-                                //   parent blocks are not already in the ChainStore, so blocks
-                                //   with missing parents in one iteration will not have missing
-                                //   parents in the next.
-                                // - Therefore, if the missing parents in one iteration have at
-                                //   most block number N, then the missing parents in the next
-                                //   iteration will have at most block number N-1.
-                                // - Therefore, the loop will iterate at most ancestor_count times.
-                                future::loop_fn(
-                                    missing_block_hashes,
-                                    move |missing_block_hashes| -> Box<dyn Future<Item = _, Error = _> + Send> {
-                                        if missing_block_hashes.is_empty() {
-                                            // If no blocks were missing, then the block head pointer was updated
-                                            // successfully, and this poll has completed.
-                                            Box::new(future::ok(future::Loop::Break(())))
-                                        } else {
-                                            // Some blocks are missing: load them, ingest them, and repeat.
-                                            let missing_blocks = self.get_blocks(&missing_block_hashes);
-                                            Box::new(self.ingest_blocks(missing_blocks).map(future::Loop::Continue))
-                                        }
-                                    },
-                                )
-                            })
-                        )
-                    })
-            })
+        // Store latest block in block store.
+        // Might be a no-op if latest block is one that we have seen.
+        // ingest_blocks will return a (potentially incomplete) list of blocks that are
+        // missing.
+        let mut missing_block_hashes = self.ingest_blocks(stream::once(Ok(latest_block))).await?;
+
+        // Repeatedly fetch missing parent blocks, and ingest them.
+        // ingest_blocks will continue to tell us about more missing parent
+        // blocks until we have filled in all missing pieces of the
+        // blockchain in the block number range we care about.
+        //
+        // Loop will terminate because:
+        // - The number of blocks in the ChainStore in the block number
+        //   range [latest - ancestor_count, latest] is finite.
+        // - The missing parents in the first iteration have at most block
+        //   number latest-1.
+        // - Each iteration loads parents of all blocks in the range whose
+        //   parent blocks are not already in the ChainStore, so blocks
+        //   with missing parents in one iteration will not have missing
+        //   parents in the next.
+        // - Therefore, if the missing parents in one iteration have at
+        //   most block number N, then the missing parents in the next
+        //   iteration will have at most block number N-1.
+        // - Therefore, the loop will iterate at most ancestor_count times.
+        while !missing_block_hashes.is_empty() {
+            // Some blocks are missing: load them, ingest them, and repeat.
+            let missing_blocks = self.get_blocks(&missing_block_hashes);
+            missing_block_hashes = self.ingest_blocks(missing_blocks).await?;
+        }
+        Ok(())
     }
 
     /// Put some blocks into the block store (if they are not there already), and try to update the
     /// head block pointer. If missing blocks prevent such an update, return a Vec with at least
     /// one of the missing blocks' hashes.
-    fn ingest_blocks<
+    async fn ingest_blocks<
         B: Stream<Item = EthereumBlock, Error = EthereumAdapterError> + Send + 'static,
     >(
         &'static self,
         blocks: B,
-    ) -> impl Future<Item = Vec<H256>, Error = EthereumAdapterError> + Send + 'static {
-        self.chain_store.upsert_blocks(blocks).and_then(move |()| {
-            self.chain_store
-                .attempt_chain_head_update(self.ancestor_count)
-                .map_err(|e| {
-                    error!(self.logger, "failed to update chain head");
-                    EthereumAdapterError::Unknown(e)
-                })
-        })
+    ) -> Result<Vec<H256>, EthereumAdapterError> {
+        self.chain_store.upsert_blocks(blocks).compat().await?;
+
+        self.chain_store
+            .attempt_chain_head_update(self.ancestor_count)
+            .map_err(|e| {
+                error!(self.logger, "failed to update chain head");
+                EthereumAdapterError::Unknown(e)
+            })
     }
 
     /// Requests the specified blocks via web3, returning them in a stream (potentially out of

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -659,7 +659,8 @@ where
     fn latest_block(
         &self,
         logger: &Logger,
-    ) -> Box<dyn Future<Item = LightEthereumBlock, Error = EthereumAdapterError> + Send> {
+    ) -> Box<dyn Future<Item = LightEthereumBlock, Error = EthereumAdapterError> + Send + Unpin>
+    {
         let web3 = self.web3.clone();
 
         Box::new(

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -8,6 +8,7 @@ use petgraph::graphmap::GraphMap;
 use std::cmp;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::marker::Unpin;
 use tiny_keccak::keccak256;
 use web3::types::*;
 
@@ -624,7 +625,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     fn latest_block(
         &self,
         logger: &Logger,
-    ) -> Box<dyn Future<Item = LightEthereumBlock, Error = EthereumAdapterError> + Send>;
+    ) -> Box<dyn Future<Item = LightEthereumBlock, Error = EthereumAdapterError> + Send + Unpin>;
 
     /// Get the latest block, with only the header and transaction hashes.
     fn latest_block_header(

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -620,11 +620,17 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         logger: &Logger,
     ) -> Box<dyn Future<Item = EthereumNetworkIdentifier, Error = Error> + Send>;
 
-    /// Find the most recent block.
+    /// Get the latest block, including full transactions.
     fn latest_block(
         &self,
         logger: &Logger,
     ) -> Box<dyn Future<Item = LightEthereumBlock, Error = EthereumAdapterError> + Send>;
+
+    /// Get the latest block, with only the header and transaction hashes.
+    fn latest_block_header(
+        &self,
+        logger: &Logger,
+    ) -> Box<dyn Future<Item = web3::types::Block<H256>, Error = EthereumAdapterError> + Send>;
 
     fn load_block(
         &self,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -206,7 +206,7 @@ async fn main() {
             Arg::with_name("ethereum-polling-interval")
                 .long("ethereum-polling-interval")
                 .value_name("MILLISECONDS")
-                .default_value("500")
+                .default_value("1000")
                 .env("ETHEREUM_POLLING_INTERVAL")
                 .help("How often to poll the Ethereum node for new blocks"),
         )

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -618,7 +618,7 @@ async fn main() {
                     .expect("failed to create Ethereum block ingestor");
 
                     // Run the Ethereum block ingestor in the background
-                    graph::spawn(block_ingestor.into_polling_stream().compat());
+                    graph::spawn(block_ingestor.into_polling_stream());
                 });
             }
 


### PR DESCRIPTION
This asyncifies most of the block ingestor and does the following functional changes, aiming at reducing the cost of block polling:
- Increase the default polling interval from 500ms to 1s. This is to reduce the overall number of requests made, though it will still add up to millions in month.
- Fetch only the header when checking for a new block, without full transactions. This is a cheaper call which suffices for most polls where we find no new block.
- A minor change: Use a delay at the end of the loop instead of a tokio interval stream. The interval stream would queue up triggers if the polling took longer than the interval duration, which could then lead to burst. Waiting a fixed amount after a poll has more predictable behavior. 