### PR TITLE
Revamp how we handle Prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,6 +1449,7 @@ dependencies = [
  "ipfs-api",
  "lazy_static",
  "lru_time_cache 0.9.0",
+ "prometheus",
  "semver 0.10.0",
  "serde 1.0.115",
  "serde_json",

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -1,5 +1,4 @@
 use lazy_static;
-use std::collections::HashMap;
 use std::time::Duration;
 
 use graph::prelude::*;
@@ -23,7 +22,6 @@ impl BlockIngestorMetrics {
                 .new_gauge_vec(
                     "ethereum_chain_head_number",
                     "Block number of the most recent block synced from Ethereum",
-                    HashMap::new(),
                     vec![String::from("network")],
                 )
                 .unwrap(),

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -21,8 +21,8 @@ impl BlockIngestorMetrics {
         Self {
             chain_head_number: registry
                 .new_gauge_vec(
-                    String::from("ethereum_chain_head_number"),
-                    String::from("Block number of the most recent block synced from Ethereum"),
+                    "ethereum_chain_head_number",
+                    "Block number of the most recent block synced from Ethereum",
                     HashMap::new(),
                     vec![String::from("network")],
                 )

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -22,7 +22,7 @@ impl BlockWriterMetrics {
     ) -> Self {
         let transaction = Aggregate::new(
             "subgraph_transaction",
-            subgraph_id.to_string(),
+            subgraph_id.as_str(),
             "Transactions to the store",
             registry.clone(),
         );

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -21,7 +21,8 @@ impl BlockWriterMetrics {
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
         let transaction = Aggregate::new(
-            format!("{}_transaction", subgraph_id.to_string()),
+            "subgraph_transaction",
+            subgraph_id.to_string(),
             "Transactions to the store",
             registry.clone(),
         );

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -21,7 +21,7 @@ impl BlockWriterMetrics {
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
         let transaction = Aggregate::new(
-            "subgraph_transaction",
+            "deployment_transaction",
             subgraph_id.as_str(),
             "Transactions to the store",
             registry.clone(),

--- a/chain/ethereum/src/network_indexer/metrics.rs
+++ b/chain/ethereum/src/network_indexer/metrics.rs
@@ -84,63 +84,63 @@ impl NetworkIndexerMetrics {
 
             reorg_depth: Aggregate::new(
                 "subgraph_reorg_depth",
-                subgraph_id.to_string(),
+                subgraph_id.as_str(),
                 "The depth of reorgs over time",
                 registry.clone(),
             ),
 
             poll_chain_head: Aggregate::new(
                 "subgraph_poll_chain_head",
-                subgraph_id.to_string(),
+                subgraph_id.as_str(),
                 "Polling the network's chain head",
                 registry.clone(),
             ),
 
             fetch_block_by_number: Aggregate::new(
                 "subgraph_fetch_block_by_number",
-                subgraph_id.to_string(),
+                subgraph_id.as_str(),
                 "Fetching a block using a block number",
                 registry.clone(),
             ),
 
             fetch_block_by_hash: Aggregate::new(
                 "subgraph_fetch_block_by_hash",
-                subgraph_id.to_string(),
+                subgraph_id.as_str(),
                 "Fetching a block using a block hash",
                 registry.clone(),
             ),
 
             fetch_full_block: Aggregate::new(
                 "subgraph_fetch_full_block",
-                subgraph_id.to_string(),
+                subgraph_id.as_str(),
                 "Fetching a full block",
                 registry.clone(),
             ),
 
             fetch_ommers: Aggregate::new(
                 "subgraph_fetch_ommers",
-                subgraph_id.to_string(),
+                subgraph_id.as_str(),
                 "Fetching the ommers of a block",
                 registry.clone(),
             ),
 
             load_local_head: Aggregate::new(
                 "subgraph_load_local_head",
-                subgraph_id.to_string(),
+                subgraph_id.as_str(),
                 "Load the local head block from the store",
                 registry.clone(),
             ),
 
             revert_local_head: Aggregate::new(
                 "subgraph_id_revert_local_head",
-                subgraph_id.to_string(),
+                subgraph_id.as_str(),
                 "Revert the local head block in the store",
                 registry.clone(),
             ),
 
             write_block: Aggregate::new(
                 "subgraph_write_block",
-                subgraph_id.to_string(),
+                subgraph_id.as_str(),
                 "Write a block to the store",
                 registry.clone(),
             ),

--- a/chain/ethereum/src/network_indexer/metrics.rs
+++ b/chain/ethereum/src/network_indexer/metrics.rs
@@ -48,7 +48,7 @@ pub struct NetworkIndexerMetrics {
 
 impl NetworkIndexerMetrics {
     pub fn new(
-        subgraph_id: SubgraphDeploymentId,
+        subgraph_id: &SubgraphDeploymentId,
         stopwatch: StopwatchMetrics,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {

--- a/chain/ethereum/src/network_indexer/metrics.rs
+++ b/chain/ethereum/src/network_indexer/metrics.rs
@@ -54,7 +54,7 @@ impl NetworkIndexerMetrics {
     ) -> Self {
         let make_gauge = |name: &str, help: &str| {
             registry
-                .new_subgraph_gauge(name, help, subgraph_id.as_str())
+                .new_deployment_gauge(name, help, subgraph_id.as_str())
                 .expect(
                     format!("failed to register metric `{}` for {}", name, subgraph_id).as_str(),
                 )
@@ -62,7 +62,7 @@ impl NetworkIndexerMetrics {
 
         let make_counter = |name: &str, help: &str| {
             registry
-                .new_subgraph_counter(name, help, subgraph_id.as_str())
+                .new_deployment_counter(name, help, subgraph_id.as_str())
                 .expect(
                     format!("failed to register metric `{}` for {}", name, subgraph_id).as_str(),
                 )
@@ -71,127 +71,127 @@ impl NetworkIndexerMetrics {
         Self {
             stopwatch,
 
-            chain_head: make_gauge("subgraph_chain_head", "The current chain head block"),
+            chain_head: make_gauge("deployment_chain_head", "The current chain head block"),
 
-            local_head: make_gauge("subgraph_local_head", "The current local head block"),
+            local_head: make_gauge("deployment_local_head", "The current local head block"),
 
-            reorg_count: make_counter("subgraph_reorg_count", "The number of reorgs handled"),
+            reorg_count: make_counter("deployment_reorg_count", "The number of reorgs handled"),
 
             reorg_cancel_count: make_counter(
-                "subgraph_reorg_cancel_count",
+                "deployment_reorg_cancel_count",
                 "The number of reorgs that had to be canceled / restarted",
             ),
 
             reorg_depth: Aggregate::new(
-                "subgraph_reorg_depth",
+                "deployment_reorg_depth",
                 subgraph_id.as_str(),
                 "The depth of reorgs over time",
                 registry.clone(),
             ),
 
             poll_chain_head: Aggregate::new(
-                "subgraph_poll_chain_head",
+                "deployment_poll_chain_head",
                 subgraph_id.as_str(),
                 "Polling the network's chain head",
                 registry.clone(),
             ),
 
             fetch_block_by_number: Aggregate::new(
-                "subgraph_fetch_block_by_number",
+                "deployment_fetch_block_by_number",
                 subgraph_id.as_str(),
                 "Fetching a block using a block number",
                 registry.clone(),
             ),
 
             fetch_block_by_hash: Aggregate::new(
-                "subgraph_fetch_block_by_hash",
+                "deployment_fetch_block_by_hash",
                 subgraph_id.as_str(),
                 "Fetching a block using a block hash",
                 registry.clone(),
             ),
 
             fetch_full_block: Aggregate::new(
-                "subgraph_fetch_full_block",
+                "deployment_fetch_full_block",
                 subgraph_id.as_str(),
                 "Fetching a full block",
                 registry.clone(),
             ),
 
             fetch_ommers: Aggregate::new(
-                "subgraph_fetch_ommers",
+                "deployment_fetch_ommers",
                 subgraph_id.as_str(),
                 "Fetching the ommers of a block",
                 registry.clone(),
             ),
 
             load_local_head: Aggregate::new(
-                "subgraph_load_local_head",
+                "deployment_load_local_head",
                 subgraph_id.as_str(),
                 "Load the local head block from the store",
                 registry.clone(),
             ),
 
             revert_local_head: Aggregate::new(
-                "subgraph_id_revert_local_head",
+                "deployment_revert_local_head",
                 subgraph_id.as_str(),
                 "Revert the local head block in the store",
                 registry.clone(),
             ),
 
             write_block: Aggregate::new(
-                "subgraph_write_block",
+                "deployment_write_block",
                 subgraph_id.as_str(),
                 "Write a block to the store",
                 registry.clone(),
             ),
 
             poll_chain_head_problems: make_gauge(
-                "subgraph_poll_chain_head_problems",
+                "deployment_poll_chain_head_problems",
                 "Problems polling the chain head",
             ),
 
             fetch_block_by_number_problems: make_gauge(
-                "subgraph_fetch_block_by_number_problems",
+                "deployment_fetch_block_by_number_problems",
                 "Problems fetching a block by number",
             ),
 
             fetch_block_by_hash_problems: make_gauge(
-                "subgraph_fetch_block_by_hash_problems",
+                "deployment_fetch_block_by_hash_problems",
                 "Problems fetching a block by hash",
             ),
 
             fetch_full_block_problems: make_gauge(
-                "subgraph_fetch_full_block_problems",
+                "deployment_fetch_full_block_problems",
                 "Problems fetching a full block",
             ),
 
             fetch_ommers_problems: make_gauge(
-                "subgraph_fetch_ommers_problems",
+                "deployment_fetch_ommers_problems",
                 "Problems fetching ommers of a block",
             ),
 
             load_local_head_problems: make_gauge(
-                "subgraph_load_local_head_problems",
+                "deployment_load_local_head_problems",
                 "Problems loading the local head block",
             ),
 
             revert_local_head_problems: make_gauge(
-                "subgraph_revert_local_head_problems",
+                "deployment_revert_local_head_problems",
                 "Problems reverting the local head block during a reorg",
             ),
 
             write_block_problems: make_gauge(
-                "subgraph_write_block_problems",
+                "deployment_write_block_problems",
                 "Problems writing a block to the store",
             ),
 
             last_new_chain_head_time: make_gauge(
-                "subgraph_last_new_chain_head_time",
+                "deployment_last_new_chain_head_time",
                 "The last time a chain head was received that was different from before",
             ),
 
             last_written_block_time: make_gauge(
-                "subgraph_last_written_block_time",
+                "deployment_last_written_block_time",
                 "The last time a block was written to the store",
             ),
         }

--- a/chain/ethereum/src/network_indexer/metrics.rs
+++ b/chain/ethereum/src/network_indexer/metrics.rs
@@ -52,17 +52,17 @@ impl NetworkIndexerMetrics {
         stopwatch: StopwatchMetrics,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
-        let const_labels = registry.subgraph_labels(subgraph_id.as_ref());
-
         let make_gauge = |name: &str, help: &str| {
-            registry.new_gauge(name, help, const_labels.clone()).expect(
-                format!("failed to register metric `{}` for {}", name, subgraph_id).as_str(),
-            )
+            registry
+                .new_subgraph_gauge(name, help, subgraph_id.as_str())
+                .expect(
+                    format!("failed to register metric `{}` for {}", name, subgraph_id).as_str(),
+                )
         };
 
         let make_counter = |name: &str, help: &str| {
             registry
-                .new_counter(name, help, const_labels.clone())
+                .new_subgraph_counter(name, help, subgraph_id.as_str())
                 .expect(
                     format!("failed to register metric `{}` for {}", name, subgraph_id).as_str(),
                 )

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -1145,7 +1145,7 @@ impl NetworkIndexer {
         );
 
         let metrics = Arc::new(NetworkIndexerMetrics::new(
-            subgraph_id.clone(),
+            &subgraph_id,
             stopwatch.clone(),
             metrics_registry.clone(),
         ));

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,3 +25,4 @@ walkdir = "2.3.1"
 test-store = { path = "../store/test-store" }
 hex = "0.4.2"
 graphql-parser = "0.2.3"
+prometheus = "0.7"

--- a/core/src/metrics/registry.rs
+++ b/core/src/metrics/registry.rs
@@ -78,7 +78,7 @@ impl MetricsRegistry {
         gauge
     }
 
-    pub fn register(&self, name: String, c: Box<dyn Collector>) {
+    pub fn register(&self, name: &str, c: Box<dyn Collector>) {
         let err = match self.registry.register(c).err() {
             None => {
                 self.registered_metrics.inc();
@@ -145,8 +145,8 @@ impl Clone for MetricsRegistry {
 impl MetricsRegistryTrait for MetricsRegistry {
     fn new_gauge(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Box<Gauge>, PrometheusError> {
         let labels: HashMap<String, String> = self
@@ -163,8 +163,8 @@ impl MetricsRegistryTrait for MetricsRegistry {
 
     fn new_gauge_vec(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
     ) -> Result<Box<GaugeVec>, PrometheusError> {
@@ -189,8 +189,8 @@ impl MetricsRegistryTrait for MetricsRegistry {
 
     fn new_counter(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Box<Counter>, PrometheusError> {
         let labels: HashMap<String, String> = self
@@ -207,46 +207,46 @@ impl MetricsRegistryTrait for MetricsRegistry {
 
     fn global_counter(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Counter, PrometheusError> {
-        let maybe_counter = self.global_counters.read().unwrap().get(&name).cloned();
+        let maybe_counter = self.global_counters.read().unwrap().get(name).cloned();
         if let Some(counter) = maybe_counter {
             Ok(counter.clone())
         } else {
-            let counter = *self.new_counter(name.clone(), help, const_labels)?;
+            let counter = *self.new_counter(&name, &help, const_labels)?;
             self.global_counters
                 .write()
                 .unwrap()
-                .insert(name.clone(), counter.clone());
+                .insert(name.to_owned(), counter.clone());
             Ok(counter)
         }
     }
 
     fn global_gauge(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Gauge, PrometheusError> {
-        let maybe_gauge = self.global_gauges.read().unwrap().get(&name).cloned();
+        let maybe_gauge = self.global_gauges.read().unwrap().get(name).cloned();
         if let Some(gauge) = maybe_gauge {
             Ok(gauge.clone())
         } else {
-            let gauge = *self.new_gauge(name.clone(), help, const_labels)?;
+            let gauge = *self.new_gauge(name, help, const_labels)?;
             self.global_gauges
                 .write()
                 .unwrap()
-                .insert(name.clone(), gauge.clone());
+                .insert(name.to_owned(), gauge.clone());
             Ok(gauge)
         }
     }
 
     fn new_counter_vec(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
     ) -> Result<Box<CounterVec>, PrometheusError> {
@@ -271,8 +271,8 @@ impl MetricsRegistryTrait for MetricsRegistry {
 
     fn new_histogram(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
         buckets: Vec<f64>,
     ) -> Result<Box<Histogram>, PrometheusError> {
@@ -292,8 +292,8 @@ impl MetricsRegistryTrait for MetricsRegistry {
 
     fn new_histogram_vec(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
         buckets: Vec<f64>,

--- a/core/src/metrics/registry.rs
+++ b/core/src/metrics/registry.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, RwLock};
 
 use graph::prelude::{MetricsRegistry as MetricsRegistryTrait, *};
 
+#[derive(Clone)]
 pub struct MetricsRegistry {
     logger: Logger,
     registry: Arc<Registry>,
@@ -123,21 +124,6 @@ impl MetricsRegistry {
                     "registering metric [{}] failed due to protobuf error: {}", name, err
                 );
             }
-        };
-    }
-}
-
-impl Clone for MetricsRegistry {
-    fn clone(&self) -> Self {
-        return Self {
-            logger: self.logger.clone(),
-            registry: self.registry.clone(),
-            const_labels: self.const_labels.clone(),
-            register_errors: self.register_errors.clone(),
-            unregister_errors: self.unregister_errors.clone(),
-            registered_metrics: self.registered_metrics.clone(),
-            global_counters: self.global_counters.clone(),
-            global_gauges: self.global_gauges.clone(),
         };
     }
 }

--- a/core/src/metrics/registry.rs
+++ b/core/src/metrics/registry.rs
@@ -7,7 +7,6 @@ use graph::prelude::{MetricsRegistry as MetricsRegistryTrait, *};
 pub struct MetricsRegistry {
     logger: Logger,
     registry: Arc<Registry>,
-    const_labels: HashMap<String, String>,
     register_errors: Box<Counter>,
     unregister_errors: Box<Counter>,
     registered_metrics: Box<Gauge>,
@@ -19,8 +18,6 @@ pub struct MetricsRegistry {
 
 impl MetricsRegistry {
     pub fn new(logger: Logger, registry: Arc<Registry>) -> Self {
-        let const_labels = HashMap::new();
-
         // Generate internal metrics
         let register_errors = Self::gen_register_errors_counter(registry.clone());
         let unregister_errors = Self::gen_unregister_errors_counter(registry.clone());
@@ -29,7 +26,6 @@ impl MetricsRegistry {
         MetricsRegistry {
             logger: logger.new(o!("component" => String::from("MetricsRegistry"))),
             registry,
-            const_labels,
             register_errors,
             unregister_errors,
             registered_metrics,
@@ -135,13 +131,7 @@ impl MetricsRegistryTrait for MetricsRegistry {
         help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Box<Gauge>, PrometheusError> {
-        let labels: HashMap<String, String> = self
-            .const_labels
-            .clone()
-            .into_iter()
-            .chain(const_labels)
-            .collect();
-        let opts = Opts::new(name.clone(), help).const_labels(labels);
+        let opts = Opts::new(name.clone(), help).const_labels(const_labels);
         let gauge = Box::new(Gauge::with_opts(opts)?);
         self.register(name, gauge.clone());
         Ok(gauge)
@@ -154,13 +144,7 @@ impl MetricsRegistryTrait for MetricsRegistry {
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
     ) -> Result<Box<GaugeVec>, PrometheusError> {
-        let labels: HashMap<String, String> = self
-            .const_labels
-            .clone()
-            .into_iter()
-            .chain(const_labels)
-            .collect();
-        let opts = Opts::new(name.clone(), help).const_labels(labels);
+        let opts = Opts::new(name.clone(), help).const_labels(const_labels);
         let gauges = Box::new(GaugeVec::new(
             opts,
             variable_labels
@@ -179,13 +163,7 @@ impl MetricsRegistryTrait for MetricsRegistry {
         help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Box<Counter>, PrometheusError> {
-        let labels: HashMap<String, String> = self
-            .const_labels
-            .clone()
-            .into_iter()
-            .chain(const_labels)
-            .collect();
-        let opts = Opts::new(name.clone(), help).const_labels(labels);
+        let opts = Opts::new(name.clone(), help).const_labels(const_labels);
         let counter = Box::new(Counter::with_opts(opts)?);
         self.register(name, counter.clone());
         Ok(counter)
@@ -236,13 +214,7 @@ impl MetricsRegistryTrait for MetricsRegistry {
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
     ) -> Result<Box<CounterVec>, PrometheusError> {
-        let labels: HashMap<String, String> = self
-            .const_labels
-            .clone()
-            .into_iter()
-            .chain(const_labels)
-            .collect();
-        let opts = Opts::new(name.clone(), help).const_labels(labels);
+        let opts = Opts::new(name.clone(), help).const_labels(const_labels);
         let counters = Box::new(CounterVec::new(
             opts,
             variable_labels
@@ -262,14 +234,8 @@ impl MetricsRegistryTrait for MetricsRegistry {
         const_labels: HashMap<String, String>,
         buckets: Vec<f64>,
     ) -> Result<Box<Histogram>, PrometheusError> {
-        let labels: HashMap<String, String> = self
-            .const_labels
-            .clone()
-            .into_iter()
-            .chain(const_labels)
-            .collect();
         let opts = HistogramOpts::new(name.clone(), help)
-            .const_labels(labels)
+            .const_labels(const_labels)
             .buckets(buckets);
         let histogram = Box::new(Histogram::with_opts(opts)?);
         self.register(name, histogram.clone());
@@ -284,13 +250,7 @@ impl MetricsRegistryTrait for MetricsRegistry {
         variable_labels: Vec<String>,
         buckets: Vec<f64>,
     ) -> Result<Box<HistogramVec>, PrometheusError> {
-        let labels: HashMap<String, String> = self
-            .const_labels
-            .clone()
-            .into_iter()
-            .chain(const_labels)
-            .collect();
-        let opts = Opts::new(name.clone(), help).const_labels(labels);
+        let opts = Opts::new(name.clone(), help).const_labels(const_labels);
         let histograms = Box::new(HistogramVec::new(
             HistogramOpts {
                 common_opts: opts,

--- a/core/src/metrics/registry.rs
+++ b/core/src/metrics/registry.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
+use graph::components::metrics::{counter_with_labels, gauge_with_labels};
 use graph::prelude::{MetricsRegistry as MetricsRegistryTrait, *};
 
 #[derive(Clone)]
@@ -11,9 +12,10 @@ pub struct MetricsRegistry {
     unregister_errors: Box<Counter>,
     registered_metrics: Box<Gauge>,
 
-    /// Global metrics are are lazily initialized and identified by name.
-    global_counters: Arc<RwLock<HashMap<String, Counter>>>,
-    global_gauges: Arc<RwLock<HashMap<String, Gauge>>>,
+    /// Global metrics are lazily initialized and identified by
+    /// the `Desc.id` that hashes the name and const label values
+    global_counters: Arc<RwLock<HashMap<u64, Counter>>>,
+    global_gauges: Arc<RwLock<HashMap<u64, Gauge>>>,
 }
 
 impl MetricsRegistry {
@@ -131,15 +133,17 @@ impl MetricsRegistryTrait for MetricsRegistry {
         help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Counter, PrometheusError> {
-        let maybe_counter = self.global_counters.read().unwrap().get(name).cloned();
+        let counter = counter_with_labels(name, help, const_labels)?;
+        let id = counter.desc().first().unwrap().id;
+        let maybe_counter = self.global_counters.read().unwrap().get(&id).cloned();
         if let Some(counter) = maybe_counter {
-            Ok(counter.clone())
+            Ok(counter)
         } else {
-            let counter = *self.new_counter_with_labels(&name, &help, const_labels)?;
+            self.register(name, Box::new(counter.clone()));
             self.global_counters
                 .write()
                 .unwrap()
-                .insert(name.to_owned(), counter.clone());
+                .insert(id, counter.clone());
             Ok(counter)
         }
     }
@@ -150,15 +154,17 @@ impl MetricsRegistryTrait for MetricsRegistry {
         help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Gauge, PrometheusError> {
-        let maybe_gauge = self.global_gauges.read().unwrap().get(name).cloned();
+        let gauge = gauge_with_labels(name, help, const_labels)?;
+        let id = gauge.desc().first().unwrap().id;
+        let maybe_gauge = self.global_gauges.read().unwrap().get(&id).cloned();
         if let Some(gauge) = maybe_gauge {
             Ok(gauge.clone())
         } else {
-            let gauge = *self.new_gauge(name, help, const_labels)?;
+            self.register(name, Box::new(gauge.clone()));
             self.global_gauges
                 .write()
                 .unwrap()
-                .insert(name.to_owned(), gauge.clone());
+                .insert(id, gauge.clone());
             Ok(gauge)
         }
     }
@@ -174,4 +180,56 @@ impl MetricsRegistryTrait for MetricsRegistry {
             }
         };
     }
+}
+
+#[test]
+fn global_counters_are_shared() {
+    use graph::log;
+
+    let logger = log::logger(false);
+    let prom_reg = Arc::new(Registry::new());
+    let registry = MetricsRegistry::new(logger, prom_reg.clone());
+
+    fn check_counters(
+        registry: &MetricsRegistry,
+        name: &str,
+        const_labels: HashMap<String, String>,
+    ) {
+        let c1 = registry
+            .global_counter(name, "help me", const_labels.clone())
+            .expect("first test counter");
+        let c2 = registry
+            .global_counter(name, "help me", const_labels)
+            .expect("second test counter");
+        let desc1 = c1.desc();
+        let desc2 = c2.desc();
+        let d1 = desc1.first().unwrap();
+        let d2 = desc2.first().unwrap();
+
+        // Registering the same metric with the same name and
+        // const labels twice works and returns the same metric (logically)
+        assert_eq!(d1.id, d2.id, "counters: {}", name);
+
+        // They share the reported values
+        c1.inc_by(7.0);
+        c2.inc_by(2.0);
+        assert_eq!(9.0, c1.get(), "counters: {}", name);
+        assert_eq!(9.0, c2.get(), "counters: {}", name);
+    }
+
+    check_counters(&registry, "nolabels", HashMap::new());
+
+    let const_labels = {
+        let mut map = HashMap::new();
+        map.insert("pool".to_owned(), "main".to_owned());
+        map
+    };
+    check_counters(&registry, "pool", const_labels);
+
+    let const_labels = {
+        let mut map = HashMap::new();
+        map.insert("pool".to_owned(), "replica0".to_owned());
+        map
+    };
+    check_counters(&registry, "pool", const_labels);
 }

--- a/core/src/metrics/registry.rs
+++ b/core/src/metrics/registry.rs
@@ -135,7 +135,7 @@ impl MetricsRegistryTrait for MetricsRegistry {
         if let Some(counter) = maybe_counter {
             Ok(counter.clone())
         } else {
-            let counter = *self.new_counter(&name, &help, const_labels)?;
+            let counter = *self.new_counter_with_labels(&name, &help, const_labels)?;
             self.global_counters
                 .write()
                 .unwrap()

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -119,40 +119,36 @@ struct SubgraphInstanceMetrics {
 
 impl SubgraphInstanceMetrics {
     pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: String) -> Self {
-        let const_labels = [(String::from("subgraph"), subgraph_hash)]
-            .iter()
-            .cloned()
-            .collect::<HashMap<_, _>>();
         let block_trigger_count = registry
-            .new_histogram(
+            .new_subgraph_histogram(
                 "subgraph_block_trigger_count",
                 "Measures the number of triggers in each block for a subgraph deployment",
-                const_labels.clone(),
+                &subgraph_hash,
                 vec![1.0, 5.0, 10.0, 20.0, 50.0],
             )
             .expect("failed to create `subgraph_block_trigger_count` histogram");
         let trigger_processing_duration = registry
-            .new_histogram_vec(
+            .new_subgraph_histogram_vec(
                 "subgraph_trigger_processing_duration",
                 "Measures duration of trigger processing for a subgraph deployment",
-                const_labels.clone(),
+                &subgraph_hash,
                 vec![String::from("trigger_type")],
                 vec![0.01, 0.05, 0.1, 0.5, 1.5, 5.0, 10.0, 30.0, 120.0],
             )
             .expect("failed to create `subgraph_trigger_processing_duration` histogram");
         let block_processing_duration = registry
-            .new_histogram(
+            .new_subgraph_histogram(
                 "subgraph_block_processing_duration",
                 "Measures duration of block processing for a subgraph deployment",
-                const_labels.clone(),
+                &subgraph_hash,
                 vec![0.05, 0.2, 0.7, 1.5, 4.0, 10.0, 60.0, 120.0, 240.0],
             )
             .expect("failed to create `subgraph_block_processing_duration` histogram");
         let block_ops_transaction_duration = registry
-            .new_histogram(
+            .new_subgraph_histogram(
                 "subgraph_transact_block_operations_duration",
                 "Measures duration of commiting all the entity operations in a block and updating the subgraph pointer",
-                const_labels.clone(),
+                &subgraph_hash,
                 vec![0.01, 0.05, 0.1, 0.3, 0.7, 2.0],
             )
             .expect("failed to create `subgraph_transact_block_operations_duration_{}");

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -120,38 +120,38 @@ struct SubgraphInstanceMetrics {
 impl SubgraphInstanceMetrics {
     pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: &str) -> Self {
         let block_trigger_count = registry
-            .new_subgraph_histogram(
-                "subgraph_block_trigger_count",
+            .new_deployment_histogram(
+                "deployment_block_trigger_count",
                 "Measures the number of triggers in each block for a subgraph deployment",
                 subgraph_hash,
                 vec![1.0, 5.0, 10.0, 20.0, 50.0],
             )
-            .expect("failed to create `subgraph_block_trigger_count` histogram");
+            .expect("failed to create `deployment_block_trigger_count` histogram");
         let trigger_processing_duration = registry
-            .new_subgraph_histogram_vec(
-                "subgraph_trigger_processing_duration",
+            .new_deployment_histogram_vec(
+                "deployment_trigger_processing_duration",
                 "Measures duration of trigger processing for a subgraph deployment",
                 subgraph_hash,
                 vec![String::from("trigger_type")],
                 vec![0.01, 0.05, 0.1, 0.5, 1.5, 5.0, 10.0, 30.0, 120.0],
             )
-            .expect("failed to create `subgraph_trigger_processing_duration` histogram");
+            .expect("failed to create `deployment_trigger_processing_duration` histogram");
         let block_processing_duration = registry
-            .new_subgraph_histogram(
-                "subgraph_block_processing_duration",
+            .new_deployment_histogram(
+                "deployment_block_processing_duration",
                 "Measures duration of block processing for a subgraph deployment",
                 subgraph_hash,
                 vec![0.05, 0.2, 0.7, 1.5, 4.0, 10.0, 60.0, 120.0, 240.0],
             )
-            .expect("failed to create `subgraph_block_processing_duration` histogram");
+            .expect("failed to create `deployment_block_processing_duration` histogram");
         let block_ops_transaction_duration = registry
-            .new_subgraph_histogram(
-                "subgraph_transact_block_operations_duration",
+            .new_deployment_histogram(
+                "deployment_transact_block_operations_duration",
                 "Measures duration of commiting all the entity operations in a block and updating the subgraph pointer",
                 subgraph_hash,
                 vec![0.01, 0.05, 0.1, 0.3, 0.7, 2.0],
             )
-            .expect("failed to create `subgraph_transact_block_operations_duration_{}");
+            .expect("failed to create `deployment_transact_block_operations_duration_{}");
 
         Self {
             block_trigger_count,

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -84,10 +84,8 @@ impl SubgraphInstanceManagerMetrics {
     pub fn new(registry: Arc<impl MetricsRegistry>) -> Self {
         let subgraph_count = registry
             .new_gauge(
-                String::from("subgraph_count"),
-                String::from(
-                    "Counts the number of subgraphs currently being indexed by the graph-node.",
-                ),
+                "subgraph_count",
+                "Counts the number of subgraphs currently being indexed by the graph-node.",
                 HashMap::new(),
             )
             .expect("failed to create `subgraph_count` gauge");
@@ -121,38 +119,40 @@ struct SubgraphInstanceMetrics {
 
 impl SubgraphInstanceMetrics {
     pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: String) -> Self {
+        let const_labels = [(String::from("subgraph"), subgraph_hash)]
+            .iter()
+            .cloned()
+            .collect::<HashMap<_, _>>();
         let block_trigger_count = registry
             .new_histogram(
-                format!("subgraph_block_trigger_count_{}", subgraph_hash),
-                String::from(
-                    "Measures the number of triggers in each block for a subgraph deployment",
-                ),
-                HashMap::new(),
+                "subgraph_block_trigger_count",
+                "Measures the number of triggers in each block for a subgraph deployment",
+                const_labels.clone(),
                 vec![1.0, 5.0, 10.0, 20.0, 50.0],
             )
             .expect("failed to create `subgraph_block_trigger_count` histogram");
         let trigger_processing_duration = registry
             .new_histogram_vec(
-                format!("subgraph_trigger_processing_duration_{}", subgraph_hash),
-                String::from("Measures duration of trigger processing for a subgraph deployment"),
-                HashMap::new(),
+                "subgraph_trigger_processing_duration",
+                "Measures duration of trigger processing for a subgraph deployment",
+                const_labels.clone(),
                 vec![String::from("trigger_type")],
                 vec![0.01, 0.05, 0.1, 0.5, 1.5, 5.0, 10.0, 30.0, 120.0],
             )
             .expect("failed to create `subgraph_trigger_processing_duration` histogram");
         let block_processing_duration = registry
             .new_histogram(
-                format!("subgraph_block_processing_duration_{}", subgraph_hash),
-                String::from("Measures duration of block processing for a subgraph deployment"),
-                HashMap::new(),
+                "subgraph_block_processing_duration",
+                "Measures duration of block processing for a subgraph deployment",
+                const_labels.clone(),
                 vec![0.05, 0.2, 0.7, 1.5, 4.0, 10.0, 60.0, 120.0, 240.0],
             )
             .expect("failed to create `subgraph_block_processing_duration` histogram");
         let block_ops_transaction_duration = registry
             .new_histogram(
-                format!("subgraph_transact_block_operations_duration_{}", subgraph_hash),
-                String::from("Measures duration of commiting all the entity operations in a block and updating the subgraph pointer"),
-                HashMap::new(),
+                "subgraph_transact_block_operations_duration",
+                "Measures duration of commiting all the entity operations in a block and updating the subgraph pointer",
+                const_labels.clone(),
                 vec![0.01, 0.05, 0.1, 0.3, 0.7, 2.0],
             )
             .expect("failed to create `subgraph_transact_block_operations_duration_{}");

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -118,12 +118,12 @@ struct SubgraphInstanceMetrics {
 }
 
 impl SubgraphInstanceMetrics {
-    pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: String) -> Self {
+    pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: &str) -> Self {
         let block_trigger_count = registry
             .new_subgraph_histogram(
                 "subgraph_block_trigger_count",
                 "Measures the number of triggers in each block for a subgraph deployment",
-                &subgraph_hash,
+                subgraph_hash,
                 vec![1.0, 5.0, 10.0, 20.0, 50.0],
             )
             .expect("failed to create `subgraph_block_trigger_count` histogram");
@@ -131,7 +131,7 @@ impl SubgraphInstanceMetrics {
             .new_subgraph_histogram_vec(
                 "subgraph_trigger_processing_duration",
                 "Measures duration of trigger processing for a subgraph deployment",
-                &subgraph_hash,
+                subgraph_hash,
                 vec![String::from("trigger_type")],
                 vec![0.01, 0.05, 0.1, 0.5, 1.5, 5.0, 10.0, 30.0, 120.0],
             )
@@ -140,7 +140,7 @@ impl SubgraphInstanceMetrics {
             .new_subgraph_histogram(
                 "subgraph_block_processing_duration",
                 "Measures duration of block processing for a subgraph deployment",
-                &subgraph_hash,
+                subgraph_hash,
                 vec![0.05, 0.2, 0.7, 1.5, 4.0, 10.0, 60.0, 120.0, 240.0],
             )
             .expect("failed to create `subgraph_block_processing_duration` histogram");
@@ -148,7 +148,7 @@ impl SubgraphInstanceMetrics {
             .new_subgraph_histogram(
                 "subgraph_transact_block_operations_duration",
                 "Measures duration of commiting all the entity operations in a block and updating the subgraph pointer",
-                &subgraph_hash,
+                subgraph_hash,
                 vec![0.01, 0.05, 0.1, 0.3, 0.7, 2.0],
             )
             .expect("failed to create `subgraph_transact_block_operations_duration_{}");
@@ -371,22 +371,19 @@ impl SubgraphInstanceManager {
             StopwatchMetrics::new(logger.clone(), deployment_id.clone(), registry.clone());
         let subgraph_metrics = Arc::new(SubgraphInstanceMetrics::new(
             registry.clone(),
-            deployment_id.clone().to_string(),
+            deployment_id.as_str(),
         ));
         let subgraph_metrics_unregister = subgraph_metrics.clone();
         let host_metrics = Arc::new(HostMetrics::new(
             registry.clone(),
-            deployment_id.clone().to_string(),
+            deployment_id.as_str(),
             stopwatch_metrics.clone(),
         ));
-        let ethrpc_metrics = Arc::new(SubgraphEthRpcMetrics::new(
-            registry.clone(),
-            deployment_id.to_string(),
-        ));
+        let ethrpc_metrics = Arc::new(SubgraphEthRpcMetrics::new(registry.clone(), &deployment_id));
         let block_stream_metrics = Arc::new(BlockStreamMetrics::new(
             registry.clone(),
             ethrpc_metrics.clone(),
-            deployment_id.clone(),
+            &deployment_id,
             stopwatch_metrics,
         ));
         let instance =

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -84,11 +84,11 @@ impl SubgraphInstanceManagerMetrics {
     pub fn new(registry: Arc<impl MetricsRegistry>) -> Self {
         let subgraph_count = registry
             .new_gauge(
-                "subgraph_count",
-                "Counts the number of subgraphs currently being indexed by the graph-node.",
+                "deployment_count",
+                "Counts the number of deployments currently being indexed by the graph-node.",
                 HashMap::new(),
             )
-            .expect("failed to create `subgraph_count` gauge");
+            .expect("failed to create `deployment_count` gauge");
         Self { subgraph_count }
     }
 }

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -499,7 +499,6 @@ impl ProviderEthRpcMetrics {
             .new_histogram_vec(
                 "eth_rpc_request_duration",
                 "Measures eth rpc request duration",
-                HashMap::new(),
                 vec![String::from("method")],
                 vec![0.05, 0.2, 0.5, 1.0, 3.0, 5.0],
             )
@@ -508,7 +507,6 @@ impl ProviderEthRpcMetrics {
             .new_counter_vec(
                 "eth_rpc_errors",
                 "Counts eth rpc request errors",
-                HashMap::new(),
                 vec![String::from("method")],
             )
             .unwrap();
@@ -537,20 +535,19 @@ pub struct SubgraphEthRpcMetrics {
 
 impl SubgraphEthRpcMetrics {
     pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: String) -> Self {
-        let const_labels = registry.subgraph_labels(&subgraph_hash);
         let request_duration = registry
-            .new_gauge_vec(
+            .new_subgraph_gauge_vec(
                 "subgraph_eth_rpc_request_duration",
                 "Measures eth rpc request duration for a subgraph deployment",
-                const_labels.clone(),
+                &subgraph_hash,
                 vec![String::from("method")],
             )
             .unwrap();
         let errors = registry
-            .new_counter_vec(
+            .new_subgraph_counter_vec(
                 "subgraph_eth_rpc_errors",
                 "Counts eth rpc request errors for a subgraph deployment",
-                const_labels.clone(),
+                &subgraph_hash,
                 vec![String::from("method")],
             )
             .unwrap();
@@ -586,19 +583,18 @@ impl BlockStreamMetrics {
         deployment_id: SubgraphDeploymentId,
         stopwatch: StopwatchMetrics,
     ) -> Self {
-        let const_labels = registry.subgraph_labels(deployment_id.as_str());
         let blocks_behind = registry
-            .new_gauge(
+            .new_subgraph_gauge(
                 "subgraph_blocks_behind",
                 "Track the number of blocks a subgraph deployment is behind the HEAD block",
-                const_labels.clone(),
+                deployment_id.as_str(),
             )
             .expect("failed to create `subgraph_blocks_behind` gauge");
         let reverted_blocks = registry
-            .new_gauge(
+            .new_subgraph_gauge(
                 "subgraph_reverted_blocks",
                 "Track the last reverted block for a subgraph deployment",
-                const_labels,
+                deployment_id.as_str(),
             )
             .expect("Failed to create `subgraph_reverted_blocks` gauge");
         Self {

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -536,16 +536,16 @@ pub struct SubgraphEthRpcMetrics {
 impl SubgraphEthRpcMetrics {
     pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: &str) -> Self {
         let request_duration = registry
-            .new_subgraph_gauge_vec(
-                "subgraph_eth_rpc_request_duration",
+            .new_deployment_gauge_vec(
+                "deployment_eth_rpc_request_duration",
                 "Measures eth rpc request duration for a subgraph deployment",
                 &subgraph_hash,
                 vec![String::from("method")],
             )
             .unwrap();
         let errors = registry
-            .new_subgraph_counter_vec(
-                "subgraph_eth_rpc_errors",
+            .new_deployment_counter_vec(
+                "deployment_eth_rpc_errors",
                 "Counts eth rpc request errors for a subgraph deployment",
                 &subgraph_hash,
                 vec![String::from("method")],
@@ -584,15 +584,15 @@ impl BlockStreamMetrics {
         stopwatch: StopwatchMetrics,
     ) -> Self {
         let blocks_behind = registry
-            .new_subgraph_gauge(
-                "subgraph_blocks_behind",
+            .new_deployment_gauge(
+                "deployment_blocks_behind",
                 "Track the number of blocks a subgraph deployment is behind the HEAD block",
                 deployment_id.as_str(),
             )
             .expect("failed to create `subgraph_blocks_behind` gauge");
         let reverted_blocks = registry
-            .new_subgraph_gauge(
-                "subgraph_reverted_blocks",
+            .new_deployment_gauge(
+                "deployment_reverted_blocks",
                 "Track the last reverted block for a subgraph deployment",
                 deployment_id.as_str(),
             )

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -534,7 +534,7 @@ pub struct SubgraphEthRpcMetrics {
 }
 
 impl SubgraphEthRpcMetrics {
-    pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: String) -> Self {
+    pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: &str) -> Self {
         let request_duration = registry
             .new_subgraph_gauge_vec(
                 "subgraph_eth_rpc_request_duration",
@@ -580,7 +580,7 @@ impl BlockStreamMetrics {
     pub fn new(
         registry: Arc<impl MetricsRegistry>,
         ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
-        deployment_id: SubgraphDeploymentId,
+        deployment_id: &SubgraphDeploymentId,
         stopwatch: StopwatchMetrics,
     ) -> Self {
         let blocks_behind = registry

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -589,14 +589,14 @@ impl BlockStreamMetrics {
                 "Track the number of blocks a subgraph deployment is behind the HEAD block",
                 deployment_id.as_str(),
             )
-            .expect("failed to create `subgraph_blocks_behind` gauge");
+            .expect("failed to create `deployment_blocks_behind` gauge");
         let reverted_blocks = registry
             .new_deployment_gauge(
                 "deployment_reverted_blocks",
                 "Track the last reverted block for a subgraph deployment",
                 deployment_id.as_str(),
             )
-            .expect("Failed to create `subgraph_reverted_blocks` gauge");
+            .expect("Failed to create `deployment_reverted_blocks` gauge");
         Self {
             ethrpc_metrics,
             blocks_behind,

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -497,8 +497,8 @@ impl ProviderEthRpcMetrics {
     pub fn new(registry: Arc<impl MetricsRegistry>) -> Self {
         let request_duration = registry
             .new_histogram_vec(
-                String::from("eth_rpc_request_duration"),
-                String::from("Measures eth rpc request duration"),
+                "eth_rpc_request_duration",
+                "Measures eth rpc request duration",
                 HashMap::new(),
                 vec![String::from("method")],
                 vec![0.05, 0.2, 0.5, 1.0, 3.0, 5.0],
@@ -506,8 +506,8 @@ impl ProviderEthRpcMetrics {
             .unwrap();
         let errors = registry
             .new_counter_vec(
-                String::from("eth_rpc_errors"),
-                String::from("Counts eth rpc request errors"),
+                "eth_rpc_errors",
+                "Counts eth rpc request errors",
                 HashMap::new(),
                 vec![String::from("method")],
             )
@@ -537,19 +537,20 @@ pub struct SubgraphEthRpcMetrics {
 
 impl SubgraphEthRpcMetrics {
     pub fn new(registry: Arc<impl MetricsRegistry>, subgraph_hash: String) -> Self {
+        let const_labels = registry.subgraph_labels(&subgraph_hash);
         let request_duration = registry
             .new_gauge_vec(
-                format!("subgraph_eth_rpc_request_duration_{}", subgraph_hash),
-                String::from("Measures eth rpc request duration for a subgraph deployment"),
-                HashMap::new(),
+                "subgraph_eth_rpc_request_duration",
+                "Measures eth rpc request duration for a subgraph deployment",
+                const_labels.clone(),
                 vec![String::from("method")],
             )
             .unwrap();
         let errors = registry
             .new_counter_vec(
-                format!("subgraph_eth_rpc_errors_{}", subgraph_hash),
-                String::from("Counts eth rpc request errors for a subgraph deployment"),
-                HashMap::new(),
+                "subgraph_eth_rpc_errors",
+                "Counts eth rpc request errors for a subgraph deployment",
+                const_labels.clone(),
                 vec![String::from("method")],
             )
             .unwrap();
@@ -585,20 +586,19 @@ impl BlockStreamMetrics {
         deployment_id: SubgraphDeploymentId,
         stopwatch: StopwatchMetrics,
     ) -> Self {
+        let const_labels = registry.subgraph_labels(deployment_id.as_str());
         let blocks_behind = registry
             .new_gauge(
-                format!("subgraph_blocks_behind_{}", deployment_id.to_string()),
-                String::from(
-                    "Track the number of blocks a subgraph deployment is behind the HEAD block",
-                ),
-                HashMap::new(),
+                "subgraph_blocks_behind",
+                "Track the number of blocks a subgraph deployment is behind the HEAD block",
+                const_labels.clone(),
             )
             .expect("failed to create `subgraph_blocks_behind` gauge");
         let reverted_blocks = registry
             .new_gauge(
-                format!("subgraph_reverted_blocks_{}", deployment_id.to_string()),
-                String::from("Track the last reverted block for a subgraph deployment"),
-                HashMap::new(),
+                "subgraph_reverted_blocks",
+                "Track the last reverted block for a subgraph deployment",
+                const_labels,
             )
             .expect("Failed to create `subgraph_reverted_blocks` gauge");
         Self {

--- a/graph/src/components/metrics/aggregate.rs
+++ b/graph/src/components/metrics/aggregate.rs
@@ -17,12 +17,7 @@ pub struct Aggregate {
 }
 
 impl Aggregate {
-    pub fn new(
-        name: &str,
-        subgraph: String,
-        help: &str,
-        registry: Arc<dyn MetricsRegistry>,
-    ) -> Self {
+    pub fn new(name: &str, subgraph: &str, help: &str, registry: Arc<dyn MetricsRegistry>) -> Self {
         let make_gauge = |suffix: &str| {
             registry
                 .new_subgraph_gauge(
@@ -33,7 +28,7 @@ impl Aggregate {
                 .expect(
                     format!(
                         "failed to register metric `{}_{}` for {}",
-                        name, suffix, &subgraph
+                        name, suffix, subgraph
                     )
                     .as_str(),
                 )

--- a/graph/src/components/metrics/aggregate.rs
+++ b/graph/src/components/metrics/aggregate.rs
@@ -25,10 +25,10 @@ impl Aggregate {
     ) -> Self {
         let make_gauge = |suffix: &str| {
             registry
-                .new_gauge(
+                .new_subgraph_gauge(
                     &format!("{}_{}", name, suffix),
                     &format!("{} ({})", help, suffix),
-                    registry.subgraph_labels(&subgraph),
+                    &subgraph,
                 )
                 .expect(
                     format!(

--- a/graph/src/components/metrics/aggregate.rs
+++ b/graph/src/components/metrics/aggregate.rs
@@ -20,7 +20,7 @@ impl Aggregate {
     pub fn new(name: &str, subgraph: &str, help: &str, registry: Arc<dyn MetricsRegistry>) -> Self {
         let make_gauge = |suffix: &str| {
             registry
-                .new_subgraph_gauge(
+                .new_deployment_gauge(
                     &format!("{}_{}", name, suffix),
                     &format!("{} ({})", help, suffix),
                     &subgraph,

--- a/graph/src/components/metrics/aggregate.rs
+++ b/graph/src/components/metrics/aggregate.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::time::Duration;
 
 use crate::prelude::*;
@@ -18,44 +17,33 @@ pub struct Aggregate {
 }
 
 impl Aggregate {
-    pub fn new(name: String, help: &str, registry: Arc<dyn MetricsRegistry>) -> Self {
-        let count = registry
-            .new_gauge(
-                format!("{}_count", name),
-                format!("{} (count)", help),
-                HashMap::new(),
-            )
-            .expect(format!("failed to register metric `{}_count`", name).as_str());
-
-        let sum = registry
-            .new_gauge(
-                format!("{}_sum", name),
-                format!("{} (sum)", help),
-                HashMap::new(),
-            )
-            .expect(format!("failed to register metric `{}_sum`", name).as_str());
-
-        let avg = registry
-            .new_gauge(
-                format!("{}_avg", name),
-                format!("{} (avg)", help),
-                HashMap::new(),
-            )
-            .expect(format!("failed to register metric `{}_avg`", name).as_str());
-
-        let cur = registry
-            .new_gauge(
-                format!("{}_cur", name),
-                format!("{} (cur)", help),
-                HashMap::new(),
-            )
-            .expect(format!("failed to register metric `{}_cur`", name).as_str());
+    pub fn new(
+        name: &str,
+        subgraph: String,
+        help: &str,
+        registry: Arc<dyn MetricsRegistry>,
+    ) -> Self {
+        let make_gauge = |suffix: &str| {
+            registry
+                .new_gauge(
+                    &format!("{}_{}", name, suffix),
+                    &format!("{} ({})", help, suffix),
+                    registry.subgraph_labels(&subgraph),
+                )
+                .expect(
+                    format!(
+                        "failed to register metric `{}_{}` for {}",
+                        name, suffix, &subgraph
+                    )
+                    .as_str(),
+                )
+        };
 
         Aggregate {
-            count,
-            sum,
-            avg,
-            cur,
+            count: make_gauge("count"),
+            sum: make_gauge("sum"),
+            avg: make_gauge("avg"),
+            cur: make_gauge("cur"),
         }
     }
 

--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -11,8 +11,8 @@ pub mod stopwatch;
 /// Aggregates over individual values.
 pub mod aggregate;
 
-fn subgraph_labels(subgraph: &str) -> HashMap<String, String> {
-    labels! { String::from("subgraph") => String::from(subgraph), }
+fn deployment_labels(subgraph: &str) -> HashMap<String, String> {
+    labels! { String::from("deployment") => String::from(subgraph), }
 }
 
 pub trait MetricsRegistry: Send + Sync + 'static {
@@ -27,13 +27,13 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         const_labels: HashMap<String, String>,
     ) -> Result<Counter, PrometheusError>;
 
-    fn global_subgraph_counter(
+    fn global_deployment_counter(
         &self,
         name: &str,
         help: &str,
         subgraph: &str,
     ) -> Result<Counter, PrometheusError> {
-        self.global_counter(name, help, subgraph_labels(subgraph))
+        self.global_counter(name, help, deployment_labels(subgraph))
     }
 
     fn global_gauge(
@@ -55,13 +55,13 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         Ok(gauge)
     }
 
-    fn new_subgraph_gauge(
+    fn new_deployment_gauge(
         &self,
         name: &str,
         help: &str,
         subgraph: &str,
     ) -> Result<Box<Gauge>, PrometheusError> {
-        let opts = Opts::new(name.clone(), help).const_labels(subgraph_labels(subgraph));
+        let opts = Opts::new(name.clone(), help).const_labels(deployment_labels(subgraph));
         let gauge = Box::new(Gauge::with_opts(opts)?);
         self.register(name, gauge.clone());
         Ok(gauge)
@@ -86,14 +86,14 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         Ok(gauges)
     }
 
-    fn new_subgraph_gauge_vec(
+    fn new_deployment_gauge_vec(
         &self,
         name: &str,
         help: &str,
         subgraph: &str,
         variable_labels: Vec<String>,
     ) -> Result<Box<GaugeVec>, PrometheusError> {
-        let opts = Opts::new(name.clone(), help).const_labels(subgraph_labels(subgraph));
+        let opts = Opts::new(name.clone(), help).const_labels(deployment_labels(subgraph));
         let gauges = Box::new(GaugeVec::new(
             opts,
             variable_labels
@@ -125,13 +125,13 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         Ok(counter)
     }
 
-    fn new_subgraph_counter(
+    fn new_deployment_counter(
         &self,
         name: &str,
         help: &str,
         subgraph: &str,
     ) -> Result<Box<Counter>, PrometheusError> {
-        let opts = Opts::new(name.clone(), help).const_labels(subgraph_labels(subgraph));
+        let opts = Opts::new(name.clone(), help).const_labels(deployment_labels(subgraph));
         let counter = Box::new(Counter::with_opts(opts)?);
         self.register(name, counter.clone());
         Ok(counter)
@@ -156,14 +156,14 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         Ok(counters)
     }
 
-    fn new_subgraph_counter_vec(
+    fn new_deployment_counter_vec(
         &self,
         name: &str,
         help: &str,
         subgraph: &str,
         variable_labels: Vec<String>,
     ) -> Result<Box<CounterVec>, PrometheusError> {
-        let opts = Opts::new(name.clone(), help).const_labels(subgraph_labels(subgraph));
+        let opts = Opts::new(name.clone(), help).const_labels(deployment_labels(subgraph));
         let counters = Box::new(CounterVec::new(
             opts,
             variable_labels
@@ -176,7 +176,7 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         Ok(counters)
     }
 
-    fn new_subgraph_histogram(
+    fn new_deployment_histogram(
         &self,
         name: &str,
         help: &str,
@@ -184,7 +184,7 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         buckets: Vec<f64>,
     ) -> Result<Box<Histogram>, PrometheusError> {
         let opts = HistogramOpts::new(name.clone(), help)
-            .const_labels(subgraph_labels(subgraph))
+            .const_labels(deployment_labels(subgraph))
             .buckets(buckets);
         let histogram = Box::new(Histogram::with_opts(opts)?);
         self.register(name, histogram.clone());
@@ -214,7 +214,7 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         Ok(histograms)
     }
 
-    fn new_subgraph_histogram_vec(
+    fn new_deployment_histogram_vec(
         &self,
         name: &str,
         help: &str,
@@ -222,7 +222,7 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         variable_labels: Vec<String>,
         buckets: Vec<f64>,
     ) -> Result<Box<HistogramVec>, PrometheusError> {
-        let opts = Opts::new(name.clone(), help).const_labels(subgraph_labels(subgraph));
+        let opts = Opts::new(name.clone(), help).const_labels(deployment_labels(subgraph));
         let histograms = Box::new(HistogramVec::new(
             HistogramOpts {
                 common_opts: opts,
@@ -236,9 +236,5 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         )?);
         self.register(name, histograms.clone());
         Ok(histograms)
-    }
-
-    fn subgraph_labels(&self, subgraph: &str) -> HashMap<String, String> {
-        labels! { String::from("subgraph") => String::from(subgraph), }
     }
 }

--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -1,7 +1,7 @@
 pub use prometheus::core::Collector;
 pub use prometheus::{
-    Counter, CounterVec, Error as PrometheusError, Gauge, GaugeVec, Histogram, HistogramOpts,
-    HistogramVec, Opts, Registry,
+    labels, Counter, CounterVec, Error as PrometheusError, Gauge, GaugeVec, Histogram,
+    HistogramOpts, HistogramVec, Opts, Registry,
 };
 use std::collections::HashMap;
 
@@ -14,64 +14,68 @@ pub mod aggregate;
 pub trait MetricsRegistry: Send + Sync + 'static {
     fn new_gauge(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Box<Gauge>, PrometheusError>;
 
     fn new_gauge_vec(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
     ) -> Result<Box<GaugeVec>, PrometheusError>;
 
     fn new_counter(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Box<Counter>, PrometheusError>;
 
     fn global_counter(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Counter, PrometheusError>;
 
     fn global_gauge(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Gauge, PrometheusError>;
 
     fn new_counter_vec(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
     ) -> Result<Box<CounterVec>, PrometheusError>;
 
     fn new_histogram(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
         buckets: Vec<f64>,
     ) -> Result<Box<Histogram>, PrometheusError>;
 
     fn new_histogram_vec(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
         buckets: Vec<f64>,
     ) -> Result<Box<HistogramVec>, PrometheusError>;
 
     fn unregister(&self, metric: Box<dyn Collector>);
+
+    fn subgraph_labels(&self, subgraph: &str) -> HashMap<String, String> {
+        labels! { String::from("subgraph") => String::from(subgraph), }
+    }
 }

--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -15,6 +15,26 @@ fn deployment_labels(subgraph: &str) -> HashMap<String, String> {
     labels! { String::from("deployment") => String::from(subgraph), }
 }
 
+/// Create an unregistered counter with labels
+pub fn counter_with_labels(
+    name: &str,
+    help: &str,
+    const_labels: HashMap<String, String>,
+) -> Result<Counter, PrometheusError> {
+    let opts = Opts::new(name.clone(), help).const_labels(const_labels);
+    Counter::with_opts(opts)
+}
+
+/// Create an unregistered gauge with labels
+pub fn gauge_with_labels(
+    name: &str,
+    help: &str,
+    const_labels: HashMap<String, String>,
+) -> Result<Gauge, PrometheusError> {
+    let opts = Opts::new(name.clone(), help).const_labels(const_labels);
+    Gauge::with_opts(opts)
+}
+
 pub trait MetricsRegistry: Send + Sync + 'static {
     fn register(&self, name: &str, c: Box<dyn Collector>);
 
@@ -119,8 +139,7 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Box<Counter>, PrometheusError> {
-        let opts = Opts::new(name.clone(), help).const_labels(const_labels);
-        let counter = Box::new(Counter::with_opts(opts)?);
+        let counter = Box::new(counter_with_labels(name, help, const_labels)?);
         self.register(name, counter.clone());
         Ok(counter)
     }
@@ -131,8 +150,11 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         help: &str,
         subgraph: &str,
     ) -> Result<Box<Counter>, PrometheusError> {
-        let opts = Opts::new(name.clone(), help).const_labels(deployment_labels(subgraph));
-        let counter = Box::new(Counter::with_opts(opts)?);
+        let counter = Box::new(counter_with_labels(
+            name,
+            help,
+            deployment_labels(subgraph),
+        )?);
         self.register(name, counter.clone());
         Ok(counter)
     }

--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -176,18 +176,6 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         Ok(counters)
     }
 
-    fn new_histogram(
-        &self,
-        name: &str,
-        help: &str,
-        buckets: Vec<f64>,
-    ) -> Result<Box<Histogram>, PrometheusError> {
-        let opts = HistogramOpts::new(name.clone(), help).buckets(buckets);
-        let histogram = Box::new(Histogram::with_opts(opts)?);
-        self.register(name, histogram.clone());
-        Ok(histogram)
-    }
-
     fn new_subgraph_histogram(
         &self,
         name: &str,

--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -12,27 +12,9 @@ pub mod stopwatch;
 pub mod aggregate;
 
 pub trait MetricsRegistry: Send + Sync + 'static {
-    fn new_gauge(
-        &self,
-        name: &str,
-        help: &str,
-        const_labels: HashMap<String, String>,
-    ) -> Result<Box<Gauge>, PrometheusError>;
+    fn register(&self, name: &str, c: Box<dyn Collector>);
 
-    fn new_gauge_vec(
-        &self,
-        name: &str,
-        help: &str,
-        const_labels: HashMap<String, String>,
-        variable_labels: Vec<String>,
-    ) -> Result<Box<GaugeVec>, PrometheusError>;
-
-    fn new_counter(
-        &self,
-        name: &str,
-        help: &str,
-        const_labels: HashMap<String, String>,
-    ) -> Result<Box<Counter>, PrometheusError>;
+    fn unregister(&self, metric: Box<dyn Collector>);
 
     fn global_counter(
         &self,
@@ -48,13 +30,69 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         const_labels: HashMap<String, String>,
     ) -> Result<Gauge, PrometheusError>;
 
+    fn new_gauge(
+        &self,
+        name: &str,
+        help: &str,
+        const_labels: HashMap<String, String>,
+    ) -> Result<Box<Gauge>, PrometheusError> {
+        let opts = Opts::new(name.clone(), help).const_labels(const_labels);
+        let gauge = Box::new(Gauge::with_opts(opts)?);
+        self.register(name, gauge.clone());
+        Ok(gauge)
+    }
+
+    fn new_gauge_vec(
+        &self,
+        name: &str,
+        help: &str,
+        const_labels: HashMap<String, String>,
+        variable_labels: Vec<String>,
+    ) -> Result<Box<GaugeVec>, PrometheusError> {
+        let opts = Opts::new(name.clone(), help).const_labels(const_labels);
+        let gauges = Box::new(GaugeVec::new(
+            opts,
+            variable_labels
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<&str>>()
+                .as_slice(),
+        )?);
+        self.register(name, gauges.clone());
+        Ok(gauges)
+    }
+
+    fn new_counter(
+        &self,
+        name: &str,
+        help: &str,
+        const_labels: HashMap<String, String>,
+    ) -> Result<Box<Counter>, PrometheusError> {
+        let opts = Opts::new(name.clone(), help).const_labels(const_labels);
+        let counter = Box::new(Counter::with_opts(opts)?);
+        self.register(name, counter.clone());
+        Ok(counter)
+    }
+
     fn new_counter_vec(
         &self,
         name: &str,
         help: &str,
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
-    ) -> Result<Box<CounterVec>, PrometheusError>;
+    ) -> Result<Box<CounterVec>, PrometheusError> {
+        let opts = Opts::new(name.clone(), help).const_labels(const_labels);
+        let counters = Box::new(CounterVec::new(
+            opts,
+            variable_labels
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<&str>>()
+                .as_slice(),
+        )?);
+        self.register(name, counters.clone());
+        Ok(counters)
+    }
 
     fn new_histogram(
         &self,
@@ -62,7 +100,14 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         help: &str,
         const_labels: HashMap<String, String>,
         buckets: Vec<f64>,
-    ) -> Result<Box<Histogram>, PrometheusError>;
+    ) -> Result<Box<Histogram>, PrometheusError> {
+        let opts = HistogramOpts::new(name.clone(), help)
+            .const_labels(const_labels)
+            .buckets(buckets);
+        let histogram = Box::new(Histogram::with_opts(opts)?);
+        self.register(name, histogram.clone());
+        Ok(histogram)
+    }
 
     fn new_histogram_vec(
         &self,
@@ -71,9 +116,22 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
         buckets: Vec<f64>,
-    ) -> Result<Box<HistogramVec>, PrometheusError>;
-
-    fn unregister(&self, metric: Box<dyn Collector>);
+    ) -> Result<Box<HistogramVec>, PrometheusError> {
+        let opts = Opts::new(name.clone(), help).const_labels(const_labels);
+        let histograms = Box::new(HistogramVec::new(
+            HistogramOpts {
+                common_opts: opts,
+                buckets,
+            },
+            variable_labels
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<&str>>()
+                .as_slice(),
+        )?);
+        self.register(name, histograms.clone());
+        Ok(histograms)
+    }
 
     fn subgraph_labels(&self, subgraph: &str) -> HashMap<String, String> {
         labels! { String::from("subgraph") => String::from(subgraph), }

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -47,8 +47,8 @@ impl StopwatchMetrics {
     ) -> Self {
         let mut inner = StopwatchInner {
             counter: *registry
-                .new_subgraph_counter_vec(
-                    "subgraph_sync_secs",
+                .new_deployment_counter_vec(
+                    "deployment_sync_secs",
                     "total time spent syncing",
                     subgraph_id.as_str(),
                     vec!["section".to_owned()],

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -46,14 +46,18 @@ impl StopwatchMetrics {
         subgraph_id: SubgraphDeploymentId,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
+        let const_labels = registry.subgraph_labels(subgraph_id.as_str());
         let mut inner = StopwatchInner {
             total_counter: *registry
                 .new_counter(
-                    format!("{}_sync_total_secs", subgraph_id),
-                    format!("total time spent syncing"),
-                    HashMap::new(),
+                    "subgraph_sync_total_secs",
+                    "total time spent syncing",
+                    const_labels.clone(),
                 )
-                .expect("failed to register total_secs prometheus counter"),
+                .expect(&format!(
+                    "failed to register subgraph_sync_total_secs prometheus counter for {}",
+                    subgraph_id
+                )),
             logger,
             subgraph_id,
             registry,
@@ -126,7 +130,7 @@ impl StopwatchInner {
             } else {
                 let name = format!("{}_{}_secs", self.subgraph_id, section);
                 let help = format!("section {}", section);
-                match self.registry.new_counter(name, help, HashMap::new()) {
+                match self.registry.new_counter(&name, &help, HashMap::new()) {
                     Ok(counter) => {
                         self.counters.insert(section.clone(), (*counter).clone());
                         *counter

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -46,13 +46,12 @@ impl StopwatchMetrics {
         subgraph_id: SubgraphDeploymentId,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
-        let const_labels = registry.subgraph_labels(subgraph_id.as_str());
         let mut inner = StopwatchInner {
             total_counter: *registry
-                .new_counter(
+                .new_subgraph_counter(
                     "subgraph_sync_total_secs",
                     "total time spent syncing",
-                    const_labels.clone(),
+                    subgraph_id.as_str(),
                 )
                 .expect(&format!(
                     "failed to register subgraph_sync_total_secs prometheus counter for {}",
@@ -130,7 +129,7 @@ impl StopwatchInner {
             } else {
                 let name = format!("{}_{}_secs", self.subgraph_id, section);
                 let help = format!("section {}", section);
-                match self.registry.new_counter(&name, &help, HashMap::new()) {
+                match self.registry.new_counter(&name, &help) {
                     Ok(counter) => {
                         self.counters.insert(section.clone(), (*counter).clone());
                         *counter

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -74,21 +74,20 @@ impl HostMetrics {
         subgraph: String,
         stopwatch: StopwatchMetrics,
     ) -> Self {
-        let const_labels = registry.subgraph_labels(&subgraph);
         let handler_execution_time = registry
-            .new_histogram_vec(
+            .new_subgraph_histogram_vec(
                 "subgraph_handler_execution_time",
                 "Measures the execution time for handlers",
-                const_labels.clone(),
+                &subgraph,
                 vec![String::from("handler")],
                 vec![0.1, 0.5, 1.0, 10.0, 100.0],
             )
             .expect("failed to create `subgraph_handler_execution_time` histogram");
         let host_fn_execution_time = registry
-            .new_histogram_vec(
+            .new_subgraph_histogram_vec(
                 "subgraph_host_fn_execution_time",
                 "Measures the execution time for host functions",
-                const_labels.clone(),
+                &subgraph,
                 vec![String::from("host_fn_name")],
                 vec![0.025, 0.05, 0.2, 2.0, 8.0, 20.0],
             )

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
@@ -72,23 +71,24 @@ impl fmt::Debug for HostMetrics {
 impl HostMetrics {
     pub fn new(
         registry: Arc<impl MetricsRegistry>,
-        subgraph_hash: String,
+        subgraph: String,
         stopwatch: StopwatchMetrics,
     ) -> Self {
+        let const_labels = registry.subgraph_labels(&subgraph);
         let handler_execution_time = registry
             .new_histogram_vec(
-                format!("subgraph_handler_execution_time_{}", subgraph_hash),
-                String::from("Measures the execution time for handlers"),
-                HashMap::new(),
+                "subgraph_handler_execution_time",
+                "Measures the execution time for handlers",
+                const_labels.clone(),
                 vec![String::from("handler")],
                 vec![0.1, 0.5, 1.0, 10.0, 100.0],
             )
             .expect("failed to create `subgraph_handler_execution_time` histogram");
         let host_fn_execution_time = registry
             .new_histogram_vec(
-                format!("subgraph_host_fn_execution_time_{}", subgraph_hash),
-                String::from("Measures the execution time for host functions"),
-                HashMap::new(),
+                "subgraph_host_fn_execution_time",
+                "Measures the execution time for host functions",
+                const_labels.clone(),
                 vec![String::from("host_fn_name")],
                 vec![0.025, 0.05, 0.2, 2.0, 8.0, 20.0],
             )

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -75,23 +75,23 @@ impl HostMetrics {
         stopwatch: StopwatchMetrics,
     ) -> Self {
         let handler_execution_time = registry
-            .new_subgraph_histogram_vec(
-                "subgraph_handler_execution_time",
+            .new_deployment_histogram_vec(
+                "deployment_handler_execution_time",
                 "Measures the execution time for handlers",
                 subgraph,
                 vec![String::from("handler")],
                 vec![0.1, 0.5, 1.0, 10.0, 100.0],
             )
-            .expect("failed to create `subgraph_handler_execution_time` histogram");
+            .expect("failed to create `deployment_handler_execution_time` histogram");
         let host_fn_execution_time = registry
-            .new_subgraph_histogram_vec(
-                "subgraph_host_fn_execution_time",
+            .new_deployment_histogram_vec(
+                "deployment_host_fn_execution_time",
                 "Measures the execution time for host functions",
                 subgraph,
                 vec![String::from("host_fn_name")],
                 vec![0.025, 0.05, 0.2, 2.0, 8.0, 20.0],
             )
-            .expect("failed to create `subgraph_host_fn_execution_time` histogram");
+            .expect("failed to create `deployment_host_fn_execution_time` histogram");
         Self {
             handler_execution_time,
             host_fn_execution_time,

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -71,14 +71,14 @@ impl fmt::Debug for HostMetrics {
 impl HostMetrics {
     pub fn new(
         registry: Arc<impl MetricsRegistry>,
-        subgraph: String,
+        subgraph: &str,
         stopwatch: StopwatchMetrics,
     ) -> Self {
         let handler_execution_time = registry
             .new_subgraph_histogram_vec(
                 "subgraph_handler_execution_time",
                 "Measures the execution time for handlers",
-                &subgraph,
+                subgraph,
                 vec![String::from("handler")],
                 vec![0.1, 0.5, 1.0, 10.0, 100.0],
             )
@@ -87,7 +87,7 @@ impl HostMetrics {
             .new_subgraph_histogram_vec(
                 "subgraph_host_fn_execution_time",
                 "Measures the execution time for host functions",
-                &subgraph,
+                subgraph,
                 vec![String::from("host_fn_name")],
                 vec![0.025, 0.05, 0.2, 2.0, 8.0, 20.0],
             )

--- a/graph/src/data/graphql/effort.rs
+++ b/graph/src/data/graphql/effort.rs
@@ -263,8 +263,8 @@ impl LoadManager {
 
         let effort_gauge = registry
             .new_gauge(
-                String::from("query_effort_ms"),
-                String::from("Moving average of time spent running queries"),
+                "query_effort_ms",
+                "Moving average of time spent running queries",
                 HashMap::new(),
             )
             .expect("failed to create `query_effort_ms` counter");

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -1,7 +1,4 @@
-use graph::components::metrics::{
-    Collector, Counter, CounterVec, Gauge, GaugeVec, Histogram, HistogramOpts, HistogramVec, Opts,
-    PrometheusError,
-};
+use graph::components::metrics::{Collector, Counter, Gauge, Opts, PrometheusError};
 use graph::prelude::MetricsRegistry as MetricsRegistryTrait;
 
 use std::collections::HashMap;
@@ -21,45 +18,8 @@ impl Clone for MockMetricsRegistry {
 }
 
 impl MetricsRegistryTrait for MockMetricsRegistry {
-    fn new_gauge(
-        &self,
-        name: &str,
-        help: &str,
-        const_labels: HashMap<String, String>,
-    ) -> Result<Box<Gauge>, PrometheusError> {
-        let opts = Opts::new(name, help).const_labels(const_labels);
-        let gauge = Box::new(Gauge::with_opts(opts)?);
-        Ok(gauge)
-    }
-
-    fn new_gauge_vec(
-        &self,
-        name: &str,
-        help: &str,
-        const_labels: HashMap<String, String>,
-        variable_labels: Vec<String>,
-    ) -> Result<Box<GaugeVec>, PrometheusError> {
-        let opts = Opts::new(name, help).const_labels(const_labels);
-        let gauges = Box::new(GaugeVec::new(
-            opts,
-            variable_labels
-                .iter()
-                .map(|s| s.as_str())
-                .collect::<Vec<&str>>()
-                .as_slice(),
-        )?);
-        Ok(gauges)
-    }
-
-    fn new_counter(
-        &self,
-        name: &str,
-        help: &str,
-        const_labels: HashMap<String, String>,
-    ) -> Result<Box<Counter>, PrometheusError> {
-        let opts = Opts::new(name, help).const_labels(const_labels);
-        let counter = Box::new(Counter::with_opts(opts)?);
-        Ok(counter)
+    fn register(&self, _name: &str, _c: Box<dyn Collector>) {
+        // Ignore, we do not register metrics
     }
 
     fn global_counter(
@@ -80,62 +40,6 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
     ) -> Result<Gauge, PrometheusError> {
         let opts = Opts::new(name, help).const_labels(const_labels);
         Gauge::with_opts(opts)
-    }
-
-    fn new_counter_vec(
-        &self,
-        name: &str,
-        help: &str,
-        const_labels: HashMap<String, String>,
-        variable_labels: Vec<String>,
-    ) -> Result<Box<CounterVec>, PrometheusError> {
-        let opts = Opts::new(name, help).const_labels(const_labels);
-        let counters = Box::new(CounterVec::new(
-            opts,
-            variable_labels
-                .iter()
-                .map(|s| s.as_str())
-                .collect::<Vec<&str>>()
-                .as_slice(),
-        )?);
-        Ok(counters)
-    }
-
-    fn new_histogram(
-        &self,
-        name: &str,
-        help: &str,
-        const_labels: HashMap<String, String>,
-        buckets: Vec<f64>,
-    ) -> Result<Box<Histogram>, PrometheusError> {
-        let opts = HistogramOpts::new(name, help)
-            .const_labels(const_labels)
-            .buckets(buckets);
-        let histogram = Box::new(Histogram::with_opts(opts)?);
-        Ok(histogram)
-    }
-
-    fn new_histogram_vec(
-        &self,
-        name: &str,
-        help: &str,
-        const_labels: HashMap<String, String>,
-        variable_labels: Vec<String>,
-        buckets: Vec<f64>,
-    ) -> Result<Box<HistogramVec>, PrometheusError> {
-        let opts = Opts::new(name, help).const_labels(const_labels);
-        let histogram = Box::new(HistogramVec::new(
-            HistogramOpts {
-                common_opts: opts,
-                buckets,
-            },
-            variable_labels
-                .iter()
-                .map(|s| s.as_str())
-                .collect::<Vec<&str>>()
-                .as_slice(),
-        )?);
-        Ok(histogram)
     }
 
     fn unregister(&self, _: Box<dyn Collector>) {

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -23,8 +23,8 @@ impl Clone for MockMetricsRegistry {
 impl MetricsRegistryTrait for MockMetricsRegistry {
     fn new_gauge(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Box<Gauge>, PrometheusError> {
         let opts = Opts::new(name, help).const_labels(const_labels);
@@ -34,8 +34,8 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
 
     fn new_gauge_vec(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
     ) -> Result<Box<GaugeVec>, PrometheusError> {
@@ -53,8 +53,8 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
 
     fn new_counter(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Box<Counter>, PrometheusError> {
         let opts = Opts::new(name, help).const_labels(const_labels);
@@ -64,8 +64,8 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
 
     fn global_counter(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Counter, PrometheusError> {
         let opts = Opts::new(name, help).const_labels(const_labels);
@@ -74,8 +74,8 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
 
     fn global_gauge(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
     ) -> Result<Gauge, PrometheusError> {
         let opts = Opts::new(name, help).const_labels(const_labels);
@@ -84,8 +84,8 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
 
     fn new_counter_vec(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
     ) -> Result<Box<CounterVec>, PrometheusError> {
@@ -103,8 +103,8 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
 
     fn new_histogram(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
         buckets: Vec<f64>,
     ) -> Result<Box<Histogram>, PrometheusError> {
@@ -117,8 +117,8 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
 
     fn new_histogram_vec(
         &self,
-        name: String,
-        help: String,
+        name: &str,
+        help: &str,
         const_labels: HashMap<String, String>,
         variable_labels: Vec<String>,
         buckets: Vec<f64>,

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -51,7 +51,7 @@ fn test_valid_module_and_store(
     );
     let host_metrics = Arc::new(HostMetrics::new(
         metrics_registry,
-        deployment_id.to_string(),
+        deployment_id.as_str(),
         stopwatch_metrics,
     ));
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -30,21 +30,21 @@ impl GraphQLServiceMetrics {
     pub fn new(registry: Arc<impl MetricsRegistry>) -> Self {
         let query_execution_time = registry
             .new_histogram_vec(
-                "subgraph_query_execution_time",
-                "Execution time for GraphQL queries",
-                vec![String::from("subgraph_deployment")],
+                "query_execution_time",
+                "Execution time for successful GraphQL queries",
+                vec![String::from("deployment")],
                 vec![0.1, 0.5, 1.0, 10.0, 100.0],
             )
-            .expect("failed to create `subgraph_query_execution_time` histogram");
+            .expect("failed to create `query_execution_time` histogram");
 
         let failed_query_execution_time = registry
             .new_histogram_vec(
-                "subgraph_failed_query_execution_time",
+                "query_failed_execution_time",
                 "Execution time for failed GraphQL queries",
-                vec![String::from("subgraph_deployment")],
+                vec![String::from("deployment")],
                 vec![0.1, 0.5, 1.0, 10.0, 100.0],
             )
-            .expect("failed to create `subgraph_failed_query_execution_time` histogram");
+            .expect("failed to create `query_failed_execution_time` histogram");
 
         Self {
             query_execution_time,

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -31,8 +31,8 @@ impl GraphQLServiceMetrics {
     pub fn new(registry: Arc<impl MetricsRegistry>) -> Self {
         let query_execution_time = registry
             .new_histogram_vec(
-                format!("subgraph_query_execution_time"),
-                String::from("Execution time for GraphQL queries"),
+                "subgraph_query_execution_time",
+                "Execution time for GraphQL queries",
                 HashMap::new(),
                 vec![String::from("subgraph_deployment")],
                 vec![0.1, 0.5, 1.0, 10.0, 100.0],
@@ -41,8 +41,8 @@ impl GraphQLServiceMetrics {
 
         let failed_query_execution_time = registry
             .new_histogram_vec(
-                format!("subgraph_failed_query_execution_time"),
-                String::from("Execution time for failed GraphQL queries"),
+                "subgraph_failed_query_execution_time",
+                "Execution time for failed GraphQL queries",
                 HashMap::new(),
                 vec![String::from("subgraph_deployment")],
                 vec![0.1, 0.5, 1.0, 10.0, 100.0],

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
 use std::ops::Deref;
@@ -33,7 +32,6 @@ impl GraphQLServiceMetrics {
             .new_histogram_vec(
                 "subgraph_query_execution_time",
                 "Execution time for GraphQL queries",
-                HashMap::new(),
                 vec![String::from("subgraph_deployment")],
                 vec![0.1, 0.5, 1.0, 10.0, 100.0],
             )
@@ -43,7 +41,6 @@ impl GraphQLServiceMetrics {
             .new_histogram_vec(
                 "subgraph_failed_query_execution_time",
                 "Execution time for failed GraphQL queries",
-                HashMap::new(),
                 vec![String::from("subgraph_deployment")],
                 vec![0.1, 0.5, 1.0, 10.0, 100.0],
             )

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -113,7 +113,7 @@ pub fn create_connection_pool(
         .global_counter(
             "store_connection_error_count",
             "The number of Postgres connections errors",
-            const_labels.clone(),
+            HashMap::new(),
         )
         .expect("failed to create `store_connection_error_count` counter");
     let error_handler = Box::new(ErrorHandler(logger_pool.clone(), error_counter));

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -40,16 +40,16 @@ impl EventHandler {
     ) -> Self {
         let count_gauge = registry
             .global_gauge(
-                String::from("store_connection_checkout_count"),
-                String::from("The number of Postgres connections currently checked out"),
+                "store_connection_checkout_count",
+                "The number of Postgres connections currently checked out",
                 const_labels.clone(),
             )
             .expect("failed to create `store_connection_checkout_count` counter");
         let wait_gauge = registry
             .global_gauge(
-                String::from("store_connection_wait_time_ms"),
-                String::from("Average connection wait time"),
-                const_labels,
+                "store_connection_wait_time_ms",
+                "Average connection wait time",
+                const_labels.clone(),
             )
             .expect("failed to create `store_connection_wait_time_ms` counter");
         EventHandler {
@@ -111,8 +111,8 @@ pub fn create_connection_pool(
     };
     let error_counter = registry
         .global_counter(
-            String::from("store_connection_error_count"),
-            String::from("The number of Postgres connections errors"),
+            "store_connection_error_count",
+            "The number of Postgres connections errors",
             const_labels.clone(),
         )
         .expect("failed to create `store_connection_error_count` counter");

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -750,9 +750,9 @@ impl Store {
         self.with_conn(move |conn, cancel_handle| {
             registry
                 .global_counter(
-                    format!("{}_get_entity_conn_secs", &subgraph),
-                    "total time spent getting an entity connection".to_string(),
-                    HashMap::new(),
+                    "subgraph_get_entity_conn_secs",
+                    "total time spent getting an entity connection",
+                    registry.subgraph_labels(subgraph.as_str()),
                 )
                 .map_err(Into::<Error>::into)?
                 .inc_by(start.elapsed().as_secs_f64());
@@ -801,9 +801,9 @@ impl Store {
         };
         self.registry
             .global_counter(
-                format!("{}_get_entity_conn_secs", subgraph),
-                "total time spent getting an entity connection".to_string(),
-                HashMap::new(),
+                "subgraph_get_entity_conn_secs",
+                "total time spent getting an entity connection",
+                self.registry.subgraph_labels(subgraph.as_str()),
             )?
             .inc_by(start.elapsed().as_secs_f64());
         let storage = self.storage(&conn, subgraph)?;

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -749,8 +749,8 @@ impl Store {
 
         self.with_conn(move |conn, cancel_handle| {
             registry
-                .global_subgraph_counter(
-                    "subgraph_get_entity_conn_secs",
+                .global_deployment_counter(
+                    "deployment_get_entity_conn_secs",
                     "total time spent getting an entity connection",
                     subgraph.as_str(),
                 )
@@ -800,8 +800,8 @@ impl Store {
             ReplicaId::ReadOnly(idx) => self.read_only_conn(idx)?,
         };
         self.registry
-            .global_subgraph_counter(
-                "subgraph_get_entity_conn_secs",
+            .global_deployment_counter(
+                "deployment_get_entity_conn_secs",
                 "total time spent getting an entity connection",
                 subgraph.as_str(),
             )?

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -749,10 +749,10 @@ impl Store {
 
         self.with_conn(move |conn, cancel_handle| {
             registry
-                .global_counter(
+                .global_subgraph_counter(
                     "subgraph_get_entity_conn_secs",
                     "total time spent getting an entity connection",
-                    registry.subgraph_labels(subgraph.as_str()),
+                    subgraph.as_str(),
                 )
                 .map_err(Into::<Error>::into)?
                 .inc_by(start.elapsed().as_secs_f64());
@@ -800,10 +800,10 @@ impl Store {
             ReplicaId::ReadOnly(idx) => self.read_only_conn(idx)?,
         };
         self.registry
-            .global_counter(
+            .global_subgraph_counter(
                 "subgraph_get_entity_conn_secs",
                 "total time spent getting an entity connection",
-                self.registry.subgraph_labels(subgraph.as_str()),
+                subgraph.as_str(),
             )?
             .inc_by(start.elapsed().as_secs_f64());
         let storage = self.storage(&conn, subgraph)?;


### PR DESCRIPTION
The biggest change in this PR is that metrics no longer have dynamically constructed names; instead, names are fixed, and labels are used to attach, e.g. the subgraph to the metric.

The PR also changes the `MetricsRegistry` trait a bit to make the various constructor methods a little more ergonomic and clearer in what they should be used for (like `new_counter` vs `new_subgraph_counter`)