### PR TITLE
docker: Make postgres_port configurable

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,8 @@ Preconfigured Docker image for running a Graph Node.
 
 ```sh
 docker run -it \
-  -e postgres_host=<HOST>[:<PORT>] \
+  -e postgres_host=<HOST> \
+  -e postgres_port=<PORT> \
   -e postgres_user=<USER> \
   -e postgres_pass=<PASSWORD> \
   -e postgres_db=<DBNAME> \
@@ -19,7 +20,8 @@ docker run -it \
 
 ```sh
 docker run -it \
-  -e postgres_host=host.docker.internal:5432
+  -e postgres_host=host.docker.internal \
+  -e postgres_port=5432 \
   -e postgres_user=graph-node \
   -e postgres_pass=oh-hello \
   -e postgres_db=graph-node \

--- a/docker/start
+++ b/docker/start
@@ -65,10 +65,10 @@ start_index_node() {
     fi
 
     graph-node \
-	    --node-id "${node_id//-/_}" \
-	    --postgres-url "$postgres_url" \
-	    --ethereum-rpc $ethereum \
-	    --ipfs "$ipfs"
+        --node-id "${node_id//-/_}" \
+        --postgres-url "$postgres_url" \
+        --ethereum-rpc $ethereum \
+        --ipfs "$ipfs"
 }
 
 start_combined_node() {
@@ -78,10 +78,11 @@ start_combined_node() {
         --ipfs "$ipfs"
 }
 
-postgres_url="postgresql://$postgres_user:$postgres_pass@$postgres_host/$postgres_db"
+postgres_port=${postgres_port:-5432}
+postgres_url="postgresql://$postgres_user:$postgres_pass@$postgres_host:$postgres_port/$postgres_db"
 
 wait_for_ipfs "$ipfs"
-wait_for "$postgres_host:5432" -t 120
+wait_for "$postgres_host:$postgres_port" -t 120
 sleep 5
 
 trap save_coredumps EXIT


### PR DESCRIPTION
The current start script allows custom ports in postgres_host but still uses the default `5432` for checking if the database is available. This small fix introduces a new variable `postgres_port` which is `5432` by default, causing no breaking changes for previous docker setups.

Background: We're running a self-hosted graph node on a managed Digital Ocean database cluster which has a custom post.