### PR TITLE
Better query cache

### DIFF
--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -115,11 +115,12 @@ where
         let mut values = BTreeMap::new();
         let mut errors = Vec::new();
         for (bc, selection_set) in query.block_constraint()? {
-            let (resolver, _block_ptr) =
+            let (resolver, block_ptr) =
                 StoreResolver::at_block(&self.logger, self.store.clone(), bc, &query.schema.id)?;
             match execute_query(
                 query.clone(),
                 Some(&selection_set),
+                Some(block_ptr),
                 QueryExecutionOptions {
                     logger: self.logger.clone(),
                     resolver,

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -210,7 +210,7 @@ async fn execute_subscription_event(
     // once, from flooding the blocking thread pool and the DB connection pool.
     let _permit = SUBSCRIPTION_QUERY_SEMAPHORE.acquire();
     let result = graph::spawn_blocking_allow_panic(async move {
-        execute_root_selection_set(&ctx, &ctx.query.selection_set, &subscription_type)
+        execute_root_selection_set(&ctx, &ctx.query.selection_set, &subscription_type, None)
     })
     .await
     .map_err(|e| vec![QueryExecutionError::Panic(e.to_string())])

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -560,8 +560,8 @@ fn introspection_query(schema: Schema, query: &str) -> QueryResult {
         max_first: std::u32::MAX,
     };
 
-    let result =
-        PreparedQuery::new(query, None, 100).and_then(|query| execute_query(query, None, options));
+    let result = PreparedQuery::new(query, None, 100)
+        .and_then(|query| execute_query(query, None, None, options));
     QueryResult::from(result)
 }
 

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -119,7 +119,7 @@ where
                         max_first: std::u32::MAX,
                     };
                     let result = PreparedQuery::new(query, None, 100)
-                        .and_then(|query| execute_query(query, None, options));
+                        .and_then(|query| execute_query(query, None, None, options));
 
                     futures03::future::ok(QueryResult::from(result))
                 })

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -396,6 +396,7 @@ fn execute_subgraph_query_internal(
         match execute_query(
             query.clone(),
             Some(&selection_set),
+            None,
             QueryExecutionOptions {
                 logger,
                 resolver,


### PR DESCRIPTION
The current one may serve stale data, since the expiry is time-based, and also has a bug where it wasn't evicting entries, and even if that was fixed the eviction would be slow because the used library did a linear scan to evict entries.

This revamps the query cache so that entries are cached by block pointer. It is designed with the assumption that most queries are for the latest block, so historical queries are not cached. This is implemented with a ring buffer of caches per block, the buffer has a configurable length corresponding to the amount of recent blocks we wish to keep cached. I suggest we start with length 1 when trying it in a production setting.

Because of the way the code is structured right now, subscriptions are no longer cached.

Adds a config option to turn on the cache globally, for all subgraphs.