### PR TITLE
all: Allow varying block constraints in GraphQL queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,6 +3495,7 @@ dependencies = [
  "graph-graphql",
  "graph-mock",
  "graph-store-postgres",
+ "graphql-parser",
  "hex-literal",
  "lazy_static",
 ]

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -60,7 +60,6 @@ pub enum QueryExecutionError {
     Panic(String),
     EventStreamError,
     FulltextQueryRequiresFilter,
-    InconsistentBlockConstraints,
 }
 
 impl Error for QueryExecutionError {
@@ -208,7 +207,6 @@ impl fmt::Display for QueryExecutionError {
             Panic(msg) => write!(f, "panic processing query: {}", msg),
             EventStreamError => write!(f, "error in the subscription event stream"),
             FulltextQueryRequiresFilter => write!(f, "fulltext search queries can only use EntityFilter::Equal"),
-            InconsistentBlockConstraints => write!(f, "when a query has multiple top level fields, they all must have the same block constraint")
         }
     }
 }

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -69,3 +69,12 @@ impl From<Result<q::Value, Vec<QueryExecutionError>>> for QueryResult {
         }
     }
 }
+
+impl From<Result<BTreeMap<String, q::Value>, Vec<QueryExecutionError>>> for QueryResult {
+    fn from(result: Result<BTreeMap<String, q::Value>, Vec<QueryExecutionError>>) -> Self {
+        match result {
+            Ok(v) => QueryResult::new(Some(q::Value::Object(v))),
+            Err(errors) => QueryResult::from(errors),
+        }
+    }
+}

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -105,7 +105,7 @@ pub fn prefetch(
 pub fn execute_root_selection_set(
     ctx: &ExecutionContext<impl Resolver>,
     selection_set: &q::SelectionSet,
-) -> Result<q::Value, Vec<QueryExecutionError>> {
+) -> Result<BTreeMap<String, q::Value>, Vec<QueryExecutionError>> {
     // Obtain the root Query type and fail if there isn't one
     let query_type = match sast::get_root_query_type(&ctx.query.schema.document) {
         Some(t) => t,
@@ -165,7 +165,7 @@ pub fn execute_root_selection_set(
             &None,
         )?);
     }
-    Ok(q::Value::Object(values))
+    Ok(values)
 }
 
 /// Executes a selection set, requiring the result to be of the given object type.

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,5 +1,6 @@
 use graph::prelude::{info, o, Logger, QueryExecutionError};
 use graphql_parser::query as q;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Instant;
 use uuid::Uuid;
@@ -35,7 +36,7 @@ pub fn execute_query<R>(
     query: Arc<Query>,
     selection_set: Option<&q::SelectionSet>,
     options: QueryExecutionOptions<R>,
-) -> Result<q::Value, Vec<QueryExecutionError>>
+) -> Result<BTreeMap<String, q::Value>, Vec<QueryExecutionError>>
 where
     R: Resolver,
 {

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -33,6 +33,7 @@ where
 /// Executes a query and returns a result.
 pub fn execute_query<R>(
     query: Arc<Query>,
+    selection_set: Option<&q::SelectionSet>,
     options: QueryExecutionOptions<R>,
 ) -> Result<q::Value, Vec<QueryExecutionError>>
 where
@@ -65,10 +66,11 @@ where
             "Only queries are supported".to_string(),
         )]);
     }
+    let selection_set = selection_set.unwrap_or(&query.selection_set);
 
     // Execute top-level `query { ... }` and `{ ... }` expressions.
     let start = Instant::now();
-    let result = execute_root_selection_set(&ctx, &query.selection_set);
+    let result = execute_root_selection_set(&ctx, selection_set);
     if *graph::log::LOG_GQL_TIMING {
         info!(
             query_logger,

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -128,10 +128,7 @@ where
                 },
             ) {
                 Err(errs) => errors.extend(errs),
-                Ok(vals) => match vals {
-                    q::Value::Object(mut map) => values.append(&mut map),
-                    _ => unreachable!("execute_query returns a q::Value::Object"),
-                },
+                Ok(mut vals) => values.append(&mut vals),
             }
         }
         if !errors.is_empty() {

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -564,7 +564,7 @@ fn introspection_query(schema: Schema, query: &str) -> QueryResult {
     };
 
     let result =
-        PreparedQuery::new(query, None, 100).and_then(|query| execute_query(query, options));
+        PreparedQuery::new(query, None, 100).and_then(|query| execute_query(query, None, options));
     QueryResult::from(result)
 }
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1310,6 +1310,7 @@ fn query_at_block() {
 
 /// Check that the `extensions` field in the query result has the correct format
 #[test]
+#[ignore]
 fn block_extension() {
     let query = format!("query {{ musicians(block: {{ number: 0 }}) {{ id }} }}");
     let query = graphql_parser::parse_query(&query).expect("invalid test query");

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -119,7 +119,7 @@ where
                         max_first: std::u32::MAX,
                     };
                     let result = PreparedQuery::new(query, None, 100)
-                        .and_then(|query| execute_query(query, options));
+                        .and_then(|query| execute_query(query, None, options));
 
                     futures03::future::ok(QueryResult::from(result))
                 })

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -7,6 +7,7 @@ description = "Provides static store instance for tests."
 
 [dependencies]
 graph-graphql = { path = "../../graphql" }
+graphql-parser = "0.2.3"
 graph-mock = { path = "../../mock" }
 graph = { path = "../../graph" }
 graph-store-postgres = { path = "../postgres" }

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -389,10 +389,7 @@ fn execute_subgraph_query_internal(
             },
         ) {
             Err(errs) => errors.extend(errs),
-            Ok(vals) => match vals {
-                q::Value::Object(mut map) => values.append(&mut map),
-                _ => unreachable!("execute_query returns a q::Value::Object"),
-            },
+            Ok(mut vals) => values.append(&mut vals),
         };
     }
     if !errors.is_empty() {


### PR DESCRIPTION
This makes it possible to have different block constraints for different toplevel fields in GraphQL queries. It also removes the 'extensions' field in the response that reported the block against which a query was run.

