### PR TITLE
Log GraphQL queries only once

### DIFF
--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,4 +1,4 @@
-use graph::prelude::{EthereumBlockPointer, Logger, QueryExecutionError, QueryResult};
+use graph::prelude::{EthereumBlockPointer, QueryExecutionError, QueryResult};
 use graphql_parser::query as q;
 use std::sync::Arc;
 use std::time::Instant;
@@ -16,9 +16,6 @@ pub mod ext;
 
 /// Options available for query execution.
 pub struct QueryExecutionOptions<R> {
-    /// The logger to use during query execution.
-    pub logger: Logger,
-
     /// The resolver to use.
     pub resolver: R,
 

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -126,7 +126,6 @@ where
                 Some(&selection_set),
                 Some(block_ptr),
                 QueryExecutionOptions {
-                    logger: self.logger.clone(),
                     resolver,
                     deadline: GRAPHQL_QUERY_TIMEOUT.map(|t| Instant::now() + t),
                     max_first: max_first.unwrap_or(*GRAPHQL_MAX_FIRST),

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -60,6 +60,7 @@ where
     R: Resolver + CheapClone + 'static,
 {
     let query = crate::execution::Query::new(
+        &options.logger,
         subscription.query,
         options.max_complexity,
         options.max_depth,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -557,15 +557,15 @@ fn introspection_query(schema: Schema, query: &str) -> QueryResult {
     );
 
     // Execute it
+    let logger = Logger::root(slog::Discard, o!());
     let options = QueryExecutionOptions {
-        logger: Logger::root(slog::Discard, o!()),
         resolver: MockResolver,
         deadline: None,
         max_first: std::u32::MAX,
         load_manager: LOAD_MANAGER.clone(),
     };
 
-    let result = PreparedQuery::new(&options.logger, query, None, 100).map(|query| {
+    let result = PreparedQuery::new(&logger, query, None, 100).map(|query| {
         let result = Arc::try_unwrap(execute_query(query.clone(), None, None, options)).unwrap();
         query.log_execution(0);
         result

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -565,8 +565,11 @@ fn introspection_query(schema: Schema, query: &str) -> QueryResult {
         load_manager: LOAD_MANAGER.clone(),
     };
 
-    let result = PreparedQuery::new(query, None, 100)
-        .map(|query| Arc::try_unwrap(execute_query(query, None, None, options)).unwrap());
+    let result = PreparedQuery::new(&options.logger, query, None, 100).map(|query| {
+        let result = Arc::try_unwrap(execute_query(query.clone(), None, None, options)).unwrap();
+        query.log_execution(0);
+        result
+    });
     QueryResult::from(result)
 }
 

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -104,7 +104,6 @@ where
         let result = tokio::task::spawn_blocking(move || {
             let options = QueryExecutionOptions {
                 resolver: IndexNodeResolver::new(&logger, graphql_runner, store),
-                logger,
                 deadline: None,
                 max_first: std::u32::MAX,
                 load_manager,

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -410,7 +410,6 @@ fn execute_subgraph_query_internal(
                 Some(&selection_set),
                 None,
                 QueryExecutionOptions {
-                    logger,
                     resolver,
                     deadline,
                     load_manager: LOAD_MANAGER.clone(),

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -394,7 +394,7 @@ fn execute_subgraph_query_internal(
     deadline: Option<Instant>,
 ) -> QueryResult {
     let logger = Logger::root(slog::Discard, o!());
-    let query = return_err!(PreparedQuery::new(query, max_complexity, 100));
+    let query = return_err!(PreparedQuery::new(&logger, query, max_complexity, 100));
     let mut result = QueryResult::empty();
     for (bc, selection_set) in return_err!(query.block_constraint()) {
         let logger = logger.clone();


### PR DESCRIPTION
Because block constraints might cause us to execute a GraphQL query in several steps, we used to log the entire query for each of these steps. That leads to inaccurate query execution counts and times, and to logs that are hugely inflated in size.
    
We now log the overall query execution only once. To get insight into cache usage, we also log cache usage information separately from the overall query execution. To keep log size manageable, we do not log the query text with the cache information. That would have to be inferred from the `query_id` logged with both log statements.