### PR TITLE
Deterministic errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,6 +1429,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "test-store",
+ "thiserror",
  "tiny-keccak 1.5.0",
  "tokio 0.2.22",
  "tokio-retry",
@@ -1494,7 +1495,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "test-store",
- "thiserror",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,18 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
 dependencies = [
- "gimli",
+ "gimli 0.22.0",
 ]
+
+[[package]]
+name = "adler"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aho-corasick"
@@ -123,14 +129,15 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.48"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
+checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
- "object",
+ "miniz_oxide",
+ "object 0.21.1",
  "rustc-demangle",
 ]
 
@@ -238,7 +245,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "constant_time_eq",
  "crypto-mac 0.8.0",
  "digest 0.9.0",
@@ -351,6 +358,12 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -471,23 +484,25 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.65.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f065f6889758f817f61a230220d1811ba99a9762af2fb69ae23048314f75ff2"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.65.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510aa2ab4307644100682b94e449940a0ea15c5887f1d4b9678b8dd5ef31e736"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli",
+ "gimli 0.21.0",
  "log 0.4.8",
  "regalloc",
  "serde",
@@ -498,8 +513,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.65.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4cb0c7e87c60d63b35f9670c15479ee4a5e557dd127efab88b2f9b2ca83c9a0"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -507,21 +523,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.65.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60636227098693e06de8d6d88beea2a7d32ecf8a8030dacdb57c68e06f381826"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.65.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6156db73e0c9f65f80c512988d63ec736be0dee3dd66bf951e3e28aed9dc02d3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.65.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e09cd158c9a820a4cc14a34076811da225cce1d31dc6d03c5ef85b91aef560b9"
 dependencies = [
  "cranelift-codegen",
  "log 0.4.8",
@@ -531,8 +550,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.65.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7054533ae1fc2048c1a6110bdf8f4314b77c60329ec6a7df79d2cfb84e3dcc1c"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -541,8 +561,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.65.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aee0e0b68eba99f99a4923212d97aca9e44655ca8246f07fffe11236109b0d0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -550,7 +571,7 @@ dependencies = [
  "log 0.4.8",
  "serde",
  "thiserror",
- "wasmparser 0.57.0",
+ "wasmparser 0.59.0",
 ]
 
 [[package]]
@@ -559,7 +580,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -568,7 +589,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -604,7 +625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg 1.0.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-utils",
  "lazy_static",
  "maybe-uninit",
@@ -618,7 +639,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-utils",
 ]
 
@@ -629,7 +650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
 ]
 
@@ -848,7 +869,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -858,7 +879,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -918,7 +939,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -1299,7 +1320,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -1314,6 +1335,12 @@ dependencies = [
  "indexmap",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "git-testament"
@@ -1468,6 +1495,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "test-store",
+ "thiserror",
  "walkdir",
 ]
 
@@ -2017,6 +2045,7 @@ checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg 1.0.0",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -2078,7 +2107,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.8",
@@ -2194,7 +2223,7 @@ checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 dependencies = [
  "arrayvec",
  "bitflags 1.2.1",
- "cfg-if",
+ "cfg-if 0.1.10",
  "ryu",
  "static_assertions",
 ]
@@ -2244,7 +2273,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -2369,12 +2398,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+dependencies = [
+ "adler",
+ "autocfg 1.0.0",
+]
+
+[[package]]
 name = "mio"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -2416,7 +2455,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ecfc6340c5b98a9a270b56e5f43353d87ebb18d9458a9301344bc79317c563"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "downcast",
  "fragile",
  "lazy_static",
@@ -2431,7 +2470,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b873f753808fe0c3827ce76edb3ace27804966dfde3043adfac1c24d0a2559df"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "proc-macro2 1.0.18",
  "quote 1.0.3",
  "syn 1.0.33",
@@ -2467,7 +2506,7 @@ version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.8",
 ]
@@ -2535,9 +2574,16 @@ name = "object"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+
+[[package]]
+name = "object"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
 dependencies = [
  "crc32fast",
  "indexmap",
+ "wasmparser 0.57.0",
 ]
 
 [[package]]
@@ -2559,7 +2605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
 dependencies = [
  "bitflags 1.2.1",
- "cfg-if",
+ "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -2693,7 +2739,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
@@ -2708,7 +2754,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
@@ -2722,7 +2768,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.1.0",
  "instant",
  "libc",
@@ -3003,7 +3049,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5567486d5778e2c6455b1b90ff1c558f29e751fc018130fa182e15828e728af1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fnv",
  "lazy_static",
  "protobuf",
@@ -3298,9 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.26"
+version = "0.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c03092d79e0fd610932d89ed53895a38c0dd3bcd317a0046e69940de32f1d95"
+checksum = "2041c2d34f6ff346d6f428974f03d8bf12679b0c816bb640dc5eb1d48848d8d1"
 dependencies = [
  "log 0.4.8",
  "rustc-hash",
@@ -3803,7 +3849,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.8",
@@ -3971,9 +4017,9 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "target-lexicon"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
+checksum = "4ee5a98e506fb7231a304c3a1bd7c132a55016cf65001e0282480665870dfcb9"
 
 [[package]]
 name = "tempfile"
@@ -3981,7 +4027,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand 0.7.3",
  "redox_syscall",
@@ -4439,7 +4485,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e2a2de6b0d5cbb13fc21193a2296888eaab62b6044479aafb3c54c01c29fcd"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "log 0.4.8",
  "tracing-core",
 ]
@@ -4709,7 +4755,7 @@ version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -4736,7 +4782,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4779,25 +4825,36 @@ checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
 
 [[package]]
 name = "wasmparser"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
+
+[[package]]
+name = "wasmparser"
 version = "0.63.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e4bce139034f66d49ad6071f6eda10f7188b0ad3cbfe080d673535ee30c23e"
 
 [[package]]
 name = "wasmtime"
-version = "0.18.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373b87ebd6721f4121e28eeaaa41943548c48bcca04ac9bb063004207e5e7d70"
 dependencies = [
  "anyhow",
  "backtrace",
- "cfg-if",
+ "bincode",
+ "cfg-if 0.1.10",
  "lazy_static",
  "libc",
  "log 0.4.8",
  "region",
  "rustc-demangle",
+ "serde",
+ "smallvec 1.4.2",
  "target-lexicon",
- "wasmparser 0.57.0",
+ "wasmparser 0.59.0",
+ "wasmtime-cache",
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-profiling",
@@ -4807,85 +4864,133 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-debug"
-version = "0.18.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
-dependencies = [
- "anyhow",
- "gimli",
- "more-asserts",
- "object",
- "target-lexicon",
- "thiserror",
- "wasmparser 0.57.0",
- "wasmtime-environ",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "0.18.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+name = "wasmtime-cache"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62454bad18f85ca4052cd2d5640d29397c0c06703c89580125d89c09b2e313dd"
 dependencies = [
  "anyhow",
  "base64 0.12.1",
  "bincode",
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-wasm",
  "directories",
  "errno",
  "file-per-thread-logger",
- "indexmap",
  "libc",
  "log 0.4.8",
- "more-asserts",
- "rayon",
  "serde",
  "sha2 0.8.1",
- "thiserror",
  "toml",
- "wasmparser 0.57.0",
  "winapi 0.3.8",
  "zstd",
 ]
 
 [[package]]
-name = "wasmtime-jit"
-version = "0.18.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+name = "wasmtime-cranelift"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c01df908e54d40bed80326ade122825d464888991beafd950d186f1be309c2"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-wasm",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-debug"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28962772f96fadb79dc7be5ade135ca55d2b0017a012f4869e2476a03abbe733"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "gimli 0.21.0",
+ "more-asserts",
+ "object 0.21.1",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.59.0",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c0d7401bf253b7b1f426afd70d285bb23ea9a1c7605d6af788c95db5084edf5"
+dependencies = [
+ "anyhow",
+ "cfg-if 0.1.10",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-wasm",
+ "gimli 0.21.0",
+ "indexmap",
+ "log 0.4.8",
+ "more-asserts",
+ "serde",
+ "thiserror",
+ "wasmparser 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-jit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c838a108318e7c5a2201addb3d3b27a6ef3d142f0eb0addc815b9c2541e5db5"
+dependencies = [
+ "anyhow",
+ "cfg-if 0.1.10",
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli",
+ "gimli 0.21.0",
  "log 0.4.8",
  "more-asserts",
+ "object 0.21.1",
+ "rayon",
  "region",
+ "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.57.0",
+ "wasmparser 0.59.0",
+ "wasmtime-cranelift",
  "wasmtime-debug",
  "wasmtime-environ",
+ "wasmtime-obj",
  "wasmtime-profiling",
  "wasmtime-runtime",
  "winapi 0.3.8",
 ]
 
 [[package]]
-name = "wasmtime-profiling"
-version = "0.18.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+name = "wasmtime-obj"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8422b0acce519b74c3ae5db59167c611ea92220e5c334ad406e977277e0f23"
 dependencies = [
  "anyhow",
- "cfg-if",
- "gimli",
+ "more-asserts",
+ "object 0.21.1",
+ "target-lexicon",
+ "wasmtime-debug",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-profiling"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33f2689bf523f843555e57e24d59abf0c5013007366b866081d73a15e510b4b2"
+dependencies = [
+ "anyhow",
+ "cfg-if 0.1.10",
+ "gimli 0.21.0",
  "lazy_static",
  "libc",
- "object",
+ "object 0.19.0",
  "scroll",
  "serde",
  "target-lexicon",
@@ -4895,15 +5000,17 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.18.0"
-source = "git+https://github.com/graphprotocol/wasmtime#ba7bb10e4510020557eeadb10627d949adc3394a"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7353f5e79390048128e44b5ceda7255723b2066de4026df9a168b0b2593df71"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "indexmap",
  "lazy_static",
  "libc",
+ "log 0.4.8",
  "memoffset",
  "more-asserts",
  "region",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
 dependencies = [
- "gimli 0.22.0",
+ "gimli",
 ]
 
 [[package]]
@@ -137,7 +137,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.21.1",
+ "object",
  "rustc-demangle",
 ]
 
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
  "byteorder",
  "serde",
@@ -485,8 +485,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 [[package]]
 name = "cranelift-bforest"
 version = "0.67.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f065f6889758f817f61a230220d1811ba99a9762af2fb69ae23048314f75ff2"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "cranelift-entity",
 ]
@@ -494,15 +493,14 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.67.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510aa2ab4307644100682b94e449940a0ea15c5887f1d4b9678b8dd5ef31e736"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli 0.21.0",
+ "gimli",
  "log 0.4.8",
  "regalloc",
  "serde",
@@ -514,8 +512,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.67.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4cb0c7e87c60d63b35f9670c15479ee4a5e557dd127efab88b2f9b2ca83c9a0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -524,14 +521,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.67.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60636227098693e06de8d6d88beea2a7d32ecf8a8030dacdb57c68e06f381826"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 
 [[package]]
 name = "cranelift-entity"
 version = "0.67.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6156db73e0c9f65f80c512988d63ec736be0dee3dd66bf951e3e28aed9dc02d3"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "serde",
 ]
@@ -539,8 +534,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.67.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e09cd158c9a820a4cc14a34076811da225cce1d31dc6d03c5ef85b91aef560b9"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "cranelift-codegen",
  "log 0.4.8",
@@ -551,8 +545,7 @@ dependencies = [
 [[package]]
 name = "cranelift-native"
 version = "0.67.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7054533ae1fc2048c1a6110bdf8f4314b77c60329ec6a7df79d2cfb84e3dcc1c"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -562,16 +555,17 @@ dependencies = [
 [[package]]
 name = "cranelift-wasm"
 version = "0.67.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aee0e0b68eba99f99a4923212d97aca9e44655ca8246f07fffe11236109b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
+ "itertools",
  "log 0.4.8",
  "serde",
+ "smallvec 1.4.2",
  "thiserror",
- "wasmparser 0.59.0",
+ "wasmparser 0.63.1",
 ]
 
 [[package]]
@@ -864,13 +858,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "2.0.2"
+name = "directories-next"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
+checksum = "8a28ccebc1239c5c57f0c55986e2ac03f49af0d0ca3dff29bfcad39d60a8be56"
 dependencies = [
- "cfg-if 0.1.10",
- "dirs-sys",
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
 ]
 
 [[package]]
@@ -897,6 +891,17 @@ name = "dirs-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
 dependencies = [
  "libc",
  "redox_users",
@@ -1327,20 +1332,14 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 dependencies = [
  "fallible-iterator 0.2.0",
  "indexmap",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "git-testament"
@@ -2114,6 +2113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,12 +2576,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "object"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
 
 [[package]]
 name = "object"
@@ -3344,9 +3346,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.30"
+version = "0.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2041c2d34f6ff346d6f428974f03d8bf12679b0c816bb640dc5eb1d48848d8d1"
+checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
 dependencies = [
  "log 0.4.8",
  "rustc-hash",
@@ -4825,12 +4827,6 @@ checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
 
 [[package]]
 name = "wasmparser"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
-
-[[package]]
-name = "wasmparser"
 version = "0.63.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e4bce139034f66d49ad6071f6eda10f7188b0ad3cbfe080d673535ee30c23e"
@@ -4838,13 +4834,12 @@ checksum = "89e4bce139034f66d49ad6071f6eda10f7188b0ad3cbfe080d673535ee30c23e"
 [[package]]
 name = "wasmtime"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b87ebd6721f4121e28eeaaa41943548c48bcca04ac9bb063004207e5e7d70"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "anyhow",
  "backtrace",
  "bincode",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "lazy_static",
  "libc",
  "log 0.4.8",
@@ -4853,7 +4848,7 @@ dependencies = [
  "serde",
  "smallvec 1.4.2",
  "target-lexicon",
- "wasmparser 0.59.0",
+ "wasmparser 0.63.1",
  "wasmtime-cache",
  "wasmtime-environ",
  "wasmtime-jit",
@@ -4866,13 +4861,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-cache"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62454bad18f85ca4052cd2d5640d29397c0c06703c89580125d89c09b2e313dd"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "anyhow",
  "base64 0.12.1",
  "bincode",
- "directories",
+ "directories-next",
  "errno",
  "file-per-thread-logger",
  "libc",
@@ -4887,8 +4881,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cranelift"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c01df908e54d40bed80326ade122825d464888991beafd950d186f1be309c2"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -4900,62 +4893,59 @@ dependencies = [
 [[package]]
 name = "wasmtime-debug"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28962772f96fadb79dc7be5ade135ca55d2b0017a012f4869e2476a03abbe733"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "anyhow",
- "gimli 0.21.0",
+ "gimli",
  "more-asserts",
- "object 0.21.1",
+ "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.59.0",
+ "wasmparser 0.63.1",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0d7401bf253b7b1f426afd70d285bb23ea9a1c7605d6af788c95db5084edf5"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "anyhow",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-wasm",
- "gimli 0.21.0",
+ "gimli",
  "indexmap",
  "log 0.4.8",
  "more-asserts",
  "serde",
  "thiserror",
- "wasmparser 0.59.0",
+ "wasmparser 0.63.1",
 ]
 
 [[package]]
 name = "wasmtime-jit"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c838a108318e7c5a2201addb3d3b27a6ef3d142f0eb0addc815b9c2541e5db5"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "anyhow",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli 0.21.0",
+ "gimli",
  "log 0.4.8",
  "more-asserts",
- "object 0.21.1",
+ "object",
  "rayon",
  "region",
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.59.0",
+ "wasmparser 0.63.1",
  "wasmtime-cranelift",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -4968,12 +4958,11 @@ dependencies = [
 [[package]]
 name = "wasmtime-obj"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8422b0acce519b74c3ae5db59167c611ea92220e5c334ad406e977277e0f23"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "anyhow",
  "more-asserts",
- "object 0.21.1",
+ "object",
  "target-lexicon",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -4982,15 +4971,14 @@ dependencies = [
 [[package]]
 name = "wasmtime-profiling"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f2689bf523f843555e57e24d59abf0c5013007366b866081d73a15e510b4b2"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "anyhow",
- "cfg-if 0.1.10",
- "gimli 0.21.0",
+ "cfg-if 1.0.0",
+ "gimli",
  "lazy_static",
  "libc",
- "object 0.19.0",
+ "object",
  "scroll",
  "serde",
  "target-lexicon",
@@ -5001,12 +4989,11 @@ dependencies = [
 [[package]]
 name = "wasmtime-runtime"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7353f5e79390048128e44b5ceda7255723b2066de4026df9a168b0b2593df71"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?branch=main#61f0b8fc56b2399078e3922ebf984c797fe319a7"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "indexmap",
  "lazy_static",
  "libc",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ semver = "0.10.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
+thiserror = "1.0"
 
 [dev-dependencies]
 graph-mock = { path = "../mock" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,6 @@ semver = "0.10.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
-thiserror = "1.0"
 
 [dev-dependencies]
 graph-mock = { path = "../mock" }

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -681,6 +681,9 @@ where
         Err(MappingError::Unknown(e)) => {
             return Err(CancelableError::Error(ProcessBlockError::Unknown(e)))
         }
+        Err(MappingError::Deterministic(e)) => {
+            return Err(CancelableError::Error(ProcessBlockError::Deterministic(e)))
+        }
         Err(MappingError::PossibleReorg(e)) => {
             info!(ctx.state.logger,
                     "Possible reorg detected, retrying";
@@ -778,10 +781,13 @@ where
                 // way to revert the effect of `create_dynamic_data_sources` so we may return a
                 // clean context as in b21fa73b-6453-4340-99fb-1a78ec62efb1.
                 match e {
-                    MappingError::PossibleReorg(e) | MappingError::Unknown(e) => e,
+                    MappingError::PossibleReorg(e) | MappingError::Unknown(e) => {
+                        ProcessBlockError::Unknown(e)
+                    }
+                    MappingError::Deterministic(e) => ProcessBlockError::Deterministic(e),
                 }
             })
-            .compat_err()?;
+            .map_err(CancelableError::Error)?;
         }
     }
 

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -576,6 +576,7 @@ where
                         message: e.to_string(),
                         block_ptr: Some(block_ptr),
                         handler: None,
+                        deterministic: e.is_deterministic(),
                     };
 
                     // Set subgraph status to Failed
@@ -597,11 +598,20 @@ where
 
 #[derive(thiserror::Error, Debug)]
 enum ProcessBlockError {
-    #[error("{0}")]
+    #[error("{0:#}")]
     Unknown(anyhow::Error),
 
-    #[error("{0}")]
+    #[error("{0:#}")]
     Deterministic(anyhow::Error),
+}
+
+impl ProcessBlockError {
+    fn is_deterministic(&self) -> bool {
+        match self {
+            ProcessBlockError::Unknown(_) => false,
+            ProcessBlockError::Deterministic(_) => true,
+        }
+    }
 }
 
 impl From<failure::Error> for ProcessBlockError {

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -173,6 +173,7 @@ where
                 message: e.to_string(),
                 block_ptr: None,
                 handler: None,
+                deterministic: false,
             };
 
             let _ignore_error = store.apply_metadata_operations(

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -56,6 +56,7 @@ priority-queue = "0.7.0"
 futures03 = { version = "0.3.1", package = "futures", features = ["compat"] }
 uuid = { version = "0.8.1", features = ["v4"] }
 wasmparser = "0.63.1"
+thiserror = "1.0"
 
 # Our fork contains a small but hacky patch.
 web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "master" }

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -15,6 +15,7 @@ use web3::types::{Log, Transaction};
 pub enum MappingError {
     /// A possible reorg was detected while running the mapping.
     PossibleReorg(anyhow::Error),
+    Deterministic(anyhow::Error),
     Unknown(anyhow::Error),
 }
 
@@ -38,6 +39,7 @@ impl MappingError {
         use MappingError::*;
         match self {
             PossibleReorg(e) => PossibleReorg(e.context(s)),
+            Deterministic(e) => Deterministic(e.context(s)),
             Unknown(e) => Unknown(e.context(s)),
         }
     }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -1382,6 +1382,9 @@ pub struct SubgraphError {
     pub message: String,
     pub block_ptr: Option<EthereumBlockPointer>,
     pub handler: Option<String>,
+
+    // `true` if we are certain the error is determinsitic. If in doubt, this is `false`.
+    pub deterministic: bool,
 }
 
 impl TypedEntity for SubgraphError {
@@ -1404,6 +1407,7 @@ impl From<SubgraphError> for Entity {
             message,
             block_ptr,
             handler,
+            deterministic,
         } = subgraph_error;
 
         let mut entity = Entity::new();
@@ -1412,6 +1416,7 @@ impl From<SubgraphError> for Entity {
         entity.set("blockNumber", block_ptr.map(|x| x.number));
         entity.set("blockHash", block_ptr.map(|x| x.hash));
         entity.set("handler", handler);
+        entity.set("deterministic", deterministic);
         entity
     }
 }
@@ -1431,6 +1436,7 @@ impl TryFromValue for SubgraphError {
             message: value.get_required("message")?,
             block_ptr,
             handler: value.get_optional("handler")?,
+            deterministic: value.get_optional("deterministic")?.unwrap_or(false),
         })
     }
 }

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -263,9 +263,9 @@ pub enum CancelableError<E = Error> {
     Error(E),
 }
 
-impl From<Error> for CancelableError<Error> {
+impl<E: From<Error>> From<Error> for CancelableError<E> {
     fn from(e: Error) -> Self {
-        Self::Error(e)
+        Self::Error(e.into())
     }
 }
 

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -65,6 +65,7 @@ pub mod prelude {
     pub use std::pin::Pin;
     pub use std::sync::Arc;
     pub use std::time::Duration;
+    pub use thiserror;
     pub use tiny_keccak;
     pub use tokio;
     pub use web3;

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -19,7 +19,9 @@ uuid = { version = "0.8.1", features = ["v4"] }
 strum = "0.19.2"
 strum_macros = "0.19.2"
 bytes = "0.5"
-wasmtime = "0.20.0"
+
+# Go back to a released version on any version over 0.20.0
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime.git", branch = "main" }
 
 defer = "0.1"
 

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -19,16 +19,7 @@ uuid = { version = "0.8.1", features = ["v4"] }
 strum = "0.19.2"
 strum_macros = "0.19.2"
 bytes = "0.5"
-
-# We need patch in order to be able to call host exports when initializing globals.
-#
-# By this conversation, wasmtime does not want to upstream this, pointing out that there is an
-# incompatibility between the way AS does things and the direction wasmtime wants to take.
-# See:
-# https://bytecodealliance.zulipchat.com/#narrow/stream/206238-general/topic/Host.20functions.20in.20start
-# https://github.com/AssemblyScript/assemblyscript/issues/1333
-# See also 3a23f045-eb9d-4b12-8c7c-3a4c2e34bea1
-wasmtime = { git = "https://github.com/graphprotocol/wasmtime", branch = "master" }
+wasmtime = "0.20.0"
 
 defer = "0.1"
 

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -19,6 +19,7 @@ static DEPLOYMENT_STATUS_FRAGMENT: &str = r#"
             blockNumber
             blockHash
             handler
+            deterministic
         }
         nonFatalErrors(first: 1000, orderBy: blockNumber) {
             subgraphId
@@ -26,6 +27,7 @@ static DEPLOYMENT_STATUS_FRAGMENT: &str = r#"
             blockNumber
             blockHash
             handler
+            deterministic
         }
         ethereumHeadBlockNumber
         ethereumHeadBlockHash
@@ -233,6 +235,7 @@ impl From<IndexingStatus> for q::Value {
                 message,
                 block_ptr,
                 handler,
+                deterministic,
             } = subgraph_error;
 
             object! {
@@ -244,7 +247,8 @@ impl From<IndexingStatus> for q::Value {
                     __typename: "Block",
                     number: block_ptr.map(|x| x.number),
                     hash: block_ptr.map(|x| q::Value::from(Value::Bytes(x.hash.as_ref().into()))),
-                }
+                },
+                deterministic: deterministic,
             }
         }
 
@@ -653,9 +657,9 @@ where
                     "subgraph" => subgraph_name,
                     "errors" => format!("{:?}", errors)
                 );
-                return Ok(q::Value::List(vec![]));
+                return Ok(q::Value::Null);
             }
-            Ok(None) => return Ok(q::Value::List(vec![])),
+            Ok(None) => return Ok(q::Value::Null),
             Ok(Some(data)) => data,
         };
 

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -60,6 +60,9 @@ type SubgraphError {
   # Context for the error.
   block: Block
   handler: String
+
+  # `true` means we have certainty that the error is deterministic.
+  deterministic: Boolean!
 }
 
 enum Health {

--- a/store/postgres/migrations/2020-10-31-150000_deterministic_errors/down.sql
+++ b/store/postgres/migrations/2020-10-31-150000_deterministic_errors/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE subgraphs.subgraph_error DROP COLUMN deterministic;

--- a/store/postgres/migrations/2020-10-31-150000_deterministic_errors/up.sql
+++ b/store/postgres/migrations/2020-10-31-150000_deterministic_errors/up.sql
@@ -1,0 +1,5 @@
+-- add `deterministic` column to subgraph_error
+alter table
+    subgraphs.subgraph_error
+add
+    column deterministic boolean not null default false;

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -201,6 +201,9 @@ type SubgraphError {
   blockNumber: BigInt
   blockHash: Bytes
   handler: String
+
+  # `true` means we have certainty that the error is deterministic.
+  deterministic: Boolean!
 }
 
 enum Health {

--- a/tests/integration-tests/fatal-error/test/test.js
+++ b/tests/integration-tests/fatal-error/test/test.js
@@ -33,6 +33,7 @@ const waitForSubgraphToFailWithError = async (blockNumber) =>
                 block {
                   number
                 }
+                deterministic
               }
 
               # Test that non-fatal errors can be queried
@@ -56,7 +57,7 @@ const waitForSubgraphToFailWithError = async (blockNumber) =>
 
         let status = result.data.indexingStatusForCurrentVersion;
         if (status.health == "failed") {
-          if (status.fatalError.block.number != blockNumber) {
+          if (status.fatalError.block.number != blockNumber || status.fatalError.deterministic != true) {
             reject(
               new Error(
                 "Subgraph failed with unexpected block number: " +


### PR DESCRIPTION
This marks as determinstic few common reasons for subgraph failures, for example:
- An `unreachable` wasm trap which is caused by an array access out of bounds.
- An `abort` which AssemblyScript uses for multiple reasons including failed assert.
- Some uncontroversial host export erros such as division by zero.

There may be more cases we'd like to cover, but those can be added as long as we consider it a breaking change and bump the `specVersion` (or `apiVersion`?). Deterministic errors are flagged by a boolean in the metadata which can be accessed through the indexing status API.