### PR TITLE
Don't crash node and show better error on invalid subgraph transitions

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -741,11 +741,11 @@ pub enum StoreError {
     #[fail(display = "invalid identifier: {}", _0)]
     InvalidIdentifier(String),
     #[fail(
-        display = "subgraph `{}`: invalid transition from block `{}` to `{}`; \
+        display = "subgraph `{}` has already processed block `{}`; \
                    there are most likely two (or more) nodes indexing this subgraph",
-        _0, _1, _2
+        _0, _1
     )]
-    InvalidSubgraphTransition(SubgraphDeploymentId, u64, u64),
+    DuplicateBlockProcessing(SubgraphDeploymentId, u64),
 }
 
 impl From<TransactionAbortError> for StoreError {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -740,6 +740,12 @@ pub enum StoreError {
     QueryExecutionError(String),
     #[fail(display = "invalid identifier: {}", _0)]
     InvalidIdentifier(String),
+    #[fail(
+        display = "subgraph `{}`: invalid transition from block `{}` to `{}`; \
+                   there are most likely two (or more) nodes indexing this subgraph",
+        _0, _1, _2
+    )]
+    InvalidSubgraphTransition(SubgraphDeploymentId, u64, u64),
 }
 
 impl From<TransactionAbortError> for StoreError {

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1139,9 +1139,8 @@ impl StoreTrait for Store {
                 let block_ptr_from = Self::block_ptr_with_conn(&subgraph_id, &econn)?;
                 if let Some(ref block_ptr_from) = block_ptr_from {
                     if block_ptr_from.number >= block_ptr_to.number {
-                        return Err(StoreError::InvalidSubgraphTransition(
+                        return Err(StoreError::DuplicateBlockProcessing(
                             subgraph_id,
-                            block_ptr_from.number,
                             block_ptr_to.number,
                         ));
                     }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1138,7 +1138,16 @@ impl StoreTrait for Store {
             econn.transaction(|| -> Result<_, StoreError> {
                 let block_ptr_from = Self::block_ptr_with_conn(&subgraph_id, &econn)?;
                 if let Some(ref block_ptr_from) = block_ptr_from {
-                    assert!(block_ptr_from.number < block_ptr_to.number);
+                    assert!(
+                        block_ptr_from.number < block_ptr_to.number,
+                        format!(
+                            "subgraph `{}`: invalid transition from block `{}` to `{}`; \
+                             there are most likely two (or more) nodes indexing this subgraph",
+                            subgraph_id,
+                            block_ptr_from.number
+                            block_ptr_to.number
+                        )
+                    );
                 }
 
                 // Ensure the history event exists in the database

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1138,16 +1138,13 @@ impl StoreTrait for Store {
             econn.transaction(|| -> Result<_, StoreError> {
                 let block_ptr_from = Self::block_ptr_with_conn(&subgraph_id, &econn)?;
                 if let Some(ref block_ptr_from) = block_ptr_from {
-                    assert!(
-                        block_ptr_from.number < block_ptr_to.number,
-                        format!(
-                            "subgraph `{}`: invalid transition from block `{}` to `{}`; \
-                             there are most likely two (or more) nodes indexing this subgraph",
+                    if block_ptr_from.number >= block_ptr_to.number {
+                        return Err(StoreError::InvalidSubgraphTransition(
                             subgraph_id,
-                            block_ptr_from.number
-                            block_ptr_to.number
-                        )
-                    );
+                            block_ptr_from.number,
+                            block_ptr_to.number,
+                        ));
+                    }
                 }
 
                 // Ensure the history event exists in the database


### PR DESCRIPTION
When a subgraph is indexed by two or more graph nodes that share a database, we're currently crashing nodes when they run into from/to block conflicts. What we should do (and what this PR does) is only make the subgraph fail and also print a message that points out the likely cause of the issue: that multiple nodes are indexing the same subgraph.