### PR TITLE
Add `subgraphError` argument only when the feature is present

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -1305,3 +1305,22 @@ impl DeploymentState {
 pub enum SubgraphFeature {
     nonFatalErrors,
 }
+
+impl std::fmt::Display for SubgraphFeature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SubgraphFeature::nonFatalErrors => write!(f, "nonFatalErrors"),
+        }
+    }
+}
+
+impl FromStr for SubgraphFeature {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        match s {
+            "nonFatalErrors" => Ok(SubgraphFeature::nonFatalErrors),
+            _ => Err(anyhow::anyhow!("invalid subgraph feature {}", s)),
+        }
+    }
+}

--- a/graphql/examples/schema.rs
+++ b/graphql/examples/schema.rs
@@ -1,7 +1,7 @@
 use graphql_parser::parse_schema;
-use std::env;
 use std::fs;
 use std::process::exit;
+use std::{collections::BTreeSet, env};
 
 use graph_graphql::schema::api::api_schema;
 
@@ -31,7 +31,10 @@ pub fn main() {
     };
     let schema = ensure(fs::read_to_string(schema), "Can not read schema file");
     let schema = ensure(parse_schema(&schema), "Failed to parse schema");
-    let schema = ensure(api_schema(&schema), "Failed to convert to API schema");
+    let schema = ensure(
+        api_schema(&schema, &BTreeSet::new()),
+        "Failed to convert to API schema",
+    );
 
     println!("{}", schema);
 }

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -2,7 +2,7 @@
 extern crate pretty_assertions;
 
 use graphql_parser::{query as q, schema as s};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use graph::data::graphql::{object, object_value, ObjectOrInterface};
@@ -1132,7 +1132,7 @@ async fn successfully_runs_introspection_query_against_complex_schema() {
         SubgraphDeploymentId::new("complexschema").unwrap(),
     )
     .unwrap();
-    schema.document = api_schema(&schema.document).unwrap();
+    schema.document = api_schema(&schema.document, &BTreeSet::new()).unwrap();
 
     let result = introspection_query(
         schema.clone(),
@@ -1242,7 +1242,7 @@ async fn introspection_possible_types() {
         SubgraphDeploymentId::new("complexschema").unwrap(),
     )
     .unwrap();
-    schema.document = api_schema(&schema.document).unwrap();
+    schema.document = api_schema(&schema.document, &BTreeSet::new()).unwrap();
 
     // Test "possibleTypes" introspection in interfaces
     let response = introspection_query(

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -1,6 +1,6 @@
 use mockall::predicate::*;
 use mockall::*;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use graph::data::subgraph::status;
 use graph::prelude::*;
@@ -264,8 +264,8 @@ pub fn mock_store_with_users_subgraph() -> (Arc<MockStore>, SubgraphDeploymentId
 
             let mut schema = Schema::parse(USERS_SCHEMA, subgraph_id_for_api_schema.clone())
                 .expect("failed to parse users schema");
-            schema.document =
-                api_schema(&schema.document).expect("failed to generate users API schema");
+            schema.document = api_schema(&schema.document, &BTreeSet::new())
+                .expect("failed to generate users API schema");
             Ok(Arc::new(ApiSchema::from_api_schema(schema).unwrap()))
         });
 

--- a/store/postgres/migrations/2020-12-11-142000_subgraph_manifest_features/down.sql
+++ b/store/postgres/migrations/2020-12-11-142000_subgraph_manifest_features/down.sql
@@ -1,0 +1,4 @@
+alter table
+    subgraphs.subgraph_manifest
+drop
+    column features;

--- a/store/postgres/migrations/2020-12-11-142000_subgraph_manifest_features/up.sql
+++ b/store/postgres/migrations/2020-12-11-142000_subgraph_manifest_features/up.sql
@@ -1,0 +1,4 @@
+alter table
+    subgraphs.subgraph_manifest
+add
+    column features text[] NOT NULL DEFAULT '{}';

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -706,10 +706,12 @@ impl Store {
         let graft_block =
             metadata::deployment_graft(&conn, &subgraph_id)?.map(|(_, ptr)| ptr.number as i32);
 
+        let features = metadata::subgraph_features(&conn, subgraph_id)?;
+
         // Generate an API schema for the subgraph and make sure all types in the
         // API schema have a @subgraphId directive as well
         let mut schema = input_schema.clone();
-        schema.document = api_schema(&schema.document)?;
+        schema.document = api_schema(&schema.document, &features)?;
         schema.add_subgraph_id_directives(subgraph_id.clone());
 
         let info = SubgraphInfo {

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -101,6 +101,7 @@ type SubgraphManifest @entity {
     specVersion: String!
     description: String
     repository: String
+    features: [String!]!
     schema: String!
     dataSources: [EthereumContractDataSource!]!
     templates: [EthereumContractDataSourceTemplate!]


### PR DESCRIPTION
We saw an issue in a graphql client that is avoided by doing this. And it is generally more correct to only include it if the subgraph opts in. This requires storing the `features` field in the metadata, which we should be doing anyways.

