### PR TITLE
Use `execute_root_selection_set` for subscriptions

### DIFF
--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,7 +1,7 @@
 use graph::prelude::{info, o, Logger, QueryExecutionError};
 use graphql_parser::query as q;
 use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 use std::time::Instant;
 use uuid::Uuid;
 
@@ -54,6 +54,7 @@ where
         query: query.clone(),
         deadline: options.deadline,
         max_first: options.max_first,
+        cached: AtomicBool::new(false),
     };
 
     if !query.is_query() {
@@ -79,6 +80,7 @@ where
             "query" => &query.query_text,
             "variables" => &query.variables_text,
             "query_time_ms" => start.elapsed().as_millis(),
+            "cached" => ctx.cached.load(std::sync::atomic::Ordering::SeqCst),
         );
     }
     result

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -2,7 +2,7 @@ use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 use std::iter;
 use std::result::Result;
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 use std::time::{Duration, Instant};
 
 use graph::prelude::*;
@@ -82,6 +82,7 @@ where
         query: query.clone(),
         deadline: None,
         max_first: options.max_first,
+        cached: AtomicBool::new(false),
     };
 
     if !query.is_subscription() {
@@ -197,6 +198,7 @@ async fn execute_subscription_event(
         query,
         deadline: timeout.map(|t| Instant::now() + t),
         max_first,
+        cached: AtomicBool::new(false),
     };
 
     // We have established that this exists earlier in the subscription execution


### PR DESCRIPTION
This makes prefetching and the cache use the same code path for regular queries and subscriptions.