### PR TITLE
Bump max block range size default

### DIFF
--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -17,7 +17,7 @@ use graph::prelude::{
 lazy_static! {
     /// Maximum number of blocks to request in each chunk.
     static ref MAX_BLOCK_RANGE_SIZE: u64 = std::env::var("GRAPH_ETHEREUM_MAX_BLOCK_RANGE_SIZE")
-        .unwrap_or("1000".into())
+        .unwrap_or("2000".into())
         .parse::<u64>()
         .expect("invalid GRAPH_ETHEREUM_MAX_BLOCK_RANGE_SIZE");
 


### PR DESCRIPTION
This is limited for compatibility with Alchemy's limit, which was of 1000 blocks and was now increased to 2000 blocks.