### PR TITLE
Cargo.lock: Revert ipfs-api update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "ipfs-api"
-version = "0.7.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e7fbfe5c8cb04c27fe20bf2624354f4d102652fd465a297a924c24e60aba4a"
+checksum = "e93cd854b7d68085b438401625317dc38b88a7c586cdea09ccdbe19cb49ac55b"
 dependencies = [
  "bytes 0.5.6",
  "dirs 2.0.2",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,7 @@ futures01 = { package="futures", version="0.1.29" }
 futures = { version="0.3.4", features=["compat"] }
 graph = { path = "../graph" }
 graph-graphql = { path = "../graphql" }
-ipfs-api = { version = "0.7.1", features = ["hyper-tls"] }
+ipfs-api = { version = "=0.7.1", features = ["hyper-tls"] }
 lazy_static = "1.2.0"
 lru_time_cache = "0.9"
 semver = "0.10.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,7 +10,7 @@ git-testament = "0.1"
 graphql-parser = "0.2.3"
 prometheus = "0.7"
 futures = { version = "0.3.1", features = ["compat"] }
-ipfs-api = { version = "0.7.1", features = ["hyper-tls"] }
+ipfs-api = { version = "=0.7.1", features = ["hyper-tls"] }
 lazy_static = "1.2.0"
 url = "2.1.1"
 crossbeam-channel = "0.4.4"

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,5 +1,5 @@
 use git_testament::{git_testament, render_testament};
-use ipfs_api::{IpfsClient, TryFromUri};
+use ipfs_api::IpfsClient;
 use lazy_static::lazy_static;
 use prometheus::Registry;
 use std::collections::HashMap;
@@ -616,7 +616,7 @@ fn create_ipfs_clients(logger: &Logger, ipfs_addresses: &Vec<String>) -> Vec<Ipf
                 SafeDisplay(&ipfs_address)
             );
 
-            let ipfs_client: IpfsClient = match TryFromUri::from_str(&ipfs_address) {
+            let ipfs_client = match IpfsClient::new_from_uri(&ipfs_address) {
                 Ok(ipfs_client) => ipfs_client,
                 Err(e) => {
                     error!(

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -29,5 +29,5 @@ graphql-parser = "0.2.3"
 graph-core = { path = "../../core" }
 graph-mock = { path = "../../mock" }
 test-store = { path = "../../store/test-store" }
-ipfs-api = { version = "0.7.1", features = ["hyper-tls"] }
+ipfs-api = { version = "=0.7.1", features = ["hyper-tls"] }
 graph-chain-arweave = { path = "../../chain/arweave" }


### PR DESCRIPTION
It's causing problems with the IPFS version we currently use with graph-node.