### PR TITLE
store: Include a redundant clause in RevertClampQuery

### DIFF
--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2574,6 +2574,7 @@ impl<'a> QueryFragment<Pg> for RevertClampQuery<'a> {
         //   where block_range @> $block
         //     and not block_range @> INTMAX
         //     and lower(block_range) <= $block
+        //     and coalesce(upper(block_range), INTMAX) > $block
         //     and coalesce(upper(block_range), INTMAX) < INTMAX
         //   returning id
         //
@@ -2596,6 +2597,10 @@ impl<'a> QueryFragment<Pg> for RevertClampQuery<'a> {
         out.push_sql(" and lower(");
         out.push_sql(BLOCK_RANGE_COLUMN);
         out.push_sql(") <= ");
+        out.push_bind_param::<Integer, _>(&self.block)?;
+        out.push_sql(" and coalesce(upper(");
+        out.push_sql(BLOCK_RANGE_COLUMN);
+        out.push_sql("), 2147483647) > ");
         out.push_bind_param::<Integer, _>(&self.block)?;
         out.push_sql(" and coalesce(upper(");
         out.push_sql(BLOCK_RANGE_COLUMN);


### PR DESCRIPTION
This makes it possible to support reversion with an index

```
create index concurrently manual_revert_clamp
    on <table>(coalesce(upper(block_range), 2147483647))
 where coalesce(upper(block_range), 2147483647) < 2147483647;
```

for subgraphs where `RevertClampQuery` runs slow

