### PR TITLE
Consider in-memory state of data sources for reverts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fail"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
+dependencies = [
+ "lazy_static",
+ "log 0.4.11",
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1577,7 @@ dependencies = [
  "config",
  "diesel",
  "dirs 3.0.1",
+ "fail",
  "futures 0.1.30",
  "graph",
  "graph-core",
@@ -1588,6 +1600,7 @@ dependencies = [
  "async-trait",
  "atomic_refcell",
  "bytes 0.5.6",
+ "fail",
  "futures 0.1.30",
  "futures 0.3.8",
  "graph",
@@ -1650,6 +1663,7 @@ dependencies = [
  "crossbeam-channel 0.5.0",
  "diesel",
  "env_logger 0.8.2",
+ "fail",
  "futures 0.3.8",
  "git-testament",
  "graph",
@@ -1819,7 +1833,9 @@ dependencies = [
 name = "graph-tests"
 version = "0.19.2"
 dependencies = [
+ "defer",
  "duct",
+ "fail",
  "lazy_static",
 ]
 

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -15,6 +15,7 @@ serde = "1.0"
 config = { version = "0.10", features = ["toml"], default-features = false }
 dirs = "3.0"
 anyhow = "1.0"
+fail = "0.4"
 
 [dev-dependencies]
 diesel = { version = "1.4.5", features = ["postgres", "serde_json", "numeric", "r2d2"] }

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -63,7 +63,9 @@ enum BlockStreamState {
 /// A single next step to take in reconciling the state of the subgraph store with the state of the
 /// chain store.
 enum ReconciliationStep {
-    /// Revert the current block pointed at by the subgraph pointer.
+    /// Revert the current block pointed at by the subgraph pointer. The pointer is to the current
+    /// subgraph head, and a single block will be reverted so the new head will be the parent of the
+    /// current one.
     Revert(EthereumBlockPointer),
 
     /// Move forwards, processing one or more blocks. Second element is the block range size.
@@ -126,9 +128,12 @@ pub struct BlockStream<S, C> {
     ctx: BlockStreamContext<S, C>,
 }
 
+// This is the same as `ReconciliationStep` but without retries.
 enum NextBlocks {
     /// Blocks and range size
     Blocks(VecDeque<EthereumBlockWithTriggers>, u64),
+
+    /// Revert the current block pointed at by the subgraph pointer.
     Revert(EthereumBlockPointer),
     Done,
 }

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -252,14 +252,14 @@ where
         // Only continue if the subgraph block ptr is behind the head block ptr.
         // subgraph_ptr > head_ptr shouldn't happen, but if it does, it's safest to just stop.
         if let Some(ptr) = subgraph_ptr {
-            self.metrics
-                .blocks_behind
-                .set((head_ptr.number - ptr.number) as f64);
-
             if ptr.number >= head_ptr.number {
                 return Box::new(future::ok(ReconciliationStep::Done))
                     as Box<dyn Future<Item = _, Error = _> + Send>;
             }
+
+            self.metrics
+                .blocks_behind
+                .set((head_ptr.number - ptr.number) as f64);
         }
 
         // Subgraph ptr is behind head ptr.

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -357,11 +357,7 @@ fn revert_local_head(context: &Context, local_head: EthereumBlockPointer) -> Rev
                 future::result(
                     store
                         .clone()
-                        .revert_block_operations(
-                            subgraph_id.clone(),
-                            local_head.clone(),
-                            parent_block.clone(),
-                        )
+                        .revert_block_operations(subgraph_id.clone(), parent_block.clone())
                         .map_err(|e| e.into())
                         .map(|_| (local_head, parent_block)),
                 )

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ semver = "0.10.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
+fail = "0.4"
 
 [dev-dependencies]
 graph-mock = { path = "../mock" }

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -278,6 +278,12 @@ where
             }
         }
 
+        // `hosts` will remain ordered by the creation block.
+        // See also 8f1bca33-d3b7-4035-affc-fd6161a12448.
+        assert!(
+            self.hosts.last().and_then(|h| h.creation_block_number()) <= data_source.creation_block
+        );
+
         let host =
             Arc::new(self.new_host(logger.clone(), data_source, templates, metrics.clone())?);
 

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -294,4 +294,17 @@ where
             Some(host)
         })
     }
+
+    fn revert_data_sources(&mut self, reverted_block: u64) {
+        // `hosts` is ordered by the creation block.
+        // See also 8f1bca33-d3b7-4035-affc-fd6161a12448.
+        while self
+            .hosts
+            .last()
+            .filter(|h| h.creation_block_number() >= Some(reverted_block))
+            .is_some()
+        {
+            self.hosts.pop();
+        }
+    }
 }

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -534,6 +534,9 @@ where
                     // Revert the in-memory state:
                     // - Remove hosts for reverted dynamic data sources.
                     // - Clear the entity cache.
+                    //
+                    // Note that we do not currently revert the filters,
+                    // which is not ideal, but also not incorrect.
                     ctx.state.instance.revert_data_sources(subgraph_ptr.number);
                     ctx.state.entity_lfu_cache = LfuCache::new();
                     continue;

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -535,8 +535,10 @@ where
                     // - Remove hosts for reverted dynamic data sources.
                     // - Clear the entity cache.
                     //
-                    // Note that we do not currently revert the filters,
-                    // which is not ideal, but also not incorrect.
+                    // Note that we do not currently revert the filters, which means the filters
+                    // will be broader than necessary. This is not ideal for performance, but is not
+                    // incorrect since we will discard triggers that match the filters but do not
+                    // match any data sources.
                     ctx.state.instance.revert_data_sources(subgraph_ptr.number);
                     ctx.state.entity_lfu_cache = LfuCache::new();
                     continue;

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -514,7 +514,6 @@ where
                                 .store
                                 .revert_block_operations(
                                     ctx.inputs.deployment_id.clone(),
-                                    subgraph_ptr,
                                     parent_ptr,
                                 )
                                 .map_err(Into::into)

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -39,7 +39,7 @@ where
                 .iter()
                 .map(|template| (template.name.as_str(), template)),
         );
-        let mut data_sources = vec![];
+        let mut data_sources: Vec<DataSource> = vec![];
 
         for stored in self
             .store
@@ -73,6 +73,11 @@ where
                 context,
                 creation_block,
             };
+
+            // The data sources are ordered by the creation block.
+            // See also 8f1bca33-d3b7-4035-affc-fd6161a12448.
+            assert!(data_sources.last().and_then(|d| d.creation_block) <= ds.creation_block);
+
             data_sources.push(ds);
         }
 

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -50,6 +50,7 @@ where
                 name,
                 source,
                 context,
+                creation_block,
             } = stored;
 
             let template = template_map.get(name.as_str()).ok_or_else(|| {
@@ -70,6 +71,7 @@ where
                 source,
                 mapping: template.mapping.clone(),
                 context,
+                creation_block,
             };
             data_sources.push(ds);
         }

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -7,7 +7,7 @@ pub enum BlockStreamEvent {
     Block(EthereumBlockWithTriggers),
 
     /// Signals that a revert happened and was processed.
-    Revert,
+    Revert(EthereumBlockPointer),
 }
 
 pub trait BlockStream: Stream<Item = BlockStreamEvent, Error = Error> {}

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -5,8 +5,6 @@ use crate::prelude::*;
 
 pub enum BlockStreamEvent {
     Block(EthereumBlockWithTriggers),
-
-    /// Signals that a revert happened and was processed.
     Revert(EthereumBlockPointer),
 }
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -989,14 +989,12 @@ pub trait Store: Send + Sync + 'static {
     ) -> Result<(), StoreError>;
 
     /// Revert the entity changes from a single block atomically in the store, and update the
-    /// subgraph block pointer from `block_ptr_from` to `block_ptr_to`.
+    /// subgraph block pointer to `block_ptr_to`.
     ///
-    /// `block_ptr_from` must match the current value of the subgraph block pointer.
-    /// `block_ptr_to` must point to the parent block of `block_ptr_from`.
+    /// `block_ptr_to` must point to the parent block of the subgraph block pointer.
     fn revert_block_operations(
         &self,
         subgraph_id: SubgraphDeploymentId,
-        block_ptr_from: EthereumBlockPointer,
         block_ptr_to: EthereumBlockPointer,
     ) -> Result<(), StoreError>;
 
@@ -1223,7 +1221,6 @@ impl Store for MockStore {
     fn revert_block_operations(
         &self,
         _subgraph_id: SubgraphDeploymentId,
-        _block_ptr_from: EthereumBlockPointer,
         _block_ptr_to: EthereumBlockPointer,
     ) -> Result<(), StoreError> {
         unimplemented!()

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -925,6 +925,7 @@ pub struct StoredDynamicDataSource {
     pub name: String,
     pub source: Source,
     pub context: Option<String>,
+    pub creation_block: Option<u64>,
 }
 
 /// Common trait for store implementations.

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -77,6 +77,10 @@ pub trait RuntimeHost: Send + Sync + Debug + 'static {
         state: BlockState,
         proof_of_indexing: SharedProofOfIndexing,
     ) -> Result<BlockState, MappingError>;
+
+    /// Block number in which this host was created.
+    /// Returns `None` for static data sources.
+    fn creation_block_number(&self) -> Option<u64>;
 }
 
 pub struct HostMetrics {

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -14,6 +14,7 @@ pub struct DataSourceTemplateInfo {
     pub template: DataSourceTemplate,
     pub params: Vec<String>,
     pub context: Option<DataSourceContext>,
+    pub creation_block: u64,
 }
 
 #[derive(Debug)]

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -136,4 +136,6 @@ pub trait SubgraphInstance<H: RuntimeHost> {
         top_level_templates: Arc<Vec<DataSourceTemplate>>,
         metrics: Arc<HostMetrics>,
     ) -> Result<Option<Arc<H>>, anyhow::Error>;
+
+    fn revert_data_sources(&mut self, reverted_block: u64);
 }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -582,6 +582,7 @@ impl<'a, 'b, 'c>
             source,
             mapping,
             context,
+            creation_block: _,
         } = data_source;
 
         Self {

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1550,7 +1550,7 @@ fn query_detects_reorg() {
 
         // Revert one block
         STORE
-            .revert_block_operations(id.clone(), BLOCK_ONE.clone(), GENESIS_PTR.clone())
+            .revert_block_operations(id.clone(), GENESIS_PTR.clone())
             .unwrap();
         // A query is still fine since we implicitly query at block 0; we were
         // at block 1 when we got `state`, and reorged once by one block, which
@@ -1729,7 +1729,7 @@ fn non_fatal_errors() {
 
             // Test error reverts.
             STORE
-                .revert_block_operations(id.clone(), BLOCK_TWO.block_ptr(), *BLOCK_ONE)
+                .revert_block_operations(id.clone(), *BLOCK_ONE)
                 .unwrap();
             let query = "query { musician(id: \"m1\") { id }  _meta { hasIndexingErrors } }";
             let query = graphql_parser::parse_query(query).unwrap().into_static();

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -117,7 +117,6 @@ impl Store for MockStore {
     fn revert_block_operations(
         &self,
         _subgraph_id: SubgraphDeploymentId,
-        _block_ptr_from: EthereumBlockPointer,
         _block_ptr_to: EthereumBlockPointer,
     ) -> Result<(), StoreError> {
         unimplemented!()

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -42,6 +42,7 @@ structopt = "0.3.20"
 toml = "0.5.7"
 shellexpand = "2.0.0"
 diesel = "1.4.5"
+fail = "0.4"
 
 [dev-dependencies]
 assert_cli = "0.6"

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -101,6 +101,10 @@ fn read_expensive_queries() -> Result<Vec<Arc<q::Document>>, std::io::Error> {
 async fn main() {
     env_logger::init();
 
+    // Allow configuring fail points on debug builds. Used for integration tests.
+    #[cfg(debug_assertions)]
+    std::mem::forget(fail::FailScenario::setup());
+
     let opt = opt::Opt::from_args();
 
     // Set up logger

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -43,6 +43,7 @@ struct RuntimeHostConfig {
     data_source_network: String,
     data_source_name: String,
     data_source_context: Option<DataSourceContext>,
+    data_source_creation_block: Option<u64>,
     contract: Source,
     templates: Arc<Vec<DataSourceTemplate>>,
 }
@@ -148,6 +149,7 @@ where
                 data_source_network: network_name,
                 data_source_name: data_source.name,
                 data_source_context: data_source.context,
+                data_source_creation_block: data_source.creation_block,
                 contract: data_source.source,
                 templates,
             },
@@ -167,6 +169,7 @@ pub struct RuntimeHost {
     data_source_event_handlers: Vec<MappingEventHandler>,
     data_source_call_handlers: Vec<MappingCallHandler>,
     data_source_block_handlers: Vec<MappingBlockHandler>,
+    data_source_creation_block: Option<u64>,
     mapping_request_sender: Sender<MappingRequest>,
     host_exports: Arc<HostExports>,
     metrics: Arc<HostMetrics>,
@@ -235,6 +238,7 @@ impl RuntimeHost {
             data_source_event_handlers: config.mapping.event_handlers,
             data_source_call_handlers: config.mapping.call_handlers,
             data_source_block_handlers: config.mapping.block_handlers,
+            data_source_creation_block: config.data_source_creation_block,
             mapping_request_sender,
             host_exports,
             metrics,
@@ -715,6 +719,10 @@ impl RuntimeHostTrait for RuntimeHost {
         .err_into()
         .await
     }
+
+    fn creation_block_number(&self) -> Option<u64> {
+        self.data_source_creation_block
+    }
 }
 
 impl PartialEq for RuntimeHost {
@@ -727,6 +735,9 @@ impl PartialEq for RuntimeHost {
             data_source_call_handlers,
             data_source_block_handlers,
             host_exports,
+
+            // Data sources created at different blocks can be considered duplicated.
+            data_source_creation_block: _,
             mapping_request_sender: _,
             metrics: _,
         } = self;

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -736,7 +736,7 @@ impl PartialEq for RuntimeHost {
             data_source_block_handlers,
             host_exports,
 
-            // Data sources created at different blocks can be considered duplicated.
+            // The creation block is ignored for detection duplicate data sources.
             data_source_creation_block: _,
             mapping_request_sender: _,
             metrics: _,

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -556,6 +556,7 @@ impl HostExports {
         name: String,
         params: Vec<String>,
         context: Option<DataSourceContext>,
+        creation_block: u64,
     ) -> Result<(), anyhow::Error> {
         info!(
             logger,
@@ -591,6 +592,7 @@ impl HostExports {
             template,
             params,
             context,
+            creation_block,
         });
 
         Ok(())

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -1230,6 +1230,7 @@ impl WasmInstanceContext {
             name,
             params,
             None,
+            self.ctx.block.block_ptr().number,
         )?;
         Ok(())
     }
@@ -1250,6 +1251,7 @@ impl WasmInstanceContext {
             name,
             params,
             Some(context.into()),
+            self.ctx.block.block_ptr().number,
         )?;
         Ok(())
     }

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -103,6 +103,7 @@ fn mock_data_source(path: &str) -> DataSource {
             runtime: Arc::new(runtime.clone()),
         },
         context: None,
+        creation_block: None,
     }
 }
 
@@ -163,9 +164,12 @@ fn mock_context(
     data_source: DataSource,
     store: Arc<impl Store + EthereumCallCache>,
 ) -> MappingContext {
+    let mut block = LightEthereumBlock::default();
+    block.hash = Some(Default::default());
+    block.number = Some(0.into());
     MappingContext {
         logger: test_store::LOGGER.clone(),
-        block: Default::default(),
+        block: Arc::new(block),
         host_exports: Arc::new(mock_host_exports(subgraph_id, data_source, store.clone())),
         state: BlockState::new(store, Default::default()),
         proof_of_indexing: None,

--- a/store/postgres/src/network_store.rs
+++ b/store/postgres/src/network_store.rs
@@ -141,11 +141,10 @@ impl StoreTrait for NetworkStore {
     fn revert_block_operations(
         &self,
         subgraph_id: graph::prelude::SubgraphDeploymentId,
-        block_ptr_from: EthereumBlockPointer,
         block_ptr_to: EthereumBlockPointer,
     ) -> Result<(), graph::prelude::StoreError> {
         self.store
-            .revert_block_operations(subgraph_id, block_ptr_from, block_ptr_to)
+            .revert_block_operations(subgraph_id, block_ptr_to)
     }
 
     fn subscribe(

--- a/store/postgres/src/sharded_store.rs
+++ b/store/postgres/src/sharded_store.rs
@@ -419,11 +419,10 @@ impl StoreTrait for ShardedStore {
     fn revert_block_operations(
         &self,
         id: SubgraphDeploymentId,
-        block_ptr_from: EthereumBlockPointer,
         block_ptr_to: EthereumBlockPointer,
     ) -> Result<(), StoreError> {
         let (store, site) = self.store(&id)?;
-        let event = store.revert_block_operations(site.as_ref(), block_ptr_from, block_ptr_to)?;
+        let event = store.revert_block_operations(site.as_ref(), block_ptr_to)?;
         self.send_store_event(&event)
     }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1055,35 +1055,35 @@ impl Store {
     pub(crate) fn revert_block_operations(
         &self,
         site: &Site,
-        block_ptr_from: EthereumBlockPointer,
         block_ptr_to: EthereumBlockPointer,
     ) -> Result<StoreEvent, StoreError> {
-        // Sanity check on block numbers
-        if block_ptr_from.number != block_ptr_to.number + 1 {
-            panic!("revert_block_operations must revert a single block only");
-        }
-        // Don't revert past a graft point
         let econn = self.get_entity_conn(site, ReplicaId::Main)?;
-        let info = self.subgraph_info_with_conn(&econn.conn, &site.deployment)?;
-        if let Some(graft_block) = info.graft_block {
-            if graft_block as u64 > block_ptr_to.number {
-                return Err(anyhow!(
-                    "Can not revert subgraph `{}` to block {} as it was \
-                    grafted at block {} and reverting past a graft point \
-                    is not possible",
-                    site.deployment.clone(),
-                    block_ptr_to.number,
-                    graft_block
-                )
-                .into());
-            }
-        }
 
         let event = econn.transaction(|| -> Result<_, StoreError> {
-            assert_eq!(
-                Some(block_ptr_from),
-                Self::block_ptr_with_conn(&site.deployment, &econn)?
-            );
+            // Unwrap: If we are reverting then the block ptr is not `None`.
+            let block_ptr_from = Self::block_ptr_with_conn(&site.deployment, &econn)?.unwrap();
+
+            // Sanity check on block numbers
+            if block_ptr_from.number != block_ptr_to.number + 1 {
+                panic!("revert_block_operations must revert a single block only");
+            }
+
+            // Don't revert past a graft point
+            let info = self.subgraph_info_with_conn(&econn.conn, &site.deployment)?;
+            if let Some(graft_block) = info.graft_block {
+                if graft_block as u64 > block_ptr_to.number {
+                    return Err(anyhow!(
+                        "Can not revert subgraph `{}` to block {} as it was \
+                        grafted at block {} and reverting past a graft point \
+                        is not possible",
+                        site.deployment.clone(),
+                        block_ptr_to.number,
+                        graft_block
+                    )
+                    .into());
+                }
+            }
+
             let metadata_event =
                 deployment::revert_block_ptr(&econn.conn, &site.deployment, block_ptr_to)?;
 

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -306,11 +306,11 @@ fn graft() {
         transact_entity_operations(&store, subgraph_id.clone(), BLOCKS[2], vec![op]).unwrap();
 
         store
-            .revert_block_operations(subgraph_id.clone(), BLOCKS[2], BLOCKS[1])
+            .revert_block_operations(subgraph_id.clone(), BLOCKS[1])
             .expect("We can revert a block we just created");
 
         let err = store
-            .revert_block_operations(subgraph_id.clone(), BLOCKS[1], BLOCKS[0])
+            .revert_block_operations(subgraph_id.clone(), BLOCKS[0])
             .expect_err("Reverting past graft point is not allowed");
 
         assert!(err.to_string().contains("Can not revert subgraph"));

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -269,7 +269,6 @@ fn graft() {
             TEST_SUBGRAPH_ID.as_str(),
             BLOCKS[1],
         );
-        dbg!(&res);
         assert!(res.is_ok());
 
         let query = EntityQuery::new(

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1189,6 +1189,7 @@ fn mock_data_source() -> DataSource {
             runtime: Arc::new(Vec::new()),
         },
         context: None,
+        creation_block: None,
     }
 }
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -996,11 +996,7 @@ async fn check_basic_revert(
 
     // Revert block 3
     store
-        .revert_block_operations(
-            TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_2_PTR,
-            *TEST_BLOCK_1_PTR,
-        )
+        .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_1_PTR)
         .unwrap();
 
     let returned_entities = store
@@ -1066,11 +1062,7 @@ fn revert_block_with_delete() {
         // Revert deletion
         let count = get_entity_count(store.clone(), &TEST_SUBGRAPH_ID);
         store
-            .revert_block_operations(
-                TEST_SUBGRAPH_ID.clone(),
-                *TEST_BLOCK_3_PTR,
-                *TEST_BLOCK_2_PTR,
-            )
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_2_PTR)
             .unwrap();
         assert_eq!(
             count + 1,
@@ -1136,11 +1128,7 @@ fn revert_block_with_partial_update() {
         // Perform revert operation, reversing the partial update
         let count = get_entity_count(store.clone(), &TEST_SUBGRAPH_ID);
         store
-            .revert_block_operations(
-                TEST_SUBGRAPH_ID.clone(),
-                *TEST_BLOCK_3_PTR,
-                *TEST_BLOCK_2_PTR,
-            )
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_2_PTR)
             .unwrap();
         assert_eq!(count, get_entity_count(store.clone(), &TEST_SUBGRAPH_ID));
 
@@ -1252,11 +1240,7 @@ fn revert_block_with_dynamic_data_source_operations() {
 
         // Revert block that added the user and the dynamic data source
         store
-            .revert_block_operations(
-                TEST_SUBGRAPH_ID.clone(),
-                *TEST_BLOCK_3_PTR,
-                *TEST_BLOCK_2_PTR,
-            )
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_2_PTR)
             .expect("revert block operations failed unexpectedly");
 
         // Verify that the user is the original again
@@ -1930,21 +1914,13 @@ fn reorg_tracking() {
 
         // Back to block 3
         store
-            .revert_block_operations(
-                TEST_SUBGRAPH_ID.clone(),
-                *TEST_BLOCK_4_PTR,
-                *TEST_BLOCK_3_PTR,
-            )
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_3_PTR)
             .unwrap();
         check_state!(store, 1, 1, 3);
 
         // Back to block 2
         store
-            .revert_block_operations(
-                TEST_SUBGRAPH_ID.clone(),
-                *TEST_BLOCK_3_PTR,
-                *TEST_BLOCK_2_PTR,
-            )
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_2_PTR)
             .unwrap();
         check_state!(store, 2, 2, 2);
 
@@ -1962,29 +1938,17 @@ fn reorg_tracking() {
 
         // Revert all the way back to block 2
         store
-            .revert_block_operations(
-                TEST_SUBGRAPH_ID.clone(),
-                *TEST_BLOCK_5_PTR,
-                *TEST_BLOCK_4_PTR,
-            )
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_4_PTR)
             .unwrap();
         check_state!(store, 3, 2, 4);
 
         store
-            .revert_block_operations(
-                TEST_SUBGRAPH_ID.clone(),
-                *TEST_BLOCK_4_PTR,
-                *TEST_BLOCK_3_PTR,
-            )
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_3_PTR)
             .unwrap();
         check_state!(store, 4, 2, 3);
 
         store
-            .revert_block_operations(
-                TEST_SUBGRAPH_ID.clone(),
-                *TEST_BLOCK_3_PTR,
-                *TEST_BLOCK_2_PTR,
-            )
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_2_PTR)
             .unwrap();
         check_state!(store, 5, 3, 2);
     })

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2018"
 [dev-dependencies]
 duct = "0.13"
 lazy_static = "1.4.0"
+fail = { version = "0.4", features = ["failpoints"] }
+defer = "0.1"

--- a/tests/integration-tests/data-source-context/abis/Contract.abi
+++ b/tests/integration-tests/data-source-context/abis/Contract.abi
@@ -1,1 +1,0 @@
-[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint16","name":"x","type":"uint16"}],"name":"Trigger","type":"event"},{"inputs":[{"internalType":"uint16","name":"x","type":"uint16"}],"name":"emitTrigger","outputs":[],"stateMutability":"nonpayable","type":"function"}]

--- a/tests/integration-tests/data-source-context/abis/Contract.abi
+++ b/tests/integration-tests/data-source-context/abis/Contract.abi
@@ -1,0 +1,1 @@
+[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint16","name":"x","type":"uint16"}],"name":"Trigger","type":"event"},{"inputs":[{"internalType":"uint16","name":"x","type":"uint16"}],"name":"emitTrigger","outputs":[],"stateMutability":"nonpayable","type":"function"}]

--- a/tests/integration-tests/data-source-revert/abis/Contract.abi
+++ b/tests/integration-tests/data-source-revert/abis/Contract.abi
@@ -1,0 +1,1 @@
+[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint16","name":"x","type":"uint16"}],"name":"Trigger","type":"event"},{"inputs":[{"internalType":"uint16","name":"x","type":"uint16"}],"name":"emitTrigger","outputs":[],"stateMutability":"nonpayable","type":"function"}]

--- a/tests/integration-tests/data-source-revert/package.json
+++ b/tests/integration-tests/data-source-revert/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "data-source-revert",
+  "version": "0.1.0",
+  "scripts": {
+    "build-contracts": "rm -rf abis bin && solcjs ../common/SimpleContract.sol --abi -o abis && mv abis/*Contract.abi abis/Contract.abi && solcjs ../common/SimpleContract.sol --bin -o bin && mv bin/*Contract.bin bin/Contract.bin",
+    "codegen": "graph codegen",
+    "test": "yarn build-contracts && truffle test --network test",
+    "create:test": "graph create test/data-source-revert --node http://localhost:18020/",
+    "deploy:test": "graph deploy test/data-source-revert --ipfs http://localhost:15001/ --node http://localhost:18020/"
+  },
+  "devDependencies": {
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "solc": "^0.6.1"
+  },
+  "dependencies": {
+    "apollo-fetch": "^0.7.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-register": "^6.26.0",
+    "gluegun": "^3.2.1",
+    "truffle": "^5.0.4",
+    "truffle-contract": "^4.0.5",
+    "truffle-hdwallet-provider": "^1.0.4"
+  }
+}

--- a/tests/integration-tests/data-source-revert/schema.graphql
+++ b/tests/integration-tests/data-source-revert/schema.graphql
@@ -1,0 +1,5 @@
+# The `id` is the block number and `count` the handler invocations at that block.
+type DataSourceCount @entity {
+  id: ID!
+  count: Int!
+}

--- a/tests/integration-tests/data-source-revert/src/mapping.ts
+++ b/tests/integration-tests/data-source-revert/src/mapping.ts
@@ -1,0 +1,38 @@
+import {
+  ethereum,
+  DataSourceContext,
+  dataSource,
+  Address,
+  BigInt,
+} from "@graphprotocol/graph-ts";
+import { Template } from "../generated/templates";
+import { DataSourceCount } from "../generated/schema";
+
+export function handleBlock(block: ethereum.Block): void {
+  let context = new DataSourceContext();
+  context.setBigInt("number", block.number);
+
+  Template.createWithContext(
+    Address.fromHexString(
+      "0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"
+    ) as Address,
+    context
+  );
+}
+
+export function handleBlockTemplate(block: ethereum.Block): void {
+  let count = DataSourceCount.load(block.number.toString());
+  if (count == null) {
+    count = new DataSourceCount(block.number.toString());
+    count.count = 0;
+  }
+
+  let ctx = dataSource.context();
+  let number = ctx.getBigInt("number");
+  assert(
+    count.count == number.toI32(),
+    "wrong count, found " + BigInt.fromI32(count.count).toString()
+  );
+  count.count += 1;
+  count.save();
+}

--- a/tests/integration-tests/data-source-revert/subgraph.yaml
+++ b/tests/integration-tests/data-source-revert/subgraph.yaml
@@ -1,0 +1,43 @@
+specVersion: 0.0.2
+repository: https://github.com/graphprotocol/example-subgraph
+schema:
+  file: ./schema.graphql
+features:
+  - nonFatalErrors
+dataSources:
+  - kind: ethereum/contract
+    name: Contract
+    network: test
+    source:
+      address: "0xCfEB869F69431e42cdB54A4F4f105C19C080A601"
+      abi: Contract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - Gravatar
+      abis:
+        - name: Contract
+          file: ./abis/Contract.abi
+      blockHandlers:
+        - handler: handleBlock
+      file: ./src/mapping.ts
+templates:
+  - kind: ethereum/contract
+    name: Template
+    network: test
+    source:
+      abi: Contract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - Gravatar
+      abis:
+        - name: Contract
+          file: ./abis/Contract.abi
+      blockHandlers:
+        - handler: handleBlockTemplate
+      file: ./src/mapping.ts

--- a/tests/integration-tests/data-source-revert/test/test.js
+++ b/tests/integration-tests/data-source-revert/test/test.js
@@ -1,0 +1,77 @@
+const path = require("path");
+const execSync = require("child_process").execSync;
+const { system, patching } = require("gluegun");
+const { createApolloFetch } = require("apollo-fetch");
+
+const Contract = artifacts.require("./Contract.sol");
+
+const srcDir = path.join(__dirname, "..");
+
+const fetchSubgraphs = createApolloFetch({
+  uri: "http://localhost:18030/graphql",
+});
+
+const exec = (cmd) => {
+  try {
+    return execSync(cmd, { cwd: srcDir, stdio: "inherit" });
+  } catch (e) {
+    throw new Error(`Failed to run command \`${cmd}\``);
+  }
+};
+
+const waitForSubgraphToBeSynced = async () =>
+  new Promise((resolve, reject) => {
+    // Wait for 5s
+    let deadline = Date.now() + 5 * 1000;
+
+    // Function to check if the subgraph is synced
+    const checkSubgraphSynced = async () => {
+      try {
+        let result = await fetchSubgraphs({
+          query: `{ indexingStatuses { synced, health } }`,
+        });
+
+        if (result.data.indexingStatuses[0].synced) {
+          resolve();
+        } else if (result.data.indexingStatuses[0].health != "healthy") {
+          reject(new Error("Subgraph failed"));
+        } else {
+          throw new Error("reject or retry");
+        }
+      } catch (e) {
+        if (Date.now() > deadline) {
+          reject(new Error(`Timed out waiting for the subgraph to sync`));
+        } else {
+          setTimeout(checkSubgraphSynced, 500);
+        }
+      }
+    };
+
+    // Periodically check whether the subgraph has synced
+    setTimeout(checkSubgraphSynced, 0);
+  });
+
+contract("Contract", (accounts) => {
+  // Deploy the subgraph once before all tests
+  before(async () => {
+    // Deploy the contract
+    const contract = await Contract.deployed();
+
+    // Insert its address into subgraph manifest
+    await patching.replace(
+      path.join(srcDir, "subgraph.yaml"),
+      "0x0000000000000000000000000000000000000000",
+      contract.address
+    );
+
+    // Create and deploy the subgraph
+    exec(`yarn codegen`);
+    exec(`yarn create:test`);
+    exec(`yarn deploy:test`);
+  });
+
+  it("subgraph does not fail", async () => {
+    // Wait for the subgraph to be indexed, and not fail
+    await waitForSubgraphToBeSynced();
+  });
+});

--- a/tests/integration-tests/data-source-revert/truffle.js
+++ b/tests/integration-tests/data-source-revert/truffle.js
@@ -1,0 +1,21 @@
+require("babel-register");
+require("babel-polyfill");
+
+module.exports = {
+  contracts_directory: "../common",
+  migrations_directory: "../common",
+  networks: {
+    test: {
+      host: "localhost",
+      port: 18545,
+      network_id: "*",
+      gas: "100000000000",
+      gasPrice: "1",
+    },
+  },
+  compilers: {
+    solc: {
+      version: "0.6.1",
+    },
+  },
+};

--- a/tests/tests/tests.rs
+++ b/tests/tests/tests.rs
@@ -121,3 +121,17 @@ fn non_fatal_errors() {
     std::env::set_var("GRAPH_DISABLE_FAIL_FAST", "yesplease");
     run_test("non-fatal-errors");
 }
+
+#[test]
+fn data_source_revert() {
+    let _m = TEST_MUTEX.lock();
+
+    // Reorg block 1.
+    std::env::set_var(
+        "FAILPOINTS",
+        "test_reorg=return(2);error_on_duplicate_ds=return",
+    );
+    let _env_guard = defer::defer(|| std::env::remove_var("FAILPOINTS"));
+
+    run_test("data-source-revert");
+}


### PR DESCRIPTION
Currently when a block is reverted, data sources that were created on it remain in memory and continue to process triggers until the node is restarted. This fixes that so that the runtime hosts of the reverted data sources are removed. To enable this fix the block reversion logic was moved from the block stream to the instance manager.

A test subgraph was built to reproduce this. Previously this assert would trigger on a revert https://github.com/leoyvens/ds-revert-in-memory-state/blob/main/src/mapping.ts#L27, now it works as expected. We should also run integration tests of this branch against itself and verify that all tests pass and there are no more random PoI differences. 