### PR TITLE
Support read replicas

### DIFF
--- a/core/src/metrics/registry.rs
+++ b/core/src/metrics/registry.rs
@@ -202,12 +202,11 @@ impl MetricsRegistryTrait for MetricsRegistry {
         Ok(counter)
     }
 
-    fn global_counter(&self, name: String) -> Result<Counter, PrometheusError> {
+    fn global_counter(&self, name: String, help: String) -> Result<Counter, PrometheusError> {
         let maybe_counter = self.global_counters.read().unwrap().get(&name).cloned();
         if let Some(counter) = maybe_counter {
             Ok(counter.clone())
         } else {
-            let help = "global counter".to_owned();
             let counter = *self.new_counter(name.clone(), help, HashMap::new())?;
             self.global_counters
                 .write()

--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -36,6 +36,8 @@ pub trait MetricsRegistry: Send + Sync + 'static {
 
     fn global_counter(&self, name: String, help: String) -> Result<Counter, PrometheusError>;
 
+    fn global_gauge(&self, name: String, help: String) -> Result<Gauge, PrometheusError>;
+
     fn new_counter_vec(
         &self,
         name: String,

--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -34,7 +34,7 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         const_labels: HashMap<String, String>,
     ) -> Result<Box<Counter>, PrometheusError>;
 
-    fn global_counter(&self, name: String) -> Result<Counter, PrometheusError>;
+    fn global_counter(&self, name: String, help: String) -> Result<Counter, PrometheusError>;
 
     fn new_counter_vec(
         &self,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -99,8 +99,8 @@ pub mod prelude {
         AttributeIndexDefinition, BlockNumber, ChainStore, ChildMultiplicity, EntityCache,
         EntityChange, EntityChangeOperation, EntityCollection, EntityFilter, EntityKey, EntityLink,
         EntityModification, EntityOperation, EntityOrder, EntityQuery, EntityRange, EntityWindow,
-        EthereumCallCache, MetadataOperation, ParentLink, PoolWaitStats, Store, StoreError,
-        StoreEvent, StoreEventStream, StoreEventStreamBox, SubgraphDeploymentStore,
+        EthereumCallCache, MetadataOperation, ParentLink, PoolWaitStats, QueryStore, Store,
+        StoreError, StoreEvent, StoreEventStream, StoreEventStreamBox, SubgraphDeploymentStore,
         TransactionAbortError, WindowAttribute, BLOCK_NUMBER_MAX, SUBSCRIPTION_THROTTLE_INTERVAL,
     };
     pub use crate::components::subgraph::{

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -61,7 +61,7 @@ impl<'a> ObjectOrInterface<'a> {
 }
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
-pub trait Resolver: Sized + Send + Sync {
+pub trait Resolver: Send + Sync + Sized {
     const CACHEABLE: bool;
 
     /// Prepare for executing a query by prefetching as much data as possible

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -214,7 +214,7 @@ where
             query,
             SubscriptionExecutionOptions {
                 logger: self.logger.clone(),
-                resolver: StoreResolver::new(&self.logger, self.store.clone()),
+                resolver: StoreResolver::for_subscription(&self.logger, self.store.clone()),
                 timeout: GRAPHQL_QUERY_TIMEOUT.clone(),
                 max_complexity: *GRAPHQL_MAX_COMPLEXITY,
                 max_depth: *GRAPHQL_MAX_DEPTH,

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 use graph::data::graphql::ext::ObjectTypeExt;
 use graph::prelude::{
     BlockNumber, ChildMultiplicity, EntityCollection, EntityFilter, EntityLink, EntityOrder,
-    EntityWindow, Logger, ParentLink, QueryExecutionError, Schema, Store, Value as StoreValue,
+    EntityWindow, Logger, ParentLink, QueryExecutionError, QueryStore, Schema, Value as StoreValue,
     WindowAttribute,
 };
 
@@ -478,7 +478,7 @@ impl<'a> Join<'a> {
 /// multiple values for what should be a relationship to a single object in
 /// @derivedFrom fields
 pub fn run(
-    resolver: &StoreResolver<impl Store>,
+    resolver: &StoreResolver,
     ctx: &ExecutionContext<impl Resolver>,
     selection_set: &q::SelectionSet,
 ) -> Result<q::Value, Vec<QueryExecutionError>> {
@@ -496,7 +496,7 @@ pub fn run(
 
 /// Executes the root selection set of a query.
 fn execute_root_selection_set(
-    resolver: &StoreResolver<impl Store>,
+    resolver: &StoreResolver,
     ctx: &ExecutionContext<impl Resolver>,
     selection_set: &q::SelectionSet,
 ) -> Result<Vec<Node>, Vec<QueryExecutionError>> {
@@ -564,7 +564,7 @@ fn object_or_interface_by_name<'a>(
 }
 
 fn execute_selection_set<'a>(
-    resolver: &StoreResolver<impl Store>,
+    resolver: &StoreResolver,
     ctx: &'a ExecutionContext<impl Resolver>,
     mut parents: Vec<Node>,
     selection_sets: Vec<&'a q::SelectionSet>,
@@ -791,7 +791,7 @@ fn collect_fields<'a>(
 
 /// Executes a field.
 fn execute_field(
-    resolver: &StoreResolver<impl Store>,
+    resolver: &StoreResolver,
     ctx: &ExecutionContext<impl Resolver>,
     object_type: &ObjectOrInterface<'_>,
     parents: &Vec<Node>,
@@ -847,9 +847,9 @@ fn execute_field(
 /// Query child entities for `parents` from the store. The `join` indicates
 /// in which child field to look for the parent's id/join field. When
 /// `is_single` is `true`, there is at most one child per parent.
-fn fetch<S: Store>(
+fn fetch(
     logger: Logger,
-    store: &S,
+    store: &(impl QueryStore + ?Sized),
     parents: &Vec<Node>,
     join: &Join<'_>,
     arguments: HashMap<&q::Name, q::Value>,

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -761,7 +761,7 @@ fn query_complexity() {
 #[tokio::test]
 async fn query_complexity_subscriptions() {
     let logger = Logger::root(slog::Discard, o!());
-    let store_resolver = StoreResolver::new(&logger, STORE.clone());
+    let store_resolver = StoreResolver::for_subscription(&logger, STORE.clone());
 
     let query = Query::new(
         Arc::new(api_test_schema()),
@@ -785,7 +785,7 @@ async fn query_complexity_subscriptions() {
     let max_complexity = Some(1_010_100);
     let options = SubscriptionExecutionOptions {
         logger: logger.clone(),
-        resolver: store_resolver.clone(),
+        resolver: store_resolver,
         timeout: None,
         max_complexity,
         max_depth: 100,
@@ -820,6 +820,8 @@ async fn query_complexity_subscriptions() {
         None,
         None,
     );
+
+    let store_resolver = StoreResolver::for_subscription(&logger, STORE.clone());
 
     let options = SubscriptionExecutionOptions {
         logger,
@@ -1134,7 +1136,7 @@ fn cannot_filter_by_derved_relationship_fields() {
 #[tokio::test]
 async fn subscription_gets_result_even_without_events() {
     let logger = Logger::root(slog::Discard, o!());
-    let store_resolver = StoreResolver::new(&logger, STORE.clone());
+    let store_resolver = StoreResolver::for_subscription(&logger, STORE.clone());
 
     let query = Query::new(
         Arc::new(api_test_schema()),
@@ -1152,7 +1154,7 @@ async fn subscription_gets_result_even_without_events() {
 
     let options = SubscriptionExecutionOptions {
         logger: logger.clone(),
-        resolver: store_resolver.clone(),
+        resolver: store_resolver,
         timeout: None,
         max_complexity: None,
         max_depth: 100,

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -62,8 +62,8 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
         Ok(counter)
     }
 
-    fn global_counter(&self, name: String) -> Result<Counter, PrometheusError> {
-        let opts = Opts::new(name, "global_counter".to_owned());
+    fn global_counter(&self, name: String, help: String) -> Result<Counter, PrometheusError> {
+        let opts = Opts::new(name, help);
         Counter::with_opts(opts)
     }
 

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -67,6 +67,11 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
         Counter::with_opts(opts)
     }
 
+    fn global_gauge(&self, name: String, help: String) -> Result<Gauge, PrometheusError> {
+        let opts = Opts::new(name, help);
+        Gauge::with_opts(opts)
+    }
+
     fn new_counter_vec(
         &self,
         name: String,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -96,13 +96,6 @@ impl Store for MockStore {
         unimplemented!()
     }
 
-    fn find_query_values(
-        &self,
-        _: EntityQuery,
-    ) -> Result<Vec<BTreeMap<String, graphql_parser::query::Value>>, QueryExecutionError> {
-        unimplemented!()
-    }
-
     fn find_one(&self, _query: EntityQuery) -> Result<Option<Entity>, QueryExecutionError> {
         unimplemented!()
     }
@@ -180,6 +173,10 @@ impl Store for MockStore {
         _subgraph_id: &SubgraphDeploymentId,
         _block_hash: H256,
     ) -> Result<Option<BlockNumber>, StoreError> {
+        unimplemented!()
+    }
+
+    fn query_store(self: Arc<Self>, _: bool) -> Arc<dyn QueryStore + Send + Sync> {
         unimplemented!()
     }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -127,10 +127,10 @@ async fn main() {
                 .use_delimiter(true)
                 .long("postgres-secondary-hosts")
                 .value_name("URL,")
-                .env("GRAPH_PG_SECONDARY_HOSTS")
+                .env("GRAPH_POSTGRES_SECONDARY_HOSTS")
                 .help(
-                    "Comma-separated urls for read-only Postgres replicas, \
-                       which will share the load with the primary server.",
+                    "Comma-separated URLs for read-only Postgres replicas, \
+                       which will share the load with the primary server",
                 ),
         )
         .arg(

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -122,6 +122,18 @@ async fn main() {
                 .help("Location of the Postgres database used for storing entities"),
         )
         .arg(
+            Arg::with_name("postgres-secondary-hosts")
+                .multiple(true)
+                .use_delimiter(true)
+                .long("postgres-secondary-hosts")
+                .value_name("URL,")
+                .env("GRAPH_PG_SECONDARY_HOSTS")
+                .help(
+                    "Comma-separated urls for read-only Postgres replicas, \
+                       which will share the load with the primary server.",
+                ),
+        )
+        .arg(
             Arg::with_name("ethereum-rpc")
                 .takes_value(true)
                 .multiple(true)
@@ -391,6 +403,8 @@ async fn main() {
         matches.value_of("3box-api").unwrap().to_string(),
     ));
 
+    let pg_read_replicas = matches.values_of("postgres-secondary-hosts");
+
     info!(logger, "Starting up");
 
     // Parse the IPFS URL from the `--ipfs` command line argument
@@ -533,9 +547,23 @@ async fn main() {
         postgres_url.clone(),
         store_conn_pool_size,
         &logger,
-        connection_pool_registry,
+        connection_pool_registry.cheap_clone(),
         wait_stats.cheap_clone(),
     );
+
+    let read_only_conn_pools: Vec<_> = pg_read_replicas
+        .into_iter()
+        .flatten()
+        .map(|url| {
+            create_connection_pool(
+                url.to_string(),
+                store_conn_pool_size,
+                &logger,
+                connection_pool_registry.cheap_clone(),
+                wait_stats.cheap_clone(),
+            )
+        })
+        .collect();
 
     let chain_head_update_listener = Arc::new(PostgresChainHeadUpdateListener::new(
         &logger,
@@ -587,6 +615,7 @@ async fn main() {
                     chain_head_update_listener.clone(),
                     subscriptions.clone(),
                     postgres_conn_pool.clone(),
+                    read_only_conn_pools.clone(),
                     stores_metrics_registry.clone(),
                 )),
             )

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
-struct ErrorHandler(Logger, Box<Counter>);
+struct ErrorHandler(Logger, Counter);
 
 impl Debug for ErrorHandler {
     fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
@@ -99,10 +99,9 @@ pub fn create_connection_pool(
     let logger_store = logger.new(o!("component" => "Store"));
     let logger_pool = logger.new(o!("component" => "PostgresConnectionPool"));
     let error_counter = registry
-        .new_counter(
+        .global_counter(
             String::from("store_connection_error_count"),
             String::from("The number of Postgres connections errors"),
-            HashMap::new(),
         )
         .expect("failed to create `store_connection_error_count` counter");
     let error_handler = Box::new(ErrorHandler(logger_pool.clone(), error_counter));

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -4,7 +4,6 @@ use diesel::r2d2::{self, event as e, ConnectionManager, HandleEvent, Pool};
 use graph::prelude::*;
 use graph::util::security::SafeDisplay;
 
-use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
@@ -26,25 +25,23 @@ impl r2d2::HandleError<r2d2::Error> for ErrorHandler {
 
 struct EventHandler {
     logger: Logger,
-    count_gauge: Box<Gauge>,
-    wait_gauge: Box<Gauge>,
+    count_gauge: Gauge,
+    wait_gauge: Gauge,
     wait_stats: PoolWaitStats,
 }
 
 impl EventHandler {
     fn new(logger: Logger, registry: Arc<dyn MetricsRegistry>, wait_stats: PoolWaitStats) -> Self {
         let count_gauge = registry
-            .new_gauge(
+            .global_gauge(
                 String::from("store_connection_checkout_count"),
                 String::from("The number of Postgres connections currently checked out"),
-                HashMap::new(),
             )
             .expect("failed to create `store_connection_checkout_count` counter");
         let wait_gauge = registry
-            .new_gauge(
+            .global_gauge(
                 String::from("store_connection_wait_time_ms"),
                 String::from("Average connection wait time"),
-                HashMap::new(),
             )
             .expect("failed to create `store_connection_wait_time_ms` counter");
         EventHandler {

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -33,6 +33,7 @@ mod jsonb;
 mod jsonb_queries;
 mod metadata;
 mod notification_listener;
+pub mod query_store;
 pub mod relational;
 mod relational_queries;
 mod sql_value;

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -1,0 +1,48 @@
+use std::collections::BTreeMap;
+
+use crate::store::ReplicaId;
+use graph::components::store::QueryStore as QueryStoreTrait;
+use graph::prelude::{Store as _, *};
+
+pub(crate) struct QueryStore {
+    replica_id: ReplicaId,
+    store: Arc<crate::Store>,
+    for_subscription: bool,
+}
+
+impl QueryStore {
+    pub(crate) fn new(store: Arc<crate::Store>, for_subscription: bool) -> Self {
+        // Subscriptions always go to the main replica.
+        let replica_id = match for_subscription {
+            false => store.pick_replica(),
+            true => ReplicaId::Main,
+        };
+        QueryStore {
+            replica_id,
+            store,
+            for_subscription,
+        }
+    }
+}
+impl QueryStoreTrait for QueryStore {
+    fn find_query_values(
+        &self,
+        query: EntityQuery,
+    ) -> Result<Vec<BTreeMap<String, graphql_parser::query::Value>>, QueryExecutionError> {
+        let conn = self
+            .store
+            .get_entity_conn(&query.subgraph_id, self.replica_id)
+            .map_err(|e| QueryExecutionError::StoreError(e.into()))?;
+        self.store.execute_query(&conn, query)
+    }
+
+    fn subscribe(&self, entities: Vec<SubgraphEntityPair>) -> StoreEventStreamBox {
+        assert!(self.for_subscription);
+        assert_eq!(self.replica_id, ReplicaId::Main);
+        self.store.subscribe(entities)
+    }
+
+    fn is_deployment_synced(&self, id: SubgraphDeploymentId) -> Result<bool, Error> {
+        self.store.is_deployment_synced(id)
+    }
+}

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -11,12 +11,11 @@ pub(crate) struct QueryStore {
 }
 
 impl QueryStore {
-    pub(crate) fn new(store: Arc<crate::Store>, for_subscription: bool) -> Self {
-        // Subscriptions always go to the main replica.
-        let replica_id = match for_subscription {
-            false => store.pick_replica(),
-            true => ReplicaId::Main,
-        };
+    pub(crate) fn new(
+        store: Arc<crate::Store>,
+        for_subscription: bool,
+        replica_id: ReplicaId,
+    ) -> Self {
         QueryStore {
             replica_id,
             store,
@@ -24,6 +23,7 @@ impl QueryStore {
         }
     }
 }
+
 impl QueryStoreTrait for QueryStore {
     fn find_query_values(
         &self,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -709,7 +709,10 @@ impl Store {
 
         self.with_conn(move |conn, cancel_handle| {
             registry
-                .global_counter(format!("{}_get_entity_conn_secs", &subgraph))
+                .global_counter(
+                    format!("{}_get_entity_conn_secs", &subgraph),
+                    "total time spent getting an entity connection".to_string(),
+                )
                 .map_err(Into::<Error>::into)?
                 .inc_by(start.elapsed().as_secs_f64());
 
@@ -741,7 +744,10 @@ impl Store {
         let start = Instant::now();
         let conn = self.get_conn()?;
         self.registry
-            .global_counter(format!("{}_get_entity_conn_secs", subgraph))?
+            .global_counter(
+                format!("{}_get_entity_conn_secs", subgraph),
+                "total time spent getting an entity connection".to_string(),
+            )?
             .inc_by(start.elapsed().as_secs_f64());
         let storage = self.storage(&conn, subgraph)?;
         let metadata = self.storage(&conn, &*SUBGRAPHS_ID)?;

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1744,7 +1744,7 @@ fn throttle_subscription_delivers() {
             subscribe_and_consume(store.clone(), &SUBGRAPHS_ID, "SubgraphDeployment")
                 .throttle_while_syncing(
                     &*LOGGER,
-                    store.clone(),
+                    store.clone().query_store(true),
                     SUBGRAPHS_ID.clone(),
                     Duration::from_millis(500),
                 );
@@ -1752,7 +1752,7 @@ fn throttle_subscription_delivers() {
         let subscription = subscribe_and_consume(store.clone(), &TEST_SUBGRAPH_ID, USER)
             .throttle_while_syncing(
                 &*LOGGER,
-                store.clone(),
+                store.clone().query_store(true),
                 TEST_SUBGRAPH_ID.clone(),
                 Duration::from_millis(500),
             );
@@ -1803,7 +1803,7 @@ fn throttle_subscription_throttles() {
             let subscription = subscribe_and_consume(store.clone(), &TEST_SUBGRAPH_ID, USER)
                 .throttle_while_syncing(
                     &*LOGGER,
-                    store.clone(),
+                    store.clone().query_store(true),
                     TEST_SUBGRAPH_ID.clone(),
                     Duration::from_secs(30),
                 );

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -84,6 +84,7 @@ lazy_static! {
                     chain_head_update_listener,
                     subscriptions,
                     postgres_conn_pool,
+                    Vec::new(),
                     registry.clone(),
                 ))
             })


### PR DESCRIPTION
This adds a configuration to pass in a sequence of postgres urls for replicas, which is turned into a sequence of DB connections pools passed to each store. In the store, each use of a connection is either in `ConnMode::Read` or `ConnMode::Write`. Writes always use the main DB. Reads are distributed between all available DBs, including the main one.