### PR TITLE
Fix host functions in globals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "object 0.19.0",
+ "object",
  "rustc-demangle",
 ]
 
@@ -448,16 +448,16 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.64.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.65.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.64.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.65.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -475,8 +475,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.64.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.65.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -484,21 +484,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.64.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.65.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.64.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.65.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.64.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.65.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "cranelift-codegen",
  "log 0.4.8",
@@ -508,8 +508,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.64.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.65.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -518,8 +518,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.64.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.65.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -528,6 +528,15 @@ dependencies = [
  "serde",
  "thiserror",
  "wasmparser",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -957,21 +966,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "faerie"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfef65b0e94693295c5d2fe2506f0ee6f43465342d4b5331659936aee8b16084"
-dependencies = [
- "goblin",
- "indexmap",
- "log 0.4.8",
- "scroll",
- "string-interner",
- "target-lexicon",
- "thiserror",
-]
-
-[[package]]
 name = "failure"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,17 +1290,6 @@ dependencies = [
  "fnv",
  "log 0.4.8",
  "regex",
-]
-
-[[package]]
-name = "goblin"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3081214398d39e4bd7f2c1975f0488ed04614ffdd976c6fc7a0708278552c0da"
-dependencies = [
- "log 0.4.8",
- "plain",
- "scroll",
 ]
 
 [[package]]
@@ -2431,18 +2414,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5666bbb90bc4d1e5bdcb26c0afda1822d25928341e9384ab187a9b37ab69e36"
-dependencies = [
- "target-lexicon",
-]
-
-[[package]]
-name = "object"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+]
 
 [[package]]
 name = "once_cell"
@@ -2702,12 +2680,6 @@ name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "postgres"
@@ -3175,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.25"
+version = "0.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca5b48c9db66c5ba084e4660b4c0cfe8b551a96074bc04b7c11de86ad0bf1f9"
+checksum = "7c03092d79e0fd610932d89ed53895a38c0dd3bcd317a0046e69940de32f1d95"
 dependencies = [
  "log 0.4.8",
  "rustc-hash",
@@ -3725,15 +3697,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 dependencies = [
  "bytes 0.4.12",
-]
-
-[[package]]
-name = "string-interner"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd710eadff449a1531351b0e43eb81ea404336fa2f56c777427ab0e32a4cf183"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -4607,8 +4570,8 @@ checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
 
 [[package]]
 name = "wasmtime"
-version = "0.17.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.18.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4630,13 +4593,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.17.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.18.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "anyhow",
- "faerie",
  "gimli",
  "more-asserts",
+ "object",
  "target-lexicon",
  "thiserror",
  "wasmparser",
@@ -4645,8 +4608,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.17.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.18.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "anyhow",
  "base64 0.12.1",
@@ -4673,8 +4636,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.17.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.18.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4699,15 +4662,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-profiling"
-version = "0.17.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.18.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "anyhow",
  "cfg-if",
  "gimli",
  "lazy_static",
  "libc",
- "object 0.18.0",
+ "object",
  "scroll",
  "serde",
  "target-lexicon",
@@ -4717,8 +4680,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.17.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#bc555468a7503c356001142d84326390a51c3385"
+version = "0.18.0"
+source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
 dependencies = [
  "backtrace",
  "cc",

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -28,9 +28,10 @@ maybe-owned = { git = "https://github.com/rustonaut/maybe-owned", branch = "mast
 # We need patch in order to be able to call host exports when initializing globals.
 #
 # By this conversation, wasmtime does not want to upstream this, pointing out that there is an
-# incompatibility between the way AS does things and the direction wasmtime wants to take:
+# incompatibility between the way AS does things and the direction wasmtime wants to take.
+# See:
 # https://bytecodealliance.zulipchat.com/#narrow/stream/206238-general/topic/Host.20functions.20in.20start
-#
+# https://github.com/AssemblyScript/assemblyscript/issues/1333
 # See also 3a23f045-eb9d-4b12-8c7c-3a4c2e34bea1
 wasmtime = { git = "https://github.com/graphprotocol/wasmtime", branch = "master" }
 

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -25,8 +25,14 @@ bytes = "0.5"
 # See also 92cd8019-0136-4011-96a0-40b3eec37f73
 maybe-owned = { git = "https://github.com/rustonaut/maybe-owned", branch = "master" }
 
-# Use a released version once 0.18 is released.
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime" }
+# We need patch in order to be able to call host exports when initializing globals.
+#
+# By this conversation, wasmtime does not want to upstream this, pointing out that there is an
+# incompatibility between the way AS does things and the direction wasmtime wants to take:
+# https://bytecodealliance.zulipchat.com/#narrow/stream/206238-general/topic/Host.20functions.20in.20start
+#
+# See also 3a23f045-eb9d-4b12-8c7c-3a4c2e34bea1
+wasmtime = { git = "https://github.com/graphprotocol/wasmtime", branch = "master" }
 
 defer = "0.1"
 

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -18,7 +18,7 @@ use web3::types::H160;
 
 use graph_graphql::prelude::validate_entity;
 
-use crate::module::WasmInstance;
+use crate::module::{WasmInstance, WasmInstanceContext};
 
 pub(crate) struct HostExports {
     subgraph_id: SubgraphDeploymentId,
@@ -351,7 +351,7 @@ impl HostExports {
     // parameter is passed to the callback without any changes
     pub(crate) fn ipfs_map(
         link_resolver: &Arc<dyn LinkResolver>,
-        module: &mut WasmInstance,
+        module: &mut WasmInstanceContext,
         link: String,
         callback: &str,
         user_data: store::Value,

--- a/tests/integration-tests/big-decimal/src/mapping.ts
+++ b/tests/integration-tests/big-decimal/src/mapping.ts
@@ -1,6 +1,9 @@
 import { Trigger } from "../generated/Contract/Contract";
 import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
 
+// Test that host exports work in globals.
+let one = BigDecimal.fromString("1");
+
 export function handleTrigger(event: Trigger): void {
   // There are 35 digits after the dot.
   // big_decimal exponent will be: -35 - 6109 = -6144.
@@ -39,6 +42,5 @@ export function handleTrigger(event: Trigger): void {
   assert(big2 == rounded2, "big2 not equal to rounded2 " + big2.toString());
 
   // Test big decimal division.
-  let one = BigDecimal.fromString("1");
   assert(one / BigDecimal.fromString("10") == BigDecimal.fromString("0.1"));
 }


### PR DESCRIPTION
The first commit is the regression test, plus a pure refactor which renames `WasmInstanceHandle` -> `WasmInstance`, and pulls the `wasmtime::Instance` to it. The other rename is `WasmInstance` -> `WasmInstanceContext`. These names hopefully better reflect the purpose of each struct.

The second commit is where it gets wild. To support calling host functions in the Wasm start function so that AS can use them when initializing globals, we lazily initialize the `WasmInstanceContext` in the host export if necessary, taking from the `Caller` the memory and the memory allocation function. I needed to patch wasmtime to support that last part. But wasmtime would rather not merge that upstream and instead suggests that AS makes changes on their side, that discussion will happen here https://github.com/AssemblyScript/assemblyscript/issues/1333.

On the side, this also makes the timeout apply to the start function.