### PR TITLE
Reset block range size on error

### DIFF
--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -837,6 +837,8 @@ impl<S: Store, C: ChainStore> Stream for BlockStream<S, C> {
                         }
 
                         Err(e) => {
+                            // Reset the block range size in an attempt to recover from the error.
+                            self.ctx.previous_block_range_size = 1;
                             self.consecutive_err_count += 1;
 
                             // Pause before trying again


### PR DESCRIPTION
In case the Ethereum node is returning errors due to overly expensive requests, resetting the range size might help the subgraph recover from a retry loop. If we can infer that resetting the block range size worked, reduce the maximum block range size in an attempt to prevent the error from happening again.