### PR TITLE
Fetch logs in parallel (regression fix)

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1059,17 +1059,16 @@ where
         let logger = logger.clone();
 
         futures03::stream::iter(log_filter.eth_get_logs_filters().map(move |filter| {
-            eth.cheap_clone()
-                .log_stream(
-                    logger.cheap_clone(),
-                    subgraph_metrics.cheap_clone(),
-                    from,
-                    to,
-                    filter,
-                )
-                .into_stream()
+            eth.cheap_clone().log_stream(
+                logger.cheap_clone(),
+                subgraph_metrics.cheap_clone(),
+                from,
+                to,
+                filter,
+            )
         }))
-        .flatten()
+        // Real limits on the number of parallel requests are imposed within the adapter.
+        .buffered(1000)
         .try_concat()
         .boxed()
     }


### PR DESCRIPTION
I messed this up in https://github.com/graphprotocol/graph-node/pull/1540 which actually made the eth_getLogs calls sequential. This is what I meant to do.