### PR TITLE
Optimize graphql execution

### DIFF
--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -168,13 +168,6 @@ where
     }
 }
 
-pub fn prefetch(
-    ctx: &ExecutionContext<impl Resolver>,
-    selection_set: &q::SelectionSet,
-) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
-    ctx.resolver.prefetch(&ctx, selection_set)
-}
-
 /// Executes the root selection set of a query.
 pub fn execute_root_selection_set(
     ctx: &ExecutionContext<impl Resolver>,
@@ -234,7 +227,7 @@ pub fn execute_root_selection_set(
     let mut values = if data_set.items.is_empty() {
         BTreeMap::default()
     } else {
-        let initial_data = prefetch(&ctx, &data_set)?;
+        let initial_data = ctx.resolver.prefetch(&ctx, selection_set)?;
         execute_selection_set_to_map(&ctx, &data_set, query_type, initial_data)?
     };
 

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -259,13 +259,13 @@ pub fn execute_selection_set(
     ctx: &ExecutionContext<impl Resolver>,
     selection_set: &q::SelectionSet,
     object_type: &s::ObjectType,
-    object_value: Option<q::Value>,
+    prefetched_value: Option<q::Value>,
 ) -> Result<q::Value, Vec<QueryExecutionError>> {
     Ok(q::Value::Object(execute_selection_set_to_map(
         ctx,
         selection_set,
         object_type,
-        object_value,
+        prefetched_value,
     )?))
 }
 
@@ -273,9 +273,9 @@ fn execute_selection_set_to_map(
     ctx: &ExecutionContext<impl Resolver>,
     selection_set: &q::SelectionSet,
     object_type: &s::ObjectType,
-    object_value: Option<q::Value>,
+    prefetched_value: Option<q::Value>,
 ) -> Result<BTreeMap<String, q::Value>, Vec<QueryExecutionError>> {
-    let mut object_value = match object_value {
+    let mut prefetched_object = match prefetched_value {
         Some(q::Value::Object(object)) => Some(object),
         Some(_) => unreachable!(),
         None => None,
@@ -300,7 +300,7 @@ fn execute_selection_set_to_map(
         if let Some(ref field) = sast::get_field(object_type, &fields[0].name) {
             // If we have the value already, because it's a scalar or a prefetched object, we want
             // to use it and avoid cloning, so we take it from the object value.
-            let field_value = object_value
+            let field_value = prefetched_object
                 .as_mut()
                 .map(|o| {
                     o.remove(&format!("prefetch:{}", response_key))

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -777,11 +777,11 @@ fn complete_value(
             match named_type {
                 // Complete scalar values
                 s::TypeDefinition::Scalar(scalar_type) => {
-                    resolved_value.coerce(scalar_type).ok_or_else(|| {
+                    resolved_value.coerce(scalar_type).map_err(|value| {
                         vec![QueryExecutionError::ScalarCoercionError(
                             field.position.clone(),
                             field.name.to_owned(),
-                            resolved_value.clone(),
+                            value,
                             scalar_type.name.to_owned(),
                         )]
                     })
@@ -789,11 +789,11 @@ fn complete_value(
 
                 // Complete enum values
                 s::TypeDefinition::Enum(enum_type) => {
-                    resolved_value.coerce(enum_type).ok_or_else(|| {
+                    resolved_value.coerce(enum_type).map_err(|value| {
                         vec![QueryExecutionError::EnumCoercionError(
                             field.position.clone(),
                             field.name.to_owned(),
-                            resolved_value.clone(),
+                            value,
                             enum_type.name.to_owned(),
                             enum_type
                                 .values

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -37,10 +37,7 @@ pub struct Query {
     pub selection_set: q::SelectionSet,
     pub(crate) fragments: HashMap<String, q::FragmentDefinition>,
     kind: Kind,
-    /// This is `true` if the query should run in both prefetch and slow
-    /// execution modes, and the results of the two executions should be
-    /// checked against each other
-    pub verify: bool,
+
     /// Used only for logging; if logging is configured off, these will
     /// have dummy values
     pub(crate) query_text: Arc<String>,
@@ -86,12 +83,6 @@ impl Query {
         }
         let operation = operation.ok_or(QueryExecutionError::OperationNameRequired)?;
 
-        let verify = if let q::OperationDefinition::Query(query) = &operation {
-            query.directives.iter().any(|dir| dir.name == "verify")
-        } else {
-            false
-        };
-
         let variables = coerce_variables(&query.schema, &operation, query.variables)?;
         let (kind, selection_set) = match operation {
             q::OperationDefinition::Query(q::Query { selection_set, .. }) => {
@@ -115,7 +106,6 @@ impl Query {
             fragments,
             selection_set,
             kind,
-            verify,
             query_text,
             variables_text,
         });
@@ -169,7 +159,6 @@ impl Query {
             fragments: self.fragments.clone(),
             selection_set: self.selection_set.clone(),
             kind: self.kind,
-            verify: self.verify,
             query_text: self.query_text.clone(),
             variables_text: self.variables_text.clone(),
         })

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,5 +1,5 @@
 use graphql_parser::{query as q, schema as s};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use crate::prelude::*;
 use crate::schema::ast::get_named_type;
@@ -72,24 +72,21 @@ pub trait Resolver: Clone + Send + Sync {
     /// Resolves entities referenced by a parent object.
     fn resolve_objects(
         &self,
-        parent: &Option<q::Value>,
+        objects_value: Option<q::Value>,
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
-        types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
-        max_first: u32,
     ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an entity referenced by a parent object.
     fn resolve_object(
         &self,
-        parent: &Option<q::Value>,
+        object_value: Option<q::Value>,
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
-        types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an enum value for a given enum type.
@@ -97,24 +94,23 @@ pub trait Resolver: Clone + Send + Sync {
         &self,
         _field: &q::Field,
         _enum_type: &s::EnumType,
-        value: Option<&q::Value>,
+        value: Option<q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
-        Ok(value.cloned().unwrap_or(q::Value::Null))
+        Ok(value.unwrap_or(q::Value::Null))
     }
 
     /// Resolves a scalar value for a given scalar type.
     fn resolve_scalar_value(
         &self,
         _parent_object_type: &s::ObjectType,
-        _parent: &BTreeMap<String, q::Value>,
         _field: &q::Field,
         _scalar_type: &s::ScalarType,
-        value: Option<&q::Value>,
+        value: Option<q::Value>,
         _argument_values: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         // This code is duplicated.
         // See also c2112309-44fd-4a84-92a0-5a651e6ed548
-        Ok(value.cloned().unwrap_or(q::Value::Null))
+        Ok(value.unwrap_or(q::Value::Null))
     }
 
     /// Resolves a list of enum values for a given enum type.
@@ -122,9 +118,9 @@ pub trait Resolver: Clone + Send + Sync {
         &self,
         _field: &q::Field,
         _enum_type: &s::EnumType,
-        value: Option<&q::Value>,
+        value: Option<q::Value>,
     ) -> Result<q::Value, Vec<QueryExecutionError>> {
-        Ok(value.cloned().unwrap_or(q::Value::Null))
+        Ok(value.unwrap_or(q::Value::Null))
     }
 
     /// Resolves a list of scalar values for a given list type.
@@ -132,9 +128,9 @@ pub trait Resolver: Clone + Send + Sync {
         &self,
         _field: &q::Field,
         _scalar_type: &s::ScalarType,
-        value: Option<&q::Value>,
+        value: Option<q::Value>,
     ) -> Result<q::Value, Vec<QueryExecutionError>> {
-        Ok(value.cloned().unwrap_or(q::Value::Null))
+        Ok(value.unwrap_or(q::Value::Null))
     }
 
     // Resolves an abstract type into the specific type of an object.

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -69,20 +69,20 @@ pub trait Resolver: Clone + Send + Sync {
         selection_set: &q::SelectionSet,
     ) -> Result<Option<q::Value>, Vec<QueryExecutionError>>;
 
-    /// Resolves entities referenced by a parent object.
+    /// Resolves list of objects, `prefetched_objects` is `Some` if the parent already calculated the value.
     fn resolve_objects(
         &self,
-        objects_value: Option<q::Value>,
+        prefetched_objects: Option<q::Value>,
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError>;
 
-    /// Resolves an entity referenced by a parent object.
+    /// Resolves an object, `prefetched_object` is `Some` if the parent already calculated the value.
     fn resolve_object(
         &self,
-        object_value: Option<q::Value>,
+        prefetched_object: Option<q::Value>,
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -358,7 +358,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
 
     fn resolve_objects(
         &self,
-        objects_value: Option<q::Value>,
+        prefetched_objects: Option<q::Value>,
         field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
@@ -366,7 +366,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
     ) -> Result<q::Value, QueryExecutionError> {
         match field.name.as_str() {
             "possibleTypes" => {
-                let type_names = match objects_value {
+                let type_names = match prefetched_objects {
                     Some(q::Value::List(type_names)) => Some(type_names),
                     _ => None,
                 }
@@ -387,13 +387,13 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
                     Ok(q::Value::Null)
                 }
             }
-            _ => Ok(objects_value.unwrap_or(q::Value::Null)),
+            _ => Ok(prefetched_objects.unwrap_or(q::Value::Null)),
         }
     }
 
     fn resolve_object(
         &self,
-        object_value: Option<q::Value>,
+        prefetched_object: Option<q::Value>,
         field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
@@ -410,7 +410,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
                 })?;
                 self.type_object(name)
             }
-            "type" | "ofType" => match object_value {
+            "type" | "ofType" => match prefetched_object {
                 Some(q::Value::String(type_name)) => self
                     .type_objects
                     .get(&type_name)
@@ -419,7 +419,7 @@ impl<'a> Resolver for IntrospectionResolver<'a> {
                 Some(v) => v,
                 None => q::Value::Null,
             },
-            _ => object_value.unwrap_or(q::Value::Null),
+            _ => prefetched_object.unwrap_or(q::Value::Null),
         };
         Ok(object)
     }

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -46,12 +46,6 @@ where
         "query_id" => query_id
     ));
 
-    let mode = if query.verify {
-        ExecutionMode::Verify
-    } else {
-        ExecutionMode::Prefetch
-    };
-
     // Create a fresh execution context
     let ctx = ExecutionContext {
         logger: query_logger.clone(),
@@ -59,7 +53,6 @@ where
         query: query.clone(),
         deadline: options.deadline,
         max_first: options.max_first,
-        mode,
     };
 
     if !query.is_query() {

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -163,13 +163,13 @@ where
 
     fn resolve_objects(
         &self,
-        objects_value: Option<q::Value>,
+        prefetched_objects: Option<q::Value>,
         field: &q::Field,
         _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
-        if let Some(child) = objects_value {
+        if let Some(child) = prefetched_objects {
             Ok(child)
         } else {
             Err(QueryExecutionError::ResolveEntitiesError(format!(
@@ -183,13 +183,13 @@ where
 
     fn resolve_object(
         &self,
-        object_value: Option<q::Value>,
+        prefetched_object: Option<q::Value>,
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
-        if let Some(q::Value::List(children)) = object_value {
+        if let Some(q::Value::List(children)) = prefetched_object {
             if children.len() > 1 {
                 let derived_from_field =
                     sast::get_derived_from_field(object_type, field_definition)

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -1,5 +1,5 @@
 use graphql_parser::{query as q, schema as s};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::result;
 use std::sync::Arc;
 
@@ -7,7 +7,6 @@ use graph::components::store::*;
 use graph::prelude::*;
 
 use crate::prelude::*;
-use crate::query::ast as qast;
 use crate::query::ext::BlockConstraint;
 use crate::schema::ast as sast;
 
@@ -69,169 +68,32 @@ where
         Ok((resolver, block_ptr))
     }
 
-    /// Adds a filter for matching entities that correspond to a derived field.
-    ///
-    /// Returns true if the field is a derived field (i.e., if it is defined with
-    /// a @derivedFrom directive).
-    fn add_filter_for_derived_field(
-        query: &mut EntityQuery,
-        parent: &Option<q::Value>,
-        derived_from_field: &s::Field,
-    ) {
-        // This field is derived from a field in the object type that we're trying
-        // to resolve values for; e.g. a `bandMembers` field maybe be derived from
-        // a `bands` or `band` field in a `Musician` type.
-        //
-        // Our goal here is to identify the ID of the parent entity (e.g. the ID of
-        // a band) and add a `Contains("bands", [<id>])` or `Equal("band", <id>)`
-        // filter to the arguments.
-
-        let field_name = derived_from_field.name.clone();
-
-        // To achieve this, we first identify the parent ID
-        let parent_id = parent
-            .as_ref()
-            .and_then(|value| match value {
-                q::Value::Object(o) => Some(o),
-                _ => None,
-            })
-            .and_then(|object| object.get(&q::Name::from("id")))
-            .and_then(|value| match value {
-                q::Value::String(s) => Some(Value::from(s)),
-                _ => None,
-            })
-            .expect("Parent object is missing an \"id\"")
-            .clone();
-
-        // Depending on whether the field we're deriving from has a list or a
-        // single value type, we either create a `Contains` or `Equal`
-        // filter argument
-        let filter = if sast::is_list_or_non_null_list_field(derived_from_field) {
-            EntityFilter::Contains(field_name, Value::List(vec![parent_id]))
-        } else {
-            EntityFilter::Equal(field_name, parent_id)
-        };
-
-        // Add the `Contains`/`Equal` filter to the top-level `And` filter, creating one
-        // if necessary
-        let top_level_filter = query.filter.get_or_insert(EntityFilter::And(vec![]));
-        match top_level_filter {
-            EntityFilter::And(ref mut filters) => {
-                filters.push(filter);
-            }
-            _ => unreachable!("top level filter is always `And`"),
-        };
-    }
-
-    /// Adds a filter for matching entities that are referenced by the given field.
-    fn add_filter_for_reference_field(
-        query: &mut EntityQuery,
-        parent: &Option<q::Value>,
-        field_definition: &s::Field,
-        _object_type: ObjectOrInterface,
-    ) {
-        if let Some(q::Value::Object(object)) = parent {
-            // Create an `Or(Equals("id", ref_id1), ...)` filter that includes
-            // all referenced IDs.
-            let filter = object
-                .get(&field_definition.name)
-                .and_then(|value| match value {
-                    q::Value::String(id) => {
-                        Some(EntityFilter::Equal(String::from("id"), Value::from(id)))
-                    }
-                    q::Value::List(ids) => Some(EntityFilter::Or(
-                        ids.iter()
-                            .filter_map(|id| match id {
-                                q::Value::String(s) => Some(s),
-                                _ => None,
-                            })
-                            .map(|id| EntityFilter::Equal(String::from("id"), Value::from(id)))
-                            .collect(),
-                    )),
-                    _ => None,
-                })
-                .unwrap_or_else(|| {
-                    // Caught by `UnknownField` error.
-                    unreachable!(
-                        "Field \"{}\" missing in parent object",
-                        field_definition.name
-                    )
-                });
-
-            // Add the `Or` filter to the top-level `And` filter, creating one if necessary
-            let top_level_filter = query.filter.get_or_insert(EntityFilter::And(vec![]));
-            match top_level_filter {
-                EntityFilter::And(ref mut filters) => {
-                    filters.push(filter);
-                }
-                _ => unreachable!("top level filter is always `And`"),
-            };
-        }
-    }
-
-    /// Returns true if the object has no references in the given field.
-    fn references_field_is_empty(parent: &Option<q::Value>, field: &q::Name) -> bool {
-        parent
-            .as_ref()
-            .and_then(|value| match value {
-                q::Value::Object(object) => Some(object),
-                _ => None,
-            })
-            .and_then(|object| object.get(field))
-            .map(|value| match value {
-                q::Value::List(values) => values.is_empty(),
-                _ => true,
-            })
-            .unwrap_or(true)
-    }
-
-    fn get_prefetched_child<'a>(
-        parent: &'a Option<q::Value>,
-        field: &q::Field,
-    ) -> Option<&'a q::Value> {
-        match parent {
-            Some(q::Value::Object(map)) => {
-                let key = format!("prefetch:{}", qast::get_response_key(field));
-                map.get(&key)
-            }
-            _ => None,
-        }
-    }
-
-    fn was_prefetched(parent: &Option<q::Value>) -> bool {
-        match parent {
-            Some(q::Value::Object(map)) => map.contains_key(super::prefetch::PREFETCH_KEY),
-            _ => false,
-        }
-    }
-
     fn resolve_objects_prefetch(
         &self,
-        parent: &Option<q::Value>,
+        objects_value: Option<q::Value>,
         field: &q::Field,
         object_type: ObjectOrInterface<'_>,
     ) -> Result<q::Value, QueryExecutionError> {
-        if let Some(child) = Self::get_prefetched_child(parent, field) {
-            Ok(child.clone())
+        if let Some(child) = objects_value {
+            Ok(child)
         } else {
             Err(QueryExecutionError::ResolveEntitiesError(format!(
-                "internal error resolving {}.{} for {:?}: \
+                "internal error resolving {}.{}: \
                  expected prefetched result, but found nothing",
                 object_type.name(),
                 &field.name,
-                parent
             )))
         }
     }
 
     fn resolve_object_prefetch(
         &self,
-        parent: &Option<q::Value>,
+        object_value: Option<q::Value>,
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
     ) -> Result<q::Value, QueryExecutionError> {
-        if let Some(q::Value::List(children)) = Self::get_prefetched_child(parent, field) {
+        if let Some(q::Value::List(children)) = object_value {
             if children.len() > 1 {
                 let derived_from_field =
                     sast::get_derived_from_field(object_type, field_definition)
@@ -252,11 +114,10 @@ where
             }
         } else {
             return Err(QueryExecutionError::ResolveEntitiesError(format!(
-                "internal error resolving {}.{} for {:?}: \
+                "internal error resolving {}.{}: \
                  expected prefetched result, but found nothing",
                 object_type.name(),
                 &field.name,
-                parent
             )));
         }
     }
@@ -356,144 +217,24 @@ where
 
     fn resolve_objects(
         &self,
-        parent: &Option<q::Value>,
+        objects_value: Option<q::Value>,
         field: &q::Field,
-        field_definition: &s::Field,
+        _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&q::Name, q::Value>,
-        types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
-        max_first: u32,
+        _arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
-        if Self::was_prefetched(parent) {
-            return self.resolve_objects_prefetch(parent, field, object_type);
-        }
-
-        let object_type = object_type.into();
-        let mut query = build_query(
-            object_type,
-            self.block,
-            arguments,
-            types_for_interface,
-            max_first,
-        )?;
-
-        // Add matching filter for derived fields
-        let derived_from_field = sast::get_derived_from_field(object_type, field_definition);
-        let is_derived = derived_from_field.is_some();
-        if let Some(derived_from_field) = derived_from_field {
-            Self::add_filter_for_derived_field(&mut query, parent, derived_from_field);
-        }
-
-        // Return an empty list if we're dealing with a non-derived field that
-        // holds an empty list of references; there's no point in querying the store
-        // if the result will be empty anyway
-        if !is_derived
-            && parent.is_some()
-            && Self::references_field_is_empty(parent, &field_definition.name)
-        {
-            return Ok(q::Value::List(vec![]));
-        }
-
-        // Add matching filter for reference fields
-        if !is_derived {
-            Self::add_filter_for_reference_field(&mut query, parent, field_definition, object_type);
-        }
-
-        let mut entity_values = Vec::new();
-        for entity in self.store.find(query)? {
-            entity_values.push(entity.into())
-        }
-        Ok(q::Value::List(entity_values))
+        self.resolve_objects_prefetch(objects_value, field, object_type)
     }
 
     fn resolve_object(
         &self,
-        parent: &Option<q::Value>,
+        object_value: Option<q::Value>,
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&q::Name, q::Value>,
-        types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
+        _arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
-        if Self::was_prefetched(parent) {
-            return self.resolve_object_prefetch(parent, field, field_definition, object_type);
-        }
-
-        let id = arguments.get(&"id".to_string()).and_then(|id| match id {
-            q::Value::String(s) => Some(s),
-            _ => None,
-        });
-
-        // The subgraph_id directive is injected in all types.
-        let subgraph_id = parse_subgraph_id(object_type).unwrap();
-        let subgraph_id_for_resolve_object = subgraph_id.clone();
-
-        let resolve_object_with_id = |id: &String| -> Result<Option<Entity>, QueryExecutionError> {
-            let collection = match object_type {
-                ObjectOrInterface::Object(_) => {
-                    EntityCollection::All(vec![object_type.name().to_owned()])
-                }
-                ObjectOrInterface::Interface(interface) => {
-                    let entity_types = types_for_interface[&interface.name]
-                        .iter()
-                        .map(|o| o.name.clone())
-                        .collect();
-                    EntityCollection::All(entity_types)
-                }
-            };
-            let query = EntityQuery::new(subgraph_id_for_resolve_object, self.block, collection)
-                .filter(EntityFilter::Equal(String::from("id"), Value::from(id)))
-                .first(1);
-            Ok(self.store.find(query)?.into_iter().next())
-        };
-
-        let entity = if let Some(id) = id {
-            resolve_object_with_id(id)?
-        } else {
-            // Identify whether the field is derived with @derivedFrom
-            let derived_from_field = sast::get_derived_from_field(object_type, field_definition);
-            if let Some(derived_from_field) = derived_from_field {
-                // The field is derived -> build a query for the entity that might be
-                // referencing the parent object
-
-                let mut arguments = arguments.clone();
-
-                // We use first: 2 here to detect and fail if there is more than one
-                // entity that matches the `@derivedFrom`.
-                let first_arg_name = q::Name::from("first");
-                arguments.insert(&first_arg_name, q::Value::Int(q::Number::from(2)));
-
-                let skip_arg_name = q::Name::from("skip");
-                arguments.insert(&skip_arg_name, q::Value::Int(q::Number::from(0)));
-                let mut query =
-                    build_query(object_type, self.block, &arguments, types_for_interface, 2)?;
-                Self::add_filter_for_derived_field(&mut query, parent, derived_from_field);
-
-                // Find the entity or entities that reference the parent entity
-                let entities = self.store.find(query)?;
-
-                if entities.len() > 1 {
-                    return Err(QueryExecutionError::AmbiguousDerivedFromResult(
-                        field.position.clone(),
-                        field.name.to_owned(),
-                        object_type.name().to_owned(),
-                        derived_from_field.name.to_owned(),
-                    ));
-                } else {
-                    entities.into_iter().next()
-                }
-            } else {
-                match parent {
-                    Some(q::Value::Object(parent_object)) => match parent_object.get(&field.name) {
-                        Some(q::Value::String(id)) => resolve_object_with_id(id)?,
-                        _ => None,
-                    },
-                    _ => panic!("top level queries must either take an `id` or return a list"),
-                }
-            }
-        };
-
-        Ok(entity.map_or(q::Value::Null, Into::into))
+        self.resolve_object_prefetch(object_value, field, field_definition, object_type)
     }
 
     fn resolve_field_stream<'a, 'b>(

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -81,7 +81,6 @@ where
         query: query.clone(),
         deadline: None,
         max_first: options.max_first,
-        mode: ExecutionMode::Prefetch,
     };
 
     if !query.is_subscription() {
@@ -192,7 +191,6 @@ async fn execute_subscription_event(
         query,
         deadline: timeout.map(|t| Instant::now() + t),
         max_first,
-        mode: ExecutionMode::Prefetch,
     };
 
     // We have established that this exists earlier in the subscription execution
@@ -209,7 +207,7 @@ async fn execute_subscription_event(
             &ctx,
             &ctx.query.selection_set,
             &subscription_type,
-            &initial_data,
+            initial_data,
         )
     })
     .await

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -202,7 +202,7 @@ async fn execute_subscription_event(
     // once, from flooding the blocking thread pool and the DB connection pool.
     let _permit = SUBSCRIPTION_QUERY_SEMAPHORE.acquire();
     let result = graph::spawn_blocking_allow_panic(async move {
-        let initial_data = prefetch(&ctx, &ctx.query.selection_set)?;
+        let initial_data = ctx.resolver.prefetch(&ctx, &ctx.query.selection_set)?;
         execute_selection_set(
             &ctx,
             &ctx.query.selection_set,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -2,7 +2,7 @@
 extern crate pretty_assertions;
 
 use graphql_parser::{query as q, schema as s};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use graph::prelude::{
@@ -28,25 +28,22 @@ impl Resolver for MockResolver {
 
     fn resolve_objects<'a>(
         &self,
-        _parent: &Option<q::Value>,
+        _: Option<q::Value>,
         _field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
-        _types_for_interface: &BTreeMap<q::Name, Vec<s::ObjectType>>,
-        _max_first: u32,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }
 
     fn resolve_object(
         &self,
-        _parent: &Option<q::Value>,
+        __: Option<q::Value>,
         _field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&q::Name, q::Value>,
-        _types_for_interface: &BTreeMap<q::Name, Vec<s::ObjectType>>,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -729,13 +729,13 @@ where
 
     fn resolve_objects(
         &self,
-        objects_value: Option<q::Value>,
+        prefetched_objects: Option<q::Value>,
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
-        match (objects_value, object_type.name(), field.name.as_str()) {
+        match (prefetched_objects, object_type.name(), field.name.as_str()) {
             // The top-level `indexingStatuses` field
             (None, "SubgraphIndexingStatus", "indexingStatuses") => {
                 self.resolve_indexing_statuses(arguments)
@@ -760,13 +760,13 @@ where
 
     fn resolve_object(
         &self,
-        object_value: Option<q::Value>,
+        prefetched_object: Option<q::Value>,
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
-        match (object_value, field.name.as_str()) {
+        match (prefetched_object, field.name.as_str()) {
             // The top-level `indexingStatusForCurrentVersion` field
             (None, "indexingStatusForCurrentVersion") => {
                 self.resolve_indexing_statuses_for_version(arguments, true)


### PR DESCRIPTION
This does a pass at simplifying and optimizing our graphql execution. Non-prefetched execution is removed. I couldn't get very amazing numbers locally, maybe a 10% speed up and a 20% resource usage reduction, but we'll see how it goes in real workloads.

The commits can be read separately. The first commit makes so `coerce` doesn't clone. The annoying part here is that it has to return the value on a failure to coerce so we can have good errors, so most of the diff is about the change to a `Result<Value, Value>` return type.

The second commit completes values in place so we don't allocate a new vec for it.

The third commit is probably the most impactful one. It removes non-prefetched execution. The optimization is instead of passing down a reference to the prefetched parent object, only so that the field being resolved is cloned later, we remove the field being resolved from the parent object in `execute_selection_set_to_map`, and then pass down the field value. This is more efficient and makes the code nicer overall.