### PR TITLE
Add a facility to not query certain queries

### DIFF
--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -54,6 +54,7 @@ pub enum QueryExecutionError {
     ScalarCoercionError(Pos, String, q::Value, String),
     TooComplex(u64, u64), // (complexity, max_complexity)
     TooDeep(u8),          // max_depth
+    TooExpensive,
     UndefinedFragment(String),
     // Using slow and prefetch query resolution yield different results
     IncorrectPrefetchResult { slow: q::Value, prefetch: q::Value },
@@ -209,6 +210,7 @@ impl fmt::Display for QueryExecutionError {
             EventStreamError => write!(f, "error in the subscription event stream"),
             FulltextQueryRequiresFilter => write!(f, "fulltext search queries can only use EntityFilter::Equal"),
             SubscriptionsDisabled => write!(f, "subscriptions are disabled"),
+            TooExpensive => write!(f, "query is too expensive")
         }
     }
 }

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -14,6 +14,9 @@ pub mod ast;
 /// Extension traits
 pub mod ext;
 
+/// Hashing the 'shape' of a query
+pub mod shape_hash;
+
 /// Options available for query execution.
 pub struct QueryExecutionOptions<R>
 where

--- a/graphql/src/query/shape_hash.rs
+++ b/graphql/src/query/shape_hash.rs
@@ -1,0 +1,172 @@
+//! Calculate a hash for a GraphQL query that reflects the shape of
+//! the query. The shape hash will be the same for two instancs of a query
+//! that are deemed identical except for unimportant details. Those details
+//! are any values used with filters, and any differences in the query
+//! name or response keys
+
+use graphql_parser::query as q;
+use graphql_parser::schema as s;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+type ShapeHasher = DefaultHasher;
+
+pub trait ShapeHash {
+    fn shape_hash(&self, hasher: &mut ShapeHasher);
+}
+
+pub fn shape_hash(query: &q::Document) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    query.shape_hash(&mut hasher);
+    hasher.finish()
+}
+
+// In all ShapeHash implementations, we never include anything to do with
+// the position of the element in the query, i.e., fields that involve
+// `Pos`
+
+impl ShapeHash for q::Document {
+    fn shape_hash(&self, hasher: &mut ShapeHasher) {
+        for defn in &self.definitions {
+            use q::Definition::*;
+            match defn {
+                Operation(op) => op.shape_hash(hasher),
+                Fragment(frag) => frag.shape_hash(hasher),
+            }
+        }
+    }
+}
+
+impl ShapeHash for q::OperationDefinition {
+    fn shape_hash(&self, hasher: &mut ShapeHasher) {
+        use q::OperationDefinition::*;
+        // We want `[query|subscription|mutation] things { BODY }` to hash
+        // to the same thing as just `things { BODY }`
+        match self {
+            SelectionSet(set) => set.shape_hash(hasher),
+            Query(query) => query.selection_set.shape_hash(hasher),
+            Mutation(mutation) => mutation.selection_set.shape_hash(hasher),
+            Subscription(subscription) => subscription.selection_set.shape_hash(hasher),
+        }
+    }
+}
+
+impl ShapeHash for q::FragmentDefinition {
+    fn shape_hash(&self, hasher: &mut ShapeHasher) {
+        // Omit directives
+        self.name.hash(hasher);
+        self.type_condition.shape_hash(hasher);
+        self.selection_set.shape_hash(hasher);
+    }
+}
+
+impl ShapeHash for q::SelectionSet {
+    fn shape_hash(&self, hasher: &mut ShapeHasher) {
+        for item in &self.items {
+            item.shape_hash(hasher);
+        }
+    }
+}
+
+impl ShapeHash for q::Selection {
+    fn shape_hash(&self, hasher: &mut ShapeHasher) {
+        use q::Selection::*;
+        match self {
+            Field(field) => field.shape_hash(hasher),
+            FragmentSpread(spread) => spread.shape_hash(hasher),
+            InlineFragment(frag) => frag.shape_hash(hasher),
+        }
+    }
+}
+
+impl ShapeHash for q::Field {
+    fn shape_hash(&self, hasher: &mut ShapeHasher) {
+        // Omit alias, directives
+        self.name.hash(hasher);
+        self.selection_set.shape_hash(hasher);
+        for (name, value) in &self.arguments {
+            name.hash(hasher);
+            value.shape_hash(hasher);
+        }
+    }
+}
+
+impl ShapeHash for s::Value {
+    fn shape_hash(&self, hasher: &mut ShapeHasher) {
+        use s::Value::*;
+
+        match self {
+            Variable(_) | Int(_) | Float(_) | String(_) | Boolean(_) | Null | Enum(_) => {
+                /* ignore */
+            }
+            List(values) => {
+                for value in values {
+                    value.shape_hash(hasher);
+                }
+            }
+            Object(map) => {
+                for (name, value) in map {
+                    name.hash(hasher);
+                    value.shape_hash(hasher);
+                }
+            }
+        }
+    }
+}
+
+impl ShapeHash for q::FragmentSpread {
+    fn shape_hash(&self, hasher: &mut ShapeHasher) {
+        // Omit directives
+        self.fragment_name.hash(hasher)
+    }
+}
+
+impl ShapeHash for q::InlineFragment {
+    fn shape_hash(&self, hasher: &mut ShapeHasher) {
+        // Omit directives
+        self.type_condition.shape_hash(hasher);
+        self.selection_set.shape_hash(hasher);
+    }
+}
+
+impl<T: ShapeHash> ShapeHash for Option<T> {
+    fn shape_hash(&self, hasher: &mut ShapeHasher) {
+        match self {
+            None => false.hash(hasher),
+            Some(t) => {
+                Some(true).hash(hasher);
+                t.shape_hash(hasher);
+            }
+        }
+    }
+}
+
+impl ShapeHash for q::TypeCondition {
+    fn shape_hash(&self, hasher: &mut ShapeHasher) {
+        match self {
+            q::TypeCondition::On(value) => value.hash(hasher),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use graphql_parser::parse_query;
+
+    #[test]
+    fn identical_and_different() {
+        const Q1: &str = "query things($stuff: Int) { things(where: { stuff_gt: $stuff }) { id } }";
+        const Q2: &str = "{ things(where: { stuff_gt: 42 }) { id } }";
+        const Q3: &str = "{ things(where: { stuff_lte: 42 }) { id } }";
+        const Q4: &str = "{ things(where: { stuff_gt: 42 }) { id name } }";
+        let q1 = parse_query(Q1).expect("q1 is syntactically valid");
+        let q2 = parse_query(Q2).expect("q2 is syntactically valid");
+        let q3 = parse_query(Q3).expect("q3 is syntactically valid");
+        let q4 = parse_query(Q4).expect("q4 is syntactically valid");
+
+        assert_eq!(shape_hash(&q1), shape_hash(&q2));
+        assert_ne!(shape_hash(&q1), shape_hash(&q3));
+        assert_ne!(shape_hash(&q2), shape_hash(&q4));
+    }
+}

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -230,7 +230,7 @@ fn execute_query_document_with_variables(
     query: q::Document,
     variables: Option<QueryVariables>,
 ) -> QueryResult {
-    let runner = GraphQlRunner::new(&*LOGGER, STORE.clone());
+    let runner = GraphQlRunner::new(&*LOGGER, STORE.clone(), &vec![]);
     let query = Query::new(Arc::new(api_test_schema()), query, variables);
 
     return_err!(runner.execute(query, None, None, None))


### PR DESCRIPTION
We now read a file `/etc/graph-node/expensive-queries.txt`; if the file exists, it has to contain one GraphQL query per line.

We respond to any query that has the same `ShapeHash` as one of the queries from the file with a `TooExpensive` error. Queries have the same `ShapeHash` if they are identical except that they can differ in the query name, the values for any field arguments (filters), and field aliases.
