### PR TITLE
Replace unwrap with error in block stream

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -21,6 +21,7 @@ use web3::types::{Filter, *};
 
 #[derive(Clone)]
 pub struct EthereumAdapter<T: web3::Transport> {
+    url: Arc<String>,
     web3: Arc<Web3<T>>,
     metrics: Arc<ProviderEthRpcMetrics>,
 }
@@ -66,6 +67,7 @@ lazy_static! {
 impl<T: web3::Transport> CheapClone for EthereumAdapter<T> {
     fn cheap_clone(&self) -> Self {
         Self {
+            url: self.url.cheap_clone(),
             web3: self.web3.cheap_clone(),
             metrics: self.metrics.cheap_clone(),
         }
@@ -78,8 +80,9 @@ where
     T::Batch: Send,
     T::Out: Send,
 {
-    pub fn new(transport: T, provider_metrics: Arc<ProviderEthRpcMetrics>) -> Self {
+    pub fn new(url: String, transport: T, provider_metrics: Arc<ProviderEthRpcMetrics>) -> Self {
         EthereumAdapter {
+            url: Arc::new(url),
             web3: Arc::new(Web3::new(transport)),
             metrics: provider_metrics,
         }
@@ -601,6 +604,10 @@ where
     T::Batch: Send,
     T::Out: Send,
 {
+    fn url(&self) -> &str {
+        &self.url
+    }
+
     fn net_identifiers(
         &self,
         logger: &Logger,

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -614,7 +614,7 @@ impl BlockStreamMetrics {
 /// or a remote node over RPC.
 #[automock]
 pub trait EthereumAdapter: Send + Sync + 'static {
-    fn url(&self) -> &str;
+    fn url_hostname(&self) -> &str;
 
     /// Ask the Ethereum node for some identifying information about the Ethereum network it is
     /// connected to.
@@ -958,7 +958,7 @@ pub fn blocks_with_triggers(
                         Ok(n) => n.ok_or_else(|| {
                             warn!(logger2,
                                     "Ethereum endpoint is behind";
-                                    "url" => eth_clone.url()
+                                    "url" => eth_clone.url_hostname()
                             );
                             format_err!("Block {} not found in the chain", to)
                         }),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -989,6 +989,7 @@ fn parse_ethereum_networks(
                 name.to_string(),
                 capabilities,
                 Arc::new(graph_chain_ethereum::EthereumAdapter::new(
+                    url.to_string(),
                     transport,
                     eth_rpc_metrics.clone(),
                 )) as Arc<dyn EthereumAdapter>,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -989,7 +989,7 @@ fn parse_ethereum_networks(
                 name.to_string(),
                 capabilities,
                 Arc::new(graph_chain_ethereum::EthereumAdapter::new(
-                    url.to_string(),
+                    url,
                     transport,
                     eth_rpc_metrics.clone(),
                 )) as Arc<dyn EthereumAdapter>,


### PR DESCRIPTION
Now that we support multiple endpoints, this can happen if the call goes to an endpoint that's behind.