### PR TITLE
all: Limit the 'skip' parameter in the same way as 'first'

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -93,6 +93,9 @@ those.
 - `GRAPH_GRAPHQL_MAX_FIRST`: maximum value that can be used for the `first`
   argument in GraphQL queries. If not provided, `first` defaults to 100. The
   default value for `GRAPH_GRAPHQL_MAX_FIRST` is 1000.
+- `GRAPH_GRAPHQL_MAX_SKIP`: maximum value that can be used for the `skip`
+  argument in GraphQL queries. The default value for
+  `GRAPH_GRAPHQL_MAX_SKIP` is unlimited.
 - `GRAPH_GRAPHQL_MAX_OPERATIONS_PER_CONNECTION`: maximum number of GraphQL
   operations per WebSocket connection. Any operation created after the limit
   will return an error to the client. Default: unlimited.

--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -28,6 +28,7 @@ pub trait GraphQlRunner: Send + Sync + 'static {
         max_complexity: Option<u64>,
         max_depth: Option<u8>,
         max_first: Option<u32>,
+        max_skip: Option<u32>,
     ) -> Arc<QueryResult>;
 
     /// Runs a GraphQL subscription and returns a stream of results.
@@ -38,7 +39,7 @@ pub trait GraphQlRunner: Send + Sync + 'static {
 
     async fn query_metadata(self: Arc<Self>, query: Query) -> Result<q::Value, Error> {
         let result = self
-            .run_query_with_complexity(query, None, None, None)
+            .run_query_with_complexity(query, None, None, None, None)
             .await;
 
         // Metadata queries are not cached.

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -296,6 +296,9 @@ where
     /// Max value for `first`.
     pub max_first: u32,
 
+    /// Max value for `skip`
+    pub max_skip: u32,
+
     /// Records whether this was a cache hit, used for logging.
     pub(crate) cache_status: AtomicCell<CacheStatus>,
 
@@ -348,6 +351,7 @@ where
             query: self.query.as_introspection_query(),
             deadline: self.deadline,
             max_first: std::u32::MAX,
+            max_skip: std::u32::MAX,
 
             // `cache_status` and `load_manager` are dead values for the introspection context.
             cache_status: AtomicCell::new(CacheStatus::Miss),

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -24,6 +24,9 @@ pub struct QueryExecutionOptions<R> {
     /// Maximum value for the `first` argument.
     pub max_first: u32,
 
+    /// Maximum value for the `skip` argument
+    pub max_skip: u32,
+
     pub load_manager: Arc<LoadManager>,
 }
 
@@ -45,6 +48,7 @@ where
         query: query.clone(),
         deadline: options.deadline,
         max_first: options.max_first,
+        max_skip: options.max_skip,
         cache_status: Default::default(),
         load_manager: options.load_manager.cheap_clone(),
     });

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -805,6 +805,7 @@ fn execute_field(
         ctx.query.schema.types_for_interface(),
         resolver.block,
         ctx.max_first,
+        ctx.max_skip,
     )
     .map_err(|e| vec![e])
 }
@@ -822,6 +823,7 @@ fn fetch(
     types_for_interface: &BTreeMap<s::Name, Vec<s::ObjectType>>,
     block: BlockNumber,
     max_first: u32,
+    max_skip: u32,
 ) -> Result<Vec<Node>, QueryExecutionError> {
     let mut query = build_query(
         join.child_type,
@@ -829,6 +831,7 @@ fn fetch(
         &arguments,
         types_for_interface,
         max_first,
+        max_skip,
     )?;
 
     if multiplicity == ChildMultiplicity::Single {

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -22,6 +22,7 @@ pub fn build_query<'a>(
     arguments: &HashMap<&q::Name, q::Value>,
     types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
     max_first: u32,
+    max_skip: u32,
 ) -> Result<EntityQuery, QueryExecutionError> {
     let entity = entity.into();
     let entity_types = EntityCollection::All(match &entity {
@@ -32,7 +33,7 @@ pub fn build_query<'a>(
             .collect(),
     });
     let mut query = EntityQuery::new(parse_subgraph_id(entity)?, block, entity_types)
-        .range(build_range(arguments, max_first)?);
+        .range(build_range(arguments, max_first, max_skip)?);
     if let Some(filter) = build_filter(entity, arguments)? {
         query = query.filter(filter);
     }
@@ -56,6 +57,7 @@ pub fn build_query<'a>(
 fn build_range(
     arguments: &HashMap<&q::Name, q::Value>,
     max_first: u32,
+    max_skip: u32,
 ) -> Result<EntityRange, QueryExecutionError> {
     let first = match arguments.get(&"first".to_string()) {
         Some(q::Value::Int(n)) => {
@@ -73,7 +75,7 @@ fn build_range(
     let skip = match arguments.get(&"skip".to_string()) {
         Some(q::Value::Int(n)) => {
             let n = n.as_i64().expect("skip is Int");
-            if n >= 0 {
+            if n >= 0 && n <= (max_skip as i64) {
                 Ok(n as u32)
             } else {
                 Err("skip")
@@ -428,6 +430,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &default_arguments(),
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -440,6 +443,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &default_arguments(),
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -456,6 +460,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &default_arguments(),
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -475,6 +480,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -490,6 +496,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -509,6 +516,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -524,6 +532,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -545,6 +554,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -561,6 +571,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -580,6 +591,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -599,6 +611,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -620,6 +633,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -636,6 +650,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -652,6 +667,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &default_arguments(),
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -671,6 +687,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX
             )
             .unwrap()
@@ -702,6 +719,7 @@ mod tests {
                 BLOCK_NUMBER_MAX,
                 &args,
                 &BTreeMap::new(),
+                std::u32::MAX,
                 std::u32::MAX,
             )
             .unwrap()

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -31,6 +31,9 @@ where
     /// Maximum value for the `first` argument.
     pub max_first: u32,
 
+    /// Maximum value for the `skip` argument.
+    pub max_skip: u32,
+
     pub load_manager: Arc<dyn QueryLoadManager>,
 }
 
@@ -64,6 +67,7 @@ where
         query: query.clone(),
         deadline: None,
         max_first: options.max_first,
+        max_skip: options.max_skip,
         cache_status: Default::default(),
         load_manager: options.load_manager,
     };
@@ -136,6 +140,7 @@ fn map_source_to_response_stream(
     let resolver = ctx.resolver.cheap_clone();
     let query = ctx.query.cheap_clone();
     let max_first = ctx.max_first;
+    let max_skip = ctx.max_skip;
     let load_manager = ctx.load_manager.cheap_clone();
 
     // Create a stream with a single empty event. By chaining this in front
@@ -163,6 +168,7 @@ fn map_source_to_response_stream(
                     event,
                     timeout,
                     max_first,
+                    max_skip,
                     load_manager.cheap_clone(),
                 )
                 .boxed(),
@@ -177,6 +183,7 @@ async fn execute_subscription_event(
     event: Arc<StoreEvent>,
     timeout: Option<Duration>,
     max_first: u32,
+    max_skip: u32,
     load_manager: Arc<dyn QueryLoadManager>,
 ) -> Arc<QueryResult> {
     debug!(logger, "Execute subscription event"; "event" => format!("{:?}", event));
@@ -188,6 +195,7 @@ async fn execute_subscription_event(
         query,
         deadline: timeout.map(|t| Instant::now() + t),
         max_first,
+        max_skip,
         cache_status: Default::default(),
         load_manager,
     });

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -564,6 +564,7 @@ async fn introspection_query(schema: Schema, query: &str) -> QueryResult {
         resolver: MockResolver,
         deadline: None,
         max_first: std::u32::MAX,
+        max_skip: std::u32::MAX,
         load_manager: LOAD_MANAGER.clone(),
     };
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -240,7 +240,7 @@ async fn execute_query_document_with_variables(
     let query = Query::new(Arc::new(api_test_schema()), query, variables, None);
 
     runner
-        .run_query_with_complexity(query, None, None, None)
+        .run_query_with_complexity(query, None, None, None, None)
         .await
         .as_ref()
         .clone()
@@ -829,6 +829,7 @@ async fn query_complexity_subscriptions() {
         max_complexity,
         max_depth: 100,
         max_first: std::u32::MAX,
+        max_skip: std::u32::MAX,
         load_manager: mock_query_load_manager(),
     };
 
@@ -870,6 +871,7 @@ async fn query_complexity_subscriptions() {
         max_complexity,
         max_depth: 100,
         max_first: std::u32::MAX,
+        max_skip: std::u32::MAX,
         load_manager: mock_query_load_manager(),
     };
 
@@ -1210,6 +1212,7 @@ async fn subscription_gets_result_even_without_events() {
         max_complexity: None,
         max_depth: 100,
         max_first: std::u32::MAX,
+        max_skip: std::u32::MAX,
         load_manager: mock_query_load_manager(),
     };
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -468,6 +468,7 @@ mod tests {
             _complexity: Option<u64>,
             _max_depth: Option<u8>,
             _max_first: Option<u32>,
+            _max_skip: Option<u32>,
         ) -> Arc<QueryResult> {
             unimplemented!();
         }

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -23,6 +23,7 @@ impl GraphQlRunner for TestGraphQlRunner {
         _complexity: Option<u64>,
         _max_depth: Option<u8>,
         _max_first: Option<u32>,
+        _max_skip: Option<u32>,
     ) -> Arc<QueryResult> {
         unimplemented!();
     }

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -380,6 +380,7 @@ where
             None,
             None,
             Some(std::u32::MAX),
+            Some(std::u32::MAX),
         ));
 
         // Metadata queries are not cached.
@@ -461,6 +462,7 @@ where
             query,
             None,
             None,
+            Some(std::u32::MAX),
             Some(std::u32::MAX),
         ));
 
@@ -624,6 +626,7 @@ where
             query,
             None,
             None,
+            Some(std::u32::MAX),
             Some(std::u32::MAX),
         ));
 

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -106,6 +106,7 @@ where
                 resolver: IndexNodeResolver::new(&logger, graphql_runner, store),
                 deadline: None,
                 max_first: std::u32::MAX,
+                max_skip: std::u32::MAX,
                 load_manager,
             };
             let result = execute_query(query_clone.cheap_clone(), None, None, options).await;

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -422,6 +422,7 @@ fn execute_subgraph_query_internal(
                     deadline,
                     load_manager: LOAD_MANAGER.clone(),
                     max_first: std::u32::MAX,
+                    max_skip: std::u32::MAX,
                 },
             ))
             .as_ref()


### PR DESCRIPTION
This change adds the ability to enforce a global limit on the `skip` parameter in queries, in the same way that we limit `first`. This is prompted by the hosted service where we see queries with absurdly high `skip` values (10000 and more) Since `GRAPH_GRAPHQL_MAX_SKIP` defaults to `u32::MAX` this change will not do anything for now, though we should absolutely limit `skip` to something like 2000. Apps should only page through collections with `first`/`skip` to display them to humans, where 2000 items is more than any human will ever want to look at.

If an app needs to download an entire collection, it should not do that with `first`/`skip` as that will perform very badly for larger collections. Instead, it should follow the approach described [here](https://github.com/graphprotocol/docs/pull/160) In addition, we should give apps a way to poll for updates to a collection they downloaded as described [here](https://github.com/graphprotocol/graph-node/issues/1888)