### PR TITLE
Instrument RwLock cache

### DIFF
--- a/graph/src/util/mod.rs
+++ b/graph/src/util/mod.rs
@@ -14,3 +14,5 @@ pub mod error;
 pub mod stats;
 
 pub mod cache_weight;
+
+pub mod timed_rw_lock;

--- a/graph/src/util/timed_rw_lock.rs
+++ b/graph/src/util/timed_rw_lock.rs
@@ -1,0 +1,46 @@
+use slog::{warn, Logger};
+use std::{
+    sync::RwLock,
+    time::{Duration, Instant},
+};
+
+/// Adds instrumentation for timing the performance of the lock.
+pub struct TimedRwLock<T> {
+    id: String,
+    lock: RwLock<T>,
+}
+
+impl<T> TimedRwLock<T> {
+    pub fn new(id: impl Into<String>, x: T) -> Self {
+        TimedRwLock {
+            id: id.into(),
+            lock: RwLock::new(x),
+        }
+    }
+
+    pub fn write(&self, logger: &Logger) -> std::sync::RwLockWriteGuard<T> {
+        let start = Instant::now();
+        let guard = self.lock.write().unwrap();
+        let elapsed = start.elapsed();
+        if elapsed > Duration::from_millis(100) {
+            warn!(logger, "Write lock took a long time to acquire";
+                          "id" => &self.id,
+                          "wait_ms" => elapsed.as_millis(),
+            );
+        }
+        guard
+    }
+
+    pub fn read(&self, logger: &Logger) -> std::sync::RwLockReadGuard<T> {
+        let start = Instant::now();
+        let guard = self.lock.read().unwrap();
+        let elapsed = start.elapsed();
+        if elapsed > Duration::from_millis(100) {
+            warn!(logger, "Read lock took a long time to acquire";
+                          "id" => &self.id,
+                          "wait_ms" => elapsed.as_millis(),
+            );
+        }
+        guard
+    }
+}

--- a/graph/src/util/timed_rw_lock.rs
+++ b/graph/src/util/timed_rw_lock.rs
@@ -1,20 +1,35 @@
 use slog::{warn, Logger};
 use std::{
-    sync::RwLock,
+    sync::{Mutex, RwLock},
     time::{Duration, Instant},
 };
+
+lazy_static::lazy_static! {
+    /// If an instrumented lock is contended for longer than the specified duration, a warning will
+    /// be logged. Environment variable specified in milliseconds. Defaults to 100ms.
+    static ref LOCK_CONTENTION_LOG_THRESHOLD: Duration = {
+        Duration::from_millis(
+            std::env::var("GRAPH_LOCK_CONTENTION_LOG_THRESHOLD_MS")
+                .unwrap_or("100".to_string())
+                .parse::<u64>()
+                .expect("Invalid value for LOCK_CONTENTION_LOG_THRESHOLD_MS environment variable")
+       )
+    };
+}
 
 /// Adds instrumentation for timing the performance of the lock.
 pub struct TimedRwLock<T> {
     id: String,
     lock: RwLock<T>,
+    log_threshold: Duration,
 }
 
 impl<T> TimedRwLock<T> {
-    pub fn new(id: impl Into<String>, x: T) -> Self {
+    pub fn new(x: T, id: impl Into<String>) -> Self {
         TimedRwLock {
             id: id.into(),
             lock: RwLock::new(x),
+            log_threshold: *LOCK_CONTENTION_LOG_THRESHOLD,
         }
     }
 
@@ -22,7 +37,7 @@ impl<T> TimedRwLock<T> {
         let start = Instant::now();
         let guard = self.lock.write().unwrap();
         let elapsed = start.elapsed();
-        if elapsed > Duration::from_millis(100) {
+        if elapsed > self.log_threshold {
             warn!(logger, "Write lock took a long time to acquire";
                           "id" => &self.id,
                           "wait_ms" => elapsed.as_millis(),
@@ -35,8 +50,38 @@ impl<T> TimedRwLock<T> {
         let start = Instant::now();
         let guard = self.lock.read().unwrap();
         let elapsed = start.elapsed();
-        if elapsed > Duration::from_millis(100) {
+        if elapsed > self.log_threshold {
             warn!(logger, "Read lock took a long time to acquire";
+                          "id" => &self.id,
+                          "wait_ms" => elapsed.as_millis(),
+            );
+        }
+        guard
+    }
+}
+
+/// Adds instrumentation for timing the performance of the lock.
+pub struct TimedMutex<T> {
+    id: String,
+    lock: Mutex<T>,
+    log_threshold: Duration,
+}
+
+impl<T> TimedMutex<T> {
+    pub fn new(x: T, id: impl Into<String>) -> Self {
+        TimedMutex {
+            id: id.into(),
+            lock: Mutex::new(x),
+            log_threshold: *LOCK_CONTENTION_LOG_THRESHOLD,
+        }
+    }
+
+    pub fn lock(&self, logger: &Logger) -> std::sync::MutexGuard<T> {
+        let start = Instant::now();
+        let guard = self.lock.lock().unwrap();
+        let elapsed = start.elapsed();
+        if elapsed > self.log_threshold {
+            warn!(logger, "Mutex lock took a long time to acquire";
                           "id" => &self.id,
                           "wait_ms" => elapsed.as_millis(),
             );


### PR DESCRIPTION
On Linux, readers will by [default starve writers](https://man7.org/linux/man-pages/man3/pthread_rwlockattr_setkind_np.3.html).
> As long as there are readers, the writer will be starved.

The query cache is a very busy lock and it runs in a non-blocking task, so we want to log any contention on it.