### PR TITLE
Remove "Graphql query served" log

### DIFF
--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -280,22 +280,15 @@ where
                     sd_id.deref().to_string(),
                 );
                 let elapsed = start.elapsed().as_millis();
-                match result {
-                    Ok(_) => info!(
-                        logger,
-                        "GraphQL query served";
-                        "subgraph_deployment" => sd_id.deref(),
-                        "query_time_ms" => elapsed,
-                        "code" => LogCode::GraphQlQuerySuccess,
-                    ),
-                    Err(ref e) => error!(
+                if let Err(e) = &result {
+                    error!(
                         logger,
                         "GraphQL query failed";
                         "subgraph_deployment" => sd_id.deref(),
                         "error" => e.to_string(),
                         "query_time_ms" => elapsed,
                         "code" => LogCode::GraphQlQueryFailure,
-                    ),
+                    )
                 }
                 GraphQLResponse::new(result).compat()
             })

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -126,20 +126,14 @@ where
             })
             .then(move |result| {
                 let elapsed = start.elapsed().as_millis();
-                match result {
-                    Ok(_) => info!(
-                        result_logger,
-                        "GraphQL query served";
-                        "query_time_ms" => elapsed,
-                        "code" => LogCode::GraphQlQuerySuccess,
-                    ),
-                    Err(ref e) => error!(
+                if let Err(e) = &result {
+                    error!(
                         result_logger,
                         "GraphQL query failed";
                         "error" => e.to_string(),
                         "query_time_ms" => elapsed,
                         "code" => LogCode::GraphQlQueryFailure,
-                    ),
+                    )
                 }
                 IndexNodeResponse::new(result).compat()
             })


### PR DESCRIPTION
We already have a metric for this and also the `GRAPH_LOG_QUERY_TIMING` env var which can be turned on. This log is noisy and not useful, and I could even measure a throughput increase of about 5% in fast queries by removing it.