### PR TITLE
Don't reenter the load manager semaphore

### DIFF
--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -20,7 +20,12 @@ pub type SubscriptionResultFuture =
 #[async_trait]
 pub trait GraphQlRunner: Send + Sync + 'static {
     /// Runs a GraphQL query and returns its result.
-    async fn run_query(self: Arc<Self>, query: Query, state: DeploymentState) -> Arc<QueryResult>;
+    async fn run_query(
+        self: Arc<Self>,
+        query: Query,
+        state: DeploymentState,
+        nested_resolver: bool,
+    ) -> Arc<QueryResult>;
 
     /// Runs a GraphqL query up to the given complexity. Overrides the global complexity limit.
     async fn run_query_with_complexity(
@@ -31,6 +36,7 @@ pub trait GraphQlRunner: Send + Sync + 'static {
         max_depth: Option<u8>,
         max_first: Option<u32>,
         max_skip: Option<u32>,
+        nested_resolver: bool,
     ) -> Arc<QueryResult>;
 
     /// Runs a GraphQL subscription and returns a stream of results.
@@ -42,7 +48,7 @@ pub trait GraphQlRunner: Send + Sync + 'static {
     async fn query_metadata(self: Arc<Self>, query: Query) -> Result<q::Value, Error> {
         let state = DeploymentState::meta();
         let result = self
-            .run_query_with_complexity(query, state, None, None, None, None)
+            .run_query_with_complexity(query, state, None, None, None, None, false)
             .await;
 
         // Metadata queries are not cached.

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -303,6 +303,10 @@ where
     pub(crate) cache_status: AtomicCell<CacheStatus>,
 
     pub load_manager: Arc<dyn QueryLoadManager>,
+
+    /// Set if this query is being executed in another resolver and therefore reentering functions
+    /// such as `execute_root_selection_set`.
+    pub nested_resolver: bool,
 }
 
 // Helpers to look for types and fields on both the introspection and regular schemas.
@@ -356,6 +360,7 @@ where
             // `cache_status` and `load_manager` are dead values for the introspection context.
             cache_status: AtomicCell::new(CacheStatus::Miss),
             load_manager: self.load_manager.cheap_clone(),
+            nested_resolver: self.nested_resolver,
         }
     }
 }
@@ -457,11 +462,22 @@ pub async fn execute_root_selection_set<R: Resolver>(
     let execute_ctx = ctx.cheap_clone();
     let execute_selection_set = selection_set.cheap_clone();
     let execute_root_type = root_type.cheap_clone();
+    let nested_resolver = ctx.nested_resolver;
     let run_query = async move {
         // Limiting the cuncurrent queries prevents increase in resource usage when the DB is
         // contended and queries start queing up. This semaphore organizes the queueing so that
         // waiting queries consume few resources.
-        let _permit = execute_ctx.load_manager.query_permit().await;
+        //
+        // Do not request a permit in a nested resolver, since it is already holding a permit and
+        // requesting another could deadlock.
+        let _permit = if !nested_resolver {
+            execute_ctx.load_manager.query_permit().await
+        } else {
+            // Acquire a dummy semaphore.
+            Arc::new(tokio::sync::Semaphore::new(1))
+                .acquire_owned()
+                .await
+        };
 
         let logger = execute_ctx.logger.clone();
         let query_text = execute_ctx.query.query_text.cheap_clone();

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -37,6 +37,7 @@ pub async fn execute_query<R>(
     selection_set: Option<q::SelectionSet>,
     block_ptr: Option<EthereumBlockPointer>,
     options: QueryExecutionOptions<R>,
+    nested_resolver: bool,
 ) -> Arc<QueryResult>
 where
     R: Resolver,
@@ -51,6 +52,7 @@ where
         max_skip: options.max_skip,
         cache_status: Default::default(),
         load_manager: options.load_manager.cheap_clone(),
+        nested_resolver,
     });
 
     if !query.is_query() {

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -70,6 +70,7 @@ where
         max_skip: options.max_skip,
         cache_status: Default::default(),
         load_manager: options.load_manager,
+        nested_resolver: false,
     };
 
     if !query.is_subscription() {
@@ -198,6 +199,7 @@ async fn execute_subscription_event(
         max_skip,
         cache_status: Default::default(),
         load_manager,
+        nested_resolver: false,
     });
 
     let subscription_type = match ctx.query.schema.subscription_type.as_ref() {

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -569,7 +569,9 @@ async fn introspection_query(schema: Schema, query: &str) -> QueryResult {
     };
 
     let result = match PreparedQuery::new(&logger, query, None, 100) {
-        Ok(query) => Ok(Arc::try_unwrap(execute_query(query, None, None, options).await).unwrap()),
+        Ok(query) => {
+            Ok(Arc::try_unwrap(execute_query(query, None, None, options, false).await).unwrap())
+        }
         Err(e) => Err(e),
     };
     QueryResult::from(result)

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -245,7 +245,7 @@ async fn execute_query_document_with_variables(
     };
 
     runner
-        .run_query_with_complexity(query, state, None, None, None, None)
+        .run_query_with_complexity(query, state, None, None, None, None, false)
         .await
         .as_ref()
         .clone()
@@ -264,7 +264,7 @@ async fn execute_query_document_with_state(
     let query = Query::new(Arc::new(api_test_schema(id)), query, None, None);
 
     graph::prelude::futures03::executor::block_on(
-        runner.run_query_with_complexity(query, state, None, None, None, None),
+        runner.run_query_with_complexity(query, state, None, None, None, None, false),
     )
     .as_ref()
     .clone()

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -251,7 +251,7 @@ where
         let query = GraphQLRequest::new(body, schema, network).compat().await;
 
         let result = match query {
-            Ok(query) => service.graphql_runner.run_query(query, state).await,
+            Ok(query) => service.graphql_runner.run_query(query, state, false).await,
             Err(GraphQLServerError::QueryError(e)) => Arc::new(QueryResult::from(e)),
             Err(e) => return Err(e),
         };
@@ -454,6 +454,7 @@ mod tests {
             _max_depth: Option<u8>,
             _max_first: Option<u32>,
             _max_skip: Option<u32>,
+            _nested_resolver: bool,
         ) -> Arc<QueryResult> {
             unimplemented!();
         }
@@ -462,6 +463,7 @@ mod tests {
             self: Arc<Self>,
             _query: Query,
             _state: DeploymentState,
+            _: bool,
         ) -> Arc<QueryResult> {
             Arc::new(QueryResult::new(Some(q::Value::Object(
                 BTreeMap::from_iter(

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -25,11 +25,17 @@ impl GraphQlRunner for TestGraphQlRunner {
         _max_depth: Option<u8>,
         _max_first: Option<u32>,
         _max_skip: Option<u32>,
+        _nested_resolver: bool,
     ) -> Arc<QueryResult> {
         unimplemented!();
     }
 
-    async fn run_query(self: Arc<Self>, query: Query, _state: DeploymentState) -> Arc<QueryResult> {
+    async fn run_query(
+        self: Arc<Self>,
+        query: Query,
+        _state: DeploymentState,
+        _: bool,
+    ) -> Arc<QueryResult> {
         Arc::new(QueryResult::new(Some(q::Value::Object(
             if query.variables.is_some()
                 && query

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -382,6 +382,7 @@ where
             None,
             Some(std::u32::MAX),
             Some(std::u32::MAX),
+            true,
         ));
 
         // Metadata queries are not cached.
@@ -466,6 +467,7 @@ where
             None,
             Some(std::u32::MAX),
             Some(std::u32::MAX),
+            true,
         ));
 
         // Metadata queries are not cached.
@@ -563,7 +565,7 @@ where
         Ok(poi)
     }
 
-    fn resolve_indexing_statuses_for_version(
+    fn resolve_indexing_status_for_version(
         &self,
         arguments: &HashMap<&q::Name, q::Value>,
 
@@ -631,6 +633,7 @@ where
             None,
             Some(std::u32::MAX),
             Some(std::u32::MAX),
+            true,
         ));
 
         // Metadata queries are not cached.
@@ -654,7 +657,7 @@ where
             .expect("invalid subgraphs")
         {
             Some(subgraphs) => subgraphs,
-            None => return Ok(q::Value::List(vec![])),
+            None => return Ok(q::Value::Null),
         };
 
         let subgraphs = subgraphs
@@ -663,7 +666,7 @@ where
 
         let subgraph = match subgraphs.into_iter().next() {
             Some(subgraph) => subgraph,
-            None => return Ok(q::Value::List(vec![])),
+            None => return Ok(q::Value::Null),
         };
 
         let field_name = match current_version {
@@ -785,12 +788,12 @@ where
         match (prefetched_object, field.name.as_str()) {
             // The top-level `indexingStatusForCurrentVersion` field
             (None, "indexingStatusForCurrentVersion") => {
-                self.resolve_indexing_statuses_for_version(arguments, true)
+                self.resolve_indexing_status_for_version(arguments, true)
             }
 
             // The top-level `indexingStatusForPendingVersion` field
             (None, "indexingStatusForPendingVersion") => {
-                self.resolve_indexing_statuses_for_version(arguments, false)
+                self.resolve_indexing_status_for_version(arguments, false)
             }
 
             // Resolve fields of `Object` values (e.g. the `latestBlock` field of `EthereumBlock`)

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -109,7 +109,7 @@ where
                 max_skip: std::u32::MAX,
                 load_manager,
             };
-            let result = execute_query(query_clone.cheap_clone(), None, None, options).await;
+            let result = execute_query(query_clone.cheap_clone(), None, None, options, false).await;
             query_clone.log_execution(0);
             QueryResult::from(
                 // Index status queries are not cacheable, so we may unwrap this.

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -457,6 +457,7 @@ fn execute_subgraph_query_internal(
                     max_first: std::u32::MAX,
                     max_skip: std::u32::MAX,
                 },
+                false,
             ))
             .as_ref()
             .clone(),


### PR DESCRIPTION
That happened when the indexing status resolver called the store resolver, and could potentially deadlock.

In passing also fix getting `panic processing query: internal error: entered unreachable code` when querying the indexing status of a non-existing subgraph.