### PR TITLE
travis: Remove `cargo audit`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,13 +67,10 @@ env:
 
 # Test pipeline
 before_script:
-  - cargo install --force cargo-audit
-  - cargo generate-lockfile
   - psql -c "ALTER USER travis WITH PASSWORD 'travis';"
   - psql -c 'create database graph_node_test;' -U travis
 
 script:
-  - cargo audit
   # Run tests
   - ipfs daemon &> /dev/null &
   - RUST_BACKTRACE=1 cargo test --verbose --all -- --nocapture


### PR DESCRIPTION
We ran `cargo generate-lockfile` as part of running `cargo audit` which
meant that our tests were against different versions of dependencies than
what we actually use in our public builds.

We'll need to revisit scanning of dependency vulnerabilities in some other
way.

