### PR TITLE
Eth call by hash

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -377,9 +377,9 @@ where
         logger: &Logger,
         contract_address: Address,
         call_data: Bytes,
-        block_number_opt: Option<BlockNumber>,
+        block_hash: H256,
     ) -> impl Future<Item = Bytes, Error = EthereumContractCallError> + Send {
-        let block_number_opt = block_number_opt.map(Into::into);
+        let block_id = BlockId::Hash(block_hash);
         let web3 = self.web3.clone();
         let logger = logger.clone();
 
@@ -420,7 +420,7 @@ where
                             value: None,
                             data: Some(call_data.clone()),
                         };
-                        web3.eth().call(req, block_number_opt).then(|result| {
+                        web3.eth().call(req, Some(block_id)).then(|result| {
                             // Try to check if the call was reverted. The JSON-RPC response for
                             // reverts is not standardized, the current situation for the tested
                             // clients is:
@@ -1233,7 +1233,7 @@ where
                             &logger,
                             call.address,
                             Bytes(call_data.clone()),
-                            Some(call.block_ptr.number.into()),
+                            call.block_ptr.hash,
                         )
                         .map(move |result| {
                             let _ = cache

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -95,13 +95,17 @@ where
             .to_string();
 
         let web3 = Arc::new(Web3::new(transport));
+
+        // Use the client version to check if it is ganache. For compatibility with unit tests, be
+        // are lenient with errors, defaulting to false.
         let is_ganache = web3
             .web3()
             .client_version()
             .compat()
             .await
-            .unwrap()
-            .contains("TestRPC");
+            .map(|s| s.contains("TestRPC"))
+            .unwrap_or(false);
+
         EthereumAdapter {
             url_hostname: Arc::new(hostname),
             web3,

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -386,7 +386,7 @@ where
                 Ok(_) | Err(EthereumContractCallError::Revert(_)) => false,
                 Err(_) => true,
             })
-            .no_limit()
+            .limit(10)
             .timeout_secs(*JSON_RPC_TIMEOUT)
             .run(move || {
                 let req = CallRequest {
@@ -397,115 +397,120 @@ where
                     value: None,
                     data: Some(call_data.clone()),
                 };
-                web3.eth().call(req, Some(BlockId::Hash(block_hash))).then(|result| {
-                    // Try to check if the call was reverted. The JSON-RPC response for
-                    // reverts is not standardized, the current situation for the tested
-                    // clients is:
-                    //
-                    // - Parity returns a reliable RPC error response for reverts.
-                    // - Ganache also returns a reliable RPC error.
-                    // - Geth now also returns an RPC error. It used to return `0x` on a
-                    //   revert with no reason string, or a Solidity encoded `Error(string)`
-                    //   call from `revert` and `require` calls with a reason string. We
-                    //   still have support for those but that can be removed on the next
-                    //   hard fork (Berlin).
+                web3.eth()
+                    .call(req, Some(BlockId::Hash(block_hash)))
+                    .then(|result| {
+                        // Try to check if the call was reverted. The JSON-RPC response for
+                        // reverts is not standardized, the current situation for the tested
+                        // clients is:
+                        //
+                        // - Parity returns a reliable RPC error response for reverts.
+                        // - Ganache also returns a reliable RPC error.
+                        // - Geth now also returns an RPC error. It used to return `0x` on a
+                        //   revert with no reason string, or a Solidity encoded `Error(string)`
+                        //   call from `revert` and `require` calls with a reason string. We
+                        //   still have support for those but that can be removed on the next
+                        //   hard fork (Berlin).
 
-                    // 0xfe is the "designated bad instruction" of the EVM, and Solidity
-                    // uses it for asserts.
-                    const PARITY_BAD_INSTRUCTION_FE: &str = "Bad instruction fe";
+                        // 0xfe is the "designated bad instruction" of the EVM, and Solidity
+                        // uses it for asserts.
+                        const PARITY_BAD_INSTRUCTION_FE: &str = "Bad instruction fe";
 
-                    // 0xfd is REVERT, but on some contracts, and only on older blocks,
-                    // this happens. Makes sense to consider it a revert as well.
-                    const PARITY_BAD_INSTRUCTION_FD: &str = "Bad instruction fd";
+                        // 0xfd is REVERT, but on some contracts, and only on older blocks,
+                        // this happens. Makes sense to consider it a revert as well.
+                        const PARITY_BAD_INSTRUCTION_FD: &str = "Bad instruction fd";
 
-                    const PARITY_BAD_JUMP_PREFIX: &str = "Bad jump";
-                    const GANACHE_VM_EXECUTION_ERROR: i64 = -32000;
-                    const GANACHE_REVERT_MESSAGE: &str =
-                        "VM Exception while processing transaction: revert";
-                    const PARITY_VM_EXECUTION_ERROR: i64 = -32015;
-                    const PARITY_REVERT_PREFIX: &str = "Reverted 0x";
+                        const PARITY_BAD_JUMP_PREFIX: &str = "Bad jump";
+                        const GANACHE_VM_EXECUTION_ERROR: i64 = -32000;
+                        const GANACHE_REVERT_MESSAGE: &str =
+                            "VM Exception while processing transaction: revert";
+                        const PARITY_VM_EXECUTION_ERROR: i64 = -32015;
+                        const PARITY_REVERT_PREFIX: &str = "Reverted 0x";
 
-                    // Deterministic Geth execution errors. We might need to expand this as
-                    // subgraphs come across other errors. See
-                    // https://github.com/ethereum/go-ethereum/blob/cd57d5cd38ef692de8fbedaa56598b4e9fbfbabc/core/vm/errors.go
-                    const GETH_EXECUTION_ERRORS: &[&str] = &[
-                        "execution reverted",
-                        "invalid jump destination",
-                        "invalid opcode",
-                    ];
+                        // Deterministic Geth execution errors. We might need to expand this as
+                        // subgraphs come across other errors. See
+                        // https://github.com/ethereum/go-ethereum/blob/cd57d5cd38ef692de8fbedaa56598b4e9fbfbabc/core/vm/errors.go
+                        const GETH_EXECUTION_ERRORS: &[&str] = &[
+                            "execution reverted",
+                            "invalid jump destination",
+                            "invalid opcode",
+                        ];
 
-                    let as_solidity_revert_with_reason = |bytes: &[u8]| {
-                        let solidity_revert_function_selector =
-                            &tiny_keccak::keccak256(b"Error(string)")[..4];
+                        let as_solidity_revert_with_reason = |bytes: &[u8]| {
+                            let solidity_revert_function_selector =
+                                &tiny_keccak::keccak256(b"Error(string)")[..4];
 
-                        match bytes.len() >= 4 && &bytes[..4] == solidity_revert_function_selector {
-                            false => None,
-                            true => ethabi::decode(&[ParamType::String], &bytes[4..])
-                                .ok()
-                                .and_then(|tokens| tokens[0].clone().to_string()),
-                        }
-                    };
-
-                    match result {
-                        // Check for old Geth revert with reason.
-                        Ok(bytes) => match as_solidity_revert_with_reason(&bytes.0) {
-                            None => Ok(bytes),
-                            Some(reason) => Err(EthereumContractCallError::Revert(reason)),
-                        },
-
-                        // Check for Geth revert.
-                        Err(web3::Error::Rpc(rpc_error))
-                            if GETH_EXECUTION_ERRORS
-                                .iter()
-                                .any(|e| rpc_error.message.contains(e)) =>
-                        {
-                            Err(EthereumContractCallError::Revert(rpc_error.message))
-                        }
-
-                        // Check for Parity revert.
-                        Err(web3::Error::Rpc(ref rpc_error))
-                            if rpc_error.code.code() == PARITY_VM_EXECUTION_ERROR =>
-                        {
-                            match rpc_error.data.as_ref().and_then(|d| d.as_str()) {
-                                Some(data)
-                                    if data.starts_with(PARITY_REVERT_PREFIX)
-                                        || data.starts_with(PARITY_BAD_JUMP_PREFIX)
-                                        || data == PARITY_BAD_INSTRUCTION_FE
-                                        || data == PARITY_BAD_INSTRUCTION_FD =>
-                                {
-                                    let reason = if data == PARITY_BAD_INSTRUCTION_FE {
-                                        PARITY_BAD_INSTRUCTION_FE.to_owned()
-                                    } else {
-                                        let payload = data.trim_start_matches(PARITY_REVERT_PREFIX);
-                                        hex::decode(payload)
-                                            .ok()
-                                            .and_then(|payload| {
-                                                as_solidity_revert_with_reason(&payload)
-                                            })
-                                            .unwrap_or("no reason".to_owned())
-                                    };
-                                    Err(EthereumContractCallError::Revert(reason))
-                                }
-
-                                // The VM execution error was not identified as a revert.
-                                _ => Err(EthereumContractCallError::Web3Error(web3::Error::Rpc(
-                                    rpc_error.clone(),
-                                ))),
+                            match bytes.len() >= 4
+                                && &bytes[..4] == solidity_revert_function_selector
+                            {
+                                false => None,
+                                true => ethabi::decode(&[ParamType::String], &bytes[4..])
+                                    .ok()
+                                    .and_then(|tokens| tokens[0].clone().to_string()),
                             }
-                        }
+                        };
 
-                        // Check for Ganache revert.
-                        Err(web3::Error::Rpc(ref rpc_error))
-                            if rpc_error.code.code() == GANACHE_VM_EXECUTION_ERROR
-                                && rpc_error.message.starts_with(GANACHE_REVERT_MESSAGE) =>
-                        {
-                            Err(EthereumContractCallError::Revert(rpc_error.message.clone()))
-                        }
+                        match result {
+                            // Check for old Geth revert with reason.
+                            Ok(bytes) => match as_solidity_revert_with_reason(&bytes.0) {
+                                None => Ok(bytes),
+                                Some(reason) => Err(EthereumContractCallError::Revert(reason)),
+                            },
 
-                        // The error was not identified as a revert.
-                        Err(err) => Err(EthereumContractCallError::Web3Error(err)),
-                    }
-                })
+                            // Check for Geth revert.
+                            Err(web3::Error::Rpc(rpc_error))
+                                if GETH_EXECUTION_ERRORS
+                                    .iter()
+                                    .any(|e| rpc_error.message.contains(e)) =>
+                            {
+                                Err(EthereumContractCallError::Revert(rpc_error.message))
+                            }
+
+                            // Check for Parity revert.
+                            Err(web3::Error::Rpc(ref rpc_error))
+                                if rpc_error.code.code() == PARITY_VM_EXECUTION_ERROR =>
+                            {
+                                match rpc_error.data.as_ref().and_then(|d| d.as_str()) {
+                                    Some(data)
+                                        if data.starts_with(PARITY_REVERT_PREFIX)
+                                            || data.starts_with(PARITY_BAD_JUMP_PREFIX)
+                                            || data == PARITY_BAD_INSTRUCTION_FE
+                                            || data == PARITY_BAD_INSTRUCTION_FD =>
+                                    {
+                                        let reason = if data == PARITY_BAD_INSTRUCTION_FE {
+                                            PARITY_BAD_INSTRUCTION_FE.to_owned()
+                                        } else {
+                                            let payload =
+                                                data.trim_start_matches(PARITY_REVERT_PREFIX);
+                                            hex::decode(payload)
+                                                .ok()
+                                                .and_then(|payload| {
+                                                    as_solidity_revert_with_reason(&payload)
+                                                })
+                                                .unwrap_or("no reason".to_owned())
+                                        };
+                                        Err(EthereumContractCallError::Revert(reason))
+                                    }
+
+                                    // The VM execution error was not identified as a revert.
+                                    _ => Err(EthereumContractCallError::Web3Error(
+                                        web3::Error::Rpc(rpc_error.clone()),
+                                    )),
+                                }
+                            }
+
+                            // Check for Ganache revert.
+                            Err(web3::Error::Rpc(ref rpc_error))
+                                if rpc_error.code.code() == GANACHE_VM_EXECUTION_ERROR
+                                    && rpc_error.message.starts_with(GANACHE_REVERT_MESSAGE) =>
+                            {
+                                Err(EthereumContractCallError::Revert(rpc_error.message.clone()))
+                            }
+
+                            // The error was not identified as a revert.
+                            Err(err) => Err(EthereumContractCallError::Web3Error(err)),
+                        }
+                    })
             })
             .map_err(|e| e.into_inner().unwrap_or(EthereumContractCallError::Timeout))
     }

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::env;
 use std::str::FromStr;
 
-use graph::components::subgraph::SharedProofOfIndexing;
+use graph::components::subgraph::{MappingError, SharedProofOfIndexing};
 use graph::prelude::{SubgraphInstance as SubgraphInstanceTrait, *};
 use web3::types::Log;
 
@@ -139,7 +139,7 @@ where
         trigger: EthereumTrigger,
         state: BlockState,
         proof_of_indexing: SharedProofOfIndexing,
-    ) -> Result<BlockState, anyhow::Error> {
+    ) -> Result<BlockState, MappingError> {
         Self::process_trigger_in_runtime_hosts(
             logger,
             &self.hosts,
@@ -158,7 +158,7 @@ where
         trigger: EthereumTrigger,
         mut state: BlockState,
         proof_of_indexing: SharedProofOfIndexing,
-    ) -> Result<BlockState, anyhow::Error> {
+    ) -> Result<BlockState, MappingError> {
         match trigger {
             EthereumTrigger::Log(log) => {
                 let log = Arc::new(log);

--- a/graph/src/components/ethereum/network.rs
+++ b/graph/src/components/ethereum/network.rs
@@ -41,7 +41,7 @@ impl PartialOrd for NodeCapabilities {
 }
 
 impl FromStr for NodeCapabilities {
-    type Err = Error;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let capabilities: Vec<&str> = s.split(",").collect();

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -40,13 +40,6 @@ impl MappingError {
             Unknown(e) => Unknown(e.context(s)),
         }
     }
-
-    pub fn inner_error(self) -> anyhow::Error {
-        use MappingError::*;
-        match self {
-            PossibleReorg(e) | Unknown(e) => e,
-        }
-    }
 }
 
 /// Common trait for runtime host implementations.

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use web3::types::Log;
 
-use crate::components::subgraph::SharedProofOfIndexing;
+use crate::components::subgraph::{MappingError, SharedProofOfIndexing};
 use crate::prelude::*;
 use crate::util::lfu_cache::LfuCache;
 
@@ -42,7 +42,7 @@ pub trait SubgraphInstance<H: RuntimeHost> {
         trigger: EthereumTrigger,
         state: BlockState,
         proof_of_indexing: SharedProofOfIndexing,
-    ) -> Result<BlockState, anyhow::Error>;
+    ) -> Result<BlockState, MappingError>;
 
     /// Like `process_trigger` but processes an Ethereum event in a given list of hosts.
     async fn process_trigger_in_runtime_hosts(
@@ -52,7 +52,7 @@ pub trait SubgraphInstance<H: RuntimeHost> {
         trigger: EthereumTrigger,
         state: BlockState,
         proof_of_indexing: SharedProofOfIndexing,
-    ) -> Result<BlockState, anyhow::Error>;
+    ) -> Result<BlockState, MappingError>;
 
     /// Adds dynamic data sources to the subgraph.
     fn add_dynamic_data_source(

--- a/graph/src/components/subgraph/mod.rs
+++ b/graph/src/components/subgraph/mod.rs
@@ -8,7 +8,7 @@ mod registrar;
 
 pub use crate::prelude::Entity;
 
-pub use self::host::{HostMetrics, RuntimeHost, RuntimeHostBuilder};
+pub use self::host::{HostMetrics, MappingError, RuntimeHost, RuntimeHostBuilder};
 pub use self::instance::{BlockState, DataSourceTemplateInfo, SubgraphInstance};
 pub use self::instance_manager::SubgraphInstanceManager;
 pub use self::loader::DataSourceLoader;

--- a/graph/src/util/error.rs
+++ b/graph/src/util/error.rs
@@ -29,3 +29,23 @@ impl<T, E: CompatErr> CompatErr for Result<T, E> {
         self.map_err(CompatErr::compat_err)
     }
 }
+
+// `ensure!` from `anyhow`, but calling `from`.
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr, $msg:literal $(,)?) => {
+        if !$cond {
+            return Err(From::from($crate::prelude::anyhow::anyhow!($msg)));
+        }
+    };
+    ($cond:expr, $err:expr $(,)?) => {
+        if !$cond {
+            return Err(From::from($crate::prelude::anyhow::anyhow!($err)));
+        }
+    };
+    ($cond:expr, $fmt:expr, $($arg:tt)*) => {
+        if !$cond {
+            return Err(From::from($crate::prelude::anyhow::anyhow!($fmt, $($arg)*)));
+        }
+    };
+}

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -318,7 +318,7 @@ impl HostExports {
             }
 
             // Any error reported by the Ethereum node could be due to the block no longer being on
-            // the main chain. This is very inespecific but we don't want to risk failing a
+            // the main chain. This is very unespecific but we don't want to risk failing a
             // subgraph due to a transient error such as a reorg.
             Err(EthereumContractCallError::Web3Error(e)) => Err(EthereumCallError::PossibleReorg(anyhow::anyhow!(
                 "Ethereum node returned an error when calling function \"{}\" of contract \"{}\": {}",

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -3,7 +3,7 @@ use ethabi::LogParam;
 use futures::sync::mpsc;
 use futures03::channel::oneshot::Sender;
 use graph::components::ethereum::*;
-use graph::components::subgraph::SharedProofOfIndexing;
+use graph::components::subgraph::{MappingError, SharedProofOfIndexing};
 use graph::prelude::*;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -128,7 +128,7 @@ pub(crate) enum MappingTrigger {
 }
 
 type MappingResponse = (
-    Result<BlockState, anyhow::Error>,
+    Result<BlockState, MappingError>,
     futures::Finished<Instant, Error>,
 );
 


### PR DESCRIPTION
This makes calls by block hash instead of block number. The tricky part is that contract calls may no longer be retried indefinitely, so if the eth node returns an error after 10 retries, we consider that a possible reorg. Getting that information returned to the instance manager requires some plumbing. The instance manager will then reset the block stream so we may handle the reorg.

There is one edge case which is when re-processing a block for new data sources. At this point we have a dirty indexing context due to the new data sources, and reverting that isn't a straightforward task, so if we fail to make a contract call that is treated as an ordinary error and not retried. Ideally we'd be able to retry this case as well, but that's left as future work.

I could not test this handling an actual reorg because that's not easy to reproduce. But I did test that when forcing an invalid hash on the call, the block stream would be reset.