### PR TITLE
Add env variable options for sensitive arguments

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -109,6 +109,7 @@ async fn main() {
                 .takes_value(true)
                 .long("subgraph")
                 .value_name("[NAME:]IPFS_HASH")
+                .env("SUBGRAPH")
                 .help("name and IPFS hash of the subgraph manifest"),
         )
         .arg(
@@ -117,6 +118,7 @@ async fn main() {
                 .required(true)
                 .long("postgres-url")
                 .value_name("URL")
+                .env("POSTGRES_URL")
                 .help("Location of the Postgres database used for storing entities"),
         )
         .arg(
@@ -128,6 +130,7 @@ async fn main() {
                 .conflicts_with_all(&["ethereum-ws", "ethereum-ipc"])
                 .long("ethereum-rpc")
                 .value_name("NETWORK_NAME:URL")
+                .env("ETHEREUM_RPC")
                 .help(
                     "Ethereum network name (e.g. 'mainnet') and \
                      Ethereum RPC URL, separated by a ':'",

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -145,6 +145,7 @@ async fn main() {
                 .conflicts_with_all(&["ethereum-rpc", "ethereum-ipc"])
                 .long("ethereum-ws")
                 .value_name("NETWORK_NAME:URL")
+                .env("ETHEREUM_WS")
                 .help(
                     "Ethereum network name (e.g. 'mainnet') and \
                      Ethereum WebSocket URL, separated by a ':'",
@@ -159,6 +160,7 @@ async fn main() {
                 .conflicts_with_all(&["ethereum-rpc", "ethereum-ws"])
                 .long("ethereum-ipc")
                 .value_name("NETWORK_NAME:FILE")
+                .env("ETHEREUM_IPC")
                 .help(
                     "Ethereum network name (e.g. 'mainnet') and \
                      Ethereum IPC pipe, separated by a ':'",
@@ -171,6 +173,7 @@ async fn main() {
                 .long("ipfs")
                 .multiple(true)
                 .value_name("HOST:PORT")
+                .env("IPFS")
                 .help("HTTP addresses of IPFS nodes"),
         )
         .arg(


### PR DESCRIPTION
This PR adds the option to pass sensitive arguments like database passwords to the application without leaking them in bash history, docker logs or process managers (like `htop` / `top`).

Related discussion: https://github.com/graphprotocol/graph-node/issues/849#issuecomment-658731288