### PR TITLE
Quick and dirty query cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68df31bdf2bbb567e5adf8f21ac125dc0e897b1381e7b841f181521f06fc3134"
+checksum = "423897d97e11b810c9da22458400b28ec866991c711409073662eb34dc44bfff"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1199,7 +1199,7 @@ dependencies = [
  "hex 0.4.2",
  "ipfs-api",
  "lazy_static",
- "lru_time_cache",
+ "lru_time_cache 0.9.0",
  "semver",
  "serde",
  "serde_json",
@@ -1213,11 +1213,13 @@ name = "graph-graphql"
 version = "0.18.0"
 dependencies = [
  "Inflector",
+ "blake3",
  "futures 0.1.29",
  "graph",
  "graphql-parser",
  "indexmap",
  "lazy_static",
+ "lru_time_cache 0.10.0",
  "pretty_assertions",
  "test-store",
  "uuid 0.8.1",
@@ -1398,7 +1400,7 @@ dependencies = [
  "hex 0.4.2",
  "hex-literal",
  "lazy_static",
- "lru_time_cache",
+ "lru_time_cache 0.9.0",
  "maybe-owned",
  "parity-wasm",
  "postgres",
@@ -1947,6 +1949,12 @@ name = "lru_time_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab44e08e5b5110188be64dc8f0865635206ad7386fe672903bef195df3cc8960"
+
+[[package]]
+name = "lru_time_cache"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb241df5c4caeb888755363fc95f8a896618dc0d435e9e775f7930cb099beab"
 
 [[package]]
 name = "maplit"

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -11,6 +11,8 @@ indexmap = "1.3"
 Inflector = "0.11.3"
 lazy_static = "1.2.0"
 uuid = { version = "0.8.1", features = ["v4"] }
+lru_time_cache = "0.10"
+blake3 = "0.3"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -54,13 +54,15 @@ fn cache_key(ctx: &ExecutionContext<impl Resolver>, selection_set: &q::Selection
     hasher.update(selection_set.to_string().as_bytes());
 
     // variables
-    for (key, value) in &ctx.query.variables {
+    let variables: BTreeMap<_, _> = ctx.query.variables.iter().collect();
+    for (key, value) in variables {
         hasher.update(key.as_bytes());
         hasher.update(value.to_string().as_bytes());
     }
 
     // fragment definitions
-    for (key, fragment) in &ctx.query.fragments {
+    let fragments: BTreeMap<_, _> = ctx.query.fragments.iter().collect();
+    for (key, fragment) in fragments {
         hasher.update(key.as_bytes());
         hasher.update(fragment.to_string().as_bytes());
     }

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -35,7 +35,7 @@ pub struct Query {
     pub variables: HashMap<q::Name, q::Value>,
     /// The root selection set of the query
     pub selection_set: q::SelectionSet,
-    fragments: HashMap<String, q::FragmentDefinition>,
+    pub(crate) fragments: HashMap<String, q::FragmentDefinition>,
     kind: Kind,
     /// This is `true` if the query should run in both prefetch and slow
     /// execution modes, and the results of the two executions should be


### PR DESCRIPTION
Only for the subgraphs listed in the env var `GRAPH_CACHED_SUBGRAPH_IDS`, we keep a result cached for `GRAPH_CACHE_EXPIRY_SECS`. This might serve stale data but is useful as a way to temporarily alleviate pressure on the DB.

I did a manual test that this works as expected, logging `Query cache hit` on a second query, but expiring one minute after the first query.