### PR TITLE
Bug fix: Fetch correct function abi from contract abi 

### DIFF
--- a/graph/src/util/ethereum.rs
+++ b/graph/src/util/ethereum.rs
@@ -122,21 +122,25 @@ pub fn contract_function_with_signature<'a>(
     contract: &'a Contract,
     target_signature: &str,
 ) -> Option<&'a Function> {
-    contract.functions().find(|function| {
-        // Construct the argument function signature:
-        // `address,uint256,bool`
-        let mut arguments = function
-            .inputs
-            .iter()
-            .map(|input| format!("{}", input.kind))
-            .collect::<Vec<String>>()
-            .join(",");
-        // `address,uint256,bool)
-        arguments.push_str(")");
-        // `operation(address,uint256,bool)`
-        let actual_signature = vec![function.name.clone(), arguments].join("(");
-        function.state_mutability == ethabi::StateMutability::Payable
-            || function.state_mutability == ethabi::StateMutability::NonPayable
-                && target_signature == actual_signature
-    })
+    contract
+        .functions()
+        .filter(|function| match function.state_mutability {
+            ethabi::StateMutability::Payable | ethabi::StateMutability::NonPayable => true,
+            ethabi::StateMutability::Pure | ethabi::StateMutability::View => false,
+        })
+        .find(|function| {
+            // Construct the argument function signature:
+            // `address,uint256,bool`
+            let mut arguments = function
+                .inputs
+                .iter()
+                .map(|input| format!("{}", input.kind))
+                .collect::<Vec<String>>()
+                .join(",");
+            // `address,uint256,bool)
+            arguments.push_str(")");
+            // `operation(address,uint256,bool)`
+            let actual_signature = vec![function.name.clone(), arguments].join("(");
+            target_signature == actual_signature
+        })
 }

--- a/graph/src/util/ethereum.rs
+++ b/graph/src/util/ethereum.rs
@@ -10,7 +10,7 @@ pub fn string_to_h256(s: &str) -> H256 {
     sponge.update(&data);
     sponge.finalize(&mut result);
 
-    // This was deprecated but the replacement seems to not be availible in the
+    // This was deprecated but the replacement seems to not be available in the
     // version web3 uses.
     #[allow(deprecated)]
     H256::from_slice(&result)

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -500,7 +500,7 @@ impl RuntimeHostTrait for RuntimeHost {
         // Parse the inputs
         //
         // Take the input for the call, chop off the first 4 bytes, then call
-        // `function.decode_output` to get a vector of `Token`s. Match the `Token`s
+        // `function.decode_input` to get a vector of `Token`s. Match the `Token`s
         // with the `Param`s in `function.inputs` to create a `Vec<LogParam>`.
         let tokens = function_abi
             .decode_input(&call.input.0[4..])


### PR DESCRIPTION
Resolves #1841 

This PR fixes a bug in `contract_function_with_signature()` which allowed for false positives to be returned. This inconsistency led to incorrect function abis being used in function param decoding leading to `invalid data` errors in [ethabi](https://github.com/graphprotocol/ethabi). 

I've also restructured `contract_function_with_signature()` to reduce unnecessary work building function signature hashes for functions that can be excluded early because they are `view` or `pure` functions. 