### PR TITLE
Add an LfuCache for historical queries

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -67,9 +67,13 @@ those.
    in the query cache. This should be kept small since the lookup time and the
    cache memory usage are proportional to this value. Set to 0 to disable the cache.
    Defaults to 1.
-- `GRAPH_QUERY_CACHE_MAX_MEM`: Maximum total memory to be used by the query cache, in MB.
-   The default is plenty for most loads, particularly if `GRAPH_QUERY_CACHE_BLOCKS` is kept small.
-   Defaults to 1000, which corresponds to 1GB.
+- `GRAPH_QUERY_CACHE_MAX_MEM`: Maximum total memory to be used by the query
+   cache, in MB. The total amount of memory used for caching will be twice
+   this value - once for recent blocks, divided evenly among the
+   `GRAPH_QUERY_CACHE_BLOCKS`, and once for frequent queries against older
+   blocks.  The default is plenty for most loads, particularly if
+   `GRAPH_QUERY_CACHE_BLOCKS` is kept small.  Defaults to 1000, which
+   corresponds to 1GB.
 
 ## GraphQL
 

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -78,6 +78,9 @@ impl Default for WeightedResult {
     }
 }
 
+/// Organize block caches by network names. Since different networks
+/// will be at different block heights, we need to keep their `CacheByBlock`
+/// separate
 struct QueryBlockCache(Vec<(String, VecDeque<CacheByBlock>)>);
 
 impl QueryBlockCache {
@@ -111,11 +114,11 @@ impl QueryBlockCache {
             // We're creating a new `CacheByBlock` if:
             // - There are none yet, this is the first query being cached, or
             // - `block_ptr` is of higher or equal number than the most recent block in the cache.
-            // Otherwise this is a historical query which will not be cached.
+            // Otherwise this is a historical query that does not belong in
+            // the block cache
             let should_insert = match cache.iter().next() {
                 None => true,
-                Some(highest) if highest.block.number <= block_ptr.number => true,
-                Some(_) => false,
+                Some(highest) => highest.block.number <= block_ptr.number,
             };
 
             if should_insert {


### PR DESCRIPTION
We see a lot of historical queries in the hosted service, and our cache performs poorly for those. Add an `LfuCache` of query results for those to improve the cache hit ratio.