### PR TITLE
Handle database tables that have `text` columns where they should have enums

### DIFF
--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -320,7 +320,7 @@ pub fn main() {
     let schema = ensure(fs::read_to_string(schema), "Can not read schema file");
     let schema = ensure(Schema::parse(&schema, subgraph), "Failed to parse schema");
     let catalog = ensure(
-        Catalog::new(db_schema.to_owned()),
+        Catalog::make_empty(db_schema.to_owned()),
         "Failed to construct catalog",
     );
     let layout = ensure(

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::process::exit;
 
 use graph::prelude::{Schema, SubgraphDeploymentId};
-use graph_store_postgres::relational::{Column, ColumnType, Layout};
+use graph_store_postgres::relational::{Catalog, Column, ColumnType, Layout};
 
 pub fn usage(msg: &str) -> ! {
     println!("layout: {}", msg);
@@ -92,7 +92,7 @@ fn print_views(layout: &Layout) {
             }
             print!(" as {}", column.name.as_str());
         }
-        println!("\n  from {}.entities", layout.schema);
+        println!("\n  from {}.entities", layout.catalog.schema);
         println!(" where entity = '{}';", table.object);
     }
 }
@@ -319,9 +319,12 @@ pub fn main() {
     let subgraph = SubgraphDeploymentId::new("Qmasubgraph").unwrap();
     let schema = ensure(fs::read_to_string(schema), "Can not read schema file");
     let schema = ensure(Schema::parse(&schema, subgraph), "Failed to parse schema");
-
+    let catalog = ensure(
+        Catalog::new(db_schema.to_owned()),
+        "Failed to construct catalog",
+    );
     let layout = ensure(
-        Layout::new(&schema, db_schema, false),
+        Layout::new(&schema, catalog, false),
         "Failed to construct Mapping",
     );
     match kind {

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -1,3 +1,8 @@
+use diesel::pg::PgConnection;
+use diesel::prelude::RunQueryDsl;
+use diesel::sql_types::Text;
+use std::collections::{HashMap, HashSet};
+
 use graph::prelude::StoreError;
 
 use crate::relational::SqlName;
@@ -6,11 +11,66 @@ use crate::relational::SqlName;
 #[derive(Debug, Clone)]
 pub struct Catalog {
     pub schema: String,
+    text_columns: HashMap<String, HashSet<String>>,
 }
 
 impl Catalog {
-    pub fn new(schema: String) -> Result<Self, StoreError> {
+    pub fn new(conn: &PgConnection, schema: String) -> Result<Self, StoreError> {
         SqlName::check_valid_identifier(&schema, "database schema")?;
-        Ok(Catalog { schema })
+        let text_columns = get_text_columns(conn, &schema)?;
+        Ok(Catalog {
+            schema,
+            text_columns,
+        })
     }
+
+    /// Make a catalog as if the given `schema` did not exist in the database
+    /// yet. This function should only be used in situations where a database
+    /// connection is definitely not available, such as in unit tests
+    pub fn make_empty(schema: String) -> Result<Self, StoreError> {
+        SqlName::check_valid_identifier(&schema, "database schema")?;
+        Ok(Catalog {
+            schema,
+            text_columns: HashMap::default(),
+        })
+    }
+
+    /// Return `true` if `table` exists and contains the given `column` and
+    /// if that column is of data type `text`
+    pub fn is_existing_text_column(&self, table: &SqlName, column: &SqlName) -> bool {
+        self.text_columns
+            .get(table.as_str())
+            .map(|cols| cols.contains(column.as_str()))
+            .unwrap_or(false)
+    }
+}
+
+fn get_text_columns(
+    conn: &PgConnection,
+    schema: &str,
+) -> Result<HashMap<String, HashSet<String>>, StoreError> {
+    const QUERY: &str = "
+        select table_name, column_name
+          from information_schema.columns
+         where table_schema = $1 and data_type = 'text'";
+
+    #[derive(Debug, QueryableByName)]
+    struct Column {
+        #[sql_type = "Text"]
+        pub table_name: String,
+        #[sql_type = "Text"]
+        pub column_name: String,
+    }
+
+    let map: HashMap<String, HashSet<String>> = diesel::sql_query(QUERY)
+        .bind::<Text, _>(schema)
+        .load::<Column>(conn)?
+        .into_iter()
+        .fold(HashMap::new(), |mut map, col| {
+            map.entry(col.table_name)
+                .or_default()
+                .insert(col.column_name);
+            map
+        });
+    Ok(map)
 }

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -1,0 +1,16 @@
+use graph::prelude::StoreError;
+
+use crate::relational::SqlName;
+
+/// Information about what tables and columns we have in the database
+#[derive(Debug, Clone)]
+pub struct Catalog {
+    pub schema: String,
+}
+
+impl Catalog {
+    pub fn new(schema: String) -> Result<Self, StoreError> {
+        SqlName::check_valid_identifier(&schema, "database schema")?;
+        Ok(Catalog { schema })
+    }
+}

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -1403,7 +1403,7 @@ impl Storage {
             V::Relational => {
                 let subgraph_schema = metadata::subgraph_schema(conn, subgraph.to_owned())?;
                 let has_poi = supports_proof_of_indexing(conn, subgraph, &schema.name)?;
-                let catalog = Catalog::new(schema.name)?;
+                let catalog = Catalog::new(conn, schema.name)?;
                 let layout = Layout::new(&subgraph_schema, catalog, has_poi)?;
                 Storage::Relational(layout)
             }

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -21,6 +21,7 @@ extern crate serde;
 extern crate uuid;
 
 mod block_range;
+mod catalog;
 mod chain_head_listener;
 pub mod connection_pool;
 mod db_schema;

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -37,6 +37,7 @@ use graph::prelude::{
 };
 
 use crate::block_range::{BLOCK_RANGE_COLUMN, BLOCK_UNVERSIONED};
+pub use crate::catalog::Catalog;
 use crate::entities::STRING_PREFIX_SIZE;
 
 /// A string we use as a SQL name for a table or column. The important thing
@@ -65,7 +66,7 @@ impl SqlName {
 
     // Check that `name` matches the regular expression `/[A-Za-z][A-Za-z0-9_]*/`
     // without pulling in a regex matcher
-    fn check_valid_identifier(name: &str, kind: &str) -> Result<(), StoreError> {
+    pub fn check_valid_identifier(name: &str, kind: &str) -> Result<(), StoreError> {
         let mut chars = name.chars();
         match chars.next() {
             Some(c) => {
@@ -163,19 +164,6 @@ impl TryFrom<&s::Type> for IdType {
 type IdTypeMap = HashMap<String, IdType>;
 
 type EnumMap = BTreeMap<String, Arc<BTreeSet<String>>>;
-
-/// Information about what tables and columns we have in the database
-#[derive(Debug, Clone)]
-pub struct Catalog {
-    pub schema: String,
-}
-
-impl Catalog {
-    pub fn new(schema: String) -> Result<Self, StoreError> {
-        SqlName::check_valid_identifier(&schema, "database schema")?;
-        Ok(Catalog { schema })
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct Layout {

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -312,7 +312,7 @@ fn insert_test_data(conn: &PgConnection) -> Layout {
     let query = format!("create schema {}", SCHEMA_NAME);
     conn.batch_execute(&*query).unwrap();
 
-    Layout::create_relational_schema(&conn, &schema, SCHEMA_NAME)
+    Layout::create_relational_schema(&conn, &schema, SCHEMA_NAME.to_owned())
         .expect("Failed to create relational schema")
 }
 

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -102,7 +102,7 @@ fn create_schema(conn: &PgConnection) -> Layout {
     let query = format!("create schema {}", SCHEMA_NAME);
     conn.batch_execute(&*query).unwrap();
 
-    Layout::create_relational_schema(&conn, &schema, SCHEMA_NAME)
+    Layout::create_relational_schema(&conn, &schema, SCHEMA_NAME.to_owned())
         .expect("Failed to create relational schema")
 }
 


### PR DESCRIPTION
We had a bug that if the GraphQL schema for a subgraph used an enum before it was defined, the generated database schema would have a 'text' column instead of an 'enum' column. Since that bug was (inadvertently) fixed in commit 3d23bccf, queries against such tables would fail if they tried to filter by the presumptive enum attribute.
    
With this commit, we check whether we have a text column where we should have an enum, and then switch the internal table representation to treat the enum as 'String' and not as an enum when querying or storing data.

Verifying that this actually fixes the problem is unfortunately a little complicated. [This gist](https://gist.github.com/lutter/70158472fc237b188e33ee8d6a1a201a) contains instructions on how to do that. I have also verified that use-before-declare of enums was not a problem before 3d23bccf (by running the test at commit 77e697b4)