### PR TITLE
graphql: Use the same QueryStore for the entire query

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1266,6 +1266,17 @@ pub trait QueryStore: Send + Sync {
     fn subscribe(&self, entities: Vec<SubgraphEntityPair>) -> StoreEventStreamBox;
 
     fn is_deployment_synced(&self, id: SubgraphDeploymentId) -> Result<bool, Error>;
+
+    fn block_ptr(
+        &self,
+        subgraph_id: SubgraphDeploymentId,
+    ) -> Result<Option<EthereumBlockPointer>, Error>;
+
+    fn block_number(
+        &self,
+        subgraph_id: &SubgraphDeploymentId,
+        block_hash: H256,
+    ) -> Result<Option<BlockNumber>, StoreError>;
 }
 
 /// An entity operation that can be transacted into the store; as opposed to

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -49,7 +49,7 @@ impl StoreResolver {
     /// created
     pub async fn at_block(
         logger: &Logger,
-        store: Arc<impl Store + SubgraphDeploymentStore>,
+        store: Arc<dyn QueryStore>,
         bc: BlockConstraint,
         deployment: SubgraphDeploymentId,
     ) -> Result<Self, QueryExecutionError> {
@@ -63,7 +63,7 @@ impl StoreResolver {
         .and_then(|x| x)?; // Propagate panics.
         let resolver = StoreResolver {
             logger: logger.new(o!("component" => "StoreResolver")),
-            store: store.query_store(false),
+            store,
             block_ptr: Some(block_ptr),
             deployment,
         };
@@ -77,7 +77,7 @@ impl StoreResolver {
     }
 
     fn locate_block(
-        store: &(impl Store + SubgraphDeploymentStore),
+        store: &dyn QueryStore,
         bc: BlockConstraint,
         subgraph: SubgraphDeploymentId,
     ) -> Result<EthereumBlockPointer, QueryExecutionError> {

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use web3::types::H256;
+
 use crate::store::ReplicaId;
 use graph::components::store::QueryStore as QueryStoreTrait;
 use graph::prelude::{Store as _, *};
@@ -44,5 +46,20 @@ impl QueryStoreTrait for QueryStore {
 
     fn is_deployment_synced(&self, id: SubgraphDeploymentId) -> Result<bool, Error> {
         self.store.is_deployment_synced(id)
+    }
+
+    fn block_ptr(
+        &self,
+        subgraph_id: SubgraphDeploymentId,
+    ) -> Result<Option<EthereumBlockPointer>, Error> {
+        self.store.block_ptr(subgraph_id)
+    }
+
+    fn block_number(
+        &self,
+        subgraph_id: &SubgraphDeploymentId,
+        block_hash: H256,
+    ) -> Result<Option<BlockNumber>, StoreError> {
+        self.store.block_number(subgraph_id, block_hash)
     }
 }

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -459,7 +459,7 @@ fn execute_subgraph_query_internal(
         let logger = logger.clone();
         let resolver = return_err!(rt.block_on(StoreResolver::at_block(
             &logger,
-            STORE.clone(),
+            STORE.clone().query_store(false),
             bc,
             query.schema.id().clone()
         )));


### PR DESCRIPTION
Make queries more consistent when replication is in use. We were using a
different QueryStore for each block constraint, and were also resolving
block pointers against the primary. This could lead to us mixing data from
different states of indexing a subgraph, without us even knowing.

