### PR TITLE
store: Do not add redundant clauses to BlockRangeContainsClause

### DIFF
--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -4,9 +4,6 @@ use diesel::result::QueryResult;
 ///! Utilities to deal with block numbers and block ranges
 use diesel::serialize::{Output, ToSql};
 use diesel::sql_types::{Integer, Range};
-use lazy_static::lazy_static;
-use std::collections::HashSet;
-use std::env;
 use std::io::Write;
 use std::ops::{Bound, RangeBounds, RangeFrom};
 
@@ -14,15 +11,6 @@ use graph::prelude::{BlockNumber, BLOCK_NUMBER_MAX};
 
 use crate::history_event::HistoryEvent;
 use crate::relational::Table;
-
-lazy_static! {
-    static ref USE_BLOCK_RANGE_BRIN_CLAUSE: HashSet<String> = {
-        env::var("GRAPH_ACCOUNT_TABLES")
-            .ok()
-            .map(|v| v.split(",").map(|s| s.to_owned()).collect())
-            .unwrap_or(HashSet::new())
-    };
-}
 
 /// The name of the column in which we store the block range
 pub(crate) const BLOCK_RANGE_COLUMN: &str = "block_range";
@@ -126,4 +114,12 @@ impl<'a> QueryFragment<Pg> for BlockRangeContainsClause<'a> {
             Ok(())
         }
     }
+}
+
+#[test]
+fn block_number_max_is_i32_max() {
+    // The code in this file embeds i32::MAX aka BLOCK_NUMBER_MAX in strings
+    // for efficiency. This assertion makes sure that BLOCK_NUMBER_MAX still
+    // is what we think it is
+    assert_eq!(2147483647, BLOCK_NUMBER_MAX);
 }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1083,7 +1083,7 @@ impl<'a> QueryFragment<Pg> for FindQuery<'a> {
         out.push_sql(" e\n where ");
         self.table.primary_key().eq(&self.id, &mut out)?;
         out.push_sql(" and ");
-        BlockRangeContainsClause::new("e.", self.block).walk_ast(out)
+        BlockRangeContainsClause::new(&self.table, "e.", self.block).walk_ast(out)
     }
 }
 
@@ -1137,7 +1137,7 @@ impl<'a> QueryFragment<Pg> for FindManyQuery<'a> {
                 .primary_key()
                 .is_in(&self.ids_for_type[table.object.as_str()], &mut out)?;
             out.push_sql(" and ");
-            BlockRangeContainsClause::new("e.", self.block).walk_ast(out.reborrow())?;
+            BlockRangeContainsClause::new(&table, "e.", self.block).walk_ast(out.reborrow())?;
         }
         Ok(())
     }
@@ -1625,7 +1625,7 @@ impl<'a> FilterWindow<'a> {
         out.push_sql(") as p(id) cross join lateral (select * from ");
         out.push_sql(self.table.qualified_name.as_str());
         out.push_sql(" c where ");
-        BlockRangeContainsClause::new("c.", block).walk_ast(out.reborrow())?;
+        BlockRangeContainsClause::new(&self.table, "c.", block).walk_ast(out.reborrow())?;
         limit.filter(out);
         out.push_sql(" and p.id = any(c.");
         out.push_identifier(column.name.as_str())?;
@@ -1661,7 +1661,7 @@ impl<'a> FilterWindow<'a> {
         out.push_sql(") as p(id), ");
         out.push_sql(self.table.qualified_name.as_str());
         out.push_sql(" c where ");
-        BlockRangeContainsClause::new("c.", block).walk_ast(out.reborrow())?;
+        BlockRangeContainsClause::new(&self.table, "c.", block).walk_ast(out.reborrow())?;
         limit.filter(out);
         out.push_sql(" and c.");
         out.push_identifier(column.name.as_str())?;
@@ -1702,7 +1702,7 @@ impl<'a> FilterWindow<'a> {
         out.push_sql(") as p(id) cross join lateral (select * from ");
         out.push_sql(self.table.qualified_name.as_str());
         out.push_sql(" c where ");
-        BlockRangeContainsClause::new("c.", block).walk_ast(out.reborrow())?;
+        BlockRangeContainsClause::new(&self.table, "c.", block).walk_ast(out.reborrow())?;
         limit.filter(out);
         out.push_sql(" and p.id = c.");
         out.push_identifier(column.name.as_str())?;
@@ -1732,7 +1732,7 @@ impl<'a> FilterWindow<'a> {
         out.push_sql(") as p(id), ");
         out.push_sql(self.table.qualified_name.as_str());
         out.push_sql(" c where ");
-        BlockRangeContainsClause::new("c.", block).walk_ast(out.reborrow())?;
+        BlockRangeContainsClause::new(&self.table, "c.", block).walk_ast(out.reborrow())?;
         limit.filter(out);
         out.push_sql(" and p.id = c.");
         out.push_identifier(column.name.as_str())?;
@@ -1769,7 +1769,7 @@ impl<'a> FilterWindow<'a> {
         out.push_sql(" cross join lateral (select * from ");
         out.push_sql(self.table.qualified_name.as_str());
         out.push_sql(" c where ");
-        BlockRangeContainsClause::new("c.", block).walk_ast(out.reborrow())?;
+        BlockRangeContainsClause::new(&self.table, "c.", block).walk_ast(out.reborrow())?;
         limit.filter(out);
         out.push_sql(" and c.id = any(p.child_ids)");
         self.and_filter(out.reborrow())?;
@@ -1798,7 +1798,7 @@ impl<'a> FilterWindow<'a> {
         out.push_sql(")) as p(id, child_id), ");
         out.push_sql(self.table.qualified_name.as_str());
         out.push_sql(" c where ");
-        BlockRangeContainsClause::new("c.", block).walk_ast(out.reborrow())?;
+        BlockRangeContainsClause::new(&self.table, "c.", block).walk_ast(out.reborrow())?;
         limit.filter(out);
         out.push_sql(" and ");
         out.push_sql("c.id = p.child_id");
@@ -2179,7 +2179,7 @@ impl<'a> FilterQuery<'a> {
         out.push_sql(table.qualified_name.as_str());
         out.push_sql(" c");
         out.push_sql("\n where ");
-        BlockRangeContainsClause::new("c.", self.block).walk_ast(out.reborrow())?;
+        BlockRangeContainsClause::new(&table, "c.", self.block).walk_ast(out.reborrow())?;
         if let Some(filter) = table_filter {
             out.push_sql(" and ");
             filter.walk_ast(out.reborrow())?;


### PR DESCRIPTION
For entities that are transaction-like in that entities are rarely, if ever, updated, adding redundant `block_range` clauses from PR #1854 slows queries down to the point where the overall performance of the system suffers. At the same time, for entities that are account like in that entities are updated frequently, adding redundant `block_range` clauses is indeed beneficial.

This reverts commit 9d72f3b82212b385a015230769045ab368a8981c and introduces a setting where account-like tables can be specified explicitly. Ultimately, we would like to automatically detect such tables, but to make sure that this is in fact a useful heuristic, we allow setting which tables to treat special in the environment to make it possible to test this hypothesis under load.

