### PR TITLE
Remove `graph` parity-wasm dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,6 @@ dependencies = [
  "mockall",
  "num-bigint",
  "num-traits",
- "parity-wasm",
  "petgraph 0.5.0",
  "priority-queue",
  "prometheus",

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -24,7 +24,6 @@ hex = "0.4.2"
 futures = "0.1.21"
 graphql-parser = "0.2.3"
 ipfs-api = { version = "0.7.1", features = ["hyper-tls"] }
-parity-wasm = "0.40"
 failure = "0.1.7"
 lazy_static = "1.4.0"
 mockall = "0.7"

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -125,9 +125,9 @@ pub trait RuntimeHostBuilder: Clone + Send + Sync + 'static {
     ) -> Result<Self::Host, Error>;
 
     /// Spawn a mapping and return a channel for mapping requests. The sender should be able to be
-    /// cached and shared among mappings that have the same `parsed_module`.
+    /// cached and shared among mappings that use the same wasm file.
     fn spawn_mapping(
-        parsed_module: parity_wasm::elements::Module,
+        raw_module: &[u8],
         logger: Logger,
         subgraph_id: SubgraphDeploymentId,
         metrics: Arc<HostMetrics>,

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -6,8 +6,6 @@ use futures03::{
     stream::FuturesOrdered,
     TryStreamExt as _,
 };
-use parity_wasm;
-use parity_wasm::elements::Module;
 use serde::de;
 use serde::ser;
 use serde_yaml;
@@ -588,7 +586,7 @@ pub struct Mapping {
     pub block_handlers: Vec<MappingBlockHandler>,
     pub call_handlers: Vec<MappingCallHandler>,
     pub event_handlers: Vec<MappingEventHandler>,
-    pub runtime: Arc<Module>,
+    pub runtime: Arc<Vec<u8>>,
     pub link: Link,
 }
 
@@ -620,7 +618,7 @@ impl UnresolvedMapping {
                 .try_collect::<Vec<_>>(),
             async {
                 let module_bytes = resolver.cat(logger, &link).await?;
-                Ok(Arc::new(parity_wasm::deserialize_buffer(&module_bytes)?))
+                Ok(Arc::new(module_bytes))
             },
         )
         .await?;

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -89,13 +89,13 @@ where
     type Req = MappingRequest;
 
     fn spawn_mapping(
-        parsed_module: parity_wasm::elements::Module,
+        raw_module: &[u8],
         logger: Logger,
         subgraph_id: SubgraphDeploymentId,
         metrics: Arc<HostMetrics>,
     ) -> Result<Sender<Self::Req>, Error> {
         crate::mapping::spawn_module(
-            parsed_module,
+            raw_module,
             logger,
             subgraph_id,
             metrics,

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -11,12 +11,13 @@ use web3::types::{Log, Transaction};
 
 /// Spawn a wasm module in its own thread.
 pub fn spawn_module(
-    parsed_module: parity_wasm::elements::Module,
+    raw_module: &[u8],
     logger: Logger,
     subgraph_id: SubgraphDeploymentId,
     host_metrics: Arc<HostMetrics>,
     runtime: tokio::runtime::Handle,
 ) -> Result<mpsc::Sender<MappingRequest>, Error> {
+    let parsed_module = parity_wasm::deserialize_buffer(raw_module)?;
     let valid_module = Arc::new(ValidModule::new(parsed_module)?);
 
     // Create channel for event handling requests

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -59,7 +59,12 @@ fn test_valid_module_and_store(
     ));
 
     let module = WasmiModule::from_valid_module_with_ctx(
-        Arc::new(ValidModule::new(data_source.mapping.runtime.as_ref().clone()).unwrap()),
+        Arc::new(
+            ValidModule::new(
+                parity_wasm::deserialize_buffer(data_source.mapping.runtime.as_ref()).unwrap(),
+            )
+            .unwrap(),
+        ),
         mock_context(deployment_id, data_source, store.clone()),
         host_metrics,
     )
@@ -73,7 +78,7 @@ fn test_module(subgraph_id: &str, data_source: DataSource) -> WasmiModule {
 }
 
 fn mock_data_source(path: &str) -> DataSource {
-    let runtime = parity_wasm::deserialize_file(path).expect("Failed to deserialize wasm");
+    let runtime = std::fs::read(path).unwrap();
 
     DataSource {
         kind: String::from("ethereum/contract"),

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1404,9 +1404,7 @@ fn revert_block_with_partial_update() {
     })
 }
 
-fn mock_data_source(path: &str) -> DataSource {
-    let runtime = parity_wasm::deserialize_file(path).expect("Failed to deserialize wasm");
-
+fn mock_data_source() -> DataSource {
     DataSource {
         kind: String::from("ethereum/contract"),
         name: String::from("example data source"),
@@ -1428,7 +1426,7 @@ fn mock_data_source(path: &str) -> DataSource {
             link: Link {
                 link: "link".to_owned(),
             },
-            runtime: Arc::new(runtime.clone()),
+            runtime: Arc::new(Vec::new()),
         },
         templates: vec![DataSourceTemplate {
             kind: String::from("ethereum/contract"),
@@ -1449,7 +1447,7 @@ fn mock_data_source(path: &str) -> DataSource {
                 link: Link {
                     link: "link".to_owned(),
                 },
-                runtime: Arc::new(runtime),
+                runtime: Arc::new(Vec::new()),
             },
         }],
         context: None,
@@ -1478,7 +1476,7 @@ fn revert_block_with_dynamic_data_source_operations() {
             .expect("missing entity");
 
         // Create operations to add a dynamic data source
-        let data_source = mock_data_source("../../runtime/wasm/wasm_test/abort.wasm");
+        let data_source = mock_data_source();
         let dynamic_ds = DynamicEthereumContractDataSourceEntity::from((
             &TEST_SUBGRAPH_ID.clone(),
             &data_source,


### PR DESCRIPTION
In preparation for the wasmtime switch, this makes the `graph` crate no longer depend on `parity-wasm` to parse modules, and instead treat them as a blob of bytes. This way all our wasm runtime dependencies are restricted to our runtime crate.

This makes an optimization to the `module_cache` so it uses the hash of the module as key. Though modules are typically only a few kb.