### PR TITLE
core/subgraph: Use while loop to process assignment provider stream

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -244,7 +244,7 @@ impl SubgraphInstanceManager {
             let mut assignment_stream = receiver.compat();
 
             // The channel will always be open so it never errors.
-            for event in assignment_stream.next().await.unwrap() {
+            while let Ok(event) = assignment_stream.next().await.unwrap() {
                 use self::SubgraphAssignmentProviderEvent::*;
 
                 match event {


### PR DESCRIPTION
This PR fixes an issue with looping through the subgraph assignment provider event stream that resulted in exiting after consuming just the first event. 

#### Explanation
In the original implementation the expression being iterated over resolves to `Option<_>`.  Since `Option<_>` implements an `iterator` that yields 0 or 1 depending on the pattern, the `for...in` was simply iterating over the `Option<_>` from the first event and then exiting.  
Now a `while..let` loop is used to continue to poll the future until the channel closes or it returns an error.  