### PR TITLE
Load dynamic data sources without using GraphQL

### DIFF
--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -4,207 +4,71 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 
-use graph::data::subgraph::schema::*;
-use graph::data::subgraph::UnresolvedDataSource;
-use graph::prelude::{DataSourceLoader as DataSourceLoaderTrait, GraphQlRunner, *};
-use graph_graphql::graphql_parser::{parse_query, query as q};
+use graph::components::store::StoredDynamicDataSource;
+use graph::prelude::{DataSourceLoader as DataSourceLoaderTrait, *};
 
-pub struct DataSourceLoader<L, Q, S> {
+pub struct DataSourceLoader<S> {
     store: Arc<S>,
-    link_resolver: Arc<L>,
-    graphql_runner: Arc<Q>,
 }
 
-impl<L, Q, S> DataSourceLoader<L, Q, S>
+impl<S> DataSourceLoader<S>
 where
-    L: LinkResolver,
     S: Store + SubgraphDeploymentStore,
-    Q: GraphQlRunner,
 {
-    pub fn new(store: Arc<S>, link_resolver: Arc<L>, graphql_runner: Arc<Q>) -> Self {
-        Self {
-            store,
-            link_resolver,
-            graphql_runner,
-        }
-    }
-
-    fn dynamic_data_sources_query(
-        &self,
-        deployment: &SubgraphDeploymentId,
-        skip: i32,
-    ) -> Result<Query, Error> {
-        // Obtain the "subgraphs" schema
-        let schema = self.store.api_schema(&SUBGRAPHS_ID)?;
-
-        // Construct a query for the subgraph deployment and all its
-        // dynamic data sources
-        //
-        // See also: ed42d219c6704a4aab57ce1ea66698e7.
-        // Note: This query needs to be in sync with the metadata schema.
-        let document = parse_query(
-            r#"
-            query deployment($id: ID!, $skip: Int!) {
-              subgraphDeployment(id: $id) {
-                dynamicDataSources(orderBy: id, skip: $skip) {
-                  kind
-                  network
-                  name
-                  context
-                  source { address abi }
-                  mapping {
-                    kind
-                    apiVersion
-                    language
-                    file
-                    entities
-                    abis { name file }
-                    blockHandlers { handler filter }
-                    callHandlers {  function handler }
-                    eventHandlers { event handler topic0 }
-                  }
-                  templates {
-                    kind
-                    network
-                    name
-                    source { abi }
-                    mapping {
-                      kind
-                      apiVersion
-                      language
-                      file
-                      entities
-                      abis { name file }
-                      blockHandlers { handler filter }
-                      callHandlers { function handler }
-                      eventHandlers { event handler topic0 }
-                    }
-                  }
-                }
-              }
-            }
-            "#,
-        )
-        .expect("invalid query for dynamic data sources");
-        let variables = Some(QueryVariables::new(HashMap::from_iter(
-            vec![
-                (String::from("id"), q::Value::String(deployment.to_string())),
-                (String::from("skip"), q::Value::Int(skip.into())),
-            ]
-            .into_iter(),
-        )));
-
-        Ok(Query::new(schema, document, variables, None))
-    }
-
-    fn parse_data_sources(
-        &self,
-        deployment_id: &SubgraphDeploymentId,
-        query_result: q::Value,
-    ) -> Result<Vec<UnresolvedDataSource>, Error> {
-        let data = match query_result {
-            q::Value::Object(obj) => Ok(obj),
-            _ => Err(format_err!(
-                "Query result for deployment `{}` is not an on object",
-                deployment_id,
-            )),
-        }?;
-
-        // Extract the deployment from the query result
-        let deployment = match data.get("subgraphDeployment") {
-            Some(q::Value::Object(obj)) => Ok(obj),
-            _ => Err(format_err!(
-                "Deployment `{}` is not an object",
-                deployment_id,
-            )),
-        }?;
-
-        // Extract the dynamic data sources from the query result
-        let values = match deployment.get("dynamicDataSources") {
-            Some(q::Value::List(objs)) => {
-                if objs.iter().all(|obj| match obj {
-                    q::Value::Object(_) => true,
-                    _ => false,
-                }) {
-                    Ok(objs)
-                } else {
-                    Err(format_err!(
-                        "Not all dynamic data sources of deployment `{}` are objects",
-                        deployment_id
-                    ))
-                }
-            }
-            _ => Err(format_err!(
-                "Dynamic data sources of deployment `{}` are not a list",
-                deployment_id
-            )),
-        }?;
-
-        // Parse the raw data sources into typed entities
-        let entities = values.iter().try_fold(vec![], |mut entities, value| {
-            entities.push(UnresolvedDataSource::try_from_value(value)?);
-            Ok(entities)
-        });
-
-        entities.map_err(|e: Error| {
-            format_err!(
-                "Failed to parse dynamic data source entities of deployment `{}`: {}",
-                deployment_id,
-                e
-            )
-        })
-    }
-
-    async fn resolve_data_sources(
-        &self,
-        unresolved_data_sources: Vec<UnresolvedDataSource>,
-        logger: &Logger,
-    ) -> Result<Vec<DataSource>, Error> {
-        // Resolve the data sources and return them
-        let mut result = Vec::new();
-        for item in unresolved_data_sources.into_iter() {
-            let resolved = item.resolve(&*self.link_resolver, logger).await?;
-            result.push(resolved);
-        }
-        Ok(result)
+    pub fn new(store: Arc<S>) -> Self {
+        Self { store }
     }
 }
 
 #[async_trait]
-impl<L, Q, S> DataSourceLoaderTrait for DataSourceLoader<L, Q, S>
+impl<S> DataSourceLoaderTrait for DataSourceLoader<S>
 where
-    L: LinkResolver,
-    Q: GraphQlRunner,
     S: Store + SubgraphDeploymentStore,
 {
     async fn load_dynamic_data_sources(
         &self,
         deployment_id: SubgraphDeploymentId,
         logger: Logger,
+        manifest: SubgraphManifest,
     ) -> Result<Vec<DataSource>, Error> {
         let start_time = Instant::now();
 
+        let template_map: HashMap<&str, &DataSourceTemplate> = HashMap::from_iter(
+            manifest
+                .templates
+                .iter()
+                .map(|template| (template.name.as_str(), template)),
+        );
         let mut data_sources = vec![];
 
-        loop {
-            let skip = data_sources.len() as i32;
-            let query = self.dynamic_data_sources_query(&deployment_id, skip)?;
-            let query_result = self
-                .graphql_runner
-                .cheap_clone()
-                .query_metadata(query)
-                .await?;
-            let unresolved_data_sources =
-                self.parse_data_sources(&deployment_id, query_result.as_ref().clone())?;
-            let next_data_sources = self
-                .resolve_data_sources(unresolved_data_sources, &logger)
-                .await?;
+        for stored in self.store.load_dynamic_data_sources(&deployment_id)? {
+            let StoredDynamicDataSource {
+                name,
+                source,
+                context,
+            } = stored;
 
-            if next_data_sources.is_empty() {
-                break;
-            }
+            let template = template_map.get(name.as_str()).ok_or_else(|| {
+                format_err!(
+                    "deployment `{}` does not have a template called `{}`",
+                    deployment_id.as_str(),
+                    name
+                )
+            })?;
+            let context = context
+                .map(|ctx| serde_json::from_str::<Entity>(&ctx))
+                .transpose()?;
 
-            data_sources.extend(next_data_sources);
+            let ds = DataSource {
+                kind: template.kind.clone(),
+                network: template.network.clone(),
+                name,
+                source,
+                mapping: template.mapping.clone(),
+                context,
+                templates: Vec::new(),
+            };
+            data_sources.push(ds);
         }
 
         trace!(

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -88,11 +88,7 @@ where
         let store = self.store.clone();
         let subgraph_id = id.clone();
 
-        let loader = Arc::new(DataSourceLoader::new(
-            store.clone(),
-            self.resolver.clone(),
-            self.graphql_runner.clone(),
-        ));
+        let loader = Arc::new(DataSourceLoader::new(store.clone()));
 
         let link = format!("/ipfs/{}", id);
 
@@ -112,7 +108,7 @@ where
             .await?;
 
             let data_sources = loader
-                .load_dynamic_data_sources(id.clone(), logger.clone())
+                .load_dynamic_data_sources(id.clone(), logger.clone(), subgraph.clone())
                 .map_err(SubgraphAssignmentProviderError::DynamicDataSourcesError)
                 .await?;
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -15,9 +15,9 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 use web3::types::{Address, H256};
 
-use crate::data::store::*;
 use crate::data::subgraph::schema::*;
 use crate::data::subgraph::status;
+use crate::data::{store::*, subgraph::Source};
 use crate::prelude::*;
 use crate::util::lfu_cache::LfuCache;
 
@@ -784,6 +784,12 @@ pub enum TransactionAbortError {
     Other(String),
 }
 
+pub struct StoredDynamicDataSource {
+    pub name: String,
+    pub source: Source,
+    pub context: Option<String>,
+}
+
 /// Common trait for store implementations.
 pub trait Store: Send + Sync + 'static {
     /// Get a pointer to the most recently processed block in the subgraph.
@@ -984,6 +990,12 @@ pub trait Store: Send + Sync + 'static {
     fn query_store(self: Arc<Self>, for_subscription: bool) -> Arc<dyn QueryStore + Send + Sync>;
 
     fn status(&self, filter: status::Filter) -> Result<Vec<status::Info>, StoreError>;
+
+    /// Load the dynamic data sources for the given deployment
+    fn load_dynamic_data_sources(
+        &self,
+        subgraph_id: &SubgraphDeploymentId,
+    ) -> Result<Vec<StoredDynamicDataSource>, StoreError>;
 }
 
 mock! {
@@ -1148,6 +1160,13 @@ impl Store for MockStore {
     }
 
     fn status(&self, _: status::Filter) -> Result<Vec<status::Info>, StoreError> {
+        unimplemented!()
+    }
+
+    fn load_dynamic_data_sources(
+        &self,
+        _subgraph_id: &SubgraphDeploymentId,
+    ) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
         unimplemented!()
     }
 }

--- a/graph/src/components/subgraph/loader.rs
+++ b/graph/src/components/subgraph/loader.rs
@@ -8,5 +8,6 @@ pub trait DataSourceLoader {
         &self,
         id: SubgraphDeploymentId,
         logger: Logger,
+        manifest: SubgraphManifest,
     ) -> Result<Vec<DataSource>, Error>;
 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -2,7 +2,7 @@ use mockall::predicate::*;
 use mockall::*;
 use std::collections::BTreeMap;
 
-use graph::data::subgraph::schema::*;
+use graph::components::store::StoredDynamicDataSource;
 use graph::data::subgraph::status;
 use graph::prelude::*;
 use graph_graphql::prelude::api_schema;
@@ -206,6 +206,13 @@ impl Store for MockStore {
     }
 
     fn status(&self, _: status::Filter) -> Result<Vec<status::Info>, StoreError> {
+        unimplemented!()
+    }
+
+    fn load_dynamic_data_sources(
+        &self,
+        _: &SubgraphDeploymentId,
+    ) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
         unimplemented!()
     }
 }

--- a/store/postgres/src/dynds.rs
+++ b/store/postgres/src/dynds.rs
@@ -1,0 +1,131 @@
+//! SQL queries to load dynamic data sources
+
+use diesel::pg::PgConnection;
+use diesel::prelude::{ExpressionMethods, JoinOnDsl, QueryDsl, RunQueryDsl};
+
+use graph::{
+    components::store::StoredDynamicDataSource,
+    data::subgraph::Source,
+    prelude::{bigdecimal::ToPrimitive, web3::types::H160, BigDecimal, StoreError},
+};
+
+// Diesel tables for some of the metadata
+// See also: ed42d219c6704a4aab57ce1ea66698e7
+// Changes to the GraphQL schema might require changes to these tables.
+// The definitions of the tables can be generated with
+//    cargo run -p graph-store-postgres --example layout -- \
+//      -g diesel store/postgres/src/subgraphs.graphql subgraphs
+// BEGIN GENERATED CODE
+table! {
+    subgraphs.dynamic_ethereum_contract_data_source (vid) {
+        vid -> BigInt,
+        id -> Text,
+        kind -> Text,
+        name -> Text,
+        network -> Nullable<Text>,
+        source -> Text,
+        mapping -> Text,
+        templates -> Nullable<Array<Text>>,
+        ethereum_block_hash -> Binary,
+        ethereum_block_number -> Numeric,
+        deployment -> Text,
+        context -> Nullable<Text>,
+        block_range -> Range<Integer>,
+    }
+}
+
+table! {
+    subgraphs.ethereum_contract_source (vid) {
+        vid -> BigInt,
+        id -> Text,
+        address -> Nullable<Binary>,
+        abi -> Text,
+        start_block -> Nullable<Numeric>,
+        block_range -> Range<Integer>,
+    }
+}
+
+// END GENERATED CODE
+
+allow_tables_to_appear_in_same_query!(
+    dynamic_ethereum_contract_data_source,
+    ethereum_contract_source
+);
+
+fn to_source(
+    deployment: &str,
+    ds_id: &str,
+    (address, abi, start_block): (Option<Vec<u8>>, String, Option<BigDecimal>),
+) -> Result<Source, StoreError> {
+    // Treat a missing address as an error. TODO: Is that correct?
+    let address = match address {
+        Some(address) => address,
+        None => {
+            return Err(StoreError::ConstraintViolation(format!(
+                "Dynamic data source {} for deployment {} is missing an address",
+                ds_id, deployment
+            )));
+        }
+    };
+    if address.len() != 20 {
+        return Err(StoreError::ConstraintViolation(format!(
+            "Data source address 0x`{:?}` for dynamic data source {} in deployment {} should have be 20 bytes long but is {} bytes long",
+            address, ds_id, deployment,
+            address.len()
+        )));
+    }
+    let address = Some(H160::from_slice(address.as_slice()));
+
+    // Assume a missing start block is the same as 0
+    let start_block = start_block
+        .map(|s| {
+            s.to_u64().ok_or_else(|| {
+                StoreError::ConstraintViolation(format!(
+                    "Start block {:?} for dynamic data source {} in deployment {} is not a u64",
+                    s, ds_id, deployment
+                ))
+            })
+        })
+        .transpose()?
+        .unwrap_or(0);
+
+    Ok(Source {
+        address,
+        abi,
+        start_block,
+    })
+}
+
+#[allow(dead_code)]
+pub fn load(conn: &PgConnection, id: &str) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
+    use dynamic_ethereum_contract_data_source as decds;
+    use ethereum_contract_source as ecs;
+
+    let dds: Vec<_> = decds::table
+        .inner_join(ecs::table.on(decds::source.eq(ecs::id)))
+        .filter(decds::deployment.eq(id))
+        .select((
+            decds::id,
+            decds::name,
+            decds::context,
+            (ecs::address, ecs::abi, ecs::start_block),
+        ))
+        .load::<(
+            String,
+            String,
+            Option<String>,
+            (Option<Vec<u8>>, String, Option<BigDecimal>),
+        )>(conn)?;
+
+    let mut data_sources = Vec::new();
+    for (ds_id, name, context, source) in dds.into_iter() {
+        let source = to_source(id, &ds_id, source)?;
+        let data_source = StoredDynamicDataSource {
+            name,
+            source,
+            context,
+        };
+        data_sources.push(data_source);
+    }
+    Ok(data_sources)
+}

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -27,6 +27,7 @@ mod chain_store;
 pub mod connection_pool;
 mod db_schema;
 mod detail;
+mod dynds;
 mod entities;
 mod functions;
 mod jsonb;

--- a/store/postgres/src/network_store.rs
+++ b/store/postgres/src/network_store.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use graph::{
+    components::store::StoredDynamicDataSource,
     data::subgraph::status,
     prelude::{
         ethabi,
@@ -233,6 +234,13 @@ impl StoreTrait for NetworkStore {
 
     fn status(&self, filter: status::Filter) -> Result<Vec<status::Info>, StoreError> {
         self.store.status(filter)
+    }
+
+    fn load_dynamic_data_sources(
+        &self,
+        subgraph_id: &SubgraphDeploymentId,
+    ) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
+        self.store.load_dynamic_data_sources(subgraph_id)
     }
 }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -4,6 +4,7 @@ use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use diesel::{insert_into, update};
 use futures03::FutureExt as _;
+use graph::components::store::StoredDynamicDataSource;
 use graph::data::subgraph::status;
 use graph::prelude::{
     CancelGuard, CancelHandle, CancelToken, CancelableError, NodeId, PoolWaitStats,
@@ -1342,6 +1343,14 @@ impl StoreTrait for Store {
 
     fn status(&self, filter: status::Filter) -> Result<Vec<status::Info>, StoreError> {
         self.status_internal(filter)
+    }
+
+    fn load_dynamic_data_sources(
+        &self,
+        id: &SubgraphDeploymentId,
+    ) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
+        let econn = self.get_entity_conn(&*SUBGRAPHS_ID, ReplicaId::Main)?;
+        econn.transaction(|| crate::dynds::load(&econn.conn, id.as_str()))
     }
 }
 


### PR DESCRIPTION
With this change, we load dynamic data sources by directly querying key data from the database and using the manifest we already have in memory to fill in the remainder of the data source.

This avoids using GraphQL, and also does not resolve data sources against IPFS redundantly, which should lead to a considerable speed up when starting subgraphs with a lot of dynamic data sources.

This branch sits on top of the `lutter/indexing` branch; since it touches parts of the system that are complex and very seinsitive to maintain correctness, I'd appreciate feedback on whether something about this approach is obviously wrong.