### PR TITLE
Gracefully fail on null `block.hash` and encoding failures in Ethereum adapter

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1204,7 +1204,10 @@ where
         }
 
         // Encode the call parameters according to the ABI
-        let call_data = call.function.encode_input(&call.args).unwrap();
+        let call_data = match call.function.encode_input(&call.args) {
+            Ok(data) => data,
+            Err(e) => return Box::new(future::err(EthereumContractCallError::EncodingError(e))),
+        };
 
         // Check if we have it cached, if not do the call and cache.
         Box::new(
@@ -1212,7 +1215,7 @@ where
                 .get_call(call.address, &call_data, call.block_ptr)
                 .map_err(|e| error!(logger, "call cache get error"; "error" => e.to_string()))
                 .ok()
-                .and_then(|x| x)
+                .flatten()
             {
                 Some(result) => {
                     Box::new(future::ok(result)) as Box<dyn Future<Item = _, Error = _> + Send>

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -57,6 +57,8 @@ pub enum EthereumContractCallError {
     /// `Token` is not of expected `ParamType`
     #[fail(display = "type mismatch, token {:?} is not of kind {:?}", _0, _1)]
     TypeError(Token, ParamType),
+    #[fail(display = "error encoding input call data: {}", _0)]
+    EncodingError(ethabi::Error),
     #[fail(display = "call error: {}", _0)]
     Web3Error(web3::Error),
     #[fail(display = "call reverted: {}", _0)]


### PR DESCRIPTION
As a more diverse set of indexers use `graph-node` syncing from different Ethereum clients and providers, edge cases have been encountered in which block's are being returned without a `hash`.  This PR removes the assumption that the block.hash will always be `Some()` in these cases, so the cases fail gracefully and the steps are retried. 
Contract_call() has also been updated, so failed call_data input encoding returns an error (no unwrap.) 

