### PR TITLE
Add a _meta field

### DIFF
--- a/graph/src/data/graphql/ext.rs
+++ b/graph/src/data/graphql/ext.rs
@@ -1,4 +1,4 @@
-use crate::data::schema::SCHEMA_TYPE_NAME;
+use crate::data::schema::{META_FIELD_TYPE, SCHEMA_TYPE_NAME};
 use graphql_parser::schema::{
     Definition, Directive, Document, EnumType, Field, InterfaceType, Name, ObjectType, Type,
     TypeDefinition, Value,
@@ -10,17 +10,26 @@ use std::collections::{BTreeMap, HashMap};
 
 pub trait ObjectTypeExt {
     fn field(&self, name: &Name) -> Option<&Field>;
+    fn is_meta(&self) -> bool;
 }
 
 impl ObjectTypeExt for ObjectType {
     fn field(&self, name: &Name) -> Option<&Field> {
         self.fields.iter().find(|field| &field.name == name)
     }
+
+    fn is_meta(&self) -> bool {
+        self.name == META_FIELD_TYPE
+    }
 }
 
 impl ObjectTypeExt for InterfaceType {
     fn field(&self, name: &Name) -> Option<&Field> {
         self.fields.iter().find(|field| &field.name == name)
+    }
+
+    fn is_meta(&self) -> bool {
+        false
     }
 }
 

--- a/graph/src/data/graphql/object_or_interface.rs
+++ b/graph/src/data/graphql/object_or_interface.rs
@@ -2,6 +2,8 @@ use crate::prelude::Schema;
 use graphql_parser::schema as s;
 use std::collections::BTreeMap;
 
+use super::ObjectTypeExt;
+
 #[derive(Copy, Clone, Debug)]
 pub enum ObjectOrInterface<'a> {
     Object(&'a s::ObjectType),
@@ -82,6 +84,13 @@ impl<'a> ObjectOrInterface<'a> {
             ObjectOrInterface::Interface(i) => types_for_interface[&i.name]
                 .iter()
                 .any(|o| o.name == typename),
+        }
+    }
+
+    pub fn is_meta(&self) -> bool {
+        match self {
+            ObjectOrInterface::Object(o) => o.is_meta(),
+            ObjectOrInterface::Interface(i) => i.is_meta(),
         }
     }
 }

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -25,6 +25,9 @@ use std::sync::Arc;
 
 pub const SCHEMA_TYPE_NAME: &str = "_Schema_";
 
+pub const META_FIELD_TYPE: &str = "Meta_field_type";
+pub const META_FIELD_NAME: &str = "_meta";
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Strings(Vec<String>);
 

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 pub const SCHEMA_TYPE_NAME: &str = "_Schema_";
 
-pub const META_FIELD_TYPE: &str = "Meta_field_type";
+pub const META_FIELD_TYPE: &str = "_Meta_";
 pub const META_FIELD_NAME: &str = "_meta";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -537,7 +537,13 @@ pub async fn execute_root_selection_set<R: Resolver>(
         let mut cache = QUERY_BLOCK_CACHE.write().unwrap();
 
         // Get or insert the cache for this network.
-        if cache.insert(network, block_ptr, key, result.cheap_clone(), weight) {
+        if cache.insert(
+            network,
+            block_ptr.clone(),
+            key,
+            result.cheap_clone(),
+            weight,
+        ) {
             ctx.cache_status.store(CacheStatus::Insert);
         } else {
             // Results that are too old for the QUERY_BLOCK_CACHE go into the QUERY_LFU_CACHE

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -12,7 +12,7 @@ use graph::data::graphql::{
 use graph::data::query::{Query as GraphDataQuery, QueryVariables};
 use graph::data::schema::ApiSchema;
 use graph::data::subgraph::schema::SUBGRAPHS_ID;
-use graph::prelude::{info, o, CheapClone, Logger, QueryExecutionError};
+use graph::prelude::{info, o, BlockNumber, CheapClone, Logger, QueryExecutionError};
 
 use crate::execution::{get_field, get_named_type, object_or_interface};
 use crate::introspection::introspection_schema;
@@ -250,7 +250,7 @@ impl Query {
     }
 
     /// Log details about the overall execution of the query
-    pub fn log_execution(&self, block: u64) {
+    pub fn log_execution(&self, block: BlockNumber) {
         if *graph::log::LOG_GQL_TIMING {
             info!(
                 &self.logger,

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -280,11 +280,16 @@ where
             return Err(SubscriptionError::GraphQLError(vec![err]));
         }
 
+        let deployment = query.schema.id().clone();
         execute_prepared_subscription(
             query,
             SubscriptionExecutionOptions {
                 logger: self.logger.clone(),
-                resolver: StoreResolver::for_subscription(&self.logger, self.store.clone()),
+                resolver: StoreResolver::for_subscription(
+                    &self.logger,
+                    deployment,
+                    self.store.clone(),
+                ),
                 timeout: GRAPHQL_QUERY_TIMEOUT.clone(),
                 max_complexity: *GRAPHQL_MAX_COMPLEXITY,
                 max_depth: *GRAPHQL_MAX_DEPTH,

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -5,7 +5,10 @@ use lazy_static::lazy_static;
 
 use crate::schema::ast;
 
-use graph::data::graphql::ext::{DirectiveExt, DocumentExt, ValueExt};
+use graph::data::{
+    graphql::ext::{DirectiveExt, DocumentExt, ValueExt},
+    schema::{META_FIELD_NAME, META_FIELD_TYPE},
+};
 use graph::prelude::*;
 
 #[derive(Fail, Debug)]
@@ -17,7 +20,6 @@ pub enum APISchemaError {
 }
 
 const BLOCK_HEIGHT: &str = "Block_height";
-const META_FIELD_TYPE: &str = "Meta_field_type";
 
 /// Derives a full-fledged GraphQL API schema from an input schema.
 ///
@@ -653,7 +655,7 @@ fn meta_field() -> Field {
     Field {
         position: Pos::default(),
         description: Some("Access to subgraph metadata".to_string()),
-        name: "_meta".to_string(),
+        name: META_FIELD_NAME.to_string(),
         arguments: vec![
             // block: BlockHeight
             InputValue {

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -652,24 +652,27 @@ fn query_fields_for_type(schema: &Document, type_name: &Name) -> Vec<Field> {
 }
 
 fn meta_field() -> Field {
-    Field {
-        position: Pos::default(),
-        description: Some("Access to subgraph metadata".to_string()),
-        name: META_FIELD_NAME.to_string(),
-        arguments: vec![
-            // block: BlockHeight
-            InputValue {
-                position: Pos::default(),
-                description: None,
-                name: String::from("block"),
-                value_type: Type::NamedType(BLOCK_HEIGHT.to_string()),
-                default_value: None,
-                directives: vec![],
-            },
-        ],
-        field_type: Type::NamedType(META_FIELD_TYPE.to_string()),
-        directives: vec![],
+    lazy_static! {
+        static ref META_FIELD: Field = Field {
+            position: Pos::default(),
+            description: Some("Access to subgraph metadata".to_string()),
+            name: META_FIELD_NAME.to_string(),
+            arguments: vec![
+                // block: BlockHeight
+                InputValue {
+                    position: Pos::default(),
+                    description: None,
+                    name: String::from("block"),
+                    value_type: Type::NamedType(BLOCK_HEIGHT.to_string()),
+                    default_value: None,
+                    directives: vec![],
+                },
+            ],
+            field_type: Type::NamedType(META_FIELD_TYPE.to_string()),
+            directives: vec![],
+        };
     }
+    META_FIELD.clone()
 }
 
 /// Generates arguments for collection queries of a named type (e.g. User).

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -174,7 +174,7 @@ fn add_block_height_type(schema: &mut Document) {
     schema.definitions.push(def);
 }
 
-/// Adds a global `Meta_field_type` type to the schema. The `_meta` field
+/// Adds a global `_Meta_` type to the schema. The `_meta` field
 /// accepts values of this type
 fn add_meta_field_type(schema: &mut Document) {
     lazy_static! {

--- a/graphql/src/schema/meta.graphql
+++ b/graphql/src/schema/meta.graphql
@@ -1,0 +1,16 @@
+# The type names are purposely awkward to minimize the risk of them
+# colliding with user-supplied types
+"The type for the top-level _meta field"
+type Meta_field_type {
+    "Information about a specific subgraph block"
+    block: Block_field_type!
+    "The deployment ID"
+    deployment: String!
+}
+
+type Block_field_type {
+    "The hash of the block"
+    hash: Bytes!
+    "The block number"
+    number: Int!
+}

--- a/graphql/src/schema/meta.graphql
+++ b/graphql/src/schema/meta.graphql
@@ -2,7 +2,10 @@
 # colliding with user-supplied types
 "The type for the top-level _meta field"
 type Meta_field_type {
-    "Information about a specific subgraph block"
+    """Information about a specific subgraph block. The hash of the block
+    will be null if the _meta field has a block constraint that asks for
+    a block number. It will be filled if the _meta field has no block constraint
+    and therefore asks for the latest  block"""
     block: Block_field_type!
     "The deployment ID"
     deployment: String!
@@ -10,7 +13,7 @@ type Meta_field_type {
 
 type Block_field_type {
     "The hash of the block"
-    hash: Bytes!
+    hash: Bytes
     "The block number"
     number: Int!
 }

--- a/graphql/src/schema/meta.graphql
+++ b/graphql/src/schema/meta.graphql
@@ -1,17 +1,17 @@
 # The type names are purposely awkward to minimize the risk of them
 # colliding with user-supplied types
 "The type for the top-level _meta field"
-type Meta_field_type {
+type _Meta_ {
     """Information about a specific subgraph block. The hash of the block
     will be null if the _meta field has a block constraint that asks for
     a block number. It will be filled if the _meta field has no block constraint
     and therefore asks for the latest  block"""
-    block: Block_field_type!
+    block: _Block_!
     "The deployment ID"
     deployment: String!
 }
 
-type Block_field_type {
+type _Block_ {
     "The hash of the block"
     hash: Bytes
     "The block number"

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -803,7 +803,7 @@ fn execute_field(
         argument_values,
         multiplicity,
         ctx.query.schema.types_for_interface(),
-        resolver.block,
+        resolver.block_number(),
         ctx.max_first,
         ctx.max_skip,
         ctx.query.query_id.clone(),

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -110,6 +110,7 @@ impl StoreResolver {
                             // that we have the block in our cache. We therefore
                             // always return an all zeroes hash when users specify
                             // a block number
+                            // See 7a7b9708-adb7-4fc2-acec-88680cb07ec1
                             Ok(EthereumBlockPointer::from((
                                 web3::types::H256::zero(),
                                 number as u64,
@@ -169,6 +170,9 @@ impl StoreResolver {
             let hash = self
                 .block_ptr
                 .and_then(|ptr| {
+                    // locate_block indicates that we do not have a block hash
+                    // by setting the hash to `zero`
+                    // See 7a7b9708-adb7-4fc2-acec-88680cb07ec1
                     if ptr.hash == web3::types::H256::zero() {
                         None
                     } else {

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -845,7 +845,7 @@ fn query_complexity() {
 fn query_complexity_subscriptions() {
     run_test_sequentially(setup, |_, id| async move {
         let logger = Logger::root(slog::Discard, o!());
-        let store_resolver = StoreResolver::for_subscription(&logger, STORE.clone());
+        let store_resolver = StoreResolver::for_subscription(&logger, id.clone(), STORE.clone());
 
         let query = Query::new(
             Arc::new(api_test_schema(&id)),
@@ -907,7 +907,7 @@ fn query_complexity_subscriptions() {
             None,
         );
 
-        let store_resolver = StoreResolver::for_subscription(&logger, STORE.clone());
+        let store_resolver = StoreResolver::for_subscription(&logger, id.clone(), STORE.clone());
 
         let options = SubscriptionExecutionOptions {
             logger,
@@ -1251,7 +1251,7 @@ fn cannot_filter_by_derved_relationship_fields() {
 fn subscription_gets_result_even_without_events() {
     run_test_sequentially(setup, |_, id| async move {
         let logger = Logger::root(slog::Discard, o!());
-        let store_resolver = StoreResolver::for_subscription(&logger, STORE.clone());
+        let store_resolver = StoreResolver::for_subscription(&logger, id.clone(), STORE.clone());
 
         let query = Query::new(
             Arc::new(api_test_schema(&id)),

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -441,7 +441,7 @@ fn execute_subgraph_query_internal(
     let mut result = QueryResult::empty();
     for (bc, selection_set) in return_err!(query.block_constraint()) {
         let logger = logger.clone();
-        let (resolver, _block_ptr) = return_err!(rt.block_on(StoreResolver::at_block(
+        let resolver = return_err!(rt.block_on(StoreResolver::at_block(
             &logger,
             STORE.clone(),
             bc,


### PR DESCRIPTION
This PR makes it possible to include a `_meta` field at the toplevel of queries that reports the block against which the query was run and the deployment id. A query like
```
query {
  _meta {
    block {
      number
      hash
    }
    deployment
  }
  things(..) { }
}
```

will return the block number and hash of the latest block that the subgraph has indexed, as well as the deployment ID for the subgraph.