### PR TITLE
Graft by only copying data at the graft point

### DIFF
--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -377,7 +377,8 @@ impl Layout {
             .filter_map(|dst| base.table(&dst.name).map(|src| (dst, src)))
         {
             let start = Instant::now();
-            let count = rq::CopyEntityDataQuery::new(dst, src)?.execute(conn)?;
+            let count =
+                rq::CopyEntityDataQuery::new(dst, src, block.number as i32)?.execute(conn)?;
             info!(logger, "Copied {} {} entities", count, src.object;
                   "time_ms" => start.elapsed().as_millis());
         }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2339,10 +2339,11 @@ pub struct CopyEntityDataQuery<'a> {
     // A list of columns common between src and dst that
     // need to be copied
     columns: Vec<&'a Column>,
+    block: BlockNumber,
 }
 
 impl<'a> CopyEntityDataQuery<'a> {
-    pub fn new(dst: &'a Table, src: &'a Table) -> Result<Self, StoreError> {
+    pub fn new(dst: &'a Table, src: &'a Table, block: BlockNumber) -> Result<Self, StoreError> {
         let mut columns = Vec::new();
         for dcol in &dst.columns {
             if let Some(scol) = src.column(&dcol.name) {
@@ -2364,7 +2365,12 @@ impl<'a> CopyEntityDataQuery<'a> {
             }
         }
 
-        Ok(Self { src, dst, columns })
+        Ok(Self {
+            src,
+            dst,
+            columns,
+            block,
+        })
     }
 }
 
@@ -2395,6 +2401,8 @@ impl<'a> QueryFragment<Pg> for CopyEntityDataQuery<'a> {
         }
         out.push_sql("block_range from ");
         out.push_sql(self.src.qualified_name.as_str());
+        out.push_sql(" where block_range @> ");
+        out.push_sql(&self.block.to_string());
         Ok(())
     }
 }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2331,7 +2331,8 @@ impl<'a> LoadQuery<PgConnection, RevertEntityData> for DeleteByPrefixQuery<'a> {
 
 impl<'a, Conn> RunQueryDsl<Conn> for DeleteByPrefixQuery<'a> {}
 
-/// Copy the data of one table to another table
+/// Copy the data at a given block from one table to another table and
+/// mark all the copied entities as valid forever
 #[derive(Debug, Clone)]
 pub struct CopyEntityDataQuery<'a> {
     src: &'a Table,
@@ -2399,7 +2400,7 @@ impl<'a> QueryFragment<Pg> for CopyEntityDataQuery<'a> {
             }
             out.push_sql(", ");
         }
-        out.push_sql("block_range from ");
+        out.push_sql("int4range(lower(block_range), null) from ");
         out.push_sql(self.src.qualified_name.as_str());
         out.push_sql(" where block_range @> ");
         out.push_sql(&self.block.to_string());


### PR DESCRIPTION
Rather than grafting onto a subgraph by copying the entire source subgraph, graft by only copying the data that is valid at the block at which the graft is performed. This should greatly reduce the time that it takes to initialize a graft.