### PR TITLE
all: Do not store the chain head block in SubgraphDeployment

### DIFF
--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -216,11 +216,7 @@ where
             let ctx2 = ctx.clone();
             let ctx3 = ctx.clone();
 
-            // Update progress metrics
-            future::result(ctx1.update_subgraph_block_count())
-                // Determine the next step.
-                .and_then(move |()| ctx1.get_next_step())
-                // Do the next step.
+            ctx1.get_next_step()
                 .and_then(move |step| ctx2.do_step(step))
                 // Check outcome.
                 // Exit loop if done or there are blocks to process.
@@ -775,25 +771,6 @@ where
             self.subgraph_store
                 .apply_metadata_operations(ops)
                 .map_err(|e| format_err!("Failed to set deployment synced flag: {}", e))
-        }
-    }
-
-    /// Write latest block counts into subgraph entity based on current value of head and subgraph
-    /// block pointers.
-    fn update_subgraph_block_count(&self) -> Result<(), Error> {
-        let head_ptr_opt = self.chain_store.chain_head_ptr()?;
-
-        match head_ptr_opt {
-            None => Ok(()),
-            Some(head_ptr) => {
-                let ops = SubgraphDeploymentEntity::update_ethereum_head_block_operations(
-                    &self.subgraph_id,
-                    head_ptr,
-                );
-                self.subgraph_store
-                    .apply_metadata_operations(ops)
-                    .map_err(|e| format_err!("Failed to set subgraph block count: {}", e))
-            }
         }
     }
 }

--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -95,13 +95,8 @@ fn create_subgraph(
         templates: vec![],
     };
 
-    // Create deployment entity
-    let chain_head_block = match store.chain_head_ptr() {
-        Ok(block_ptr) => block_ptr,
-        Err(e) => return future::err(e.into()),
-    };
     ops.extend(
-        SubgraphDeploymentEntity::new(&manifest, false, start_block, chain_head_block)
+        SubgraphDeploymentEntity::new(&manifest, false, start_block)
             .create_operations(&manifest.id),
     );
 

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -292,9 +292,6 @@ pub struct SubgraphDeploymentEntity {
     earliest_ethereum_block_number: Option<u64>,
     latest_ethereum_block_hash: Option<H256>,
     latest_ethereum_block_number: Option<u64>,
-    ethereum_head_block_hash: Option<H256>,
-    ethereum_head_block_number: Option<u64>,
-    total_ethereum_blocks_count: u64,
     graft_base: Option<SubgraphDeploymentId>,
     graft_block_hash: Option<H256>,
     graft_block_number: Option<u64>,
@@ -310,7 +307,6 @@ impl SubgraphDeploymentEntity {
         source_manifest: &SubgraphManifest,
         synced: bool,
         earliest_ethereum_block: Option<EthereumBlockPointer>,
-        chain_head_block: Option<EthereumBlockPointer>,
     ) -> Self {
         Self {
             manifest: SubgraphManifestEntity::from(source_manifest),
@@ -323,9 +319,6 @@ impl SubgraphDeploymentEntity {
             earliest_ethereum_block_number: earliest_ethereum_block.map(Into::into),
             latest_ethereum_block_hash: earliest_ethereum_block.map(Into::into),
             latest_ethereum_block_number: earliest_ethereum_block.map(Into::into),
-            ethereum_head_block_hash: chain_head_block.map(Into::into),
-            ethereum_head_block_number: chain_head_block.map(Into::into),
-            total_ethereum_blocks_count: chain_head_block.map_or(0, |block| block.number + 1),
             graft_base: None,
             graft_block_hash: None,
             graft_block_number: None,
@@ -377,9 +370,6 @@ impl SubgraphDeploymentEntity {
             earliest_ethereum_block_number,
             latest_ethereum_block_hash,
             latest_ethereum_block_number,
-            ethereum_head_block_hash,
-            ethereum_head_block_number,
-            total_ethereum_blocks_count,
             graft_base,
             graft_block_hash,
             graft_block_number,
@@ -404,9 +394,6 @@ impl SubgraphDeploymentEntity {
             earliestEthereumBlockNumber: earliest_ethereum_block_number,
             latestEthereumBlockHash: latest_ethereum_block_hash,
             latestEthereumBlockNumber: latest_ethereum_block_number,
-            ethereumHeadBlockHash: ethereum_head_block_hash,
-            ethereumHeadBlockNumber: ethereum_head_block_number,
-            totalEthereumBlocksCount: total_ethereum_blocks_count,
             entityCount: 0 as u64,
             graftBase: graft_base.map(|sid| sid.to_string()),
             graftBlockHash: graft_block_hash,
@@ -429,23 +416,6 @@ impl SubgraphDeploymentEntity {
         let entity = entity! {
             latestEthereumBlockHash: block_ptr_to.hash,
             latestEthereumBlockNumber: block_ptr_to.number
-        };
-
-        vec![update_metadata_operation(
-            Self::TYPENAME,
-            id.to_string(),
-            entity,
-        )]
-    }
-
-    pub fn update_ethereum_head_block_operations(
-        id: &SubgraphDeploymentId,
-        block_ptr: EthereumBlockPointer,
-    ) -> Vec<MetadataOperation> {
-        let entity = entity! {
-            totalEthereumBlocksCount: block_ptr.number,
-            ethereumHeadBlockHash: block_ptr.hash,
-            ethereumHeadBlockNumber: block_ptr.number,
         };
 
         vec![update_metadata_operation(

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -96,7 +96,7 @@ fn insert_test_entities(store: &impl Store, id: SubgraphDeploymentId) {
         templates: vec![],
     };
 
-    let ops = SubgraphDeploymentEntity::new(&manifest, false, None, None)
+    let ops = SubgraphDeploymentEntity::new(&manifest, false, None)
         .create_operations_replace(&id)
         .into_iter()
         .map(|op| op.into())

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -9,7 +9,7 @@ use std::convert::TryInto;
 use web3::types::H256;
 
 static DEPLOYMENT_STATUS_FRAGMENT: &str = r#"
-    fragment deploymentStatus on SubgraphDeployment {
+    fragment deploymentStatus on SubgraphDeploymentDetail {
         id
         synced
         health
@@ -351,7 +351,7 @@ where
                   $whereDeployments: SubgraphDeployment_filter!,
                   $whereAssignments: SubgraphDeploymentAssignment_filter!
                 ) {
-                  subgraphDeployments(where: $whereDeployments, first: 1000000) {
+                  subgraphDeployments: subgraphDeploymentDetails(where: $whereDeployments, first: 1000000) {
                     ...deploymentStatus
                   }
                   subgraphDeploymentAssignments(where: $whereAssignments, first: 1000000) {

--- a/store/postgres/migrations/2020-05-16-225611_add_deployment_detail_view/down.sql
+++ b/store/postgres/migrations/2020-05-16-225611_add_deployment_detail_view/down.sql
@@ -1,0 +1,15 @@
+alter table subgraphs.subgraph_deployment
+  add column ethereum_head_block_hash bytea;
+alter table subgraphs.subgraph_deployment
+  add column ethereum_head_block_number numeric;
+alter table subgraphs.subgraph_deployment
+  add column total_ethereum_blocks_count numeric;
+
+update subgraphs.subgraph_deployment sd
+   set ethereum_head_block_hash = sdd.ethereum_head_block_hash,
+       ethereum_head_block_number = sdd.ethereum_head_block_number,
+       total_ethereum_blocks_count = sdd.ethereum_head_block_number
+  from subgraphs.subgraph_deployment_detail sdd
+ where sd.id = sdd.id;
+
+drop view subgraphs.subgraph_deployment_detail;

--- a/store/postgres/migrations/2020-05-16-225611_add_deployment_detail_view/up.sql
+++ b/store/postgres/migrations/2020-05-16-225611_add_deployment_detail_view/up.sql
@@ -1,0 +1,47 @@
+alter table subgraphs.subgraph_deployment
+  drop column ethereum_head_block_hash;
+alter table subgraphs.subgraph_deployment
+  drop column ethereum_head_block_number;
+alter table subgraphs.subgraph_deployment
+  drop column total_ethereum_blocks_count;
+
+-- This view needs to handle 'normal' subgraphs and the fake subgraphs that
+-- the network indexer creates. Those don't have datasources, and we can
+-- therefore not determine the network through the data source.  Instead,
+-- we rely on the fact that their name is 'network_ethereum_${NETWORK}_v0'
+-- and use that as the network
+create or replace view subgraphs.subgraph_deployment_detail as
+select sd.*,
+       decode(en.head_block_hash,'hex') as ethereum_head_block_hash,
+       en.head_block_number as ethereum_head_block_number,
+       ecds.network,
+       sda.node_id
+  from subgraphs.subgraph_deployment sd
+    inner join
+       subgraphs.subgraph_manifest sm
+         on (sd.manifest = sm.id)
+    inner join
+       subgraphs.ethereum_contract_data_source ecds
+         on (ecds.id = sm.data_sources[1])
+    inner join
+       ethereum_networks en
+         on (en.name = ecds.network)
+    left outer join
+       subgraphs.subgraph_deployment_assignment sda
+         on (sd.id = sda.id)
+union all
+select sd.*,
+       decode(en.head_block_hash,'hex') as ethereum_head_block_hash,
+       en.head_block_number as ethereum_head_block_number,
+       split_part(sd.id, '_', 3) as network,
+       sda.node_id
+  from subgraphs.subgraph_deployment sd
+    inner join
+       subgraphs.subgraph_manifest sm
+         on (sd.manifest = sm.id and sm.data_sources[1] is null)
+    inner join
+       ethereum_networks en
+         on (en.name = split_part(sd.id, '_', 3))
+    left outer join
+       subgraphs.subgraph_deployment_assignment sda
+         on (sd.id = sda.id);

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -14,7 +14,10 @@ type Subgraph @entity {
 type SubgraphVersion @entity {
     id: ID!
     subgraph: Subgraph!
-    deployment: SubgraphDeployment!
+    # We store the id of a SubgraphDeployment, but since when we read
+    # through GraphQL, we pull back a SubgraphDeploymentDetail which
+    # contains a superset of the attributes of a SubgraphDeployment
+    deployment: SubgraphDeploymentDetail!
     createdAt: BigInt!
 }
 
@@ -35,14 +38,45 @@ type SubgraphDeployment @entity {
     earliestEthereumBlockNumber: BigInt
     latestEthereumBlockHash: Bytes
     latestEthereumBlockNumber: BigInt
-    ethereumHeadBlockNumber: BigInt
-    ethereumHeadBlockHash: Bytes
-    totalEthereumBlocksCount: BigInt!
     entityCount: BigInt!
     dynamicDataSources: [DynamicEthereumContractDataSource!] @derivedFrom(field: "deployment")
     graftBase: SubgraphDeployment
     graftBlockHash: Bytes
     graftBlockNumber: BigInt
+}
+
+# This is not a real entity type. It is a view that can be queried, but
+# not modified
+type SubgraphDeploymentDetail @entity {
+    id: ID! # Subgraph IPFS hash
+    manifest: SubgraphManifest!
+    failed: Boolean! @deprecated(reason: "Use `health`.")
+    health: Health!
+    synced: Boolean!
+
+    "If the subgraph has failed, this is the error caused it"
+    fatalError: SubgraphError
+
+    "Sorted by block number, limited to 1000"
+    nonFatalErrors: [SubgraphError!]!
+
+    earliestEthereumBlockHash: Bytes
+    earliestEthereumBlockNumber: BigInt
+    latestEthereumBlockHash: Bytes
+    latestEthereumBlockNumber: BigInt
+    entityCount: BigInt!
+    dynamicDataSources: [DynamicEthereumContractDataSource!] @derivedFrom(field: "deployment")
+    graftBase: SubgraphDeployment
+    graftBlockHash: Bytes
+    graftBlockNumber: BigInt
+    # From ethereum_networks
+    ethereumHeadBlockNumber: BigInt
+    ethereumHeadBlockHash: Bytes
+    # From the first EthereumContractDataSource
+    network: String
+    # From SubgraphDeploymentAssignment, it is nullable here
+    # as not every deployment is assigned
+    nodeId: String
 }
 
 type SubgraphDeploymentAssignment @entity {

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -131,8 +131,8 @@ fn insert_test_data(store: Arc<DieselStore>) {
     };
 
     // Create SubgraphDeploymentEntity
-    let ops = SubgraphDeploymentEntity::new(&manifest, false, None, Some(BLOCKS[0]))
-        .create_operations(&*TEST_SUBGRAPH_ID);
+    let ops =
+        SubgraphDeploymentEntity::new(&manifest, false, None).create_operations(&*TEST_SUBGRAPH_ID);
     store
         .create_subgraph_deployment(&TEST_SUBGRAPH_SCHEMA, ops)
         .unwrap();

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -164,8 +164,8 @@ fn insert_test_data(store: Arc<DieselStore>) {
     };
 
     // Create SubgraphDeploymentEntity
-    let ops = SubgraphDeploymentEntity::new(&manifest, false, None, Some(*TEST_BLOCK_0_PTR))
-        .create_operations(&*TEST_SUBGRAPH_ID);
+    let ops =
+        SubgraphDeploymentEntity::new(&manifest, false, None).create_operations(&*TEST_SUBGRAPH_ID);
     store
         .create_subgraph_deployment(&TEST_SUBGRAPH_SCHEMA, ops)
         .unwrap();
@@ -1610,13 +1610,8 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
         };
 
         // Create SubgraphDeploymentEntity
-        let ops = SubgraphDeploymentEntity::new(
-            &manifest,
-            false,
-            Some(*TEST_BLOCK_0_PTR),
-            Some(*TEST_BLOCK_0_PTR),
-        )
-        .create_operations(&subgraph_id);
+        let ops = SubgraphDeploymentEntity::new(&manifest, false, Some(*TEST_BLOCK_0_PTR))
+            .create_operations(&subgraph_id);
         store.create_subgraph_deployment(&schema, ops).unwrap();
 
         // Create store subscriptions

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -107,7 +107,7 @@ fn create_subgraph(
         templates: vec![],
     };
 
-    let ops = SubgraphDeploymentEntity::new(&manifest, false, None, None)
+    let ops = SubgraphDeploymentEntity::new(&manifest, false, None)
         .graft(base)
         .create_operations_replace(&subgraph_id)
         .into_iter()


### PR DESCRIPTION
Storing it there requires that we update every subgraph deployment for a network whenever we get a new block for that network which causes a huge amount of writes to subgraphs.subgraph_deployment, and bloats the table.

The information is already available in ethereum_networks; instead of denormalizing that data, make it available to GraphQL queries through a view in the database. The view pretends to be an entity, though any attempt to write that entity will fail as it is not possible to write into this view.

