### PR TITLE
graph, graphql: Better error message when we decline to run a query

### DIFF
--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -71,6 +71,7 @@ pub enum QueryExecutionError {
     TooComplex(u64, u64), // (complexity, max_complexity)
     TooDeep(u8),          // max_depth
     TooExpensive,
+    Throttled,
     UndefinedFragment(String),
     // Using slow and prefetch query resolution yield different results
     IncorrectPrefetchResult { slow: q::Value, prefetch: q::Value },
@@ -224,7 +225,8 @@ impl fmt::Display for QueryExecutionError {
             Panic(msg) => write!(f, "panic processing query: {}", msg),
             EventStreamError => write!(f, "error in the subscription event stream"),
             FulltextQueryRequiresFilter => write!(f, "fulltext search queries can only use EntityFilter::Equal"),
-            TooExpensive => write!(f, "query is too expensive")
+            TooExpensive => write!(f, "query is too expensive"),
+            Throttled=> write!(f, "service is overloaded and can not run the query right now. Please try again in a few minutes")
         }
     }
 }


### PR DESCRIPTION
We used to always produce 'query too expensive' when the load manager
decided to decline running a query, which made users think there was
something wrong with their query.

We now return 'query too expensive' for queries that have been blocked
wholesale because we decided they were too expensive. For queries that we
will not run because the service is overloaded, we now return an error that
says that and makes it clear that that is a temporary condition.

