### PR TITLE
Fetch genesis block by number 0 instead of 'earliest'

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -597,7 +597,7 @@ where
             .timeout_secs(30)
             .run(move || {
                 web3.eth()
-                    .block(BlockNumber::Earliest.into())
+                    .block(BlockId::Number(BlockNumber::Number(0.into())))
                     .from_err()
                     .and_then(|gen_block_opt| {
                         future::result(


### PR DESCRIPTION
There are some implementations of Ethereum that don't support `eth_getBlockByNumber` requests where the requested block number is `"earliest"`. It seems safe to just request the block by number (`0`). At least I am not aware of any chains where the block number starts with.. `1` or `500`.

Reported by @fubhy.