### PR TITLE
Revert "store: Speed queries of type A up by adding a redundant clause"

### DIFF
--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1631,12 +1631,8 @@ impl<'a> FilterWindow<'a> {
         //      from unnest({parent_ids}) as p(id),
         //           children c
         //     where c.{parent_field} @> array[p.id]
-        //       and c.{parent_field} && {parent_ids}
         //       and .. other conditions on c ..
         //     limit {parent_ids.len} + 1
-        //
-        // The redundant `&&` clause helps Postgres to narrow down the
-        // rows it needs to pick from `children` to join with `p(id)`
 
         out.push_sql("\n/* child_type_a */ from unnest(");
         column.bind_ids(&self.ids, out)?;
@@ -1648,10 +1644,6 @@ impl<'a> FilterWindow<'a> {
         out.push_sql(" and c.");
         out.push_identifier(column.name.as_str())?;
         out.push_sql(" @> array[p.id]");
-        out.push_sql(" and c.");
-        out.push_identifier(column.name.as_str())?;
-        out.push_sql(" && ");
-        column.bind_ids(&self.ids, out)?;
         self.and_filter(out.reborrow())?;
         limit.single_limit(self.ids.len(), out);
         Ok(())


### PR DESCRIPTION
In production, this change actually slows queries that look up
a large number of children (500+) down tremendously; could be
because evaluating the clause 'c.{parent_field} && {parent_ids}'
becomes very slow with a large number of parent ids.

This reverts commit e566447ab312e2a86edba372331068c015d3aae9.

