### PR TITLE
Refactor the event listeners

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -158,12 +158,13 @@ where
             .map(|event| {
                 // We're only interested in the SubgraphDeploymentAssignment change; we
                 // know that there is at least one, as that is what we subscribed to
-                stream::iter_ok(
-                    event
-                        .changes
-                        .into_iter()
-                        .filter(|change| change.entity_type == "SubgraphDeploymentAssignment"),
-                )
+                let assignments = event
+                    .changes
+                    .iter()
+                    .filter(|change| change.entity_type == "SubgraphDeploymentAssignment")
+                    .map(|change| change.to_owned())
+                    .collect::<Vec<_>>();
+                stream::iter_ok(assignments)
             })
             .flatten()
             .and_then(

--- a/graph/src/components/ethereum/listener.rs
+++ b/graph/src/components/ethereum/listener.rs
@@ -27,6 +27,6 @@ pub struct ChainHeadUpdate {
 pub type ChainHeadUpdateStream = Box<dyn Stream<Item = (), Error = ()> + Send>;
 
 pub trait ChainHeadUpdateListener {
-    // Subscribe to chain head updates.
-    fn subscribe(&self) -> ChainHeadUpdateStream;
+    // Subscribe to chain head updates for the given network.
+    fn subscribe(&self, network: String) -> ChainHeadUpdateStream;
 }

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -150,10 +150,10 @@ fn map_source_to_response_stream(
     // at least once. This satisfies the GraphQL over Websocket protocol
     // requirement of "respond[ing] with at least one GQL_DATA message", see
     // https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_data
-    let trigger_stream = futures03::stream::iter(vec![Ok(StoreEvent {
+    let trigger_stream = futures03::stream::iter(vec![Ok(Arc::new(StoreEvent {
         tag: 0,
         changes: Default::default(),
-    })]);
+    }))]);
 
     Box::new(
         trigger_stream
@@ -179,7 +179,7 @@ async fn execute_subscription_event(
     logger: Logger,
     resolver: Arc<impl Resolver + 'static>,
     query: Arc<crate::execution::Query>,
-    event: StoreEvent,
+    event: Arc<StoreEvent>,
     timeout: Option<Duration>,
     max_first: u32,
 ) -> QueryResult {

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -7,6 +7,15 @@ use graph::prelude::{ChainHeadUpdateListener as ChainHeadUpdateListenerTrait, *}
 use graph_chain_ethereum::BlockIngestorMetrics;
 
 pub struct ChainHeadUpdateListener {
+    /// A receiver that gets all chain head updates for all networks. We
+    /// filter notifications to the desired network in `subscribe`. Using
+    /// a `watch::Receiver` here has the downside that the notification for
+    /// one network can make the notification for another network disappear
+    /// if events aren't processed fast enough. If that happens, the update
+    /// for the preempted network will happen on the next block. Since even
+    /// the fastest network generates new blocks a few seconds apart, the
+    /// risk for collisions, and in particular sustained collisions is
+    /// very low
     update_receiver: watch::Receiver<ChainHeadUpdate>,
     _listener: NotificationListener,
 }

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -13,11 +13,12 @@ pub struct ChainHeadUpdateListener {
 impl ChainHeadUpdateListener {
     pub fn new(
         logger: &Logger,
-        ingestor_metrics: Arc<BlockIngestorMetrics>,
+        registry: Arc<dyn MetricsRegistry>,
         postgres_url: String,
         network_name: String,
     ) -> Self {
         let logger = logger.new(o!("component" => "ChainHeadUpdateListener"));
+        let ingestor_metrics = Arc::new(BlockIngestorMetrics::new(registry.clone()));
 
         // Create a Postgres notification listener for chain head updates
         let mut listener = NotificationListener::new(

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -54,3 +54,4 @@ pub mod layout_for_tests {
 
 pub use self::chain_head_listener::ChainHeadUpdateListener;
 pub use self::store::{Store, StoreConfig};
+pub use self::store_events::SubscriptionManager;

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -162,7 +162,7 @@ pub struct StoreInner {
 
     /// listen to StoreEvents generated when applying entity operations
     listener: Mutex<StoreEventListener>,
-    chain_head_update_listener: ChainHeadUpdateListener,
+    chain_head_update_listener: Arc<ChainHeadUpdateListener>,
     network_name: String,
     genesis_block_ptr: EthereumBlockPointer,
     conn: Pool<ConnectionManager<PgConnection>>,
@@ -196,6 +196,7 @@ impl Store {
         config: StoreConfig,
         logger: &Logger,
         net_identifiers: EthereumNetworkIdentifier,
+        chain_head_update_listener: Arc<ChainHeadUpdateListener>,
         pool: Pool<ConnectionManager<PgConnection>>,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
@@ -216,11 +217,7 @@ impl Store {
             logger: logger.clone(),
             subscriptions: Arc::new(RwLock::new(HashMap::new())),
             listener: Mutex::new(listener),
-            chain_head_update_listener: ChainHeadUpdateListener::new(
-                &logger,
-                registry.clone(),
-                config.postgres_url,
-            ),
+            chain_head_update_listener,
             network_name: config.network_name.clone(),
             genesis_block_ptr: (net_identifiers.genesis_block_hash, 0 as u64).into(),
             conn: pool,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -220,7 +220,6 @@ impl Store {
                 &logger,
                 registry.clone(),
                 config.postgres_url,
-                config.network_name.clone(),
             ),
             network_name: config.network_name.clone(),
             genesis_block_ptr: (net_identifiers.genesis_block_hash, 0 as u64).into(),
@@ -1538,7 +1537,8 @@ impl ChainStore for Store {
     }
 
     fn chain_head_updates(&self) -> ChainHeadUpdateStream {
-        self.chain_head_update_listener.subscribe()
+        self.chain_head_update_listener
+            .subscribe(self.0.network_name.to_owned())
     }
 
     fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error> {

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -36,7 +36,6 @@ use graph::prelude::{
     Value, BLOCK_NUMBER_MAX,
 };
 
-use graph_chain_ethereum::BlockIngestorMetrics;
 use graph_graphql::prelude::api_schema;
 use web3::types::{Address, H256};
 
@@ -211,7 +210,6 @@ impl Store {
         let store_events = listener
             .take_event_stream()
             .expect("Failed to listen to entity change events in Postgres");
-        let block_ingestor_metrics = Arc::new(BlockIngestorMetrics::new(registry.clone()));
 
         // Create the store
         let store = StoreInner {
@@ -220,7 +218,7 @@ impl Store {
             listener: Mutex::new(listener),
             chain_head_update_listener: ChainHeadUpdateListener::new(
                 &logger,
-                block_ingestor_metrics,
+                registry.clone(),
                 config.postgres_url,
                 config.network_name.clone(),
             ),

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -192,6 +192,7 @@ impl Store {
         logger: &Logger,
         net_identifiers: EthereumNetworkIdentifier,
         chain_head_update_listener: Arc<ChainHeadUpdateListener>,
+        subscriptions: Arc<SubscriptionManager>,
         pool: Pool<ConnectionManager<PgConnection>>,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
@@ -201,10 +202,6 @@ impl Store {
         // Create the entities table (if necessary)
         initiate_schema(&logger, &pool.get().unwrap(), &pool.get().unwrap());
 
-        let subscriptions = Arc::new(SubscriptionManager::new(
-            logger.clone(),
-            config.postgres_url.clone(),
-        ));
         // Create the store
         let store = StoreInner {
             logger: logger.clone(),

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -1,3 +1,8 @@
+use futures::sync::mpsc::{channel, Sender};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
+use uuid::Uuid;
+
 use crate::notification_listener::{NotificationListener, SafeChannelName};
 use graph::prelude::serde_json;
 use graph::prelude::*;
@@ -42,5 +47,133 @@ impl EventProducer<StoreEvent> for StoreEventListener {
                 }))
             },
         )
+    }
+}
+
+pub(crate) struct SubscriptionManager {
+    logger: Logger,
+    subscriptions: Arc<RwLock<HashMap<String, Sender<StoreEvent>>>>,
+
+    /// listen to StoreEvents generated when applying entity operations
+    listener: Mutex<StoreEventListener>,
+}
+
+impl SubscriptionManager {
+    pub fn new(logger: Logger, postgres_url: String) -> Self {
+        let mut listener = StoreEventListener::new(&logger, postgres_url);
+        let store_events = listener
+            .take_event_stream()
+            .expect("Failed to listen to entity change events in Postgres");
+
+        let manager = SubscriptionManager {
+            logger,
+            subscriptions: Arc::new(RwLock::new(HashMap::new())),
+            listener: Mutex::new(listener),
+        };
+
+        // Deal with store subscriptions
+        manager.handle_store_events(store_events);
+        manager.periodically_clean_up_stale_subscriptions();
+
+        let mut listener = manager.listener.lock().unwrap();
+        listener.start();
+        drop(listener);
+
+        manager
+    }
+
+    /// Receive store events from Postgres and send them to all active
+    /// subscriptions. Detect stale subscriptions in the process and
+    /// close them.
+    fn handle_store_events(
+        &self,
+        store_events: Box<dyn Stream<Item = StoreEvent, Error = ()> + Send>,
+    ) {
+        let logger = self.logger.clone();
+        let subscriptions = self.subscriptions.clone();
+
+        graph::spawn(
+            store_events
+                .for_each(move |event| {
+                    let senders = subscriptions.read().unwrap().clone();
+                    let logger = logger.clone();
+                    let subscriptions = subscriptions.clone();
+
+                    // Write change to all matching subscription streams; remove subscriptions
+                    // whose receiving end has been dropped
+                    stream::iter_ok::<_, ()>(senders).for_each(move |(id, sender)| {
+                        let logger = logger.clone();
+                        let subscriptions = subscriptions.clone();
+
+                        sender.send(event.clone()).then(move |result| {
+                            match result {
+                                Err(_send_error) => {
+                                    // Receiver was dropped
+                                    debug!(logger, "Unsubscribe"; "id" => &id);
+                                    subscriptions.write().unwrap().remove(&id);
+                                    Ok(())
+                                }
+                                Ok(_sender) => Ok(()),
+                            }
+                        })
+                    })
+                })
+                .compat(),
+        );
+    }
+
+    fn periodically_clean_up_stale_subscriptions(&self) {
+        use futures03::stream::StreamExt;
+
+        let logger = self.logger.clone();
+        let subscriptions = self.subscriptions.clone();
+
+        // Clean up stale subscriptions every 5s
+        graph::spawn(
+            tokio::time::interval(Duration::from_secs(5)).for_each(move |_| {
+                let mut subscriptions = subscriptions.write().unwrap();
+
+                // Obtain IDs of subscriptions whose receiving end has gone
+                let stale_ids = subscriptions
+                    .iter_mut()
+                    .filter_map(|(id, sender)| match sender.poll_ready() {
+                        Err(_) => Some(id.clone()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+
+                // Remove all stale subscriptions
+                for id in stale_ids {
+                    debug!(logger, "Unsubscribe"; "id" => &id);
+                    subscriptions.remove(&id);
+                }
+
+                futures03::future::ready(())
+            }),
+        );
+    }
+
+    pub fn subscribe(&self, entities: Vec<SubgraphEntityPair>) -> StoreEventStreamBox {
+        let subscriptions = self.subscriptions.clone();
+
+        // Generate a new (unique) UUID; we're looping just to be sure we avoid collisions
+        let mut id = Uuid::new_v4().to_string();
+        while subscriptions.read().unwrap().contains_key(&id) {
+            id = Uuid::new_v4().to_string();
+        }
+
+        debug!(self.logger, "Subscribe";
+               "id" => &id,
+               "entities" => format!("{:?}", entities));
+
+        // Prepare the new subscription by creating a channel and a subscription object
+        let (sender, receiver) = channel(100);
+
+        // Add the new subscription
+        let mut subscriptions = subscriptions.write().unwrap();
+        subscriptions.insert(id, sender);
+
+        // Return the subscription ID and entity change stream
+        StoreEventStream::new(Box::new(receiver)).filter_by_entities(entities)
     }
 }

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -50,6 +50,8 @@ impl EventProducer<StoreEvent> for StoreEventListener {
     }
 }
 
+/// Manage subscriptions to the `StoreEvent` stream. Keep a list of
+/// currently active subscribers and forward new events to each of them
 pub struct SubscriptionManager {
     logger: Logger,
     subscriptions: Arc<RwLock<HashMap<String, Sender<StoreEvent>>>>,

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -50,7 +50,7 @@ impl EventProducer<StoreEvent> for StoreEventListener {
     }
 }
 
-pub(crate) struct SubscriptionManager {
+pub struct SubscriptionManager {
     logger: Logger,
     subscriptions: Arc<RwLock<HashMap<String, Sender<StoreEvent>>>>,
 

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -9,7 +9,7 @@ use graph_graphql::prelude::{
 };
 use graph_mock::MockMetricsRegistry;
 use graph_store_postgres::connection_pool::create_connection_pool;
-use graph_store_postgres::{Store, StoreConfig};
+use graph_store_postgres::{ChainHeadUpdateListener, Store, StoreConfig};
 use graphql_parser::query as q;
 use hex_literal::hex;
 use lazy_static::lazy_static;
@@ -53,6 +53,12 @@ lazy_static! {
                 &logger,
                 Arc::new(MockMetricsRegistry::new()),
             );
+            let registry = Arc::new(MockMetricsRegistry::new());
+            let chain_head_update_listener = Arc::new(ChainHeadUpdateListener::new(
+                &logger,
+                registry.clone(),
+                postgres_url.clone(),
+            ));
             Arc::new(Store::new(
                 StoreConfig {
                     postgres_url,
@@ -60,8 +66,9 @@ lazy_static! {
                 },
                 &logger,
                 net_identifiers,
+                chain_head_update_listener,
                 postgres_conn_pool,
-                Arc::new(MockMetricsRegistry::new()),
+                registry.clone(),
             ))
         })
     };

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -9,7 +9,7 @@ use graph_graphql::prelude::{
 };
 use graph_mock::MockMetricsRegistry;
 use graph_store_postgres::connection_pool::create_connection_pool;
-use graph_store_postgres::{ChainHeadUpdateListener, Store, StoreConfig};
+use graph_store_postgres::{ChainHeadUpdateListener, Store, StoreConfig, SubscriptionManager};
 use graphql_parser::query as q;
 use hex_literal::hex;
 use lazy_static::lazy_static;
@@ -59,6 +59,10 @@ lazy_static! {
                 registry.clone(),
                 postgres_url.clone(),
             ));
+            let subscriptions = Arc::new(SubscriptionManager::new(
+                logger.clone(),
+                postgres_url.clone(),
+            ));
             Arc::new(Store::new(
                 StoreConfig {
                     postgres_url,
@@ -67,6 +71,7 @@ lazy_static! {
                 &logger,
                 net_identifiers,
                 chain_head_update_listener,
+                subscriptions,
                 postgres_conn_pool,
                 registry.clone(),
             ))


### PR DESCRIPTION
Each `graph-node` process would have one `ChainHeadUpdateListener` and one `StoreEventListener` for each network that the process was dealing with. With 8 networks, that would eat up 16 database connections, which adds up if you run a lot of `graph-node` processes.

With these changes, each process only uses one listener each, independent of the number of networks that are being processed, so that we only need 2 database connections per process.

Thanks to @leoyvens for helping me with some gnarly futures issues with the `ChainHeadUpdateListener`