### PR TITLE
Reduce cloning in graphql execution

### DIFF
--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -557,11 +557,7 @@ impl DerefMut for Entity {
 
 impl From<Entity> for BTreeMap<String, query::Value> {
     fn from(entity: Entity) -> BTreeMap<String, query::Value> {
-        let mut fields = BTreeMap::new();
-        for (attr, value) in entity.0.into_iter() {
-            fields.insert(attr, value.into());
-        }
-        fields
+        entity.0.into_iter().map(|(k, v)| (k, v.into())).collect()
     }
 }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -364,7 +364,7 @@ impl fmt::Display for Value {
 impl From<Value> for query::Value {
     fn from(value: Value) -> Self {
         match value {
-            Value::String(s) => query::Value::String(s.to_string()),
+            Value::String(s) => query::Value::String(s),
             Value::Int(i) => query::Value::Int(query::Number::from(i)),
             Value::BigDecimal(d) => query::Value::String(d.to_string()),
             Value::Bool(b) => query::Value::Boolean(b),
@@ -558,8 +558,8 @@ impl DerefMut for Entity {
 impl From<Entity> for BTreeMap<String, query::Value> {
     fn from(entity: Entity) -> BTreeMap<String, query::Value> {
         let mut fields = BTreeMap::new();
-        for (attr, value) in entity.iter() {
-            fields.insert(attr.to_string(), value.clone().into());
+        for (attr, value) in entity.0.into_iter() {
+            fields.insert(attr, value.into());
         }
         fields
     }

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -202,11 +202,7 @@ where
                     derived_from_field.name.to_owned(),
                 ));
             } else {
-                return Ok(children
-                    .into_iter()
-                    .next()
-                    .map(|value| value.clone())
-                    .unwrap_or(q::Value::Null));
+                return Ok(children.into_iter().next().unwrap_or(q::Value::Null));
             }
         } else {
             return Err(QueryExecutionError::ResolveEntitiesError(format!(


### PR DESCRIPTION
The first commit removes `merge_selection_sets`, because it does an expensive clone in `extend_from_slice`. This procedure turns out to not be necessary if we make `collect_fields` directly handle a sequence of selection sets, merging them into the collected fields. Read with whitespace diff disabled.

The second commit removes some completely unecessary clones, found by running `cargo flamegraph`.

There are other ideas such as caching the `collect_fields` procedure, but as far as easy optimizations go these were all I could identify.