### PR TITLE
Keep wait stats for each connection pool separately

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1277,6 +1277,8 @@ pub trait QueryStore: Send + Sync {
         subgraph_id: &SubgraphDeploymentId,
         block_hash: H256,
     ) -> Result<Option<BlockNumber>, StoreError>;
+
+    fn wait_stats(&self) -> &PoolWaitStats;
 }
 
 /// An entity operation that can be transacted into the store; as opposed to

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -32,11 +32,11 @@ impl StoreResolver {
     pub fn for_subscription(
         logger: &Logger,
         deployment: SubgraphDeploymentId,
-        store: Arc<impl Store>,
+        store: Arc<dyn QueryStore>,
     ) -> Self {
         StoreResolver {
             logger: logger.new(o!("component" => "StoreResolver")),
-            store: store.query_store(true),
+            store,
             block_ptr: None,
             deployment,
         }

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -854,7 +854,8 @@ fn query_complexity() {
 fn query_complexity_subscriptions() {
     run_test_sequentially(setup, |_, id| async move {
         let logger = Logger::root(slog::Discard, o!());
-        let store_resolver = StoreResolver::for_subscription(&logger, id.clone(), STORE.clone());
+        let store = STORE.clone().query_store(true);
+        let store_resolver = StoreResolver::for_subscription(&logger, id.clone(), store);
 
         let query = Query::new(
             Arc::new(api_test_schema(&id)),
@@ -916,7 +917,8 @@ fn query_complexity_subscriptions() {
             None,
         );
 
-        let store_resolver = StoreResolver::for_subscription(&logger, id.clone(), STORE.clone());
+        let store = STORE.clone().query_store(true);
+        let store_resolver = StoreResolver::for_subscription(&logger, id.clone(), store);
 
         let options = SubscriptionExecutionOptions {
             logger,
@@ -1260,7 +1262,8 @@ fn cannot_filter_by_derved_relationship_fields() {
 fn subscription_gets_result_even_without_events() {
     run_test_sequentially(setup, |_, id| async move {
         let logger = Logger::root(slog::Discard, o!());
-        let store_resolver = StoreResolver::for_subscription(&logger, id.clone(), STORE.clone());
+        let store = STORE.clone().query_store(true);
+        let store_resolver = StoreResolver::for_subscription(&logger, id.clone(), store);
 
         let query = Query::new(
             Arc::new(api_test_schema(&id)),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -7,7 +7,6 @@ use std::env;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::str::FromStr;
-use std::sync::RwLock;
 use std::time::Duration;
 use structopt::StructOpt;
 use tokio::sync::mpsc;
@@ -194,7 +193,6 @@ async fn main() {
     let stores_error_logger = logger.clone();
     let stores_eth_networks = eth_networks.clone();
     let contention_logger = logger.clone();
-    let wait_stats = Arc::new(RwLock::new(MovingStats::default()));
 
     let expensive_queries = read_expensive_queries().unwrap();
 
@@ -204,7 +202,6 @@ async fn main() {
         opt.store_connection_pool_size,
         opt.postgres_secondary_hosts.clone(),
         opt.postgres_host_weights.clone(),
-        wait_stats.clone(),
         metrics_registry.cheap_clone(),
     ));
     let store_builder2 = store_builder.clone();

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -245,7 +245,6 @@ async fn main() {
         .and_then(move |network_stores| {
             let load_manager = Arc::new(LoadManager::new(
                 &logger,
-                wait_stats.clone(),
                 expensive_queries,
                 metrics_registry.clone(),
                 store_conn_pool_size as usize,

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -3,7 +3,7 @@ use url::Url;
 
 use graph::prelude::{info, CheapClone, EthereumNetworkIdentifier, Logger, MovingStats};
 use graph_core::MetricsRegistry;
-use graph_store_postgres::connection_pool::{create_connection_pool, ConnectionPool};
+use graph_store_postgres::connection_pool::ConnectionPool;
 use graph_store_postgres::{
     ChainHeadUpdateListener as PostgresChainHeadUpdateListener, ChainStore as DieselChainStore,
     NetworkStore as DieselNetworkStore, Store as DieselStore, SubscriptionManager,
@@ -47,7 +47,7 @@ impl StoreBuilder {
             panic!("--store-connection-pool-size/STORE_CONNECTION_POOL_SIZE must be > 1")
         }
 
-        let conn_pool = create_connection_pool(
+        let conn_pool = ConnectionPool::create(
             "main",
             postgres_url.to_owned(),
             pool_size,
@@ -62,7 +62,7 @@ impl StoreBuilder {
             .map(|(i, host)| {
                 info!(&logger, "Connecting to Postgres read replica at {}", host);
                 let url = replace_host(postgres_url, &host);
-                create_connection_pool(
+                ConnectionPool::create(
                     &format!("replica{}", i),
                     url,
                     pool_size,

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -1,7 +1,7 @@
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use url::Url;
 
-use graph::prelude::{info, CheapClone, EthereumNetworkIdentifier, Logger, MovingStats};
+use graph::prelude::{info, CheapClone, EthereumNetworkIdentifier, Logger};
 use graph_core::MetricsRegistry;
 use graph_store_postgres::connection_pool::ConnectionPool;
 use graph_store_postgres::{
@@ -39,7 +39,6 @@ impl StoreBuilder {
         pool_size: u32,
         read_replicas: Vec<String>,
         replica_weights: Vec<usize>,
-        wait_stats: Arc<RwLock<MovingStats>>,
         registry: Arc<MetricsRegistry>,
     ) -> Self {
         // Minimum of two connections needed for the pool in order for the Store to bootstrap
@@ -53,7 +52,6 @@ impl StoreBuilder {
             pool_size,
             &logger,
             registry.cheap_clone(),
-            wait_stats.cheap_clone(),
         );
 
         let read_only_conn_pools: Vec<_> = read_replicas
@@ -68,7 +66,6 @@ impl StoreBuilder {
                     pool_size,
                     &logger,
                     registry.cheap_clone(),
-                    wait_stats.cheap_clone(),
                 )
             })
             .collect();

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -2,7 +2,7 @@ use graph::prelude::ChainStore as ChainStoreTrait;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
+use diesel::r2d2::{ConnectionManager, PooledConnection};
 use diesel::{insert_into, select, update};
 use std::convert::TryFrom;
 use std::iter::FromIterator;
@@ -16,11 +16,11 @@ use graph::prelude::{
 
 //use web3::types::H256;
 
-use crate::chain_head_listener::ChainHeadUpdateListener;
 use crate::functions::{attempt_chain_head_update, lookup_ancestor_block};
+use crate::{chain_head_listener::ChainHeadUpdateListener, connection_pool::ConnectionPool};
 
 pub struct ChainStore {
-    conn: Pool<ConnectionManager<PgConnection>>,
+    conn: ConnectionPool,
     network: String,
     genesis_block_ptr: EthereumBlockPointer,
     chain_head_update_listener: Arc<ChainHeadUpdateListener>,
@@ -31,7 +31,7 @@ impl ChainStore {
         network: String,
         net_identifier: EthereumNetworkIdentifier,
         chain_head_update_listener: Arc<ChainHeadUpdateListener>,
-        pool: Pool<ConnectionManager<PgConnection>>,
+        pool: ConnectionPool,
     ) -> Self {
         let store = ChainStore {
             conn: pool,

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 #[derive(Clone)]
 pub struct ConnectionPool {
     pool: Pool<ConnectionManager<PgConnection>>,
-    wait_stats: PoolWaitStats,
+    pub(crate) wait_stats: PoolWaitStats,
 }
 
 struct ErrorHandler(Logger, Counter);

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -108,66 +108,68 @@ impl std::ops::Deref for ConnectionPool {
     }
 }
 
-pub fn create_connection_pool(
-    pool_name: &str,
-    postgres_url: String,
-    pool_size: u32,
-    logger: &Logger,
-    registry: Arc<dyn MetricsRegistry>,
-    wait_time: PoolWaitStats,
-) -> ConnectionPool {
-    let logger_store = logger.new(o!("component" => "Store"));
-    let logger_pool = logger.new(o!("component" => "PostgresConnectionPool"));
-    let const_labels = {
-        let mut map = HashMap::new();
-        map.insert("pool".to_owned(), pool_name.to_owned());
-        map
-    };
-    let error_counter = registry
-        .global_counter(
-            "store_connection_error_count",
-            "The number of Postgres connections errors",
-            HashMap::new(),
-        )
-        .expect("failed to create `store_connection_error_count` counter");
-    let error_handler = Box::new(ErrorHandler(logger_pool.clone(), error_counter));
-    let event_handler = Box::new(EventHandler::new(
-        logger_pool.clone(),
-        registry,
-        wait_time.clone(),
-        const_labels,
-    ));
+impl ConnectionPool {
+    pub fn create(
+        pool_name: &str,
+        postgres_url: String,
+        pool_size: u32,
+        logger: &Logger,
+        registry: Arc<dyn MetricsRegistry>,
+        wait_time: PoolWaitStats,
+    ) -> ConnectionPool {
+        let logger_store = logger.new(o!("component" => "Store"));
+        let logger_pool = logger.new(o!("component" => "PostgresConnectionPool"));
+        let const_labels = {
+            let mut map = HashMap::new();
+            map.insert("pool".to_owned(), pool_name.to_owned());
+            map
+        };
+        let error_counter = registry
+            .global_counter(
+                "store_connection_error_count",
+                "The number of Postgres connections errors",
+                HashMap::new(),
+            )
+            .expect("failed to create `store_connection_error_count` counter");
+        let error_handler = Box::new(ErrorHandler(logger_pool.clone(), error_counter));
+        let event_handler = Box::new(EventHandler::new(
+            logger_pool.clone(),
+            registry,
+            wait_time.clone(),
+            const_labels,
+        ));
 
-    // Connect to Postgres
-    let conn_manager = ConnectionManager::new(postgres_url.clone());
-    // Set the time we wait for a connection to 6h. The default is 30s
-    // which can be too little if database connections are highly
-    // contended; if we don't get a connection within the timeout,
-    // ultimately subgraphs get marked as failed. This effectively
-    // turns off this timeout and makes it possible that work needing
-    // a database connection blocks for a very long time
-    //
-    // When running tests however, use the default of 30 seconds.
-    // There should not be a lot of contention when running tests,
-    // and this can help debug the issue faster when a test appears
-    // to be hanging but really there is just no connection to postgres
-    // available.
-    let timeout_seconds = if cfg!(test) { 30 } else { 6 * 60 * 60 };
-    let pool = Pool::builder()
-        .error_handler(error_handler)
-        .event_handler(event_handler)
-        .connection_timeout(Duration::from_secs(timeout_seconds))
-        .max_size(pool_size)
-        .build(conn_manager)
-        .unwrap();
-    info!(
-        logger_store,
-        "Connected to Postgres";
-        "pool_name" => pool_name,
-        "url" => SafeDisplay(postgres_url.as_str())
-    );
-    ConnectionPool {
-        pool,
-        wait_stats: wait_time,
+        // Connect to Postgres
+        let conn_manager = ConnectionManager::new(postgres_url.clone());
+        // Set the time we wait for a connection to 6h. The default is 30s
+        // which can be too little if database connections are highly
+        // contended; if we don't get a connection within the timeout,
+        // ultimately subgraphs get marked as failed. This effectively
+        // turns off this timeout and makes it possible that work needing
+        // a database connection blocks for a very long time
+        //
+        // When running tests however, use the default of 30 seconds.
+        // There should not be a lot of contention when running tests,
+        // and this can help debug the issue faster when a test appears
+        // to be hanging but really there is just no connection to postgres
+        // available.
+        let timeout_seconds = if cfg!(test) { 30 } else { 6 * 60 * 60 };
+        let pool = Pool::builder()
+            .error_handler(error_handler)
+            .event_handler(event_handler)
+            .connection_timeout(Duration::from_secs(timeout_seconds))
+            .max_size(pool_size)
+            .build(conn_manager)
+            .unwrap();
+        info!(
+            logger_store,
+            "Connected to Postgres";
+            "pool_name" => pool_name,
+            "url" => SafeDisplay(postgres_url.as_str())
+        );
+        ConnectionPool {
+            pool,
+            wait_stats: wait_time,
+        }
     }
 }

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -62,4 +62,8 @@ impl QueryStoreTrait for QueryStore {
     ) -> Result<Option<BlockNumber>, StoreError> {
         self.store.block_number(subgraph_id, block_hash)
     }
+
+    fn wait_stats(&self) -> &PoolWaitStats {
+        self.store.wait_stats(self.replica_id)
+    }
 }

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -44,7 +44,6 @@ lazy_static! {
 
     pub static ref LOAD_MANAGER: Arc<LoadManager> = Arc::new(
         LoadManager::new(&*LOGGER,
-                         POOL_WAIT_STATS.clone(),
                          Vec::new(),
                          Arc::new(MockMetricsRegistry::new()),
                          CONN_POOL_SIZE));

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -9,7 +9,7 @@ use graph_graphql::prelude::{
     execute_query, Query as PreparedQuery, QueryExecutionOptions, StoreResolver,
 };
 use graph_mock::MockMetricsRegistry;
-use graph_store_postgres::connection_pool::create_connection_pool;
+use graph_store_postgres::connection_pool::ConnectionPool;
 use graph_store_postgres::{
     ChainHeadUpdateListener, ChainStore, NetworkStore, Store, SubscriptionManager,
 };
@@ -61,7 +61,7 @@ lazy_static! {
                     net_version: NETWORK_VERSION.to_owned(),
                     genesis_block_hash: GENESIS_PTR.hash,
                 };
-                let postgres_conn_pool = create_connection_pool(
+                let postgres_conn_pool = ConnectionPool::create(
                     "test",
                     postgres_url.clone(),
                     CONN_POOL_SIZE as u32,

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -16,7 +16,7 @@ use graph_store_postgres::{
 use hex_literal::hex;
 use lazy_static::lazy_static;
 use std::env;
-use std::sync::{Mutex, RwLock};
+use std::sync::Mutex;
 use std::time::Instant;
 use web3::types::H256;
 
@@ -39,8 +39,6 @@ lazy_static! {
     };
 
     pub static ref STORE_RUNTIME: Mutex<Runtime> = Mutex::new(Builder::new().basic_scheduler().enable_all().build().unwrap());
-
-    pub static ref POOL_WAIT_STATS: PoolWaitStats = Arc::new(RwLock::new(MovingStats::default()));
 
     pub static ref LOAD_MANAGER: Arc<LoadManager> = Arc::new(
         LoadManager::new(&*LOGGER,
@@ -66,7 +64,6 @@ lazy_static! {
                     CONN_POOL_SIZE as u32,
                     &logger,
                     Arc::new(MockMetricsRegistry::new()),
-                    POOL_WAIT_STATS.clone()
                 );
                 let registry = Arc::new(MockMetricsRegistry::new());
                 let chain_head_update_listener = Arc::new(ChainHeadUpdateListener::new(


### PR DESCRIPTION
When we added replicas, we kept measuring connection wait times across all databases, even though they can be sharply different. This PR gives each connection pool its own wait statistics which will both give us more insight into where exactly we wait too long for connections, and also makes sure that load manager decisions are appropriate for the store we are about to use in a query.