### PR TITLE
Disable `ipfs.cat` by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,8 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "12.0.0"
-source = "git+https://github.com/graphprotocol/ethabi.git#fe7cab524f7d713e020dbec05b332008ad88a517"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
 dependencies = [
  "ethereum-types",
  "rustc-hex",
@@ -977,8 +978,7 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
+source = "git+https://github.com/graphprotocol/ethabi.git#fe7cab524f7d713e020dbec05b332008ad88a517"
 dependencies = [
  "ethereum-types",
  "rustc-hex",

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -28,10 +28,8 @@ use web3::types::{Log, Transaction};
 use crate::host_exports::HostExports;
 use crate::mapping::{MappingContext, MappingRequest, MappingTrigger};
 
-pub(crate) const TIMEOUT_ENV_VAR: &str = "GRAPH_MAPPING_HANDLER_TIMEOUT";
-
 lazy_static! {
-    pub static ref TIMEOUT: Option<Duration> = std::env::var(TIMEOUT_ENV_VAR)
+    static ref TIMEOUT: Option<Duration> = std::env::var("GRAPH_MAPPING_HANDLER_TIMEOUT")
         .ok()
         .map(|s| u64::from_str(&s).expect("Invalid value for GRAPH_MAPPING_HANDLER_TIMEOUT"))
         .map(Duration::from_secs);

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -413,6 +413,7 @@ impl HostExports {
                     ctx.derive_with_empty_block_state(),
                     host_metrics.clone(),
                     module.timeout,
+                    module.allow_non_determinstic_ipfs,
                 )?;
                 let result = module.handle_json_callback(&callback, &sv.value, &user_data)?;
                 // Log progress every 15s

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -20,6 +20,7 @@ pub fn spawn_module(
     host_metrics: Arc<HostMetrics>,
     runtime: tokio::runtime::Handle,
     timeout: Option<Duration>,
+    allow_non_deterministic_ipfs: bool,
 ) -> Result<mpsc::Sender<MappingRequest>, anyhow::Error> {
     let valid_module = Arc::new(ValidModule::new(&raw_module)?);
 
@@ -54,6 +55,7 @@ pub fn spawn_module(
                         ctx,
                         host_metrics.clone(),
                         timeout,
+                        allow_non_deterministic_ipfs,
                     )?;
                     section.end();
 

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -28,6 +28,17 @@ fn test_valid_module_and_store(
     WasmInstance,
     Arc<impl Store + SubgraphDeploymentStore + EthereumCallCache>,
 ) {
+    test_valid_module_and_store_with_timeout(subgraph_id, data_source, None)
+}
+
+fn test_valid_module_and_store_with_timeout(
+    subgraph_id: &str,
+    data_source: DataSource,
+    timeout: Option<Duration>,
+) -> (
+    WasmInstance,
+    Arc<impl Store + SubgraphDeploymentStore + EthereumCallCache>,
+) {
     let store = STORE.clone();
     let metrics_registry = Arc::new(MockMetricsRegistry::new());
     test_store::create_test_subgraph(
@@ -59,7 +70,7 @@ fn test_valid_module_and_store(
         Arc::new(ValidModule::new(data_source.mapping.runtime.as_ref()).unwrap()),
         mock_context(deployment_id, data_source, store.clone()),
         host_metrics,
-        *crate::host::TIMEOUT,
+        timeout,
         true,
     )
     .unwrap();

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -59,10 +59,8 @@ fn test_valid_module_and_store(
         Arc::new(ValidModule::new(data_source.mapping.runtime.as_ref()).unwrap()),
         mock_context(deployment_id, data_source, store.clone()),
         host_metrics,
-        std::env::var(crate::host::TIMEOUT_ENV_VAR)
-            .ok()
-            .and_then(|s| u64::from_str(&s).ok())
-            .map(std::time::Duration::from_secs),
+        *crate::host::TIMEOUT,
+        true,
     )
     .unwrap();
 

--- a/runtime/wasm/src/module/test/abi.rs
+++ b/runtime/wasm/src/module/test/abi.rs
@@ -1,14 +1,14 @@
 use super::*;
-use std::env;
 
 #[tokio::test(threaded_scheduler)]
 async fn unbounded_loop() {
     // Set handler timeout to 3 seconds.
-    env::set_var(crate::host::TIMEOUT_ENV_VAR, "3");
-    let module = test_module(
+    let module = test_valid_module_and_store_with_timeout(
         "unboundedLoop",
         mock_data_source("wasm_test/non_terminating.wasm"),
-    );
+        Some(Duration::from_secs(3)),
+    )
+    .0;
     let func = module.get_func("loop").get0().unwrap();
     let res: Result<(), _> = func();
     assert!(res.unwrap_err().to_string().contains(TRAP_TIMEOUT));


### PR DESCRIPTION
In preparation for the network, where the current IPFS API will not be usable.