### PR TITLE
server/index-node: Fix missing `scalar Int` in the GraphQL schema

### DIFF
--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -2,6 +2,7 @@ scalar BigInt
 scalar Boolean
 scalar Bytes
 scalar ID
+scalar Int
 scalar String
 
 type Query {


### PR DESCRIPTION
This was causing JS clients (such as indexer-service) to fail with the
following error:

    Error: Decorated type deeper than introspection query.

With this fix, that no longer happens.

