### PR TITLE
node: Increment ipfs-api to 0.7.2

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,7 +10,7 @@ git-testament = "0.1"
 graphql-parser = "0.2.3"
 prometheus = "0.7"
 futures = { version = "0.3.1", features = ["compat"] }
-ipfs-api = { version = "0.7.1", features = ["hyper-tls"] }
+ipfs-api = { version = "0.7.2", features = ["hyper-tls"] }
 lazy_static = "1.2.0"
 url = "2.1.1"
 crossbeam-channel = "0.4.3"


### PR DESCRIPTION
Fixes #1799. `ipfs-api` 0.7.2 uses the correct messaging for newer IPFS clients. 

The fix also introduces a depwarning, since `IpfsClient::new_from_uri` in 

https://github.com/graphprotocol/graph-node/blob/087bc1d0a159c3fce4f613168b4ab43cc9f7c699/node/src/main.rs#L445

will be deprecated in `ipfs-api` 0.8.0, which isn't out yet.