### PR TITLE
EthereumNetworkAdapters used in place of single adapter

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -622,13 +622,14 @@ where
 
         let web3 = self.web3.clone();
         let net_version_future = retry("net_version RPC call", &logger)
-            .no_limit()
+            .limit(5)
             .timeout_secs(20)
             .run(move || web3.net().version().from_err());
 
         let web3 = self.web3.clone();
+        // TODO: Use an env var for the retry limit?
         let gen_block_hash_future = retry("eth_getBlockByNumber(0, false) RPC call", &logger)
-            .no_limit()
+            .limit(5)
             .timeout_secs(30)
             .run(move || {
                 web3.eth()

--- a/chain/ethereum/tests/network_indexer.rs
+++ b/chain/ethereum/tests/network_indexer.rs
@@ -17,7 +17,7 @@ use graph_core::MetricsRegistry;
 use graph_store_postgres::Store as DieselStore;
 use web3::types::{H2048, H256, H64, U256};
 
-use graph::components::ethereum::{EthereumNetworkAdapters, EthereumNetworks, NodeCapabilities};
+use graph::components::ethereum::{EthereumNetworks, NodeCapabilities};
 use test_store::*;
 
 // Helper macros to define indexer events.
@@ -64,13 +64,12 @@ fn run_network_indexer(
     let prometheus_registry = Arc::new(Registry::new());
     let metrics_registry = Arc::new(MetricsRegistry::new(logger.clone(), prometheus_registry));
 
-    let capabilities = NodeCapabilities { archive: true, traces: true};
+    let capabilities = NodeCapabilities {
+        archive: true,
+        traces: true,
+    };
     let mut ethereum_networks = EthereumNetworks::new();
-    ethereum_networks.insert(
-        "test".into(),
-        capabilities,
-        adapter,
-    );
+    ethereum_networks.insert("test".into(), capabilities, adapter);
     let ethereum_adapters = ethereum_networks
         .adapters_with_capabilities("test".into(), &capabilities)
         .unwrap();

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -29,7 +29,7 @@ graphql-parser = "0.2.3"
 ipfs-api = { version = "0.7.1", features = ["hyper-tls"] }
 failure = "0.1.7"
 lazy_static = "1.4.0"
-mockall = "0.7"
+mockall = "0.7.2"
 num-bigint = { version = "^0.2.6", features = ["serde"] }
 num-traits = "0.2"
 rand = "0.6.1"

--- a/graph/src/components/ethereum/network.rs
+++ b/graph/src/components/ethereum/network.rs
@@ -158,10 +158,6 @@ impl EthereumNetworkAdapters {
 }
 
 impl EthereumAdapter for EthereumNetworkAdapters {
-    fn url_hostname(&self) -> &str {
-        unimplemented!()
-    }
-
     fn net_identifiers(
         &self,
         logger: &Logger,

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -9,5 +9,5 @@ futures = "0.1.21"
 graphql-parser = "0.2.3"
 graph = { path = "../graph" }
 graph-graphql = { path = "../graphql" }
-mockall = "0.7"
+mockall = "0.7.2"
 rand = "0.6.1"

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -670,7 +670,7 @@ async fn main() {
                         let mut indexer = network_indexer::NetworkIndexer::new(
                             &logger,
                             eth_networks
-                                .adapter_with_capabilities(
+                                .adapters_with_capabilities(
                                     network_name.clone(),
                                     &NodeCapabilities {
                                         archive: false,
@@ -1050,16 +1050,16 @@ mod test {
             traces: false,
         };
         let has_mainnet_with_traces = ethereum_networks
-            .adapter_with_capabilities("mainnet".to_string(), &traces)
+            .adapters_with_capabilities("mainnet".to_string(), &traces)
             .is_ok();
         let has_goerli_with_archive = ethereum_networks
-            .adapter_with_capabilities("goerli".to_string(), &archive)
+            .adapters_with_capabilities("goerli".to_string(), &archive)
             .is_ok();
         let has_mainnet_with_archive = ethereum_networks
-            .adapter_with_capabilities("mainnet".to_string(), &archive)
+            .adapters_with_capabilities("mainnet".to_string(), &archive)
             .is_ok();
         let has_goerli_with_traces = ethereum_networks
-            .adapter_with_capabilities("goerli".to_string(), &traces)
+            .adapters_with_capabilities("goerli".to_string(), &traces)
             .is_ok();
 
         assert_eq!(has_mainnet_with_traces, true);

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -133,9 +133,9 @@ where
                 || data_source.mapping.has_call_handler(),
         };
 
-        let ethereum_adapter = self
+        let ethereum_adapters = self
             .ethereum_networks
-            .adapter_with_capabilities(network_name.clone(), &required_capabilities)?;
+            .adapters_with_capabilities(network_name.clone(), &required_capabilities)?;
 
         // Detect whether the subgraph uses templates in data sources, which are
         // deprecated, or the top-level templates field.
@@ -145,7 +145,7 @@ where
         };
 
         RuntimeHost::new(
-            ethereum_adapter.clone(),
+            ethereum_adapters.clone(),
             self.link_resolver.clone(),
             store.clone(),
             store.clone(),
@@ -181,7 +181,7 @@ pub struct RuntimeHost {
 
 impl RuntimeHost {
     fn new(
-        ethereum_adapter: Arc<dyn EthereumAdapter>,
+        ethereum_adapters: EthereumNetworkAdapters,
         link_resolver: Arc<dyn LinkResolver>,
         store: Arc<dyn crate::RuntimeStore>,
         call_cache: Arc<dyn EthereumCallCache>,
@@ -227,7 +227,7 @@ impl RuntimeHost {
             config.data_source_context,
             config.templates,
             config.mapping.abis,
-            ethereum_adapter,
+            ethereum_adapters,
             link_resolver,
             store,
             call_cache,

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -34,7 +34,7 @@ pub(crate) struct HostExports {
     causality_region: String,
     templates: Arc<Vec<DataSourceTemplate>>,
     abis: Vec<MappingABI>,
-    ethereum_adapter: Arc<dyn EthereumAdapter>,
+    ethereum_adapters: EthereumNetworkAdapters,
     pub(crate) link_resolver: Arc<dyn LinkResolver>,
     call_cache: Arc<dyn EthereumCallCache>,
     store: Arc<dyn crate::RuntimeStore>,
@@ -59,7 +59,7 @@ impl HostExports {
         data_source_context: Option<DataSourceContext>,
         templates: Arc<Vec<DataSourceTemplate>>,
         abis: Vec<MappingABI>,
-        ethereum_adapter: Arc<dyn EthereumAdapter>,
+        ethereum_adapters: EthereumNetworkAdapters,
         link_resolver: Arc<dyn LinkResolver>,
         store: Arc<dyn crate::RuntimeStore>,
         call_cache: Arc<dyn EthereumCallCache>,
@@ -78,7 +78,7 @@ impl HostExports {
             causality_region,
             templates,
             abis,
-            ethereum_adapter,
+            ethereum_adapters,
             link_resolver,
             call_cache,
             store,
@@ -293,11 +293,11 @@ impl HostExports {
         };
 
         // Run Ethereum call in tokio runtime
-        let eth_adapter = self.ethereum_adapter.clone();
+        let eth_adapters = self.ethereum_adapters.clone();
         let logger1 = logger.clone();
         let call_cache = self.call_cache.clone();
         let result = match block_on(future::lazy(move || {
-            eth_adapter.contract_call(&logger1, call, call_cache)
+            eth_adapters.contract_call(&logger1, call, call_cache)
         })) {
             Ok(tokens) => Ok(Some(tokens)),
             Err(EthereumContractCallError::Revert(reason)) => {

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -130,7 +130,10 @@ fn mock_host_exports(
     data_source: DataSource,
     store: Arc<impl Store + SubgraphDeploymentStore + EthereumCallCache>,
 ) -> HostExports {
-    let capabilities = NodeCapabilities { archive: true, traces: true};
+    let capabilities = NodeCapabilities {
+        archive: true,
+        traces: true,
+    };
     let mut ethereum_networks = EthereumNetworks::new();
     ethereum_networks.insert(
         "test".into(),

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -130,7 +130,17 @@ fn mock_host_exports(
     data_source: DataSource,
     store: Arc<impl Store + SubgraphDeploymentStore + EthereumCallCache>,
 ) -> HostExports {
-    let mock_ethereum_adapter = Arc::new(MockEthereumAdapter::default());
+    let capabilities = NodeCapabilities { archive: true, traces: true};
+    let mut ethereum_networks = EthereumNetworks::new();
+    ethereum_networks.insert(
+        "test".into(),
+        capabilities,
+        Arc::new(MockEthereumAdapter::default()),
+    );
+    let ethereum_adapters = ethereum_networks
+        .adapters_with_capabilities("test".into(), &capabilities)
+        .unwrap();
+
     let arweave_adapter = Arc::new(ArweaveAdapter::new("https://arweave.net".to_string()));
     let three_box_adapter = Arc::new(ThreeBoxAdapter::new("https://ipfs.3box.io/".to_string()));
 
@@ -143,7 +153,7 @@ fn mock_host_exports(
         data_source.context,
         Arc::new(data_source.templates),
         data_source.mapping.abis,
-        mock_ethereum_adapter,
+        ethereum_adapters,
         Arc::new(graph_core::LinkResolver::from(
             ipfs_api::IpfsClient::default(),
         )),


### PR DESCRIPTION
With this PR EthereumNetworkAdapters now implements the EthereumAdapter trait which is a retry wrapper on top of the trait impl for EthereumAdapters.  This way a failed Ethereum request will be retried across all sufficient adapters thus increasing robustness and allowing more Ethereum request volume to be split across Ethereum endpoints. 

_Note: I'm currently doing some local testing with "bad" endpoints to ensure the desired robustness is achieved._