### PR TITLE
Use blocking task for store events

### DIFF
--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -112,7 +112,7 @@ impl NotificationListener {
         let worker_barrier = barrier.clone();
 
         // Create a channel for notifications
-        let (sender, receiver) = channel(1024);
+        let (sender, receiver) = channel(100);
 
         let worker_handle = thread::spawn(move || {
             // We exit the process on panic so unwind safety is irrelevant.


### PR DESCRIPTION
This PR improves a few things to rule them out as a cause of trouble under load:

- Reduce the size of the notifications channel from 1000 to 100, in case that buffer could ever use too much memory.
- Make the task that distributes store events to subscriptions a blocking one, just in case it's using too much CPU and causing contention.
- In `fn subscription`, Remove the duplicate UUID check which takes a lock and is unnecessary. Also do some refactoring in that method.