### PR TITLE
graph: Actually block blocked queries

### DIFF
--- a/graph/src/data/graphql/effort.rs
+++ b/graph/src/data/graphql/effort.rs
@@ -335,7 +335,7 @@ impl LoadManager {
         use Decision::*;
 
         if self.blocked_queries.contains(&shape_hash) {
-            return Proceed;
+            return TooExpensive;
         }
         if *LOAD_MANAGEMENT_DISABLED {
             return Proceed;


### PR DESCRIPTION
Commit 1d3b54e2 reversed the logic for blocked queries. This change does
indeed block them again.

