### PR TITLE
Remove templates nested in data sources

### DIFF
--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -20,7 +20,7 @@ fn create_subgraph(
     let manifest = SubgraphManifest {
         id: subgraph_id.clone(),
         location: subgraph_name.to_string(),
-        spec_version: String::from("0.0.1"),
+        spec_version: String::from("0.0.2"),
         features: BTreeSet::new(),
         description: None,
         repository: None,

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -87,7 +87,7 @@ where
         &mut self,
         logger: Logger,
         data_source: DataSource,
-        top_level_templates: Arc<Vec<DataSourceTemplate>>,
+        templates: Arc<Vec<DataSourceTemplate>>,
         host_metrics: Arc<HostMetrics>,
     ) -> Result<T::Host, Error> {
         let mapping_request_sender = {
@@ -110,7 +110,7 @@ where
             self.network.clone(),
             self.subgraph_id.clone(),
             data_source,
-            top_level_templates,
+            templates,
             mapping_request_sender,
             host_metrics,
         )
@@ -265,7 +265,7 @@ where
         &mut self,
         logger: &Logger,
         data_source: DataSource,
-        top_level_templates: Arc<Vec<DataSourceTemplate>>,
+        templates: Arc<Vec<DataSourceTemplate>>,
         metrics: Arc<HostMetrics>,
     ) -> Result<Option<Arc<T::Host>>, Error> {
         // Protect against creating more than the allowed maximum number of data sources
@@ -278,12 +278,8 @@ where
             }
         }
 
-        let host = Arc::new(self.new_host(
-            logger.clone(),
-            data_source,
-            top_level_templates,
-            metrics.clone(),
-        )?);
+        let host =
+            Arc::new(self.new_host(logger.clone(), data_source, templates, metrics.clone())?);
 
         Ok(if self.hosts.contains(&host) {
             None

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -47,7 +47,7 @@ struct IndexingInputs<B, S> {
     eth_adapter: Arc<dyn EthereumAdapter>,
     stream_builder: B,
     include_calls_in_blocks: bool,
-    top_level_templates: Arc<Vec<DataSourceTemplate>>,
+    templates: Arc<Vec<DataSourceTemplate>>,
 }
 
 struct IndexingState<T: RuntimeHostBuilder> {
@@ -323,13 +323,6 @@ impl SubgraphInstanceManager {
 
         store.start_subgraph_deployment(&logger, &manifest.id)?;
 
-        let mut templates: Vec<DataSourceTemplate> = vec![];
-        for data_source in manifest.data_sources.iter() {
-            for template in data_source.templates.iter() {
-                templates.push(template.clone());
-            }
-        }
-
         // Clone the deployment ID for later
         let deployment_id = manifest.id.clone();
         let network_name = manifest.network_name();
@@ -345,7 +338,7 @@ impl SubgraphInstanceManager {
         // include calls in all blocks
         let include_calls_in_blocks = manifest.requires_traces();
 
-        let top_level_templates = Arc::new(manifest.templates.clone());
+        let templates = Arc::new(manifest.templates.clone());
 
         // Create a subgraph instance from the manifest; this moves
         // ownership of the manifest and host builder into the new instance
@@ -383,7 +376,7 @@ impl SubgraphInstanceManager {
                 eth_adapter,
                 stream_builder,
                 include_calls_in_blocks,
-                top_level_templates,
+                templates,
             },
             state: IndexingState {
                 logger,
@@ -994,7 +987,7 @@ where
         let host = ctx.state.instance.add_dynamic_data_source(
             &logger,
             data_source.clone(),
-            ctx.inputs.top_level_templates.clone(),
+            ctx.inputs.templates.clone(),
             host_metrics.clone(),
         )?;
 

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -70,7 +70,6 @@ where
                 source,
                 mapping: template.mapping.clone(),
                 context,
-                templates: Vec::new(),
             };
             data_sources.push(ds);
         }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -436,7 +436,6 @@ pub struct EthereumContractDataSourceEntity {
     pub name: String,
     pub source: EthereumContractSourceEntity,
     pub mapping: EthereumContractMappingEntity,
-    pub templates: Vec<EthereumContractDataSourceTemplateEntity>,
 }
 
 impl TypedEntity for EthereumContractDataSourceEntity {
@@ -458,17 +457,6 @@ impl EthereumContractDataSourceEntity {
         let mapping_id = format!("{}-mapping", id);
         ops.extend(self.mapping.write_operations(subgraph, &mapping_id));
 
-        let template_ids: Vec<Value> = self
-            .templates
-            .into_iter()
-            .enumerate()
-            .map(|(i, template)| {
-                let template_id = format!("{}-templates-{}", id, i);
-                ops.extend(template.write_operations(subgraph, &template_id));
-                template_id.into()
-            })
-            .collect();
-
         let entity = entity! {
             id: id,
             kind: self.kind,
@@ -476,7 +464,6 @@ impl EthereumContractDataSourceEntity {
             name: self.name,
             source: source_id,
             mapping: mapping_id,
-            templates: template_ids,
         };
 
         ops.push(set_metadata_operation(
@@ -498,11 +485,6 @@ impl<'a> From<&'a super::DataSource> for EthereumContractDataSourceEntity {
             network: data_source.network.clone(),
             source: data_source.source.clone().into(),
             mapping: EthereumContractMappingEntity::from(&data_source.mapping),
-            templates: data_source
-                .templates
-                .iter()
-                .map(EthereumContractDataSourceTemplateEntity::from)
-                .collect(),
         }
     }
 }
@@ -517,7 +499,6 @@ pub struct DynamicEthereumContractDataSourceEntity {
     name: String,
     source: EthereumContractSourceEntity,
     mapping: EthereumContractMappingEntity,
-    templates: Vec<EthereumContractDataSourceTemplateEntity>,
     context: Option<DataSourceContext>,
 }
 
@@ -557,19 +538,8 @@ impl WriteOperations for DynamicEthereumContractDataSourceEntity {
             network,
             source: _,
             mapping: _,
-            templates,
             context,
         } = self;
-
-        let template_ids: Vec<Value> = templates
-            .into_iter()
-            .enumerate()
-            .map(|(i, template)| {
-                let template_id = format!("{}-templates-{}", id, i);
-                template.generate(&template_id, ops);
-                template_id.into()
-            })
-            .collect();
 
         let entity = entity! {
             id: id,
@@ -578,7 +548,6 @@ impl WriteOperations for DynamicEthereumContractDataSourceEntity {
             name: name,
             source: source_id,
             mapping: mapping_id,
-            templates: template_ids,
             deployment: deployment,
             ethereumBlockHash: ethereum_block_hash,
             ethereumBlockNumber: ethereum_block_number,
@@ -612,7 +581,6 @@ impl<'a, 'b, 'c>
             name,
             source,
             mapping,
-            templates,
             context,
         } = data_source;
 
@@ -625,10 +593,6 @@ impl<'a, 'b, 'c>
             network: network.clone(),
             source: source.clone().into(),
             mapping: EthereumContractMappingEntity::from(mapping),
-            templates: templates
-                .iter()
-                .map(EthereumContractDataSourceTemplateEntity::from)
-                .collect(),
             context: context.clone(),
         }
     }

--- a/graph/tests/manifest.rs
+++ b/graph/tests/manifest.rs
@@ -91,7 +91,7 @@ dataSources: []
 schema:
   file:
     /: /ipfs/Qmschema
-specVersion: 0.0.1
+specVersion: 0.0.2
 ";
 
     let manifest = resolve_manifest(YAML).await;
@@ -110,7 +110,7 @@ schema:
 graft:
   base: Qmbase
   block: 12345
-specVersion: 0.0.1
+specVersion: 0.0.2
 ";
 
     let manifest = resolve_manifest(YAML).await;
@@ -131,7 +131,7 @@ schema:
 graft:
   base: Qmbase
   block: 1
-specVersion: 0.0.1
+specVersion: 0.0.2
 ";
 
     let store = test_store::STORE.clone();
@@ -214,7 +214,7 @@ dataSources:
 schema:
   file:
     /: /ipfs/Qmschema
-specVersion: 0.0.1
+specVersion: 0.0.2
 ";
 
     let manifest = resolve_manifest(YAML).await;

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -120,7 +120,7 @@ where
         network_name: String,
         subgraph_id: SubgraphDeploymentId,
         data_source: DataSource,
-        top_level_templates: Arc<Vec<DataSourceTemplate>>,
+        templates: Arc<Vec<DataSourceTemplate>>,
         mapping_request_sender: Sender<MappingRequest>,
         metrics: Arc<HostMetrics>,
     ) -> Result<Self::Host, Error> {
@@ -136,13 +136,6 @@ where
         let ethereum_adapter = self
             .ethereum_networks
             .adapter_with_capabilities(network_name.clone(), &required_capabilities)?;
-
-        // Detect whether the subgraph uses templates in data sources, which are
-        // deprecated, or the top-level templates field.
-        let templates = match top_level_templates.is_empty() {
-            false => top_level_templates,
-            true => Arc::new(data_source.templates),
-        };
 
         RuntimeHost::new(
             ethereum_adapter.clone(),

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -102,28 +102,6 @@ fn mock_data_source(path: &str) -> DataSource {
             },
             runtime: Arc::new(runtime.clone()),
         },
-        templates: vec![DataSourceTemplate {
-            kind: String::from("ethereum/contract"),
-            name: String::from("example template"),
-            network: Some(String::from("mainnet")),
-            source: TemplateSource {
-                abi: String::from("foo"),
-            },
-            mapping: Mapping {
-                kind: String::from("ethereum/events"),
-                api_version: String::from("0.1.0"),
-                language: String::from("wasm/assemblyscript"),
-                entities: vec![],
-                abis: vec![],
-                event_handlers: vec![],
-                call_handlers: vec![],
-                block_handlers: vec![],
-                link: Link {
-                    link: "link".to_owned(),
-                },
-                runtime: Arc::new(runtime),
-            },
-        }],
         context: None,
     }
 }
@@ -137,6 +115,29 @@ fn mock_host_exports(
     let arweave_adapter = Arc::new(ArweaveAdapter::new("https://arweave.net".to_string()));
     let three_box_adapter = Arc::new(ThreeBoxAdapter::new("https://ipfs.3box.io/".to_string()));
 
+    let templates = vec![DataSourceTemplate {
+        kind: String::from("ethereum/contract"),
+        name: String::from("example template"),
+        network: Some(String::from("mainnet")),
+        source: TemplateSource {
+            abi: String::from("foo"),
+        },
+        mapping: Mapping {
+            kind: String::from("ethereum/events"),
+            api_version: String::from("0.1.0"),
+            language: String::from("wasm/assemblyscript"),
+            entities: vec![],
+            abis: vec![],
+            event_handlers: vec![],
+            call_handlers: vec![],
+            block_handlers: vec![],
+            link: Link {
+                link: "link".to_owned(),
+            },
+            runtime: Arc::new(vec![]),
+        },
+    }];
+
     HostExports::new(
         subgraph_id,
         Version::parse(&data_source.mapping.api_version).unwrap(),
@@ -144,7 +145,7 @@ fn mock_host_exports(
         data_source.source.address,
         data_source.network.unwrap(),
         data_source.context,
-        Arc::new(data_source.templates),
+        Arc::new(templates),
         data_source.mapping.abis,
         mock_ethereum_adapter,
         Arc::new(graph_core::LinkResolver::from(

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -181,16 +181,15 @@ fn print_copy_dds(layout: &Layout) {
     println!(
         r#"
 insert into subgraphs.dynamic_ethereum_contract_data_source(id, kind, name,
-              network, source, mapping, templates, ethereum_block_hash,
+              network, source, mapping, ethereum_block_hash,
               ethereum_block_number, deployment, block_range)
-select x.new_id, e.kind, e.name, e.network, {source}, {mapping}, {templates},
+select x.new_id, e.kind, e.name, e.network, {source}, {mapping},
        e.ethereum_block_hash, e.ethereum_block_number, $3 as deployment,
        e.block_range
   from xlat x, subgraphs.dynamic_ethereum_contract_data_source e
  where x.id = e.id"#,
         source = xlat("source", false),
         mapping = xlat("mapping", false),
-        templates = xlat("templates", true),
     );
 }
 
@@ -313,7 +312,7 @@ pub fn main() {
     .get_matches();
 
     let schema = args.value_of("schema").unwrap();
-    let namespace = args.value_of("db_schema").unwrap_or("rel");
+    let namespace = args.value_of("db_schema").unwrap_or("subgraphs");
     let kind = args.value_of("generate").unwrap_or("ddl");
 
     let subgraph = SubgraphDeploymentId::new("Qmasubgraph").unwrap();

--- a/store/postgres/migrations/2020-12-15-000000_remove_nested_templates/down.sql
+++ b/store/postgres/migrations/2020-12-15-000000_remove_nested_templates/down.sql
@@ -1,0 +1,9 @@
+alter table
+    subgraphs.dynamic_ethereum_contract_data_source
+add
+    column templates;
+
+alter table
+    subgraphs.ethereum_contract_data_source
+add
+    column templates;

--- a/store/postgres/migrations/2020-12-15-000000_remove_nested_templates/up.sql
+++ b/store/postgres/migrations/2020-12-15-000000_remove_nested_templates/up.sql
@@ -1,0 +1,9 @@
+alter table
+    subgraphs.dynamic_ethereum_contract_data_source
+drop
+    column templates;
+
+alter table
+    subgraphs.ethereum_contract_data_source
+drop
+    column templates;

--- a/store/postgres/src/copy_dds.sql
+++ b/store/postgres/src/copy_dds.sql
@@ -21,8 +21,8 @@ with xlat as (
       from subgraphs.ethereum_contract_abi e, xlat x
      where left(e.id, 40) = x.id),
  md4 as (
-    insert into subgraphs.ethereum_contract_data_source(id, kind, name, network, source, mapping, templates, block_range)
-    select (x.new_id || right(e.id, -40)) as id, kind, name, network, (x.new_id || right(e.source, -40)) as source, (x.new_id || right(e.mapping, -40)) as mapping, (select array_agg(x.new_id || right(a.elt, -40)) from unnest(e.templates) a(elt)) as templates, block_range
+    insert into subgraphs.ethereum_contract_data_source(id, kind, name, network, source, mapping, block_range)
+    select (x.new_id || right(e.id, -40)) as id, kind, name, network, (x.new_id || right(e.source, -40)) as source, (x.new_id || right(e.mapping, -40)) as mapping, block_range
       from subgraphs.ethereum_contract_data_source e, xlat x
      where left(e.id, 40) = x.id),
  md5 as (
@@ -51,9 +51,9 @@ with xlat as (
       from subgraphs.ethereum_contract_source e, xlat x
      where left(e.id, 40) = x.id)
 insert into subgraphs.dynamic_ethereum_contract_data_source(id, kind, name,
-              network, source, mapping, templates, ethereum_block_hash,
+              network, source, mapping, ethereum_block_hash,
               ethereum_block_number, deployment, block_range)
-select x.new_id, e.kind, e.name, e.network, (x.new_id || right(e.source, -40)) as source, (x.new_id || right(e.mapping, -40)) as mapping, (select array_agg(x.new_id || right(a.elt, -40)) from unnest(e.templates) a(elt)) as templates,
+select x.new_id, e.kind, e.name, e.network, (x.new_id || right(e.source, -40)) as source, (x.new_id || right(e.mapping, -40)) as mapping,
        e.ethereum_block_hash, e.ethereum_block_number, $3 as deployment,
        e.block_range
   from xlat x, subgraphs.dynamic_ethereum_contract_data_source e

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -86,7 +86,6 @@ table! {
         network -> Nullable<Text>,
         source -> Text,
         mapping -> Text,
-        templates -> Nullable<Array<Text>>,
         ethereum_block_hash -> Binary,
         ethereum_block_number -> Numeric,
         deployment -> Text,
@@ -118,7 +117,6 @@ table! {
         network -> Nullable<Text>,
         source -> Text,
         mapping -> Text,
-        templates -> Nullable<Array<Text>>,
         block_range -> Range<Integer>,
     }
 }

--- a/store/postgres/src/dynds.rs
+++ b/store/postgres/src/dynds.rs
@@ -26,7 +26,6 @@ table! {
         network -> Nullable<Text>,
         source -> Text,
         mapping -> Text,
-        templates -> Nullable<Array<Text>>,
         ethereum_block_hash -> Binary,
         ethereum_block_number -> Numeric,
         deployment -> Text,

--- a/store/postgres/src/subgraphs.graphql
+++ b/store/postgres/src/subgraphs.graphql
@@ -114,7 +114,6 @@ type EthereumContractDataSource @entity {
     network: String
     source: EthereumContractSource!
     mapping: EthereumContractMapping!
-    templates: [EthereumContractDataSourceTemplate!]
 }
 
 type DynamicEthereumContractDataSource @entity {
@@ -124,7 +123,6 @@ type DynamicEthereumContractDataSource @entity {
     network: String
     source: EthereumContractSource!
     mapping: EthereumContractMapping!
-    templates: [EthereumContractDataSourceTemplate!]
     ethereumBlockHash: Bytes!
     ethereumBlockNumber: BigInt!
     deployment: SubgraphDeployment!

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1188,28 +1188,6 @@ fn mock_data_source() -> DataSource {
             },
             runtime: Arc::new(Vec::new()),
         },
-        templates: vec![DataSourceTemplate {
-            kind: String::from("ethereum/contract"),
-            name: String::from("example template"),
-            network: Some(String::from("mainnet")),
-            source: TemplateSource {
-                abi: String::from("foo"),
-            },
-            mapping: Mapping {
-                kind: String::from("ethereum/events"),
-                api_version: String::from("0.1.0"),
-                language: String::from("wasm/assemblyscript"),
-                entities: vec![],
-                abis: vec![],
-                event_handlers: vec![],
-                call_handlers: vec![],
-                block_handlers: vec![],
-                link: Link {
-                    link: "link".to_owned(),
-                },
-                runtime: Arc::new(Vec::new()),
-            },
-        }],
         context: None,
     }
 }


### PR DESCRIPTION
We've already dropped support for it, this is doing a cleanup removing related code. specVersion 0.0.1 is no longer accepted. There are only 11 subgraphs on the hosted service that are still on that, and they do not get any queries.