### PR TITLE
graphql: Include the hash of the variables in the query hash

### DIFF
--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -143,6 +143,7 @@ impl Query {
         let query_hash = {
             let mut hasher = DefaultHasher::new();
             query.query_text.hash(&mut hasher);
+            query.variables_text.hash(&mut hasher);
             hasher.finish()
         };
         let query_id = format!("{:x}-{:x}", query.shape_hash, query_hash);


### PR DESCRIPTION
That makes it so that two queries that have the same query text and the
same variables text have a query id whose second part is identical. This is
useful in logs to tell if two queries are identical.

