### PR TITLE
Disable subgraph grafting for now

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -6,6 +6,7 @@ use futures03::{
     stream::FuturesOrdered,
     TryStreamExt as _,
 };
+use lazy_static::lazy_static;
 use serde::de;
 use serde::ser;
 use serde_yaml;
@@ -35,6 +36,13 @@ use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
+
+lazy_static! {
+    static ref DISABLE_GRAFTS: bool = std::env::var("GRAPH_DISABLE_GRAFTS")
+        .ok()
+        .map(|s| s.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+}
 
 /// Rust representation of the GraphQL schema for a `SubgraphManifest`.
 pub mod schema;
@@ -1018,6 +1026,11 @@ impl UnvalidatedSubgraphManifest {
             });
 
         if let Some(graft) = &self.0.graft {
+            if *DISABLE_GRAFTS {
+                errors.push(SubgraphManifestValidationError::GraftBaseInvalid(
+                    "Grafting of subgraphs is currently disabled".to_owned(),
+                ));
+            }
             errors.extend(graft.validate(store));
         }
 


### PR DESCRIPTION
Based on observations in hosted, subgraph grafting isn't quite ready for prime time yet for reasons that are only apparent once subgraphs are grafted on a system with lots of subgraphs and under decent load (like hosted)

The core problem is that the data copying for grafting happens in one transaction which can take hours. That has at least two bad side effects:

1. Because of the long running transaction, autovacuum can't remove garbage until after the txn finishes. That is especially bad for the `subgraph_deployment` table which becomes very bloated, directly impacting performance for everything
1. Any interruption of the long-running transaction will require that data copying starts from scratch. If a new version is rolled out a few hours into a copy transaction, the user will have just lost these hours and wait even longer

The answer to both these problems is to split the long-running transaction up so that we copy each table separately in its own transaction (and without indexes on the table yet) and create indexes similarly one by one in a transaction for each index.