### PR TITLE
*: Require a block number in `proofOfIndexing` queries

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -91,9 +91,7 @@ impl EntityType {
     /// This method will panic if `self` is a `Data` type
     pub fn expect_metadata(&self) -> &str {
         match self {
-            Self::Data(_) => {
-                unreachable!("callers check that this is never called for data")
-            }
+            Self::Data(_) => unreachable!("callers check that this is never called for data"),
             Self::Metadata(typ) => typ.as_str(),
         }
     }
@@ -950,7 +948,7 @@ pub trait Store: Send + Sync + 'static {
         self: Arc<Self>,
         subgraph_id: &'a SubgraphDeploymentId,
         indexer: &'a Option<Address>,
-        block_hash: H256,
+        block: EthereumBlockPointer,
     ) -> DynTryFuture<'a, Option<[u8; 32]>>;
 
     /// Looks up an entity using the given store key at the latest block.
@@ -1179,7 +1177,7 @@ impl Store for MockStore {
         self: Arc<Self>,
         _subgraph_id: &'a SubgraphDeploymentId,
         _indexer: &'a Option<Address>,
-        _block_hash: H256,
+        _block: EthereumBlockPointer,
     ) -> DynTryFuture<'a, Option<[u8; 32]>> {
         unimplemented!();
     }

--- a/graph/src/data/graphql/values.rs
+++ b/graph/src/data/graphql/values.rs
@@ -51,6 +51,7 @@ impl TryFromValue for u64 {
         }
     }
 }
+
 impl TryFromValue for H160 {
     fn try_from_value(value: &q::Value) -> Result<Self, Error> {
         match value {

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -86,7 +86,7 @@ impl Store for MockStore {
         self: Arc<Self>,
         _subgraph_id: &'a SubgraphDeploymentId,
         _indexer: &'a Option<Address>,
-        _block_hash: H256,
+        _block: EthereumBlockPointer,
     ) -> DynTryFuture<'a, Option<[u8; 32]>> {
         unimplemented!()
     }

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -11,7 +11,12 @@ type Query {
     subgraphName: String!
   ): [SubgraphIndexingStatus!]!
   indexingStatuses(subgraphs: [String!]): [SubgraphIndexingStatus!]!
-  proofOfIndexing(subgraph: String!, blockHash: Bytes!, indexer: Bytes): Bytes
+  proofOfIndexing(
+    subgraph: String!
+    blockNumber: Int!
+    blockHash: Bytes!
+    indexer: Bytes
+  ): Bytes
 }
 
 type SubgraphIndexingStatus {

--- a/store/postgres/src/network_store.rs
+++ b/store/postgres/src/network_store.rs
@@ -75,11 +75,11 @@ impl StoreTrait for NetworkStore {
         self: Arc<Self>,
         subgraph_id: &'a graph::prelude::SubgraphDeploymentId,
         indexer: &'a Option<Address>,
-        block_hash: H256,
+        block: EthereumBlockPointer,
     ) -> graph::prelude::DynTryFuture<'a, Option<[u8; 32]>> {
         self.store
             .clone()
-            .get_proof_of_indexing(subgraph_id, indexer, block_hash)
+            .get_proof_of_indexing(subgraph_id, indexer, block)
     }
 
     fn get(

--- a/store/postgres/src/sharded_store.rs
+++ b/store/postgres/src/sharded_store.rs
@@ -16,13 +16,11 @@ use graph::{
     prelude::StoreEvent,
     prelude::SubgraphDeploymentEntity,
     prelude::{
-        lazy_static,
-        web3::types::{Address, H256},
-        ApiSchema, DeploymentState, DynTryFuture, Entity, EntityKey, EntityModification,
-        EntityQuery, Error, EthereumBlockPointer, EthereumCallCache, Logger, MetadataOperation,
-        NodeId, QueryExecutionError, Schema, StopwatchMetrics, Store as StoreTrait, StoreError,
-        StoreEventStreamBox, SubgraphDeploymentId, SubgraphName, SubgraphVersionSwitchingMode,
-        SubscriptionFilter,
+        lazy_static, web3::types::Address, ApiSchema, DeploymentState, DynTryFuture, Entity,
+        EntityKey, EntityModification, EntityQuery, Error, EthereumBlockPointer, EthereumCallCache,
+        Logger, MetadataOperation, NodeId, QueryExecutionError, Schema, StopwatchMetrics,
+        Store as StoreTrait, StoreError, StoreEventStreamBox, SubgraphDeploymentId, SubgraphName,
+        SubgraphVersionSwitchingMode, SubscriptionFilter,
     },
 };
 use store::StoredDynamicDataSource;
@@ -357,12 +355,10 @@ impl StoreTrait for ShardedStore {
         self: Arc<Self>,
         id: &'a SubgraphDeploymentId,
         indexer: &'a Option<Address>,
-        block_hash: H256,
+        block: EthereumBlockPointer,
     ) -> DynTryFuture<'a, Option<[u8; 32]>> {
         let (store, site) = self.store(&id).unwrap();
-        store
-            .clone()
-            .get_proof_of_indexing(site, indexer, block_hash)
+        store.clone().get_proof_of_indexing(site, indexer, block)
     }
 
     fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError> {


### PR DESCRIPTION
This is to avoid `null` POIs if the block hash isn't found in the block store (which could be the case on one indexer but not on another). This can lead to indexers losing rewards despite indexing a subgraph correctly.

By requiring e.g. the indexer agent to always provide block number and hash in `proofOfIndexing` queries, we can compute the POI on any indexer, regardless of what is in their block store. This is easier than resolving the block hash -> number on-demand in the `proofOfIndexing` resolver. The agent already knows both values anyway.

Part of fixing https://github.com/graphprotocol/indexer/issues/186.

_Note: This is a breaking change but I didn't want to make the block number argument optional, as that just adds unnecessary complexity._
