### PR TITLE
Fix duplicated scalar fields

### DIFF
--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -566,7 +566,17 @@ fn alias() {
                     parent: Legged
                   }";
 
-    let query = "query { l: legged(id: \"child\") { ... on Animal { p: parent { i: id, t: __typename } } } }";
+    let query = "query {
+                    l: legged(id: \"child\") {
+                        ... on Animal {
+                            p: parent {
+                                i: id,
+                                t: __typename,
+                                __typename
+                            }
+                        }
+                    }
+            }";
 
     let parent = (
         Entity::from(vec![
@@ -594,7 +604,8 @@ fn alias() {
             l: object! {
                 p: object! {
                     i: "parent",
-                    t: "Animal"
+                    t: "Animal",
+                    __typename: "Animal"
                 }
             }
         }


### PR DESCRIPTION
This was a regression in the optimization to not clone all fields before resolving them. The problematic case is when the same scalar field redundantly appears in multiple response keys, in which we really have to clone the field. But we don't want to reverse the optimization and go back to cloning everything, so this checks which fields are duplicated and clones only those.