### PR TITLE
Fix fragment bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,7 @@ dependencies = [
  "ipfs-api",
  "lazy_static",
  "lru_time_cache 0.9.0",
+ "pretty_assertions",
  "prometheus",
  "semver 0.10.0",
  "serde 1.0.116",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,3 +26,4 @@ test-store = { path = "../store/test-store" }
 hex = "0.4.2"
 graphql-parser = "0.2.3"
 prometheus = "0.7"
+pretty_assertions = "0.6.1"

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -658,14 +658,25 @@ fn fragments_dont_panic() {
 
     // The panic manifests if two parents exist.
     let parent = (
-        Entity::from(vec![("id", Value::from("p")), ("child", Value::from("c"))]),
+        entity!(
+            id: "p",
+            child: "c",
+        ),
         "Parent",
     );
     let parent2 = (
-        Entity::from(vec![("id", Value::from("p2")), ("child", Value::Null)]),
+        entity!(
+            id: "p2",
+            child: Value::Null,
+        ),
         "Parent",
     );
-    let child = (Entity::from(vec![("id", Value::from("c"))]), "Child");
+    let child = (
+        entity!(
+            id:"c"
+        ),
+        "Child",
+    );
 
     let res = insert_and_query(subgraph_id, schema, vec![parent, parent2, child], query).unwrap();
 
@@ -734,7 +745,12 @@ fn fragments_dont_duplicate_data() {
         ),
         "Parent",
     );
-    let child = (Entity::from(vec![("id", Value::from("c"))]), "Child");
+    let child = (
+        entity!(
+            id:"c"
+        ),
+        "Child",
+    );
 
     let res = insert_and_query(subgraph_id, schema, vec![parent, parent2, child], query).unwrap();
 
@@ -778,14 +794,17 @@ fn redundant_fields() {
             }";
 
     let parent = (
-        Entity::from(vec![("id", Value::from("parent")), ("parent", Value::Null)]),
+        entity!(
+            id: "parent",
+            parent: Value::Null,
+        ),
         "Animal",
     );
     let child = (
-        Entity::from(vec![
-            ("id", Value::from("child")),
-            ("parent", Value::String("parent".into())),
-        ]),
+        entity!(
+            id: "child",
+            parent: "parent",
+        ),
         "Animal",
     );
 
@@ -849,7 +868,10 @@ fn fragments_merge_selections() {
         "Parent",
     );
     let child = (
-        Entity::from(vec![("id", Value::from("c")), ("foo", Value::from(1))]),
+        entity!(
+            id: "c",
+            foo: 1,
+        ),
         "Child",
     );
 
@@ -1123,5 +1145,38 @@ fn nested_interface_fragments_overlapping() {
                 },
             ]
         }
-    )
+    );
+
+    // let query = "query {
+    //     i1Faces {
+    //         __typename
+    //         foo1 {
+    //             id
+    //         }
+    //         ...on I2face {
+    //             foo1 {
+    //                 id
+    //             }
+    //         }
+    //     }
+    // }";
+
+    // let res = insert_and_query(subgraph_id, schema, vec![], query).unwrap();
+    // assert!(res.errors.is_none(), format!("{:#?}", res.errors));
+    // assert_eq!(
+    //     res.data.unwrap(),
+    //     object! {
+    //         i1Faces: vec![
+    //             object! {
+    //                 __typename: "One"
+    //             },
+    //             object! {
+    //                 __typename: "Two",
+    //                 foo1: object! {
+    //                     id: "foo",
+    //                 },
+    //             },
+    //         ]
+    //     }
+    // );
 }

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -1147,36 +1147,39 @@ fn nested_interface_fragments_overlapping() {
         }
     );
 
-    // let query = "query {
-    //     i1Faces {
-    //         __typename
-    //         foo1 {
-    //             id
-    //         }
-    //         ...on I2face {
-    //             foo1 {
-    //                 id
-    //             }
-    //         }
-    //     }
-    // }";
+    let query = "query {
+        i1Faces {
+            __typename
+            foo1 {
+                id
+            }
+            ...on I2face {
+                foo1 {
+                    id
+                }
+            }
+        }
+    }";
 
-    // let res = insert_and_query(subgraph_id, schema, vec![], query).unwrap();
-    // assert!(res.errors.is_none(), format!("{:#?}", res.errors));
-    // assert_eq!(
-    //     res.data.unwrap(),
-    //     object! {
-    //         i1Faces: vec![
-    //             object! {
-    //                 __typename: "One"
-    //             },
-    //             object! {
-    //                 __typename: "Two",
-    //                 foo1: object! {
-    //                     id: "foo",
-    //                 },
-    //             },
-    //         ]
-    //     }
-    // );
+    let res = insert_and_query(subgraph_id, schema, vec![], query).unwrap();
+    assert!(res.errors.is_none(), format!("{:#?}", res.errors));
+    assert_eq!(
+        res.data.unwrap(),
+        object! {
+            i1Faces: vec![
+                object! {
+                    __typename: "One",
+                    foo1: object! {
+                        id: "foo"
+                    }
+                },
+                object! {
+                    __typename: "Two",
+                    foo1: object! {
+                        id: "foo",
+                    },
+                },
+            ]
+        }
+    );
 }

--- a/graph/src/data/graphql/mod.rs
+++ b/graph/src/data/graphql/mod.rs
@@ -2,6 +2,7 @@ mod serialization;
 
 /// Traits to navigate the GraphQL AST
 pub mod ext;
+pub use ext::{DirectiveExt, DocumentExt, ObjectTypeExt, TypeExt, ValueExt};
 
 /// Utilities for working with GraphQL values.
 mod values;
@@ -23,3 +24,6 @@ pub use self::values::{
 pub mod shape_hash;
 
 pub mod effort;
+
+pub mod object_or_interface;
+pub use object_or_interface::ObjectOrInterface;

--- a/graph/src/data/graphql/object_or_interface.rs
+++ b/graph/src/data/graphql/object_or_interface.rs
@@ -1,0 +1,64 @@
+use crate::prelude::Schema;
+use graphql_parser::schema as s;
+
+#[derive(Copy, Clone, Debug)]
+pub enum ObjectOrInterface<'a> {
+    Object(&'a s::ObjectType),
+    Interface(&'a s::InterfaceType),
+}
+
+impl<'a> From<&'a s::ObjectType> for ObjectOrInterface<'a> {
+    fn from(object: &'a s::ObjectType) -> Self {
+        ObjectOrInterface::Object(object)
+    }
+}
+
+impl<'a> From<&'a s::InterfaceType> for ObjectOrInterface<'a> {
+    fn from(interface: &'a s::InterfaceType) -> Self {
+        ObjectOrInterface::Interface(interface)
+    }
+}
+
+impl<'a> ObjectOrInterface<'a> {
+    pub fn is_object(self) -> bool {
+        match self {
+            ObjectOrInterface::Object(_) => true,
+            ObjectOrInterface::Interface(_) => false,
+        }
+    }
+
+    pub fn name(self) -> &'a str {
+        match self {
+            ObjectOrInterface::Object(object) => &object.name,
+            ObjectOrInterface::Interface(interface) => &interface.name,
+        }
+    }
+
+    pub fn directives(self) -> &'a Vec<s::Directive> {
+        match self {
+            ObjectOrInterface::Object(object) => &object.directives,
+            ObjectOrInterface::Interface(interface) => &interface.directives,
+        }
+    }
+
+    pub fn fields(self) -> &'a Vec<s::Field> {
+        match self {
+            ObjectOrInterface::Object(object) => &object.fields,
+            ObjectOrInterface::Interface(interface) => &interface.fields,
+        }
+    }
+
+    pub fn field(&self, name: &s::Name) -> Option<&s::Field> {
+        self.fields().iter().find(|field| &field.name == name)
+    }
+
+    pub fn object_types(self, schema: &'a Schema) -> Option<Vec<&'a s::ObjectType>> {
+        match self {
+            ObjectOrInterface::Object(object) => Some(vec![object]),
+            ObjectOrInterface::Interface(interface) => schema
+                .types_for_interface()
+                .get(&interface.name)
+                .map(|object_types| object_types.iter().collect()),
+        }
+    }
+}

--- a/graph/src/data/graphql/object_or_interface.rs
+++ b/graph/src/data/graphql/object_or_interface.rs
@@ -1,5 +1,6 @@
 use crate::prelude::Schema;
 use graphql_parser::schema as s;
+use std::collections::BTreeMap;
 
 #[derive(Copy, Clone, Debug)]
 pub enum ObjectOrInterface<'a> {
@@ -59,6 +60,21 @@ impl<'a> ObjectOrInterface<'a> {
                 .types_for_interface()
                 .get(&interface.name)
                 .map(|object_types| object_types.iter().collect()),
+        }
+    }
+
+    /// `typename` is the name of an object type. Matches if `self` is an object and has the same
+    /// name, or if self is an interface implemented by `typename`.
+    pub fn matches(
+        self,
+        typename: &str,
+        types_for_interface: &BTreeMap<s::Name, Vec<s::ObjectType>>,
+    ) -> bool {
+        match self {
+            ObjectOrInterface::Object(o) => o.name == typename,
+            ObjectOrInterface::Interface(i) => types_for_interface[&i.name]
+                .iter()
+                .any(|o| o.name == typename),
         }
     }
 }

--- a/graph/src/data/graphql/object_or_interface.rs
+++ b/graph/src/data/graphql/object_or_interface.rs
@@ -28,6 +28,13 @@ impl<'a> ObjectOrInterface<'a> {
         }
     }
 
+    pub fn is_interface(self) -> bool {
+        match self {
+            ObjectOrInterface::Object(_) => false,
+            ObjectOrInterface::Interface(_) => true,
+        }
+    }
+
     pub fn name(self) -> &'a str {
         match self {
             ObjectOrInterface::Object(object) => &object.name,

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -630,7 +630,9 @@ fn execute_selection_set_to_map<'a>(
     }
 }
 
-/// Collects fields from selection sets.
+/// Collects fields from selection sets. Returns a map from response key to fields. There will
+/// typically be a single field for a response key. If there are multiple, the overall execution
+/// logic will effectively merged them into the output for the response key.
 pub fn collect_fields<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -665,7 +665,10 @@ pub fn collect_fields_inner<'a>(
                 q::Selection::FragmentSpread(spread) => {
                     // Only consider the fragment if it hasn't already been included,
                     // as would be the case if the same fragment spread ...Foo appeared
-                    // twice in the same selection set
+                    // twice in the same selection set.
+                    //
+                    // Note: This will skip both duplicate fragments and will break cycles,
+                    // so we support fragments even though the GraphQL spec prohibits them.
                     if visited_fragments.insert(&spread.fragment_name) {
                         let fragment = ctx.query.get_fragment(&spread.fragment_name);
                         if does_fragment_type_apply(ctx, object_type, &fragment.type_condition) {

--- a/graphql/src/execution/mod.rs
+++ b/graphql/src/execution/mod.rs
@@ -7,4 +7,4 @@ mod resolver;
 
 pub use self::execution::*;
 pub use self::query::Query;
-pub use self::resolver::{ObjectOrInterface, Resolver};
+pub use self::resolver::Resolver;

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -11,6 +11,7 @@ use graph::data::graphql::{
 };
 use graph::data::query::{Query as GraphDataQuery, QueryVariables};
 use graph::data::schema::ApiSchema;
+use graph::data::subgraph::schema::SUBGRAPHS_ID;
 use graph::prelude::{info, o, CheapClone, Logger, QueryExecutionError};
 
 use crate::execution::{get_field, get_named_type, object_or_interface};
@@ -335,7 +336,9 @@ impl Query {
         selection_set: &q::SelectionSet,
     ) -> Vec<QueryExecutionError> {
         let schema = self.schema.document();
-        if selection_set.items.is_empty() {
+
+        // The dynamic data sources query uses empty selection sets, though ideally it shouldn't.
+        if selection_set.items.is_empty() && *self.schema.id() != *SUBGRAPHS_ID {
             return vec![QueryExecutionError::EmptySelectionSet(ty.name().to_owned())];
         }
         selection_set

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -24,6 +24,13 @@ impl<'a> From<&'a s::InterfaceType> for ObjectOrInterface<'a> {
 }
 
 impl<'a> ObjectOrInterface<'a> {
+    pub fn is_object(self) -> bool {
+        match self {
+            ObjectOrInterface::Object(_) => true,
+            ObjectOrInterface::Interface(_) => false,
+        }
+    }
+
     pub fn name(self) -> &'a str {
         match self {
             ObjectOrInterface::Object(object) => &object.name,

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -56,7 +56,7 @@ impl<'a> ObjectOrInterface<'a> {
         self.fields().iter().find(|field| &field.name == name)
     }
 
-    pub fn object_types(&'a self, schema: &'a ApiSchema) -> Option<Vec<&'a s::ObjectType>> {
+    pub fn object_types(self, schema: &'a ApiSchema) -> Option<Vec<&'a s::ObjectType>> {
         match self {
             ObjectOrInterface::Object(object) => Some(vec![object]),
             ObjectOrInterface::Interface(interface) => schema

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,71 +1,9 @@
 use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 
-use crate::prelude::*;
-use crate::schema::ast::get_named_type;
-use graph::prelude::{ApiSchema, QueryExecutionError, StoreEventStreamBox};
-
-#[derive(Copy, Clone, Debug)]
-pub enum ObjectOrInterface<'a> {
-    Object(&'a s::ObjectType),
-    Interface(&'a s::InterfaceType),
-}
-
-impl<'a> From<&'a s::ObjectType> for ObjectOrInterface<'a> {
-    fn from(object: &'a s::ObjectType) -> Self {
-        ObjectOrInterface::Object(object)
-    }
-}
-
-impl<'a> From<&'a s::InterfaceType> for ObjectOrInterface<'a> {
-    fn from(interface: &'a s::InterfaceType) -> Self {
-        ObjectOrInterface::Interface(interface)
-    }
-}
-
-impl<'a> ObjectOrInterface<'a> {
-    pub fn is_object(self) -> bool {
-        match self {
-            ObjectOrInterface::Object(_) => true,
-            ObjectOrInterface::Interface(_) => false,
-        }
-    }
-
-    pub fn name(self) -> &'a str {
-        match self {
-            ObjectOrInterface::Object(object) => &object.name,
-            ObjectOrInterface::Interface(interface) => &interface.name,
-        }
-    }
-
-    pub fn directives(self) -> &'a Vec<s::Directive> {
-        match self {
-            ObjectOrInterface::Object(object) => &object.directives,
-            ObjectOrInterface::Interface(interface) => &interface.directives,
-        }
-    }
-
-    pub fn fields(self) -> &'a Vec<s::Field> {
-        match self {
-            ObjectOrInterface::Object(object) => &object.fields,
-            ObjectOrInterface::Interface(interface) => &interface.fields,
-        }
-    }
-
-    pub fn field(&self, name: &s::Name) -> Option<&s::Field> {
-        self.fields().iter().find(|field| &field.name == name)
-    }
-
-    pub fn object_types(self, schema: &'a ApiSchema) -> Option<Vec<&'a s::ObjectType>> {
-        match self {
-            ObjectOrInterface::Object(object) => Some(vec![object]),
-            ObjectOrInterface::Interface(interface) => schema
-                .types_for_interface()
-                .get(&interface.name)
-                .map(|object_types| object_types.iter().collect()),
-        }
-    }
-}
+use crate::execution::ExecutionContext;
+use graph::data::graphql::{ext::DocumentExt, ObjectOrInterface};
+use graph::prelude::{QueryExecutionError, StoreEventStreamBox};
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
 pub trait Resolver: Sized + Send + Sync + 'static {
@@ -159,7 +97,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         };
 
         // A name returned in a `__typename` must exist in the schema.
-        match get_named_type(schema, &concrete_type_name).unwrap() {
+        match schema.get_named_type(&concrete_type_name).unwrap() {
             s::TypeDefinition::Object(object) => Some(object),
             _ => unreachable!("only objects may implement interfaces"),
         }

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -1,6 +1,7 @@
 use graphql_parser::{query as q, schema as s, Pos};
 use std::collections::{BTreeMap, HashMap};
 
+use graph::data::graphql::ObjectOrInterface;
 use graph::prelude::*;
 
 use crate::prelude::*;

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -28,7 +28,7 @@ mod runner;
 
 /// Prelude that exports the most important traits and types.
 pub mod prelude {
-    pub use super::execution::{ExecutionContext, ObjectOrInterface, Query, Resolver};
+    pub use super::execution::{ExecutionContext, Query, Resolver};
     pub use super::introspection::{introspection_schema, IntrospectionResolver};
     pub use super::query::{execute_query, ext::BlockConstraint, QueryExecutionOptions};
     pub use super::schema::{api_schema, ast::validate_entity, APISchemaError};

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -4,8 +4,8 @@ use lazy_static::lazy_static;
 use std::ops::Deref;
 use std::str::FromStr;
 
-use crate::execution::ObjectOrInterface;
 use crate::query::ast as qast;
+use graph::data::graphql::ObjectOrInterface;
 use graph::data::store;
 use graph::prelude::*;
 

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -169,7 +169,7 @@ pub fn get_field_name(field_type: &Type) -> Name {
 }
 
 /// Returns the type with the given name.
-pub fn get_named_type<'a>(schema: &'a Document, name: &Name) -> Option<&'a TypeDefinition> {
+pub fn get_named_type<'a>(schema: &'a Document, name: &str) -> Option<&'a TypeDefinition> {
     schema
         .definitions
         .iter()

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -362,20 +362,17 @@ impl<'a> Join<'a> {
 
         // Add appropriate children using grouped map
         for parent in parents {
-            // Set the `response_key` field in `parent`. Make sure that even
-            // if `parent` has no matching `children`, the field gets set (to
-            // an empty `Vec`).
+            // Set the `response_key` field in `parent`. Make sure that even if `parent` has no
+            // matching `children`, the field gets set (to an empty `Vec`).
             //
             // This `insert` will overwrite in the case where the response key occurs both at the
-            // interface level and in concrete types. The interface is always joined first, and may
-            // then be overwritten by the merged selection set under. the concrete type condition.
-            // See also: e0d6da3e-60cf-41a5-b83c-b60a7a766d4a
-            let values = parent
-                .id()
-                .ok()
-                .and_then(|id| grouped.get(&*id).map(|values| values.clone()))
-                .unwrap_or(vec![]);
-            parent.children.insert(response_key.to_owned(), values);
+            // interface level and in nested object type conditions. The values for the interface
+            // query are always joined first, and may then be overwritten by the merged selection
+            // set under the object type condition. See also: e0d6da3e-60cf-41a5-b83c-b60a7a766d4a
+            let values = parent.id().ok().and_then(|id| grouped.get(&*id).cloned());
+            parent
+                .children
+                .insert(response_key.to_owned(), values.unwrap_or(vec![]));
         }
     }
 

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -10,14 +10,14 @@ use std::iter::once;
 use std::rc::Rc;
 use std::time::Instant;
 
-use graph::data::graphql::ext::ObjectTypeExt;
+use graph::data::graphql::*;
 use graph::prelude::{
     ApiSchema, BlockNumber, ChildMultiplicity, EntityCollection, EntityFilter, EntityLink,
     EntityOrder, EntityWindow, Logger, ParentLink, QueryExecutionError, QueryStore,
     Value as StoreValue, WindowAttribute,
 };
 
-use crate::execution::{ExecutionContext, ObjectOrInterface, Resolver};
+use crate::execution::{ExecutionContext, Resolver};
 use crate::query::ast as qast;
 use crate::schema::ast as sast;
 use crate::store::{build_query, StoreResolver};
@@ -317,10 +317,10 @@ impl<'a> Join<'a> {
         field_name: &s::Name,
     ) -> Self {
         let parent_types = parent_type
-            .object_types(schema)
+            .object_types(schema.schema())
             .expect("the name of the parent type is valid");
         let child_types = child_type
-            .object_types(schema)
+            .object_types(schema.schema())
             .expect("the name of the child type is valid");
 
         let conds = parent_types
@@ -463,32 +463,10 @@ fn execute_root_selection_set(
     // Obtain the root Query type and fail if there isn't one
     let query_type = ctx.query.schema.query_type.as_ref().into();
 
-    let grouped_field_set = collect_fields(ctx, query_type, once(selection_set))?;
+    let grouped_field_set = collect_fields(ctx, query_type, once(selection_set));
 
     // Execute the root selection set against the root query type
     execute_selection_set(resolver, ctx, make_root_node(), grouped_field_set)
-}
-
-fn object_or_interface_from_type<'a>(
-    schema: &'a s::Document,
-    field_type: &'a s::Type,
-) -> Option<ObjectOrInterface<'a>> {
-    match field_type {
-        s::Type::NonNullType(inner_type) => object_or_interface_from_type(schema, inner_type),
-        s::Type::ListType(inner_type) => object_or_interface_from_type(schema, inner_type),
-        s::Type::NamedType(name) => object_or_interface_by_name(schema, name),
-    }
-}
-
-fn object_or_interface_by_name<'a>(
-    schema: &'a s::Document,
-    name: &str,
-) -> Option<ObjectOrInterface<'a>> {
-    match sast::get_named_type(schema, name) {
-        Some(s::TypeDefinition::Object(t)) => Some(t.into()),
-        Some(s::TypeDefinition::Interface(t)) => Some(t.into()),
-        _ => None,
-    }
 }
 
 fn execute_selection_set<'a>(
@@ -535,11 +513,15 @@ fn execute_selection_set<'a>(
                 })
                 .map(|(c, f)| (ObjectOrInterface::Object(c.0), f)),
         ) {
-            // Unwrap: The query was validated to contain only valid fields.
+            // Unwrap: The query was validated to contain only valid fields,
+            // and `collect_fields` will skip introspection fields.
             let field = type_cond.field(&fields[0].name).unwrap();
-            let child_type =
-                object_or_interface_from_type(&ctx.query.schema.document(), &field.field_type)
-                    .expect("we only collect fields that are objects or interfaces");
+            let child_type = ctx
+                .query
+                .schema
+                .document()
+                .object_or_interface(field.field_type.get_base_type())
+                .expect("we only collect fields that are objects or interfaces");
 
             let join = Join::new(
                 ctx.query.schema.as_ref(),
@@ -550,7 +532,7 @@ fn execute_selection_set<'a>(
 
             // Group fields with the same response key, so we can execute them together
             let grouped_field_set =
-                collect_fields(ctx, child_type, fields.iter().map(|f| &f.selection_set))?;
+                collect_fields(ctx, child_type, fields.iter().map(|f| &f.selection_set));
 
             match execute_field(
                 resolver, &ctx, type_cond, &parents, &join, &fields[0], field,
@@ -606,7 +588,7 @@ fn collect_fields<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     parent_ty: ObjectOrInterface<'a>,
     selection_sets: impl Iterator<Item = &'a q::SelectionSet>,
-) -> Result<IndexMap<&'a String, CollectedResponseKey<'a>>, QueryExecutionError> {
+) -> IndexMap<&'a String, CollectedResponseKey<'a>> {
     let mut grouped_fields = IndexMap::new();
     collect_fields_inner(
         ctx,
@@ -614,7 +596,7 @@ fn collect_fields<'a>(
         selection_sets,
         &mut HashSet::new(),
         &mut grouped_fields,
-    )?;
+    );
 
     // For interfaces, if a response key occurs both under the interface and under concrete types,
     // we want to add the fields selected at the interface level to the selections in the specific
@@ -626,7 +608,7 @@ fn collect_fields<'a>(
         }
     }
 
-    Ok(grouped_fields)
+    grouped_fields
 }
 
 // When querying an object type, `type_condition` will always be that object type, even if it passes
@@ -640,8 +622,8 @@ fn collect_fields_inner<'a>(
     selection_sets: impl Iterator<Item = &'a q::SelectionSet>,
     visited_fragments: &mut HashSet<&'a q::Name>,
     output: &mut IndexMap<&'a String, CollectedResponseKey<'a>>,
-) -> Result<(), QueryExecutionError> {
-    let schema = &ctx.query.schema.document();
+) {
+    let schema = ctx.query.schema.document();
 
     for selection_set in selection_sets {
         // Only consider selections that are not skipped and should be included
@@ -688,10 +670,9 @@ fn collect_fields_inner<'a>(
                     if visited_fragments.insert(&spread.fragment_name) {
                         let fragment = ctx.query.get_fragment(&spread.fragment_name);
                         let fragment_ty = {
+                            // Unwrap: Validation ensures this is an object or interface.
                             let q::TypeCondition::On(ty_name) = &fragment.type_condition;
-                            object_or_interface_by_name(schema, ty_name).ok_or_else(|| {
-                                QueryExecutionError::NamedTypeError(ty_name.clone())
-                            })?
+                            schema.object_or_interface(ty_name).unwrap()
                         };
 
                         if fragment_ty.is_object() {
@@ -704,7 +685,7 @@ fn collect_fields_inner<'a>(
                             once(&fragment.selection_set),
                             visited_fragments,
                             output,
-                        )?;
+                        );
                     }
                 }
 
@@ -712,9 +693,8 @@ fn collect_fields_inner<'a>(
                     let fragment_ty = {
                         match &fragment.type_condition {
                             Some(q::TypeCondition::On(ty_name)) => {
-                                object_or_interface_by_name(schema, &ty_name).ok_or_else(|| {
-                                    QueryExecutionError::NamedTypeError(ty_name.clone())
-                                })?
+                                // Unwrap: Validation ensures this is an object or interface.
+                                schema.object_or_interface(&ty_name).unwrap()
                             }
                             None => type_condition,
                         }
@@ -730,12 +710,11 @@ fn collect_fields_inner<'a>(
                         once(&fragment.selection_set),
                         visited_fragments,
                         output,
-                    )?;
+                    );
                 }
             }
         }
     }
-    Ok(())
 }
 
 /// Executes a field.

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -590,11 +590,6 @@ fn execute_selection_set<'a>(
     if errors.is_empty() {
         Ok(parents)
     } else {
-        if errors.is_empty() {
-            errors.push(QueryExecutionError::EmptySelectionSet(
-                object_type.name().to_owned(),
-            ));
-        }
         Err(errors)
     }
 }

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -531,6 +531,13 @@ fn execute_selection_set<'a>(
     }
 }
 
+/// If the top-level selection is on an object, there will be a single entry in `obj_types` with all
+/// the collected fields.
+///
+/// The interesting case is if the top-level selection is an interface. `iface_cond` will be the
+/// interface type and `iface_fields` the selected fields on the interface. `obj_types` are the
+/// fields selected on objects by fragments. In `collect_fields`, the `iface_fields` will then be
+/// merged into each entry in `obj_types`. See also: e0d6da3e-60cf-41a5-b83c-b60a7a766d4a
 #[derive(Default)]
 struct CollectedResponseKey<'a> {
     iface_cond: Option<&'a s::InterfaceType>,

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -2,9 +2,9 @@ use graphql_parser::{query as q, query::Name, schema as s, schema::ObjectType};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::mem::discriminant;
 
+use graph::data::graphql::ObjectOrInterface;
 use graph::prelude::*;
 
-use crate::execution::ObjectOrInterface;
 use crate::schema::ast as sast;
 
 #[derive(Debug)]

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -4,6 +4,7 @@ use std::result;
 use std::sync::Arc;
 
 use graph::components::store::*;
+use graph::data::graphql::ObjectOrInterface;
 use graph::prelude::*;
 
 use crate::prelude::*;

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -212,15 +212,6 @@ impl Resolver for StoreResolver {
         object_type: &'a s::ObjectType,
         field: &'b q::Field,
     ) -> result::Result<StoreEventStreamBox, QueryExecutionError> {
-        // Fail if the field does not exist on the object type
-        if sast::get_field(object_type, &field.name).is_none() {
-            return Err(QueryExecutionError::UnknownField(
-                field.position,
-                object_type.name.clone(),
-                field.name.clone(),
-            ));
-        }
-
         // Collect all entities involved in the query field
         let entities = collect_entities_from_query_field(schema, object_type, field);
 

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -99,7 +99,6 @@ fn create_source_event_stream(
         ctx,
         &subscription_type,
         iter::once(ctx.query.selection_set.as_ref()),
-        None,
     );
 
     if grouped_field_set.is_empty() {

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -5,13 +5,14 @@ use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use graph::data::graphql::ObjectOrInterface;
 use graph::prelude::{
     o, slog, tokio, ApiSchema, Logger, Query, QueryExecutionError, QueryResult, Schema,
     SubgraphDeploymentId,
 };
 use graph_graphql::prelude::{
-    api_schema, execute_query, object, object_value, ExecutionContext, ObjectOrInterface,
-    Query as PreparedQuery, QueryExecutionOptions, Resolver,
+    api_schema, execute_query, object, object_value, ExecutionContext, Query as PreparedQuery,
+    QueryExecutionOptions, Resolver,
 };
 use test_store::LOAD_MANAGER;
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1056,7 +1056,9 @@ async fn ambiguous_derived_from_result() {
         {
           songs(first: 100, orderBy: id) {
             id
-            band
+            band {
+              id
+            }
           }
         }
         ",

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -1,10 +1,10 @@
 use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 
-use graph::data::graphql::{TryFromValue, ValueList, ValueMap};
+use graph::data::graphql::{ObjectOrInterface, TryFromValue, ValueList, ValueMap};
 use graph::data::subgraph::schema::{SubgraphError, SubgraphHealth, SUBGRAPHS_ID};
 use graph::prelude::*;
-use graph_graphql::prelude::{object, ExecutionContext, IntoValue, ObjectOrInterface, Resolver};
+use graph_graphql::prelude::{object, ExecutionContext, IntoValue, Resolver};
 use std::convert::TryInto;
 use web3::types::{Address, H256};
 


### PR DESCRIPTION
This fixes issues in how prefetch handles redundant selections in fragments. The changes are mostly around field collection, which will now have a single group of fields for response keys of objects, and for response keys of interfaces it will have a group of fields for the interface and one for each concrete type that appears in a type condition in the query.

Field collection in `execution.rs` was also refactored, even though it's not directly related to the issues.

This also changes where field collection happens, to make selecting only the relevant fields from the DB in a future patch easier.

Resolves #1816.