### PR TITLE
Fix regression in indexing status

### DIFF
--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -731,7 +731,7 @@ where
         &self,
         prefetched_objects: Option<q::Value>,
         field: &q::Field,
-        field_definition: &s::Field,
+        _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
@@ -741,20 +741,13 @@ where
                 self.resolve_indexing_statuses(arguments)
             }
 
-            // Resolve fields of `Object` values (e.g. the `chains` field of `ChainIndexingStatus`)
-            (Some(value), _, _) => Ok(value),
-
             // The top-level `indexingStatusesForSubgraphName` field
             (None, "SubgraphIndexingStatus", "indexingStatusesForSubgraphName") => {
                 self.resolve_indexing_statuses_for_subgraph_name(arguments)
             }
 
-            // Something we don't know how to resolve.
-            (_, _, name) => Err(QueryExecutionError::UnknownField(
-                field_definition.position.clone(),
-                "Query".into(),
-                name.into(),
-            )),
+            // Resolve fields of `Object` values (e.g. the `chains` field of `ChainIndexingStatus`)
+            (value, _, _) => Ok(value.unwrap_or(q::Value::Null)),
         }
     }
 
@@ -762,8 +755,8 @@ where
         &self,
         prefetched_object: Option<q::Value>,
         field: &q::Field,
-        field_definition: &s::Field,
-        object_type: ObjectOrInterface<'_>,
+        _field_definition: &s::Field,
+        _object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&q::Name, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         match (prefetched_object, field.name.as_str()) {
@@ -778,14 +771,7 @@ where
             }
 
             // Resolve fields of `Object` values (e.g. the `latestBlock` field of `EthereumBlock`)
-            (Some(object_value), _) => Ok(object_value),
-
-            // Something we don't know how to resolve.
-            (_, name) => Err(QueryExecutionError::UnknownField(
-                field_definition.position.clone(),
-                object_type.name().into(),
-                name.into(),
-            )),
+            (value, _) => Ok(value.unwrap_or(q::Value::Null)),
         }
     }
 }

--- a/tests/integration-tests/fatal-error/test/test.js
+++ b/tests/integration-tests/fatal-error/test/test.js
@@ -34,16 +34,24 @@ const waitForSubgraphToFailWithError = async (blockNumber) =>
                   number
                 }
               }
+
               # Test that non-fatal errors can be queried
               nonFatalErrors {
                 handler
+              }
+
+              # Test that the last healthy block can be queried
+              chains {
+                lastHealthyBlock {
+                  number
+                }
               }
             }
           }`,
         });
 
         if (result.errors != null) {
-          reject("query contains errors: " + JSON.stringify(result.errors))
+          reject("query contains errors: " + JSON.stringify(result.errors));
         }
 
         let status = result.data.indexingStatusForCurrentVersion;


### PR DESCRIPTION
This regressed in https://github.com/graphprotocol/graph-node/pull/1712. Instead of returning `null`, here we were returning `UnknownField`. Which makes no sense really, we check for unknown fields way up in the stack, before executing the field. As far as these resolvers care if they were not given the field value, then there is no value so return `Null`.