### PR TITLE
Improve estimate of how much memory is used by an LfuCache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,6 +1387,7 @@ dependencies = [
  "slog-envlogger",
  "slog-term",
  "stable-hash",
+ "structopt",
  "strum",
  "strum_macros",
  "test-store",
@@ -2908,6 +2909,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.18",
+ "quote 1.0.3",
+ "syn 1.0.33",
+ "version_check 0.9.1",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.3",
+ "version_check 0.9.1",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3848,6 +3873,30 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc388d94ffabf39b5ed5fadddc40147cb21e605f53db6f8f36a625d27489ac5"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2513111825077552a6751dfad9e11ce0fba07d7276a3943a037d7e93e64c5f"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.18",
+ "quote 1.0.3",
+ "syn 1.0.33",
+]
 
 [[package]]
 name = "strum"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -62,3 +62,4 @@ web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "master" }
 [dev-dependencies]
 test-store = { path = "../store/test-store" }
 maplit = "1.0.2"
+structopt = { version = "0.3" }

--- a/graph/examples/stress.rs
+++ b/graph/examples/stress.rs
@@ -1,0 +1,210 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::{BTreeMap, HashMap};
+use std::iter::FromIterator;
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+
+use graphql_parser::query as q;
+use rand::{thread_rng, Rng};
+use structopt::StructOpt;
+
+use graph::util::cache_weight::CacheWeight;
+use graph::util::lfu_cache::LfuCache;
+
+struct Counter;
+
+static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for Counter {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ret = System.alloc(layout);
+        if !ret.is_null() {
+            ALLOCATED.fetch_add(layout.size(), SeqCst);
+        }
+        return ret;
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        ALLOCATED.fetch_sub(layout.size(), SeqCst);
+    }
+}
+
+#[global_allocator]
+static A: Counter = Counter;
+
+#[derive(StructOpt)]
+#[structopt(name = "stress", about = "Stress test for the LFU Cache")]
+struct Opt {
+    #[structopt(short, long, default_value = "1000")]
+    niter: usize,
+    #[structopt(short, long, default_value = "10")]
+    print_count: usize,
+    #[structopt(short, long, default_value = "1024")]
+    obj_size: usize,
+    #[structopt(short, long, default_value = "1000000")]
+    cache_size: usize,
+}
+
+trait Template<T> {
+    type Item;
+
+    fn create(size: usize) -> Self;
+    fn sample(&self, size: usize) -> Self::Item;
+}
+
+impl Template<Vec<usize>> for Vec<usize> {
+    type Item = Vec<usize>;
+
+    fn create(size: usize) -> Self {
+        Vec::from_iter(0..size)
+    }
+    fn sample(&self, size: usize) -> Self::Item {
+        self[0..size].into()
+    }
+}
+
+impl Template<HashMap<String, String>> for HashMap<String, String> {
+    type Item = Self;
+
+    fn create(size: usize) -> Self {
+        let mut map = HashMap::new();
+        for i in 0..size {
+            map.insert(format!("key{}", i), format!("value{}", i));
+        }
+        map
+    }
+
+    fn sample(&self, size: usize) -> Self::Item {
+        HashMap::from_iter(
+            self.iter()
+                .take(size)
+                .map(|(k, v)| (k.to_owned(), v.to_owned())),
+        )
+    }
+}
+
+type ValueMap = BTreeMap<String, q::Value>;
+impl Template<ValueMap> for ValueMap {
+    type Item = ValueMap;
+
+    fn create(size: usize) -> Self {
+        let mut map = BTreeMap::new();
+        for i in 0..size {
+            let value = match i % 9 {
+                0 => q::Value::Boolean(i % 11 > 5),
+                1 => q::Value::Int((i as i32).into()),
+                2 => q::Value::Null,
+                3 => q::Value::Float(i as f64 / 17.0),
+                4 => q::Value::Enum(format!("enum{}", i)),
+                5 => q::Value::String(format!("string{}", i)),
+                6 => q::Value::Variable(format!("var{}", i)),
+                7 => {
+                    let vals = (0..(i % 51)).map(|i| q::Value::String(format!("list{}", i)));
+                    q::Value::List(Vec::from_iter(vals))
+                }
+                8 => {
+                    let mut map = BTreeMap::new();
+                    for j in 0..(i % 51) {
+                        map.insert(format!("key{}", j), q::Value::String(format!("value{}", j)));
+                    }
+                    q::Value::Object(map)
+                }
+                _ => q::Value::String(format!("other{}", i)),
+            };
+            map.insert(format!("val{}", i), value);
+        }
+        map
+    }
+
+    fn sample(&self, size: usize) -> Self::Item {
+        BTreeMap::from_iter(
+            self.iter()
+                .take(size)
+                .map(|(k, v)| (k.to_owned(), v.to_owned())),
+        )
+    }
+}
+
+struct Cacheable<T> {
+    cache: LfuCache<usize, T>,
+    template: T,
+}
+
+impl<T: CacheWeight + Default + Template<T>> Cacheable<T> {
+    fn new(size: usize) -> Self {
+        Cacheable {
+            cache: LfuCache::new(),
+            template: T::create(size),
+        }
+    }
+
+    fn sample(&self, size: usize) -> T::Item {
+        self.template.sample(size)
+    }
+
+    fn name(&self) -> &'static str {
+        std::any::type_name::<T>()
+    }
+}
+
+pub fn main() {
+    let opt = Opt::from_args();
+
+    // Use different Cacheables to see how the cache manages memory with
+    // different types of cache entries. Uncomment one of the 'let mut cacheable'
+    // lines
+
+    // With Vec<usize> we stay within between opt.cache_size and 3*opt.cache_size
+    // Larger heap factors for very small arrays
+    // obj_size  |  heap factor
+    //   10      |     4.02
+    //   20      |     2.39
+    //   30      |     2.40
+    //   50      |     1.76
+    //  100      |     1.38
+    // 1000      |     1.05
+    // let mut cacheable: Cacheable<Vec<usize>> = Cacheable::new(opt.obj_size);
+
+    // Cache HashMap<String, String>
+    // The heap factor ranges between 2.23 (size 3) and 1.06 (size 100)
+    //let mut cacheable: Cacheable<HashMap<String, String>> = Cacheable::new(opt.obj_size);
+
+    // Cache BTreeMap<String, Value>
+    // obj_size  |  heap factor
+    //    3      |     16.51
+    //    5      |     12.07
+    //   10      |      4.64
+    //   50      |      3.07
+    //  100      |      2.94
+    let mut cacheable: Cacheable<ValueMap> = Cacheable::new(opt.obj_size);
+
+    println!("type: {}", cacheable.name());
+    println!(
+        "obj: {} nitems: {} cache_size: {}",
+        cacheable.template.weight(),
+        opt.niter,
+        opt.cache_size
+    );
+    println!("heap_factor is heap_size / cache_size");
+
+    let mut rng = thread_rng();
+    let base_mem = ALLOCATED.load(SeqCst);
+    let print_mod = opt.niter / opt.print_count + 1;
+    let mut should_print = true;
+    for key in 0..opt.niter {
+        should_print = should_print || key % print_mod == 0;
+        if let Some((evicted, _, new_weight)) = cacheable.cache.evict(opt.cache_size) {
+            if should_print {
+                let heap_factor =
+                    (ALLOCATED.load(SeqCst) - base_mem) as f64 / opt.cache_size as f64;
+                println!(
+                    "evicted: {:6}  new_weight: {:8} heap_factor: {:0.2}  ",
+                    evicted, new_weight, heap_factor
+                );
+                should_print = false;
+            }
+        }
+        let size = rng.gen_range(2, opt.obj_size);
+        cacheable.cache.insert(key, cacheable.sample(size));
+    }
+}

--- a/graph/examples/stress.rs
+++ b/graph/examples/stress.rs
@@ -262,6 +262,12 @@ pub fn main() {
         //   10      |      4.64
         //   50      |      3.07
         //  100      |      2.94
+        //
+        // The above is for a weight calculation that does not take the
+        // allocated, unused space in the BTree into account. With a guess
+        // at those, the above heap factors range from 1.14 to 0.88, with the
+        // exception of obj_size 0 where we get a factor of 2.88, but that
+        // must be caused by some other effect
         stress::<ValueMap>(&opt);
     } else {
         println!("unknown value for --template")

--- a/graph/examples/stress.rs
+++ b/graph/examples/stress.rs
@@ -165,6 +165,8 @@ struct Opt {
     cache_size: usize,
     #[structopt(short, long, default_value = "vec")]
     template: String,
+    #[structopt(short, long)]
+    samples: bool,
 }
 
 fn stress<T: Template<T, Item = T>>(opt: &Opt) {
@@ -201,6 +203,15 @@ fn stress<T: Template<T, Item = T>>(opt: &Opt) {
             }
         }
         let size = rng.gen_range(2, opt.obj_size);
+        let before = ALLOCATED.load(SeqCst);
+        let sample = cacheable.sample(size);
+        if opt.samples {
+            println!(
+                "sample: weight {:6} alloc {:6}",
+                sample.weight(),
+                ALLOCATED.load(SeqCst) - before,
+            );
+        }
         cacheable.cache.insert(key, cacheable.sample(size));
     }
 }

--- a/graph/examples/stress.rs
+++ b/graph/examples/stress.rs
@@ -167,6 +167,8 @@ struct Opt {
     template: String,
     #[structopt(short, long)]
     samples: bool,
+    #[structopt(short, long)]
+    fixed: bool,
 }
 
 fn stress<T: Template<T, Item = T>>(opt: &Opt) {
@@ -202,7 +204,11 @@ fn stress<T: Template<T, Item = T>>(opt: &Opt) {
                 should_print = false;
             }
         }
-        let size = rng.gen_range(2, opt.obj_size);
+        let size = if opt.fixed {
+            opt.obj_size
+        } else {
+            rng.gen_range(2, opt.obj_size)
+        };
         let before = ALLOCATED.load(SeqCst);
         let sample = cacheable.sample(size);
         if opt.samples {

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -97,6 +97,12 @@ impl CacheWeight for graphql_parser::query::Value {
     }
 }
 
+impl CacheWeight for usize {
+    fn indirect_weight(&self) -> usize {
+        0
+    }
+}
+
 #[test]
 fn big_decimal_cache_weight() {
     use std::str::FromStr;

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{BigDecimal, BigInt, Value};
+use crate::prelude::{BigDecimal, BigInt, EntityKey, Value};
 use std::mem;
 
 /// Estimate of how much memory a value consumes.
@@ -125,6 +125,27 @@ impl CacheWeight for graphql_parser::query::Value {
 }
 
 impl CacheWeight for usize {
+    fn indirect_weight(&self) -> usize {
+        0
+    }
+}
+
+impl CacheWeight for EntityKey {
+    fn indirect_weight(&self) -> usize {
+        self.subgraph_id.indirect_weight()
+            + self.entity_id.indirect_weight()
+            + self.entity_type.indirect_weight()
+    }
+}
+
+impl CacheWeight for [u8; 32] {
+    fn indirect_weight(&self) -> usize {
+        0
+    }
+}
+
+#[cfg(test)]
+impl CacheWeight for &'static str {
     fn indirect_weight(&self) -> usize {
         0
     }

--- a/graph/src/util/lfu_cache.rs
+++ b/graph/src/util/lfu_cache.rs
@@ -163,6 +163,14 @@ impl<K: Clone + Ord + Eq + Hash + Debug + CacheWeight, V: CacheWeight + Default>
         self.queue.len()
     }
 
+    /// Evict entries in the cache until the total weight of the cache is
+    /// equal to or smaller than `max_weight`.
+    ///
+    /// The return value is mostly useful for testing and diagnostics and can
+    /// safely ignored in normal use. It gives the sum of the weight of all
+    /// evicted entries, the weight before anything was evicted and the new
+    /// total weight of the cache, in that order, if anything was evicted
+    /// at all. If there was no reason to evict, `None` is returned.
     pub fn evict(&mut self, max_weight: usize) -> Option<(usize, usize, usize)> {
         if self.total_weight <= max_weight {
             return None;

--- a/graph/src/util/lfu_cache.rs
+++ b/graph/src/util/lfu_cache.rs
@@ -145,9 +145,9 @@ impl<K: Clone + Ord + Eq + Hash + Debug, V: CacheWeight + Default> LfuCache<K, V
         self.queue.len()
     }
 
-    pub fn evict(&mut self, max_weight: usize) {
+    pub fn evict(&mut self, max_weight: usize) -> Option<(usize, usize, usize)> {
         if self.total_weight <= max_weight {
-            return;
+            return None;
         }
 
         self.stale_counter += 1;
@@ -164,14 +164,18 @@ impl<K: Clone + Ord + Eq + Hash + Debug, V: CacheWeight + Default> LfuCache<K, V
             }
         }
 
+        let mut evicted = 0;
+        let old_weight = self.total_weight;
         while self.total_weight > max_weight {
             let entry = self
                 .queue
                 .pop()
                 .expect("empty cache but total_weight > max_weight")
                 .0;
+            evicted += entry.weight;
             self.total_weight -= entry.weight;
         }
+        return Some((evicted, old_weight, self.total_weight));
     }
 }
 


### PR DESCRIPTION
This PR improves the estimates that `LfuCache` uses to determine how big a cache entry is. Under heavy load, `LfuCache` would appear to leak memory. At least part of that apparent leak was that `LfuCache` underestimated how much memory cache entries use, which would lead to the cache growing much bigger than intended. In some cases, for example for small `BTreeMap`s, the estimate was off by more than an order of magnitude, which in practice has the same consequences as an actual leak.

With the tweaks to memory estimates, `LfuCache` now mostly overestimates the amount of memory an entry takes, though running the `stress` example still shows that overall memory usage can be a factor of 3 larger than the estimate that the cache tracks, for example, when caching strings less than 50 bytes long.

The PR also includes a small tool to show how cache estimates relate to actually used memory. You can run the tool with
```
cargo run -p graph --release --example stress -- \
      --niter 1000000 --print-count 10 --obj-size 50 --template string
```
which will perform 1M insertions of strings up to 50 bytes in size and print information about the cache about 10 times during the run. The information printed looks like
```
evicted:     59  dropped:     19 new_weight:   999991 heap_factor: 3.00
```
where `evicted` is the cache weight removed from the cache by the last call to `LfuCache.evict`, `dropped` is how much memory was actually freed, `new_weight` is the weight of the cache after the last `evict`, and `heap_factor` is the ratio of memory allocated by the cache divided by its weight.

The `stress` example defines tests for a few different data structures which can be selected with the `--template` option:
* `string`: cache `String` of length `obj_size`
* `vec`: cache `Vec<usize>` of length `obj_size`
* `hashmap`: cache `HashMap<String, String>` with `obj_size` entries; keys and values are short strings of less than 10 bytes
* `valuemap`: cache `BTreeMap<String, q::Value>` with `obj_size` entries, where entries cycle through the 9 possible kinds of `q::Value`
