### PR TITLE
docker: Only push builds on master to the 'latest' tag

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -39,6 +39,7 @@ steps:
     - 'TAG_NAME=$TAG_NAME'
     - 'PROJECT_ID=$PROJECT_ID'
     - 'DOCKER_HUB_USER=$_DOCKER_HUB_USER'
+    - 'BRANCH_NAME=$BRANCH_NAME'
 images:
   - 'gcr.io/$PROJECT_ID/graph-node-build:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/graph-node:$SHORT_SHA'

--- a/docker/tag.sh
+++ b/docker/tag.sh
@@ -19,9 +19,8 @@ echo $PASSWORD | docker login --username="$DOCKER_HUB_USER" --password-stdin
 set -x
 
 tag_and_push "$SHORT_SHA"
-tag_and_push latest
 
-if [ -n "$TAG_NAME" ]
-then
-    tag_and_push "$TAG_NAME"
-fi
+# Builds on the master branch become the 'latest'
+[ "$BRANCH_NAME" = master ] && tag_and_push latest
+# Builds of tags set the tag in Docker Hub, too
+[ -n "$TAG_NAME" ] && tag_and_push "$TAG_NAME"


### PR DESCRIPTION
We do not modify the 'latest' tag in Docker Hub if we build something that is not on the master branch.