### PR TITLE
Allow to run against read-only Postgres replicas

### DIFF
--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -170,7 +170,9 @@ where
         BlockStream {
             state: Mutex::new(BlockStreamState::New),
             consecutive_err_count: 0,
-            chain_head_update_stream: chain_store.chain_head_updates(),
+            chain_head_update_stream: chain_store
+                .chain_head_updates()
+                .expect("running against a readonly database"),
             ctx: BlockStreamContext {
                 subgraph_store,
                 chain_store,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -154,6 +154,7 @@ where
             .subscribe(vec![
                 SubgraphDeploymentAssignmentEntity::subgraph_entity_pair(),
             ])
+            .expect("running against a readonly database")
             .map_err(|()| format_err!("Entity change stream failed"))
             .map(|event| {
                 // We're only interested in the SubgraphDeploymentAssignment change; we

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -881,7 +881,7 @@ pub trait Store: Send + Sync + 'static {
     /// Subscribe to changes for specific subgraphs and entities.
     ///
     /// Returns a stream of store events that match the input arguments.
-    fn subscribe(&self, entities: Vec<SubgraphEntityPair>) -> StoreEventStreamBox;
+    fn subscribe(&self, entities: Vec<SubgraphEntityPair>) -> Option<StoreEventStreamBox>;
 
     fn resolve_subgraph_name_to_id(
         &self,
@@ -1304,7 +1304,7 @@ impl Store for MockStore {
         unimplemented!()
     }
 
-    fn subscribe(&self, _entities: Vec<SubgraphEntityPair>) -> StoreEventStreamBox {
+    fn subscribe(&self, _entities: Vec<SubgraphEntityPair>) -> Option<StoreEventStreamBox> {
         unimplemented!()
     }
 
@@ -1403,7 +1403,7 @@ pub trait ChainStore: Send + Sync + 'static {
     fn attempt_chain_head_update(&self, ancestor_count: u64) -> Result<Vec<H256>, Error>;
 
     /// Subscribe to chain head updates.
-    fn chain_head_updates(&self) -> ChainHeadUpdateStream;
+    fn chain_head_updates(&self) -> Option<ChainHeadUpdateStream>;
 
     /// Get the current head block pointer for this chain.
     /// Any changes to the head block pointer will be to a block with a larger block number, never

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -60,6 +60,7 @@ pub enum QueryExecutionError {
     Panic(String),
     EventStreamError,
     FulltextQueryRequiresFilter,
+    SubscriptionsDisabled,
 }
 
 impl Error for QueryExecutionError {
@@ -207,6 +208,7 @@ impl fmt::Display for QueryExecutionError {
             Panic(msg) => write!(f, "panic processing query: {}", msg),
             EventStreamError => write!(f, "error in the subscription event stream"),
             FulltextQueryRequiresFilter => write!(f, "fulltext search queries can only use EntityFilter::Equal"),
+            SubscriptionsDisabled => write!(f, "subscriptions are disabled"),
         }
     }
 }

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -234,11 +234,15 @@ where
 
         // Subscribe to the store and return the entity change stream
         let deployment_id = parse_subgraph_id(object_type)?;
-        Ok(self.store.subscribe(entities).throttle_while_syncing(
-            &self.logger,
-            self.store.clone(),
-            deployment_id,
-            *SUBSCRIPTION_THROTTLE_INTERVAL,
-        ))
+
+        match self.store.subscribe(entities) {
+            Some(stream) => Ok(stream.throttle_while_syncing(
+                &self.logger,
+                self.store.clone(),
+                deployment_id,
+                *SUBSCRIPTION_THROTTLE_INTERVAL,
+            )),
+            None => Err(QueryExecutionError::SubscriptionsDisabled),
+        }
     }
 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -36,7 +36,7 @@ mock! {
 
         fn attempt_chain_head_update(&self, ancestor_count: u64) -> Result<Vec<H256>, Error>;
 
-        fn chain_head_updates(&self) -> ChainHeadUpdateStream;
+        fn chain_head_updates(&self) -> Option<ChainHeadUpdateStream>;
 
         fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error>;
 
@@ -145,7 +145,7 @@ impl Store for MockStore {
         unimplemented!()
     }
 
-    fn subscribe(&self, _entities: Vec<SubgraphEntityPair>) -> StoreEventStreamBox {
+    fn subscribe(&self, _entities: Vec<SubgraphEntityPair>) -> Option<StoreEventStreamBox> {
         unimplemented!()
     }
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -259,6 +259,12 @@ async fn main() {
                 .value_name("URL")
                 .help("HTTP endpoint for 3box profiles"),
         )
+        .arg(
+            Arg::with_name("readonly-db")
+                .takes_value(false)
+                .long("readonly-db")
+                .help("Run against a readonly db (no subscriptions etc.)"),
+        )
         .get_matches();
 
     // Set up logger
@@ -496,16 +502,26 @@ async fn main() {
         connection_pool_registry,
     );
 
-    let chain_head_update_listener = Arc::new(PostgresChainHeadUpdateListener::new(
-        &logger,
-        stores_metrics_registry.clone(),
-        postgres_url.clone(),
-    ));
+    let readonly_db = matches.is_present("readonly-db");
 
-    let subscriptions = Arc::new(SubscriptionManager::new(
-        logger.clone(),
-        postgres_url.clone(),
-    ));
+    let chain_head_update_listener = if readonly_db {
+        None
+    } else {
+        Some(Arc::new(PostgresChainHeadUpdateListener::new(
+            &logger,
+            stores_metrics_registry.clone(),
+            postgres_url.clone(),
+        )))
+    };
+
+    let subscriptions = if readonly_db {
+        None
+    } else {
+        Some(Arc::new(SubscriptionManager::new(
+            logger.clone(),
+            postgres_url.clone(),
+        )))
+    };
 
     graph::spawn(
         futures::stream::FuturesOrdered::from_iter(stores_eth_adapters.into_iter().map(
@@ -561,11 +577,19 @@ async fn main() {
                 generic_store.clone(),
                 node_id.clone(),
             );
-            let subscription_server = GraphQLSubscriptionServer::new(
-                &logger,
-                graphql_runner.clone(),
-                generic_store.clone(),
-            );
+
+            // Disable the subscriptions server when running against a read-only
+            // database
+            if !readonly_db {
+                let subscription_server = GraphQLSubscriptionServer::new(
+                    &logger,
+                    graphql_runner.clone(),
+                    generic_store.clone(),
+                );
+
+                // Serve GraphQL subscriptions over WebSockets
+                graph::spawn(subscription_server.serve(ws_port));
+            }
 
             let mut index_node_server = IndexNodeServer::new(
                 &logger_factory,
@@ -574,177 +598,181 @@ async fn main() {
                 node_id.clone(),
             );
 
-            // Spawn Ethereum network indexers for all networks that are to be indexed
-            if let Some(network_subgraphs) = matches.values_of("network-subgraphs") {
-                network_subgraphs
-                    .into_iter()
-                    .filter(|network_subgraph| network_subgraph.starts_with("ethereum/"))
-                    .for_each(|network_subgraph| {
-                        let network_name = network_subgraph.replace("ethereum/", "");
-                        let mut indexer = network_indexer::NetworkIndexer::new(
-                            &logger,
-                            eth_adapters
-                                .get(&network_name)
-                                .expect("adapter for network")
-                                .clone(),
-                            stores
-                                .get(&network_name)
-                                .expect("store for network")
-                                .clone(),
-                            metrics_registry.clone(),
-                            format!("network/{}", network_subgraph).into(),
-                            None,
-                        );
-                        graph::spawn(
-                            indexer
-                                .take_event_stream()
-                                .unwrap()
-                                .for_each(|_| {
-                                    // For now we simply ignore these events; we may later use them
-                                    // to drive subgraph indexing
-                                    Ok(())
-                                })
-                                .compat(),
-                        );
-                    })
-            };
-
-            if !disable_block_ingestor {
-                // BlockIngestor must be configured to keep at least REORG_THRESHOLD ancestors,
-                // otherwise BlockStream will not work properly.
-                // BlockStream expects the blocks after the reorg threshold to be present in the
-                // database.
-                assert!(*ANCESTOR_COUNT >= *REORG_THRESHOLD);
-
-                info!(logger, "Starting block ingestors");
-
-                // Create Ethereum block ingestors and spawn a thread to run each
-                eth_adapters.iter().for_each(|(network_name, eth_adapter)| {
-                    info!(
-                        logger,
-                        "Starting block ingestor for network";
-                        "network_name" => &network_name
-                    );
-
-                    let block_ingestor = BlockIngestor::new(
-                        stores.get(network_name).expect("network with name").clone(),
-                        eth_adapter.clone(),
-                        *ANCESTOR_COUNT,
-                        network_name.to_string(),
-                        &logger_factory,
-                        block_polling_interval,
-                    )
-                    .expect("failed to create Ethereum block ingestor");
-
-                    // Run the Ethereum block ingestor in the background
-                    graph::spawn(block_ingestor.into_polling_stream());
-                });
-            }
-
-            let block_stream_builder = BlockStreamBuilder::new(
-                generic_store.clone(),
-                stores.clone(),
-                eth_adapters.clone(),
-                node_id.clone(),
-                *REORG_THRESHOLD,
-                metrics_registry.clone(),
-            );
-            let runtime_host_builder = WASMRuntimeHostBuilder::new(
-                eth_adapters.clone(),
-                link_resolver.clone(),
-                stores.clone(),
-                arweave_adapter,
-                three_box_adapter,
-            );
-
-            let subgraph_instance_manager = SubgraphInstanceManager::new(
-                &logger_factory,
-                stores.clone(),
-                eth_adapters.clone(),
-                runtime_host_builder,
-                block_stream_builder,
-                metrics_registry.clone(),
-                graphql_runner.cheap_clone(),
-            );
-
-            // Create IPFS-based subgraph provider
-            let mut subgraph_provider = IpfsSubgraphAssignmentProvider::new(
-                &logger_factory,
-                link_resolver.clone(),
-                generic_store.clone(),
-                graphql_runner.clone(),
-            );
-
-            // Forward subgraph events from the subgraph provider to the subgraph instance manager
-            graph::spawn(
-                forward(&mut subgraph_provider, &subgraph_instance_manager)
-                    .unwrap()
-                    .compat(),
-            );
-
-            // Check version switching mode environment variable
-            let version_switching_mode = SubgraphVersionSwitchingMode::parse(
-                env::var_os("EXPERIMENTAL_SUBGRAPH_VERSION_SWITCHING_MODE")
-                    .unwrap_or_else(|| "instant".into())
-                    .to_str()
-                    .expect("invalid version switching mode"),
-            );
-
-            // Create named subgraph provider for resolving subgraph name->ID mappings
-            let subgraph_registrar = Arc::new(IpfsSubgraphRegistrar::new(
-                &logger_factory,
-                link_resolver,
-                Arc::new(subgraph_provider),
-                generic_store.clone(),
-                stores,
-                eth_adapters.clone(),
-                node_id.clone(),
-                version_switching_mode,
-            ));
-            graph::spawn(
-                subgraph_registrar
-                    .start()
-                    .map_err(|e| panic!("failed to initialize subgraph provider {}", e))
-                    .compat(),
-            );
-
-            // Start admin JSON-RPC server.
-            let json_rpc_server = JsonRpcServer::serve(
-                json_rpc_port,
-                http_port,
-                ws_port,
-                subgraph_registrar.clone(),
-                node_id.clone(),
-                logger.clone(),
-            )
-            .expect("failed to start JSON-RPC admin server");
-
-            // Let the server run forever.
-            std::mem::forget(json_rpc_server);
-
-            // Add the CLI subgraph with a REST request to the admin server.
-            if let Some(subgraph) = subgraph {
-                let (name, hash) = if subgraph.contains(':') {
-                    let mut split = subgraph.split(':');
-                    (split.next().unwrap(), split.next().unwrap().to_owned())
-                } else {
-                    ("cli", subgraph)
+            if !readonly_db {
+                // Spawn Ethereum network indexers for all networks that are to be indexed
+                if let Some(network_subgraphs) = matches.values_of("network-subgraphs") {
+                    network_subgraphs
+                        .into_iter()
+                        .filter(|network_subgraph| network_subgraph.starts_with("ethereum/"))
+                        .for_each(|network_subgraph| {
+                            let network_name = network_subgraph.replace("ethereum/", "");
+                            let mut indexer = network_indexer::NetworkIndexer::new(
+                                &logger,
+                                eth_adapters
+                                    .get(&network_name)
+                                    .expect("adapter for network")
+                                    .clone(),
+                                stores
+                                    .get(&network_name)
+                                    .expect("store for network")
+                                    .clone(),
+                                metrics_registry.clone(),
+                                format!("network/{}", network_subgraph).into(),
+                                None,
+                            );
+                            graph::spawn(
+                                indexer
+                                    .take_event_stream()
+                                    .unwrap()
+                                    .for_each(|_| {
+                                        // For now we simply ignore these events; we may later use them
+                                        // to drive subgraph indexing
+                                        Ok(())
+                                    })
+                                    .compat(),
+                            );
+                        })
                 };
 
-                let name = SubgraphName::new(name)
-                    .expect("Subgraph name must contain only a-z, A-Z, 0-9, '-' and '_'");
-                let subgraph_id = SubgraphDeploymentId::new(hash)
-                    .expect("Subgraph hash must be a valid IPFS hash");
+                if !disable_block_ingestor {
+                    // BlockIngestor must be configured to keep at least REORG_THRESHOLD ancestors,
+                    // otherwise BlockStream will not work properly.
+                    // BlockStream expects the blocks after the reorg threshold to be present in the
+                    // database.
+                    assert!(*ANCESTOR_COUNT >= *REORG_THRESHOLD);
 
-                graph::spawn(
-                    async move {
-                        subgraph_registrar.create_subgraph(name.clone()).await?;
-                        subgraph_registrar
-                            .create_subgraph_version(name, subgraph_id, node_id)
-                            .await
-                    }
-                    .map_err(|e| panic!("Failed to deploy subgraph from `--subgraph` flag: {}", e)),
+                    info!(logger, "Starting block ingestors");
+
+                    // Create Ethereum block ingestors and spawn a thread to run each
+                    eth_adapters.iter().for_each(|(network_name, eth_adapter)| {
+                        info!(
+                            logger,
+                            "Starting block ingestor for network";
+                            "network_name" => &network_name
+                        );
+
+                        let block_ingestor = BlockIngestor::new(
+                            stores.get(network_name).expect("network with name").clone(),
+                            eth_adapter.clone(),
+                            *ANCESTOR_COUNT,
+                            network_name.to_string(),
+                            &logger_factory,
+                            block_polling_interval,
+                        )
+                        .expect("failed to create Ethereum block ingestor");
+
+                        // Run the Ethereum block ingestor in the background
+                        graph::spawn(block_ingestor.into_polling_stream());
+                    });
+                }
+
+                let block_stream_builder = BlockStreamBuilder::new(
+                    generic_store.clone(),
+                    stores.clone(),
+                    eth_adapters.clone(),
+                    node_id.clone(),
+                    *REORG_THRESHOLD,
+                    metrics_registry.clone(),
                 );
+                let runtime_host_builder = WASMRuntimeHostBuilder::new(
+                    eth_adapters.clone(),
+                    link_resolver.clone(),
+                    stores.clone(),
+                    arweave_adapter,
+                    three_box_adapter,
+                );
+
+                let subgraph_instance_manager = SubgraphInstanceManager::new(
+                    &logger_factory,
+                    stores.clone(),
+                    eth_adapters.clone(),
+                    runtime_host_builder,
+                    block_stream_builder,
+                    metrics_registry.clone(),
+                    graphql_runner.cheap_clone(),
+                );
+
+                // Create IPFS-based subgraph provider
+                let mut subgraph_provider = IpfsSubgraphAssignmentProvider::new(
+                    &logger_factory,
+                    link_resolver.clone(),
+                    generic_store.clone(),
+                    graphql_runner.clone(),
+                );
+
+                // Forward subgraph events from the subgraph provider to the subgraph instance manager
+                graph::spawn(
+                    forward(&mut subgraph_provider, &subgraph_instance_manager)
+                        .unwrap()
+                        .compat(),
+                );
+
+                // Check version switching mode environment variable
+                let version_switching_mode = SubgraphVersionSwitchingMode::parse(
+                    env::var_os("EXPERIMENTAL_SUBGRAPH_VERSION_SWITCHING_MODE")
+                        .unwrap_or_else(|| "instant".into())
+                        .to_str()
+                        .expect("invalid version switching mode"),
+                );
+
+                // Create named subgraph provider for resolving subgraph name->ID mappings
+                let subgraph_registrar = Arc::new(IpfsSubgraphRegistrar::new(
+                    &logger_factory,
+                    link_resolver,
+                    Arc::new(subgraph_provider),
+                    generic_store.clone(),
+                    stores,
+                    eth_adapters.clone(),
+                    node_id.clone(),
+                    version_switching_mode,
+                ));
+                graph::spawn(
+                    subgraph_registrar
+                        .start()
+                        .map_err(|e| panic!("failed to initialize subgraph provider {}", e))
+                        .compat(),
+                );
+
+                // Start admin JSON-RPC server.
+                let json_rpc_server = JsonRpcServer::serve(
+                    json_rpc_port,
+                    http_port,
+                    ws_port,
+                    subgraph_registrar.clone(),
+                    node_id.clone(),
+                    logger.clone(),
+                )
+                .expect("failed to start JSON-RPC admin server");
+
+                // Let the server run forever.
+                std::mem::forget(json_rpc_server);
+
+                // Add the CLI subgraph with a REST request to the admin server.
+                if let Some(subgraph) = subgraph {
+                    let (name, hash) = if subgraph.contains(':') {
+                        let mut split = subgraph.split(':');
+                        (split.next().unwrap(), split.next().unwrap().to_owned())
+                    } else {
+                        ("cli", subgraph)
+                    };
+
+                    let name = SubgraphName::new(name)
+                        .expect("Subgraph name must contain only a-z, A-Z, 0-9, '-' and '_'");
+                    let subgraph_id = SubgraphDeploymentId::new(hash)
+                        .expect("Subgraph hash must be a valid IPFS hash");
+
+                    graph::spawn(
+                        async move {
+                            subgraph_registrar.create_subgraph(name.clone()).await?;
+                            subgraph_registrar
+                                .create_subgraph_version(name, subgraph_id, node_id)
+                                .await
+                        }
+                        .map_err(|e| {
+                            panic!("Failed to deploy subgraph from `--subgraph` flag: {}", e)
+                        }),
+                    );
+                }
             }
 
             // Serve GraphQL queries over HTTP
@@ -754,9 +782,6 @@ async fn main() {
                     .expect("Failed to start GraphQL query server")
                     .compat(),
             );
-
-            // Serve GraphQL subscriptions over WebSockets
-            graph::spawn(subscription_server.serve(ws_port));
 
             // Run the index node server
             graph::spawn(

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -156,9 +156,9 @@ struct SubgraphInfo {
 
 pub struct StoreInner {
     logger: Logger,
-    subscriptions: Arc<SubscriptionManager>,
+    subscriptions: Option<Arc<SubscriptionManager>>,
 
-    chain_head_update_listener: Arc<ChainHeadUpdateListener>,
+    chain_head_update_listener: Option<Arc<ChainHeadUpdateListener>>,
     network_name: String,
     genesis_block_ptr: EthereumBlockPointer,
     conn: Pool<ConnectionManager<PgConnection>>,
@@ -192,8 +192,8 @@ impl Store {
         config: StoreConfig,
         logger: &Logger,
         net_identifiers: EthereumNetworkIdentifier,
-        chain_head_update_listener: Arc<ChainHeadUpdateListener>,
-        subscriptions: Arc<SubscriptionManager>,
+        chain_head_update_listener: Option<Arc<ChainHeadUpdateListener>>,
+        subscriptions: Option<Arc<SubscriptionManager>>,
         pool: Pool<ConnectionManager<PgConnection>>,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
@@ -1204,8 +1204,10 @@ impl StoreTrait for Store {
         })
     }
 
-    fn subscribe(&self, entities: Vec<SubgraphEntityPair>) -> StoreEventStreamBox {
-        self.subscriptions.subscribe(entities)
+    fn subscribe(&self, entities: Vec<SubgraphEntityPair>) -> Option<StoreEventStreamBox> {
+        self.subscriptions
+            .as_ref()
+            .map(|subs| subs.subscribe(entities))
     }
 
     fn create_subgraph_deployment(
@@ -1427,9 +1429,10 @@ impl ChainStore for Store {
         .and_then(|r| r.map_err(Error::from))
     }
 
-    fn chain_head_updates(&self) -> ChainHeadUpdateStream {
+    fn chain_head_updates(&self) -> Option<ChainHeadUpdateStream> {
         self.chain_head_update_listener
-            .subscribe(self.0.network_name.to_owned())
+            .as_ref()
+            .map(|listener| listener.subscribe(self.0.network_name.to_owned()))
     }
 
     fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error> {

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1166,6 +1166,7 @@ fn subscribe_and_consume(
         .expect("Failed to apply marker operation");
 
     let source = subscription
+        .expect("read-only db?")
         .skip_while(move |event| {
             // Skip events until we see the fake event we generated above
             future::ok(

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -72,8 +72,8 @@ lazy_static! {
                     },
                     &logger,
                     net_identifiers,
-                    chain_head_update_listener,
-                    subscriptions,
+                    Some(chain_head_update_listener),
+                    Some(subscriptions),
                     postgres_conn_pool,
                     registry.clone(),
                 ))


### PR DESCRIPTION
This is useful when running a Graph Node against a Postgres read replica.

It disables:
- Chain head listeners.
- All indexing functionality.
- The JSON-RPC admin server.
- The GraphQL subscription server (which currently relies on Postgres `LISTEN`/`NOTIFY`, which doesn't work with replicas).