### PR TITLE
Allow using variables in block constraints

### DIFF
--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -123,7 +123,7 @@ impl Query {
             q::Selection::Field(f) => Some(f),
             _ => None,
         }) {
-            match field.block_constraint() {
+            match field.block_constraint(&self.variables) {
                 Ok(bc) => {
                     let selection_set = bcs.entry(bc).or_insert(q::SelectionSet {
                         span: self.selection_set.span.clone(),


### PR DESCRIPTION
So far, it was not possible to use a variable in a block constraint. As it turns out, after various refactorings over the last few months, fixing #1460 was rather easy.