### PR TITLE
Optimize queries for single-object lookups

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -244,7 +244,7 @@ pub const BLOCK_NUMBER_MAX: BlockNumber = std::i32::MAX;
 /// A query for entities in a store.
 ///
 /// Details of how query generation for `EntityQuery` works can be found
-/// in `docs/implementation/query-prefetching.md`
+/// at https://github.com/graphprotocol/rfcs/blob/master/engineering-plans/0001-graphql-query-prefetching.md
 #[derive(Clone, Debug)]
 pub struct EntityQuery {
     /// ID of the subgraph.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -186,13 +186,21 @@ pub enum ParentLink {
     Scalar(Vec<String>),
 }
 
+/// How many children a parent can have when the child stores
+/// the id of the parent
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ChildMultiplicity {
+    Single,
+    Many,
+}
+
 /// How to select children for their parents depending on whether the
 /// child stores parent ids (`Direct`) or the parent
 /// stores child ids (`Parent`)
 #[derive(Clone, Debug, PartialEq)]
 pub enum EntityLink {
     /// The parent id is stored in this child attribute
-    Direct(WindowAttribute),
+    Direct(WindowAttribute, ChildMultiplicity),
     /// Join with the parents table to get at the parent id
     Parent(ParentLink),
 }
@@ -328,7 +336,7 @@ impl EntityQuery {
                 let window = windows.first().expect("we just checked");
                 if window.ids.len() == 1 {
                     let id = window.ids.first().expect("we just checked");
-                    if let EntityLink::Direct(attribute) = &window.link {
+                    if let EntityLink::Direct(attribute, _) = &window.link {
                         let filter = match attribute {
                             WindowAttribute::Scalar(name) => {
                                 EntityFilter::Equal(name.to_owned(), id.into())

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -98,8 +98,8 @@ pub mod prelude {
     pub use crate::components::server::query::GraphQLServer;
     pub use crate::components::server::subscription::SubscriptionServer;
     pub use crate::components::store::{
-        AttributeIndexDefinition, BlockNumber, ChainStore, EntityCache, EntityChange,
-        EntityChangeOperation, EntityCollection, EntityFilter, EntityKey, EntityLink,
+        AttributeIndexDefinition, BlockNumber, ChainStore, ChildMultiplicity, EntityCache,
+        EntityChange, EntityChangeOperation, EntityCollection, EntityFilter, EntityKey, EntityLink,
         EntityModification, EntityOperation, EntityOrder, EntityQuery, EntityRange, EntityWindow,
         EthereumCallCache, MetadataOperation, ParentLink, Store, StoreError, StoreEvent,
         StoreEventStream, StoreEventStreamBox, SubgraphDeploymentStore, TransactionAbortError,

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -832,23 +832,12 @@ fn fetch<S: Store>(
     store: &S,
     parents: &Vec<Node>,
     join: &Join<'_>,
-    mut arguments: HashMap<&q::Name, q::Value>,
+    arguments: HashMap<&q::Name, q::Value>,
     multiplicity: ChildMultiplicity,
     types_for_interface: &BTreeMap<s::Name, Vec<s::ObjectType>>,
     block: BlockNumber,
     max_first: u32,
 ) -> Result<Vec<Node>, QueryExecutionError> {
-    if multiplicity == ChildMultiplicity::Single {
-        // For non-list fields, get up to 2 entries so we can spot
-        // ambiguous references that should only have one entry
-        arguments.insert(&*ARG_FIRST, q::Value::Int(2.into()));
-    }
-
-    if !arguments.contains_key(&*ARG_SKIP) {
-        // Use the default in build_range
-        arguments.insert(&*ARG_SKIP, q::Value::Null);
-    }
-
     let mut query = build_query(
         join.child_type,
         block,

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -66,7 +66,7 @@ fn build_range(
                 Err("first")
             }
         }
-        Some(q::Value::Null) => Ok(100),
+        Some(q::Value::Null) | None => Ok(100),
         _ => unreachable!("first is an Int with a default value"),
     };
 
@@ -79,7 +79,7 @@ fn build_range(
                 Err("skip")
             }
         }
-        Some(q::Value::Null) => Ok(0),
+        Some(q::Value::Null) | None => Ok(0),
         _ => unreachable!("skip is an Int with a default value"),
     };
 

--- a/store/postgres/src/jsonb_queries.rs
+++ b/store/postgres/src/jsonb_queries.rs
@@ -216,7 +216,7 @@ impl<'a> FilterQuery<'a> {
 
     fn expand_parents(&self, window: &EntityWindow, out: &mut AstPass<Pg>) -> QueryResult<()> {
         match &window.link {
-            EntityLink::Direct(_) => {
+            EntityLink::Direct(_, _) => {
                 // Type A and B
                 // unnest($parent_ids) as p(id)
                 out.push_sql("unnest(");
@@ -247,7 +247,7 @@ impl<'a> FilterQuery<'a> {
 
     fn linked_children(&self, window: &EntityWindow, out: &mut AstPass<Pg>) -> QueryResult<()> {
         match &window.link {
-            EntityLink::Direct(WindowAttribute::List(name)) => {
+            EntityLink::Direct(WindowAttribute::List(name), _) => {
                 // Type A
                 // The `in (..)` part turns the id's stored in `name` into
                 // a list of parent ids
@@ -255,7 +255,7 @@ impl<'a> FilterQuery<'a> {
                 out.push_bind_param::<Text, _>(name)?;
                 out.push_sql("->'data') ary)");
             }
-            EntityLink::Direct(WindowAttribute::Scalar(name)) => {
+            EntityLink::Direct(WindowAttribute::Scalar(name), _) => {
                 // Type B
                 // p.id = c.data->{name}->>'data'
                 out.push_sql("p.id = c.data->");

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1368,7 +1368,7 @@ enum TableLink<'a> {
 impl<'a> TableLink<'a> {
     fn new(child_table: &'a Table, link: EntityLink) -> Result<Self, QueryExecutionError> {
         match link {
-            EntityLink::Direct(attribute) => {
+            EntityLink::Direct(attribute, _) => {
                 let column = child_table.column_for_field(attribute.name())?;
                 Ok(TableLink::Direct(column))
             }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1410,9 +1410,15 @@ impl<'a> ParentLimit<'a> {
     /// Include a 'limit {num_parents}+1' clause for single-object queries
     /// if that is needed
     fn single_limit(&self, num_parents: usize, out: &mut AstPass<Pg>) {
-        if let ParentLimit::Ranked(_, _) = self {
-            out.push_sql(" limit ");
-            out.push_sql(&(num_parents + 1).to_string());
+        match self {
+            ParentLimit::Ranked(_, _) => {
+                out.push_sql(" limit ");
+                out.push_sql(&(num_parents + 1).to_string());
+            }
+            ParentLimit::Outer => {
+                // limiting is taken care of in a wrapper around
+                // the query we are currently building
+            }
         }
     }
 }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1406,6 +1406,15 @@ impl<'a> ParentLimit<'a> {
         }
         Ok(())
     }
+
+    /// Include a 'limit {num_parents}+1' clause for single-object queries
+    /// if that is needed
+    fn single_limit(&self, num_parents: usize, out: &mut AstPass<Pg>) {
+        if let ParentLimit::Ranked(_, _) = self {
+            out.push_sql(" limit ");
+            out.push_sql(&(num_parents + 1).to_string());
+        }
+    }
 }
 
 /// This is the parallel to `EntityWindow`, with names translated to

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -10,9 +10,9 @@ use std::fmt::Debug;
 
 use graph::data::store::scalar::{BigDecimal, BigInt};
 use graph::prelude::{
-    web3::types::H256, Entity, EntityCollection, EntityKey, EntityLink, EntityOrder, EntityRange,
-    EntityWindow, Future01CompatExt, ParentLink, Schema, SubgraphDeploymentId, Value,
-    WindowAttribute, BLOCK_NUMBER_MAX,
+    web3::types::H256, ChildMultiplicity, Entity, EntityCollection, EntityKey, EntityLink,
+    EntityOrder, EntityRange, EntityWindow, Future01CompatExt, ParentLink, Schema,
+    SubgraphDeploymentId, Value, WindowAttribute, BLOCK_NUMBER_MAX,
 };
 use graph_store_postgres::layout_for_tests::Layout;
 
@@ -390,7 +390,10 @@ fn query() {
         let coll = EntityCollection::Window(vec![EntityWindow {
             child_type: "Thing".to_owned(),
             ids: vec![CHILD1.to_owned()],
-            link: EntityLink::Direct(WindowAttribute::List("children".to_string())),
+            link: EntityLink::Direct(
+                WindowAttribute::List("children".to_string()),
+                ChildMultiplicity::Many,
+            ),
         }]);
         let things = fetch(conn, layout, coll);
         assert_eq!(vec![ROOT], things);
@@ -400,7 +403,10 @@ fn query() {
         let coll = EntityCollection::Window(vec![EntityWindow {
             child_type: "Thing".to_owned(),
             ids: vec![ROOT.to_owned()],
-            link: EntityLink::Direct(WindowAttribute::Scalar("parent".to_string())),
+            link: EntityLink::Direct(
+                WindowAttribute::Scalar("parent".to_string()),
+                ChildMultiplicity::Single,
+            ),
         }]);
         let things = fetch(conn, layout, coll);
         assert_eq!(vec![CHILD1, CHILD2], things);

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -2011,7 +2011,7 @@ impl WindowQuery {
             .into_iter()
             .map(|child_type| {
                 let attribute = WindowAttribute::Scalar("favorite_color".to_owned());
-                let link = EntityLink::Direct(attribute);
+                let link = EntityLink::Direct(attribute, ChildMultiplicity::Many);
                 let ids = vec!["red", "green", "yellow", "blue"]
                     .into_iter()
                     .map(String::from)


### PR DESCRIPTION
When we query for children where we know that each parent can have at most one child, it is possible to simplify queries considerably. With this PR, we pass the necessary information to know whether we expect one or many children per parent into the store, and use it to generate better queries.

The background on why these queries look the way they do can be found in [the RFC](https://graphprotocol.github.io/rfcs/engineering-plans/0001-graphql-query-prefetching.html)