### PR TITLE
Fix issue inserting fulltext fields when all included field values are null

### DIFF
--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1049,12 +1049,17 @@ impl<'a> InsertQuery<'a> {
         for column in table.columns.iter() {
             match column.fulltext_fields.as_ref() {
                 Some(fields) => {
-                    let fulltext_updates = fields
+                    let fulltext_field_values = fields
                         .iter()
                         .filter_map(|field| entity.get(field))
                         .cloned()
-                        .collect();
-                    entity.insert(column.field.to_string(), Value::List(fulltext_updates));
+                        .collect::<Vec<Value>>();
+                    if !fulltext_field_values.is_empty() {
+                        entity.insert(
+                            column.field.to_string(),
+                            Value::List(fulltext_field_values),
+                        );
+                    }
                 }
                 None => (),
             }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1055,10 +1055,7 @@ impl<'a> InsertQuery<'a> {
                         .cloned()
                         .collect::<Vec<Value>>();
                     if !fulltext_field_values.is_empty() {
-                        entity.insert(
-                            column.field.to_string(),
-                            Value::List(fulltext_field_values),
-                        );
+                        entity.insert(column.field.to_string(), Value::List(fulltext_field_values));
                     }
                 }
                 None => (),


### PR DESCRIPTION
This PR fixes an issue causing invalid insert queries to be constructed for fulltext fields.  

In the case of an insert of an entity with a fulltext field, an issue arose when all fields included in the fulltext field are null.  When walking the ast of the `QueryFragments` in an `InsertQuery` this led to an invalid query fragment, `())`, being constructed  [here](https://github.com/graphprotocol/graph-node/blob/master/store/postgres/src/relational_queries.rs#L367-L378).