### PR TITLE
Add capability to remove unused deployments to graphman

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -926,6 +926,13 @@ pub struct StoredDynamicDataSource {
     pub creation_block: Option<u64>,
 }
 
+pub trait SubscriptionManager: Send + Sync + 'static {
+    /// Subscribe to changes for specific subgraphs and entities.
+    ///
+    /// Returns a stream of store events that match the input arguments.
+    fn subscribe(&self, entities: Vec<SubscriptionFilter>) -> StoreEventStreamBox;
+}
+
 /// Common trait for store implementations.
 #[async_trait]
 pub trait Store: Send + Sync + 'static {
@@ -995,11 +1002,6 @@ pub trait Store: Send + Sync + 'static {
         subgraph_id: SubgraphDeploymentId,
         block_ptr_to: EthereumBlockPointer,
     ) -> Result<(), StoreError>;
-
-    /// Subscribe to changes for specific subgraphs and entities.
-    ///
-    /// Returns a stream of store events that match the input arguments.
-    fn subscribe(&self, entities: Vec<SubscriptionFilter>) -> StoreEventStreamBox;
 
     /// Find the deployment for the current version of subgraph `name` and
     /// return details about it needed for executing queries
@@ -1224,10 +1226,6 @@ impl Store for MockStore {
         unimplemented!()
     }
 
-    fn subscribe(&self, _entities: Vec<SubscriptionFilter>) -> StoreEventStreamBox {
-        unimplemented!()
-    }
-
     fn deployment_state_from_name(&self, _: SubgraphName) -> Result<DeploymentState, StoreError> {
         unimplemented!()
     }
@@ -1441,8 +1439,6 @@ pub trait QueryStore: Send + Sync {
         &self,
         query: EntityQuery,
     ) -> Result<Vec<BTreeMap<String, q::Value>>, QueryExecutionError>;
-
-    fn subscribe(&self, entities: Vec<SubscriptionFilter>) -> StoreEventStreamBox;
 
     fn is_deployment_synced(&self, id: &SubgraphDeploymentId) -> Result<bool, Error>;
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -24,7 +24,7 @@ use graph_graphql::{prelude::*, subscription::execute_subscription};
 use test_store::{
     execute_subgraph_query_with_complexity, execute_subgraph_query_with_deadline,
     run_test_sequentially, transact_entity_operations, transact_errors, BLOCK_ONE, GENESIS_PTR,
-    LOAD_MANAGER, LOGGER, STORE,
+    LOAD_MANAGER, LOGGER, STORE, SUBSCRIPTION_MANAGER,
 };
 
 const NETWORK_NAME: &str = "fake_network";
@@ -244,6 +244,7 @@ async fn execute_query_document_with_variables(
     let runner = Arc::new(GraphQlRunner::new(
         &*LOGGER,
         STORE.clone(),
+        SUBSCRIPTION_MANAGER.clone(),
         LOAD_MANAGER.clone(),
     ));
     let target = QueryTarget::Deployment(id.clone());
@@ -860,6 +861,7 @@ fn query_complexity_subscriptions() {
         let options = SubscriptionExecutionOptions {
             logger: logger.clone(),
             store: store.clone(),
+            subscription_manager: SUBSCRIPTION_MANAGER.clone(),
             timeout: None,
             max_complexity,
             max_depth: 100,
@@ -903,6 +905,7 @@ fn query_complexity_subscriptions() {
         let options = SubscriptionExecutionOptions {
             logger,
             store,
+            subscription_manager: SUBSCRIPTION_MANAGER.clone(),
             timeout: None,
             max_complexity,
             max_depth: 100,
@@ -1269,6 +1272,7 @@ fn subscription_gets_result_even_without_events() {
         let options = SubscriptionExecutionOptions {
             logger: logger.clone(),
             store,
+            subscription_manager: SUBSCRIPTION_MANAGER.clone(),
             timeout: None,
             max_complexity: None,
             max_depth: 100,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -122,10 +122,6 @@ impl Store for MockStore {
         unimplemented!()
     }
 
-    fn subscribe(&self, _entities: Vec<SubscriptionFilter>) -> StoreEventStreamBox {
-        unimplemented!()
-    }
-
     fn deployment_state_from_name(&self, _: SubgraphName) -> Result<DeploymentState, StoreError> {
         unimplemented!()
     }

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -80,6 +80,18 @@ pub enum UnusedCommand {
     },
     /// Update and record currently unused deployments
     Record,
+    /// Remove deployments that were marked as unused with `record`.
+    ///
+    /// Deployments are removed in descending order of number of entities,
+    /// i.e., smaller deployments are removed before larger ones
+    Remove {
+        /// How many unused deployments to remove (default: all)
+        #[structopt(short, long)]
+        count: Option<usize>,
+        /// Remove a specific deployment
+        #[structopt(short, long, conflicts_with = "count")]
+        deployment: Option<String>,
+    },
 }
 
 impl From<Opt> for config::Opt {
@@ -156,6 +168,10 @@ async fn main() {
             match cmd {
                 List { existing } => commands::unused_deployments::list(store, existing),
                 Record => commands::unused_deployments::record(store),
+                Remove { count, deployment } => {
+                    let count = count.unwrap_or(1_000_000);
+                    commands::unused_deployments::remove(store, count, deployment)
+                }
             }
         }
     };

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -109,9 +109,8 @@ fn make_main_pool(logger: &Logger, config: &Config) -> ConnectionPool {
     )
 }
 
-#[allow(dead_code)]
 fn make_store(logger: &Logger, config: &Config) -> Arc<ShardedStore> {
-    StoreBuilder::new(logger, config, make_registry(logger)).store()
+    StoreBuilder::make_sharded_store(logger, config, make_registry(logger))
 }
 
 #[tokio::main]

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -60,6 +60,15 @@ pub enum Command {
     Info {
         /// The deployment, an id, schema name or subgraph name
         name: String,
+        /// List only current version
+        #[structopt(long, short)]
+        current: bool,
+        /// List only pending versions
+        #[structopt(long, short)]
+        pending: bool,
+        /// List only used (current and pending) versions
+        #[structopt(long, short)]
+        used: bool,
     },
     /// Print how a specific subgraph would be placed
     Place { name: String, network: String },
@@ -156,9 +165,14 @@ async fn main() {
             let pool = make_main_pool(&logger, &config);
             commands::txn_speed::run(pool, delay)
         }
-        Info { name } => {
+        Info {
+            name,
+            current,
+            pending,
+            used,
+        } => {
             let pool = make_main_pool(&logger, &config);
-            commands::info::run(pool, name)
+            commands::info::run(pool, name, current, pending, used)
         }
         Place { name, network } => commands::place::run(&config.deployment, &name, &network),
         Unused(cmd) => {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -259,6 +259,7 @@ async fn main() {
             let graphql_runner = Arc::new(GraphQlRunner::new(
                 &logger,
                 generic_network_store,
+                store_builder.subscription_manager(),
                 load_manager,
             ));
             let mut graphql_server = GraphQLQueryServer::new(
@@ -384,6 +385,7 @@ async fn main() {
                 link_resolver,
                 Arc::new(subgraph_provider),
                 store_builder.store(),
+                store_builder.subscription_manager(),
                 network_stores,
                 eth_networks.clone(),
                 node_id.clone(),

--- a/node/src/manager/commands/info.rs
+++ b/node/src/manager/commands/info.rs
@@ -6,21 +6,7 @@ use crate::manager::deployment::Deployment;
 pub fn run(pool: ConnectionPool, name: String) -> Result<(), anyhow::Error> {
     let conn = pool.get()?;
 
-    let mut first = true;
-    for deployment in Deployment::lookup(&conn, name)? {
-        if !first {
-            println!("-------------+-----------------------------------------------");
-        }
-        first = false;
-
-        println!(
-            "{:12} | {}",
-            "name",
-            deployment.name.unwrap_or("---".to_string())
-        );
-        println!("{:12} | {}", "id", deployment.id);
-        println!("{:12} | {}", "nsp", deployment.namespace);
-        println!("{:12} | {}", "shard", deployment.shard);
-    }
+    let deployments = Deployment::lookup(&conn, name)?;
+    Deployment::print_table(deployments);
     Ok(())
 }

--- a/node/src/manager/commands/info.rs
+++ b/node/src/manager/commands/info.rs
@@ -3,10 +3,30 @@ use graph_store_postgres::connection_pool::ConnectionPool;
 
 use crate::manager::deployment::Deployment;
 
-pub fn run(pool: ConnectionPool, name: String) -> Result<(), anyhow::Error> {
+pub fn run(
+    pool: ConnectionPool,
+    name: String,
+    current: bool,
+    pending: bool,
+    used: bool,
+) -> Result<(), anyhow::Error> {
     let conn = pool.get()?;
+    let current = current || used;
+    let pending = pending || used;
 
     let deployments = Deployment::lookup(&conn, name)?;
+    // Filter by status; if neither `current` or `pending` are set, list
+    // all deployments
+    let deployments: Vec<_> = deployments
+        .into_iter()
+        .filter(|deployment| match (current, pending) {
+            (true, false) => deployment.status == "current",
+            (false, true) => deployment.status == "pending",
+            (true, true) => deployment.status == "current" || deployment.status == "pending",
+            (false, false) => true,
+        })
+        .collect();
+
     if deployments.is_empty() {
         println!("No matches");
     } else {

--- a/node/src/manager/commands/info.rs
+++ b/node/src/manager/commands/info.rs
@@ -7,6 +7,10 @@ pub fn run(pool: ConnectionPool, name: String) -> Result<(), anyhow::Error> {
     let conn = pool.get()?;
 
     let deployments = Deployment::lookup(&conn, name)?;
-    Deployment::print_table(deployments);
+    if deployments.is_empty() {
+        println!("No matches");
+    } else {
+        Deployment::print_table(deployments);
+    }
     Ok(())
 }

--- a/node/src/manager/commands/mod.rs
+++ b/node/src/manager/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod info;
 pub mod place;
 pub mod txn_speed;
+pub mod unused_deployments;

--- a/node/src/manager/commands/unused_deployments.rs
+++ b/node/src/manager/commands/unused_deployments.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use graph::prelude::anyhow::Error;
+use graph_store_postgres::{unused, ShardedStore, UnusedDeployment};
+
+use crate::manager::display::List;
+
+fn make_list() -> List {
+    List::new(vec!["id", "shard", "namespace", "subgraphs", "entities"])
+}
+
+fn add_row(list: &mut List, deployment: UnusedDeployment) {
+    let UnusedDeployment {
+        id,
+        shard,
+        namespace,
+        subgraphs,
+        entity_count,
+        ..
+    } = deployment;
+    let subgraphs = subgraphs.unwrap_or(vec![]).join(", ");
+
+    list.append(vec![
+        id,
+        shard,
+        namespace,
+        subgraphs,
+        entity_count.to_string(),
+    ])
+}
+
+pub fn list(store: Arc<ShardedStore>, existing: bool) -> Result<(), Error> {
+    let mut list = make_list();
+
+    let filter = if existing {
+        unused::Filter::New
+    } else {
+        unused::Filter::All
+    };
+
+    for deployment in store.list_unused_deployments(filter)? {
+        add_row(&mut list, deployment);
+    }
+
+    if list.is_empty() {
+        println!("no unused deployments");
+    } else {
+        list.render();
+    }
+
+    Ok(())
+}
+
+pub fn record(store: Arc<ShardedStore>) -> Result<(), Error> {
+    let mut list = make_list();
+
+    println!("Recording unused deployments. This might take a while.");
+    let recorded = store.record_unused_deployments()?;
+
+    for deployment in store.list_unused_deployments(unused::Filter::New)? {
+        if recorded.iter().find(|r| r.id == deployment.id).is_some() {
+            add_row(&mut list, deployment);
+        }
+    }
+
+    list.render();
+    println!("Recorded {} unused deployments", recorded.len());
+
+    Ok(())
+}

--- a/node/src/manager/commands/unused_deployments.rs
+++ b/node/src/manager/commands/unused_deployments.rs
@@ -1,6 +1,6 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
-use graph::prelude::anyhow::Error;
+use graph::prelude::{anyhow::anyhow, anyhow::Error, SubgraphDeploymentId};
 use graph_store_postgres::{unused, ShardedStore, UnusedDeployment};
 
 use crate::manager::display::List;
@@ -66,5 +66,68 @@ pub fn record(store: Arc<ShardedStore>) -> Result<(), Error> {
     list.render();
     println!("Recorded {} unused deployments", recorded.len());
 
+    Ok(())
+}
+
+pub fn remove(
+    store: Arc<ShardedStore>,
+    count: usize,
+    deployment: Option<String>,
+) -> Result<(), Error> {
+    let unused = store.list_unused_deployments(unused::Filter::New)?;
+    let unused = match &deployment {
+        None => unused,
+        Some(deployment) => unused
+            .into_iter()
+            .filter(|u| u.id.as_str() == deployment)
+            .collect::<Vec<_>>(),
+    };
+
+    if unused.is_empty() {
+        match &deployment {
+            Some(s) => println!("No unused subgraph matches `{}`", s),
+            None => println!("Nothing to remove."),
+        }
+        return Ok(());
+    }
+
+    for (i, deployment) in unused.iter().take(count).enumerate() {
+        let id = SubgraphDeploymentId::new(&deployment.id)
+            .map_err(|s| anyhow!("illegal subgraph deployment id: {}", s))?;
+
+        println!("{:=<36} {:4} {:=<36}", "", i + 1, "");
+        println!(
+            "removing {} from {}",
+            deployment.namespace, deployment.shard
+        );
+        println!("  {:>14}: {}", "deployment id", deployment.id);
+        println!("  {:>14}: {}", "entities", deployment.entity_count);
+        if let Some(subgraphs) = &deployment.subgraphs {
+            let mut first = true;
+            for name in subgraphs {
+                if first {
+                    println!("  {:>14}: {}", "subgraphs", name);
+                } else {
+                    println!("  {:>14}  {}", "", name);
+                }
+                first = false;
+            }
+        }
+
+        let start = Instant::now();
+        match store.remove_deployment(&id) {
+            Ok(()) => {
+                println!(
+                    "done removing {} from {} in {:.1}s\n",
+                    deployment.namespace,
+                    deployment.shard,
+                    start.elapsed().as_millis() as f64 / 1000.0
+                );
+            }
+            Err(e) => {
+                println!("removal failed: {}", e)
+            }
+        }
+    }
     Ok(())
 }

--- a/node/src/manager/deployment.rs
+++ b/node/src/manager/deployment.rs
@@ -1,9 +1,12 @@
+use std::collections::BTreeMap;
+
 use diesel::PgConnection;
 use diesel::{dsl::any, prelude::*};
 
 use graph::prelude::anyhow;
 use graph_store_postgres::command_support::catalog as store_catalog;
 
+#[derive(PartialEq, Eq, Hash)]
 pub struct Deployment {
     pub id: String,
     pub namespace: String,
@@ -36,12 +39,21 @@ impl Deployment {
                 .select(v::deployment)
                 .load(conn)?
         };
+        Self::deployments(conn, ids)
+    }
+
+    fn deployments(conn: &PgConnection, ids: Vec<String>) -> Result<Vec<Self>, anyhow::Error> {
+        use store_catalog::deployment_schemas as ds;
+        use store_catalog::subgraph as s;
+        use store_catalog::subgraph_version as v;
+
         let deployments = s::table
             .inner_join(v::table.on(s::id.eq(v::subgraph)))
             .inner_join(ds::table.on(v::deployment.eq(ds::subgraph)))
             .filter(v::deployment.eq(any(ids)))
             .order_by(s::name)
             .select((v::deployment, ds::name, s::name, ds::shard))
+            .distinct()
             .load(conn)?
             .into_iter()
             .map(|(id, namespace, name, shard)| Deployment {
@@ -52,5 +64,57 @@ impl Deployment {
             })
             .collect::<Vec<_>>();
         Ok(deployments)
+    }
+
+    pub fn print_table(deployments: Vec<Self>) {
+        let mut first = true;
+        for deployment in deployments {
+            if !first {
+                println!("-------------+-----------------------------------------------");
+            }
+            first = false;
+
+            println!(
+                "{:12} | {}",
+                "name",
+                deployment.name.unwrap_or("---".to_string())
+            );
+            println!("{:12} | {}", "id", deployment.id);
+            println!("{:12} | {}", "nsp", deployment.namespace);
+            println!("{:12} | {}", "shard", deployment.shard);
+        }
+    }
+
+    pub fn print_by_deployment(deployments: Vec<Self>) {
+        let mut by_id: BTreeMap<String, Vec<Deployment>> = BTreeMap::new();
+        for deployment in deployments {
+            by_id
+                .entry(deployment.id.clone())
+                .or_default()
+                .push(deployment);
+        }
+
+        let mut first = true;
+        for deployments in by_id.values().into_iter() {
+            if !first {
+                println!("-------------+-----------------------------------------------");
+            }
+            first = false;
+
+            let deployment = deployments.first().unwrap();
+            println!("{:12} | {}", "id", deployment.id);
+            println!("{:12} | {}", "nsp", deployment.namespace);
+            println!("{:12} | {}", "shard", deployment.shard);
+
+            let mut name = "name";
+            for deployment in deployments {
+                println!(
+                    "{:12} | {}",
+                    name,
+                    deployment.name.as_deref().unwrap_or("---")
+                );
+                name = "";
+            }
+        }
     }
 }

--- a/node/src/manager/deployment.rs
+++ b/node/src/manager/deployment.rs
@@ -1,16 +1,18 @@
-use std::collections::BTreeMap;
-
-use diesel::PgConnection;
-use diesel::{dsl::any, prelude::*};
+use diesel::{dsl::sql, prelude::*};
+use diesel::{sql_types::Text, PgConnection};
 
 use graph::prelude::anyhow;
 use graph_store_postgres::command_support::catalog as store_catalog;
 
-#[derive(PartialEq, Eq, Hash)]
+use crate::manager::display::List;
+
+#[derive(Queryable, PartialEq, Eq, Hash)]
 pub struct Deployment {
-    pub id: String,
+    pub name: String,
+    pub status: String,
+    pub deployment: String,
     pub namespace: String,
-    pub name: Option<String>,
+    pub node_id: Option<String>,
     pub shard: String,
 }
 
@@ -18,103 +20,60 @@ impl Deployment {
     pub fn lookup(conn: &PgConnection, name: String) -> Result<Vec<Self>, anyhow::Error> {
         use store_catalog::deployment_schemas as ds;
         use store_catalog::subgraph as s;
+        use store_catalog::subgraph_deployment_assignment as a;
         use store_catalog::subgraph_version as v;
 
-        let ids = if name.starts_with("sgd") {
-            ds::table
-                .filter(ds::name.eq(&name))
-                .select(ds::subgraph)
-                .load::<String>(conn)?
+        let query = ds::table
+            .inner_join(v::table.on(v::deployment.eq(ds::subgraph)))
+            .inner_join(s::table.on(v::subgraph.eq(s::id)))
+            .left_outer_join(a::table.on(a::id.eq(ds::subgraph)))
+            .select((
+                s::name,
+                sql::<Text>(
+                    "(case
+                    when subgraphs.subgraph.pending_version = subgraphs.subgraph_version.id then 'pending'
+                    when subgraphs.subgraph.current_version = subgraphs.subgraph_version.id then 'current'
+                    else 'unused' end) status",
+                ),
+                v::deployment,
+                ds::name,
+                a::node_id.nullable(),
+                ds::shard,
+            ));
+
+        let deployments: Vec<Deployment> = if name.starts_with("sgd") {
+            query.filter(ds::name.eq(&name)).load(conn)?
         } else if name.starts_with("Qm") {
-            ds::table
-                .filter(ds::subgraph.eq(&name))
-                .select(ds::subgraph)
-                .load(conn)?
+            query.filter(ds::subgraph.eq(&name)).load(conn)?
         } else {
             // A subgraph name
             let pattern = format!("%{}%", name);
-            v::table
-                .inner_join(s::table.on(s::current_version.eq(v::id.nullable())))
-                .filter(s::name.ilike(&pattern))
-                .select(v::deployment)
-                .load(conn)?
+            query.filter(s::name.ilike(&pattern)).load(conn)?
         };
-        Self::deployments(conn, ids)
-    }
-
-    fn deployments(conn: &PgConnection, ids: Vec<String>) -> Result<Vec<Self>, anyhow::Error> {
-        use store_catalog::deployment_schemas as ds;
-        use store_catalog::subgraph as s;
-        use store_catalog::subgraph_version as v;
-
-        let deployments = s::table
-            .inner_join(v::table.on(s::id.eq(v::subgraph)))
-            .inner_join(ds::table.on(v::deployment.eq(ds::subgraph)))
-            .filter(v::deployment.eq(any(ids)))
-            .order_by(s::name)
-            .select((v::deployment, ds::name, s::name, ds::shard))
-            .distinct()
-            .load(conn)?
-            .into_iter()
-            .map(|(id, namespace, name, shard)| Deployment {
-                id,
-                namespace,
-                name: Some(name),
-                shard,
-            })
-            .collect::<Vec<_>>();
         Ok(deployments)
     }
 
     pub fn print_table(deployments: Vec<Self>) {
-        let mut first = true;
+        let mut list = List::new(vec![
+            "name",
+            "status",
+            "id",
+            "namespace",
+            "shard",
+            "node_id",
+        ]);
+
         for deployment in deployments {
-            if !first {
-                println!("-------------+-----------------------------------------------");
-            }
-            first = false;
-
-            println!(
-                "{:12} | {}",
-                "name",
-                deployment.name.unwrap_or("---".to_string())
-            );
-            println!("{:12} | {}", "id", deployment.id);
-            println!("{:12} | {}", "nsp", deployment.namespace);
-            println!("{:12} | {}", "shard", deployment.shard);
-        }
-    }
-
-    pub fn print_by_deployment(deployments: Vec<Self>) {
-        let mut by_id: BTreeMap<String, Vec<Deployment>> = BTreeMap::new();
-        for deployment in deployments {
-            by_id
-                .entry(deployment.id.clone())
-                .or_default()
-                .push(deployment);
+            list.append(vec![
+                deployment.name,
+                deployment.status,
+                deployment.deployment,
+                deployment.namespace,
+                deployment.shard,
+                deployment.node_id.unwrap_or("---".to_string()),
+            ]);
         }
 
-        let mut first = true;
-        for deployments in by_id.values().into_iter() {
-            if !first {
-                println!("-------------+-----------------------------------------------");
-            }
-            first = false;
-
-            let deployment = deployments.first().unwrap();
-            println!("{:12} | {}", "id", deployment.id);
-            println!("{:12} | {}", "nsp", deployment.namespace);
-            println!("{:12} | {}", "shard", deployment.shard);
-
-            let mut name = "name";
-            for deployment in deployments {
-                println!(
-                    "{:12} | {}",
-                    name,
-                    deployment.name.as_deref().unwrap_or("---")
-                );
-                name = "";
-            }
-        }
+        list.render();
     }
 }

--- a/node/src/manager/display.rs
+++ b/node/src/manager/display.rs
@@ -1,0 +1,54 @@
+pub struct List {
+    pub headers: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+}
+
+impl List {
+    pub fn new(headers: Vec<&str>) -> Self {
+        let headers = headers.into_iter().map(|s| s.to_string()).collect();
+        Self {
+            headers,
+            rows: Vec::new(),
+        }
+    }
+
+    pub fn append(&mut self, row: Vec<String>) {
+        if row.len() != self.headers.len() {
+            panic!(
+                "there are {} headers but the row has {} entries: {:?}",
+                self.headers.len(),
+                row.len(),
+                row
+            );
+        }
+        self.rows.push(row);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    pub fn render(&self) {
+        const LINE_WIDTH: usize = 78;
+
+        let header_width = self.headers.iter().map(|h| h.len()).max().unwrap_or(0);
+        let header_width = if header_width < 5 { 5 } else { header_width };
+        let mut first = true;
+        for row in &self.rows {
+            if !first {
+                println!(
+                    "{:-<width$}-+-{:-<rest$}",
+                    "",
+                    "",
+                    width = header_width,
+                    rest = LINE_WIDTH - 3 - header_width
+                );
+            }
+            first = false;
+
+            for (header, value) in self.headers.iter().zip(row) {
+                println!("{:width$} | {}", header, value, width = header_width);
+            }
+        }
+    }
+}

--- a/node/src/manager/mod.rs
+++ b/node/src/manager/mod.rs
@@ -1,3 +1,4 @@
 pub mod catalog;
 pub mod commands;
 pub mod deployment;
+mod display;

--- a/store/postgres/migrations/2021-01-07-004939_create_unused_deployments/down.sql
+++ b/store/postgres/migrations/2021-01-07-004939_create_unused_deployments/down.sql
@@ -1,0 +1,1 @@
+drop table unused_deployments;

--- a/store/postgres/migrations/2021-01-07-004939_create_unused_deployments/up.sql
+++ b/store/postgres/migrations/2021-01-07-004939_create_unused_deployments/up.sql
@@ -1,0 +1,15 @@
+create table unused_deployments (
+	id           text primary key,
+	unused_at    timestamptz not null default now(),
+	removed_at   timestamptz,
+
+    subgraphs    text[],
+	namespace    text not null,
+	shard        text not null,
+
+	entity_count int4 not null default 0,
+	latest_ethereum_block_hash bytea,
+	latest_ethereum_block_number int4,
+	failed       bool not null default false,
+	synced       bool not null default false
+);

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -598,11 +598,10 @@ pub(crate) fn revert_subgraph_errors(
     check_health(conn, id)
 }
 
-/// Drop the schema for `subgraph`. This deletes all data for the subgraph,
-/// and can not be reversed. It does not remove any of the metadata in
-/// `subgraphs.entities` associated with the subgraph
-#[cfg(debug_assertions)]
-pub fn drop_entities(
+/// Drop the schema `namespace`. This deletes all data for the subgraph,
+/// and can not be reversed. It does not remove any of the metadata
+/// in the `subgraphs` schema for the deployment
+pub fn drop_schema(
     conn: &diesel::pg::PgConnection,
     namespace: &crate::primary::Namespace,
 ) -> Result<(), StoreError> {

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -384,7 +384,7 @@ impl Connection<'_> {
     /// Remove all data and metadata for a deployment. This is an associated
     /// method so that deployment removal can work with deployments that are
     /// incomplete or damaged, e.g., in a way where we can't get the schema
-    /// for hte subgraph
+    /// for the subgraph
     pub(crate) fn drop_deployment(conn: &PgConnection, site: &Site) -> Result<(), StoreError> {
         crate::deployment::drop_schema(conn, &site.namespace)?;
         Layout::drop_metadata(conn, &site.deployment)

--- a/store/postgres/src/entities.rs
+++ b/store/postgres/src/entities.rs
@@ -381,6 +381,15 @@ impl Connection<'_> {
         Ok(())
     }
 
+    /// Remove all data and metadata for a deployment. This is an associated
+    /// method so that deployment removal can work with deployments that are
+    /// incomplete or damaged, e.g., in a way where we can't get the schema
+    /// for hte subgraph
+    pub(crate) fn drop_deployment(conn: &PgConnection, site: &Site) -> Result<(), StoreError> {
+        crate::deployment::drop_schema(conn, &site.namespace)?;
+        Layout::drop_metadata(conn, &site.deployment)
+    }
+
     pub(crate) fn supports_proof_of_indexing(&self) -> bool {
         self.data.tables.contains_key(POI_OBJECT)
     }

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -70,7 +70,9 @@ pub use self::store_events::SubscriptionManager;
 pub mod command_support {
     pub mod catalog {
         pub use crate::primary::Connection;
-        pub use crate::primary::{deployment_schemas, subgraph, subgraph_version};
+        pub use crate::primary::{
+            deployment_schemas, subgraph, subgraph_deployment_assignment, subgraph_version,
+        };
     }
     pub use crate::entities::Connection;
     pub use crate::primary::Namespace;

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -58,8 +58,10 @@ pub mod layout_for_tests {
 
 pub use self::chain_head_listener::ChainHeadUpdateListener;
 pub use self::chain_store::ChainStore;
+pub use self::detail::DeploymentDetail;
 pub use self::network_store::NetworkStore;
-pub use self::sharded_store::{DeploymentPlacer, Shard, ShardedStore, PRIMARY_SHARD};
+pub use self::primary::UnusedDeployment;
+pub use self::sharded_store::{unused, DeploymentPlacer, Shard, ShardedStore, PRIMARY_SHARD};
 pub use self::store::{Store, StoreConfig};
 pub use self::store_events::SubscriptionManager;
 

--- a/store/postgres/src/network_store.rs
+++ b/store/postgres/src/network_store.rs
@@ -147,13 +147,6 @@ impl StoreTrait for NetworkStore {
             .revert_block_operations(subgraph_id, block_ptr_to)
     }
 
-    fn subscribe(
-        &self,
-        entities: Vec<graph::prelude::SubscriptionFilter>,
-    ) -> graph::prelude::StoreEventStreamBox {
-        self.store.subscribe(entities)
-    }
-
     fn deployment_state_from_name(
         &self,
         name: graph::prelude::SubgraphName,
@@ -290,7 +283,6 @@ impl QueryStoreManager for NetworkStore {
         Ok(Arc::new(QueryStore::new(
             store,
             self.chain_store.clone(),
-            for_subscription,
             site,
             replica,
         )))

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -13,14 +13,12 @@ pub(crate) struct QueryStore {
     replica_id: ReplicaId,
     store: Arc<crate::Store>,
     chain_store: Arc<crate::ChainStore>,
-    for_subscription: bool,
 }
 
 impl QueryStore {
     pub(crate) fn new(
         store: Arc<crate::Store>,
         chain_store: Arc<crate::ChainStore>,
-        for_subscription: bool,
         site: Arc<Site>,
         replica_id: ReplicaId,
     ) -> Self {
@@ -29,7 +27,6 @@ impl QueryStore {
             replica_id,
             store,
             chain_store,
-            for_subscription,
         }
     }
 }
@@ -46,12 +43,6 @@ impl QueryStoreTrait for QueryStore {
             .get_entity_conn(self.site.as_ref(), self.replica_id)
             .map_err(|e| QueryExecutionError::StoreError(e.into()))?;
         self.store.execute_query(&conn, query)
-    }
-
-    fn subscribe(&self, entities: Vec<SubscriptionFilter>) -> StoreEventStreamBox {
-        assert!(self.for_subscription);
-        assert_eq!(self.replica_id, ReplicaId::Main);
-        self.store.subscribe(entities)
     }
 
     /// Return true if the deployment with the given id is fully synced,

--- a/store/postgres/src/sharded_store.rs
+++ b/store/postgres/src/sharded_store.rs
@@ -471,6 +471,12 @@ impl ShardedStore {
 
         Ok(())
     }
+
+    #[cfg(debug_assertions)]
+    pub fn error_count(&self, id: &SubgraphDeploymentId) -> Result<usize, StoreError> {
+        let (store, _) = self.store(id)?;
+        store.error_count(id)
+    }
 }
 
 #[async_trait::async_trait]

--- a/store/postgres/src/sharded_store.rs
+++ b/store/postgres/src/sharded_store.rs
@@ -19,8 +19,8 @@ use graph::{
         lazy_static, web3::types::Address, ApiSchema, DeploymentState, DynTryFuture, Entity,
         EntityKey, EntityModification, EntityQuery, Error, EthereumBlockPointer, EthereumCallCache,
         Logger, MetadataOperation, NodeId, QueryExecutionError, Schema, StopwatchMetrics,
-        Store as StoreTrait, StoreError, StoreEventStreamBox, SubgraphDeploymentId, SubgraphName,
-        SubgraphVersionSwitchingMode, SubscriptionFilter,
+        Store as StoreTrait, StoreError, SubgraphDeploymentId, SubgraphName,
+        SubgraphVersionSwitchingMode,
     },
 };
 use store::StoredDynamicDataSource;
@@ -557,11 +557,6 @@ impl StoreTrait for ShardedStore {
         let (store, site) = self.store(&id)?;
         let event = store.revert_block_operations(site.as_ref(), block_ptr_to)?;
         self.send_store_event(&event)
-    }
-
-    fn subscribe(&self, entities: Vec<SubscriptionFilter>) -> StoreEventStreamBox {
-        // Subscriptions always go through the primary
-        self.primary.subscribe(entities)
     }
 
     fn deployment_state_from_name(

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1199,6 +1199,12 @@ impl Store {
             econn.start_subgraph(logger, graft_base)
         })
     }
+
+    #[cfg(debug_assertions)]
+    pub fn error_count(&self, id: &SubgraphDeploymentId) -> Result<usize, StoreError> {
+        let conn = self.get_conn()?;
+        deployment::error_count(&conn, id)
+    }
 }
 
 impl EthereumCallCache for Store {

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -286,6 +286,13 @@ impl Store {
         })
     }
 
+    // Remove the data and metadata for the deployment `site`. This operation
+    // is not reversible
+    pub(crate) fn drop_deployment(&self, site: &Site) -> Result<(), StoreError> {
+        let conn = self.get_conn()?;
+        conn.transaction(|| e::Connection::drop_deployment(&conn, site))
+    }
+
     /// Gets an entity from Postgres.
     fn get_entity(
         &self,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -1,3 +1,4 @@
+use detail::DeploymentDetail;
 use diesel::connection::SimpleConnection;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
@@ -761,6 +762,14 @@ impl Store {
         conn: &e::Connection,
     ) -> Result<Option<EthereumBlockPointer>, Error> {
         Ok(deployment::block_ptr(&conn.conn, subgraph_id)?)
+    }
+
+    pub(crate) fn deployment_details(
+        &self,
+        ids: Vec<String>,
+    ) -> Result<Vec<DeploymentDetail>, StoreError> {
+        let conn = self.get_conn()?;
+        conn.transaction(|| -> Result<_, StoreError> { detail::deployment_details(&conn, ids) })
     }
 
     pub(crate) fn deployment_statuses(

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use uuid::Uuid;
 
 use crate::notification_listener::{NotificationListener, SafeChannelName};
+use graph::components::store::SubscriptionManager as SubscriptionManagerTrait;
 use graph::prelude::serde_json;
 use graph::prelude::*;
 
@@ -149,8 +150,10 @@ impl SubscriptionManager {
             }),
         );
     }
+}
 
-    pub fn subscribe(&self, entities: Vec<SubscriptionFilter>) -> StoreEventStreamBox {
+impl SubscriptionManagerTrait for SubscriptionManager {
+    fn subscribe(&self, entities: Vec<SubscriptionFilter>) -> StoreEventStreamBox {
         let id = Uuid::new_v4().to_string();
 
         // Prepare the new subscription by creating a channel and a subscription object

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -69,6 +69,23 @@ lazy_static! {
         1u64
     )
         .into();
+    pub static ref BLOCKS: [EthereumBlockPointer; 4] = {
+        let two: EthereumBlockPointer = (
+            H256::from(hex!(
+                "b98fb783b49de5652097a989414c767824dff7e7fd765a63b493772511db81c1"
+            )),
+            2u64,
+        )
+            .into();
+        let three: EthereumBlockPointer = (
+            H256::from(hex!(
+                "977c084229c72a0fa377cae304eda9099b6a2cb5d83b25cdf0f0969b69874255"
+            )),
+            3u64,
+        )
+            .into();
+        [GENESIS_PTR.clone(), BLOCK_ONE.clone(), two, three]
+    };
 }
 
 /// Run the `test` after performing `setup`. The result of `setup` is passed
@@ -162,6 +179,16 @@ fn create_subgraph(
 
 pub fn create_test_subgraph(subgraph_id: &SubgraphDeploymentId, schema: &str) {
     create_subgraph(subgraph_id, schema, None).unwrap()
+}
+
+pub fn remove_subgraph(id: &SubgraphDeploymentId) {
+    let name = {
+        let mut name = id.to_string();
+        name.truncate(32);
+        SubgraphName::new(name).unwrap()
+    };
+    STORE.remove_subgraph(name).unwrap();
+    STORE.store().remove_deployment(id).unwrap();
 }
 
 pub fn create_grafted_subgraph(


### PR DESCRIPTION
This PR adds a new subcommand `graphman unused` that can be used to record, list, and ultimately remove unused deployments. See `graphman unused --help` for details.

The most important thing to check in this review is to make sure that we will never delete any data that does not belong to the subgraph we are currently removing. My testing so far has not turned up any problems.