### PR TITLE
docker: fix bug in docker-compose set up for postgres

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ipfs
       - postgres
     environment:
-      postgres_host: postgres:5432
+      postgres_host: postgres
       postgres_user: graph-node
       postgres_pass: let-me-in
       postgres_db: graph-node


### PR DESCRIPTION
it looks like the following [PR](https://github.com/graphprotocol/graph-node/pull/1975) introduced a variable ``` postgres_port``` which is 5432 by default, which in turn causes the current docker-compose to break as it also defines a default port for postgres, hence causing the following error:
```url: postgresql://graph-node:let-me-in@postgres:5432:5432/graph-node, at 'failed to connect notification listener to Postgres: Error(ConnectParams("Invalid \':\' in authority."))', store/postgres/src/notification_listener.rs:122:22```
The current PR proposes a fix by removing the port from ```environment.postgres_host```