### PR TITLE
Separate query cache by network

### DIFF
--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -94,7 +94,7 @@ where
             .into_iter(),
         )));
 
-        Ok(Query::new(schema, document, variables))
+        Ok(Query::new(schema, document, variables, None))
     }
 
     fn parse_data_sources(

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -33,7 +33,12 @@ fn insert_and_query(
     )?;
 
     let document = graphql_parser::parse_query(query).unwrap();
-    let query = Query::new(STORE.api_schema(&subgraph_id).unwrap(), document, None);
+    let query = Query::new(
+        STORE.api_schema(&subgraph_id).unwrap(),
+        document,
+        None,
+        STORE.network_name(&subgraph_id).unwrap(),
+    );
     Ok(execute_subgraph_query(query))
 }
 

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -111,14 +111,17 @@ pub struct Query {
     pub document: q::Document,
     pub variables: Option<QueryVariables>,
     pub shape_hash: u64,
+    pub network: Option<String>,
     _force_use_of_new: (),
 }
 
 impl Query {
+    /// The `network` is currently used only for caching purposes, so it is not mandatory.
     pub fn new(
         schema: Arc<Schema>,
         document: q::Document,
         variables: Option<QueryVariables>,
+        network: Option<String>,
     ) -> Self {
         let shape_hash = shape_hash(&document);
         Query {
@@ -126,6 +129,7 @@ impl Query {
             document,
             variables,
             shape_hash,
+            network,
             _force_use_of_new: (),
         }
     }

--- a/graph/src/data/subgraph/schema/queries.rs
+++ b/graph/src/data/subgraph/schema/queries.rs
@@ -38,6 +38,7 @@ impl<S: SubgraphDeploymentStore, Q: GraphQlRunner> LazyMetadata<S, Q> {
                 Some(QueryVariables::new(HashMap::from_iter(
                     vec![(String::from("id"), q::Value::String(self.id.to_string()))].into_iter(),
                 ))),
+                None,
             ))
             .await?;
 
@@ -72,6 +73,7 @@ impl<S: SubgraphDeploymentStore, Q: GraphQlRunner> LazyMetadata<S, Q> {
                 Some(QueryVariables::new(HashMap::from_iter(
                     vec![(String::from("id"), q::Value::String(self.id.to_string()))].into_iter(),
                 ))),
+                None,
             ))
             .await?;
 

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -38,6 +38,8 @@ pub struct Query {
     /// The ShapeHash of the original query
     pub shape_hash: u64,
 
+    pub network: Option<String>,
+
     pub(crate) fragments: HashMap<String, q::FragmentDefinition>,
     kind: Kind,
 
@@ -111,6 +113,7 @@ impl Query {
             selection_set,
             shape_hash: query.shape_hash,
             kind,
+            network: query.network,
             query_text,
             variables_text,
             complexity: 0,
@@ -165,6 +168,7 @@ impl Query {
             selection_set: self.selection_set.clone(),
             shape_hash: self.shape_hash,
             kind: self.kind,
+            network: self.network.clone(),
             query_text: self.query_text.clone(),
             variables_text: self.variables_text.clone(),
             complexity: self.complexity,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -553,6 +553,7 @@ fn introspection_query(schema: Schema, query: &str) -> QueryResult {
         Arc::new(schema),
         graphql_parser::parse_query(query).unwrap(),
         None,
+        None,
     );
 
     // Execute it

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -231,7 +231,7 @@ fn execute_query_document_with_variables(
     variables: Option<QueryVariables>,
 ) -> QueryResult {
     let runner = GraphQlRunner::new(&*LOGGER, STORE.clone(), LOAD_MANAGER.clone());
-    let query = Query::new(Arc::new(api_test_schema()), query, variables);
+    let query = Query::new(Arc::new(api_test_schema()), query, variables, None);
 
     return_err!(runner.execute(query, None, None, None))
         .as_ref()
@@ -715,6 +715,7 @@ fn query_complexity() {
         )
         .unwrap(),
         None,
+        None,
     );
     let max_complexity = Some(1_010_100);
 
@@ -743,6 +744,7 @@ fn query_complexity() {
             }",
         )
         .unwrap(),
+        None,
         None,
     );
 
@@ -775,6 +777,7 @@ async fn query_complexity_subscriptions() {
             }",
         )
         .unwrap(),
+        None,
         None,
     );
     let max_complexity = Some(1_010_100);
@@ -813,6 +816,7 @@ async fn query_complexity_subscriptions() {
         )
         .unwrap(),
         None,
+        None,
     );
 
     let options = SubscriptionExecutionOptions {
@@ -840,6 +844,7 @@ fn instant_timeout() {
     let query = Query::new(
         Arc::new(api_test_schema()),
         graphql_parser::parse_query("query { musicians(first: 100) { name } }").unwrap(),
+        None,
         None,
     );
 
@@ -1139,6 +1144,7 @@ async fn subscription_gets_result_even_without_events() {
             }",
         )
         .unwrap(),
+        None,
         None,
     );
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -226,5 +226,7 @@ pub fn mock_store_with_users_subgraph() -> (Arc<MockStore>, SubgraphDeploymentId
             Ok(Arc::new(schema))
         });
 
+    store.expect_network_name().returning(|_| Ok(None));
+
     (Arc::new(store), subgraph_id)
 }

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -260,10 +260,17 @@ where
             }
         };
 
+        let network = match self.store.network_name(&id) {
+            Ok(network) => network,
+            Err(e) => {
+                return Err(GraphQLServerError::InternalError(e.to_string()));
+            }
+        };
+
         let start = Instant::now();
         hyper::body::to_bytes(request_body)
             .map_err(|_| GraphQLServerError::from("Failed to read request body"))
-            .and_then(move |body| GraphQLRequest::new(body, schema).compat())
+            .and_then(move |body| GraphQLRequest::new(body, schema, network).compat())
             .and_then(move |query| {
                 // Run the query using the query runner
                 tokio::task::block_in_place(|| {

--- a/server/index-node/src/request.rs
+++ b/server/index-node/src/request.rs
@@ -66,7 +66,7 @@ impl Future for IndexNodeRequest {
             )),
         }?;
 
-        Ok(Async::Ready(Query::new(schema, document, variables)))
+        Ok(Async::Ready(Query::new(schema, document, variables, None)))
     }
 }
 

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -371,6 +371,7 @@ where
                 ]
                 .into_iter(),
             ))),
+            None,
         );
 
         // Execute the query
@@ -451,6 +452,7 @@ where
             Some(QueryVariables::new(HashMap::from_iter(
                 vec![("where".into(), where_filter)].into_iter(),
             ))),
+            None,
         );
 
         // Execute the query
@@ -612,6 +614,7 @@ where
                 ]
                 .into_iter(),
             ))),
+            None,
         );
 
         // Execute the query

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -299,7 +299,9 @@ where
 
                     // Construct a subscription
                     let subscription = Subscription {
-                        query: Query::new(schema.clone(), query, variables),
+                        // Subscriptions currently do not benefit from the generational cache
+                        // anyways, so don't bother passing a network.
+                        query: Query::new(schema.clone(), query, variables, None),
                     };
 
                     debug!(logger, "Start operation";


### PR DESCRIPTION
The cache has a major flaw that it mixes block numbers from different networks, this makes so that each network has its own cache. This was easy thanks to the existing `network_name` store method.