### PR TITLE
graph: Fix an error in KillState::new

### DIFF
--- a/graph/src/data/graphql/effort.rs
+++ b/graph/src/data/graphql/effort.rs
@@ -149,12 +149,14 @@ struct KillState {
 
 impl KillState {
     fn new() -> Self {
-        let long_ago = Duration::from_secs(86400);
+        let long_ago = Duration::from_secs(60);
+        let now = Instant::now();
+        let before = now.checked_sub(long_ago).unwrap_or(now);
         Self {
             kill_rate: 0.0,
-            last_update: Instant::now() - long_ago,
+            last_update: before,
             overload_start: None,
-            last_overload_log: Instant::now() - long_ago,
+            last_overload_log: before,
         }
     }
 


### PR DESCRIPTION
On Mac OSX, Instant::now() is the time since the last boot, which might
have been less than a day ago, in which case KillState::new would panic. We
now use 'now - 60s' as a time in the past for initialization, and if that
fails, we'll use just 'now'. There's not much danger in using 'now', it
might just lead to spurious logging and a too-soon update of the kill_rate
if the node becomes immediately overloaded after starting.

Thanks to kevholder for root-causing the issue and demonstrating a fix.

Fixes https://github.com/graphprotocol/graph-node/issues/1805

