### PR TITLE
Move tracking the cache status of queries to a Prometheus metric

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -109,18 +109,21 @@ those.
 - `GRAPH_KILL_IF_UNRESPONSIVE`: If set, the process will be killed if unresponsive.
 - `GRAPH_LOG_QUERY_TIMING`: Control whether the process logs details of
   processing GraphQL and SQL queries. The value is a comma separated list
-  of `sql` and `gql`. If `gql` is present in the list, each GraphQL query
-  made against the node is logged at level `info`. The log message contains
-  the subgraph that was queried, the query, its variables, the amount of
-  time the query took, and a unique `query_id`. If `sql` is present, the
-  SQL queries that a GraphQL query causes are logged. The log message
-  contains the subgraph, the query, its bind variables, the amount of time
-  it took to execute the query, the number of entities found by the query,
-  and the `query_id` of the GraphQL query that caused the SQL query. These
-  SQL queries are marked with `component: GraphQlRunner` There are
-  additional SQL queries that get logged when `sql` is given. These are
+  of `sql`,`gql`, and `cache`. If `gql` is present in the list, each
+  GraphQL query made against the node is logged at level `info`. The log
+  message contains the subgraph that was queried, the query, its variables,
+  the amount of time the query took, and a unique `query_id`. If `sql` is
+  present, the SQL queries that a GraphQL query causes are logged. The log
+  message contains the subgraph, the query, its bind variables, the amount
+  of time it took to execute the query, the number of entities found by the
+  query, and the `query_id` of the GraphQL query that caused the SQL
+  query. These SQL queries are marked with `component: GraphQlRunner` There
+  are additional SQL queries that get logged when `sql` is given. These are
   queries caused by mappings when processing blocks for a subgraph, and
-  queries caused by subscriptions. Defaults to no logging.
+  queries caused by subscriptions. If `cache` is present in addition to
+  `gql`, also logs information for each toplevel GraphQL query field
+  whether that could be retrieved from cache or not. Defaults to no
+  logging.
 - `STORE_CONNECTION_POOL_SIZE`: How many simultaneous connections to allow to the store.
   Due to implementation details, this value may not be strictly adhered to. Defaults to 10.
 - `GRAPH_LOG_POI_EVENTS`: Logs Proof of Indexing events deterministically.

--- a/graph/src/data/graphql/effort.rs
+++ b/graph/src/data/graphql/effort.rs
@@ -300,11 +300,11 @@ impl LoadManager {
     /// `shape_hash`, where `cache_status` indicates whether the query
     /// was cached or had to actually run
     pub fn record_work(&self, shape_hash: u64, duration: Duration, cache_status: CacheStatus) {
+        self.query_counters
+            .get(&cache_status)
+            .map(|counter| counter.inc());
         if !*LOAD_MANAGEMENT_DISABLED {
             self.effort.add(shape_hash, duration, &self.effort_gauge);
-            self.query_counters
-                .get(&cache_status)
-                .map(|counter| counter.inc());
         }
     }
 

--- a/graph/src/data/query/cache_status.rs
+++ b/graph/src/data/query/cache_status.rs
@@ -1,7 +1,8 @@
 use std::fmt;
+use std::slice::Iter;
 
 /// Used for checking if a response hit the cache.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum CacheStatus {
     /// Hit is a hit in the generational cache.
     Hit,
@@ -30,5 +31,13 @@ impl fmt::Display for CacheStatus {
             CacheStatus::Insert => f.write_str("insert"),
             CacheStatus::Miss => f.write_str("miss"),
         }
+    }
+}
+
+impl CacheStatus {
+    pub fn iter() -> Iter<'static, CacheStatus> {
+        use CacheStatus::*;
+        static STATUSES: [CacheStatus; 4] = [Hit, Shared, Insert, Miss];
+        STATUSES.iter()
     }
 }

--- a/graph/src/data/query/cache_status.rs
+++ b/graph/src/data/query/cache_status.rs
@@ -1,0 +1,34 @@
+use std::fmt;
+
+/// Used for checking if a response hit the cache.
+#[derive(Copy, Clone)]
+pub enum CacheStatus {
+    /// Hit is a hit in the generational cache.
+    Hit,
+
+    /// Shared is a hit in the herd cache.
+    Shared,
+
+    /// Insert is a miss that inserted in the generational cache.
+    Insert,
+
+    /// A miss is none of the above.
+    Miss,
+}
+
+impl Default for CacheStatus {
+    fn default() -> Self {
+        CacheStatus::Miss
+    }
+}
+
+impl fmt::Display for CacheStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CacheStatus::Hit => f.write_str("hit"),
+            CacheStatus::Shared => f.write_str("shared"),
+            CacheStatus::Insert => f.write_str("insert"),
+            CacheStatus::Miss => f.write_str("miss"),
+        }
+    }
+}

--- a/graph/src/data/query/mod.rs
+++ b/graph/src/data/query/mod.rs
@@ -1,7 +1,9 @@
+mod cache_status;
 mod error;
 mod query;
 mod result;
 
+pub use self::cache_status::CacheStatus;
 pub use self::error::{QueryError, QueryExecutionError};
 pub use self::query::{Query, QueryVariables};
 pub use self::result::QueryResult;

--- a/graph/src/log/mod.rs
+++ b/graph/src/log/mod.rs
@@ -385,4 +385,5 @@ fn log_query_timing(kind: &str) -> bool {
 lazy_static! {
     pub static ref LOG_SQL_TIMING: bool = log_query_timing("sql");
     pub static ref LOG_GQL_TIMING: bool = log_query_timing("gql");
+    pub static ref LOG_GQL_CACHE_TIMING: bool = *LOG_GQL_TIMING && log_query_timing("cache");
 }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -9,11 +9,11 @@ use stable_hash::crypto::SetHasher;
 use stable_hash::prelude::*;
 use stable_hash::utils::stable_hash;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
-use std::fmt;
 use std::iter;
 use std::sync::{Mutex, RwLock};
 use std::time::Instant;
 
+use graph::data::query::CacheStatus;
 use graph::prelude::*;
 use graph::util::lfu_cache::LfuCache;
 
@@ -273,39 +273,6 @@ fn cache_key(
         block_ptr,
     };
     stable_hash::<SetHasher, _>(&query)
-}
-
-/// Used for checking if a response hit the cache.
-#[derive(Copy, Clone)]
-pub(crate) enum CacheStatus {
-    /// Hit is a hit in the generational cache.
-    Hit,
-
-    /// Shared is a hit in the herd cache.
-    Shared,
-
-    /// Insert is a miss that inserted in the generational cache.
-    Insert,
-
-    /// A miss is none of the above.
-    Miss,
-}
-
-impl Default for CacheStatus {
-    fn default() -> Self {
-        CacheStatus::Miss
-    }
-}
-
-impl fmt::Display for CacheStatus {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            CacheStatus::Hit => f.write_str("hit"),
-            CacheStatus::Shared => f.write_str("shared"),
-            CacheStatus::Insert => f.write_str("insert"),
-            CacheStatus::Miss => f.write_str("miss"),
-        }
-    }
 }
 
 /// Contextual information passed around during query execution.

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -245,7 +245,7 @@ impl Query {
 
     /// Log details about the overall execution of the query
     pub fn log_execution(&self, block: u64) {
-        if *graph::log::LOG_GQL_TIMING {
+        if *graph::log::LOG_GQL_CACHE_TIMING {
             info!(
                 &self.logger,
                 "Query timing (GraphQL)";

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -70,12 +70,15 @@ where
         block_ptr,
     );
     let elapsed = start.elapsed();
-    options.load_manager.add_query(query.shape_hash, elapsed);
+    let cache_status = ctx.cache_status.load();
+    options
+        .load_manager
+        .record_work(query.shape_hash, elapsed, cache_status);
     query.log_cache_status(
         selection_set,
         block_ptr.map(|b| b.number).unwrap_or(0),
         start,
-        ctx.cache_status.load().to_string(),
+        cache_status.to_string(),
     );
     result
 }


### PR DESCRIPTION
We currently use a Google cloud log-based metric, but that is both wasteful and seems to be inaccurate. With this PR, it is still possible to log the cache status of queries, but it will also be recorded in a Prometheus metric so that log analysis should in general not be necessary.