### PR TITLE
Temporarily ignore the arweave test

### DIFF
--- a/tests/tests/tests.rs
+++ b/tests/tests/tests.rs
@@ -77,7 +77,9 @@ fn data_source_context() {
     run_test("data-source-context")
 }
 
+// The arweave.net gateway is having issues, hopefully temporary.
 #[test]
+#[ignore]
 fn arweave_and_3box() {
     let _m = TEST_MUTEX.lock();
     run_test("arweave-and-3box")


### PR DESCRIPTION
It's failing our CI because their gateway is having issues as can be seen [here](https://arweave.net/tx/W2czhcswOAe4TgL4Q8kHHqoZ1jbFBntUCrtamYX_rOU/data.).