### PR TITLE
Document query cache env vars

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -63,6 +63,13 @@ those.
 - `GRAPH_MAX_IPFS_CACHE_FILE_SIZE`: maximum size of files that are cached in the
   `ipfs.cat` cache (defaults to 1MiB)
 - `GRAPH_ENTITY_CACHE_SIZE`: Size of the entity cache, in kilobytes. Defaults to 10000 which is 10MB.
+- `GRAPH_QUERY_CACHE_BLOCKS`: How many recent blocks per network should be kept
+   in the query cache. This should be kept small since the lookup time and the
+   cache memory usage are proportional to this value. Set to 0 to disable the cache.
+   Defaults to 1.
+- `GRAPH_QUERY_CACHE_MAX_MEM`: Maximum total memory to be used by the query cache.
+   The default is plenty for most loads, particularly if `GRAPH_QUERY_CACHE_BLOCKS` is kept small.
+   Defaults to 1GB.
 
 ## GraphQL
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -67,9 +67,9 @@ those.
    in the query cache. This should be kept small since the lookup time and the
    cache memory usage are proportional to this value. Set to 0 to disable the cache.
    Defaults to 1.
-- `GRAPH_QUERY_CACHE_MAX_MEM`: Maximum total memory to be used by the query cache.
+- `GRAPH_QUERY_CACHE_MAX_MEM`: Maximum total memory to be used by the query cache, in MB.
    The default is plenty for most loads, particularly if `GRAPH_QUERY_CACHE_BLOCKS` is kept small.
-   Defaults to 1GB.
+   Defaults to 1000, which corresponds to 1GB.
 
 ## GraphQL
 

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -82,12 +82,12 @@ lazy_static! {
         .expect("Invalid value for GRAPH_QUERY_CACHE_BLOCKS environment variable")
     };
 
-    /// blocks, each block has a max size of `QUERY_CACHE_MAX_MEM` / `QUERY_CACHE_BLOCKS`.
-    /// The env var is in MB.
+    /// Maximum total memory to be used by the cache. Each block has a max size of
+    /// `QUERY_CACHE_MAX_MEM` / `QUERY_CACHE_BLOCKS`. The env var is in MB.
     static ref QUERY_CACHE_MAX_MEM: usize = {
         1_000_000 *
         std::env::var("GRAPH_QUERY_CACHE_MAX_MEM")
-        .unwrap_or("100".to_string())
+        .unwrap_or("1000".to_string())
         .parse::<usize>()
         .expect("Invalid value for GRAPH_QUERY_CACHE_MAX_MEM environment variable")
     };


### PR DESCRIPTION
Also bump the default query cache size to 1GB, since 100MB is excessively conservative.