### PR TITLE
Ignore .git and Docker output folder when building images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+target


### PR DESCRIPTION
When I'm building docker images locally for development, the .git folder and the target folder contributes a whole bunch to the initial startup time to build, so this helps with the development workflow. Dunno if this breaks anything though, but it seems to work for me :shrug: 