### PR TITLE
Add query semaphore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags 1.2.1",
+]
+
+[[package]]
 name = "colored"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,7 +493,7 @@ dependencies = [
  "log 0.4.8",
  "regalloc",
  "serde 1.0.116",
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
  "target-lexicon",
  "thiserror",
 ]
@@ -518,7 +527,7 @@ source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb1
 dependencies = [
  "cranelift-codegen",
  "log 0.4.8",
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
  "target-lexicon",
 ]
 
@@ -1473,6 +1482,7 @@ dependencies = [
  "lazy_static",
  "lru_time_cache 0.10.0",
  "once_cell",
+ "parking_lot 0.11.0",
  "pretty_assertions",
  "stable-hash",
  "test-store",
@@ -2015,6 +2025,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.70"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
+checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "linked-hash-map"
@@ -2206,6 +2222,15 @@ name = "lock_api"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
 dependencies = [
  "scopeguard",
 ]
@@ -2651,7 +2676,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.3",
  "parking_lot_core 0.6.2",
  "rustc_version",
 ]
@@ -2662,8 +2687,19 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.3",
  "parking_lot_core 0.7.0",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -2673,7 +2709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
  "rustc_version",
@@ -2688,10 +2724,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.1.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.4.2",
  "winapi 0.3.8",
 ]
 
@@ -3045,7 +3096,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 dependencies = [
- "cloudabi",
+ "cloudabi 0.0.3",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.3.1",
@@ -3172,7 +3223,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "cloudabi",
+ "cloudabi 0.0.3",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.4.2",
@@ -3268,7 +3319,7 @@ checksum = "7c03092d79e0fd610932d89ed53895a38c0dd3bcd317a0046e69940de32f1d95"
 dependencies = [
  "log 0.4.8",
  "rustc-hash",
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
@@ -3791,9 +3842,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.2.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "socket2"
@@ -4545,7 +4596,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,6 +1372,7 @@ dependencies = [
  "mockall",
  "num-bigint",
  "num-traits 0.2.12",
+ "num_cpus",
  "petgraph 0.5.1",
  "priority-queue",
  "prometheus",
@@ -2511,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -189,7 +189,11 @@ where
         loop {
             let skip = data_sources.len() as i32;
             let query = self.dynamic_data_sources_query(&deployment_id, skip)?;
-            let query_result = self.graphql_runner.query_metadata(query).await?;
+            let query_result = self
+                .graphql_runner
+                .cheap_clone()
+                .query_metadata(query)
+                .await?;
             let unresolved_data_sources = self.parse_data_sources(&deployment_id, query_result)?;
             let next_data_sources = self
                 .resolve_data_sources(unresolved_data_sources, &logger)

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -31,6 +31,7 @@ failure = "0.1.7"
 lazy_static = "1.4.0"
 mockall = "0.7"
 num-bigint = { version = "^0.2.6", features = ["serde"] }
+num_cpus = "1.13.0"
 num-traits = "0.2"
 rand = "0.6.1"
 semver = "0.10.0"

--- a/graph/src/cheap_clone.rs
+++ b/graph/src/cheap_clone.rs
@@ -1,4 +1,5 @@
 use slog::Logger;
+use std::future::Future;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -30,3 +31,5 @@ impl CheapClone for Logger {}
 // Pool is implemented as a newtype over Arc,
 // So it is CheapClone.
 impl<M: diesel::r2d2::ManageConnection> CheapClone for diesel::r2d2::Pool<M> {}
+
+impl<F: Future> CheapClone for futures03::future::Shared<F> {}

--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -30,7 +30,10 @@ pub trait GraphQlRunner: Send + Sync + 'static {
     ) -> Arc<QueryResult>;
 
     /// Runs a GraphQL subscription and returns a stream of results.
-    fn run_subscription(&self, subscription: Subscription) -> SubscriptionResultFuture;
+    async fn run_subscription(
+        self: Arc<Self>,
+        subscription: Subscription,
+    ) -> Result<SubscriptionResult, SubscriptionError>;
 
     async fn query_metadata(&self, query: Query) -> Result<q::Value, Error> {
         let result = self

--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -22,7 +22,7 @@ pub trait GraphQlRunner: Send + Sync + 'static {
 
     /// Runs a GraphqL query up to the given complexity. Overrides the global complexity limit.
     async fn run_query_with_complexity(
-        &self,
+        self: Arc<Self>,
         query: Query,
         max_complexity: Option<u64>,
         max_depth: Option<u8>,
@@ -35,7 +35,7 @@ pub trait GraphQlRunner: Send + Sync + 'static {
         subscription: Subscription,
     ) -> Result<SubscriptionResult, SubscriptionError>;
 
-    async fn query_metadata(&self, query: Query) -> Result<q::Value, Error> {
+    async fn query_metadata(self: Arc<Self>, query: Query) -> Result<q::Value, Error> {
         let result = self
             .run_query_with_complexity(query, None, None, None)
             .await;

--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -1,7 +1,7 @@
 use futures::prelude::*;
 
 use crate::data::graphql::effort::LoadManager;
-use crate::data::query::{Query, QueryResult};
+use crate::data::query::{CacheStatus, Query, QueryResult};
 use crate::data::subscription::{Subscription, SubscriptionError, SubscriptionResult};
 
 use async_trait::async_trait;
@@ -9,6 +9,7 @@ use failure::format_err;
 use failure::Error;
 use graphql_parser::query as q;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Future for subscription results.
 pub type SubscriptionResultFuture =
@@ -50,4 +51,11 @@ pub trait GraphQlRunner: Send + Sync + 'static {
     }
 
     fn load_manager(&self) -> Arc<LoadManager>;
+}
+
+#[async_trait]
+pub trait QueryLoadManager: Send + Sync {
+    async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit;
+
+    fn record_work(&self, shape_hash: u64, duration: Duration, cache_status: CacheStatus);
 }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1352,7 +1352,7 @@ pub trait SubgraphDeploymentStore: Send + Sync + 'static {
 
     /// Return the GraphQL schema that was derived from the user's schema by
     /// adding a root query type etc. to it
-    fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error>;
+    fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<ApiSchema>, Error>;
 
     /// Return true if the subgraph uses the relational storage scheme; if
     /// it is false, the subgraph uses JSONB storage. This method exposes

--- a/graph/src/data/graphql/effort.rs
+++ b/graph/src/data/graphql/effort.rs
@@ -459,12 +459,13 @@ impl LoadManager {
     }
 
     fn overloaded(&self) -> (bool, Duration) {
-        let stats = self.store_wait_stats.read().unwrap();
-        let average = stats.average();
-        let overloaded = average
+        let store_avg = self.store_wait_stats.read().unwrap().average();
+        let semaphore_avg = self.semaphore_wait_stats.read().unwrap().average();
+        let max_avg = store_avg.max(semaphore_avg);
+        let overloaded = max_avg
             .map(|average| average > *LOAD_THRESHOLD)
             .unwrap_or(false);
-        (overloaded, average.unwrap_or(ZERO_DURATION))
+        (overloaded, max_avg.unwrap_or(ZERO_DURATION))
     }
 
     fn kill_state(&self) -> (f64, Instant) {

--- a/graph/src/data/graphql/ext.rs
+++ b/graph/src/data/graphql/ext.rs
@@ -34,6 +34,10 @@ pub trait DocumentExt {
     fn find_interface(&self, name: &str) -> Option<&InterfaceType>;
 
     fn get_fulltext_directives<'a>(&'a self) -> Vec<&'a Directive>;
+
+    fn get_root_query_type(&self) -> Option<&ObjectType>;
+
+    fn get_root_subscription_type(&self) -> Option<&ObjectType>;
 }
 
 impl DocumentExt for Document {
@@ -92,6 +96,35 @@ impl DocumentExt for Document {
                     .filter(|directives| directives.name.eq("fulltext"))
                     .collect()
             })
+    }
+
+    /// Returns the root query type (if there is one).
+    fn get_root_query_type(&self) -> Option<&ObjectType> {
+        self.definitions
+            .iter()
+            .filter_map(|d| match d {
+                Definition::TypeDefinition(TypeDefinition::Object(t)) if t.name == "Query" => {
+                    Some(t)
+                }
+                _ => None,
+            })
+            .peekable()
+            .next()
+    }
+
+    fn get_root_subscription_type(&self) -> Option<&ObjectType> {
+        self.definitions
+            .iter()
+            .filter_map(|d| match d {
+                Definition::TypeDefinition(TypeDefinition::Object(t))
+                    if t.name == "Subscription" =>
+                {
+                    Some(t)
+                }
+                _ => None,
+            })
+            .peekable()
+            .next()
     }
 }
 

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -34,7 +34,6 @@ pub enum QueryExecutionError {
     OperationNameRequired,
     OperationNotFound(String),
     NotSupported(String),
-    NoRootQueryObjectType,
     NoRootSubscriptionObjectType,
     NonNullError(Pos, String),
     ListValueError(Pos, String),
@@ -100,9 +99,6 @@ impl fmt::Display for QueryExecutionError {
                 write!(f, "Operation name not found `{}`", s)
             }
             NotSupported(s) => write!(f, "Not supported: {}", s),
-            NoRootQueryObjectType => {
-                write!(f, "No root Query type defined in the schema")
-            }
             NoRootSubscriptionObjectType => {
                 write!(f, "No root Subscription type defined in the schema")
             }

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -6,7 +6,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use crate::data::graphql::shape_hash::shape_hash;
-use crate::data::schema::Schema;
+use crate::data::schema::ApiSchema;
 
 fn deserialize_number<'de, D>(deserializer: D) -> Result<q::Number, D::Error>
 where
@@ -107,7 +107,7 @@ impl serde::ser::Serialize for QueryVariables {
 /// A GraphQL query as submitted by a client, either directly or through a subscription.
 #[derive(Clone, Debug)]
 pub struct Query {
-    pub schema: Arc<Schema>,
+    pub schema: Arc<ApiSchema>,
     pub document: q::Document,
     pub variables: Option<QueryVariables>,
     pub shape_hash: u64,
@@ -120,7 +120,7 @@ pub struct Query {
 impl Query {
     /// The `network` is currently used only for caching purposes, so it is not mandatory.
     pub fn new(
-        schema: Arc<Schema>,
+        schema: Arc<ApiSchema>,
         document: q::Document,
         variables: Option<QueryVariables>,
         network: Option<String>,

--- a/graph/src/data/subgraph/schema/queries.rs
+++ b/graph/src/data/subgraph/schema/queries.rs
@@ -5,6 +5,7 @@ use crate::data::graphql::ValueMap;
 use crate::data::query::{Query, QueryVariables};
 use crate::data::subgraph::schema::SUBGRAPHS_ID;
 use crate::data::subgraph::SubgraphDeploymentId;
+use crate::prelude::CheapClone;
 use failure::Error;
 use graphql_parser::parse_query;
 use graphql_parser::query as q;
@@ -23,6 +24,7 @@ impl<S: SubgraphDeploymentStore, Q: GraphQlRunner> LazyMetadata<S, Q> {
     pub async fn health(&self) -> Result<SubgraphHealth, Error> {
         let value = self
             .graphql_runner
+            .cheap_clone()
             .query_metadata(Query::new(
                 self.store.api_schema(&SUBGRAPHS_ID).unwrap(),
                 parse_query(
@@ -56,6 +58,7 @@ impl<S: SubgraphDeploymentStore, Q: GraphQlRunner> LazyMetadata<S, Q> {
     pub async fn has_non_fatal_errors(&self) -> Result<bool, Error> {
         let value = self
             .graphql_runner
+            .cheap_clone()
             .query_metadata(Query::new(
                 self.store.api_schema(&SUBGRAPHS_ID).unwrap(),
                 parse_query(

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -82,7 +82,9 @@ pub mod prelude {
         EthereumNetworkIdentifier, EthereumTransactionData, EthereumTrigger, LightEthereumBlock,
         LightEthereumBlockExt, ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
     };
-    pub use crate::components::graphql::{GraphQlRunner, SubscriptionResultFuture};
+    pub use crate::components::graphql::{
+        GraphQlRunner, QueryLoadManager, SubscriptionResultFuture,
+    };
     pub use crate::components::link_resolver::{JsonStreamValue, JsonValueStream, LinkResolver};
     pub use crate::components::metrics::{
         aggregate::Aggregate, stopwatch::StopwatchMetrics, Collector, Counter, CounterVec, Gauge,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -118,7 +118,7 @@ pub mod prelude {
     pub use crate::data::query::{
         Query, QueryError, QueryExecutionError, QueryResult, QueryVariables,
     };
-    pub use crate::data::schema::Schema;
+    pub use crate::data::schema::{ApiSchema, Schema};
     pub use crate::data::store::ethereum::*;
     pub use crate::data::store::scalar::{BigDecimal, BigInt, BigIntSign};
     pub use crate::data::store::{

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -25,8 +25,7 @@ pub mod mock {
 /// Wrapper for spawning tasks that abort on panic, which is our default.
 mod task_spawn;
 pub use task_spawn::{
-    block_on_allow_panic, spawn, spawn_allow_panic, spawn_blocking, spawn_blocking_allow_panic,
-    spawn_blocking_async_allow_panic,
+    block_on, spawn, spawn_allow_panic, spawn_blocking, spawn_blocking_allow_panic,
 };
 
 pub use bytes;

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -16,6 +16,7 @@ lru_time_cache = "0.10"
 stable-hash = { git = "https://github.com/graphprotocol/stable-hash" }
 once_cell = "1.4.1"
 defer = "0.1"
+parking_lot = "0.11"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -297,6 +297,8 @@ where
 
     /// Records whether this was a cache hit, used for logging.
     pub(crate) cache_status: AtomicCell<CacheStatus>,
+
+    pub load_manager: Arc<dyn QueryLoadManager>,
 }
 
 // Helpers to look for types and fields on both the introspection and regular schemas.
@@ -333,7 +335,10 @@ where
             query: self.query.as_introspection_query(),
             deadline: self.deadline,
             max_first: std::u32::MAX,
+
+            // `cache_status` and `load_manager` are dead values for the introspection context.
             cache_status: AtomicCell::new(CacheStatus::Miss),
+            load_manager: self.load_manager.cheap_clone(),
         }
     }
 }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -5,13 +5,12 @@ use graphql_parser::query as q;
 use graphql_parser::schema as s;
 use indexmap::IndexMap;
 use lazy_static::lazy_static;
-use parking_lot::RwLock;
 use stable_hash::crypto::SetHasher;
 use stable_hash::prelude::*;
 use stable_hash::utils::stable_hash;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::iter;
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 use std::time::Instant;
 
 use graph::data::query::CacheStatus;
@@ -421,7 +420,7 @@ pub async fn execute_root_selection_set<R: Resolver>(
                 // and then in the LfuCache for historical queries
                 // The blocks are used to delimit how long locks need to be held
                 {
-                    let cache = QUERY_BLOCK_CACHE.read();
+                    let cache = QUERY_BLOCK_CACHE.read().unwrap();
                     if let Some(result) = cache.get(network, &block_ptr, &cache_key) {
                         ctx.cache_status.store(CacheStatus::Hit);
                         return result;
@@ -503,7 +502,7 @@ pub async fn execute_root_selection_set<R: Resolver>(
     {
         // Calculate the weight outside the lock.
         let weight = result.data.as_ref().unwrap().weight();
-        let mut cache = QUERY_BLOCK_CACHE.write();
+        let mut cache = QUERY_BLOCK_CACHE.write().unwrap();
 
         // Get or insert the cache for this network.
         if cache.insert(network, block_ptr, key, result.cheap_clone(), weight) {

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::prelude::*;
 use crate::schema::ast::get_named_type;
-use graph::prelude::{QueryExecutionError, Schema, StoreEventStreamBox};
+use graph::prelude::{ApiSchema, QueryExecutionError, StoreEventStreamBox};
 
 #[derive(Copy, Clone, Debug)]
 pub enum ObjectOrInterface<'a> {
@@ -49,7 +49,7 @@ impl<'a> ObjectOrInterface<'a> {
         self.fields().iter().find(|field| &field.name == name)
     }
 
-    pub fn object_types(&'a self, schema: &'a Schema) -> Option<Vec<&'a s::ObjectType>> {
+    pub fn object_types(&'a self, schema: &'a ApiSchema) -> Option<Vec<&'a s::ObjectType>> {
         match self {
             ObjectOrInterface::Object(object) => Some(vec![object]),
             ObjectOrInterface::Interface(interface) => schema
@@ -61,7 +61,7 @@ impl<'a> ObjectOrInterface<'a> {
 }
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
-pub trait Resolver: Send + Sync + Sized {
+pub trait Resolver: Sized + Send + Sync + 'static {
     const CACHEABLE: bool;
 
     /// Prepare for executing a query by prefetching as much data as possible

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -295,15 +295,14 @@ fn input_value(
 }
 
 #[derive(Clone)]
-pub struct IntrospectionResolver<'a> {
+pub struct IntrospectionResolver {
     logger: Logger,
-    schema: &'a Schema,
     type_objects: TypeObjectsMap,
     directives: q::Value,
 }
 
-impl<'a> IntrospectionResolver<'a> {
-    pub fn new(logger: &Logger, schema: &'a Schema) -> Self {
+impl IntrospectionResolver {
+    pub fn new(logger: &Logger, schema: &Schema) -> Self {
         let logger = logger.new(o!("component" => "IntrospectionResolver"));
 
         // Generate queryable objects for all types in the schema
@@ -314,7 +313,6 @@ impl<'a> IntrospectionResolver<'a> {
 
         IntrospectionResolver {
             logger,
-            schema,
             type_objects,
             directives,
         }
@@ -347,7 +345,7 @@ impl<'a> IntrospectionResolver<'a> {
 }
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
-impl<'a> Resolver for IntrospectionResolver<'a> {
+impl Resolver for IntrospectionResolver {
     // `IntrospectionResolver` is not used as a "top level" resolver,
     // see `fn as_introspection_context`, so this value is irrelevant.
     const CACHEABLE: bool = false;

--- a/graphql/src/introspection/schema.rs
+++ b/graphql/src/introspection/schema.rs
@@ -1,12 +1,11 @@
 use graphql_parser::{self, schema::Document, schema::Name, schema::ObjectType};
 
+use graph::data::graphql::ext::DocumentExt;
 use graph::data::graphql::ext::ObjectTypeExt;
-use graph::data::schema::Schema;
+use graph::data::schema::{ApiSchema, Schema};
 use graph::data::subgraph::SubgraphDeploymentId;
 
 use lazy_static::lazy_static;
-
-use crate::schema::ast as sast;
 
 const INTROSPECTION_SCHEMA: &str = "
 scalar Boolean
@@ -118,11 +117,11 @@ lazy_static! {
     pub static ref INTROSPECTION_DOCUMENT: Document =
         graphql_parser::parse_schema(INTROSPECTION_SCHEMA).unwrap();
     pub static ref INTROSPECTION_QUERY_TYPE: &'static ObjectType =
-        sast::get_root_query_type(&*INTROSPECTION_DOCUMENT).unwrap();
+        INTROSPECTION_DOCUMENT.get_root_query_type().unwrap();
 }
 
-pub fn introspection_schema(id: SubgraphDeploymentId) -> Schema {
-    Schema::new(id, INTROSPECTION_DOCUMENT.clone())
+pub fn introspection_schema(id: SubgraphDeploymentId) -> ApiSchema {
+    ApiSchema::from_api_schema(Schema::new(id, INTROSPECTION_DOCUMENT.clone())).unwrap()
 }
 
 pub fn is_introspection_field(name: &Name) -> bool {

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,13 +1,11 @@
-use graph::prelude::{EthereumBlockPointer, QueryExecutionError, QueryResult};
+use graph::prelude::{CheapClone, EthereumBlockPointer, QueryExecutionError, QueryResult};
 use graphql_parser::query as q;
 use std::sync::Arc;
 use std::time::Instant;
 
-use graph::cheap_clone::CheapClone;
 use graph::data::graphql::effort::LoadManager;
 
 use crate::execution::*;
-use crate::schema::ast as sast;
 
 /// Utilities for working with GraphQL query ASTs.
 pub mod ast;
@@ -31,9 +29,9 @@ pub struct QueryExecutionOptions<R> {
 
 /// Executes a query and returns a result.
 /// If the query is not cacheable, the `Arc` may be unwrapped.
-pub fn execute_query<R>(
+pub async fn execute_query<R>(
     query: Arc<Query>,
-    selection_set: Option<&q::SelectionSet>,
+    selection_set: Option<q::SelectionSet>,
     block_ptr: Option<EthereumBlockPointer>,
     options: QueryExecutionOptions<R>,
 ) -> Arc<QueryResult>
@@ -41,7 +39,7 @@ where
     R: Resolver,
 {
     // Create a fresh execution context
-    let ctx = ExecutionContext {
+    let ctx = Arc::new(ExecutionContext {
         logger: query.logger.clone(),
         resolver: options.resolver,
         query: query.clone(),
@@ -49,35 +47,34 @@ where
         max_first: options.max_first,
         cache_status: Default::default(),
         load_manager: options.load_manager.cheap_clone(),
-    };
+    });
 
     if !query.is_query() {
         return Arc::new(
             QueryExecutionError::NotSupported("Only queries are supported".to_string()).into(),
         );
     }
-
-    // Obtain the root Query type and fail if there isn't one
-    let query_type = match sast::get_root_query_type(&ctx.query.schema.document) {
-        Some(t) => t,
-        None => return Arc::new(QueryExecutionError::NoRootQueryObjectType.into()),
-    };
+    let selection_set = selection_set
+        .map(Arc::new)
+        .unwrap_or_else(|| query.selection_set.cheap_clone());
 
     // Execute top-level `query { ... }` and `{ ... }` expressions.
+    let query_type = ctx.query.schema.query_type.cheap_clone();
     let start = Instant::now();
     let result = execute_root_selection_set(
-        &ctx,
-        selection_set.unwrap_or(&query.selection_set),
+        ctx.cheap_clone(),
+        selection_set.cheap_clone(),
         query_type,
         block_ptr,
-    );
+    )
+    .await;
     let elapsed = start.elapsed();
     let cache_status = ctx.cache_status.load();
     options
         .load_manager
         .record_work(query.shape_hash, elapsed, cache_status);
     query.log_cache_status(
-        selection_set,
+        &selection_set,
         block_ptr.map(|b| b.number).unwrap_or(0),
         start,
         cache_status.to_string(),

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -3,6 +3,7 @@ use graphql_parser::query as q;
 use std::sync::Arc;
 use std::time::Instant;
 
+use graph::cheap_clone::CheapClone;
 use graph::data::graphql::effort::LoadManager;
 
 use crate::execution::*;
@@ -47,6 +48,7 @@ where
         deadline: options.deadline,
         max_first: options.max_first,
         cache_status: Default::default(),
+        load_manager: options.load_manager.cheap_clone(),
     };
 
     if !query.is_query() {

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -49,19 +49,6 @@ pub(crate) fn parse_field_as_filter(key: &Name) -> (Name, FilterOp) {
     (key.trim_end_matches(suffix).to_owned(), op)
 }
 
-/// Returns the root query type (if there is one).
-pub fn get_root_query_type(schema: &Document) -> Option<&ObjectType> {
-    schema
-        .definitions
-        .iter()
-        .filter_map(|d| match d {
-            Definition::TypeDefinition(TypeDefinition::Object(t)) if t.name == "Query" => Some(t),
-            _ => None,
-        })
-        .peekable()
-        .next()
-}
-
 pub fn get_root_query_type_def(schema: &Document) -> Option<&TypeDefinition> {
     schema.definitions.iter().find_map(|d| match d {
         Definition::TypeDefinition(def @ TypeDefinition::Object(_)) => match def {
@@ -70,21 +57,6 @@ pub fn get_root_query_type_def(schema: &Document) -> Option<&TypeDefinition> {
         },
         _ => None,
     })
-}
-
-/// Returns the root subscription type (if there is one).
-pub fn get_root_subscription_type(schema: &Document) -> Option<&ObjectType> {
-    schema
-        .definitions
-        .iter()
-        .filter_map(|d| match d {
-            Definition::TypeDefinition(TypeDefinition::Object(t)) if t.name == "Subscription" => {
-                Some(t)
-            }
-            _ => None,
-        })
-        .peekable()
-        .next()
 }
 
 /// Returns all type definitions in the schema.

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -207,10 +207,7 @@ async fn execute_subscription_event(
         .unwrap()
         .clone();
 
-    // Use a semaphore to prevent subscription queries, which can be numerous and might query all at
-    // once, from flooding the blocking thread pool and the DB connection pool.
-    let _permit = SUBSCRIPTION_QUERY_SEMAPHORE.acquire();
-    match graph::spawn_blocking_allow_panic(async move {
+    match graph::spawn_blocking_allow_panic(move || {
         execute_root_selection_set(&ctx, &ctx.query.selection_set, &subscription_type, None)
     })
     .await

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -11,10 +11,11 @@ use std::time::{Duration, Instant};
 use graph::data::query::CacheStatus;
 use graph::prelude::{
     async_trait, futures03::stream::StreamExt, futures03::FutureExt, futures03::TryFutureExt, o,
-    slog, tokio, Entity, EntityKey, EntityOperation, EthereumBlockPointer, FutureExtension,
-    GraphQlRunner as _, Logger, Query, QueryError, QueryExecutionError, QueryLoadManager,
-    QueryResult, QueryVariables, Schema, Store, SubgraphDeploymentEntity, SubgraphDeploymentId,
-    SubgraphDeploymentStore, SubgraphManifest, Subscription, SubscriptionError, Value,
+    slog, tokio, ApiSchema, Entity, EntityKey, EntityOperation, EthereumBlockPointer,
+    FutureExtension, GraphQlRunner as _, Logger, Query, QueryError, QueryExecutionError,
+    QueryLoadManager, QueryResult, QueryVariables, Schema, Store, SubgraphDeploymentEntity,
+    SubgraphDeploymentId, SubgraphDeploymentStore, SubgraphManifest, Subscription,
+    SubscriptionError, Value,
 };
 use graph_graphql::prelude::*;
 use test_store::{
@@ -74,11 +75,11 @@ fn test_schema(id: SubgraphDeploymentId) -> Schema {
     .expect("Test schema invalid")
 }
 
-fn api_test_schema() -> Schema {
+fn api_test_schema() -> ApiSchema {
     let mut schema = test_schema(TEST_SUBGRAPH_ID.clone());
     schema.document = api_schema(&schema.document).expect("Failed to derive API schema");
     schema.add_subgraph_id_directives(TEST_SUBGRAPH_ID.clone());
-    schema
+    ApiSchema::from_api_schema(schema).unwrap()
 }
 
 fn insert_test_entities(store: &impl Store, id: SubgraphDeploymentId) {

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -16,7 +16,7 @@ mock! {
     trait SubgraphDeploymentStore: Send + Sync + 'static {
         fn input_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error>;
 
-        fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, Error>;
+        fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<ApiSchema>, Error>;
 
         fn uses_relational_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<bool, Error>;
 
@@ -220,7 +220,7 @@ pub fn mock_store_with_users_subgraph() -> (Arc<MockStore>, SubgraphDeploymentId
                 .expect("failed to parse users schema");
             schema.document =
                 api_schema(&schema.document).expect("failed to generate users API schema");
-            Ok(Arc::new(schema))
+            Ok(Arc::new(ApiSchema::from_api_schema(schema).unwrap()))
         });
 
     store.expect_network_name().returning(|_| Ok(None));

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -305,7 +305,6 @@ async fn main() {
                 .default_value("false")
                 .help("Ensures that the block ingestor component does not execute"),
         )
-        // See also 82d5dad6-b633-4350-86d9-70c8b2e65805
         .arg(
             Arg::with_name("store-connection-pool-size")
                 .long("store-connection-pool-size")

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -679,6 +679,7 @@ async fn main() {
                 wait_stats.clone(),
                 expensive_queries,
                 metrics_registry.clone(),
+                store_conn_pool_size as usize,
             ));
             let graphql_runner = Arc::new(GraphQlRunner::new(
                 &logger,

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -660,7 +660,7 @@ fn block_on<I, ER>(future: impl Future<Item = I, Error = ER> + Send) -> Result<I
 }
 
 fn block_on03<T>(future: impl futures03::Future<Output = T> + Send) -> T {
-    graph::block_on_allow_panic(future)
+    graph::block_on(future)
 }
 
 #[test]

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -517,7 +517,10 @@ mod tests {
             ))))
         }
 
-        fn run_subscription(&self, _subscription: Subscription) -> SubscriptionResultFuture {
+        async fn run_subscription(
+            self: Arc<Self>,
+            _subscription: Subscription,
+        ) -> Result<SubscriptionResult, SubscriptionError> {
             unreachable!();
         }
 

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -18,7 +18,7 @@ pub struct TestGraphQlRunner;
 #[async_trait]
 impl GraphQlRunner for TestGraphQlRunner {
     async fn run_query_with_complexity(
-        &self,
+        self: Arc<Self>,
         _query: Query,
         _complexity: Option<u64>,
         _max_depth: Option<u8>,

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -59,7 +59,10 @@ impl GraphQlRunner for TestGraphQlRunner {
         ))))
     }
 
-    fn run_subscription(&self, _subscription: Subscription) -> SubscriptionResultFuture {
+    async fn run_subscription(
+        self: Arc<Self>,
+        _subscription: Subscription,
+    ) -> Result<SubscriptionResult, SubscriptionError> {
         unreachable!();
     }
 

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -375,12 +375,14 @@ where
         );
 
         // Execute the query. We are in a blocking context so we may just block.
-        let result = graph::block_on_allow_panic(self.graphql_runner.run_query_with_complexity(
-            query,
-            None,
-            None,
-            Some(std::u32::MAX),
-        ));
+        let result = graph::block_on(
+            self.graphql_runner.cheap_clone().run_query_with_complexity(
+                query,
+                None,
+                None,
+                Some(std::u32::MAX),
+            ),
+        );
 
         // Metadata queries are not cached.
         let result = Arc::try_unwrap(result).unwrap();
@@ -457,12 +459,14 @@ where
         );
 
         // Execute the query. We are in a blocking context so we may just block.
-        let result = graph::block_on_allow_panic(self.graphql_runner.run_query_with_complexity(
-            query,
-            None,
-            None,
-            Some(std::u32::MAX),
-        ));
+        let result = graph::block_on(
+            self.graphql_runner.cheap_clone().run_query_with_complexity(
+                query,
+                None,
+                None,
+                Some(std::u32::MAX),
+            ),
+        );
 
         // Metadata queries are not cached.
         let result = Arc::try_unwrap(result).unwrap();
@@ -620,12 +624,14 @@ where
         );
 
         // Execute the query. We are in a blocking context so we may just block.
-        let result = graph::block_on_allow_panic(self.graphql_runner.run_query_with_complexity(
-            query,
-            None,
-            None,
-            Some(std::u32::MAX),
-        ));
+        let result = graph::block_on(
+            self.graphql_runner.cheap_clone().run_query_with_complexity(
+                query,
+                None,
+                None,
+                Some(std::u32::MAX),
+            ),
+        );
 
         // Metadata queries are not cached.
         let result = Arc::try_unwrap(result).unwrap();

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -375,14 +375,12 @@ where
         );
 
         // Execute the query. We are in a blocking context so we may just block.
-        let result = graph::block_on(
-            self.graphql_runner.cheap_clone().run_query_with_complexity(
-                query,
-                None,
-                None,
-                Some(std::u32::MAX),
-            ),
-        );
+        let result = graph::block_on(self.graphql_runner.cheap_clone().run_query_with_complexity(
+            query,
+            None,
+            None,
+            Some(std::u32::MAX),
+        ));
 
         // Metadata queries are not cached.
         let result = Arc::try_unwrap(result).unwrap();
@@ -459,14 +457,12 @@ where
         );
 
         // Execute the query. We are in a blocking context so we may just block.
-        let result = graph::block_on(
-            self.graphql_runner.cheap_clone().run_query_with_complexity(
-                query,
-                None,
-                None,
-                Some(std::u32::MAX),
-            ),
-        );
+        let result = graph::block_on(self.graphql_runner.cheap_clone().run_query_with_complexity(
+            query,
+            None,
+            None,
+            Some(std::u32::MAX),
+        ));
 
         // Metadata queries are not cached.
         let result = Arc::try_unwrap(result).unwrap();
@@ -624,14 +620,12 @@ where
         );
 
         // Execute the query. We are in a blocking context so we may just block.
-        let result = graph::block_on(
-            self.graphql_runner.cheap_clone().run_query_with_complexity(
-                query,
-                None,
-                None,
-                Some(std::u32::MAX),
-            ),
-        );
+        let result = graph::block_on(self.graphql_runner.cheap_clone().run_query_with_complexity(
+            query,
+            None,
+            None,
+            Some(std::u32::MAX),
+        ));
 
         // Metadata queries are not cached.
         let result = Arc::try_unwrap(result).unwrap();

--- a/server/index-node/src/schema.rs
+++ b/server/index-node/src/schema.rs
@@ -1,18 +1,21 @@
 use graph::prelude::*;
 
 lazy_static! {
-    pub static ref SCHEMA: Arc<Schema> = {
+    pub static ref SCHEMA: Arc<ApiSchema> = {
         let raw_schema = include_str!("./schema.graphql");
         let document = graphql_parser::parse_schema(&raw_schema).unwrap();
         let (interfaces_for_type, types_for_interface) =
             Schema::collect_interfaces(&document).unwrap();
 
-        Arc::new(Schema {
-            id: SubgraphDeploymentId::new("indexnode").unwrap(),
-            document: document,
-            interfaces_for_type,
-            types_for_interface,
-        })
+        Arc::new(
+            ApiSchema::from_api_schema(Schema {
+                id: SubgraphDeploymentId::new("indexnode").unwrap(),
+                document,
+                interfaces_for_type,
+                types_for_interface,
+            })
+            .unwrap(),
+        )
     };
 }
 

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -101,49 +101,22 @@ where
         // Run the query using the index node resolver
         let query_clone = query.cheap_clone();
         let logger = self.logger.cheap_clone();
-        let result = tokio::task::spawn_blocking(move || {
+        let result = {
             let options = QueryExecutionOptions {
                 resolver: IndexNodeResolver::new(&logger, graphql_runner, store),
                 deadline: None,
                 max_first: std::u32::MAX,
                 load_manager,
             };
-            let result = execute_query(query_clone.cheap_clone(), None, None, options);
+            let result = execute_query(query_clone.cheap_clone(), None, None, options).await;
             query_clone.log_execution(0);
             QueryResult::from(
                 // Index status queries are not cacheable, so we may unwrap this.
                 Arc::try_unwrap(result).unwrap(),
             )
-        })
-        .await;
-
-        let query_result = match result {
-            Ok(res) => res,
-
-            // `Err(JoinError)` means a panic.
-            Err(e) => {
-                let e = e.into_panic();
-                let e = match e
-                    .downcast_ref::<String>()
-                    .map(|s| s.as_str())
-                    .or(e.downcast_ref::<&'static str>().map(|&s| s))
-                {
-                    Some(e) => e.to_string(),
-                    None => "panic is not a string".to_string(),
-                };
-                let err = QueryExecutionError::Panic(e);
-                error!(
-                    self.logger,
-                    "panic when processing graphql query";
-                    "panic" => err.to_string(),
-                    "query" => &query.query_text,
-                    "variables" => &query.variables_text,
-                );
-                QueryResult::from(err)
-            }
         };
 
-        Ok(query_result.as_http_response())
+        Ok(result.as_http_response())
     }
 
     // Handles OPTIONS requests

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -309,7 +309,6 @@ where
                            "id" => &id);
 
                     // Execute the GraphQL subscription
-                    let graphql_runner = graphql_runner.clone();
                     let error_sink = msg_sink.clone();
                     let result_sink = msg_sink.clone();
                     let result_id = id.clone();
@@ -317,7 +316,9 @@ where
                     let err_connection_id = connection_id.clone();
                     let err_logger = logger.clone();
                     let run_subscription = graphql_runner
+                        .cheap_clone()
                         .run_subscription(subscription)
+                        .compat()
                         .map_err(move |e| {
                             debug!(err_logger, "Subscription error";
                                                "connection" => &err_connection_id,

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -171,7 +171,7 @@ pub struct GraphQlConnection<Q, S> {
     logger: Logger,
     graphql_runner: Arc<Q>,
     stream: WebSocketStream<S>,
-    schema: Arc<Schema>,
+    schema: Arc<ApiSchema>,
 }
 
 impl<Q, S> GraphQlConnection<Q, S>
@@ -182,7 +182,7 @@ where
     /// Creates a new GraphQL subscription service.
     pub(crate) fn new(
         logger: &Logger,
-        schema: Arc<Schema>,
+        schema: Arc<ApiSchema>,
         stream: WebSocketStream<S>,
         graphql_runner: Arc<Q>,
     ) -> Self {
@@ -200,7 +200,7 @@ where
         mut msg_sink: mpsc::UnboundedSender<WsMessage>,
         logger: Logger,
         connection_id: String,
-        schema: Arc<Schema>,
+        schema: Arc<ApiSchema>,
         graphql_runner: Arc<Q>,
     ) -> Result<(), WsError> {
         let mut operations = Operations::new(msg_sink.clone());

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1850,7 +1850,7 @@ fn subgraph_schema_types_have_subgraph_id_directive() {
             .api_schema(&TEST_SUBGRAPH_ID)
             .expect("test subgraph should have a schema");
         for typedef in schema
-            .document
+            .document()
             .definitions
             .iter()
             .filter_map(|def| match def {

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -28,6 +28,8 @@ pub fn postgres_test_url() -> String {
 pub const NETWORK_NAME: &str = "fake_network";
 pub const NETWORK_VERSION: &str = "graph test suite";
 
+const CONN_POOL_SIZE: usize = 20;
+
 lazy_static! {
     pub static ref LOGGER:Logger = match env::var_os("GRAPH_LOG") {
         Some(_) => log::logger(false),
@@ -42,7 +44,8 @@ lazy_static! {
         LoadManager::new(&*LOGGER,
                          POOL_WAIT_STATS.clone(),
                          Vec::new(),
-                         Arc::new(MockMetricsRegistry::new())));
+                         Arc::new(MockMetricsRegistry::new()),
+                         CONN_POOL_SIZE));
 
     // Create Store instance once for use with each of the tests.
     pub static ref STORE: Arc<Store> = {
@@ -56,11 +59,10 @@ lazy_static! {
                     net_version: NETWORK_VERSION.to_owned(),
                     genesis_block_hash: GENESIS_PTR.hash,
                 };
-                let conn_pool_size: u32 = 20;
                 let postgres_conn_pool = create_connection_pool(
                     "test",
                     postgres_url.clone(),
-                    conn_pool_size,
+                    CONN_POOL_SIZE as u32,
                     &logger,
                     Arc::new(MockMetricsRegistry::new()),
                     POOL_WAIT_STATS.clone()


### PR DESCRIPTION
This adds a semaphore to limit the concurrent execution of graphql queries and subscriptions. This semaphore is implemented in the `LoadManager` and is waited on with the `query_permit` method. Statistics were added so that we may track this as we currently track wait times for DB connections.

Limiting the cuncurrent queries prevents an increase in resource usage when the DB is contended. The request will wait for a permit before spawing blocking tasks and requesting DB connections, so waiting requests will consume less resources.

I experimented with different locations for the permit. It turns out that spawning less blocking tasks not only reduces the memory consumption but also reduced tokio contention in local tests. I'm not sure why that is the case, since blocking tasks run on a separate thread pool, but good news is good.

This also does some general refactoring for better use of async.