### PR TITLE
Log the calculated complexity of each query executed 

### DIFF
--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -86,6 +86,7 @@ where
             "query_time_ms" => start.elapsed().as_millis(),
             "cached" => ctx.cached.load(std::sync::atomic::Ordering::SeqCst),
             "block" => block_ptr.map(|b| b.number).unwrap_or(0),
+            "complexity" => &query.complexity
         );
     }
     result


### PR DESCRIPTION
Adds a `complexity` field to the `Query` object and includes it in the query execution logging. 