### PR TITLE
Fix a query in `cleanup_cached_blocks`

### DIFF
--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1565,17 +1565,14 @@ impl ChainStore for Store {
                            from ethereum_networks
                           where name = $2)) as block
               from (
-                select min((d.data->'latestEthereumBlockNumber'->>'data')::int) as block
-                  from subgraphs.entities d,
-                       subgraphs.entities a,
-                       subgraphs.entities ds
-                 where d.entity = 'SubgraphDeployment'
-                   and a.entity = 'SubgraphDeploymentAssignment'
-                   and ds.entity = 'EthereumContractDataSource'
-                   and left(ds.id, 46) = d.id
+                select min(d.latest_ethereum_block_number) as block
+                  from subgraphs.subgraph_deployment d,
+                       subgraphs.subgraph_deployment_assignment a,
+                       subgraphs.ethereum_contract_data_source ds
+                 where left(ds.id, 46) = d.id
                    and a.id = d.id
-                   and not (d.data->'failed'->>'data')::bool
-                   and ds.data->'network'->>'data' = $2) a;";
+                   and not d.failed
+                   and ds.network = $2) a;";
         let ancestor_count = i32::try_from(ancestor_count)
             .expect("ancestor_count fits into a signed 32 bit integer");
         diesel::sql_query(query)

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -2206,3 +2206,16 @@ fn find_at_block() {
         shaqueeena_at_block(7000, "teeko@email.com");
     }
 }
+
+#[test]
+fn cleanup_cached_blocks() {
+    run_test(|store| -> Result<(), ()> {
+        // This test is somewhat silly in that there is nothing to clean up.
+        // The main purpose for this test is to ensure that the SQL query
+        // we run in `cleanup_cached_blocks` to figure out the first block
+        // that should be removed is syntactically correct
+        let cleaned = store.cleanup_cached_blocks(10).expect("cleanup succeeds");
+        assert_eq!((0, 0), cleaned);
+        Ok(())
+    })
+}


### PR DESCRIPTION
The query to determine the first block to remove in `cleanup_cached_blocks` was never adapted to relational metadata. The query would most likely also do bad things in a few corner cases.

Thanks to @Amxx for reporting the issue.