### PR TITLE
*: No stack overflows when parsing graphql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,12 +1824,11 @@ dependencies = [
 
 [[package]]
 name = "graphql-parser"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5613c31f18676f164112732202124f373bb2103ff017b3b85ca954ea6a66ada"
+version = "0.3.0"
+source = "git+https://github.com/graphql-rust/graphql-parser#45167b53e9533c331298683577ba8df7e43480ac"
 dependencies = [
  "combine",
- "failure",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ members = [
     "graph",
     "tests",
 ]
+
+
+[patch.crates-io]
+# Include protection against stack overflow when parsing from this PR: https://github.com/graphql-rust/graphql-parser/commit/45167b53e9533c331298683577ba8df7e43480ac
+graphql-parser = {git="https://github.com/graphql-rust/graphql-parser", commit="45167b53e9533c331298683577ba8df7e43480ac"} 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,6 +24,6 @@ graph-mock = { path = "../mock" }
 walkdir = "2.3.1"
 test-store = { path = "../store/test-store" }
 hex = "0.4.2"
-graphql-parser = "0.2.3"
+graphql-parser = "0.3"
 prometheus = "0.7"
 pretty_assertions = "0.6.1"

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -2,9 +2,9 @@
 
 use pretty_assertions::assert_eq;
 
+use graph::prelude::q;
 use graph::{components::store::EntityType, data::graphql::object};
 use graph::{data::query::QueryTarget, prelude::*};
-use graphql_parser::query as q;
 use test_store::*;
 
 // `entities` is `(entity, type)`.
@@ -35,7 +35,7 @@ fn insert_and_query(
         insert_ops.collect::<Vec<_>>(),
     )?;
 
-    let document = graphql_parser::parse_query(query).unwrap();
+    let document = graphql_parser::parse_query(query).unwrap().into_static();
     let target = QueryTarget::Deployment(subgraph_id);
     let query = Query::new(document, None);
     Ok(execute_subgraph_query(query, target).unwrap_first())

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -25,7 +25,7 @@ ethabi = { git = "https://github.com/graphprotocol/ethabi.git", branch = "master
 hex = "0.4.2"
 http = "0.2"
 futures = "0.1.21"
-graphql-parser = "0.2.3"
+graphql-parser = "0.3"
 failure = "0.1.7"
 lazy_static = "1.4.0"
 mockall = "0.8"

--- a/graph/examples/stress.rs
+++ b/graph/examples/stress.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::iter::FromIterator;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 
-use graphql_parser::query as q;
+use graph::prelude::q;
 use rand::{thread_rng, Rng};
 use structopt::StructOpt;
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1461,7 +1461,7 @@ pub trait QueryStore: Send + Sync {
     fn find_query_values(
         &self,
         query: EntityQuery,
-    ) -> Result<Vec<BTreeMap<String, graphql_parser::query::Value>>, QueryExecutionError>;
+    ) -> Result<Vec<BTreeMap<String, q::Value>>, QueryExecutionError>;
 
     fn subscribe(&self, entities: Vec<SubscriptionFilter>) -> StoreEventStreamBox;
 

--- a/graph/src/data/graphql/effort.rs
+++ b/graph/src/data/graphql/effort.rs
@@ -1,6 +1,5 @@
 //! Utilities to keep moving statistics about queries
 
-use graphql_parser::query as q;
 use lazy_static::lazy_static;
 use rand::{prelude::Rng, thread_rng};
 use std::collections::{HashMap, HashSet};
@@ -14,6 +13,7 @@ use crate::components::metrics::{Counter, Gauge, MetricsRegistry};
 use crate::components::store::PoolWaitStats;
 use crate::data::graphql::shape_hash::shape_hash;
 use crate::data::query::{CacheStatus, QueryExecutionError};
+use crate::prelude::q;
 use crate::prelude::{async_trait, debug, info, o, warn, CheapClone, Logger, QueryLoadManager};
 use crate::util::stats::{MovingStats, BIN_SIZE, WINDOW_SIZE};
 

--- a/graph/src/data/graphql/ext.rs
+++ b/graph/src/data/graphql/ext.rs
@@ -1,7 +1,7 @@
 use super::ObjectOrInterface;
 use crate::data::schema::{META_FIELD_TYPE, SCHEMA_TYPE_NAME};
-use graphql_parser::schema::{
-    Definition, Directive, Document, EnumType, Field, InterfaceType, Name, ObjectType, Type,
+use crate::prelude::s::{
+    Definition, Directive, Document, EnumType, Field, InterfaceType, ObjectType, Type,
     TypeDefinition, Value,
 };
 use lazy_static::lazy_static;
@@ -16,12 +16,12 @@ lazy_static! {
 }
 
 pub trait ObjectTypeExt {
-    fn field(&self, name: &Name) -> Option<&Field>;
+    fn field(&self, name: &String) -> Option<&Field>;
     fn is_meta(&self) -> bool;
 }
 
 impl ObjectTypeExt for ObjectType {
-    fn field(&self, name: &Name) -> Option<&Field> {
+    fn field(&self, name: &String) -> Option<&Field> {
         self.fields.iter().find(|field| &field.name == name)
     }
 
@@ -31,7 +31,7 @@ impl ObjectTypeExt for ObjectType {
 }
 
 impl ObjectTypeExt for InterfaceType {
-    fn field(&self, name: &Name) -> Option<&Field> {
+    fn field(&self, name: &String) -> Option<&Field> {
         self.fields.iter().find(|field| &field.name == name)
     }
 
@@ -45,7 +45,7 @@ pub trait DocumentExt {
 
     fn get_object_type_definition(&self, name: &str) -> Option<&ObjectType>;
 
-    fn get_object_and_interface_type_fields(&self) -> HashMap<&Name, &Vec<Field>>;
+    fn get_object_and_interface_type_fields(&self) -> HashMap<&String, &Vec<Field>>;
 
     fn get_enum_definitions(&self) -> Vec<&EnumType>;
 
@@ -79,7 +79,7 @@ impl DocumentExt for Document {
             .find(|object_type| object_type.name.eq(name))
     }
 
-    fn get_object_and_interface_type_fields(&self) -> HashMap<&Name, &Vec<Field>> {
+    fn get_object_and_interface_type_fields(&self) -> HashMap<&String, &Vec<Field>> {
         self.definitions
             .iter()
             .filter_map(|d| match d {
@@ -183,11 +183,11 @@ impl DocumentExt for Document {
 }
 
 pub trait TypeExt {
-    fn get_base_type(&self) -> &Name;
+    fn get_base_type(&self) -> &String;
 }
 
 impl TypeExt for Type {
-    fn get_base_type(&self) -> &Name {
+    fn get_base_type(&self) -> &String {
         match self {
             Type::NamedType(name) => name,
             Type::NonNullType(inner) => Self::get_base_type(&inner),
@@ -210,14 +210,14 @@ impl DirectiveExt for Directive {
 }
 
 pub trait ValueExt {
-    fn as_object(&self) -> Option<&BTreeMap<Name, Value>>;
+    fn as_object(&self) -> Option<&BTreeMap<String, Value>>;
     fn as_list(&self) -> Option<&Vec<Value>>;
     fn as_string(&self) -> Option<&String>;
-    fn as_enum(&self) -> Option<&Name>;
+    fn as_enum(&self) -> Option<&String>;
 }
 
 impl ValueExt for Value {
-    fn as_object(&self) -> Option<&BTreeMap<Name, Value>> {
+    fn as_object(&self) -> Option<&BTreeMap<String, Value>> {
         match self {
             Value::Object(object) => Some(object),
             _ => None,
@@ -238,7 +238,7 @@ impl ValueExt for Value {
         }
     }
 
-    fn as_enum(&self) -> Option<&Name> {
+    fn as_enum(&self) -> Option<&String> {
         match self {
             Value::Enum(e) => Some(e),
             _ => None,
@@ -247,11 +247,11 @@ impl ValueExt for Value {
 }
 
 pub trait DirectiveFinder {
-    fn find_directive(&self, name: Name) -> Option<&Directive>;
+    fn find_directive(&self, name: String) -> Option<&Directive>;
 }
 
 impl DirectiveFinder for ObjectType {
-    fn find_directive(&self, name: Name) -> Option<&Directive> {
+    fn find_directive(&self, name: String) -> Option<&Directive> {
         self.directives
             .iter()
             .find(|directive| directive.name.eq(&name))
@@ -259,7 +259,7 @@ impl DirectiveFinder for ObjectType {
 }
 
 impl DirectiveFinder for Field {
-    fn find_directive(&self, name: Name) -> Option<&Directive> {
+    fn find_directive(&self, name: String) -> Option<&Directive> {
         self.directives
             .iter()
             .find(|directive| directive.name.eq(&name))
@@ -267,7 +267,7 @@ impl DirectiveFinder for Field {
 }
 
 impl DirectiveFinder for Vec<Directive> {
-    fn find_directive(&self, name: Name) -> Option<&Directive> {
+    fn find_directive(&self, name: String) -> Option<&Directive> {
         self.iter().find(|directive| directive.name.eq(&name))
     }
 }

--- a/graph/src/data/graphql/object_macro.rs
+++ b/graph/src/data/graphql/object_macro.rs
@@ -1,62 +1,62 @@
-use graphql_parser::query::{Number, Value};
+use crate::prelude::q::{self, Number};
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
 
 /// Creates a `graphql_parser::query::Value::Object` from key/value pairs.
 /// If you don't need to determine which keys are included dynamically at runtime
 /// consider using the `object! {}` macro instead.
-pub fn object_value(data: Vec<(&str, Value)>) -> Value {
-    Value::Object(BTreeMap::from_iter(
+pub fn object_value(data: Vec<(&str, q::Value)>) -> q::Value {
+    q::Value::Object(BTreeMap::from_iter(
         data.into_iter().map(|(k, v)| (k.to_string(), v)),
     ))
 }
 
 pub trait IntoValue {
-    fn into_value(self) -> Value;
+    fn into_value(self) -> q::Value;
 }
 
-impl IntoValue for Value {
+impl IntoValue for q::Value {
     #[inline]
-    fn into_value(self) -> Value {
+    fn into_value(self) -> q::Value {
         self
     }
 }
 
 impl IntoValue for &'_ str {
     #[inline]
-    fn into_value(self) -> Value {
+    fn into_value(self) -> q::Value {
         self.to_owned().into_value()
     }
 }
 
 impl IntoValue for i32 {
     #[inline]
-    fn into_value(self) -> Value {
-        Value::Int(Number::from(self))
+    fn into_value(self) -> q::Value {
+        q::Value::Int(q::Number::from(self))
     }
 }
 
 impl IntoValue for u64 {
     #[inline]
-    fn into_value(self) -> Value {
-        Value::String(self.to_string())
+    fn into_value(self) -> q::Value {
+        q::Value::String(self.to_string())
     }
 }
 
 impl<T: IntoValue> IntoValue for Option<T> {
     #[inline]
-    fn into_value(self) -> Value {
+    fn into_value(self) -> q::Value {
         match self {
             Some(v) => v.into_value(),
-            None => Value::Null,
+            None => q::Value::Null,
         }
     }
 }
 
 impl<T: IntoValue> IntoValue for Vec<T> {
     #[inline]
-    fn into_value(self) -> Value {
-        Value::List(self.into_iter().map(|e| e.into_value()).collect::<Vec<_>>())
+    fn into_value(self) -> q::Value {
+        q::Value::List(self.into_iter().map(|e| e.into_value()).collect::<Vec<_>>())
     }
 }
 
@@ -65,8 +65,8 @@ macro_rules! impl_into_values {
         $(
             impl IntoValue for $T {
                 #[inline]
-                fn into_value(self) -> Value {
-                    Value::$V(self)
+                fn into_value(self) -> q::Value {
+                    q::Value::$V(self)
                 }
             }
         )+

--- a/graph/src/data/graphql/object_or_interface.rs
+++ b/graph/src/data/graphql/object_or_interface.rs
@@ -1,5 +1,5 @@
+use crate::prelude::s;
 use crate::prelude::Schema;
-use graphql_parser::schema as s;
 use std::collections::BTreeMap;
 
 use super::ObjectTypeExt;
@@ -58,7 +58,7 @@ impl<'a> ObjectOrInterface<'a> {
         }
     }
 
-    pub fn field(&self, name: &s::Name) -> Option<&s::Field> {
+    pub fn field(&self, name: &String) -> Option<&s::Field> {
         self.fields().iter().find(|field| &field.name == name)
     }
 
@@ -77,7 +77,7 @@ impl<'a> ObjectOrInterface<'a> {
     pub fn matches(
         self,
         typename: &str,
-        types_for_interface: &BTreeMap<s::Name, Vec<s::ObjectType>>,
+        types_for_interface: &BTreeMap<String, Vec<s::ObjectType>>,
     ) -> bool {
         match self {
             ObjectOrInterface::Object(o) => o.name == typename,

--- a/graph/src/data/graphql/serialization.rs
+++ b/graph/src/data/graphql/serialization.rs
@@ -1,4 +1,4 @@
-use graphql_parser::query::*;
+use crate::prelude::q::*;
 use serde::ser::*;
 
 /// Serializable wrapper around a GraphQL value.

--- a/graph/src/data/graphql/shape_hash.rs
+++ b/graph/src/data/graphql/shape_hash.rs
@@ -4,8 +4,7 @@
 //! are any values used with filters, and any differences in the query
 //! name or response keys
 
-use graphql_parser::query as q;
-use graphql_parser::schema as s;
+use crate::prelude::{q, s};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
@@ -39,7 +38,7 @@ impl ShapeHash for q::Document {
 
 impl ShapeHash for q::OperationDefinition {
     fn shape_hash(&self, hasher: &mut ShapeHasher) {
-        use q::OperationDefinition::*;
+        use graphql_parser::query::OperationDefinition::*;
         // We want `[query|subscription|mutation] things { BODY }` to hash
         // to the same thing as just `things { BODY }`
         match self {
@@ -70,7 +69,7 @@ impl ShapeHash for q::SelectionSet {
 
 impl ShapeHash for q::Selection {
     fn shape_hash(&self, hasher: &mut ShapeHasher) {
-        use q::Selection::*;
+        use graphql_parser::query::Selection::*;
         match self {
             Field(field) => field.shape_hash(hasher),
             FragmentSpread(spread) => spread.shape_hash(hasher),
@@ -93,7 +92,7 @@ impl ShapeHash for q::Field {
 
 impl ShapeHash for s::Value {
     fn shape_hash(&self, hasher: &mut ShapeHasher) {
-        use s::Value::*;
+        use graphql_parser::schema::Value::*;
 
         match self {
             Variable(_) | Int(_) | Float(_) | String(_) | Boolean(_) | Null | Enum(_) => {
@@ -160,10 +159,18 @@ mod tests {
         const Q2: &str = "{ things(where: { stuff_gt: 42 }) { id } }";
         const Q3: &str = "{ things(where: { stuff_lte: 42 }) { id } }";
         const Q4: &str = "{ things(where: { stuff_gt: 42 }) { id name } }";
-        let q1 = parse_query(Q1).expect("q1 is syntactically valid");
-        let q2 = parse_query(Q2).expect("q2 is syntactically valid");
-        let q3 = parse_query(Q3).expect("q3 is syntactically valid");
-        let q4 = parse_query(Q4).expect("q4 is syntactically valid");
+        let q1 = parse_query(Q1)
+            .expect("q1 is syntactically valid")
+            .into_static();
+        let q2 = parse_query(Q2)
+            .expect("q2 is syntactically valid")
+            .into_static();
+        let q3 = parse_query(Q3)
+            .expect("q3 is syntactically valid")
+            .into_static();
+        let q4 = parse_query(Q4)
+            .expect("q4 is syntactically valid")
+            .into_static();
 
         assert_eq!(shape_hash(&q1), shape_hash(&q2));
         assert_ne!(shape_hash(&q1), shape_hash(&q3));

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -1,5 +1,5 @@
 use failure;
-use graphql_parser::{query as q, Pos};
+use graphql_parser::Pos;
 use hex::FromHexError;
 use num_bigint;
 use serde::ser::*;
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use crate::data::graphql::SerializableValue;
 use crate::data::subgraph::*;
+use crate::prelude::q;
 use crate::{components::store::StoreError, prelude::CacheWeight};
 
 #[derive(Debug)]

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -1,4 +1,3 @@
-use graphql_parser::query as q;
 use serde::de::Deserializer;
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
@@ -7,7 +6,7 @@ use std::sync::Arc;
 
 use crate::{
     data::graphql::shape_hash::shape_hash,
-    prelude::{SubgraphDeploymentId, SubgraphName},
+    prelude::{q, SubgraphDeploymentId, SubgraphName},
 };
 
 fn deserialize_number<'de, D>(deserializer: D) -> Result<q::Number, D::Error>

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -1,9 +1,8 @@
 use super::error::{QueryError, QueryExecutionError};
 use crate::{
     data::graphql::SerializableValue,
-    prelude::{CacheWeight, SubgraphDeploymentId},
+    prelude::{q, CacheWeight, SubgraphDeploymentId},
 };
-use graphql_parser::query as q;
 use serde::ser::*;
 use serde::Serialize;
 use std::collections::BTreeMap;

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -31,10 +31,9 @@ use crate::data::subgraph::schema::{
 };
 use crate::prelude::{
     anyhow::{self, Context},
-    format_err, impl_slog_value, BlockNumber, Deserialize, Fail, Serialize,
+    format_err, impl_slog_value, q, BlockNumber, Deserialize, Fail, Serialize,
 };
 use crate::util::ethereum::string_to_h256;
-use graphql_parser::query as q;
 
 use crate::components::ethereum::NodeCapabilities;
 use std::convert::TryFrom;

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -11,7 +11,6 @@
 //!
 //! See `subgraphs.graphql` in the store for corresponding graphql schema.
 
-use graphql_parser::query as q;
 use hex;
 use rand::rngs::OsRng;
 use rand::Rng;

--- a/graph/src/data/subgraph/status.rs
+++ b/graph/src/data/subgraph/status.rs
@@ -1,9 +1,8 @@
 //! Support for the indexing status API
-use graphql_parser::query as q;
 
 use super::schema::{SubgraphError, SubgraphHealth};
 use crate::data::graphql::{object, IntoValue};
-use crate::prelude::{web3::types::H256, EthereumBlockPointer, Value};
+use crate::prelude::{q, web3::types::H256, EthereumBlockPointer, Value};
 
 pub enum Filter {
     /// Get all versions for the named subgraph

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -154,4 +154,30 @@ pub mod prelude {
     pub use crate::util::error::CompatErr;
     pub use crate::util::futures::{retry, TimeoutError};
     pub use crate::util::stats::MovingStats;
+
+    macro_rules! static_graphql {
+        ($m:ident, $m2:ident, {$($n:ident,)*}) => {
+            pub mod $m {
+                use graphql_parser::$m2 as $m;
+                pub use $m::*;
+                $(
+                    pub type $n = $m::$n<'static, String>;
+                )*
+            }
+        };
+    }
+
+    // Static graphql mods. These are to be phased out, with a preference
+    // toward making graphql generic over text. This helps to ease the
+    // transition by providing the old graphql-parse 0.2.x API
+    static_graphql!(q, query, {
+        Document, Value, OperationDefinition, InlineFragment, TypeCondition,
+        FragmentSpread, Field, Selection, SelectionSet, FragmentDefinition,
+        Directive, VariableDefinition, Type,
+    });
+    static_graphql!(s, schema, {
+        Field, Directive, InterfaceType, ObjectType, Value, TypeDefinition,
+        EnumType, Type, Document, ScalarType, InputValue, DirectiveDefinition,
+        UnionType, InputObjectType, EnumValue,
+    });
 }

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -1,6 +1,6 @@
 use crate::{
     components::store::EntityType,
-    prelude::{BigDecimal, BigInt, EntityKey, Value},
+    prelude::{q, BigDecimal, BigInt, EntityKey, Value},
 };
 use std::mem;
 
@@ -114,10 +114,8 @@ impl CacheWeight for Value {
     }
 }
 
-impl CacheWeight for graphql_parser::query::Value {
+impl CacheWeight for q::Value {
     fn indirect_weight(&self) -> usize {
-        use graphql_parser::query as q;
-
         match self {
             q::Value::Boolean(_) | q::Value::Int(_) | q::Value::Null | q::Value::Float(_) => 0,
             q::Value::Enum(s) | q::Value::String(s) | q::Value::Variable(s) => s.indirect_weight(),

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 crossbeam = "0.8"
 futures01 = { package="futures", version="0.1.29" }
 graph = { path = "../graph" }
-graphql-parser = "0.2.3"
+graphql-parser = "0.3"
 indexmap = "1.6"
 Inflector = "0.11.3"
 lazy_static = "1.2.0"

--- a/graphql/examples/schema.rs
+++ b/graphql/examples/schema.rs
@@ -30,7 +30,10 @@ pub fn main() {
         _ => usage("too many arguments"),
     };
     let schema = ensure(fs::read_to_string(schema), "Can not read schema file");
-    let schema = ensure(parse_schema(&schema), "Failed to parse schema");
+    let schema = ensure(
+        parse_schema(&schema).map(|v| v.into_static()),
+        "Failed to parse schema",
+    );
     let schema = ensure(
         api_schema(&schema, &BTreeSet::new()),
         "Failed to convert to API schema",

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,8 +1,7 @@
-use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 
 use crate::execution::ExecutionContext;
-use graph::prelude::{anyhow, QueryExecutionError, StoreEventStreamBox};
+use graph::prelude::{anyhow, q, s, QueryExecutionError, StoreEventStreamBox};
 use graph::{
     data::graphql::{ext::DocumentExt, ObjectOrInterface},
     prelude::QueryResult,
@@ -26,7 +25,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&q::Name, q::Value>,
+        arguments: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an object, `prefetched_object` is `Some` if the parent already calculated the value.
@@ -36,7 +35,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&q::Name, q::Value>,
+        arguments: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an enum value for a given enum type.
@@ -56,7 +55,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         _field: &q::Field,
         _scalar_type: &s::ScalarType,
         value: Option<q::Value>,
-        _argument_values: &HashMap<&q::Name, q::Value>,
+        _argument_values: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         // This code is duplicated.
         // See also c2112309-44fd-4a84-92a0-5a651e6ed548

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -1,4 +1,4 @@
-use graphql_parser::{query as q, schema as s, Pos};
+use graphql_parser::Pos;
 use std::collections::{BTreeMap, HashMap};
 
 use graph::data::graphql::{object, ObjectOrInterface};
@@ -365,7 +365,7 @@ impl Resolver for IntrospectionResolver {
         field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&q::Name, q::Value>,
+        _arguments: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         match field.name.as_str() {
             "possibleTypes" => {
@@ -400,7 +400,7 @@ impl Resolver for IntrospectionResolver {
         field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&q::Name, q::Value>,
+        arguments: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         let object = match field.name.as_str() {
             "__schema" => self.schema_object(),

--- a/graphql/src/introspection/schema.rs
+++ b/graphql/src/introspection/schema.rs
@@ -1,9 +1,10 @@
-use graphql_parser::{self, schema::Document, schema::Name, schema::ObjectType};
+use graphql_parser;
 
 use graph::data::graphql::ext::DocumentExt;
 use graph::data::graphql::ext::ObjectTypeExt;
 use graph::data::schema::{ApiSchema, Schema};
 use graph::data::subgraph::SubgraphDeploymentId;
+use graph::prelude::s::{Document, ObjectType};
 
 use lazy_static::lazy_static;
 
@@ -124,6 +125,6 @@ pub fn introspection_schema(id: SubgraphDeploymentId) -> ApiSchema {
     ApiSchema::from_api_schema(Schema::new(id, INTROSPECTION_DOCUMENT.clone())).unwrap()
 }
 
-pub fn is_introspection_field(name: &Name) -> bool {
+pub fn is_introspection_field(name: &String) -> bool {
     INTROSPECTION_QUERY_TYPE.field(name).is_some()
 }

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -36,8 +36,8 @@ pub mod prelude {
     pub use super::subscription::SubscriptionExecutionOptions;
     pub use super::values::MaybeCoercible;
 
-    pub use super::graphql_parser::{query::Name, schema::ObjectType};
     pub use super::runner::GraphQlRunner;
+    pub use graph::prelude::s::ObjectType;
 }
 
 #[cfg(debug_assertions)]

--- a/graphql/src/query/ast.rs
+++ b/graphql/src/query/ast.rs
@@ -1,4 +1,4 @@
-use graphql_parser::query::*;
+use graph::prelude::q::*;
 use std::collections::HashMap;
 
 use graph::prelude::QueryExecutionError;
@@ -37,7 +37,7 @@ pub fn get_operations(document: &Document) -> Vec<&OperationDefinition> {
 }
 
 /// Returns the name of the given operation (if it has one).
-pub fn get_operation_name(operation: &OperationDefinition) -> Option<&Name> {
+pub fn get_operation_name(operation: &OperationDefinition) -> Option<&String> {
     match operation {
         OperationDefinition::Mutation(m) => m.name.as_ref(),
         OperationDefinition::Query(q) => q.name.as_ref(),
@@ -47,7 +47,7 @@ pub fn get_operation_name(operation: &OperationDefinition) -> Option<&Name> {
 }
 
 /// Looks up a directive in a selection, if it is provided.
-pub fn get_directive(selection: &Selection, name: Name) -> Option<&Directive> {
+pub fn get_directive(selection: &Selection, name: String) -> Option<&Directive> {
     match selection {
         Selection::Field(field) => field
             .directives
@@ -58,12 +58,12 @@ pub fn get_directive(selection: &Selection, name: Name) -> Option<&Directive> {
 }
 
 /// Looks up the value of an argument in a vector of (name, value) tuples.
-pub fn get_argument_value<'a>(arguments: &'a [(Name, Value)], name: &str) -> Option<&'a Value> {
+pub fn get_argument_value<'a>(arguments: &'a [(String, Value)], name: &str) -> Option<&'a Value> {
     arguments.iter().find(|(n, _)| n == name).map(|(_, v)| v)
 }
 
 /// Returns true if a selection should be skipped (as per the `@skip` directive).
-pub fn skip_selection(selection: &Selection, variables: &HashMap<Name, Value>) -> bool {
+pub fn skip_selection(selection: &Selection, variables: &HashMap<String, Value>) -> bool {
     match get_directive(selection, "skip".to_string()) {
         Some(directive) => match get_argument_value(&directive.arguments, "if") {
             Some(val) => match val {
@@ -85,7 +85,7 @@ pub fn skip_selection(selection: &Selection, variables: &HashMap<Name, Value>) -
 }
 
 /// Returns true if a selection should be included (as per the `@include` directive).
-pub fn include_selection(selection: &Selection, variables: &HashMap<Name, Value>) -> bool {
+pub fn include_selection(selection: &Selection, variables: &HashMap<String, Value>) -> bool {
     match get_directive(selection, "include".to_string()) {
         Some(directive) => match get_argument_value(&directive.arguments, "if") {
             Some(val) => match val {
@@ -107,12 +107,12 @@ pub fn include_selection(selection: &Selection, variables: &HashMap<Name, Value>
 }
 
 /// Returns the response key of a field, which is either its name or its alias (if there is one).
-pub fn get_response_key(field: &Field) -> &Name {
+pub fn get_response_key(field: &Field) -> &String {
     field.alias.as_ref().unwrap_or(&field.name)
 }
 
 /// Returns up the fragment with the given name, if it exists.
-pub fn get_fragment<'a>(document: &'a Document, name: &Name) -> Option<&'a FragmentDefinition> {
+pub fn get_fragment<'a>(document: &'a Document, name: &String) -> Option<&'a FragmentDefinition> {
     document
         .definitions
         .iter()

--- a/graphql/src/query/ext.rs
+++ b/graphql/src/query/ext.rs
@@ -1,18 +1,16 @@
 //! Extension traits for graphql_parser::query structs
 
-use graphql_parser::{query as q, Pos};
+use graphql_parser::Pos;
 
 use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
 
 use graph::data::graphql::TryFromValue;
 use graph::data::query::QueryExecutionError;
-use graph::prelude::failure;
-use graph::prelude::web3::types::H256;
-use graph::prelude::BlockNumber;
+use graph::prelude::{failure, q, web3::types::H256, BlockNumber};
 
 pub trait ValueExt: Sized {
-    fn as_object(&self) -> &BTreeMap<q::Name, q::Value>;
+    fn as_object(&self) -> &BTreeMap<String, q::Value>;
     fn as_string(&self) -> &str;
 
     /// If `self` is a variable reference, look it up in `vars` and return
@@ -22,13 +20,13 @@ pub trait ValueExt: Sized {
     /// an error
     fn lookup<'a>(
         &'a self,
-        vars: &'a HashMap<q::Name, Self>,
+        vars: &'a HashMap<String, Self>,
         pos: Pos,
     ) -> Result<&'a Self, QueryExecutionError>;
 }
 
 impl ValueExt for q::Value {
-    fn as_object(&self) -> &BTreeMap<q::Name, q::Value> {
+    fn as_object(&self) -> &BTreeMap<String, q::Value> {
         match self {
             q::Value::Object(object) => object,
             _ => panic!("expected a Value::Object"),
@@ -44,7 +42,7 @@ impl ValueExt for q::Value {
 
     fn lookup<'a>(
         &'a self,
-        vars: &'a HashMap<q::Name, q::Value>,
+        vars: &'a HashMap<String, q::Value>,
         pos: Pos,
     ) -> Result<&'a q::Value, QueryExecutionError> {
         match self {

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,5 +1,4 @@
-use graph::prelude::{CheapClone, EthereumBlockPointer, QueryExecutionError, QueryResult};
-use graphql_parser::query as q;
+use graph::prelude::{q, CheapClone, EthereumBlockPointer, QueryExecutionError, QueryResult};
 use std::sync::Arc;
 use std::time::Instant;
 

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -1,7 +1,5 @@
 use std::{collections::BTreeSet, str::FromStr};
 
-use graphql_parser::query as q;
-use graphql_parser::schema::{Name, Value, *};
 use graphql_parser::Pos;
 use inflector::Inflector;
 use lazy_static::lazy_static;
@@ -13,6 +11,7 @@ use graph::data::{
     schema::{META_FIELD_NAME, META_FIELD_TYPE},
     subgraph::SubgraphFeature,
 };
+use graph::prelude::s::{Value, *};
 use graph::prelude::*;
 
 #[derive(Fail, Debug)]
@@ -256,7 +255,7 @@ fn add_types_for_interface_types(
 /// Adds a `<type_name>_orderBy` enum type for the given fields to the schema.
 fn add_order_by_type(
     schema: &mut Document,
-    type_name: &Name,
+    type_name: &String,
     fields: &[Field],
 ) -> Result<(), APISchemaError> {
     let type_name = format!("{}_orderBy", type_name).to_string();
@@ -290,7 +289,7 @@ fn add_order_by_type(
 /// Adds a `<type_name>_filter` enum type for the given fields to the schema.
 fn add_filter_type(
     schema: &mut Document,
-    type_name: &Name,
+    type_name: &String,
     fields: &[Field],
 ) -> Result<(), APISchemaError> {
     let filter_type_name = format!("{}_filter", type_name).to_string();
@@ -361,7 +360,7 @@ fn field_filter_input_values(
                         field_scalar_filter_input_values(
                             schema,
                             field,
-                            &ScalarType::new(Name::from("String")),
+                            &ScalarType::new(String::from("String")),
                         )
                     }
                 }
@@ -486,7 +485,7 @@ fn field_list_filter_input_values(
 }
 
 /// Generates a `*_filter` input value for the given field name, suffix and value type.
-fn input_value(name: &Name, suffix: &'static str, value_type: Type) -> InputValue {
+fn input_value(name: &String, suffix: &'static str, value_type: Type) -> InputValue {
     InputValue {
         position: Pos::default(),
         description: None,
@@ -675,7 +674,7 @@ fn subgraph_error_argument() -> InputValue {
 /// Generates `Query` fields for the given type name (e.g. `users` and `user`).
 fn query_fields_for_type(
     schema: &Document,
-    type_name: &Name,
+    type_name: &String,
     features: &BTreeSet<SubgraphFeature>,
 ) -> Vec<Field> {
     let input_objects = ast::get_input_object_definitions(schema);
@@ -748,7 +747,7 @@ fn meta_field() -> Field {
 /// Generates arguments for collection queries of a named type (e.g. User).
 fn collection_arguments_for_named_type(
     input_objects: &[InputObjectType],
-    type_name: &Name,
+    type_name: &String,
 ) -> Vec<InputValue> {
     // `first` and `skip` should be non-nullable, but the Apollo graphql client
     // exhibts non-conforming behaviour by erroing if no value is provided for a
@@ -910,7 +909,7 @@ mod tests {
         }
         .expect("OrderDirection type is not an enum");
 
-        let values: Vec<&Name> = enum_type.values.iter().map(|value| &value.name).collect();
+        let values: Vec<&String> = enum_type.values.iter().map(|value| &value.name).collect();
         assert_eq!(values, [&"asc".to_string(), &"desc".to_string()]);
     }
 
@@ -943,7 +942,7 @@ mod tests {
         }
         .expect("User_orderBy type is not an enum");
 
-        let values: Vec<&Name> = enum_type.values.iter().map(|value| &value.name).collect();
+        let values: Vec<&String> = enum_type.values.iter().map(|value| &value.name).collect();
         assert_eq!(values, [&"id".to_string(), &"name".to_string()]);
     }
 

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -1,8 +1,6 @@
 //! Run a GraphQL query and fetch all the entitied needed to build the
 //! final result
 
-use graphql_parser::query as q;
-use graphql_parser::schema as s;
 use indexmap::IndexMap;
 use lazy_static::lazy_static;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -12,7 +10,7 @@ use std::time::Instant;
 
 use graph::data::graphql::*;
 use graph::prelude::{
-    ApiSchema, BlockNumber, ChildMultiplicity, EntityCollection, EntityFilter, EntityLink,
+    q, s, ApiSchema, BlockNumber, ChildMultiplicity, EntityCollection, EntityFilter, EntityLink,
     EntityOrder, EntityWindow, Logger, ParentLink, QueryExecutionError, QueryStore,
     Value as StoreValue, WindowAttribute,
 };
@@ -208,7 +206,7 @@ impl<'a> JoinCond<'a> {
     fn new(
         parent_type: &'a s::ObjectType,
         child_type: &'a s::ObjectType,
-        field_name: &s::Name,
+        field_name: &String,
     ) -> Self {
         let field = parent_type
             .field(field_name)
@@ -307,7 +305,7 @@ impl<'a> Join<'a> {
         schema: &'a ApiSchema,
         parent_type: ObjectOrInterface<'a>,
         child_type: ObjectOrInterface<'a>,
-        field_name: &s::Name,
+        field_name: &String,
     ) -> Self {
         let parent_types = parent_type
             .object_types(schema.schema())
@@ -629,7 +627,7 @@ fn collect_fields_inner<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     type_condition: ObjectOrInterface<'a>,
     selection_set: &'a q::SelectionSet,
-    visited_fragments: &mut HashSet<&'a q::Name>,
+    visited_fragments: &mut HashSet<&'a String>,
     output: &mut IndexMap<&'a String, CollectedResponseKey<'a>>,
 ) {
     fn is_reference_field(
@@ -653,7 +651,7 @@ fn collect_fields_inner<'a>(
         outer_type_condition: ObjectOrInterface<'a>,
         frag_ty_condition: Option<&'a q::TypeCondition>,
         frag_selection_set: &'a q::SelectionSet,
-        visited_fragments: &mut HashSet<&'a q::Name>,
+        visited_fragments: &mut HashSet<&'a String>,
         output: &mut IndexMap<&'a String, CollectedResponseKey<'a>>,
     ) {
         let schema = &ctx.query.schema.document();
@@ -795,9 +793,9 @@ fn fetch(
     store: &(impl QueryStore + ?Sized),
     parents: &Vec<&mut Node>,
     join: &Join<'_>,
-    arguments: HashMap<&q::Name, q::Value>,
+    arguments: HashMap<&String, q::Value>,
     multiplicity: ChildMultiplicity,
-    types_for_interface: &BTreeMap<s::Name, Vec<s::ObjectType>>,
+    types_for_interface: &BTreeMap<String, Vec<s::ObjectType>>,
     block: BlockNumber,
     max_first: u32,
     max_skip: u32,

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -1,4 +1,3 @@
-use graphql_parser::{query as q, query::Name, schema as s, schema::ObjectType};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::mem::discriminant;
 
@@ -19,8 +18,8 @@ enum OrderDirection {
 pub fn build_query<'a>(
     entity: impl Into<ObjectOrInterface<'a>>,
     block: BlockNumber,
-    arguments: &HashMap<&q::Name, q::Value>,
-    types_for_interface: &BTreeMap<Name, Vec<ObjectType>>,
+    arguments: &HashMap<&String, q::Value>,
+    types_for_interface: &BTreeMap<String, Vec<s::ObjectType>>,
     max_first: u32,
     max_skip: u32,
 ) -> Result<EntityQuery, QueryExecutionError> {
@@ -55,7 +54,7 @@ pub fn build_query<'a>(
 
 /// Parses GraphQL arguments into a EntityRange, if present.
 fn build_range(
-    arguments: &HashMap<&q::Name, q::Value>,
+    arguments: &HashMap<&String, q::Value>,
     max_first: u32,
     max_skip: u32,
 ) -> Result<EntityRange, QueryExecutionError> {
@@ -98,7 +97,7 @@ fn build_range(
 /// Parses GraphQL arguments into an EntityFilter, if present.
 fn build_filter(
     entity: ObjectOrInterface,
-    arguments: &HashMap<&q::Name, q::Value>,
+    arguments: &HashMap<&String, q::Value>,
 ) -> Result<Option<EntityFilter>, QueryExecutionError> {
     match arguments.get(&"where".to_string()) {
         Some(q::Value::Object(object)) => build_filter_from_object(entity, object),
@@ -113,7 +112,7 @@ fn build_filter(
 }
 
 fn build_fulltext_filter_from_object(
-    object: &BTreeMap<q::Name, q::Value>,
+    object: &BTreeMap<String, q::Value>,
 ) -> Result<Option<EntityFilter>, QueryExecutionError> {
     object.into_iter().next().map_or(
         Err(QueryExecutionError::FulltextQueryRequiresFilter),
@@ -133,7 +132,7 @@ fn build_fulltext_filter_from_object(
 /// Parses a GraphQL input object into an EntityFilter, if present.
 fn build_filter_from_object(
     entity: ObjectOrInterface,
-    object: &BTreeMap<q::Name, q::Value>,
+    object: &BTreeMap<String, q::Value>,
 ) -> Result<Option<EntityFilter>, QueryExecutionError> {
     Ok(Some(EntityFilter::And({
         object
@@ -205,7 +204,7 @@ fn list_values(value: Value, filter_type: &str) -> Result<Vec<Value>, QueryExecu
 /// Parses GraphQL arguments into an field name to order by, if present.
 fn build_order_by(
     entity: ObjectOrInterface,
-    arguments: &HashMap<&q::Name, q::Value>,
+    arguments: &HashMap<&String, q::Value>,
 ) -> Result<Option<(String, ValueType)>, QueryExecutionError> {
     match arguments.get(&"orderBy".to_string()) {
         Some(q::Value::Enum(name)) => {
@@ -230,7 +229,7 @@ fn build_order_by(
 }
 
 fn build_fulltext_order_by_from_object(
-    object: &BTreeMap<q::Name, q::Value>,
+    object: &BTreeMap<String, q::Value>,
 ) -> Result<Option<(String, ValueType)>, QueryExecutionError> {
     object.into_iter().next().map_or(
         Err(QueryExecutionError::FulltextQueryRequiresFilter),
@@ -246,7 +245,7 @@ fn build_fulltext_order_by_from_object(
 
 /// Parses GraphQL arguments into a EntityOrder, if present.
 fn build_order_direction(
-    arguments: &HashMap<&q::Name, q::Value>,
+    arguments: &HashMap<&String, q::Value>,
 ) -> Result<OrderDirection, QueryExecutionError> {
     Ok(arguments
         .get(&"orderDirection".to_string())
@@ -336,11 +335,8 @@ pub fn collect_entities_from_query_field(
 
 #[cfg(test)]
 mod tests {
-    use graphql_parser::{
-        query as q, schema as s,
-        schema::{Directive, Field, InputValue, ObjectType, Type, Value as SchemaValue},
-        Pos,
-    };
+    use graph::prelude::s::{Directive, Field, InputValue, ObjectType, Type, Value as SchemaValue};
+    use graphql_parser::Pos;
     use std::collections::{BTreeMap, HashMap};
 
     use graph::prelude::*;
@@ -349,7 +345,7 @@ mod tests {
 
     fn default_object() -> ObjectType {
         let subgraph_id_argument = (
-            s::Name::from("id"),
+            String::from("id"),
             s::Value::String("QmZ5dsusHwD1PEbx6L4dLCWkDsk1BLhrx9mPsGyPvTxPCM".to_string()),
         );
         let subgraph_id_directive = Directive {

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -1,4 +1,3 @@
-use graphql_parser::{query as q, schema as s};
 use std::collections::{BTreeMap, HashMap};
 use std::result;
 use std::sync::Arc;
@@ -212,7 +211,7 @@ impl Resolver for StoreResolver {
         field: &q::Field,
         _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&q::Name, q::Value>,
+        _arguments: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         if let Some(child) = prefetched_objects {
             Ok(child)
@@ -232,7 +231,7 @@ impl Resolver for StoreResolver {
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&q::Name, q::Value>,
+        _arguments: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         let (prefetched_object, meta) = self.handle_meta(prefetched_object, &object_type)?;
         if let Some(meta) = meta {

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -1,4 +1,3 @@
-use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 use std::iter;
 use std::result::Result;
@@ -128,7 +127,7 @@ fn resolve_field_stream(
     ctx: &ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
     field: &q::Field,
-    _argument_values: HashMap<&q::Name, q::Value>,
+    _argument_values: HashMap<&String, q::Value>,
 ) -> Result<StoreEventStreamBox, SubscriptionError> {
     ctx.resolver
         .resolve_field_stream(&ctx.query.schema.document(), object_type, field)

--- a/graphql/src/values/coercion.rs
+++ b/graphql/src/values/coercion.rs
@@ -1,7 +1,6 @@
 use crate::schema;
-use graph::prelude::QueryExecutionError;
-use graphql_parser::query as q;
-use graphql_parser::schema::{EnumType, InputValue, Name, ScalarType, Type, TypeDefinition, Value};
+use graph::prelude::s::{EnumType, InputValue, ScalarType, Type, TypeDefinition, Value};
+use graph::prelude::{q, QueryExecutionError};
 use std::collections::{BTreeMap, HashMap};
 
 /// A GraphQL value that can be coerced according to a type.
@@ -60,9 +59,9 @@ impl MaybeCoercible<ScalarType> for Value {
 /// On error, the `value` is returned as `Err(value)`.
 fn coerce_to_definition<'a>(
     value: Value,
-    definition: &Name,
-    resolver: &impl Fn(&Name) -> Option<&'a TypeDefinition>,
-    variables: &HashMap<q::Name, q::Value>,
+    definition: &String,
+    resolver: &impl Fn(&String) -> Option<&'a TypeDefinition>,
+    variables: &HashMap<String, q::Value>,
 ) -> Result<Value, Value> {
     match resolver(definition).ok_or_else(|| value.clone())? {
         // Accept enum values if they match a value in the enum type
@@ -106,8 +105,8 @@ fn coerce_to_definition<'a>(
 pub(crate) fn coerce_input_value<'a>(
     mut value: Option<Value>,
     def: &InputValue,
-    resolver: &impl Fn(&Name) -> Option<&'a TypeDefinition>,
-    variable_values: &HashMap<q::Name, q::Value>,
+    resolver: &impl Fn(&String) -> Option<&'a TypeDefinition>,
+    variable_values: &HashMap<String, q::Value>,
 ) -> Result<Option<Value>, QueryExecutionError> {
     if let Some(Value::Variable(name)) = value {
         value = variable_values.get(&name).cloned();
@@ -146,8 +145,8 @@ pub(crate) fn coerce_input_value<'a>(
 pub(crate) fn coerce_value<'a>(
     value: Value,
     ty: &Type,
-    resolver: &impl Fn(&Name) -> Option<&'a TypeDefinition>,
-    variable_values: &HashMap<q::Name, q::Value>,
+    resolver: &impl Fn(&String) -> Option<&'a TypeDefinition>,
+    variable_values: &HashMap<String, q::Value>,
 ) -> Result<Value, Value> {
     match (ty, value) {
         // Null values cannot be coerced into non-null types.

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -1,13 +1,12 @@
 #[macro_use]
 extern crate pretty_assertions;
 
-use graphql_parser::{query as q, schema as s};
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use graph::data::graphql::{object, object_value, ObjectOrInterface};
 use graph::prelude::{
-    o, slog, tokio, ApiSchema, Logger, Query, QueryExecutionError, QueryResult, Schema,
+    o, q, s, slog, tokio, ApiSchema, Logger, Query, QueryExecutionError, QueryResult, Schema,
     SubgraphDeploymentId,
 };
 use graph_graphql::prelude::{
@@ -37,7 +36,7 @@ impl Resolver for MockResolver {
         _field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&q::Name, q::Value>,
+        _arguments: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }
@@ -48,7 +47,7 @@ impl Resolver for MockResolver {
         _field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&q::Name, q::Value>,
+        _arguments: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }
@@ -551,7 +550,10 @@ fn expected_mock_schema_introspection() -> q::Value {
 /// Execute an introspection query.
 async fn introspection_query(schema: Schema, query: &str) -> QueryResult {
     // Create the query
-    let query = Query::new(graphql_parser::parse_query(query).unwrap(), None);
+    let query = Query::new(
+        graphql_parser::parse_query(query).unwrap().into_static(),
+        None,
+    );
 
     // Execute it
     let logger = Logger::root(slog::Discard, o!());

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate pretty_assertions;
 
-use graphql_parser::{query as q, Pos};
+use graphql_parser::Pos;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::iter::FromIterator;
 use std::sync::Arc;
@@ -13,7 +13,7 @@ use graph::{
     data::{query::CacheStatus, query::QueryTarget, subgraph::SubgraphFeature},
     prelude::{
         async_trait, futures03::stream::StreamExt, futures03::FutureExt, futures03::TryFutureExt,
-        o, serde_json, slog, tokio, Entity, EntityKey, EntityOperation, EthereumBlockPointer,
+        o, q, serde_json, slog, tokio, Entity, EntityKey, EntityOperation, EthereumBlockPointer,
         FutureExtension, GraphQlRunner as _, Logger, NodeId, Query, QueryError,
         QueryExecutionError, QueryLoadManager, QueryResult, QueryStoreManager, QueryVariables,
         Schema, Store, SubgraphDeploymentEntity, SubgraphDeploymentId, SubgraphManifest,
@@ -307,7 +307,8 @@ fn can_query_one_to_one_relationship() {
             }
             ",
             )
-            .expect("Invalid test query"),
+            .expect("Invalid test query")
+            .into_static(),
         )
         .await;
 
@@ -403,7 +404,8 @@ fn can_query_one_to_many_relationships_in_both_directions() {
         }
         ",
             )
-            .expect("Invalid test query"),
+            .expect("Invalid test query")
+            .into_static(),
         )
         .await;
 
@@ -502,7 +504,8 @@ fn can_query_many_to_many_relationship() {
             }
             ",
             )
-            .expect("Invalid test query"),
+            .expect("Invalid test query")
+            .into_static(),
         )
         .await;
 
@@ -574,7 +577,8 @@ fn query_variables_are_used() {
         }
     ",
         )
-        .expect("invalid test query");
+        .expect("invalid test query")
+        .into_static();
 
         let result = execute_query_document_with_variables(
             &id,
@@ -615,7 +619,8 @@ fn skip_directive_works_with_query_variables() {
         }
     ",
         )
-        .expect("invalid test query");
+        .expect("invalid test query")
+        .into_static();
 
         // Set variable $skip to true
         let result = execute_query_document_with_variables(
@@ -692,7 +697,8 @@ fn include_directive_works_with_query_variables() {
         }
     ",
         )
-        .expect("invalid test query");
+        .expect("invalid test query")
+        .into_static();
 
         // Set variable $include to true
         let result = execute_query_document_with_variables(
@@ -773,7 +779,8 @@ fn query_complexity() {
                 }
             }",
             )
-            .unwrap(),
+            .unwrap()
+            .into_static(),
             None,
         );
         let max_complexity = Some(1_010_100);
@@ -807,7 +814,8 @@ fn query_complexity() {
                 }
             }",
             )
-            .unwrap(),
+            .unwrap()
+            .into_static(),
             None,
         );
 
@@ -845,7 +853,8 @@ fn query_complexity_subscriptions() {
                 }
             }",
             )
-            .unwrap(),
+            .unwrap()
+            .into_static(),
             None,
         );
         let max_complexity = Some(1_010_100);
@@ -885,7 +894,8 @@ fn query_complexity_subscriptions() {
                 }
             }",
             )
-            .unwrap(),
+            .unwrap()
+            .into_static(),
             None,
         );
 
@@ -919,7 +929,9 @@ fn query_complexity_subscriptions() {
 fn instant_timeout() {
     run_test_sequentially(setup, |_, id| async move {
         let query = Query::new(
-            graphql_parser::parse_query("query { musicians(first: 100) { name } }").unwrap(),
+            graphql_parser::parse_query("query { musicians(first: 100) { name } }")
+                .unwrap()
+                .into_static(),
             None,
         );
 
@@ -950,7 +962,8 @@ fn variable_defaults() {
         }
     ",
         )
-        .expect("invalid test query");
+        .expect("invalid test query")
+        .into_static();
 
         // Assert that missing variables are defaulted.
         let result = execute_query_document_with_variables(
@@ -1006,7 +1019,8 @@ fn skip_is_nullable() {
         }
     ",
         )
-        .expect("invalid test query");
+        .expect("invalid test query")
+        .into_static();
 
         let result = execute_query_document_with_variables(&id, query, None).await;
 
@@ -1037,7 +1051,8 @@ fn first_is_nullable() {
         }
     ",
         )
-        .expect("invalid test query");
+        .expect("invalid test query")
+        .into_static();
 
         let result = execute_query_document_with_variables(&id, query, None).await;
 
@@ -1068,7 +1083,8 @@ fn nested_variable() {
         }
     ",
         )
-        .expect("invalid test query");
+        .expect("invalid test query")
+        .into_static();
 
         let result = execute_query_document_with_variables(
             &id,
@@ -1107,7 +1123,8 @@ fn ambiguous_derived_from_result() {
         }
         ",
         )
-        .expect("invalid test query");
+        .expect("invalid test query")
+        .into_static();
 
         let result = execute_query_document_with_variables(&id, query, None).await;
 
@@ -1156,7 +1173,8 @@ fn can_filter_by_relationship_fields() {
         }
         ",
             )
-            .expect("invalid test query"),
+            .expect("invalid test query")
+            .into_static(),
         )
         .await;
 
@@ -1209,7 +1227,8 @@ fn cannot_filter_by_derved_relationship_fields() {
         }
         ",
             )
-            .expect("invalid test query"),
+            .expect("invalid test query")
+            .into_static(),
         )
         .await;
 
@@ -1245,7 +1264,8 @@ fn subscription_gets_result_even_without_events() {
               }
             }",
             )
-            .unwrap(),
+            .unwrap()
+            .into_static(),
             None,
         );
 
@@ -1302,7 +1322,8 @@ fn can_use_nested_filter() {
         }
         ",
             )
-            .expect("invalid test query"),
+            .expect("invalid test query")
+            .into_static(),
         )
         .await;
 
@@ -1351,7 +1372,9 @@ async fn check_musicians_at(
     expected: Result<Vec<&str>, &str>,
     qid: &str,
 ) {
-    let query = graphql_parser::parse_query(query).expect("invalid test query");
+    let query = graphql_parser::parse_query(query)
+        .expect("invalid test query")
+        .into_static();
     let vars = block_var.map(|(name, value)| {
         let mut map = HashMap::new();
         map.insert(name.to_owned(), value);
@@ -1505,7 +1528,9 @@ fn query_at_block_with_vars() {
 fn query_detects_reorg() {
     run_test_sequentially(setup, |_, id| async move {
         let query = "query { musician(id: \"m1\") { id } }";
-        let query = graphql_parser::parse_query(query).expect("invalid test query");
+        let query = graphql_parser::parse_query(query)
+            .expect("invalid test query")
+            .into_static();
         let state = STORE
             .deployment_state_from_id(id.clone())
             .expect("failed to get state");
@@ -1560,7 +1585,9 @@ fn can_query_meta() {
     run_test_sequentially(setup, |_, id| async move {
         // metadata for the latest block (block 1)
         let query = "query { _meta { deployment block { hash number } } }";
-        let query = graphql_parser::parse_query(query).expect("invalid test query");
+        let query = graphql_parser::parse_query(query)
+            .expect("invalid test query")
+            .into_static();
 
         let result = execute_query_document(&id, query).await;
         let exp = object! {
@@ -1576,7 +1603,9 @@ fn can_query_meta() {
 
         // metadata for block 0 by number
         let query = "query { _meta(block: { number: 0 }) { deployment block { hash number } } }";
-        let query = graphql_parser::parse_query(query).expect("invalid test query");
+        let query = graphql_parser::parse_query(query)
+            .expect("invalid test query")
+            .into_static();
 
         let result = execute_query_document(&id, query).await;
         let exp = object! {
@@ -1593,7 +1622,9 @@ fn can_query_meta() {
         // metadata for block 0 by hash
         let query = "query { _meta(block: { hash: \"bd34884280958002c51d3f7b5f853e6febeba33de0f40d15b0363006533c924f\" }) { \
                                         deployment block { hash number } } }";
-        let query = graphql_parser::parse_query(query).expect("invalid test query");
+        let query = graphql_parser::parse_query(query)
+            .expect("invalid test query")
+            .into_static();
 
         let result = execute_query_document(&id, query).await;
         let exp = object! {
@@ -1609,7 +1640,9 @@ fn can_query_meta() {
 
         // metadata for block 2, which is beyond what the subgraph has indexed
         let query = "query { _meta(block: { number: 2 }) { deployment block { hash number } } }";
-        let query = graphql_parser::parse_query(query).expect("invalid test query");
+        let query = graphql_parser::parse_query(query)
+            .expect("invalid test query")
+            .into_static();
 
         let result = execute_query_document(&id, query).await;
         assert!(result.has_errors());
@@ -1641,7 +1674,7 @@ fn non_fatal_errors() {
 
             // `subgraphError` is implicitly `deny`, data is omitted.
             let query = "query { musician(id: \"m1\") { id } }";
-            let query = graphql_parser::parse_query(query).unwrap();
+            let query = graphql_parser::parse_query(query).unwrap().into_static();
             let result = execute_query_document(&id, query).await;
             let expected = json!({
                 "errors": [
@@ -1654,13 +1687,13 @@ fn non_fatal_errors() {
 
             // Same result for explicit `deny`.
             let query = "query { musician(id: \"m1\", subgraphError: deny) { id } }";
-            let query = graphql_parser::parse_query(query).unwrap();
+            let query = graphql_parser::parse_query(query).unwrap().into_static();
             let result = execute_query_document(&id, query).await;
             assert_eq!(expected, serde_json::to_value(&result).unwrap());
 
             // But `_meta` is still returned.
             let query = "query { musician(id: \"m1\") { id }  _meta { hasIndexingErrors } }";
-            let query = graphql_parser::parse_query(query).unwrap();
+            let query = graphql_parser::parse_query(query).unwrap().into_static();
             let result = execute_query_document(&id, query).await;
             let expected = json!({
                 "data": {
@@ -1678,7 +1711,7 @@ fn non_fatal_errors() {
 
             // With `allow`, the error remains but the data is included.
             let query = "query { musician(id: \"m1\", subgraphError: allow) { id } }";
-            let query = graphql_parser::parse_query(query).unwrap();
+            let query = graphql_parser::parse_query(query).unwrap().into_static();
             let result = execute_query_document(&id, query).await;
             let expected = json!({
                 "data": {
@@ -1699,7 +1732,7 @@ fn non_fatal_errors() {
                 .revert_block_operations(id.clone(), BLOCK_TWO.block_ptr(), *BLOCK_ONE)
                 .unwrap();
             let query = "query { musician(id: \"m1\") { id }  _meta { hasIndexingErrors } }";
-            let query = graphql_parser::parse_query(query).unwrap();
+            let query = graphql_parser::parse_query(query).unwrap().into_static();
             let result = execute_query_document(&id, query).await;
             let expected = json!({
                 "data": {

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 failure = "0.1.7"
 futures = "0.1.21"
-graphql-parser = "0.2.3"
+graphql-parser = "0.3"
 graph = { path = "../graph" }
 graph-graphql = { path = "../graphql" }
 mockall = "0.8"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/bin/manager.rs"
 clap = "2.33.3"
 env_logger = "0.8.2"
 git-testament = "0.1"
-graphql-parser = "0.2.3"
+graphql-parser = "0.3"
 prometheus = "0.7"
 futures = { version = "0.3.1", features = ["compat"] }
 ipfs-api = { version = "=0.7.1", features = ["hyper-tls"] }

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -25,7 +25,7 @@ wasmtime = "0.21.0"
 defer = "0.1"
 
 [dev-dependencies]
-graphql-parser = "0.2.3"
+graphql-parser = "0.3"
 graph-core = { path = "../../core" }
 graph-mock = { path = "../../mock" }
 test-store = { path = "../../store/test-store" }

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 failure = "0.1.7"
 futures = "0.1.21"
-graphql-parser = "0.2.3"
+graphql-parser = "0.3"
 http = "0.2"
 hyper = "0.13"
 serde = "1.0"

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -376,7 +376,6 @@ mod tests {
     };
     use graph::prelude::*;
     use graph_mock::MockMetricsRegistry;
-    use graphql_parser::query as q;
 
     use crate::test_utils;
 

--- a/server/http/tests/response.rs
+++ b/server/http/tests/response.rs
@@ -1,7 +1,7 @@
 use graph::data::{graphql::object, query::QueryResults};
 use graph::prelude::*;
 use graph_server_http::test_utils;
-use graphql_parser::{self, query as q};
+use graphql_parser;
 use std::collections::BTreeMap;
 
 #[test]
@@ -28,7 +28,7 @@ fn canonical_serialization() {
                 // get amended if q::Value ever gets more variants
                 // The order of the variants should be the same as the
                 // order of the tests below
-                use q::Value::*;
+                use graphql_parser::query::Value::*;
                 let _ = match $obj {
                     Variable(_) | Object(_) | List(_) | Enum(_) | Null | Int(_) | Float(_)
                     | String(_) | Boolean(_) => (),

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -1,4 +1,3 @@
-use graphql_parser::query as q;
 use http::StatusCode;
 use hyper::{Body, Client, Request};
 use std::collections::BTreeMap;

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -8,7 +8,7 @@ failure = "0.1.7"
 futures = "0.3.4"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
-graphql-parser = "0.2.3"
+graphql-parser = "0.3"
 http = "0.2"
 hyper = "0.13"
 serde = "1.0"

--- a/server/index-node/src/explorer.rs
+++ b/server/index-node/src/explorer.rs
@@ -1,7 +1,6 @@
 //! Functionality to support the explorer in the hosted service. Everything
 //! in this file is private API and experimental and subject to change at
 //! any time
-use graphql_parser::query as q;
 use http::{Response, StatusCode};
 use hyper::Body;
 use std::{
@@ -16,7 +15,7 @@ use graph::{
     components::server::{index_node::VersionInfo, query::GraphQLServerError},
     data::subgraph::status,
     object,
-    prelude::{lazy_static, serde_json, SerializableValue, Store},
+    prelude::{lazy_static, q, serde_json, SerializableValue, Store},
 };
 
 lazy_static! {

--- a/server/index-node/src/request.rs
+++ b/server/index-node/src/request.rs
@@ -45,9 +45,11 @@ impl Future for IndexNodeRequest {
         })?;
 
         // Parse the "query" field of the JSON body
-        let document = graphql_parser::parse_query(query_string).map_err(|e| {
-            GraphQLServerError::from(QueryError::ParseError(Arc::new(e.compat().into())))
-        })?;
+        let document = graphql_parser::parse_query(query_string)
+            .map_err(|e| {
+                GraphQLServerError::from(QueryError::ParseError(Arc::new(e.compat().into())))
+            })?
+            .into_static();
 
         // Parse the "variables" field of the JSON body, if present
         let variables = match obj.get("variables") {
@@ -69,7 +71,6 @@ impl Future for IndexNodeRequest {
 #[cfg(test)]
 mod tests {
     use graphql_parser;
-    use graphql_parser::query as q;
     use hyper;
     use std::collections::{BTreeMap, HashMap};
 
@@ -113,7 +114,9 @@ mod tests {
         let query = request.wait().expect("Should accept valid queries");
         assert_eq!(
             query.document,
-            graphql_parser::parse_query("{ user { name } }").unwrap()
+            graphql_parser::parse_query("{ user { name } }")
+                .unwrap()
+                .into_static()
         );
     }
 
@@ -128,7 +131,9 @@ mod tests {
         ));
         let query = request.wait().expect("Should accept null variables");
 
-        let expected_query = graphql_parser::parse_query("{ user { name } }").unwrap();
+        let expected_query = graphql_parser::parse_query("{ user { name } }")
+            .unwrap()
+            .into_static();
         assert_eq!(query.document, expected_query);
         assert_eq!(query.variables, None);
     }
@@ -158,7 +163,9 @@ mod tests {
         ));
         let query = request.wait().expect("Should accept valid queries");
 
-        let expected_query = graphql_parser::parse_query("{ user { name } }").unwrap();
+        let expected_query = graphql_parser::parse_query("{ user { name } }")
+            .unwrap()
+            .into_static();
         let expected_variables = QueryVariables::new(HashMap::from_iter(
             vec![
                 (String::from("string"), q::Value::String(String::from("s"))),

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -1,4 +1,3 @@
-use graphql_parser::{query as q, schema as s};
 use std::collections::HashMap;
 
 use graph::data::graphql::{IntoValue, ObjectOrInterface, ValueMap};
@@ -31,7 +30,7 @@ where
 
     fn resolve_indexing_statuses(
         &self,
-        arguments: &HashMap<&q::Name, q::Value>,
+        arguments: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         let deployments = arguments
             .get(&String::from("subgraphs"))
@@ -55,7 +54,7 @@ where
 
     fn resolve_indexing_statuses_for_subgraph_name(
         &self,
-        arguments: &HashMap<&q::Name, q::Value>,
+        arguments: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         // Get the subgraph name from the arguments; we can safely use `expect` here
         // because the argument will already have been validated prior to the resolver
@@ -79,7 +78,7 @@ where
 
     fn resolve_proof_of_indexing(
         &self,
-        argument_values: &HashMap<&q::Name, q::Value>,
+        argument_values: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         let deployment_id = argument_values
             .get_required::<SubgraphDeploymentId>("subgraph")
@@ -118,7 +117,7 @@ where
 
     fn resolve_indexing_status_for_version(
         &self,
-        arguments: &HashMap<&q::Name, q::Value>,
+        arguments: &HashMap<&String, q::Value>,
 
         // If `true` return the current version, if `false` return the pending version.
         current_version: bool,
@@ -182,7 +181,7 @@ where
         field: &q::Field,
         scalar_type: &s::ScalarType,
         value: Option<q::Value>,
-        argument_values: &HashMap<&q::Name, q::Value>,
+        argument_values: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         // Check if we are resolving the proofOfIndexing bytes
         if &parent_object_type.name == "Query"
@@ -205,7 +204,7 @@ where
         field: &q::Field,
         _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&q::Name, q::Value>,
+        arguments: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         match (prefetched_objects, object_type.name(), field.name.as_str()) {
             // The top-level `indexingStatuses` field
@@ -229,7 +228,7 @@ where
         field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&q::Name, q::Value>,
+        arguments: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         match (prefetched_object, field.name.as_str()) {
             // The top-level `indexingStatusForCurrentVersion` field

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 futures = "0.1.23"
 graph = { path = "../../graph" }
-graphql-parser = "0.2.1"
+graphql-parser = "0.3"
 http = "0.2"
 lazy_static = "1.2.0"
 serde = "1.0"

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -263,7 +263,7 @@ where
                     // Parse the GraphQL query document; respond with a GQL_ERROR if
                     // the query is invalid
                     let query = match parse_query(&payload.query) {
-                        Ok(query) => query,
+                        Ok(query) => query.into_static(),
                         Err(e) => {
                             return send_error_string(
                                 &msg_sink,

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.1.21"
 graph = { path = "../../graph" }
 graph-chain-ethereum = { path = "../../chain/ethereum" }
 graph-graphql = { path = "../../graphql" }
-graphql-parser = "0.2.3"
+graphql-parser = "0.3"
 Inflector = "0.11.3"
 lazy_static = "1.1"
 lru_time_cache = "0.11"
@@ -32,7 +32,7 @@ stable-hash = { git = "https://github.com/graphprotocol/stable-hash" }
 
 [dev-dependencies]
 clap = "2.33.3"
-graphql-parser = "0.2.3"
+graphql-parser = "0.3"
 hex = "0.4.2"
 test-store = { path = "../test-store" }
 hex-literal = "0.3"

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -39,7 +39,7 @@ impl QueryStoreTrait for QueryStore {
     fn find_query_values(
         &self,
         query: EntityQuery,
-    ) -> Result<Vec<BTreeMap<String, graphql_parser::query::Value>>, QueryExecutionError> {
+    ) -> Result<Vec<BTreeMap<String, q::Value>>, QueryExecutionError> {
         assert_eq!(&self.site.deployment, &query.subgraph_id);
         let conn = self
             .store

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -10,8 +10,7 @@ use diesel::connection::SimpleConnection;
 use diesel::{
     debug_query, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl, RunQueryDsl,
 };
-use graphql_parser::query as q;
-use graphql_parser::schema as s;
+use graph::prelude::{q, s};
 use inflector::Inflector;
 use lazy_static::lazy_static;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -1062,7 +1061,7 @@ impl Column {
 
     pub fn is_list(&self) -> bool {
         fn is_list(field_type: &q::Type) -> bool {
-            use q::Type::*;
+            use graphql_parser::query::Type::*;
 
             match field_type {
                 ListType(_) => true,
@@ -1156,7 +1155,7 @@ pub(crate) const VID_COLUMN: &str = "vid";
 #[derive(Clone, Debug)]
 pub struct Table {
     /// The name of the GraphQL object type ('Thing')
-    pub object: s::Name,
+    pub object: String,
     /// The name of the database table for this type ('thing'), snakecased
     /// version of `object`
     pub name: SqlName,
@@ -1390,7 +1389,7 @@ fn derived_column(field: &s::Field) -> bool {
     field
         .directives
         .iter()
-        .any(|dir| dir.name == s::Name::from("derivedFrom"))
+        .any(|dir| dir.name == String::from("derivedFrom"))
 }
 
 fn is_object_type(field_type: &q::Type, enums: &EnumMap) -> bool {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 
 use graph::data::{schema::FulltextAlgorithm, store::scalar};
 use graph::prelude::{
-    format_err, serde_json, Attribute, BlockNumber, ChildMultiplicity, Entity, EntityCollection,
+    format_err, q, serde_json, Attribute, BlockNumber, ChildMultiplicity, Entity, EntityCollection,
     EntityFilter, EntityKey, EntityLink, EntityOrder, EntityRange, EntityWindow, ParentLink,
     QueryExecutionError, StoreError, Value,
 };
@@ -228,8 +228,8 @@ impl FromEntityData for Entity {
     }
 }
 
-impl FromEntityData for BTreeMap<String, graphql_parser::query::Value> {
-    type Value = graphql_parser::query::Value;
+impl FromEntityData for BTreeMap<String, q::Value> {
+    type Value = q::Value;
 
     fn insert_entity_data(&mut self, key: String, v: Self::Value) {
         self.insert(key, v);
@@ -260,7 +260,6 @@ pub trait FromColumnValue: Sized {
         column_type: &ColumnType,
         json: serde_json::Value,
     ) -> Result<Self, StoreError> {
-        //use graphql_parser::query::Value as q;
         use serde_json::Value as j;
         // Many possible conversion errors are already caught by how
         // we define the schema; for example, we can only get a NULL for
@@ -318,9 +317,9 @@ pub trait FromColumnValue: Sized {
     }
 }
 
-impl FromColumnValue for graphql_parser::query::Value {
+impl FromColumnValue for q::Value {
     fn is_null(&self) -> bool {
-        self == &graphql_parser::query::Value::Null
+        self == &q::Value::Null
     }
 
     fn null() -> Self {
@@ -328,31 +327,31 @@ impl FromColumnValue for graphql_parser::query::Value {
     }
 
     fn from_string(s: String) -> Self {
-        graphql_parser::query::Value::String(s)
+        q::Value::String(s)
     }
 
     fn from_bool(b: bool) -> Self {
-        graphql_parser::query::Value::Boolean(b)
+        q::Value::Boolean(b)
     }
 
     fn from_i32(i: i32) -> Self {
-        graphql_parser::query::Value::Int(i.into())
+        q::Value::Int(i.into())
     }
 
     fn from_big_decimal(d: scalar::BigDecimal) -> Self {
-        graphql_parser::query::Value::String(d.to_string())
+        q::Value::String(d.to_string())
     }
 
     fn from_big_int(i: serde_json::Number) -> Result<Self, StoreError> {
-        Ok(graphql_parser::query::Value::String(i.to_string()))
+        Ok(q::Value::String(i.to_string()))
     }
 
     fn from_bytes(b: &str) -> Result<Self, StoreError> {
-        Ok(graphql_parser::query::Value::String(format!("0x{}", b)))
+        Ok(q::Value::String(format!("0x{}", b)))
     }
 
     fn from_vec(v: Vec<Self>) -> Self {
-        graphql_parser::query::Value::List(v)
+        q::Value::List(v)
     }
 }
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1,5 +1,4 @@
 use graph_mock::MockMetricsRegistry;
-use graphql_parser::schema as s;
 use hex_literal::hex;
 use lazy_static::lazy_static;
 use std::str::FromStr;

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -7,7 +7,7 @@ description = "Provides static store instance for tests."
 
 [dependencies]
 graph-graphql = { path = "../../graphql" }
-graphql-parser = "0.2.3"
+graphql-parser = "0.3"
 graph-mock = { path = "../../mock" }
 graph-node = { path = "../../node" }
 graph = { path = "../../graph" }


### PR DESCRIPTION
Security: GraphQL Parsing does not stack overflow when parsing deeply nested structures
Because graphql-parser now uses `anyhow`, this makes the coming migration away from `failure` easier.

This PR takes a different tact than the gas PR to minimize code churn by exporting various type aliases out of `graph::prelude::{q, s}` that are mostly the same as the old APIs. (eg: `pub type Value = graphql_parser::query::Value<'static, String>;`  Eventually we should migrate toward the generic APIs and avoid allocations when parsing.