### PR TITLE
Avoid cloning results assembled from partial results

### DIFF
--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -194,7 +194,8 @@ where
                 .cheap_clone()
                 .query_metadata(query)
                 .await?;
-            let unresolved_data_sources = self.parse_data_sources(&deployment_id, query_result)?;
+            let unresolved_data_sources =
+                self.parse_data_sources(&deployment_id, query_result.as_ref().clone())?;
             let next_data_sources = self
                 .resolve_data_sources(unresolved_data_sources, &logger)
                 .await?;

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -65,7 +65,7 @@ fn one_interface_zero_entities() {
 
     let res = insert_and_query(subgraph_id, schema, vec![], query).unwrap();
 
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(format!("{:?}", data), "Object({\"leggeds\": List([])})")
 }
 
@@ -83,7 +83,7 @@ fn one_interface_one_entity() {
     // Collection query.
     let query = "query { leggeds(first: 100) { legs } }";
     let res = insert_and_query(subgraph_id, schema, vec![entity], query).unwrap();
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
         "Object({\"leggeds\": List([Object({\"legs\": Int(Number(3))})])})"
@@ -92,7 +92,7 @@ fn one_interface_one_entity() {
     // Query by ID.
     let query = "query { legged(id: \"1\") { legs } }";
     let res = insert_and_query(subgraph_id, schema, vec![], query).unwrap();
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
         "Object({\"legged\": Object({\"legs\": Int(Number(3))})})",
@@ -113,7 +113,7 @@ fn one_interface_one_entity_typename() {
     let query = "query { leggeds(first: 100) { __typename } }";
 
     let res = insert_and_query(subgraph_id, schema, vec![entity], query).unwrap();
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
         "Object({\"leggeds\": List([Object({\"__typename\": String(\"Animal\")})])})"
@@ -140,7 +140,7 @@ fn one_interface_multiple_entities() {
     let query = "query { leggeds(first: 100, orderBy: legs) { legs } }";
 
     let res = insert_and_query(subgraph_id, schema, vec![animal, furniture], query).unwrap();
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
         "Object({\"leggeds\": List([Object({\"legs\": Int(Number(3))}), Object({\"legs\": Int(Number(4))})])})"
@@ -149,7 +149,7 @@ fn one_interface_multiple_entities() {
     // Test for support issue #32.
     let query = "query { legged(id: \"2\") { legs } }";
     let res = insert_and_query(subgraph_id, schema, vec![], query).unwrap();
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
         "Object({\"legged\": Object({\"legs\": Int(Number(4))})})",
@@ -173,7 +173,7 @@ fn reference_interface() {
 
     let res = insert_and_query(subgraph_id, schema, vec![leg, animal], query).unwrap();
 
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
         "Object({\"leggeds\": List([Object({\"leg\": Object({\"id\": String(\"1\")})})])})"
@@ -237,7 +237,7 @@ fn reference_interface_derived() {
     let entities = vec![buy, sell1, sell2, gift, txn];
     let res = insert_and_query(subgraph_id, schema, entities.clone(), query).unwrap();
 
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
         "Object({\"events\": List([\
@@ -301,7 +301,7 @@ fn follow_interface_reference() {
 
     let res = insert_and_query(subgraph_id, schema, vec![parent, child], query).unwrap();
 
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
         "Object({\"legged\": Object({\"parent\": Object({\"id\": String(\"parent\")})})})"
@@ -358,9 +358,10 @@ fn derived_interface_relationship() {
 
     let query = "query { forests(first: 100) { dwellers(first: 100) { id } } }";
 
-    let res = insert_and_query(subgraph_id, schema, vec![forest, animal], query);
+    let res = insert_and_query(subgraph_id, schema, vec![forest, animal], query).unwrap();
+    let data = extract_data!(res);
     assert_eq!(
-        res.unwrap().take_data().unwrap().to_string(),
+        data.unwrap().to_string(),
         "{forests: [{dwellers: [{id: \"1\"}]}]}"
     );
 }
@@ -399,7 +400,7 @@ fn two_interfaces() {
                     ifoos(first: 100, orderBy: foo) { foo }
                 }";
     let res = insert_and_query(subgraph_id, schema, vec![a, b, ab], query).unwrap();
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
         "Object({\"ibars\": List([Object({\"bar\": Int(Number(100))}), Object({\"bar\": Int(Number(200))})]), \
@@ -425,7 +426,7 @@ fn interface_non_inline_fragment() {
     // Query only the fragment.
     let query = "query { leggeds { ...frag } } fragment frag on Animal { name }";
     let res = insert_and_query(subgraph_id, schema, vec![entity], query).unwrap();
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
         r#"Object({"leggeds": List([Object({"name": String("cow")})])})"#
@@ -434,7 +435,7 @@ fn interface_non_inline_fragment() {
     // Query the fragment and something else.
     let query = "query { leggeds { legs, ...frag } } fragment frag on Animal { name }";
     let res = insert_and_query(subgraph_id, schema, vec![], query).unwrap();
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
         r#"Object({"leggeds": List([Object({"legs": Int(Number(3)), "name": String("cow")})])})"#,
@@ -468,7 +469,7 @@ fn interface_inline_fragment() {
     let query =
         "query { leggeds(orderBy: legs) { ... on Animal { name } ...on Bird { airspeed } } }";
     let res = insert_and_query(subgraph_id, schema, vec![animal, bird], query).unwrap();
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
         r#"Object({"leggeds": List([Object({"airspeed": Int(Number(24))}), Object({"name": String("cow")})])})"#
@@ -533,7 +534,7 @@ fn interface_inline_fragment_with_subquery() {
         query,
     )
     .unwrap();
-    let data = extract_data!(res);
+    let data = extract_data!(res).unwrap();
 
     assert_eq!(
         format!("{:?}", data),

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -57,7 +57,7 @@ fn one_interface_zero_entities() {
 
     assert!(res.errors.is_none());
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         "Object({\"leggeds\": List([])})"
     )
 }
@@ -78,7 +78,7 @@ fn one_interface_one_entity() {
     let res = insert_and_query(subgraph_id, schema, vec![entity], query).unwrap();
     assert!(res.errors.is_none());
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         "Object({\"leggeds\": List([Object({\"legs\": Int(Number(3))})])})"
     );
 
@@ -87,7 +87,7 @@ fn one_interface_one_entity() {
     let res = insert_and_query(subgraph_id, schema, vec![], query).unwrap();
     assert!(res.errors.is_none());
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         "Object({\"legged\": Object({\"legs\": Int(Number(3))})})",
     );
 }
@@ -108,7 +108,7 @@ fn one_interface_one_entity_typename() {
     let res = insert_and_query(subgraph_id, schema, vec![entity], query).unwrap();
     assert!(res.errors.is_none());
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         "Object({\"leggeds\": List([Object({\"__typename\": String(\"Animal\")})])})"
     )
 }
@@ -135,7 +135,7 @@ fn one_interface_multiple_entities() {
     let res = insert_and_query(subgraph_id, schema, vec![animal, furniture], query).unwrap();
     assert!(res.errors.is_none());
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         "Object({\"leggeds\": List([Object({\"legs\": Int(Number(3))}), Object({\"legs\": Int(Number(4))})])})"
     );
 
@@ -144,7 +144,7 @@ fn one_interface_multiple_entities() {
     let res = insert_and_query(subgraph_id, schema, vec![], query).unwrap();
     assert!(res.errors.is_none());
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         "Object({\"legged\": Object({\"legs\": Int(Number(4))})})",
     );
 }
@@ -168,7 +168,7 @@ fn reference_interface() {
 
     assert!(res.errors.is_none());
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         "Object({\"leggeds\": List([Object({\"leg\": Object({\"id\": String(\"1\")})})])})"
     )
 }
@@ -232,7 +232,7 @@ fn reference_interface_derived() {
 
     assert!(res.errors.is_none());
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         "Object({\"events\": List([\
             Object({\"id\": String(\"buy\"), \"transaction\": Object({\"id\": String(\"txn\")})}), \
             Object({\"id\": String(\"gift\"), \"transaction\": Object({\"id\": String(\"txn\")})}), \
@@ -296,7 +296,7 @@ fn follow_interface_reference() {
 
     assert!(res.errors.is_none(), format!("{:#?}", res.errors));
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         "Object({\"legged\": Object({\"parent\": Object({\"id\": String(\"parent\")})})})"
     )
 }
@@ -353,7 +353,7 @@ fn derived_interface_relationship() {
 
     let res = insert_and_query(subgraph_id, schema, vec![forest, animal], query);
     assert_eq!(
-        res.unwrap().data.unwrap().to_string(),
+        res.unwrap().take_data().unwrap().to_string(),
         "{forests: [{dwellers: [{id: \"1\"}]}]}"
     );
 }
@@ -394,7 +394,7 @@ fn two_interfaces() {
     let res = insert_and_query(subgraph_id, schema, vec![a, b, ab], query).unwrap();
     assert!(res.errors.is_none());
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         "Object({\"ibars\": List([Object({\"bar\": Int(Number(100))}), Object({\"bar\": Int(Number(200))})]), \
                  \"ifoos\": List([Object({\"foo\": String(\"bla\")}), Object({\"foo\": String(\"ble\")})])})"
     );
@@ -419,7 +419,7 @@ fn interface_non_inline_fragment() {
     let query = "query { leggeds { ...frag } } fragment frag on Animal { name }";
     let res = insert_and_query(subgraph_id, schema, vec![entity], query).unwrap();
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         r#"Object({"leggeds": List([Object({"name": String("cow")})])})"#
     );
 
@@ -428,7 +428,7 @@ fn interface_non_inline_fragment() {
     let res = insert_and_query(subgraph_id, schema, vec![], query).unwrap();
     assert!(res.errors.is_none());
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         r#"Object({"leggeds": List([Object({"legs": Int(Number(3)), "name": String("cow")})])})"#,
     );
 }
@@ -461,7 +461,7 @@ fn interface_inline_fragment() {
         "query { leggeds(orderBy: legs) { ... on Animal { name } ...on Bird { airspeed } } }";
     let res = insert_and_query(subgraph_id, schema, vec![animal, bird], query).unwrap();
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         r#"Object({"leggeds": List([Object({"airspeed": Int(Number(24))}), Object({"name": String("cow")})])})"#
     );
 }
@@ -526,7 +526,7 @@ fn interface_inline_fragment_with_subquery() {
     .unwrap();
 
     assert_eq!(
-        format!("{:?}", res.data.unwrap()),
+        format!("{:?}", res.take_data().unwrap()),
         "Object({\
          \"leggeds\": List([\
          Object({\
@@ -607,7 +607,7 @@ fn alias() {
 
     assert!(res.errors.is_none(), format!("{:#?}", res.errors));
     assert_eq!(
-        res.data.unwrap(),
+        res.take_data().unwrap(),
         object! {
             l: object! {
                 p: object! {
@@ -682,7 +682,7 @@ fn fragments_dont_panic() {
 
     assert!(res.errors.is_none(), format!("{:#?}", res.errors));
     assert_eq!(
-        res.data.unwrap(),
+        res.take_data().unwrap(),
         object! {
             parents: vec![
                 object! {
@@ -756,7 +756,7 @@ fn fragments_dont_duplicate_data() {
 
     assert!(res.errors.is_none(), format!("{:#?}", res.errors));
     assert_eq!(
-        res.data.unwrap(),
+        res.take_data().unwrap(),
         object! {
             parents: vec![
                 object! {
@@ -812,7 +812,7 @@ fn redundant_fields() {
 
     assert!(res.errors.is_none(), format!("{:#?}", res.errors));
     assert_eq!(
-        res.data.unwrap(),
+        res.take_data().unwrap(),
         object! {
             leggeds: vec![
                 object! {
@@ -879,7 +879,7 @@ fn fragments_merge_selections() {
 
     assert!(res.errors.is_none(), format!("{:#?}", res.errors));
     assert_eq!(
-        res.data.unwrap(),
+        res.take_data().unwrap(),
         object! {
             parents: vec![
                 object! {
@@ -945,7 +945,7 @@ fn merge_fields_not_in_interface() {
 
     assert!(res.errors.is_none(), format!("{:#?}", res.errors));
     assert_eq!(
-        res.data.unwrap(),
+        res.take_data().unwrap(),
         object! {
             ifaces: vec![
                 object! {
@@ -1044,7 +1044,7 @@ fn nested_interface_fragments() {
 
     assert!(res.errors.is_none(), format!("{:#?}", res.errors));
     assert_eq!(
-        res.data.unwrap(),
+        res.take_data().unwrap(),
         object! {
             i1Faces: vec![
                 object! {
@@ -1131,7 +1131,7 @@ fn nested_interface_fragments_overlapping() {
 
     assert!(res.errors.is_none(), format!("{:#?}", res.errors));
     assert_eq!(
-        res.data.unwrap(),
+        res.take_data().unwrap(),
         object! {
             i1Faces: vec![
                 object! {
@@ -1164,7 +1164,7 @@ fn nested_interface_fragments_overlapping() {
     let res = insert_and_query(subgraph_id, schema, vec![], query).unwrap();
     assert!(res.errors.is_none(), format!("{:#?}", res.errors));
     assert_eq!(
-        res.data.unwrap(),
+        res.take_data().unwrap(),
         object! {
             i1Faces: vec![
                 object! {

--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -55,12 +55,10 @@ pub trait GraphQlRunner: Send + Sync + 'static {
         let result = Arc::try_unwrap(result).unwrap();
         if result.errors.is_some() {
             Err(format_err!("Failed to query metadata: {:?}", result.errors))
-        } else if result.data.is_empty() {
+        } else if !result.has_data() {
             Err(format_err!("No metadata found"))
-        } else if result.data.len() > 1 {
-            Err(format_err!("Metadata query returned multiple results"))
         } else {
-            Ok(result.data.first().unwrap().clone())
+            Ok(Arc::new(result.take_data().unwrap()))
         }
     }
 

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -9,9 +9,9 @@ use std::fmt;
 use std::string::FromUtf8Error;
 use std::sync::Arc;
 
-use crate::components::store::StoreError;
 use crate::data::graphql::SerializableValue;
 use crate::data::subgraph::*;
+use crate::{components::store::StoreError, prelude::CacheWeight};
 
 #[derive(Debug)]
 pub struct CloneableFailureError(Arc<failure::Error>);
@@ -386,5 +386,11 @@ impl Serialize for QueryError {
 
         map.serialize_entry("message", msg.as_str())?;
         map.end()
+    }
+}
+
+impl CacheWeight for QueryError {
+    fn indirect_weight(&self) -> usize {
+        0
     }
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -391,6 +391,7 @@ impl Serialize for QueryError {
 
 impl CacheWeight for QueryError {
     fn indirect_weight(&self) -> usize {
+        // Errors don't have a weight since they are never cached
         0
     }
 }

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -102,7 +102,9 @@ impl QueryResult {
             .unwrap()
     }
 
-    pub fn take_data(mut self) -> Option<q::Value> {
+    /// Combine all the data into one `q::Value`. This method might clone
+    /// all of the data in this result
+    fn take_data(mut self) -> Option<q::Value> {
         fn take_or_clone(value: Arc<q::Value>) -> q::Value {
             Arc::try_unwrap(value).unwrap_or_else(|value| value.as_ref().clone())
         }
@@ -131,8 +133,9 @@ impl QueryResult {
         !self.data.is_empty()
     }
 
-    /// Return either the data or the errors for this `QueryResult`. If there
-    /// are errors, the data just gets dropped.
+    /// Return either the data or the errors for this `QueryResult`. The data
+    /// will be cloned for any of the entries in `self.data` that have a
+    /// reference count greater than 1. If there are errors, the data is ignored.
     pub fn to_result(self) -> Result<Option<q::Value>, Vec<QueryError>> {
         if self.has_errors() {
             Err(self.errors)

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -1,5 +1,5 @@
 use super::error::{QueryError, QueryExecutionError};
-use crate::data::graphql::SerializableValue;
+use crate::{data::graphql::SerializableValue, prelude::CacheWeight};
 use graphql_parser::query as q;
 use serde::ser::*;
 use serde::Serialize;
@@ -42,7 +42,7 @@ pub struct QueryResult {
         skip_serializing_if = "Vec::is_empty",
         serialize_with = "serialize_datas"
     )]
-    pub data: Vec<Arc<q::Value>>,
+    data: Vec<Arc<q::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub errors: Option<Vec<QueryError>>,
     #[serde(
@@ -184,6 +184,14 @@ impl<V: Into<QueryResult>, E: Into<QueryResult>> From<Result<V, E>> for QueryRes
             Ok(v) => v.into(),
             Err(e) => e.into(),
         }
+    }
+}
+
+impl CacheWeight for QueryResult {
+    fn indirect_weight(&self) -> usize {
+        self.data.indirect_weight()
+            + self.errors.indirect_weight()
+            + self.extensions.indirect_weight()
     }
 }
 

--- a/graph/src/data/subgraph/schema/queries.rs
+++ b/graph/src/data/subgraph/schema/queries.rs
@@ -44,7 +44,7 @@ impl<S: SubgraphDeploymentStore + Store, Q: GraphQlRunner> LazyMetadata<S, Q> {
             ))
             .await?;
 
-        let deployment = match &value {
+        let deployment = match value.as_ref() {
             q::Value::Object(map) => match &map["subgraphDeployment"] {
                 q::Value::Object(deployment) => deployment,
                 _ => unreachable!(),
@@ -80,7 +80,7 @@ impl<S: SubgraphDeploymentStore + Store, Q: GraphQlRunner> LazyMetadata<S, Q> {
             ))
             .await?;
 
-        let deployment = match &value {
+        let deployment = match value.as_ref() {
             q::Value::Object(map) => match &map["subgraphDeployment"] {
                 q::Value::Object(deployment) => deployment,
                 _ => unreachable!(),

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -1,5 +1,6 @@
 use crate::prelude::{BigDecimal, BigInt, EntityKey, Value};
 use std::mem;
+use std::sync::Arc;
 
 /// Estimate of how much memory a value consumes.
 /// Useful for measuring the size of caches.
@@ -27,6 +28,12 @@ impl<T: CacheWeight> CacheWeight for Vec<T> {
     fn indirect_weight(&self) -> usize {
         self.iter().map(CacheWeight::indirect_weight).sum::<usize>()
             + self.capacity() * mem::size_of::<T>()
+    }
+}
+
+impl<T: CacheWeight> CacheWeight for Arc<T> {
+    fn indirect_weight(&self) -> usize {
+        self.as_ref().indirect_weight()
     }
 }
 

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -1,6 +1,5 @@
 use crate::prelude::{BigDecimal, BigInt, EntityKey, Value};
 use std::mem;
-use std::sync::Arc;
 
 /// Estimate of how much memory a value consumes.
 /// Useful for measuring the size of caches.
@@ -28,12 +27,6 @@ impl<T: CacheWeight> CacheWeight for Vec<T> {
     fn indirect_weight(&self) -> usize {
         self.iter().map(CacheWeight::indirect_weight).sum::<usize>()
             + self.capacity() * mem::size_of::<T>()
-    }
-}
-
-impl<T: CacheWeight> CacheWeight for Arc<T> {
-    fn indirect_weight(&self) -> usize {
-        self.as_ref().indirect_weight()
     }
 }
 

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -73,7 +73,7 @@ impl CacheWeight for WeightedResult {
 impl Default for WeightedResult {
     fn default() -> Self {
         WeightedResult {
-            result: Arc::new(QueryResult::new(Some(q::Value::Null))),
+            result: Arc::new(QueryResult::new(vec![Arc::new(q::Value::Null)])),
             weight: 0,
         }
     }
@@ -533,7 +533,7 @@ pub async fn execute_root_selection_set<R: Resolver>(
         (no_cache, key, block_ptr, &ctx.query.network)
     {
         // Calculate the weight outside the lock.
-        let weight = result.data.as_ref().unwrap().weight();
+        let weight = result.data.weight();
         let mut cache = QUERY_BLOCK_CACHE.write().unwrap();
 
         // Get or insert the cache for this network.

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -73,7 +73,7 @@ impl CacheWeight for WeightedResult {
 impl Default for WeightedResult {
     fn default() -> Self {
         WeightedResult {
-            result: Arc::new(QueryResult::new(vec![Arc::new(q::Value::Null)])),
+            result: Arc::new(QueryResult::new(vec![Arc::new(BTreeMap::default())])),
             weight: 0,
         }
     }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -49,7 +49,7 @@ impl CacheByBlock {
     /// Returns `true` if the insert was successful or `false` if the cache was full.
     fn insert(&mut self, key: QueryHash, value: Arc<QueryResult>, weight: usize) -> bool {
         // We never try to insert errors into this cache, and always resolve some value.
-        assert!(value.errors.is_none());
+        assert!(!value.has_errors());
         let fits_in_cache = self.weight + weight <= self.max_weight;
         if fits_in_cache {
             self.weight += weight;

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -533,7 +533,7 @@ pub async fn execute_root_selection_set<R: Resolver>(
         (no_cache, key, block_ptr, &ctx.query.network)
     {
         // Calculate the weight outside the lock.
-        let weight = result.data.weight();
+        let weight = result.weight();
         let mut cache = QUERY_BLOCK_CACHE.write().unwrap();
 
         // Get or insert the cache for this network.

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -1230,7 +1230,7 @@ async fn successfully_runs_introspection_query_against_complex_schema() {
     )
     .await;
 
-    assert!(result.errors.is_none(), format!("{:#?}", result.errors));
+    assert!(!result.has_errors(), format!("{:#?}", result));
 }
 
 #[tokio::test]

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -823,8 +823,9 @@ async fn satisfies_graphiql_introspection_query_without_fragments() {
     .await;
 
     let data = result
-        .take_data()
-        .expect("Introspection query returned no result");
+        .to_result()
+        .expect("Introspection query returned no result")
+        .unwrap();
     assert_eq!(data, expected_mock_schema_introspection());
 }
 
@@ -929,8 +930,9 @@ async fn satisfies_graphiql_introspection_query_with_fragments() {
     .await;
 
     let data = result
-        .take_data()
-        .expect("Introspection query returned no result");
+        .to_result()
+        .expect("Introspection query returned no result")
+        .unwrap();
     assert_eq!(data, expected_mock_schema_introspection());
 }
 
@@ -1255,7 +1257,8 @@ async fn introspection_possible_types() {
         }",
     )
     .await
-    .take_data()
+    .to_result()
+    .unwrap()
     .unwrap();
 
     assert_eq!(

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -822,7 +822,9 @@ async fn satisfies_graphiql_introspection_query_without_fragments() {
     )
     .await;
 
-    let data = result.data.expect("Introspection query returned no result");
+    let data = result
+        .take_data()
+        .expect("Introspection query returned no result");
     assert_eq!(data, expected_mock_schema_introspection());
 }
 
@@ -926,7 +928,9 @@ async fn satisfies_graphiql_introspection_query_with_fragments() {
     )
     .await;
 
-    let data = result.data.expect("Introspection query returned no result");
+    let data = result
+        .take_data()
+        .expect("Introspection query returned no result");
     assert_eq!(data, expected_mock_schema_introspection());
 }
 
@@ -1251,7 +1255,7 @@ async fn introspection_possible_types() {
         }",
     )
     .await
-    .data
+    .take_data()
     .unwrap();
 
     assert_eq!(

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -327,7 +327,7 @@ fn can_query_one_to_one_relationship() {
         .await;
 
         assert_eq!(
-            result.take_data(),
+            extract_data!(result),
             Some(object_value(vec![
                 (
                     "musicians",
@@ -605,7 +605,7 @@ fn query_variables_are_used() {
         .await;
 
         assert_eq!(
-            result.take_data(),
+            extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
                 q::Value::List(vec![object_value(vec![(
@@ -644,7 +644,7 @@ fn skip_directive_works_with_query_variables() {
 
         // Assert that only names are returned
         assert_eq!(
-            result.take_data(),
+            extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
                 q::Value::List(vec![
@@ -668,7 +668,7 @@ fn skip_directive_works_with_query_variables() {
 
         // Assert that IDs and names are returned
         assert_eq!(
-            result.take_data(),
+            extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
                 q::Value::List(vec![
@@ -721,7 +721,7 @@ fn include_directive_works_with_query_variables() {
 
         // Assert that IDs and names are returned
         assert_eq!(
-            result.take_data(),
+            extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
                 q::Value::List(vec![
@@ -757,7 +757,7 @@ fn include_directive_works_with_query_variables() {
 
         // Assert that only names are returned
         assert_eq!(
-            result.take_data(),
+            extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
                 q::Value::List(vec![
@@ -1029,7 +1029,7 @@ fn skip_is_nullable() {
         let result = execute_query_document_with_variables(&id, query, None).await;
 
         assert_eq!(
-            result.take_data(),
+            extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
                 q::Value::List(vec![
@@ -1060,7 +1060,7 @@ fn first_is_nullable() {
         let result = execute_query_document_with_variables(&id, query, None).await;
 
         assert_eq!(
-            result.take_data(),
+            extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
                 q::Value::List(vec![
@@ -1326,7 +1326,7 @@ fn can_use_nested_filter() {
         .await;
 
         assert_eq!(
-            result.take_data().unwrap(),
+            extract_data!(result).unwrap(),
             object_value(vec![(
                 "musicians",
                 q::Value::List(vec![

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -465,14 +465,12 @@ mod tests {
             _state: DeploymentState,
             _: bool,
         ) -> Arc<QueryResult> {
-            Arc::new(QueryResult::new(vec![Arc::new(q::Value::Object(
-                BTreeMap::from_iter(
-                    vec![(
-                        String::from("name"),
-                        q::Value::String(String::from("Jordi")),
-                    )]
-                    .into_iter(),
-                ),
+            Arc::new(QueryResult::new(vec![Arc::new(BTreeMap::from_iter(
+                vec![(
+                    String::from("name"),
+                    q::Value::String(String::from("Jordi")),
+                )]
+                .into_iter(),
             ))]))
         }
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -465,7 +465,7 @@ mod tests {
             _state: DeploymentState,
             _: bool,
         ) -> Arc<QueryResult> {
-            Arc::new(QueryResult::new(Some(q::Value::Object(
+            Arc::new(QueryResult::new(vec![Arc::new(q::Value::Object(
                 BTreeMap::from_iter(
                     vec![(
                         String::from("name"),
@@ -473,7 +473,7 @@ mod tests {
                     )]
                     .into_iter(),
                 ),
-            ))))
+            ))]))
         }
 
         async fn run_subscription(

--- a/server/http/tests/response.rs
+++ b/server/http/tests/response.rs
@@ -7,14 +7,14 @@ use std::collections::BTreeMap;
 #[test]
 fn generates_200_for_query_results() {
     let data = graphql_parser::query::Value::Object(BTreeMap::new());
-    let query_result = QueryResult::new(Some(data)).as_http_response();
+    let query_result = QueryResult::from(data).as_http_response();
     test_utils::assert_successful_response(query_result);
 }
 
 #[test]
 fn generates_valid_json_for_an_empty_result() {
     let data = graphql_parser::query::Value::Object(BTreeMap::new());
-    let query_result = QueryResult::new(Some(data)).as_http_response();
+    let query_result = QueryResult::from(data).as_http_response();
     let data = test_utils::assert_successful_response(query_result);
     assert!(data.is_empty());
 }
@@ -34,7 +34,7 @@ fn canonical_serialization() {
                     | String(_) | Boolean(_) => (),
                 };
             }
-            let res = QueryResult::new(Some($obj));
+            let res = QueryResult::from($obj);
             assert_eq!($exp, serde_json::to_string(&res).unwrap());
         }};
     }

--- a/server/http/tests/response.rs
+++ b/server/http/tests/response.rs
@@ -6,14 +6,14 @@ use std::collections::BTreeMap;
 
 #[test]
 fn generates_200_for_query_results() {
-    let data = graphql_parser::query::Value::Object(BTreeMap::new());
+    let data = BTreeMap::new();
     let query_result = QueryResult::from(data).as_http_response();
     test_utils::assert_successful_response(query_result);
 }
 
 #[test]
 fn generates_valid_json_for_an_empty_result() {
-    let data = graphql_parser::query::Value::Object(BTreeMap::new());
+    let data = BTreeMap::new();
     let query_result = QueryResult::from(data).as_http_response();
     let data = test_utils::assert_successful_response(query_result);
     assert!(data.is_empty());
@@ -34,7 +34,7 @@ fn canonical_serialization() {
                     | String(_) | Boolean(_) => (),
                 };
             }
-            let res = QueryResult::from($obj);
+            let res = QueryResult::try_from($obj).unwrap();
             assert_eq!($exp, serde_json::to_string(&res).unwrap());
         }};
     }

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -36,7 +36,7 @@ impl GraphQlRunner for TestGraphQlRunner {
         _state: DeploymentState,
         _: bool,
     ) -> Arc<QueryResult> {
-        Arc::new(QueryResult::new(vec![Arc::new(q::Value::Object(
+        Arc::new(QueryResult::new(vec![Arc::new(
             if query.variables.is_some()
                 && query
                     .variables
@@ -64,7 +64,7 @@ impl GraphQlRunner for TestGraphQlRunner {
                     .into_iter(),
                 )
             },
-        ))]))
+        )]))
     }
 
     async fn run_subscription(

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -36,7 +36,7 @@ impl GraphQlRunner for TestGraphQlRunner {
         _state: DeploymentState,
         _: bool,
     ) -> Arc<QueryResult> {
-        Arc::new(QueryResult::new(Some(q::Value::Object(
+        Arc::new(QueryResult::new(vec![Arc::new(q::Value::Object(
             if query.variables.is_some()
                 && query
                     .variables
@@ -64,7 +64,7 @@ impl GraphQlRunner for TestGraphQlRunner {
                     .into_iter(),
                 )
             },
-        ))))
+        ))]))
     }
 
     async fn run_subscription(

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -388,17 +388,16 @@ where
         // Metadata queries are not cached.
         let result = Arc::try_unwrap(result).unwrap();
 
-        let data = match result.data {
-            Some(data) => data,
-            None => {
-                error!(
-                    self.logger,
-                    "Failed to query subgraph deployments";
-                    "subgraphs" => format!("{:?}", subgraphs),
-                    "errors" => format!("{:?}", result.errors)
-                );
-                return Ok(q::Value::List(vec![]));
-            }
+        let data = if result.has_data() {
+            result.take_data().unwrap()
+        } else {
+            error!(
+                self.logger,
+                "Failed to query subgraph deployments";
+                "subgraphs" => format!("{:?}", subgraphs),
+                "errors" => format!("{:?}", result.errors)
+            );
+            return Ok(q::Value::List(vec![]));
         };
 
         Ok(IndexingStatuses::from(data).into())
@@ -473,17 +472,16 @@ where
         // Metadata queries are not cached.
         let result = Arc::try_unwrap(result).unwrap();
 
-        let data = match result.data {
-            Some(data) => data,
-            None => {
-                error!(
-                    self.logger,
-                    "Failed to query subgraph deployments";
-                    "subgraph" => subgraph_name,
-                    "errors" => format!("{:?}", result.errors)
-                );
-                return Ok(q::Value::List(vec![]));
-            }
+        let data = if result.has_data() {
+            result.take_data().unwrap()
+        } else {
+            error!(
+                self.logger,
+                "Failed to query subgraph deployments";
+                "subgraph" => subgraph_name,
+                "errors" => format!("{:?}", result.errors)
+            );
+            return Ok(q::Value::List(vec![]));
         };
 
         let subgraphs = match data
@@ -639,17 +637,16 @@ where
         // Metadata queries are not cached.
         let result = Arc::try_unwrap(result).unwrap();
 
-        let data = match result.data {
-            Some(data) => data,
-            None => {
-                error!(
-                    self.logger,
-                    "Failed to query subgraph deployments";
-                    "subgraph" => subgraph_name,
-                    "errors" => format!("{:?}", result.errors)
-                );
-                return Ok(q::Value::List(vec![]));
-            }
+        let data = if result.has_data() {
+            result.take_data().unwrap()
+        } else {
+            error!(
+                self.logger,
+                "Failed to query subgraph deployments";
+                "subgraph" => subgraph_name,
+                "errors" => format!("{:?}", result.errors)
+            );
+            return Ok(q::Value::List(vec![]));
         };
 
         let subgraphs = match data

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -388,16 +388,20 @@ where
         // Metadata queries are not cached.
         let result = Arc::try_unwrap(result).unwrap();
 
-        let data = if result.has_data() {
-            result.take_data().unwrap()
-        } else {
-            error!(
-                self.logger,
-                "Failed to query subgraph deployments";
-                "subgraphs" => format!("{:?}", subgraphs),
-                "errors" => format!("{:?}", result.errors)
-            );
-            return Ok(q::Value::List(vec![]));
+        let data = match result.to_result() {
+            Err(errors) => {
+                error!(
+                    self.logger,
+                    "Failed to query subgraph deployments";
+                    "subgraphs" => format!("{:?}", subgraphs),
+                    "errors" => format!("{:?}", errors)
+                );
+                return Ok(q::Value::List(vec![]));
+            }
+            Ok(None) => {
+                return Ok(q::Value::List(vec![]));
+            }
+            Ok(Some(data)) => data,
         };
 
         Ok(IndexingStatuses::from(data).into())
@@ -472,16 +476,20 @@ where
         // Metadata queries are not cached.
         let result = Arc::try_unwrap(result).unwrap();
 
-        let data = if result.has_data() {
-            result.take_data().unwrap()
-        } else {
-            error!(
-                self.logger,
-                "Failed to query subgraph deployments";
-                "subgraph" => subgraph_name,
-                "errors" => format!("{:?}", result.errors)
-            );
-            return Ok(q::Value::List(vec![]));
+        let data = match result.to_result() {
+            Err(errors) => {
+                error!(
+                    self.logger,
+                    "Failed to query subgraph deployments";
+                    "subgraph" => subgraph_name,
+                    "errors" => format!("{:?}", errors)
+                );
+                return Ok(q::Value::List(vec![]));
+            }
+            Ok(None) => {
+                return Ok(q::Value::List(vec![]));
+            }
+            Ok(Some(data)) => data,
         };
 
         let subgraphs = match data
@@ -637,16 +645,18 @@ where
         // Metadata queries are not cached.
         let result = Arc::try_unwrap(result).unwrap();
 
-        let data = if result.has_data() {
-            result.take_data().unwrap()
-        } else {
-            error!(
-                self.logger,
-                "Failed to query subgraph deployments";
-                "subgraph" => subgraph_name,
-                "errors" => format!("{:?}", result.errors)
-            );
-            return Ok(q::Value::List(vec![]));
+        let data = match result.to_result() {
+            Err(errors) => {
+                error!(
+                    self.logger,
+                    "Failed to query subgraph deployments";
+                    "subgraph" => subgraph_name,
+                    "errors" => format!("{:?}", errors)
+                );
+                return Ok(q::Value::List(vec![]));
+            }
+            Ok(None) => return Ok(q::Value::List(vec![])),
+            Ok(Some(data)) => data,
         };
 
         let subgraphs = match data


### PR DESCRIPTION
When a GraphQL query contains different block constraints, we run and cache the toplevel fields grouped by the block constraint separately, and assemble the response from those partials. We now see a lot of large GraphQL queries with different block constraints - on average we run 3-4 toplevel queries for each GraphQL request.

Assembling the response used to involve cloning all the partial responses. This PR changes that so that we will not clone at all, and rather pass the partial results around behind in an `Arc`; assembling the entire response is only done when we serialize the response to JSON (that's another clone-heavy part of request processing, but is not addressed by this PR)