### PR TITLE
Prefetch directly as `q::Value` instead of `Entity`s

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -826,6 +826,11 @@ pub trait Store: Send + Sync + 'static {
     /// Queries the store for entities that match the store query.
     fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError>;
 
+    fn find_query_values(
+        &self,
+        query: EntityQuery,
+    ) -> Result<Vec<BTreeMap<String, graphql_parser::query::Value>>, QueryExecutionError>;
+
     /// Queries the store for a single entity matching the store query.
     fn find_one(&self, query: EntityQuery) -> Result<Option<Entity>, QueryExecutionError>;
 
@@ -1247,6 +1252,13 @@ impl Store for MockStore {
     }
 
     fn find(&self, _query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
+        unimplemented!()
+    }
+
+    fn find_query_values(
+        &self,
+        _: EntityQuery,
+    ) -> Result<Vec<BTreeMap<String, graphql_parser::query::Value>>, QueryExecutionError> {
         unimplemented!()
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -96,6 +96,13 @@ impl Store for MockStore {
         unimplemented!()
     }
 
+    fn find_query_values(
+        &self,
+        _: EntityQuery,
+    ) -> Result<Vec<BTreeMap<String, graphql_parser::query::Value>>, QueryExecutionError> {
+        unimplemented!()
+    }
+
     fn find_one(&self, _query: EntityQuery) -> Result<Option<Entity>, QueryExecutionError> {
         unimplemented!()
     }

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -564,7 +564,7 @@ impl Layout {
     }
 
     /// order is a tuple (attribute, value_type, direction)
-    pub fn query(
+    pub fn query<T: crate::relational_queries::FromEntityData>(
         &self,
         logger: &Logger,
         conn: &PgConnection,
@@ -573,7 +573,7 @@ impl Layout {
         order: EntityOrder,
         range: EntityRange,
         block: BlockNumber,
-    ) -> Result<Vec<Entity>, QueryExecutionError> {
+    ) -> Result<Vec<T>, QueryExecutionError> {
         fn log_query_timing(
             logger: &Logger,
             query: &FilterQuery,

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -496,7 +496,7 @@ impl Layout {
         FindQuery::new(table.as_ref(), id, block)
             .get_result::<EntityData>(conn)
             .optional()?
-            .map(|entity_data| entity_data.to_entity(self))
+            .map(|entity_data| entity_data.deserialize_with_layout(self))
             .transpose()
     }
 
@@ -521,7 +521,7 @@ impl Layout {
             entities_for_type
                 .entry(data.entity_type())
                 .or_default()
-                .push(data.to_entity(self)?);
+                .push(data.deserialize_with_layout(self)?);
         }
         Ok(entities_for_type)
     }
@@ -619,7 +619,11 @@ impl Layout {
         log_query_timing(logger, &query_clone, start.elapsed(), values.len());
         values
             .into_iter()
-            .map(|entity_data| entity_data.to_entity(self).map_err(|e| e.into()))
+            .map(|entity_data| {
+                entity_data
+                    .deserialize_with_layout(self)
+                    .map_err(|e| e.into())
+            })
             .collect()
     }
 

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -171,7 +171,7 @@ impl ForeignKeyClauses for Column {
     }
 }
 
-pub trait FromEntityData: Default {
+pub trait FromEntityData: Default + From<Entity> {
     type Value: FromColumnValue;
 
     fn insert_entity_data(&mut self, key: String, v: Self::Value);

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -538,7 +538,7 @@ fn count_scalar_entities(conn: &PgConnection, layout: &Layout) -> usize {
     ]);
     let collection = EntityCollection::All(vec!["Scalar".to_owned()]);
     layout
-        .query(
+        .query::<Entity>(
             &*LOGGER,
             &conn,
             collection,
@@ -638,7 +638,7 @@ fn test_find(expected_entity_ids: Vec<&str>, query: EntityQuery) {
 
         let unordered = matches!(query.order, EntityOrder::Unordered);
         let entities = layout
-            .query(
+            .query::<Entity>(
                 &*LOGGER,
                 conn,
                 query.collection,
@@ -1374,7 +1374,7 @@ fn text_find(expected_entity_ids: Vec<&str>, filter: EntityFilter) {
         let query = query(vec!["Ferret"]).filter(filter).asc("id");
 
         let entities = layout
-            .query(
+            .query::<Entity>(
                 &*LOGGER,
                 conn,
                 query.collection,

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -385,7 +385,7 @@ fn make_thing_tree(conn: &PgConnection, layout: &Layout) -> (Entity, Entity, Ent
 fn query() {
     fn fetch(conn: &PgConnection, layout: &Layout, coll: EntityCollection) -> Vec<String> {
         layout
-            .query(
+            .query::<Entity>(
                 &*LOGGER,
                 conn,
                 coll,


### PR DESCRIPTION
The purpose of this PR is to optimize the CPU usage of query nodes. There are no functional changes.

Currently, the conversions involved in serving a query result are:
jsonb (DB) -> json::Value (EntityData) -> Entity (prefetch) -> q::Value (graphql resolver)

After this PR it is:
jsonb (DB) -> json::Value (EntityData) -> q::Value (prefetch and graphql resolver)

Removing one round of conversion from `HashMap` to `BTreeMap`, which is heavy on allocations, and also avoids some conversions between `BigInt` and `Bytes` to string.

This make it so that the prefetch logic uses `q::Values` instead of entities, and abstracts a bit of the store so that it can serve queries as either `Vec<Entity>` or `Vec<q::Value>`. While `q::Value` has less information than `Entity`, we don't need the extra information in the query processing, and we need efficiency improvements here.

I expect this to have a large impact on the CPU usage of the query nodes, but we'll see.