### PR TITLE
Allow type named 'List'

### DIFF
--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -127,7 +127,6 @@ pub enum ValueType {
     BigDecimal,
     Int,
     String,
-    List,
 }
 
 impl FromStr for ValueType {
@@ -141,7 +140,6 @@ impl FromStr for ValueType {
             "BigDecimal" => Ok(ValueType::BigDecimal),
             "Int" => Ok(ValueType::Int),
             "String" | "ID" => Ok(ValueType::String),
-            "List" => Ok(ValueType::List),
             s => Err(anyhow!("Type not available in this context: {}", s)),
         }
     }
@@ -150,17 +148,7 @@ impl FromStr for ValueType {
 impl ValueType {
     /// Return `true` if `s` is the name of a builtin scalar type
     pub fn is_scalar(s: &str) -> bool {
-        Self::from_str(s)
-            .map(|vt| match vt {
-                ValueType::List => false,
-                ValueType::Boolean
-                | ValueType::BigDecimal
-                | ValueType::BigInt
-                | ValueType::Bytes
-                | ValueType::Int
-                | ValueType::String => true,
-            })
-            .unwrap_or(false)
+        Self::from_str(s).is_ok()
     }
 }
 

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -390,7 +390,6 @@ fn field_scalar_filter_input_values(
         "BigDecimal" => vec!["", "not", "gt", "lt", "gte", "lte", "in", "not_in"],
         "ID" => vec!["", "not", "gt", "lt", "gte", "lte", "in", "not_in"],
         "Int" => vec!["", "not", "gt", "lt", "gte", "lte", "in", "not_in"],
-        "List" => vec!["", "not", "in", "not_in", "contains", "not_contains"],
         "String" => vec![
             "",
             "not",

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -951,9 +951,6 @@ impl ColumnType {
             ValueType::Bytes => Ok(ColumnType::Bytes),
             ValueType::Int => Ok(ColumnType::Int),
             ValueType::String => Ok(ColumnType::String),
-            ValueType::List => Err(StoreError::Unknown(anyhow!(
-                "can not convert ValueType::List to ColumnType"
-            ))),
         }
     }
 


### PR DESCRIPTION
An amusing oddity that we are considering the string `"List"` as representing a list type, but that's never the case. This was discovered because a user tried using a `type List @entity { ... }` and this caused an error.