### PR TITLE
Continue indexing on deterministic error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ script:
   # not transient use through `im` https://github.com/vorner/cargo-depdiff/issues/7#issuecomment-735360113.
   # It seems preferable to continue to use it, over the alternatives
   # of using a less tested and unaudited crate, or being vulnerable to performance
-  # issues from using regular `Vec` instead of a persistent one.
+  # issues from using regular data structures instead of persistent ones.
   # So we ignore the advisory until the community figures out how to patch it.
   - cargo audit --ignore RUSTSEC-2020-0041
   # Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,17 @@ before_script:
   - psql -c 'create database graph_node_test;' -U travis
 
 script:
-  - cargo audit
+  # This advisory is about the `im` persistent vector data structures crate.
+  # It is depended on by `cargo` itself and is by far the most widely used
+  # persistent data structures crate. But it has a subdependency with soundness
+  # issues reported here https://github.com/bodil/sized-chunks/issues/11.
+  # As far as it is known, this would only affect direct use of the crate and
+  # not transient use through `im` https://github.com/vorner/cargo-depdiff/issues/7#issuecomment-735360113.
+  # It seems preferable to continue to use it, over the alternatives
+  # of using a less tested and unaudited crate, or being vulnerable to performance
+  # issues from using regular `Vec` instead of a persistent one.
+  # So we ignore the advisory until the community figures out how to patch it.
+  - cargo audit --ignore RUSTSEC-2020-0041
   # Run tests
   - ipfs daemon &> /dev/null &
   - RUST_BACKTRACE=1 cargo test --verbose --all -- --nocapture

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,17 +76,7 @@ before_script:
   - psql -c 'create database graph_node_test;' -U travis
 
 script:
-  # This advisory is about the `im` persistent vector data structures crate.
-  # It is depended on by `cargo` itself and is by far the most widely used
-  # persistent data structures crate. But it has a subdependency with soundness
-  # issues reported here https://github.com/bodil/sized-chunks/issues/11.
-  # As far as it is known, this would only affect direct use of the crate and
-  # not transient use through `im` https://github.com/vorner/cargo-depdiff/issues/7#issuecomment-735360113.
-  # It seems preferable to continue to use it, over the alternatives
-  # of using a less tested and unaudited crate, or being vulnerable to performance
-  # issues from using regular data structures instead of persistent ones.
-  # So we ignore the advisory until the community figures out how to patch it.
-  - cargo audit --ignore RUSTSEC-2020-0041
+  - cargo audit
   # Run tests
   - ipfs daemon &> /dev/null &
   - RUST_BACKTRACE=1 cargo test --verbose --all -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1516,7 @@ dependencies = [
  "graphql-parser",
  "hex 0.4.2",
  "http 0.2.1",
+ "im",
  "isatty",
  "lazy_static",
  "maplit",
@@ -2124,6 +2134,20 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "im"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.5.1",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -3439,6 +3463,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3924,6 +3957,16 @@ name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,15 +208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "bitvec"
 version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,7 +1507,6 @@ dependencies = [
  "graphql-parser",
  "hex 0.4.2",
  "http 0.2.1",
- "im",
  "isatty",
  "lazy_static",
  "maplit",
@@ -2134,20 +2124,6 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "im"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
-dependencies = [
- "bitmaps",
- "rand_core 0.5.1",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check 0.9.2",
 ]
 
 [[package]]
@@ -3463,15 +3439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
 name = "raw-cpuid"
 version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3957,16 +3924,6 @@ name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "12.0.0-graph"
-source = "git+https://github.com/graphprotocol/ethabi.git?branch=master#35977d1ce69d4c2db652c502d70e4e53a7aa9897"
+source = "git+https://github.com/graphprotocol/ethabi.git#35977d1ce69d4c2db652c502d70e4e53a7aa9897"
 dependencies = [
  "ethereum-types",
  "rustc-hex",
@@ -5319,7 +5319,7 @@ dependencies = [
 [[package]]
 name = "web3"
 version = "0.10.0-graph"
-source = "git+https://github.com/graphprotocol/rust-web3?branch=master#c37ecac19fb46e8b3991d64bb83d6bfbf578bae0"
+source = "git+https://github.com/graphprotocol/rust-web3#c37ecac19fb46e8b3991d64bb83d6bfbf578bae0"
 dependencies = [
  "arrayvec",
  "base64 0.12.3",

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -168,6 +168,7 @@ impl WriteContext {
                                 block_ptr.clone(),
                                 modifications,
                                 stopwatch,
+                                Vec::new(),
                             )
                             .map_err(|e| e.into())
                             .map(move |_| {

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -109,16 +109,13 @@ type WriteContextResult = Box<dyn Future<Item = WriteContext, Error = Error> + S
 impl WriteContext {
     /// Updates an entity to a new value (potentially merging it with existing data).
     fn set_entity(mut self, value: impl TryIntoEntity + ToEntityKey) -> WriteContextResult {
-        self.cache
-            .set(
-                value.to_entity_key(self.subgraph_id.clone()),
-                match value.try_into_entity() {
-                    Ok(entity) => entity,
-                    Err(e) => return Box::new(future::err(e.into())),
-                },
-            )
-            // An error here is only possible if entities ever get removed, which is not the case.
-            .unwrap();
+        self.cache.set(
+            value.to_entity_key(self.subgraph_id.clone()),
+            match value.try_into_entity() {
+                Ok(entity) => entity,
+                Err(e) => return Box::new(future::err(e.into())),
+            },
+        );
         Box::new(future::ok(self))
     }
 

--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -1,6 +1,6 @@
-use futures::future::FutureResult;
-
 use super::*;
+use futures::future::FutureResult;
+use std::collections::BTreeSet;
 
 fn check_subgraph_exists(
     store: Arc<dyn NetworkStore>,
@@ -25,6 +25,7 @@ fn create_subgraph(
         id: subgraph_id.clone(),
         location: subgraph_name.to_string(),
         spec_version: String::from("0.0.1"),
+        features: BTreeSet::new(),
         description: None,
         repository: None,
         schema: Schema::parse(include_str!("./ethereum.graphql"), subgraph_id.clone())

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -583,8 +583,8 @@ enum BlockProcessingError {
 
     // The error had a determinstic cause but, for a possibly non-deterministic reason, we chose to
     // halt processing due to the error.
-    #[error("{0:#}")]
-    Deterministic(anyhow::Error),
+    #[error("{0}")]
+    Deterministic(SubgraphError),
 
     #[error("subgraph stopped while processing triggers")]
     Canceled,

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -5,7 +5,6 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
-use graph::components::ethereum::{triggers_in_block, EthereumNetworks};
 use graph::components::store::ModificationsAndCache;
 use graph::components::subgraph::{MappingError, ProofOfIndexing, SharedProofOfIndexing};
 use graph::data::store::scalar::Bytes;
@@ -14,6 +13,10 @@ use graph::data::subgraph::schema::{
 };
 use graph::prelude::{SubgraphInstance as SubgraphInstanceTrait, *};
 use graph::util::lfu_cache::LfuCache;
+use graph::{
+    components::ethereum::{triggers_in_block, EthereumNetworks},
+    data::subgraph::SubgraphFeature,
+};
 
 use super::SubgraphInstance;
 
@@ -35,7 +38,7 @@ type SharedInstanceKeepAliveMap = Arc<RwLock<HashMap<SubgraphDeploymentId, Cance
 
 struct IndexingInputs<B, S> {
     deployment_id: SubgraphDeploymentId,
-    features: BTreeSet<SubgraphFeatures>,
+    features: BTreeSet<SubgraphFeature>,
     network_name: String,
     start_blocks: Vec<u64>,
     store: Arc<S>,
@@ -680,7 +683,7 @@ where
     {
         // The triggers were processed but some were skipped due to deterministic errors.
         Ok(block_state) if block_state.has_errors() => {
-            use SubgraphFeatures::*;
+            use SubgraphFeature::*;
 
             // While the version is pending we fail the subgraph even if the error is determinsitic.
             // This prevents a buggy pending version from replacing a current version.

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -666,11 +666,6 @@ where
         Err(MappingError::Unknown(e)) => {
             return Err(CancelableError::Error(BlockProcessingError::Unknown(e)))
         }
-        Err(MappingError::Deterministic(e)) => {
-            return Err(CancelableError::Error(BlockProcessingError::Deterministic(
-                e,
-            )))
-        }
         Err(MappingError::PossibleReorg(e)) => {
             info!(ctx.state.logger,
                     "Possible reorg detected, retrying";
@@ -708,7 +703,7 @@ where
             logger.clone(),
             &mut ctx,
             host_metrics.clone(),
-            block_state.created_data_sources.drain(..),
+            block_state.created_data_sources.split_off(0).into_iter(),
         )
         .compat_err()?;
 
@@ -771,7 +766,6 @@ where
                     MappingError::PossibleReorg(e) | MappingError::Unknown(e) => {
                         BlockProcessingError::Unknown(e)
                     }
-                    MappingError::Deterministic(e) => BlockProcessingError::Deterministic(e),
                 }
             })
             .map_err(CancelableError::Error)?;
@@ -833,11 +827,13 @@ where
     let stopwatch = ctx.host_metrics.stopwatch.clone();
     let start = Instant::now();
 
-    match ctx
-        .inputs
-        .store
-        .transact_block_operations(subgraph_id, block_ptr_after, mods, stopwatch)
-    {
+    match ctx.inputs.store.transact_block_operations(
+        subgraph_id,
+        block_ptr_after,
+        mods,
+        stopwatch,
+        block_state.deterministic_errors,
+    ) {
         Ok(should_migrate) => {
             let elapsed = start.elapsed().as_secs_f64();
             metrics.block_ops_transaction_duration.observe(elapsed);

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -561,10 +561,7 @@ where
                         deterministic: e.is_deterministic(),
                     };
 
-                    // Set subgraph status to Failed
-                    let status_ops = SubgraphDeploymentEntity::fail_operations(&id_for_err, error);
-                    if let Err(e) = store_for_err.apply_metadata_operations(&id_for_err, status_ops)
-                    {
+                    if let Err(e) = store_for_err.fail_subgraph(id_for_err.clone(), error).await {
                         error!(
                             &logger,
                             "Failed to set subgraph status to Failed: {}", e;
@@ -605,6 +602,12 @@ impl BlockProcessingError {
 impl From<failure::Error> for BlockProcessingError {
     fn from(e: failure::Error) -> Self {
         BlockProcessingError::Unknown(e.compat_err())
+    }
+}
+
+impl From<anyhow::Error> for BlockProcessingError {
+    fn from(e: anyhow::Error) -> Self {
+        BlockProcessingError::Unknown(e)
     }
 }
 

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -42,7 +42,7 @@ fn insert_and_query(
         None,
         STORE.network_name(&subgraph_id).unwrap(),
     );
-    Ok(execute_subgraph_query(query))
+    Ok(execute_subgraph_query(query).unwrap_first())
 }
 
 /// Extract the data from a `QueryResult`, and panic if it has errors

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -56,6 +56,7 @@ futures03 = { version = "0.3.1", package = "futures", features = ["compat"] }
 uuid = { version = "0.8.1", features = ["v4"] }
 wasmparser = "0.63.1"
 thiserror = "1.0"
+im = "15.0"
 
 # Our fork contains a small but hacky patch.
 web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "master" }

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -56,7 +56,6 @@ futures03 = { version = "0.3.1", package = "futures", features = ["compat"] }
 uuid = { version = "0.8.1", features = ["v4"] }
 wasmparser = "0.63.1"
 thiserror = "1.0"
-im = "15.0"
 
 # Our fork contains a small but hacky patch.
 web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "master" }

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -16,6 +16,7 @@ pub trait LightEthereumBlockExt {
     fn transaction_for_call(&self, call: &EthereumCall) -> Option<Transaction>;
     fn parent_ptr(&self) -> Option<EthereumBlockPointer>;
     fn format(&self) -> String;
+    fn block_ptr(&self) -> EthereumBlockPointer;
 }
 
 impl LightEthereumBlockExt for LightEthereumBlock {
@@ -53,6 +54,13 @@ impl LightEthereumBlockExt for LightEthereumBlock {
             self.hash
                 .map_or(String::from("-"), |hash| format!("{:x}", hash))
         )
+    }
+
+    fn block_ptr(&self) -> EthereumBlockPointer {
+        EthereumBlockPointer {
+            hash: self.hash.unwrap(),
+            number: self.number.unwrap().as_u64(),
+        }
     }
 }
 

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -435,6 +435,19 @@ impl EthereumBlockPointer {
     pub fn hash_hex(&self) -> String {
         format!("{:x}", self.hash)
     }
+
+    /// Block number to be passed into the store. Panics if it does not fit in an i32.
+    pub fn block_number(&self) -> crate::components::store::BlockNumber {
+        if self.number <= std::i32::MAX as u64 {
+            self.number as i32
+        } else {
+            panic!(
+                "Block numbers bigger than {} are not supported, but received block number {}",
+                std::i32::MAX,
+                self.number
+            )
+        }
+    }
 }
 
 impl fmt::Display for EthereumBlockPointer {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -785,6 +785,7 @@ pub enum TransactionAbortError {
 }
 
 /// Common trait for store implementations.
+#[async_trait]
 pub trait Store: Send + Sync + 'static {
     /// Get a pointer to the most recently processed block in the subgraph.
     fn block_ptr(
@@ -882,6 +883,13 @@ pub trait Store: Send + Sync + 'static {
         &self,
         id: SubgraphDeploymentId,
     ) -> Result<DeploymentState, StoreError>;
+
+    /// Set subgraph status to failed with the given error as the cause.
+    async fn fail_subgraph(
+        &self,
+        id: SubgraphDeploymentId,
+        error: SubgraphError,
+    ) -> Result<(), anyhow::Error>;
 
     /// Check if the store is accepting queries for the specified subgraph.
     /// May return true even if the specified subgraph is not currently assigned to an indexing
@@ -1002,6 +1010,7 @@ mock! {
 pub type PoolWaitStats = Arc<RwLock<MovingStats>>;
 
 // The store trait must be implemented manually because mockall does not support async_trait, nor borrowing from arguments.
+#[async_trait]
 impl Store for MockStore {
     fn block_ptr(
         &self,
@@ -1090,6 +1099,14 @@ impl Store for MockStore {
         &self,
         _: SubgraphDeploymentId,
     ) -> Result<DeploymentState, StoreError> {
+        unimplemented!()
+    }
+
+    async fn fail_subgraph(
+        &self,
+        _: SubgraphDeploymentId,
+        _: SubgraphError,
+    ) -> Result<(), anyhow::Error> {
         unimplemented!()
     }
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -843,6 +843,7 @@ pub trait Store: Send + Sync + 'static {
         block_ptr_to: EthereumBlockPointer,
         mods: Vec<EntityModification>,
         stopwatch: StopwatchMetrics,
+        deterministic_errors: Vec<anyhow::Error>,
     ) -> Result<bool, StoreError>;
 
     /// Apply the specified metadata operations which only concern metadata
@@ -1055,6 +1056,7 @@ impl Store for MockStore {
         _block_ptr_to: EthereumBlockPointer,
         _mods: Vec<EntityModification>,
         _stopwatch: StopwatchMetrics,
+        _deterministic_errors: Vec<anyhow::Error>,
     ) -> Result<bool, StoreError> {
         unimplemented!()
     }
@@ -1329,16 +1331,17 @@ impl EntityModification {
 ///   (1) no entity appears in more than one operation
 ///   (2) only entities that will actually be changed from what they
 ///       are in the store are changed
-#[derive(Clone)]
+#[derive(Clone)] // TODO: Check where this is used.
 pub struct EntityCache {
     /// The state of entities in the store. An entry of `None`
     /// means that the entity is not present in the store
     current: LfuCache<EntityKey, Option<Entity>>,
 
-    /// The accumulated changes to an entity. An entry of `None`
-    /// means that the entity should be deleted
-    updates: BTreeMap<EntityKey, Option<Entity>>,
+    /// The accumulated changes to an entity. An entry of `None` means that the entity should be
+    /// deleted. This is a persistent collection to cheapen cloning, see the `im` crate docs.
+    updates: im::HashMap<EntityKey, Option<Entity>>,
 
+    /// The store is only used to read entities.
     pub store: Arc<dyn Store>,
 }
 
@@ -1360,7 +1363,7 @@ impl EntityCache {
     pub fn new(store: Arc<dyn Store>) -> Self {
         Self {
             current: LfuCache::new(),
-            updates: BTreeMap::new(),
+            updates: im::HashMap::new(),
             store,
         }
     }
@@ -1371,7 +1374,7 @@ impl EntityCache {
     ) -> EntityCache {
         EntityCache {
             current,
-            updates: BTreeMap::new(),
+            updates: im::HashMap::new(),
             store,
         }
     }
@@ -1400,7 +1403,7 @@ impl EntityCache {
     }
 
     pub fn set(&mut self, key: EntityKey, mut entity: Entity) -> Result<(), QueryExecutionError> {
-        use std::collections::btree_map::Entry;
+        use im::hashmap::Entry;
 
         let update = self.updates.entry(key.clone());
 
@@ -1444,7 +1447,7 @@ impl EntityCache {
         Ok(())
     }
 
-    pub fn extend(&mut self, other: EntityCache) -> Result<(), QueryExecutionError> {
+    pub(crate) fn extend(&mut self, other: EntityCache) -> Result<(), QueryExecutionError> {
         self.current.extend(other.current);
         for (key, update) in other.updates {
             match update {
@@ -1453,6 +1456,19 @@ impl EntityCache {
             }
         }
         Ok(())
+    }
+
+    /// A copy of the pending updates. Those are kept in a persistent data structure so this is a
+    /// cheap operation.
+    pub(crate) fn updates_snapshot(&self) -> im::HashMap<EntityKey, Option<Entity>> {
+        self.updates.clone()
+    }
+
+    pub(crate) fn restore_updates_snapshot(
+        &mut self,
+        snapshot: im::HashMap<EntityKey, Option<Entity>>,
+    ) {
+        self.updates = snapshot;
     }
 
     /// Return the changes that have been made via `set` and `remove` as

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -757,6 +757,12 @@ impl From<Error> for StoreError {
     }
 }
 
+impl From<anyhow::Error> for StoreError {
+    fn from(e: anyhow::Error) -> Self {
+        StoreError::Unknown(e.compat_err())
+    }
+}
+
 impl From<serde_json::Error> for StoreError {
     fn from(e: serde_json::Error) -> Self {
         StoreError::Unknown(e.into())
@@ -844,7 +850,7 @@ pub trait Store: Send + Sync + 'static {
         block_ptr_to: EthereumBlockPointer,
         mods: Vec<EntityModification>,
         stopwatch: StopwatchMetrics,
-        deterministic_errors: Vec<anyhow::Error>,
+        deterministic_errors: Vec<SubgraphError>,
     ) -> Result<bool, StoreError>;
 
     /// Apply the specified metadata operations which only concern metadata
@@ -1065,7 +1071,7 @@ impl Store for MockStore {
         _block_ptr_to: EthereumBlockPointer,
         _mods: Vec<EntityModification>,
         _stopwatch: StopwatchMetrics,
-        _deterministic_errors: Vec<anyhow::Error>,
+        _deterministic_errors: Vec<SubgraphError>,
     ) -> Result<bool, StoreError> {
         unimplemented!()
     }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -763,6 +763,12 @@ impl From<anyhow::Error> for StoreError {
     }
 }
 
+impl From<StoreError> for anyhow::Error {
+    fn from(e: StoreError) -> Self {
+        failure::Error::from(e).compat_err()
+    }
+}
+
 impl From<serde_json::Error> for StoreError {
     fn from(e: serde_json::Error) -> Self {
         StoreError::Unknown(e.into())
@@ -895,7 +901,7 @@ pub trait Store: Send + Sync + 'static {
         &self,
         id: SubgraphDeploymentId,
         error: SubgraphError,
-    ) -> Result<(), anyhow::Error>;
+    ) -> Result<(), StoreError>;
 
     /// Check if the store is accepting queries for the specified subgraph.
     /// May return true even if the specified subgraph is not currently assigned to an indexing
@@ -1112,7 +1118,7 @@ impl Store for MockStore {
         &self,
         _: SubgraphDeploymentId,
         _: SubgraphError,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), StoreError> {
         unimplemented!()
     }
 
@@ -1318,7 +1324,7 @@ pub trait QueryStore: Send + Sync {
         &self,
         id: SubgraphDeploymentId,
         block: Option<BlockNumber>,
-    ) -> Result<bool, anyhow::Error>;
+    ) -> Result<bool, StoreError>;
 }
 
 /// An entity operation that can be transacted into the store; as opposed to

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1289,6 +1289,7 @@ pub trait EthereumCallCache: Send + Sync + 'static {
 }
 
 /// Store operations used when serving queries
+#[async_trait]
 pub trait QueryStore: Send + Sync {
     fn find_query_values(
         &self,
@@ -1311,6 +1312,13 @@ pub trait QueryStore: Send + Sync {
     ) -> Result<Option<BlockNumber>, StoreError>;
 
     fn wait_stats(&self) -> &PoolWaitStats;
+
+    /// If `block` is `None`, assumes the latest block.
+    async fn has_non_fatal_errors(
+        &self,
+        id: SubgraphDeploymentId,
+        block: Option<BlockNumber>,
+    ) -> Result<bool, anyhow::Error>;
 }
 
 /// An entity operation that can be transacted into the store; as opposed to

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1362,7 +1362,6 @@ impl EntityModification {
 ///   (1) no entity appears in more than one operation
 ///   (2) only entities that will actually be changed from what they
 ///       are in the store are changed
-#[derive(Clone)] // TODO: Check where this is used.
 pub struct EntityCache {
     /// The state of entities in the store. An entry of `None`
     /// means that the entity is not present in the store

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -15,7 +15,6 @@ use web3::types::{Log, Transaction};
 pub enum MappingError {
     /// A possible reorg was detected while running the mapping.
     PossibleReorg(anyhow::Error),
-    Deterministic(anyhow::Error),
     Unknown(anyhow::Error),
 }
 
@@ -39,7 +38,6 @@ impl MappingError {
         use MappingError::*;
         match self {
             PossibleReorg(e) => PossibleReorg(e.context(s)),
-            Deterministic(e) => Deterministic(e.context(s)),
             Unknown(e) => Unknown(e.context(s)),
         }
     }

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -24,15 +24,6 @@ impl From<anyhow::Error> for MappingError {
     }
 }
 
-impl From<CancelableError<MappingError>> for MappingError {
-    fn from(cancelable: CancelableError<MappingError>) -> Self {
-        match cancelable {
-            CancelableError::Error(e) => e,
-            CancelableError::Cancel => MappingError::Unknown(anyhow::anyhow!("mapping canceled")),
-        }
-    }
-}
-
 impl MappingError {
     pub fn context(self, s: String) -> Self {
         use MappingError::*;

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -1,9 +1,12 @@
 use async_trait::async_trait;
 use web3::types::Log;
 
-use crate::components::subgraph::{MappingError, SharedProofOfIndexing};
 use crate::prelude::*;
 use crate::util::lfu_cache::LfuCache;
+use crate::{
+    components::subgraph::{MappingError, SharedProofOfIndexing},
+    data::subgraph::schema::SubgraphError,
+};
 
 #[derive(Clone, Debug)]
 pub struct DataSourceTemplateInfo {
@@ -16,7 +19,7 @@ pub struct DataSourceTemplateInfo {
 #[derive(Debug)]
 pub struct BlockState {
     pub entity_cache: EntityCache,
-    pub deterministic_errors: Vec<anyhow::Error>,
+    pub deterministic_errors: Vec<SubgraphError>,
     pub created_data_sources: im::Vector<DataSourceTemplateInfo>,
 }
 
@@ -60,7 +63,7 @@ impl BlockState {
     pub fn restore_updates_snapshot_due_to_error(
         &mut self,
         snapshot: BlockStateUpdatesSnapshot,
-        error: anyhow::Error,
+        error: SubgraphError,
     ) {
         self.entity_cache
             .restore_updates_snapshot(snapshot.entity_updates);

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -67,6 +67,10 @@ impl BlockState {
         self.created_data_sources = snapshot.created_data_sources;
         self.deterministic_errors.push(error);
     }
+
+    pub fn has_errors(&self) -> bool {
+        !self.deterministic_errors.is_empty()
+    }
 }
 
 /// Represents a loaded instance of a subgraph.

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -9,9 +9,9 @@ use std::fmt;
 use std::string::FromUtf8Error;
 use std::sync::Arc;
 
-use crate::data::graphql::SerializableValue;
 use crate::data::subgraph::*;
 use crate::{components::store::StoreError, prelude::CacheWeight};
+use crate::{data::graphql::SerializableValue, prelude::CompatErr};
 
 #[derive(Debug)]
 pub struct CloneableFailureError(Arc<failure::Error>);
@@ -249,6 +249,12 @@ impl From<bigdecimal::ParseBigDecimalError> for QueryExecutionError {
 impl From<StoreError> for QueryExecutionError {
     fn from(e: StoreError) -> Self {
         QueryExecutionError::StoreError(CloneableFailureError(Arc::new(e.into())))
+    }
+}
+
+impl From<anyhow::Error> for QueryExecutionError {
+    fn from(e: anyhow::Error) -> Self {
+        QueryExecutionError::StoreError(CloneableFailureError(Arc::new(e.compat_err())))
     }
 }
 

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -264,6 +264,7 @@ pub enum QueryError {
     EncodingError(FromUtf8Error),
     ParseError(Arc<anyhow::Error>),
     ExecutionError(QueryExecutionError),
+    IndexingError,
 }
 
 impl From<FromUtf8Error> for QueryError {
@@ -298,6 +299,9 @@ impl fmt::Display for QueryError {
             QueryError::EncodingError(ref e) => write!(f, "{}", e),
             QueryError::ExecutionError(ref e) => write!(f, "{}", e),
             QueryError::ParseError(ref e) => write!(f, "{}", e),
+
+            // This error message is part of attestable responses.
+            QueryError::IndexingError => write!(f, "indexing_error"),
         }
     }
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -252,12 +252,6 @@ impl From<StoreError> for QueryExecutionError {
     }
 }
 
-// impl From<anyhow::Error> for QueryExecutionError {
-//     fn from(e: anyhow::Error) -> Self {
-//         QueryExecutionError::StoreError(CloneableFailureError(Arc::new(e.compat_err())))
-//     }
-// }
-
 /// Error caused while processing a [Query](struct.Query.html) request.
 #[derive(Clone, Debug)]
 pub enum QueryError {

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -9,9 +9,9 @@ use std::fmt;
 use std::string::FromUtf8Error;
 use std::sync::Arc;
 
+use crate::data::graphql::SerializableValue;
 use crate::data::subgraph::*;
 use crate::{components::store::StoreError, prelude::CacheWeight};
-use crate::{data::graphql::SerializableValue, prelude::CompatErr};
 
 #[derive(Debug)]
 pub struct CloneableFailureError(Arc<failure::Error>);
@@ -252,11 +252,11 @@ impl From<StoreError> for QueryExecutionError {
     }
 }
 
-impl From<anyhow::Error> for QueryExecutionError {
-    fn from(e: anyhow::Error) -> Self {
-        QueryExecutionError::StoreError(CloneableFailureError(Arc::new(e.compat_err())))
-    }
-}
+// impl From<anyhow::Error> for QueryExecutionError {
+//     fn from(e: anyhow::Error) -> Self {
+//         QueryExecutionError::StoreError(CloneableFailureError(Arc::new(e.compat_err())))
+//     }
+// }
 
 /// Error caused while processing a [Query](struct.Query.html) request.
 #[derive(Clone, Debug)]

--- a/graph/src/data/query/mod.rs
+++ b/graph/src/data/query/mod.rs
@@ -6,4 +6,4 @@ mod result;
 pub use self::cache_status::CacheStatus;
 pub use self::error::{QueryError, QueryExecutionError};
 pub use self::query::{Query, QueryVariables};
-pub use self::result::QueryResult;
+pub use self::result::{QueryResult, QueryResults};

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -215,6 +215,18 @@ impl QueryResult {
             Ok(self.data.map(|v| q::Value::Object(v)))
         }
     }
+
+    pub fn take_data(&mut self) -> Option<Data> {
+        self.data.take()
+    }
+
+    pub fn set_data(&mut self, data: Option<Data>) {
+        self.data = data
+    }
+
+    pub fn errors_mut(&mut self) -> &mut Vec<QueryError> {
+        &mut self.errors
+    }
 }
 
 impl From<QueryExecutionError> for QueryResult {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -955,7 +955,7 @@ pub struct BaseSubgraphManifest<S, D, T> {
     pub location: String,
     pub spec_version: String,
     #[serde(default)]
-    pub features: BTreeSet<SubgraphFeatures>,
+    pub features: BTreeSet<SubgraphFeature>,
     pub description: Option<String>,
     pub repository: Option<String>,
     pub schema: S,
@@ -1300,6 +1300,6 @@ impl DeploymentState {
 
 #[derive(Debug, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(non_camel_case_types)]
-pub enum SubgraphFeatures {
+pub enum SubgraphFeature {
     nonFatalErrors,
 }

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -10,7 +10,7 @@ use lazy_static::lazy_static;
 use serde::de;
 use serde::ser;
 use serde_yaml;
-use slog::{info, Logger};
+use slog::{info, debug, Logger};
 use stable_hash::prelude::*;
 use std::collections::BTreeSet;
 use wasmparser;
@@ -1137,6 +1137,8 @@ impl SubgraphManifest {
 
         // Parse the YAML data into an UnresolvedSubgraphManifest
         let unresolved: UnresolvedSubgraphManifest = serde_yaml::from_value(raw)?;
+
+        debug!(logger, "Features {:?}", unresolved.features);
 
         unresolved
             .resolve(&*resolver, logger)

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -12,6 +12,7 @@ use serde::ser;
 use serde_yaml;
 use slog::{info, Logger};
 use stable_hash::prelude::*;
+use std::collections::BTreeSet;
 use wasmparser;
 use web3::types::{Address, H256};
 
@@ -953,6 +954,8 @@ pub struct BaseSubgraphManifest<S, D, T> {
     pub id: SubgraphDeploymentId,
     pub location: String,
     pub spec_version: String,
+    #[serde(default)]
+    pub features: BTreeSet<SubgraphFeatures>,
     pub description: Option<String>,
     pub repository: Option<String>,
     pub schema: S,
@@ -1206,6 +1209,7 @@ impl UnresolvedSubgraphManifest {
             id,
             location,
             spec_version,
+            features,
             description,
             repository,
             schema,
@@ -1250,6 +1254,7 @@ impl UnresolvedSubgraphManifest {
             id,
             location,
             spec_version,
+            features,
             description,
             repository,
             schema,
@@ -1291,4 +1296,10 @@ impl DeploymentState {
             latest_ethereum_block_number: BLOCK_NUMBER_MAX,
         }
     }
+}
+
+#[derive(Debug, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(non_camel_case_types)]
+pub enum SubgraphFeatures {
+    nonFatalErrors,
 }

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -10,7 +10,7 @@ use lazy_static::lazy_static;
 use serde::de;
 use serde::ser;
 use serde_yaml;
-use slog::{info, debug, Logger};
+use slog::{debug, info, Logger};
 use stable_hash::prelude::*;
 use std::collections::BTreeSet;
 use wasmparser;

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -21,7 +21,7 @@ use rand::rngs::OsRng;
 use rand::Rng;
 use stable_hash::{SequenceNumber, StableHash, StableHasher};
 use std::str::FromStr;
-use std::{collections::BTreeMap, fmt::Display};
+use std::{collections::BTreeMap, fmt, fmt::Display};
 use strum_macros::IntoStaticStr;
 use uuid::Uuid;
 use web3::types::*;
@@ -1274,6 +1274,19 @@ pub struct SubgraphError {
 
     // `true` if we are certain the error is determinsitic. If in doubt, this is `false`.
     pub deterministic: bool,
+}
+
+impl Display for SubgraphError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.message)?;
+        if let Some(handler) = &self.handler {
+            write!(f, " in handler `{}`", handler)?;
+        }
+        if let Some(block_ptr) = self.block_ptr {
+            write!(f, " at block {}", block_ptr)?;
+        }
+        Ok(())
+    }
 }
 
 impl StableHash for SubgraphError {

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -281,6 +281,12 @@ impl From<diesel::result::Error> for CancelableError<Error> {
     }
 }
 
+impl From<anyhow::Error> for CancelableError<anyhow::Error> {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Error(e)
+    }
+}
+
 impl<E> fmt::Display for CancelableError<E>
 where
     E: fmt::Display,

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -1,6 +1,5 @@
 use crate::prelude::StoreError;
 use crate::util::error::CompatErr;
-use failure::Error;
 use futures::future::Fuse;
 use futures::prelude::{Future, Poll, Stream};
 use futures::sync::oneshot;
@@ -266,13 +265,6 @@ pub enum CancelableError<E: Display + Debug> {
 
     #[error("{0:}")]
     Error(E),
-}
-
-// TODO : comment out?
-impl<E: From<Error> + Display + Debug> From<Error> for CancelableError<E> {
-    fn from(e: Error) -> Self {
-        Self::Error(e.into())
-    }
 }
 
 impl From<crate::prelude::StoreError> for CancelableError<anyhow::Error> {

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -267,9 +267,24 @@ pub enum CancelableError<E: Display + Debug> {
     Error(E),
 }
 
-impl From<crate::prelude::StoreError> for CancelableError<anyhow::Error> {
+impl From<StoreError> for CancelableError<anyhow::Error> {
     fn from(e: StoreError) -> Self {
         Self::Error(failure::Error::from(e).compat_err())
+    }
+}
+
+impl From<CancelableError<anyhow::Error>> for CancelableError<StoreError> {
+    fn from(e: CancelableError<anyhow::Error>) -> Self {
+        match e {
+            CancelableError::Error(e) => CancelableError::Error(e.into()),
+            CancelableError::Cancel => CancelableError::Cancel,
+        }
+    }
+}
+
+impl From<StoreError> for CancelableError<StoreError> {
+    fn from(e: StoreError) -> Self {
+        Self::Error(e)
     }
 }
 

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -131,7 +131,7 @@ pub mod prelude {
         BlockHandlerFilter, CreateSubgraphResult, DataSource, DataSourceContext,
         DataSourceTemplate, DeploymentState, Link, MappingABI, MappingBlockHandler,
         MappingCallHandler, MappingEventHandler, SubgraphAssignmentProviderError,
-        SubgraphAssignmentProviderEvent, SubgraphDeploymentId, SubgraphManifest,
+        SubgraphAssignmentProviderEvent, SubgraphDeploymentId, SubgraphFeatures, SubgraphManifest,
         SubgraphManifestResolveError, SubgraphManifestValidationError, SubgraphName,
         SubgraphRegistrarError, UnvalidatedSubgraphManifest,
     };

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -54,6 +54,7 @@ pub mod prelude {
     pub use futures03::sink::SinkExt as _;
     pub use futures03::stream::{StreamExt as _, TryStreamExt};
     pub use hex;
+    pub use im;
     pub use lazy_static::lazy_static;
     pub use reqwest;
     pub use serde_derive::{Deserialize, Serialize};

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -29,6 +29,7 @@ pub use task_spawn::{
 };
 
 pub use bytes;
+pub use stable_hash;
 pub use url;
 
 /// A prelude that makes all system component traits and data types available.
@@ -71,7 +72,7 @@ pub mod prelude {
     pub use tokio;
     pub use web3;
 
-    pub type DynTryFuture<'a, Ok = (), Err = Error> =
+    pub type DynTryFuture<'a, Ok = (), Err = anyhow::Error> =
         Pin<Box<dyn futures03::Future<Output = Result<Ok, Err>> + Send + 'a>>;
 
     pub use crate::components::ethereum::{

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -133,7 +133,7 @@ pub mod prelude {
         BlockHandlerFilter, CreateSubgraphResult, DataSource, DataSourceContext,
         DataSourceTemplate, DeploymentState, Link, MappingABI, MappingBlockHandler,
         MappingCallHandler, MappingEventHandler, SubgraphAssignmentProviderError,
-        SubgraphAssignmentProviderEvent, SubgraphDeploymentId, SubgraphFeatures, SubgraphManifest,
+        SubgraphAssignmentProviderEvent, SubgraphDeploymentId, SubgraphManifest,
         SubgraphManifestResolveError, SubgraphManifestValidationError, SubgraphName,
         SubgraphRegistrarError, UnvalidatedSubgraphManifest,
     };

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -55,7 +55,6 @@ pub mod prelude {
     pub use futures03::sink::SinkExt as _;
     pub use futures03::stream::{StreamExt as _, TryStreamExt};
     pub use hex;
-    pub use im;
     pub use lazy_static::lazy_static;
     pub use reqwest;
     pub use serde_derive::{Deserialize, Serialize};

--- a/graph/src/util/lfu_cache.rs
+++ b/graph/src/util/lfu_cache.rs
@@ -58,7 +58,7 @@ type Priority = (bool, Reverse<u64>);
 /// of least frequency until the max weight is respected. This cache only removes entries on calls
 /// to `evict`, so the max weight may be exceeded until `evict` is called. Every STALE_PERIOD
 /// evictions entities are checked for staleness.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct LfuCache<K: Eq + Hash, V> {
     queue: PriorityQueue<CacheEntry<K, V>, Priority>,
     total_weight: usize,

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -49,15 +49,13 @@ fn insert_modifications() {
         "mogwai",
         vec![("id", "mogwai".into()), ("name", "Mogwai".into())],
     );
-    cache.set(mogwai_key.clone(), mogwai_data.clone()).unwrap();
+    cache.set(mogwai_key.clone(), mogwai_data.clone());
 
     let (sigurros_key, sigurros_data) = make_band(
         "sigurros",
         vec![("id", "sigurros".into()), ("name", "Sigur Ros".into())],
     );
-    cache
-        .set(sigurros_key.clone(), sigurros_data.clone())
-        .unwrap();
+    cache.set(sigurros_key.clone(), sigurros_data.clone());
 
     let result = cache.as_modifications(&*store);
     assert_eq!(
@@ -114,7 +112,7 @@ fn overwrite_modifications() {
             ("founded", 1995.into()),
         ],
     );
-    cache.set(mogwai_key.clone(), mogwai_data.clone()).unwrap();
+    cache.set(mogwai_key.clone(), mogwai_data.clone());
 
     let (sigurros_key, sigurros_data) = make_band(
         "sigurros",
@@ -124,9 +122,7 @@ fn overwrite_modifications() {
             ("founded", 1994.into()),
         ],
     );
-    cache
-        .set(sigurros_key.clone(), sigurros_data.clone())
-        .unwrap();
+    cache.set(sigurros_key.clone(), sigurros_data.clone());
 
     let result = cache.as_modifications(&*store);
     assert_eq!(
@@ -183,14 +179,14 @@ fn consecutive_modifications() {
             ("label", "Rock Action Records".into()),
         ],
     );
-    cache.set(update_key.clone(), update_data.clone()).unwrap();
+    cache.set(update_key.clone(), update_data.clone());
 
     // Then, just reset the "label".
     let (update_key, update_data) = make_band(
         "mogwai",
         vec![("id", "mogwai".into()), ("label", Value::Null)],
     );
-    cache.set(update_key.clone(), update_data.clone()).unwrap();
+    cache.set(update_key.clone(), update_data.clone());
 
     // We expect a single overwrite modification for the above that leaves "id"
     // and "name" untouched, sets "founded" and removes the "label" field.

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -487,11 +487,15 @@ pub async fn execute_root_selection_set<R: Resolver>(
         let query_text = execute_ctx.query.query_text.cheap_clone();
         let variables_text = execute_ctx.query.variables_text.cheap_clone();
         match graph::spawn_blocking_allow_panic(move || {
-            Arc::new(QueryResult::from(execute_root_selection_set_uncached(
+            let mut query_res = QueryResult::from(execute_root_selection_set_uncached(
                 &execute_ctx,
                 &execute_selection_set,
                 &execute_root_type,
-            )))
+            ));
+
+            // Unwrap: In practice should never fail, but if it does we will catch the panic.
+            execute_ctx.resolver.post_process(&mut query_res).unwrap();
+            Arc::new(query_res)
         })
         .await
         {

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -73,7 +73,7 @@ impl CacheWeight for WeightedResult {
 impl Default for WeightedResult {
     fn default() -> Self {
         WeightedResult {
-            result: Arc::new(QueryResult::new(vec![Arc::new(BTreeMap::default())])),
+            result: Arc::new(QueryResult::new(BTreeMap::default())),
             weight: 0,
         }
     }

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -2,8 +2,11 @@ use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 
 use crate::execution::ExecutionContext;
-use graph::data::graphql::{ext::DocumentExt, ObjectOrInterface};
-use graph::prelude::{QueryExecutionError, StoreEventStreamBox};
+use graph::prelude::{anyhow, QueryExecutionError, StoreEventStreamBox};
+use graph::{
+    data::graphql::{ext::DocumentExt, ObjectOrInterface},
+    prelude::QueryResult,
+};
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
 pub trait Resolver: Sized + Send + Sync + 'static {
@@ -113,5 +116,9 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         Err(QueryExecutionError::NotSupported(String::from(
             "Resolving field streams is not supported by this resolver",
         )))
+    }
+
+    fn post_process(&self, _result: &mut QueryResult) -> Result<(), anyhow::Error> {
+        Ok(())
     }
 }

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -149,12 +149,13 @@ where
         // Unwrap: There is always at least one block constraint, even if it
         // is an implicit 'BlockContraint::Latest'.
         let mut by_block_constraint = query.block_constraint()?.into_iter();
-        let (bc, selection_set) = by_block_constraint.next().unwrap();
+        let (bc, (selection_set, error_policy)) = by_block_constraint.next().unwrap();
 
         let resolver = StoreResolver::at_block(
             &self.logger,
             store.cheap_clone(),
             bc,
+            error_policy,
             query.schema.id().clone(),
         )
         .await?;
@@ -165,11 +166,12 @@ where
         // cloning the result. If there are multiple constraints we have to clone.
         if by_block_constraint.len() > 0 {
             let mut partial_res = result.as_ref().clone();
-            for (bc, selection_set) in by_block_constraint {
+            for (bc, (selection_set, error_policy)) in by_block_constraint {
                 let resolver = StoreResolver::at_block(
                     &self.logger,
                     store.cheap_clone(),
                     bc,
+                    error_policy,
                     query.schema.id().clone(),
                 )
                 .await?;

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -32,12 +32,6 @@ pub enum ErrorPolicy {
     Deny,
 }
 
-impl ErrorPolicy {
-    fn graphql_variants() -> [&'static str; 2] {
-        ["allow", "deny"]
-    }
-}
-
 impl std::str::FromStr for ErrorPolicy {
     type Err = anyhow::Error;
 
@@ -79,7 +73,6 @@ pub fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
     add_builtin_scalar_types(&mut schema)?;
     add_order_direction_enum(&mut schema);
     add_block_height_type(&mut schema);
-    add_subgraph_error_policy_type(&mut schema);
     add_meta_field_type(&mut schema);
     add_types_for_object_types(&mut schema, &object_types)?;
     add_types_for_interface_types(&mut schema, &interface_types)?;
@@ -211,26 +204,6 @@ fn add_block_height_type(schema: &mut Document) {
                 directives: vec![],
             },
         ],
-    });
-    let def = Definition::TypeDefinition(typedef);
-    schema.definitions.push(def);
-}
-
-fn add_subgraph_error_policy_type(schema: &mut Document) {
-    let typedef = TypeDefinition::Enum(EnumType {
-        position: Pos::default(),
-        description: None,
-        name: ERROR_POLICY_TYPE.to_string(),
-        directives: vec![],
-        values: ErrorPolicy::graphql_variants()
-            .iter()
-            .map(|name| EnumValue {
-                position: Pos::default(),
-                description: None,
-                name: name.to_string(),
-                directives: vec![],
-            })
-            .collect(),
     });
     let def = Definition::TypeDefinition(typedef);
     schema.definitions.push(def);

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -26,7 +26,7 @@ const BLOCK_HEIGHT: &str = "Block_height";
 
 const ERROR_POLICY_TYPE: &str = "_SubgraphErrorPolicy_";
 
-#[derive(PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum ErrorPolicy {
     Allow,
     Deny,
@@ -34,7 +34,7 @@ pub enum ErrorPolicy {
 
 impl ErrorPolicy {
     fn graphql_variants() -> [&'static str; 2] {
-        ["ALLOW", "DENY"]
+        ["allow", "deny"]
     }
 }
 
@@ -43,8 +43,8 @@ impl std::str::FromStr for ErrorPolicy {
 
     fn from_str(s: &str) -> Result<ErrorPolicy, anyhow::Error> {
         match s {
-            "ALLOW" => Ok(ErrorPolicy::Allow),
-            "DENY" => Ok(ErrorPolicy::Deny),
+            "allow" => Ok(ErrorPolicy::Allow),
+            "deny" => Ok(ErrorPolicy::Deny),
             _ => Err(anyhow::anyhow!("failed to parse `{}` as ErrorPolicy", s)),
         }
     }
@@ -679,7 +679,7 @@ fn subgraph_error_argument() -> InputValue {
         ),
         name: "subgraphError".to_string(),
         value_type: Type::NonNullType(Box::new(Type::NamedType(ERROR_POLICY_TYPE.to_string()))),
-        default_value: Some(Value::Enum("DENY".to_string())),
+        default_value: Some(Value::Enum("deny".to_string())),
         directives: vec![],
     }
 }
@@ -706,6 +706,7 @@ fn query_fields_for_type(schema: &Document, type_name: &Name) -> Vec<Field> {
                     directives: vec![],
                 },
                 block_argument(),
+                subgraph_error_argument(),
             ],
             field_type: Type::NamedType(type_name.to_owned()),
             directives: vec![],

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -542,14 +542,9 @@ fn query_field_for_fulltext(fulltext: &Directive) -> Option<Field> {
             directives: vec![],
         },
         // block: BlockHeight
-        InputValue {
-            position: Pos::default(),
-            description: None,
-            name: String::from("block"),
-            value_type: Type::NamedType(BLOCK_HEIGHT.to_string()),
-            default_value: None,
-            directives: vec![],
-        },
+        block_argument(),
+        // allowIndexingErrors: Boolean!
+        allow_indexing_errors_argument(),
     ];
     Some(Field {
         position: Pos::default(),
@@ -613,11 +608,26 @@ fn block_argument() -> InputValue {
     }
 }
 
+fn allow_indexing_errors_argument() -> InputValue {
+    InputValue {
+        position: Pos::default(),
+        description: Some(
+            "Set to `true` to receive data even if the subgraph has skipped over errors while syncing."
+                .to_owned(),
+        ),
+        name: "allowIndexingErrors".to_string(),
+        value_type: Type::NamedType("Boolean".to_string()),
+        default_value: Some(Value::Boolean(false)),
+        directives: vec![],
+    }
+}
+
 /// Generates `Query` fields for the given type name (e.g. `users` and `user`).
 fn query_fields_for_type(schema: &Document, type_name: &Name) -> Vec<Field> {
     let input_objects = ast::get_input_object_definitions(schema);
     let mut collection_arguments = collection_arguments_for_named_type(&input_objects, type_name);
     collection_arguments.push(block_argument());
+    collection_arguments.push(allow_indexing_errors_argument());
 
     vec![
         Field {
@@ -1014,7 +1024,8 @@ mod tests {
                 "orderBy",
                 "orderDirection",
                 "where",
-                "block"
+                "block",
+                "allowIndexingErrors"
             ]
             .iter()
             .map(|name| name.to_string())
@@ -1105,7 +1116,8 @@ mod tests {
                 "orderBy",
                 "orderDirection",
                 "where",
-                "block"
+                "block",
+                "allowIndexingErrors"
             ]
             .iter()
             .map(|name| name.to_string())

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -1059,7 +1059,11 @@ mod tests {
                 .iter()
                 .map(|input_value| input_value.name.to_owned())
                 .collect::<Vec<String>>(),
-            vec!["id".to_string(), "block".to_string()],
+            vec![
+                "id".to_string(),
+                "block".to_string(),
+                "subgraphError".to_string()
+            ],
         );
 
         let user_plural_field = match query_type {
@@ -1151,7 +1155,11 @@ mod tests {
                 .iter()
                 .map(|input_value| input_value.name.to_owned())
                 .collect::<Vec<String>>(),
-            vec!["id".to_string(), "block".to_string()],
+            vec![
+                "id".to_string(),
+                "block".to_string(),
+                "subgraphError".to_string()
+            ],
         );
 
         let plural_field = match query_type {

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -235,7 +235,7 @@ pub fn get_type_description(t: &TypeDefinition) -> &Option<String> {
 
 /// Returns the argument definitions for a field of an object type.
 pub fn get_argument_definitions<'a>(
-    object_type: &'a ObjectType,
+    object_type: impl Into<ObjectOrInterface<'a>>,
     name: &Name,
 ) -> Option<&'a Vec<InputValue>> {
     lazy_static! {

--- a/graphql/src/schema/meta.graphql
+++ b/graphql/src/schema/meta.graphql
@@ -2,18 +2,22 @@
 # colliding with user-supplied types
 "The type for the top-level _meta field"
 type _Meta_ {
-    """Information about a specific subgraph block. The hash of the block
-    will be null if the _meta field has a block constraint that asks for
-    a block number. It will be filled if the _meta field has no block constraint
-    and therefore asks for the latest  block"""
-    block: _Block_!
-    "The deployment ID"
-    deployment: String!
+  """
+  Information about a specific subgraph block. The hash of the block
+  will be null if the _meta field has a block constraint that asks for
+  a block number. It will be filled if the _meta field has no block constraint
+  and therefore asks for the latest  block
+  """
+  block: _Block_!
+  "The deployment ID"
+  deployment: String!
+  "If `true`, the subgraph encountered indexing errors at some past block"
+  hasIndexingErrors: Boolean!
 }
 
 type _Block_ {
-    "The hash of the block"
-    hash: Bytes
-    "The block number"
-    number: Int!
+  "The hash of the block"
+  hash: Bytes
+  "The block number"
+  number: Int!
 }

--- a/graphql/src/schema/meta.graphql
+++ b/graphql/src/schema/meta.graphql
@@ -21,3 +21,11 @@ type _Block_ {
   "The block number"
   number: Int!
 }
+
+enum _SubgraphErrorPolicy_ {
+  "Data will be returned even if the subgraph has indexing errors"
+  allow,
+
+  "If the subgraph has indexing errors, data will be omitted. The default."
+  deny
+}

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -764,31 +764,7 @@ fn execute_field(
     field: &q::Field,
     field_definition: &s::Field,
 ) -> Result<Vec<Node>, Vec<QueryExecutionError>> {
-    let argument_values = match object_type {
-        ObjectOrInterface::Object(object_type) => {
-            crate::execution::coerce_argument_values(ctx, object_type, field)
-        }
-        ObjectOrInterface::Interface(interface_type) => {
-            // This assumes that all implementations of the interface accept
-            // the same arguments for this field
-            match ctx
-                .query
-                .schema
-                .types_for_interface()
-                .get(&interface_type.name)
-                .expect("interface type exists")
-                .first()
-            {
-                Some(object_type) => {
-                    crate::execution::coerce_argument_values(ctx, &object_type, field)
-                }
-                None => {
-                    // Nobody is implementing this interface
-                    return Ok(vec![]);
-                }
-            }
-        }
-    }?;
+    let argument_values = crate::execution::coerce_argument_values(&ctx.query, object_type, field)?;
 
     let multiplicity = if sast::is_list_or_non_null_list_field(field_definition) {
         ChildMultiplicity::Many

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -116,7 +116,7 @@ fn create_source_event_stream(
 
     let fields = grouped_field_set.get_index(0).unwrap();
     let field = fields.1[0];
-    let argument_values = coerce_argument_values(&ctx, &subscription_type, field)?;
+    let argument_values = coerce_argument_values(&ctx.query, subscription_type.as_ref(), field)?;
 
     resolve_field_stream(ctx, &subscription_type, field, argument_values)
 }

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -92,6 +92,7 @@ fn insert_test_entities(store: &impl Store, id: SubgraphDeploymentId) {
         id: id.clone(),
         location: String::new(),
         spec_version: "1".to_owned(),
+        features: Default::default(),
         description: None,
         repository: None,
         schema: schema.clone(),

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -109,7 +109,7 @@ impl Store for MockStore {
         _block_ptr_to: EthereumBlockPointer,
         _mods: Vec<EntityModification>,
         _stopwatch: StopwatchMetrics,
-        _deterministic_errors: Vec<anyhow::Error>,
+        _deterministic_errors: Vec<SubgraphError>,
     ) -> Result<bool, StoreError> {
         unimplemented!()
     }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -108,6 +108,7 @@ impl Store for MockStore {
         _block_ptr_to: EthereumBlockPointer,
         _mods: Vec<EntityModification>,
         _stopwatch: StopwatchMetrics,
+        _deterministic_errors: Vec<anyhow::Error>,
     ) -> Result<bool, StoreError> {
         unimplemented!()
     }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -54,6 +54,7 @@ mock! {
     }
 }
 
+#[async_trait]
 impl Store for MockStore {
     fn block_ptr(
         &self,
@@ -148,6 +149,14 @@ impl Store for MockStore {
             max_reorg_depth: 0,
             latest_ethereum_block_number: 0,
         })
+    }
+
+    async fn fail_subgraph(
+        &self,
+        _: SubgraphDeploymentId,
+        _: SubgraphError,
+    ) -> Result<(), anyhow::Error> {
+        unimplemented!()
     }
 
     fn create_subgraph_deployment(

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -155,7 +155,7 @@ impl Store for MockStore {
         &self,
         _: SubgraphDeploymentId,
         _: SubgraphError,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), StoreError> {
         unimplemented!()
     }
 

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -48,7 +48,7 @@ impl From<failure::Error> for HostExportError {
 }
 
 pub(crate) struct HostExports {
-    subgraph_id: SubgraphDeploymentId,
+    pub(crate) subgraph_id: SubgraphDeploymentId,
     pub(crate) api_version: Version,
     data_source_name: String,
     data_source_address: Option<Address>,

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -592,12 +592,14 @@ impl HostExports {
             .clone();
 
         // Remember that we need to create this data source
-        state.created_data_sources.push(DataSourceTemplateInfo {
-            data_source: self.data_source_name.clone(),
-            template,
-            params,
-            context,
-        });
+        state
+            .created_data_sources
+            .push_back(DataSourceTemplateInfo {
+                data_source: self.data_source_name.clone(),
+                template,
+                params,
+                context,
+            });
 
         Ok(())
     }

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -189,7 +189,7 @@ impl HostExports {
         let entity = Entity::from(data);
         let schema = self.store.input_schema(&self.subgraph_id).compat()?;
         let is_valid = validate_entity(&schema.document, &key, &entity).is_ok();
-        state.entity_cache.set(key.clone(), entity).compat()?;
+        state.entity_cache.set(key.clone(), entity);
 
         // Validate the changes against the subgraph schema.
         // If the set of fields we have is already valid, avoid hitting the DB.
@@ -592,14 +592,12 @@ impl HostExports {
             .clone();
 
         // Remember that we need to create this data source
-        state
-            .created_data_sources
-            .push_back(DataSourceTemplateInfo {
-                data_source: self.data_source_name.clone(),
-                template,
-                params,
-                context,
-            });
+        state.push_created_data_source(DataSourceTemplateInfo {
+            data_source: self.data_source_name.clone(),
+            template,
+            params,
+            context,
+        });
 
         Ok(())
     }

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -245,9 +245,9 @@ impl WasmInstance {
         };
 
         if let Some(deterministic_error) = deterministic_error {
-            // Log the error and restore the updates snaphsot, effectively skipping the handler.
+            // Log the error and restore the updates snaphsot, effectively reverting the handler.
             error!(&self.instance_ctx().ctx.logger,
-                "Handler skipped due to execution failure";
+                "Handler reverted";
                 "error" => deterministic_error.to_string()
             );
             self.instance_ctx_mut()

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -250,7 +250,7 @@ impl WasmInstance {
         if let Some(deterministic_error) = deterministic_error {
             // Log the error and restore the updates snaphsot, effectively reverting the handler.
             error!(&self.instance_ctx().ctx.logger,
-                "Handler reverted";
+                "Handler skipped due to execution failure";
                 "handler" => handler,
                 "error" => format!("{:#}", deterministic_error)
             );

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -9,6 +9,7 @@ use graph::components::store::*;
 use graph::data::store::scalar;
 use graph::data::subgraph::*;
 use graph::mock::MockEthereumAdapter;
+use graph::prelude::im;
 use graph_chain_arweave::adapter::ArweaveAdapter;
 use graph_core;
 use graph_core::three_box::ThreeBoxAdapter;
@@ -575,19 +576,20 @@ async fn bytes_to_base58() {
 
 #[tokio::test]
 async fn data_source_create() {
-    let run_data_source_create = move |name: String,
-                                       params: Vec<String>|
-          -> Result<Vec<DataSourceTemplateInfo>, wasmtime::Trap> {
-        let mut module = test_module(
-            "DataSourceCreate",
-            mock_data_source("wasm_test/data_source_create.wasm"),
-        );
+    let run_data_source_create =
+        move |name: String,
+              params: Vec<String>|
+              -> Result<im::Vector<DataSourceTemplateInfo>, wasmtime::Trap> {
+            let mut module = test_module(
+                "DataSourceCreate",
+                mock_data_source("wasm_test/data_source_create.wasm"),
+            );
 
-        let name = module.asc_new(&name);
-        let params = module.asc_new(&*params);
-        module.invoke_export2_void("dataSourceCreate", name, params)?;
-        Ok(module.take_ctx().ctx.state.created_data_sources)
-    };
+            let name = module.asc_new(&name);
+            let params = module.asc_new(&*params);
+            module.invoke_export2_void("dataSourceCreate", name, params)?;
+            Ok(module.take_ctx().ctx.state.created_data_sources)
+        };
 
     // Test with a valid template
     let data_source = String::from("example data source");

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -9,7 +9,6 @@ use graph::components::store::*;
 use graph::data::store::scalar;
 use graph::data::subgraph::*;
 use graph::mock::MockEthereumAdapter;
-use graph::prelude::im;
 use graph_chain_arweave::adapter::ArweaveAdapter;
 use graph_core;
 use graph_core::three_box::ThreeBoxAdapter;
@@ -576,20 +575,21 @@ async fn bytes_to_base58() {
 
 #[tokio::test]
 async fn data_source_create() {
-    let run_data_source_create =
-        move |name: String,
-              params: Vec<String>|
-              -> Result<im::Vector<DataSourceTemplateInfo>, wasmtime::Trap> {
-            let mut module = test_module(
-                "DataSourceCreate",
-                mock_data_source("wasm_test/data_source_create.wasm"),
-            );
+    let run_data_source_create = move |name: String,
+                                       params: Vec<String>|
+          -> Result<Vec<DataSourceTemplateInfo>, wasmtime::Trap> {
+        let mut module = test_module(
+            "DataSourceCreate",
+            mock_data_source("wasm_test/data_source_create.wasm"),
+        );
 
-            let name = module.asc_new(&name);
-            let params = module.asc_new(&*params);
-            module.invoke_export2_void("dataSourceCreate", name, params)?;
-            Ok(module.take_ctx().ctx.state.created_data_sources)
-        };
+        let name = module.asc_new(&name);
+        let params = module.asc_new(&*params);
+        module.instance_ctx_mut().ctx.state.enter_handler();
+        module.invoke_export2_void("dataSourceCreate", name, params)?;
+        module.instance_ctx_mut().ctx.state.exit_handler();
+        Ok(module.take_ctx().ctx.state.drain_created_data_sources())
+    };
 
     // Test with a valid template
     let data_source = String::from("example data source");

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -252,7 +252,7 @@ where
 
         let result = match query {
             Ok(query) => service.graphql_runner.run_query(query, state, false).await,
-            Err(GraphQLServerError::QueryError(e)) => Arc::new(QueryResult::from(e)),
+            Err(GraphQLServerError::QueryError(e)) => QueryResult::from(e).into(),
             Err(e) => return Err(e),
         };
 
@@ -431,7 +431,7 @@ mod tests {
     use hyper::{Body, Method, Request};
     use std::collections::BTreeMap;
 
-    use graph::data::graphql::effort::LoadManager;
+    use graph::data::{graphql::effort::LoadManager, query::QueryResults};
     use graph::prelude::*;
     use graph_mock::{mock_store_with_users_subgraph, MockMetricsRegistry};
     use graphql_parser::query as q;
@@ -455,7 +455,7 @@ mod tests {
             _max_first: Option<u32>,
             _max_skip: Option<u32>,
             _nested_resolver: bool,
-        ) -> Arc<QueryResult> {
+        ) -> QueryResults {
             unimplemented!();
         }
 
@@ -464,14 +464,14 @@ mod tests {
             _query: Query,
             _state: DeploymentState,
             _: bool,
-        ) -> Arc<QueryResult> {
-            Arc::new(QueryResult::new(vec![Arc::new(BTreeMap::from_iter(
+        ) -> QueryResults {
+            QueryResults::from(BTreeMap::from_iter(
                 vec![(
                     String::from("name"),
                     q::Value::String(String::from("Jordi")),
                 )]
                 .into_iter(),
-            ))]))
+            ))
         }
 
         async fn run_subscription(

--- a/server/http/tests/response.rs
+++ b/server/http/tests/response.rs
@@ -1,4 +1,4 @@
-use graph::data::graphql::object;
+use graph::data::{graphql::object, query::QueryResults};
 use graph::prelude::*;
 use graph_server_http::test_utils;
 use graphql_parser::{self, query as q};
@@ -7,14 +7,14 @@ use std::collections::BTreeMap;
 #[test]
 fn generates_200_for_query_results() {
     let data = BTreeMap::new();
-    let query_result = QueryResult::from(data).as_http_response();
+    let query_result = QueryResults::from(data).as_http_response();
     test_utils::assert_successful_response(query_result);
 }
 
 #[test]
 fn generates_valid_json_for_an_empty_result() {
     let data = BTreeMap::new();
-    let query_result = QueryResult::from(data).as_http_response();
+    let query_result = QueryResults::from(data).as_http_response();
     let data = test_utils::assert_successful_response(query_result);
     assert!(data.is_empty());
 }

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -4,7 +4,7 @@ use hyper::{Body, Client, Request};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use graph::data::graphql::effort::LoadManager;
+use graph::data::{graphql::effort::LoadManager, query::QueryResults};
 use graph::prelude::*;
 
 use graph_server_http::test_utils;
@@ -26,7 +26,7 @@ impl GraphQlRunner for TestGraphQlRunner {
         _max_first: Option<u32>,
         _max_skip: Option<u32>,
         _nested_resolver: bool,
-    ) -> Arc<QueryResult> {
+    ) -> QueryResults {
         unimplemented!();
     }
 
@@ -35,36 +35,34 @@ impl GraphQlRunner for TestGraphQlRunner {
         query: Query,
         _state: DeploymentState,
         _: bool,
-    ) -> Arc<QueryResult> {
-        Arc::new(QueryResult::new(vec![Arc::new(
-            if query.variables.is_some()
-                && query
-                    .variables
-                    .as_ref()
-                    .unwrap()
-                    .get(&String::from("equals"))
-                    .is_some()
-                && query
-                    .variables
-                    .unwrap()
-                    .get(&String::from("equals"))
-                    .unwrap()
-                    == &q::Value::String(String::from("John"))
-            {
-                BTreeMap::from_iter(
-                    vec![(String::from("name"), q::Value::String(String::from("John")))]
-                        .into_iter(),
-                )
-            } else {
-                BTreeMap::from_iter(
-                    vec![(
-                        String::from("name"),
-                        q::Value::String(String::from("Jordi")),
-                    )]
-                    .into_iter(),
-                )
-            },
-        )]))
+    ) -> QueryResults {
+        if query.variables.is_some()
+            && query
+                .variables
+                .as_ref()
+                .unwrap()
+                .get(&String::from("equals"))
+                .is_some()
+            && query
+                .variables
+                .unwrap()
+                .get(&String::from("equals"))
+                .unwrap()
+                == &q::Value::String(String::from("John"))
+        {
+            BTreeMap::from_iter(
+                vec![(String::from("name"), q::Value::String(String::from("John")))].into_iter(),
+            )
+        } else {
+            BTreeMap::from_iter(
+                vec![(
+                    String::from("name"),
+                    q::Value::String(String::from("Jordi")),
+                )]
+                .into_iter(),
+            )
+        }
+        .into()
     }
 
     async fn run_subscription(

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -4,8 +4,8 @@ use hyper::{Body, Method, Request, Response, StatusCode};
 use std::task::Context;
 use std::task::Poll;
 
-use graph::components::server::query::GraphQLServerError;
 use graph::prelude::*;
+use graph::{components::server::query::GraphQLServerError, data::query::QueryResults};
 use graph_graphql::prelude::{execute_query, Query as PreparedQuery, QueryExecutionOptions};
 
 use crate::request::IndexNodeRequest;
@@ -92,7 +92,7 @@ where
         let query = IndexNodeRequest::new(body, schema).compat().await?;
         let query = match PreparedQuery::new(&self.logger, query, None, 100) {
             Ok(query) => query,
-            Err(e) => return Ok(QueryResult::from(e).as_http_response()),
+            Err(e) => return Ok(QueryResults::from(QueryResult::from(e)).as_http_response()),
         };
 
         let graphql_runner = graphql_runner.clone();
@@ -117,7 +117,7 @@ where
             )
         };
 
-        Ok(result.as_http_response())
+        Ok(QueryResults::from(result).as_http_response())
     }
 
     // Handles OPTIONS requests

--- a/store/postgres/migrations/2020-11-10-100000_last_healthy_block/down.sql
+++ b/store/postgres/migrations/2020-11-10-100000_last_healthy_block/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE subgraphs.subgraph_error DROP COLUMN last_healthy_ethereum_block_hash;
+ALTER TABLE subgraphs.subgraph_error DROP COLUMN last_healthy_ethereum_block_number;

--- a/store/postgres/migrations/2020-11-10-100000_last_healthy_block/up.sql
+++ b/store/postgres/migrations/2020-11-10-100000_last_healthy_block/up.sql
@@ -1,0 +1,9 @@
+alter table
+    subgraphs.subgraph_deployment
+add
+    column last_healthy_ethereum_block_hash bytea;
+
+alter table
+    subgraphs.subgraph_deployment
+add
+    column last_healthy_ethereum_block_number numeric;

--- a/store/postgres/migrations/2020-12-7-190800_subgraph_error_changes/down.sql
+++ b/store/postgres/migrations/2020-12-7-190800_subgraph_error_changes/down.sql
@@ -1,0 +1,4 @@
+alter table
+    subgraphs.subgraph_error
+drop
+    column created_at;

--- a/store/postgres/migrations/2020-12-7-190800_subgraph_error_changes/up.sql
+++ b/store/postgres/migrations/2020-12-7-190800_subgraph_error_changes/up.sql
@@ -6,4 +6,4 @@ drop
 alter table
     subgraphs.subgraph_error
 add
-    column created_at timestamp NOT NULL DEFAULT (now() at time zone 'utc');
+    column created_at timestamptz NOT NULL DEFAULT now();

--- a/store/postgres/migrations/2020-12-7-190800_subgraph_error_changes/up.sql
+++ b/store/postgres/migrations/2020-12-7-190800_subgraph_error_changes/up.sql
@@ -1,0 +1,9 @@
+alter table
+    subgraphs.subgraph_error
+drop
+    column block_number;
+
+alter table
+    subgraphs.subgraph_error
+add
+    column created_at timestamp NOT NULL DEFAULT (now() at time zone 'utc');

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -49,6 +49,20 @@ fn clone_bound(bound: Bound<&BlockNumber>) -> Bound<BlockNumber> {
     }
 }
 
+pub(crate) fn first_block_in_range(
+    bound: &(Bound<BlockNumber>, Bound<BlockNumber>),
+) -> Option<BlockNumber> {
+    if bound == &UNVERSIONED_RANGE {
+        return None;
+    }
+
+    match bound.0 {
+        Bound::Included(nr) => Some(nr),
+        Bound::Excluded(nr) => Some(nr + 1),
+        Bound::Unbounded => None,
+    }
+}
+
 /// Return the block number contained in the history event. If it is
 /// `None` panic because that indicates that we want to perform an
 /// operation that does not record history, which should not happen

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -90,7 +90,6 @@ struct ErrorDetail {
     id: String,
     subgraph_id: String,
     message: String,
-    block_number: Option<BigDecimal>,
     block_hash: Option<Bytes>,
     handler: Option<String>,
     deterministic: bool,
@@ -135,12 +134,12 @@ impl TryFrom<ErrorDetail> for SubgraphError {
             id: _,
             subgraph_id,
             message,
-            block_number,
             block_hash,
             handler,
             deterministic,
-            block_range: _,
+            block_range,
         } = value;
+        let block_number = crate::block_range::first_block_in_range(&block_range).map(|n| n.into());
         let block_ptr = block(&subgraph_id, "fatal_error", block_hash, block_number)?
             .map(|block| block.to_ptr());
         let subgraph_id = SubgraphDeploymentId::new(subgraph_id).map_err(|id| {

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -773,6 +773,7 @@ pub fn delete_all_entities_for_test_use_only(
         delete from subgraphs.ethereum_contract_data_source_template;
         delete from subgraphs.ethereum_contract_data_source_template_source;
         delete from subgraphs.ethereum_contract_event_handler;
+        delete from subgraphs.subgraph_error;
     ";
     conn.batch_execute(query)?;
     store.clear_storage_cache();

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -773,7 +773,6 @@ pub fn delete_all_entities_for_test_use_only(
         delete from subgraphs.ethereum_contract_data_source_template;
         delete from subgraphs.ethereum_contract_data_source_template_source;
         delete from subgraphs.ethereum_contract_event_handler;
-        delete from subgraphs.subgraph_error;
     ";
     conn.batch_execute(query)?;
     store.clear_storage_cache();

--- a/store/postgres/src/metadata.rs
+++ b/store/postgres/src/metadata.rs
@@ -105,7 +105,7 @@ table! {
     subgraphs.subgraph_error (vid) {
         vid -> BigInt,
         id -> Text,
-        subgraph_id -> Nullable<Text>,
+        subgraph_id -> Text,
         message -> Text,
         block_number -> Nullable<Numeric>,
         block_hash -> Nullable<Binary>,

--- a/store/postgres/src/metadata.rs
+++ b/store/postgres/src/metadata.rs
@@ -914,3 +914,66 @@ pub(crate) fn revert_subgraph_errors(
 
     check_health(conn, id)
 }
+
+#[test]
+fn subgraph_error() {
+    use diesel::Connection;
+    use subgraph_error as e;
+
+    test_store::run_test_sequentially(
+        || {},
+        |store, _| async move {
+            let url = test_store::postgres_test_url();
+            let conn = PgConnection::establish(url.as_str()).unwrap();
+
+            let subgraph_id = SubgraphDeploymentId::new("testSubgraph").unwrap();
+            test_store::create_test_subgraph(&subgraph_id, "type Foo { id: ID! }");
+
+            let error = SubgraphError {
+                subgraph_id: subgraph_id.clone(),
+                message: "test".to_string(),
+                block_ptr: None,
+                handler: None,
+                deterministic: false,
+            };
+
+            let count = || -> i64 {
+                e::table
+                    .filter(e::subgraph_id.eq(subgraph_id.as_str()))
+                    .count()
+                    .get_result(&conn)
+                    .unwrap()
+            };
+
+            assert!(count() == 0);
+
+            crate::metadata::insert_subgraph_error(&conn, error).unwrap();
+            assert!(count() == 1);
+
+            let error = SubgraphError {
+                subgraph_id: subgraph_id.clone(),
+                message: "test".to_string(),
+                block_ptr: None,
+                handler: None,
+                deterministic: false,
+            };
+
+            // Inserting the same error is allowed but ignored.
+            crate::metadata::insert_subgraph_error(&conn, error).unwrap();
+            assert!(count() == 1);
+
+            let error2 = SubgraphError {
+                subgraph_id: subgraph_id.clone(),
+                message: "test2".to_string(),
+                block_ptr: None,
+                handler: None,
+                deterministic: false,
+            };
+
+            crate::metadata::insert_subgraph_error(&conn, error2).unwrap();
+            assert!(count() == 2);
+
+            test_store::delete_all_entities_for_test_use_only(store.as_ref(), &conn).unwrap();
+        },
+    )
+}

--- a/store/postgres/src/metadata.rs
+++ b/store/postgres/src/metadata.rs
@@ -898,7 +898,7 @@ pub(crate) fn revert_subgraph_errors(
     delete(
         e::table
             .filter(e::subgraph_id.eq(id.as_str()))
-            .filter(sql("lower(block_range) >= $1").bind::<Integer, _>(reverted_block)),
+            .filter(sql("lower(block_range) >= ").bind::<Integer, _>(reverted_block)),
     )
     .execute(conn)?;
 

--- a/store/postgres/src/metadata.rs
+++ b/store/postgres/src/metadata.rs
@@ -107,7 +107,6 @@ table! {
         id -> Text,
         subgraph_id -> Text,
         message -> Text,
-        block_number -> Nullable<Numeric>,
         block_hash -> Nullable<Binary>,
         handler -> Nullable<Text>,
         deterministic -> Bool,
@@ -788,7 +787,6 @@ fn insert_subgraph_error(conn: &PgConnection, error: SubgraphError) -> anyhow::R
             e::handler.eq(handler),
             e::deterministic.eq(deterministic),
             e::block_hash.eq(block_ptr.as_ref().map(|ptr| ptr.hash.as_bytes())),
-            e::block_number.eq(sql(&format!("{}::numeric", block_num))),
             e::block_range.eq((Bound::Included(block_num), Bound::Unbounded)),
         ))
         .on_conflict_do_nothing()

--- a/store/postgres/src/network_store.rs
+++ b/store/postgres/src/network_store.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use graph::{
+    data::subgraph::schema::SubgraphError,
     data::subgraph::status,
     prelude::{
         anyhow, ethabi,
@@ -51,6 +52,7 @@ impl NetworkStore {
     }
 }
 
+#[async_trait::async_trait]
 impl StoreTrait for NetworkStore {
     fn block_ptr(
         &self,
@@ -170,6 +172,14 @@ impl StoreTrait for NetworkStore {
         id: graph::prelude::SubgraphDeploymentId,
     ) -> Result<graph::prelude::DeploymentState, graph::prelude::StoreError> {
         self.store.deployment_state_from_id(id)
+    }
+
+    async fn fail_subgraph(
+        &self,
+        id: SubgraphDeploymentId,
+        error: SubgraphError,
+    ) -> Result<(), anyhow::Error> {
+        self.store.fail_subgraph(id, error).await
     }
 
     fn create_subgraph_deployment(

--- a/store/postgres/src/network_store.rs
+++ b/store/postgres/src/network_store.rs
@@ -4,7 +4,7 @@ use graph::{
     data::subgraph::schema::SubgraphError,
     data::subgraph::status,
     prelude::{
-        anyhow, ethabi,
+        ethabi,
         web3::types::{Address, H256},
         BlockNumber, ChainHeadUpdateStream, ChainStore as ChainStoreTrait, CheapClone, Error,
         EthereumBlock, EthereumBlockPointer, EthereumCallCache, Future, LightEthereumBlock, NodeId,
@@ -178,7 +178,7 @@ impl StoreTrait for NetworkStore {
         &self,
         id: SubgraphDeploymentId,
         error: SubgraphError,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), StoreError> {
         self.store.fail_subgraph(id, error).await
     }
 

--- a/store/postgres/src/network_store.rs
+++ b/store/postgres/src/network_store.rs
@@ -123,7 +123,7 @@ impl StoreTrait for NetworkStore {
         block_ptr_to: EthereumBlockPointer,
         mods: Vec<graph::prelude::EntityModification>,
         stopwatch: graph::prelude::StopwatchMetrics,
-        deterministic_errors: Vec<anyhow::Error>,
+        deterministic_errors: Vec<SubgraphError>,
     ) -> Result<bool, graph::prelude::StoreError> {
         self.store.transact_block_operations(
             subgraph_id,

--- a/store/postgres/src/network_store.rs
+++ b/store/postgres/src/network_store.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use graph::{
     data::subgraph::status,
     prelude::{
-        ethabi,
+        anyhow, ethabi,
         web3::types::{Address, H256},
         BlockNumber, ChainHeadUpdateStream, ChainStore as ChainStoreTrait, CheapClone, Error,
         EthereumBlock, EthereumBlockPointer, EthereumCallCache, Future, LightEthereumBlock, NodeId,
@@ -121,9 +121,15 @@ impl StoreTrait for NetworkStore {
         block_ptr_to: EthereumBlockPointer,
         mods: Vec<graph::prelude::EntityModification>,
         stopwatch: graph::prelude::StopwatchMetrics,
+        deterministic_errors: Vec<anyhow::Error>,
     ) -> Result<bool, graph::prelude::StoreError> {
-        self.store
-            .transact_block_operations(subgraph_id, block_ptr_to, mods, stopwatch)
+        self.store.transact_block_operations(
+            subgraph_id,
+            block_ptr_to,
+            mods,
+            stopwatch,
+            deterministic_errors,
+        )
     }
 
     fn apply_metadata_operations(

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -72,7 +72,7 @@ impl QueryStoreTrait for QueryStore {
         &self,
         id: SubgraphDeploymentId,
         block: Option<BlockNumber>,
-    ) -> Result<bool, anyhow::Error> {
+    ) -> Result<bool, StoreError> {
         self.store
             .with_conn(move |conn, _| {
                 crate::metadata::has_non_fatal_errors(conn, &id, block).map_err(|e| e.into())

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -26,6 +26,7 @@ impl QueryStore {
     }
 }
 
+#[async_trait]
 impl QueryStoreTrait for QueryStore {
     fn find_query_values(
         &self,
@@ -65,5 +66,17 @@ impl QueryStoreTrait for QueryStore {
 
     fn wait_stats(&self) -> &PoolWaitStats {
         self.store.wait_stats(self.replica_id)
+    }
+
+    async fn has_non_fatal_errors(
+        &self,
+        id: SubgraphDeploymentId,
+        block: Option<BlockNumber>,
+    ) -> Result<bool, anyhow::Error> {
+        self.store
+            .with_conn(move |conn, _| {
+                crate::metadata::has_non_fatal_errors(conn, &id, block).map_err(|e| e.into())
+            })
+            .await
     }
 }

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -841,6 +841,9 @@ impl Layout {
                 changes.extend(deleted);
             }
         }
+
+        crate::metadata::revert_subgraph_errors(conn, &self.subgraph, block)?;
+
         Ok(StoreEvent::new(changes))
     }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -521,7 +521,7 @@ impl Store {
     ///   * This task will panic if the supplied closure panics
     ///   * This task will panic if the supplied closure returns Err(Cancelled)
     ///     when the supplied cancel token is not cancelled.
-    async fn with_conn<T: Send + 'static>(
+    pub(crate) async fn with_conn<T: Send + 'static>(
         &self,
         f: impl 'static
             + Send

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -26,7 +26,7 @@ use graph::data::subgraph::schema::{
     SubgraphDeploymentEntity, TypedEntity as _, POI_OBJECT, SUBGRAPHS_ID,
 };
 use graph::prelude::{
-    debug, ethabi, format_err, futures03, info, o, tiny_keccak, tokio, trace, warn, web3,
+    anyhow, debug, ethabi, format_err, futures03, info, o, tiny_keccak, tokio, trace, warn, web3,
     ApiSchema, BigInt, BlockNumber, CheapClone, DeploymentState, DynTryFuture, Entity, EntityKey,
     EntityModification, EntityOrder, EntityQuery, EntityRange, Error, EthereumBlockPointer,
     EthereumCallCache, Logger, MetadataOperation, MetricsRegistry, QueryExecutionError, Schema,
@@ -1049,6 +1049,7 @@ impl StoreTrait for Store {
         block_ptr_to: EthereumBlockPointer,
         mods: Vec<EntityModification>,
         stopwatch: StopwatchMetrics,
+        deterministic_errors: Vec<anyhow::Error>,
     ) -> Result<bool, StoreError> {
         // All operations should apply only to entities in this subgraph or
         // the subgraph of subgraphs
@@ -1089,6 +1090,10 @@ impl StoreTrait for Store {
                 let section = stopwatch.start_section("apply_entity_modifications");
                 self.apply_entity_modifications(&econn, mods, Some(&block_ptr_to), stopwatch)?;
                 section.end();
+
+                if !deterministic_errors.is_empty() {
+                    metadata::set_unhealthy(&econn.conn, &subgraph_id, block_ptr_to)?;
+                }
 
                 let metadata_event =
                     metadata::forward_block_ptr(&econn.conn, &subgraph_id, block_ptr_to)?;

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -38,6 +38,11 @@ type SubgraphDeployment @entity {
     earliestEthereumBlockNumber: BigInt
     latestEthereumBlockHash: Bytes
     latestEthereumBlockNumber: BigInt
+
+    # Null if still healthy.
+    lastHealthyEthereumBlockHash: Bytes
+    lastHealthyEthereumBlockNumber: BigInt
+
     entityCount: BigInt!
     dynamicDataSources: [DynamicEthereumContractDataSource!] @derivedFrom(field: "deployment")
     graftBase: SubgraphDeployment

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -122,6 +122,7 @@ fn insert_test_data(store: Arc<DieselStore>) {
         id: TEST_SUBGRAPH_ID.clone(),
         location: "/ipfs/test".to_owned(),
         spec_version: "1".to_owned(),
+        features: Default::default(),
         description: None,
         repository: None,
         schema: TEST_SUBGRAPH_SCHEMA.clone(),

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -155,6 +155,7 @@ fn insert_test_data(store: Arc<DieselStore>) {
         id: TEST_SUBGRAPH_ID.clone(),
         location: "/ipfs/test".to_owned(),
         spec_version: "1".to_owned(),
+        features: Default::default(),
         description: None,
         repository: None,
         schema: TEST_SUBGRAPH_SCHEMA.clone(),
@@ -1613,6 +1614,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             id: subgraph_id.clone(),
             location: "/ipfs/test".to_owned(),
             spec_version: "1".to_owned(),
+            features: Default::default(),
             description: None,
             repository: None,
             schema: schema.clone(),
@@ -1956,6 +1958,7 @@ fn handle_large_string_with_index() {
                     make_insert_op(TWO, &other_text),
                 ],
                 stopwatch_metrics,
+                Vec::new(),
             )
             .expect("Failed to insert large text");
 

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -146,6 +146,7 @@ fn create_subgraph() {
             id: id.clone(),
             location: String::new(),
             spec_version: "1".to_owned(),
+            features: Default::default(),
             description: None,
             repository: None,
             schema: schema.clone(),

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -15,6 +15,7 @@ use graph_store_postgres::{
 };
 use hex_literal::hex;
 use lazy_static::lazy_static;
+use std::collections::BTreeSet;
 use std::env;
 use std::sync::Mutex;
 use std::time::Instant;
@@ -148,6 +149,7 @@ fn create_subgraph(
         id: subgraph_id.clone(),
         location: String::new(),
         spec_version: "1".to_owned(),
+        features: BTreeSet::new(),
         description: None,
         repository: None,
         schema: schema.clone(),

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -23,6 +23,9 @@ use std::sync::Mutex;
 use std::time::Instant;
 use web3::types::H256;
 
+#[cfg(debug_assertions)]
+pub use graph_store_postgres::store::delete_all_entities_for_test_use_only;
+
 pub fn postgres_test_url() -> String {
     std::env::var_os("THEGRAPH_STORE_POSTGRES_DIESEL_URL")
         .expect("The THEGRAPH_STORE_POSTGRES_DIESEL_URL environment variable is not set")

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -222,7 +222,7 @@ pub fn transact_entity_operations(
     ops: Vec<EntityOperation>,
 ) -> Result<bool, StoreError> {
     let mut entity_cache = EntityCache::new(store.clone());
-    entity_cache.append(ops)?;
+    entity_cache.append(ops);
     let mods = entity_cache
         .as_modifications(store.as_ref())
         .expect("failed to convert to modifications")

--- a/store/test-store/src/lib.rs
+++ b/store/test-store/src/lib.rs
@@ -208,7 +208,13 @@ pub fn transact_entity_operations(
         subgraph_id.clone(),
         metrics_registry.clone(),
     );
-    store.transact_block_operations(subgraph_id, block_ptr_to, mods, stopwatch_metrics)
+    store.transact_block_operations(
+        subgraph_id,
+        block_ptr_to,
+        mods,
+        stopwatch_metrics,
+        Vec::new(),
+    )
 }
 
 pub fn insert_ens_name(hash: &str, name: &str) {

--- a/tests/integration-tests/data-source-context/subgraph.yaml
+++ b/tests/integration-tests/data-source-context/subgraph.yaml
@@ -1,5 +1,4 @@
 specVersion: 0.0.2
-features
 schema:
   file: ./schema.graphql
 dataSources:

--- a/tests/integration-tests/non-fatal-errors/abis/Contract.abi
+++ b/tests/integration-tests/non-fatal-errors/abis/Contract.abi
@@ -1,0 +1,1 @@
+[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint16","name":"x","type":"uint16"}],"name":"Trigger","type":"event"},{"inputs":[{"internalType":"uint16","name":"x","type":"uint16"}],"name":"emitTrigger","outputs":[],"stateMutability":"nonpayable","type":"function"}]

--- a/tests/integration-tests/non-fatal-errors/package.json
+++ b/tests/integration-tests/non-fatal-errors/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "non-fatal-errors",
+  "version": "0.1.0",
+  "scripts": {
+    "build-contracts": "rm -rf abis bin && solcjs ../common/SimpleContract.sol --abi -o abis && mv abis/*Contract.abi abis/Contract.abi && solcjs ../common/SimpleContract.sol --bin -o bin && mv bin/*Contract.bin bin/Contract.bin",
+    "codegen": "graph codegen",
+    "test": "yarn build-contracts && truffle test --network test",
+    "create:test": "graph create test/remove-then-update --node http://localhost:18020/",
+    "deploy:test": "graph deploy test/remove-then-update --ipfs http://localhost:15001/ --node http://localhost:18020/"
+  },
+  "devDependencies": {
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#leo/experimental-features",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "solc": "^0.6.1"
+  },
+  "dependencies": {
+    "apollo-fetch": "^0.7.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-register": "^6.26.0",
+    "gluegun": "^3.2.1",
+    "truffle": "^5.0.4",
+    "truffle-contract": "^4.0.5",
+    "truffle-hdwallet-provider": "^1.0.4"
+  }
+}

--- a/tests/integration-tests/non-fatal-errors/package.json
+++ b/tests/integration-tests/non-fatal-errors/package.json
@@ -9,7 +9,7 @@
     "deploy:test": "graph deploy test/remove-then-update --ipfs http://localhost:15001/ --node http://localhost:18020/"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#leo/experimental-features",
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
     "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
     "solc": "^0.6.1"
   },

--- a/tests/integration-tests/non-fatal-errors/schema.graphql
+++ b/tests/integration-tests/non-fatal-errors/schema.graphql
@@ -1,0 +1,3 @@
+type Foo @entity {
+  id: ID!
+}

--- a/tests/integration-tests/non-fatal-errors/src/mapping.ts
+++ b/tests/integration-tests/non-fatal-errors/src/mapping.ts
@@ -1,0 +1,41 @@
+import {
+  DataSourceContext,
+  Address,
+  dataSource,
+} from "@graphprotocol/graph-ts";
+import { Foo } from "../generated/schema";
+import { ethereum } from "@graphprotocol/graph-ts/chain/ethereum";
+import { Dynamic } from "../generated/templates";
+
+export function handleBlockSuccess(block: ethereum.Block): void {
+  let obj = new Foo("0");
+  obj.save();
+  let context = new DataSourceContext();
+  context.setString("id", "00");
+  Dynamic.createWithContext(
+    Address.fromHexString(
+      "0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"
+    ) as Address,
+    context
+  );
+}
+
+export function handleBlockError(block: ethereum.Block): void {
+  let obj = new Foo("1");
+  obj.save();
+  let context = new DataSourceContext();
+  context.setString("id", "11");
+  Dynamic.createWithContext(
+    Address.fromHexString(
+      "0x3E645469f354BB4F5c8a05B3b30A929361cf77eD"
+    ) as Address,
+    context
+  );
+  assert(false);
+}
+
+export function handleBlockTemplate(block: ethereum.Block): void {
+  let id = dataSource.context().getString("id");
+  let obj = new Foo(id);
+  obj.save();
+}

--- a/tests/integration-tests/non-fatal-errors/subgraph.yaml
+++ b/tests/integration-tests/non-fatal-errors/subgraph.yaml
@@ -1,10 +1,11 @@
 specVersion: 0.0.2
-features
 schema:
   file: ./schema.graphql
+features:
+  - nonFatalErrors
 dataSources:
   - kind: ethereum/contract
-    name: Contract
+    name: Success
     network: test
     source:
       address: "0xCfEB869F69431e42cdB54A4F4f105C19C080A601"
@@ -18,9 +19,26 @@ dataSources:
           file: ./abis/Contract.abi
       entities:
         - Call
-      eventHandlers:
-        - event: Trigger(uint16)
-          handler: handleTrigger
+      blockHandlers:
+        - handler: handleBlockSuccess
+      file: ./src/mapping.ts
+  - kind: ethereum/contract
+    name: Error
+    network: test
+    source:
+      address: "0xCfEB869F69431e42cdB54A4F4f105C19C080A601"
+      abi: Contract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      abis:
+        - name: Contract
+          file: ./abis/Contract.abi
+      entities:
+        - Call
+      blockHandlers:
+        - handler: handleBlockError
       file: ./src/mapping.ts
 templates:
   - kind: ethereum/contract
@@ -38,5 +56,5 @@ templates:
       entities:
         - Call
       blockHandlers:
-        - handler: handleBlock
-      file: ./src/dynamic_mapping.ts
+        - handler: handleBlockTemplate
+      file: ./src/mapping.ts

--- a/tests/integration-tests/non-fatal-errors/test/test.js
+++ b/tests/integration-tests/non-fatal-errors/test/test.js
@@ -1,0 +1,101 @@
+const path = require("path");
+const execSync = require("child_process").execSync;
+const { system, patching } = require("gluegun");
+const { createApolloFetch } = require("apollo-fetch");
+
+const Contract = artifacts.require("./Contract.sol");
+
+const srcDir = path.join(__dirname, "..");
+
+const fetchSubgraphs = createApolloFetch({
+  uri: "http://localhost:18030/graphql",
+});
+const fetchSubgraph = createApolloFetch({
+  uri: "http://localhost:18000/subgraphs/name/test/remove-then-update",
+});
+
+const exec = (cmd) => {
+  try {
+    return execSync(cmd, { cwd: srcDir, stdio: "inherit" });
+  } catch (e) {
+    throw new Error(`Failed to run command \`${cmd}\``);
+  }
+};
+
+const waitForSubgraphToBeSynced = async () =>
+  new Promise((resolve, reject) => {
+    // Wait for 5s
+    let deadline = Date.now() + 5 * 1000;
+
+    // Function to check if the subgraph is synced
+    const checkSubgraphSynced = async () => {
+      try {
+        let result = await fetchSubgraphs({
+          query: `{ indexingStatuses { synced, health } }`,
+        });
+
+        if (result.data.indexingStatuses[0].synced) {
+          resolve();
+        } else if (result.data.indexingStatuses[0].health != "healthy") {
+          reject(new Error("Subgraph failed"));
+        } else {
+          throw new Error("reject or retry");
+        }
+      } catch (e) {
+        if (Date.now() > deadline) {
+          reject(new Error(`Timed out waiting for the subgraph to sync`));
+        } else {
+          setTimeout(checkSubgraphSynced, 500);
+        }
+      }
+    };
+
+    // Periodically check whether the subgraph has synced
+    setTimeout(checkSubgraphSynced, 0);
+  });
+
+contract("Contract", (accounts) => {
+  // Deploy the subgraph once before all tests
+  before(async () => {
+    // Deploy the contract
+    const contract = await Contract.deployed();
+    await contract.emitTrigger(1);
+
+    // Insert its address into subgraph manifest
+    await patching.replace(
+      path.join(srcDir, "subgraph.yaml"),
+      "0x0000000000000000000000000000000000000000",
+      contract.address
+    );
+
+    // Create and deploy the subgraph
+    exec(`yarn codegen`);
+    exec(`yarn create:test`);
+    exec(`yarn deploy:test`);
+
+    // Wait for the subgraph to be indexed
+    await waitForSubgraphToBeSynced();
+  });
+
+  it("all overloads of the contract function are called", async () => {
+    let result = await fetchSubgraph({
+      query: `{ foos(orderBy: id, subgraphError: allow) { id } }`,
+    });
+
+    expect(result.errors).to.deep.equal([{
+      "message": "indexing_error"
+    }]);
+
+    // Importantly, "1" and "11" are not present because their handlers erroed.
+    expect(result.data).to.deep.equal({
+      foos: [
+        {
+          id: "0"
+        },
+        {
+          id: "00"
+        },
+      ],
+    });
+  });
+});

--- a/tests/integration-tests/non-fatal-errors/test/test.js
+++ b/tests/integration-tests/non-fatal-errors/test/test.js
@@ -25,7 +25,7 @@ const exec = (cmd) => {
 const waitForSubgraphToBeSynced = async () =>
   new Promise((resolve, reject) => {
     // Wait for 5s
-    let deadline = Date.now() + 5 * 1000;
+    let deadline = Date.now() + 50 * 1000;
 
     // Function to check if the subgraph is synced
     const checkSubgraphSynced = async () => {
@@ -77,7 +77,7 @@ contract("Contract", (accounts) => {
     await waitForSubgraphToBeSynced();
   });
 
-  it("all overloads of the contract function are called", async () => {
+  it("only sucessful handler register changes", async () => {
     let result = await fetchSubgraph({
       query: `{ foos(orderBy: id, subgraphError: allow) { id } }`,
     });

--- a/tests/integration-tests/non-fatal-errors/truffle.js
+++ b/tests/integration-tests/non-fatal-errors/truffle.js
@@ -1,0 +1,21 @@
+require("babel-register");
+require("babel-polyfill");
+
+module.exports = {
+  contracts_directory: "../common",
+  migrations_directory: "../common",
+  networks: {
+    test: {
+      host: "localhost",
+      port: 18545,
+      network_id: "*",
+      gas: "100000000000",
+      gasPrice: "1",
+    },
+  },
+  compilers: {
+    solc: {
+      version: "0.6.1",
+    },
+  },
+};

--- a/tests/tests/tests.rs
+++ b/tests/tests/tests.rs
@@ -112,3 +112,10 @@ fn big_decimal() {
     let _m = TEST_MUTEX.lock();
     run_test("big-decimal");
 }
+
+#[test]
+fn non_fatal_errors() {
+    let _m = TEST_MUTEX.lock();
+    std::env::set_var("GRAPH_DISABLE_FAIL_FAST", "yesplease");
+    run_test("non-fatal-errors");
+}


### PR DESCRIPTION
This implements the non-fatal errors proposal, by which a subgraph which has synced will continue indexing when encountering a deterministic error, skipping the handler and discarding any changes done while processing it. The errors will be registered when transacting operations for a block, and will be reverted if necessary. To enable non-fatal errors the manifest must include the section:
```
features:
  - nonFatalErrors
```

By default data is hidden from queries in the presence of indexing errors (except for the `_meta` field). To receive data in a query the `subgraphError: allow` argument must be passed in. See the `non_fatal_errors` test for examples of what the responses look like. The `_meta` field gains an `hasIndexingErorrs: Boolean!` field as a way of checking for errors. Additionally if indexing errors are present a graphql error with the message `"indexing_error"` will always be added.

This is ready for review. The `nonFatalErrors` field of the indexing status API will be implemented in a follow up. I'd also like to add an integration test before merging this.