### PR TITLE
store/test-store: Fix compiler warnings (#1949)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,8 +962,7 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
+source = "git+https://github.com/graphprotocol/ethabi.git#fe7cab524f7d713e020dbec05b332008ad88a517"
 dependencies = [
  "ethereum-types",
  "rustc-hex",
@@ -976,7 +975,8 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "12.0.0"
-source = "git+https://github.com/graphprotocol/ethabi.git#fe7cab524f7d713e020dbec05b332008ad88a517"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
 dependencies = [
  "ethereum-types",
  "rustc-hex",

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -2,7 +2,7 @@
 extern crate diesel;
 
 use crate::tokio::runtime::{Builder, Runtime};
-use diesel::{Connection, PgConnection};
+use diesel::{PgConnection};
 use graph::data::graphql::effort::LoadManager;
 use graph::log;
 use graph::prelude::{Store as _, *};


### PR DESCRIPTION
Tiny PR that fixes two compiler warnings in the test store. Fixes #1949.