### PR TITLE
Introduce a configuration file for multidatabase support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,6 +1651,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
+ "shellexpand",
  "structopt",
  "toml",
  "url 2.2.0",
@@ -3890,6 +3891,15 @@ checksum = "8cebcf3a403e4deafaf34dc882c4a1b6a648b43e5670aa2e4bb985914eaeb2d2"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2b22262a9aaf9464d356f656fea420634f78c881c5eebd5ef5e66d8b9bc603"
+dependencies = [
+ "dirs 2.0.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,7 @@ dependencies = [
 name = "graph-node"
 version = "0.19.2"
 dependencies = [
+ "anyhow",
  "assert_cli",
  "clap",
  "crossbeam-channel 0.5.0",
@@ -1646,7 +1647,12 @@ dependencies = [
  "ipfs-api",
  "lazy_static",
  "prometheus",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
  "structopt",
+ "toml",
  "url 2.2.0",
 ]
 
@@ -3784,6 +3790,16 @@ checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,6 @@ dependencies = [
 name = "graph-node"
 version = "0.19.2"
 dependencies = [
- "anyhow",
  "assert_cli",
  "clap",
  "crossbeam-channel 0.5.0",
@@ -1649,7 +1648,6 @@ dependencies = [
  "prometheus",
  "regex",
  "serde",
- "serde_json",
  "serde_regex",
  "shellexpand",
  "structopt",

--- a/README.md
+++ b/README.md
@@ -110,10 +110,14 @@ OPTIONS:
         --ws-port <PORT>                              Port for the GraphQL WebSocket server [default: 8001]
 ```
 
-### Environment Variables
+### Advanced Configuration
 
-See [here](https://github.com/graphprotocol/graph-node/blob/master/docs/environment-variables.md) for a list of
-the environment variables that can be configured.
+The command line arguments generally are all that is needed to run a
+`graph-node` instance. For advanced uses, various aspects of `graph-node`
+can further be configured through [environment
+variables](https://github.com/graphprotocol/graph-node/blob/master/docs/environment-variables.md). Very
+large `graph-node` instances can also split the work of querying and
+indexing across [multiple databases](./docs/multiple-databases.md).
 
 ## Project Layout
 

--- a/docs/multiple-databases.md
+++ b/docs/multiple-databases.md
@@ -1,0 +1,117 @@
+# Support for Multiple Databases
+
+For most use cases, a single Postgres database is sufficient to support a
+`graph-node` instance. When a `graph-node` instance outgrows a single
+Postgres database, it is possible to split the storage of `graph-node`'s
+data across multiple Postgres databases.
+
+Support for multiple databases is configured through a TOML configuration
+file. The location of the file is passed with the `--config` command line
+switch. When using a configuration file, it is not possible to use the
+options `--postgres-url`, `--postgres-secondary-hosts`, and
+`--postgres-host-weights`.
+
+The TOML file consists of two sections:
+* `[store]` describes the available databases
+* `[deployment]` describes how to place newly deployed subgraphs
+
+## Configuring Multiple Databases
+
+The `[store]` section must always have a primary store configured, which
+must be called `primary`. Each store can have additional read replicas that
+are used for responding to queries. Only queries are processed by read
+replicas. Indexing and block ingestion will always use the main database.
+
+Any number of additional stores, with their own read replicas, can also be
+configured. When read replicas are used, query traffic is split between the
+main database and the replicas according to their weights. In the example
+below, for the primary store, no queries will be sent to the main database,
+and the replicas will receive 50% of the traffic each. In the `vip` store,
+50% of the traffic go to the main database, and 50% to the replica.
+
+```toml
+[store]
+[store.primary]
+connection = "postgresql://graph:${PGPASSWORD}@primary/graph"
+weight = 0
+[store.primary.replicas.repl1]
+connection = "postgresql://graph:${PGPASSWORD}@primary-repl1/graph"
+weight = 1
+[store.primary.replicas.repl2]
+connection = "postgresql://graph:${PGPASSWORD}@primary-repl2/graph"
+weight = 1
+
+[store.vip]
+connection = "postgresql://graph:${PGPASSWORD}@${VIP_MAIN}/graph"
+weight = 1
+[store.vip.replicas.repl1]
+connection = "postgresql://graph:${PGPASSWORD}@${VIP_REPL1}/graph"
+weight = 1
+```
+
+The `connection` string must be a valid [libpq connection
+string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING). Before
+passing the connection string to Postgres, environment variables embedded
+in the string are expanded.
+
+## Controlling Deployment
+
+When `graph-node` receives a request to deploy a new subgraph deployment,
+it needs to decide in which store to store the data for the deployment, and
+which of any number of nodes connected to the store should index the
+deployment. That decision is based on a number of rules defined in the
+`[deployment]` which can match on the subgraph name and the network that
+the deployment is indexing.
+
+Rules are evaluated in order, and the first rule that matches determines
+where the deployment is placed. The `match` element of a rule can have a
+`name`, a [regular expression](https://docs.rs/regex/1.4.2/regex/#syntax)
+that is matched against the subgraph name for the deployment, and a
+`network` name that is compared to the network that the new deployment
+indexes.
+
+The last rule must not have a `match` statement to make sure that there is
+always some store and some indexer that will work on a deployment.
+
+The rule indicates the name of the `store` where the data for the
+deployment should be stored, which defaults to `primary`, and a list of
+`indexers`. For the matching rule, one indexer is chosen from the
+`indexers` list so that deployments are spread evenly across all the nodes
+mentioned in `indexers`. The names for the indexers must be the same names
+that are passed with `--node-id` when those index nodes are started.
+
+```toml
+[deployment]
+[[deployment.rule]]
+match = { name = "(vip|important)/.*" }
+store = "vip"
+indexers = [ "index-node-vip-0", "index-node-vip-1" ]
+[[deployment.rule]]
+match = { network = "kovan" }
+# No store, so we use the default store called 'primary'
+indexers = [ "index-node-kovan-0" ]
+[[deployment.rule]]
+# There's no 'match', so any subgraph matches
+indexers = [
+    "index-node-community-0",
+    "index-node-community-1",
+    "index-node-community-2",
+    "index-node-community-3",
+    "index-node-community-4",
+    "index-node-community-5"
+  ]
+
+```
+
+## Basic Setup
+
+The following file is equivalent to using the `--postgres-url` command line
+option:
+```toml
+[store]
+[store.primary]
+connection="<.. postgres-url argument ..>"
+[deployment]
+[[deployment.rule]]
+indexers = [ <.. list of all indexing nodes ..> ]
+```

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -27,12 +27,10 @@ graph-server-websocket = { path = "../server/websocket" }
 graph-server-metrics = { path = "../server/metrics" }
 graph-store-postgres = { path = "../store/postgres" }
 regex = "1.4.2"
-serde = { version = "1.0.117", features = ["derive"] }
+serde = { version = "1.0.117", features = ["derive", "rc"] }
 serde_regex = "1.1.0"
 structopt = "0.3.20"
 toml = "0.5.7"
-anyhow = "1.0.34"
-serde_json = "1.0.59"
 shellexpand = "2.0.0"
 
 [dev-dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -26,7 +26,13 @@ graph-server-json-rpc = { path = "../server/json-rpc"}
 graph-server-websocket = { path = "../server/websocket" }
 graph-server-metrics = { path = "../server/metrics" }
 graph-store-postgres = { path = "../store/postgres" }
+regex = "1.4.2"
+serde = { version = "1.0.117", features = ["derive"] }
+serde_regex = "1.1.0"
 structopt = "0.3.20"
+toml = "0.5.7"
+anyhow = "1.0.34"
+serde_json = "1.0.59"
 
 [dev-dependencies]
 assert_cli = "0.6"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -33,6 +33,7 @@ structopt = "0.3.20"
 toml = "0.5.7"
 anyhow = "1.0.34"
 serde_json = "1.0.59"
+shellexpand = "2.0.0"
 
 [dev-dependencies]
 assert_cli = "0.6"

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1,8 +1,10 @@
-use graph::prelude::{info, Logger};
-use serde::{Deserialize, Serialize};
+use graph::prelude::{
+    anyhow::{anyhow, Result},
+    info, serde_json, Logger,
+};
 
-use anyhow::{anyhow, Result};
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::read_to_string;
 use url::Url;

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -119,9 +119,11 @@ fn check_pool_size(pool_size: u32, connection: &str) -> Result<()> {
 
 impl Shard {
     fn validate(&mut self, opt: &Opt) -> Result<()> {
+        self.connection = shellexpand::env(&self.connection)?.into_owned();
         if self.pool_size == 0 {
             self.pool_size = opt.store_connection_pool_size;
         }
+
         check_pool_size(self.pool_size, &self.connection)?;
         for (name, replica) in self.replicas.iter_mut() {
             validate_name(name)?;
@@ -165,9 +167,11 @@ pub struct Replica {
 
 impl Replica {
     fn validate(&mut self, opt: &Opt) -> Result<()> {
+        self.connection = shellexpand::env(&self.connection)?.into_owned();
         if self.pool_size == 0 {
             self.pool_size = opt.store_connection_pool_size;
         }
+
         check_pool_size(self.pool_size, &self.connection)?;
         Ok(())
     }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -40,7 +40,7 @@ impl Config {
     /// be filled in from `opt` at the same time.
     fn validate(&mut self, opt: &Opt) -> Result<()> {
         if !self.stores.contains_key(PRIMARY) {
-            return Err(anyhow!("missing a primary store".to_string()));
+            return Err(anyhow!("missing a primary store"));
         }
         for (key, shard) in self.stores.iter_mut() {
             validate_name(key)?;
@@ -102,7 +102,7 @@ pub struct Shard {
     pub connection: String,
     #[serde(default = "one")]
     pub weight: usize,
-    #[serde(default = "zero")]
+    #[serde(default)]
     pub pool_size: u32,
     pub replicas: BTreeMap<String, Replica>,
 }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1,0 +1,329 @@
+use graph::prelude::{info, Logger};
+use serde::{Deserialize, Serialize};
+
+use anyhow::{anyhow, Result};
+use regex::Regex;
+use std::collections::HashMap;
+use std::fs::read_to_string;
+use url::Url;
+
+const PRIMARY: &str = "primary";
+const ANY_NAME: &str = ".*";
+
+use crate::opt::Opt;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Config {
+    #[serde(rename = "store")]
+    stores: HashMap<String, Shard>,
+    deployment: Deployment,
+    ingestor: Ingestor,
+}
+
+fn validate_name(s: &str) -> Result<()> {
+    for c in s.chars() {
+        if !c.is_ascii_alphanumeric() || c == '-' {
+            return Err(anyhow!(
+                "names can only contain alphanumeric characters or '-', but `{}` contains `{}`",
+                s,
+                c
+            ));
+        }
+    }
+    Ok(())
+}
+
+impl Config {
+    /// Check that the config is valid. Some defaults (like `pool_size`) will
+    /// be filled in from `opt` at the same time.
+    fn validate(&mut self, opt: &Opt) -> Result<()> {
+        if !self.stores.contains_key(PRIMARY) {
+            return Err(anyhow!("missing a primary store".to_string()));
+        }
+        for (key, shard) in self.stores.iter_mut() {
+            validate_name(key)?;
+            shard.validate(opt)?;
+        }
+        self.deployment.validate()?;
+        Ok(())
+    }
+
+    /// Load a configuration file if `opt.config` is set. If not, generate
+    /// a config from the command line arguments in `opt`
+    pub fn load(logger: &Logger, opt: &Opt) -> Result<Config> {
+        if let Some(config) = &opt.config {
+            info!(logger, "Reading configuration file `{}`", config);
+            let config = read_to_string(config)?;
+            let mut config: Config = toml::from_str(&config)?;
+            config.validate(opt)?;
+            Ok(config)
+        } else {
+            info!(
+                logger,
+                "Generating configuration from command line arguments"
+            );
+            Self::from_opt(opt)
+        }
+    }
+
+    fn from_opt(opt: &Opt) -> Result<Config> {
+        let ingestor = Ingestor::from_opt(opt);
+        let deployment = Deployment::from_opt(opt);
+        let mut stores = HashMap::new();
+        stores.insert(PRIMARY.to_string(), Shard::from_opt(opt)?);
+        Ok(Config {
+            stores,
+            deployment,
+            ingestor,
+        })
+    }
+
+    /// Genrate a JSON representation of the config.
+    pub fn to_json(&self) -> Result<String> {
+        // It would be nice to produce a TOML representation, but that runs
+        // into this error: https://github.com/alexcrichton/toml-rs/issues/142
+        // and fixing it as described in the issue didn't fix it. Since serializing
+        // this data isn't crucial and only needed for debugging, we'll
+        // just stick with JSON
+        Ok(serde_json::to_string_pretty(&self)?)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Shard {
+    connection: String,
+    #[serde(default = "one")]
+    weight: usize,
+    #[serde(default = "zero")]
+    pool_size: u32,
+    replicas: HashMap<String, Replica>,
+}
+
+fn check_pool_size(pool_size: u32, connection: &str) -> Result<()> {
+    if pool_size < 2 {
+        Err(anyhow!(
+            "connection pool size must be at least 2, but is {} for {}",
+            pool_size,
+            connection
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+impl Shard {
+    fn validate(&mut self, opt: &Opt) -> Result<()> {
+        if self.pool_size == 0 {
+            self.pool_size = opt.store_connection_pool_size;
+        }
+        check_pool_size(self.pool_size, &self.connection)?;
+        for (name, replica) in self.replicas.iter_mut() {
+            validate_name(name)?;
+            replica.validate(opt)?;
+        }
+        Ok(())
+    }
+
+    fn from_opt(opt: &Opt) -> Result<Self> {
+        check_pool_size(opt.store_connection_pool_size, &opt.postgres_url)?;
+        let mut replicas = HashMap::new();
+        for (i, host) in opt.postgres_secondary_hosts.iter().enumerate() {
+            let replica = Replica {
+                connection: replace_host(&opt.postgres_url, &host),
+                weight: opt.postgres_host_weights.get(i + 1).cloned().unwrap_or(1),
+                pool_size: opt.store_connection_pool_size,
+            };
+            replicas.insert(format!("replica{}", i + 1), replica);
+        }
+        Ok(Self {
+            connection: opt.postgres_url.clone(),
+            weight: opt.postgres_host_weights.get(0).cloned().unwrap_or(1),
+            pool_size: opt.store_connection_pool_size,
+            replicas,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Replica {
+    connection: String,
+    #[serde(default = "one")]
+    weight: usize,
+    #[serde(default = "zero")]
+    pool_size: u32,
+}
+
+impl Replica {
+    fn validate(&mut self, opt: &Opt) -> Result<()> {
+        if self.pool_size == 0 {
+            self.pool_size = opt.store_connection_pool_size;
+        }
+        check_pool_size(self.pool_size, &self.connection)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Deployment {
+    #[serde(rename = "rule")]
+    rules: Vec<Rule>,
+}
+
+impl Deployment {
+    fn validate(&self) -> Result<()> {
+        if self.rules.is_empty() {
+            return Err(anyhow!(
+                "there must be at least one deployment rule".to_string()
+            ));
+        }
+        let mut default_rule = false;
+        for rule in &self.rules {
+            rule.validate()?;
+            if default_rule {
+                return Err(anyhow!("rules after a default rule are useless"));
+            }
+            default_rule = rule.is_default();
+        }
+        if !default_rule {
+            return Err(anyhow!(
+                "the rules do not contain a default rule that matches everything"
+            ));
+        }
+        Ok(())
+    }
+
+    // This needs to be moved to some sort of trait
+    #[allow(dead_code)]
+    fn place(&self, name: &str, network: &str, default: &str) -> Option<(&str, Vec<String>)> {
+        if self.rules.is_empty() {
+            // This can only happen if we have only command line arguments and no
+            // configuration file
+            Some((PRIMARY, vec![default.to_string()]))
+        } else {
+            self.rules
+                .iter()
+                .find(|rule| rule.matches(name, network))
+                .map(|rule| (rule.store.as_str(), rule.indexers.clone()))
+        }
+    }
+
+    fn from_opt(_: &Opt) -> Self {
+        Self { rules: vec![] }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Rule {
+    #[serde(rename = "match", default)]
+    pred: Predicate,
+    #[serde(default = "primary_store")]
+    store: String,
+    indexers: Vec<String>,
+}
+
+impl Rule {
+    fn is_default(&self) -> bool {
+        self.pred.matches_anything()
+    }
+
+    fn matches(&self, name: &str, network: &str) -> bool {
+        self.pred.matches(name, network)
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.indexers.is_empty() {
+            return Err(anyhow!("useless rule without indexers"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Predicate {
+    #[serde(with = "serde_regex", default = "any_name")]
+    name: Regex,
+    network: Option<String>,
+}
+
+impl Predicate {
+    fn matches_anything(&self) -> bool {
+        self.name.as_str() == ANY_NAME && self.network.is_none()
+    }
+
+    pub fn matches(&self, name: &str, network: &str) -> bool {
+        if let Some(n) = &self.network {
+            if n != network {
+                return false;
+            }
+        }
+
+        match self.name.find(name) {
+            None => false,
+            Some(m) => m.as_str() == name,
+        }
+    }
+}
+
+impl Default for Predicate {
+    fn default() -> Self {
+        Predicate {
+            name: any_name(),
+            network: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Ingestor {
+    node: String,
+}
+
+impl Ingestor {
+    fn from_opt(opt: &Opt) -> Self {
+        // If we are not the block ingestor, set the node name
+        // to something that is definitely not our node_id
+        if opt.disable_block_ingestor {
+            Ingestor {
+                node: format!("{} is not ingesting", opt.node_id),
+            }
+        } else {
+            Ingestor {
+                node: opt.node_id.clone(),
+            }
+        }
+    }
+}
+
+/// Replace the host portion of `url` and return a new URL with `host`
+/// as the host portion
+///
+/// Panics if `url` is not a valid URL (which won't happen in our case since
+/// we would have paniced before getting here as `url` is the connection for
+/// the primary Postgres instance)
+fn replace_host(url: &str, host: &str) -> String {
+    let mut url = match Url::parse(url) {
+        Ok(url) => url,
+        Err(_) => panic!("Invalid Postgres URL {}", url),
+    };
+    if let Err(e) = url.set_host(Some(host)) {
+        panic!("Invalid Postgres url {}: {}", url, e.to_string());
+    }
+    url.into_string()
+}
+
+// Various default functions for deserialization
+fn any_name() -> Regex {
+    Regex::new(ANY_NAME).unwrap()
+}
+
+fn primary_store() -> String {
+    PRIMARY.to_string()
+}
+
+fn one() -> usize {
+    1
+}
+
+fn zero() -> u32 {
+    0
+}

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -87,16 +87,22 @@ impl Config {
         // just stick with JSON
         Ok(serde_json::to_string_pretty(&self)?)
     }
+
+    pub fn primary_store(&self) -> &Shard {
+        self.stores
+            .get(PRIMARY)
+            .expect("a validated config has a primary store")
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct Shard {
-    connection: String,
+pub struct Shard {
+    pub connection: String,
     #[serde(default = "one")]
-    weight: usize,
+    pub weight: usize,
     #[serde(default = "zero")]
-    pool_size: u32,
-    replicas: HashMap<String, Replica>,
+    pub pool_size: u32,
+    pub replicas: HashMap<String, Replica>,
 }
 
 fn check_pool_size(pool_size: u32, connection: &str) -> Result<()> {
@@ -145,12 +151,12 @@ impl Shard {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct Replica {
-    connection: String,
+pub struct Replica {
+    pub connection: String,
     #[serde(default = "one")]
-    weight: usize,
+    pub weight: usize,
     #[serde(default = "zero")]
-    pool_size: u32,
+    pub pool_size: u32,
 }
 
 impl Replica {

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -5,7 +5,7 @@ use graph::prelude::{
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fs::read_to_string;
 use url::Url;
 
@@ -17,7 +17,7 @@ use crate::opt::Opt;
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     #[serde(rename = "store")]
-    stores: HashMap<String, Shard>,
+    stores: BTreeMap<String, Shard>,
     deployment: Deployment,
     ingestor: Ingestor,
 }
@@ -71,7 +71,7 @@ impl Config {
     fn from_opt(opt: &Opt) -> Result<Config> {
         let ingestor = Ingestor::from_opt(opt);
         let deployment = Deployment::from_opt(opt);
-        let mut stores = HashMap::new();
+        let mut stores = BTreeMap::new();
         stores.insert(PRIMARY.to_string(), Shard::from_opt(opt)?);
         Ok(Config {
             stores,
@@ -104,7 +104,7 @@ pub struct Shard {
     pub weight: usize,
     #[serde(default = "zero")]
     pub pool_size: u32,
-    pub replicas: HashMap<String, Replica>,
+    pub replicas: BTreeMap<String, Replica>,
 }
 
 fn check_pool_size(pool_size: u32, connection: &str) -> Result<()> {
@@ -140,7 +140,7 @@ impl Shard {
             .as_ref()
             .expect("validation checked that postgres_url is set");
         check_pool_size(opt.store_connection_pool_size, &postgres_url)?;
-        let mut replicas = HashMap::new();
+        let mut replicas = BTreeMap::new();
         for (i, host) in opt.postgres_secondary_hosts.iter().enumerate() {
             let replica = Replica {
                 connection: replace_host(&postgres_url, &host),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -128,9 +128,6 @@ async fn main() {
         std::process::exit(0);
     }
 
-    // Safe to unwrap because a value is required by CLI
-    let postgres_url = opt.postgres_url.clone();
-
     let node_id =
         NodeId::new(opt.node_id.clone()).expect("Node ID must contain only a-z, A-Z, 0-9, and '_'");
 
@@ -197,14 +194,6 @@ async fn main() {
     )
     .await;
 
-    // Set up Store
-    info!(
-        logger,
-        "Connecting to Postgres";
-        "url" => SafeDisplay(postgres_url.as_str()),
-        "conn_pool_size" => store_conn_pool_size,
-    );
-
     let graphql_metrics_registry = metrics_registry.clone();
 
     let stores_logger = logger.clone();
@@ -216,10 +205,7 @@ async fn main() {
 
     let store_builder = Arc::new(StoreBuilder::new(
         &logger,
-        &postgres_url,
-        opt.store_connection_pool_size,
-        opt.postgres_secondary_hosts.clone(),
-        opt.postgres_host_weights.clone(),
+        &config,
         metrics_registry.cheap_clone(),
     ));
     let store_builder2 = store_builder.clone();

--- a/node/src/opt.rs
+++ b/node/src/opt.rs
@@ -17,6 +17,14 @@ lazy_static! {
 pub struct Opt {
     #[structopt(
         long,
+        env = "GRAPH_NODE_CONFIG",
+        help = "the name of the configuration file"
+    )]
+    pub config: Option<String>,
+    #[structopt(long, help = "validate the configuration and exit")]
+    pub check_config: bool,
+    #[structopt(
+        long,
         value_name = "[NAME:]IPFS_HASH",
         env = "SUBGRAPH",
         help = "name and IPFS hash of the subgraph manifest"

--- a/node/src/opt.rs
+++ b/node/src/opt.rs
@@ -18,7 +18,9 @@ pub struct Opt {
     #[structopt(
         long,
         env = "GRAPH_NODE_CONFIG",
-        help = "the name of the configuration file"
+        conflicts_with_all = &["postgres-url", "postgres-secondary-hosts", "postgres-host-weights"],
+        required_unless = "postgres-url",
+        help = "the name of the configuration file",
     )]
     pub config: Option<String>,
     #[structopt(long, help = "validate the configuration and exit")]
@@ -34,14 +36,17 @@ pub struct Opt {
         long,
         value_name = "URL",
         env = "POSTGRES_URL",
+        conflicts_with = "config",
+        required_unless = "config",
         help = "Location of the Postgres database used for storing entities"
     )]
-    pub postgres_url: String,
+    pub postgres_url: Option<String>,
     #[structopt(
         long,
         value_name = "URL,",
         use_delimiter = true,
         env = "GRAPH_POSTGRES_SECONDARY_HOSTS",
+        conflicts_with = "config",
         help = "Comma-separated list of host names/IP's for read-only Postgres replicas, \
            which will share the load with the primary server"
     )]
@@ -52,6 +57,7 @@ pub struct Opt {
         value_name = "WEIGHT,",
         use_delimiter = true,
         env = "GRAPH_POSTGRES_HOST_WEIGHTS",
+        conflicts_with = "config",
         help = "Comma-separated list of relative weights for selecting the main database \
     and secondary databases. The list is in the order MAIN,REPLICA1,REPLICA2,...\
     A host will receive approximately WEIGHT/SUM(WEIGHTS) fraction of total queries. \


### PR DESCRIPTION
This PR adds support for configuring different stores, as an alternative to the command line switches we use so far. Existing ways to start `graph-node` will still work with this change, but it makes it possible to configure more complex database topologies. This PR is only about handling the configuration (and will work as an alternative to the command line switches for a single database), but does not actually use multiple databases yet.

Note that this PR applies on top of PR #1994 