### PR TITLE
travis: Don't build on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ language: rust
 rust:
   - stable
   - beta
-  - nightly
 
 # Select pre-installed services
 addons:
@@ -31,8 +30,6 @@ before_install:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - rust: nightly
   include:
     # Some env var is always necessary to differentiate included builds
     # Check coding style


### PR DESCRIPTION
This takes up build time and provides little value since Rust has been very stable.