### PR TITLE
Strip nulls from strings

### DIFF
--- a/runtime/wasm/src/to_from/mod.rs
+++ b/runtime/wasm/src/to_from/mod.rs
@@ -67,7 +67,14 @@ impl ToAscObj<AscString> for String {
 
 impl FromAscObj<AscString> for String {
     fn from_asc_obj<H: AscHeap>(asc_string: AscString, _: &H) -> Self {
-        String::from_utf16(&asc_string.content).expect("asc string was not UTF-16")
+        let mut string =
+            String::from_utf16(&asc_string.content).expect("asc string was not UTF-16");
+
+        // Strip null characters since they are not accepted by Postgres.
+        if string.contains("\u{0000}") {
+            string = string.replace("\u{0000}", "");
+        }
+        string
     }
 }
 

--- a/tests/integration-tests/package.json
+++ b/tests/integration-tests/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "workspaces": [
+    "arweave-and-3box",
+    "data-source-context",
+    "fatal-error",
+    "ganache-reverts",
+    "overloaded-contract-functions",
+    "remove-then-update",
+    "value-roundtrip"
+  ]
+}

--- a/tests/integration-tests/value-roundtrip/abis/Contract.abi
+++ b/tests/integration-tests/value-roundtrip/abis/Contract.abi
@@ -1,0 +1,1 @@
+[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint16","name":"x","type":"uint16"}],"name":"Trigger","type":"event"},{"inputs":[{"internalType":"uint16","name":"x","type":"uint16"}],"name":"emitTrigger","outputs":[],"stateMutability":"nonpayable","type":"function"}]

--- a/tests/integration-tests/value-roundtrip/contracts/Contract.sol
+++ b/tests/integration-tests/value-roundtrip/contracts/Contract.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.6.1;
+
+
+contract Contract {
+    event Trigger(uint16 x);
+
+    constructor() public {
+        emit Trigger(0);
+    }
+
+    function emitTrigger(uint16 x) public {
+        emit Trigger(x);
+    }
+}

--- a/tests/integration-tests/value-roundtrip/contracts/Migrations.sol
+++ b/tests/integration-tests/value-roundtrip/contracts/Migrations.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.6.1;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) public restricted {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}

--- a/tests/integration-tests/value-roundtrip/migrations/1_initial_migration.js
+++ b/tests/integration-tests/value-roundtrip/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+var Migrations = artifacts.require('./Migrations.sol')
+
+module.exports = function(deployer) {
+  deployer.deploy(Migrations)
+}

--- a/tests/integration-tests/value-roundtrip/migrations/2_deploy_contracts.js
+++ b/tests/integration-tests/value-roundtrip/migrations/2_deploy_contracts.js
@@ -1,0 +1,5 @@
+const Contract = artifacts.require('./Contract.sol')
+
+module.exports = async function(deployer) {
+  await deployer.deploy(Contract)
+}

--- a/tests/integration-tests/value-roundtrip/package.json
+++ b/tests/integration-tests/value-roundtrip/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "value-roundtrip",
+  "version": "0.1.0",
+  "scripts": {
+    "build-contracts": "rm -rf abis bin && solcjs contracts/Contract.sol --abi -o abis && mv abis/*Contract.abi abis/Contract.abi && solcjs contracts/Contract.sol --bin -o bin && mv bin/*Contract.bin bin/Contract.bin",
+    "codegen": "graph codegen",
+    "test": "yarn build-contracts && truffle test --network test",
+    "create:test": "graph create test/value-roundtrip --node http://localhost:18020/",
+    "deploy:test": "graph deploy test/value-roundtrip --ipfs http://localhost:15001/ --node http://localhost:18020/"
+  },
+  "devDependencies": {
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "solc": "^0.6.1"
+  },
+  "dependencies": {
+    "apollo-fetch": "^0.7.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-register": "^6.26.0",
+    "gluegun": "^3.2.1",
+    "truffle": "^5.0.4",
+    "truffle-contract": "^4.0.5",
+    "truffle-hdwallet-provider": "^1.0.4"
+  }
+}

--- a/tests/integration-tests/value-roundtrip/schema.graphql
+++ b/tests/integration-tests/value-roundtrip/schema.graphql
@@ -1,0 +1,4 @@
+type Foo @entity {
+  id: ID!
+  value: String!
+}

--- a/tests/integration-tests/value-roundtrip/src/mapping.ts
+++ b/tests/integration-tests/value-roundtrip/src/mapping.ts
@@ -1,0 +1,12 @@
+import { Trigger } from "../generated/Contract/Contract";
+import { Foo } from "../generated/schema";
+
+export function handleTrigger(event: Trigger): void {
+  let obj = new Foo("0");
+  obj.value = "b\u0000la\u0000";
+  obj.save();
+
+  // Null characters are stripped.
+  obj = Foo.load("0") as Foo;
+  assert(obj.value == "bla", "nulls not stripped");
+}

--- a/tests/integration-tests/value-roundtrip/subgraph.yaml
+++ b/tests/integration-tests/value-roundtrip/subgraph.yaml
@@ -1,0 +1,23 @@
+specVersion: 0.0.2
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: Contract
+    network: test
+    source:
+      address: "0xCfEB869F69431e42cdB54A4F4f105C19C080A601"
+      abi: Contract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      abis:
+        - name: Contract
+          file: ./abis/Contract.abi
+      entities:
+        - Call
+      eventHandlers:
+        - event: Trigger(uint16)
+          handler: handleTrigger
+      file: ./src/mapping.ts

--- a/tests/integration-tests/value-roundtrip/test/test.js
+++ b/tests/integration-tests/value-roundtrip/test/test.js
@@ -1,0 +1,94 @@
+const path = require("path");
+const execSync = require("child_process").execSync;
+const { system, patching } = require("gluegun");
+const { createApolloFetch } = require("apollo-fetch");
+
+const Contract = artifacts.require("./Contract.sol");
+
+const srcDir = path.join(__dirname, "..");
+
+const fetchSubgraphs = createApolloFetch({
+  uri: "http://localhost:18030/graphql",
+});
+const fetchSubgraph = createApolloFetch({
+  uri: "http://localhost:18000/subgraphs/name/test/value-roundtrip",
+});
+
+const exec = (cmd) => {
+  try {
+    return execSync(cmd, { cwd: srcDir, stdio: "inherit" });
+  } catch (e) {
+    throw new Error(`Failed to run command \`${cmd}\``);
+  }
+};
+
+const waitForSubgraphToBeSynced = async () =>
+  new Promise((resolve, reject) => {
+    // Wait for 5s
+    let deadline = Date.now() + 5 * 1000;
+
+    // Function to check if the subgraph is synced
+    const checkSubgraphSynced = async () => {
+      try {
+        let result = await fetchSubgraphs({
+          query: `{ indexingStatuses { synced, health } }`,
+        });
+
+        if (result.data.indexingStatuses[0].synced) {
+          resolve();
+        } else if (result.data.indexingStatuses[0].health != "healthy") {
+          reject(new Error("Subgraph failed"));
+        } else {
+          throw new Error("reject or retry");
+        }
+      } catch (e) {
+        if (Date.now() > deadline) {
+          reject(new Error(`Timed out waiting for the subgraph to sync`));
+        } else {
+          setTimeout(checkSubgraphSynced, 500);
+        }
+      }
+    };
+
+    // Periodically check whether the subgraph has synced
+    setTimeout(checkSubgraphSynced, 0);
+  });
+
+contract("Contract", (accounts) => {
+  // Deploy the subgraph once before all tests
+  before(async () => {
+    // Deploy the contract
+    const contract = await Contract.deployed();
+
+    // Insert its address into subgraph manifest
+    await patching.replace(
+      path.join(srcDir, "subgraph.yaml"),
+      "0x0000000000000000000000000000000000000000",
+      contract.address
+    );
+
+    // Create and deploy the subgraph
+    exec(`yarn codegen`);
+    exec(`yarn create:test`);
+    exec(`yarn deploy:test`);
+
+    // Wait for the subgraph to be indexed
+    await waitForSubgraphToBeSynced();
+  });
+
+  it("all overloads of the contract function are called", async () => {
+    let result = await fetchSubgraph({
+      query: `{ foos(orderBy: id) { id value } }`,
+    });
+
+    expect(result.errors).to.be.undefined;
+    expect(result.data).to.deep.equal({
+      foos: [
+        {
+          id: "0",
+          value: "bla",
+        },
+      ],
+    });
+  });
+});

--- a/tests/integration-tests/value-roundtrip/truffle.js
+++ b/tests/integration-tests/value-roundtrip/truffle.js
@@ -1,0 +1,19 @@
+require("babel-register");
+require("babel-polyfill");
+
+module.exports = {
+  networks: {
+    test: {
+      host: "localhost",
+      port: 18545,
+      network_id: "*",
+      gas: "100000000000",
+      gasPrice: "1"
+    }
+  },
+  compilers: {
+    solc: {
+      version: "0.6.1"
+    }
+  }
+};

--- a/tests/tests/tests.rs
+++ b/tests/tests/tests.rs
@@ -103,3 +103,9 @@ fn remove_then_update() {
     let _m = TEST_MUTEX.lock();
     run_test("remove-then-update");
 }
+
+#[test]
+fn value_roundtrip() {
+    let _m = TEST_MUTEX.lock();
+    run_test("value-roundtrip");
+}


### PR DESCRIPTION
Postgres does not like nulls in strings, and probably many other systems dislike them, so this makes sure to remove any null characters coming from the mapping. Added an integration test. I also put all integration tests in a yarn workspace so they can share dependencies.

Resolves #1597.
Resolves #1427.
Resolves #1364.
Resolves https://github.com/graphprotocol/graph-cli/issues/413.
Resolves https://github.com/graphprotocol/graph-cli/issues/491.