### PR TITLE
all: Label connection pool metrics with the pool they come from

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,6 +1652,7 @@ dependencies = [
  "lru_time_cache 0.9.0",
  "maybe-owned",
  "postgres",
+ "rand 0.6.5",
  "serde 1.0.114",
  "stable-hash",
  "test-store",

--- a/core/src/metrics/registry.rs
+++ b/core/src/metrics/registry.rs
@@ -205,12 +205,17 @@ impl MetricsRegistryTrait for MetricsRegistry {
         Ok(counter)
     }
 
-    fn global_counter(&self, name: String, help: String) -> Result<Counter, PrometheusError> {
+    fn global_counter(
+        &self,
+        name: String,
+        help: String,
+        const_labels: HashMap<String, String>,
+    ) -> Result<Counter, PrometheusError> {
         let maybe_counter = self.global_counters.read().unwrap().get(&name).cloned();
         if let Some(counter) = maybe_counter {
             Ok(counter.clone())
         } else {
-            let counter = *self.new_counter(name.clone(), help, HashMap::new())?;
+            let counter = *self.new_counter(name.clone(), help, const_labels)?;
             self.global_counters
                 .write()
                 .unwrap()
@@ -219,12 +224,17 @@ impl MetricsRegistryTrait for MetricsRegistry {
         }
     }
 
-    fn global_gauge(&self, name: String, help: String) -> Result<Gauge, PrometheusError> {
+    fn global_gauge(
+        &self,
+        name: String,
+        help: String,
+        const_labels: HashMap<String, String>,
+    ) -> Result<Gauge, PrometheusError> {
         let maybe_gauge = self.global_gauges.read().unwrap().get(&name).cloned();
         if let Some(gauge) = maybe_gauge {
             Ok(gauge.clone())
         } else {
-            let gauge = *self.new_gauge(name.clone(), help, HashMap::new())?;
+            let gauge = *self.new_gauge(name.clone(), help, const_labels)?;
             self.global_gauges
                 .write()
                 .unwrap()

--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -34,9 +34,19 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         const_labels: HashMap<String, String>,
     ) -> Result<Box<Counter>, PrometheusError>;
 
-    fn global_counter(&self, name: String, help: String) -> Result<Counter, PrometheusError>;
+    fn global_counter(
+        &self,
+        name: String,
+        help: String,
+        const_labels: HashMap<String, String>,
+    ) -> Result<Counter, PrometheusError>;
 
-    fn global_gauge(&self, name: String, help: String) -> Result<Gauge, PrometheusError>;
+    fn global_gauge(
+        &self,
+        name: String,
+        help: String,
+        const_labels: HashMap<String, String>,
+    ) -> Result<Gauge, PrometheusError>;
 
     fn new_counter_vec(
         &self,

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -62,13 +62,23 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
         Ok(counter)
     }
 
-    fn global_counter(&self, name: String, help: String) -> Result<Counter, PrometheusError> {
-        let opts = Opts::new(name, help);
+    fn global_counter(
+        &self,
+        name: String,
+        help: String,
+        const_labels: HashMap<String, String>,
+    ) -> Result<Counter, PrometheusError> {
+        let opts = Opts::new(name, help).const_labels(const_labels);
         Counter::with_opts(opts)
     }
 
-    fn global_gauge(&self, name: String, help: String) -> Result<Gauge, PrometheusError> {
-        let opts = Opts::new(name, help);
+    fn global_gauge(
+        &self,
+        name: String,
+        help: String,
+        const_labels: HashMap<String, String>,
+    ) -> Result<Gauge, PrometheusError> {
+        let opts = Opts::new(name, help).const_labels(const_labels);
         Gauge::with_opts(opts)
     }
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -564,6 +564,7 @@ async fn main() {
     let wait_stats = Arc::new(RwLock::new(MovingStats::default()));
 
     let postgres_conn_pool = create_connection_pool(
+        "main",
         postgres_url.clone(),
         store_conn_pool_size,
         &logger,
@@ -574,10 +575,12 @@ async fn main() {
     let read_only_conn_pools: Vec<_> = pg_read_replicas
         .into_iter()
         .flatten()
-        .map(|host| {
+        .enumerate()
+        .map(|(i, host)| {
             info!(&logger, "Connecting to Postgres read replica at {}", host);
             let url = replace_host(&postgres_url, host);
             create_connection_pool(
+                &format!("replica{}", i),
                 url,
                 store_conn_pool_size,
                 &logger,

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -25,6 +25,7 @@ lazy_static = "1.1"
 lru_time_cache = "0.9"
 maybe-owned = "0.3.4"
 postgres = "0.15.2"
+rand = "0.6.1"
 serde = "1.0"
 uuid = { version = "0.8.1", features = ["v4"] }
 stable-hash = { git = "https://github.com/graphprotocol/stable-hash" }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -727,6 +727,7 @@ impl Store {
                 .global_counter(
                     format!("{}_get_entity_conn_secs", &subgraph),
                     "total time spent getting an entity connection".to_string(),
+                    HashMap::new(),
                 )
                 .map_err(Into::<Error>::into)?
                 .inc_by(start.elapsed().as_secs_f64());
@@ -777,6 +778,7 @@ impl Store {
             .global_counter(
                 format!("{}_get_entity_conn_secs", subgraph),
                 "total time spent getting an entity connection".to_string(),
+                HashMap::new(),
             )?
             .inc_by(start.elapsed().as_secs_f64());
         let storage = self.storage(&conn, subgraph)?;

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -86,6 +86,7 @@ lazy_static! {
                     subscriptions,
                     postgres_conn_pool,
                     Vec::new(),
+                    Vec::new(),
                     registry.clone(),
                 ))
             })

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -58,6 +58,7 @@ lazy_static! {
                 };
                 let conn_pool_size: u32 = 20;
                 let postgres_conn_pool = create_connection_pool(
+                    "test",
                     postgres_url.clone(),
                     conn_pool_size,
                     &logger,


### PR DESCRIPTION
We identify pools as either 'main' or 'replicaN' in the labels

Fixes https://github.com/graphprotocol/graph-node/issues/1861

