### PR TITLE
Ensure runtime host uniqueness, improve logging

### DIFF
--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -272,7 +272,7 @@ where
         data_source: DataSource,
         top_level_templates: Arc<Vec<DataSourceTemplate>>,
         metrics: Arc<HostMetrics>,
-    ) -> Result<Arc<T::Host>, anyhow::Error> {
+    ) -> Result<Option<Arc<T::Host>>, anyhow::Error> {
         // Protect against creating more than the allowed maximum number of data sources
         if let Some(max_data_sources) = *MAX_DATA_SOURCES {
             if self.hosts.len() >= max_data_sources {
@@ -289,7 +289,12 @@ where
             top_level_templates,
             metrics.clone(),
         )?);
-        self.hosts.push(host.clone());
-        Ok(host)
+
+        Ok(if self.hosts.contains(&host) {
+            None
+        } else {
+            self.hosts.push(host.clone());
+            Some(host)
+        })
     }
 }

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 
 use graph::components::subgraph::SharedProofOfIndexing;
 use graph::prelude::{SubgraphInstance as SubgraphInstanceTrait, *};
-use web3::types::Log;
+use web3::types::{Log, H256};
 
 lazy_static! {
     static ref MAX_DATA_SOURCES: Option<usize> = env::var("GRAPH_SUBGRAPH_MAX_DATA_SOURCES")
@@ -168,13 +168,27 @@ where
                     .map(Arc::new)
                     .context("Found no transaction for event")?;
                 let matching_hosts = hosts.iter().filter(|host| host.matches_log(&log));
+                let hosts_count = matching_hosts.clone().count();
+
+                if hosts_count > 1 {
+                    info!(
+                        logger,
+                        "{} matching runtime hosts found for log trigger.", hosts_count;
+                        "address" => &log.address.to_string(),
+                        "topic0" => &log.topics.iter().next().unwrap_or(&H256::zero()).to_string(),
+                        "transaction" => log.transaction_hash.unwrap_or(H256::zero()).to_string(),
+                    );
+                }
+
                 // Process the log in each host in the same order the corresponding data
                 // sources appear in the subgraph manifest
                 let transaction = Arc::new(transaction);
-                for host in matching_hosts {
+                for (i, host) in matching_hosts.enumerate() {
+                    let host_context = format!("{}/{}", i + 1, hosts_count);
+                    let logger = logger.new(o!("runtime_host" => host_context));
                     state = host
                         .process_log(
-                            logger,
+                            &logger,
                             block,
                             &transaction,
                             &log,
@@ -192,11 +206,24 @@ where
                     .context("Found no transaction for call")?;
                 let transaction = Arc::new(transaction);
                 let matching_hosts = hosts.iter().filter(|host| host.matches_call(&call));
+                let hosts_count = matching_hosts.clone().count();
 
-                for host in matching_hosts {
+                if hosts_count > 1 {
+                    info!(
+                        logger,
+                        "{} matching runtime hosts found for call trigger.", hosts_count;
+                        "from" => &call.from.to_string(),
+                        "to" => &call.to.to_string(),
+                        "transaction" => &call.transaction_hash.map(|hash| hash.to_string()).unwrap_or("unkown".to_string()),
+                    );
+                }
+
+                for (i, host) in matching_hosts.enumerate() {
+                    let host_context = format!("{}/{}", i + 1, hosts_count);
+                    let logger = logger.new(o!("runtime_host" => host_context));
                     state = host
                         .process_call(
-                            logger,
+                            &logger,
                             block,
                             &transaction,
                             &call,
@@ -210,10 +237,23 @@ where
                 let matching_hosts = hosts
                     .iter()
                     .filter(|host| host.matches_block(&trigger_type, ptr.number));
-                for host in matching_hosts {
+                let hosts_count = matching_hosts.clone().count();
+
+                if hosts_count > 1 {
+                    info!(
+                        logger,
+                        "{} matching runtime hosts found for block trigger.", hosts_count;
+                        "number" => &ptr.number,
+                        "hash" => &ptr.number,
+                    );
+                }
+
+                for (i, host) in matching_hosts.enumerate() {
+                    let host_context = format!("{}/{}", i + 1, hosts_count);
+                    let logger = logger.new(o!("runtime_host" => host_context));
                     state = host
                         .process_block(
-                            logger,
+                            &logger,
                             block,
                             &trigger_type,
                             state,

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -941,8 +941,22 @@ where
             host_metrics.clone(),
         )?;
 
-        data_sources.push(data_source);
-        runtime_hosts.push(host);
+        match host {
+            Some(host) => {
+                data_sources.push(data_source);
+                runtime_hosts.push(host);
+            }
+            None => warn!(
+                logger,
+                "no runtime hosted created, there is already a runtime host instantiated for \
+                 this data source";
+                "name" => &data_source.name,
+                "address" => &data_source.source.address
+                    .map(|address| address.to_string())
+                    .unwrap_or("none".to_string()),
+                "abi" => &data_source.source.abi
+            ),
+        }
     }
 
     Ok((data_sources, runtime_hosts))

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -970,6 +970,13 @@ where
     // Add entity operations to the block state in order to persist
     // the dynamic data sources
     for data_source in data_sources.iter() {
+        debug!(
+            logger,
+            "Persisting data_source";
+            "name" => &data_source.name,
+            "address" => &data_source.source.address.map(|address| address.to_string()).unwrap_or("none".to_string()),
+            "abi" => &data_source.source.abi,
+        );
         let entity = DynamicEthereumContractDataSourceEntity::from((
             &ctx.inputs.deployment_id,
             data_source,

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -1,3 +1,4 @@
+use std::cmp::PartialEq;
 use std::fmt;
 use std::sync::Arc;
 
@@ -113,7 +114,7 @@ impl HostMetrics {
 }
 
 pub trait RuntimeHostBuilder: Clone + Send + Sync + 'static {
-    type Host: RuntimeHost;
+    type Host: RuntimeHost + PartialEq;
     type Req: 'static + Send;
 
     /// Build a new runtime host for a subgraph data source.

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -61,5 +61,5 @@ pub trait SubgraphInstance<H: RuntimeHost> {
         data_source: DataSource,
         top_level_templates: Arc<Vec<DataSourceTemplate>>,
         metrics: Arc<HostMetrics>,
-    ) -> Result<Arc<H>, anyhow::Error>;
+    ) -> Result<Option<Arc<H>>, anyhow::Error>;
 }

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -488,7 +488,7 @@ impl From<EthereumContractAbiEntity> for UnresolvedMappingABI {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct MappingABI {
     pub name: String,
     pub contract: Contract,

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -1,3 +1,4 @@
+use std::cmp::PartialEq;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
@@ -716,5 +717,18 @@ impl RuntimeHostTrait for RuntimeHost {
             proof_of_indexing,
         )
         .await
+    }
+}
+
+impl PartialEq for RuntimeHost {
+    fn eq(&self, other: &Self) -> bool {
+        // mapping_request_sender, host_exports and host_metrics are operational structs not needed
+        // to define uniqueness; each runtime host should be for a unique data source.
+        self.data_source_name == other.data_source_name
+            && self.data_source_contract == other.data_source_contract
+            && self.data_source_contract_abi == other.data_source_contract_abi
+            && self.data_source_event_handlers == other.data_source_event_handlers
+            && self.data_source_call_handlers == other.data_source_call_handlers
+            && self.data_source_block_handlers == other.data_source_block_handlers
     }
 }


### PR DESCRIPTION
This PR adds some safety and clarity around the creating and usage of dynamic data sources. Subgraph developers have been susceptible to silent cases of unexpected behavior due to the ability to create multiple runtime hosts with identical triggers and data transformations.  In practice this can lead to a situation where triggers are processed through a mapping multiple times because several runtime hosts have been created with the same contract address, trigger, and mapping file. 

Now there is a check when creating a runtime host to ensure we are not instantiating any duplicate hosts and emit a warning. Additional logging has also been added to more clearly show the trigger processing path; a runtime_host context is now included which shows the number of matching runtime hosts for the trigger and the index of the current runtime host doing the processing.