### PR TITLE
Fix required capability parsing from subgraph manifest in runtime host builder

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -634,17 +634,24 @@ impl Mapping {
         return false;
     }
 
-    pub fn has_call_handler(&self) -> bool {
+    fn has_call_handler(&self) -> bool {
         !self.call_handlers.is_empty()
     }
 
-    pub fn has_block_handler_with_call_filter(&self) -> bool {
+    fn has_block_handler_with_call_filter(&self) -> bool {
         self.block_handlers
             .iter()
             .any(|handler| match handler.filter {
                 Some(BlockHandlerFilter::Call) => true,
                 _ => false,
             })
+    }
+
+    pub fn required_capabilities(&self) -> NodeCapabilities {
+        NodeCapabilities {
+            traces: self.has_block_handler_with_call_filter() || self.has_call_handler(),
+            archive: self.calls_host_fn("ethereum.call"),
+        }
     }
 }
 

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -127,11 +127,7 @@ where
             )
         })?;
 
-        let required_capabilities = NodeCapabilities {
-            traces: data_source.mapping.calls_host_fn("ethereum.call"),
-            archive: data_source.mapping.has_block_handler_with_call_filter()
-                || data_source.mapping.has_call_handler(),
-        };
+        let required_capabilities = data_source.mapping.required_capabilities();
 
         let ethereum_adapter = self
             .ethereum_networks


### PR DESCRIPTION
Subgraph Ethereum node capability requirements are parsed from each data source when buiding the runtime hosts.  A typo that mixed up `traces` and `archive` requirements led to incorrect parsing and ultimately false rejections of valid subgraph deployments. 