### PR TITLE
store: Turn Proof of Indexing off

### DIFF
--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -341,7 +341,7 @@ impl Layout {
         schema: &Schema,
         schema_name: &str,
     ) -> Result<Layout, StoreError> {
-        let layout = Self::new(schema, schema_name, true)?;
+        let layout = Self::new(schema, schema_name, false)?;
         let sql = layout
             .as_ddl()
             .map_err(|_| StoreError::Unknown(format_err!("failed to generate DDL for layout")))?;


### PR DESCRIPTION
There are more improvements we are working on for Proof-of-Indexing. Rather
than deal with an old and a new version out in the wild, we'll turn PoI off
until the new version is ready.

