### PR TITLE
*: Deterministic error work in preparation for gas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,7 @@ dependencies = [
  "hex 0.4.2",
  "ipfs-api",
  "lazy_static",
+ "never",
  "semver 0.10.0",
  "strum",
  "strum_macros",
@@ -2655,6 +2656,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "never"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
 
 [[package]]
 name = "nom"

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -639,7 +639,7 @@ enum BlockProcessingError {
     #[error("{0:#}")]
     Unknown(Error),
 
-    // The error had a determinstic cause but, for a possibly non-deterministic reason, we chose to
+    // The error had a deterministic cause but, for a possibly non-deterministic reason, we chose to
     // halt processing due to the error.
     #[error("{0}")]
     Deterministic(SubgraphError),

--- a/graph/src/data/graphql/shape_hash.rs
+++ b/graph/src/data/graphql/shape_hash.rs
@@ -1,5 +1,5 @@
 //! Calculate a hash for a GraphQL query that reflects the shape of
-//! the query. The shape hash will be the same for two instancs of a query
+//! the query. The shape hash will be the same for two instances of a query
 //! that are deemed identical except for unimportant details. Those details
 //! are any values used with filters, and any differences in the query
 //! name or response keys

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -20,10 +20,9 @@ strum = "0.20.0"
 strum_macros = "0.20.1"
 bytes = "0.5"
 anyhow = "1.0"
-
 wasmtime = "0.21.0"
-
 defer = "0.1"
+never = "0.1"
 
 [dev-dependencies]
 graphql-parser = "0.3"

--- a/runtime/wasm/src/error.rs
+++ b/runtime/wasm/src/error.rs
@@ -1,0 +1,50 @@
+use crate::{host_exports::HostExportError, module::IntoTrap};
+use anyhow::Error;
+use graph::components::subgraph::MappingError;
+use std::{error, fmt};
+use wasmtime::Trap;
+
+#[derive(Debug)]
+pub struct DeterministicHostError(pub Error);
+
+pub enum DeterminismLevel {
+    /// This error is known to be deterministic. For example, divide by zero.
+    /// TODO: For these errors, a further designation should be created about the contents
+    /// of the actual message.
+    Deterministic,
+    /// This error is known to be non-deterministic. For example, an intermittent http failure.
+    #[allow(dead_code)]
+    NonDeterministic,
+    /// An error has not yet been designated as deterministic or not. This should be phased out over time,
+    /// and is the default for errors like anyhow which are of an unknown origin.
+    Unimplemented,
+}
+
+impl fmt::Display for DeterministicHostError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl error::Error for DeterministicHostError {}
+
+impl From<DeterministicHostError> for HostExportError {
+    fn from(value: DeterministicHostError) -> Self {
+        HostExportError::Deterministic(value.0)
+    }
+}
+
+impl From<DeterministicHostError> for MappingError {
+    fn from(value: DeterministicHostError) -> MappingError {
+        MappingError::Unknown(value.0)
+    }
+}
+
+impl IntoTrap for DeterministicHostError {
+    fn determinism_level(&self) -> DeterminismLevel {
+        DeterminismLevel::Deterministic
+    }
+    fn into_trap(self) -> Trap {
+        Trap::from(self.0)
+    }
+}

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -14,6 +14,8 @@ mod module;
 /// Runtime-agnostic implementation of exports to WASM.
 mod host_exports;
 
+mod error;
+
 use graph::prelude::web3::types::Address;
 use graph::prelude::Store;
 

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -1,4 +1,4 @@
-use crate::module::WasmInstance;
+use crate::module::{ExperimentalFeatures, WasmInstance};
 use ethabi::LogParam;
 use futures::sync::mpsc;
 use futures03::channel::oneshot::Sender;
@@ -20,7 +20,7 @@ pub fn spawn_module(
     host_metrics: Arc<HostMetrics>,
     runtime: tokio::runtime::Handle,
     timeout: Option<Duration>,
-    allow_non_deterministic_ipfs: bool,
+    experimental_features: ExperimentalFeatures,
 ) -> Result<mpsc::Sender<MappingRequest>, anyhow::Error> {
     let valid_module = Arc::new(ValidModule::new(&raw_module)?);
 
@@ -51,11 +51,11 @@ pub fn spawn_module(
                     // Start the WASM module runtime.
                     let section = host_metrics.stopwatch.start_section("module_init");
                     let module = WasmInstance::from_valid_module_with_ctx(
-                        valid_module.clone(),
+                        valid_module.cheap_clone(),
                         ctx,
-                        host_metrics.clone(),
+                        host_metrics.cheap_clone(),
                         timeout,
-                        allow_non_deterministic_ipfs,
+                        experimental_features.clone(),
                     )?;
                     section.end();
 

--- a/runtime/wasm/src/module/into_wasm_ret.rs
+++ b/runtime/wasm/src/module/into_wasm_ret.rs
@@ -1,4 +1,5 @@
 use crate::asc_abi::AscPtr;
+use never::Never;
 use wasmtime::Trap;
 
 /// Helper trait for the `link!` macro.
@@ -12,6 +13,13 @@ impl IntoWasmRet for () {
     type Ret = Self;
     fn into_wasm_ret(self) -> Self {
         self
+    }
+}
+
+impl IntoWasmRet for Never {
+    type Ret = ();
+    fn into_wasm_ret(self) -> Self::Ret {
+        unreachable!()
     }
 }
 

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -60,12 +60,18 @@ fn test_valid_module_and_store_with_timeout(
         stopwatch_metrics,
     ));
 
+    let experimental_features = ExperimentalFeatures {
+        allow_non_deterministic_ipfs: true,
+        allow_non_deterministic_arweave: true,
+        allow_non_deterministic_3box: true,
+    };
+
     let module = WasmInstance::from_valid_module_with_ctx(
         Arc::new(ValidModule::new(data_source.mapping.runtime.as_ref()).unwrap()),
         mock_context(deployment_id, data_source, store.clone()),
         host_metrics,
         timeout,
-        true,
+        experimental_features,
     )
     .unwrap();
 
@@ -220,27 +226,27 @@ async fn json_conversions() {
 
     // test u64 conversion
     let number = 9223372036850770800;
-    let number_ptr = module.asc_new(&number.to_string());
+    let number_ptr = module.asc_new(&number.to_string()).unwrap();
     let converted: i64 = module.takes_ptr_returns_val("testToU64", number_ptr);
     assert_eq!(number, u64::from_le_bytes(converted.to_le_bytes()));
 
     // test i64 conversion
     let number = -9223372036850770800;
-    let number_ptr = module.asc_new(&number.to_string());
+    let number_ptr = module.asc_new(&number.to_string()).unwrap();
     let converted: i64 = module.takes_ptr_returns_val("testToI64", number_ptr);
     assert_eq!(number, converted);
 
     // test f64 conversion
     let number = -9223372036850770.92345034;
-    let number_ptr = module.asc_new(&number.to_string());
+    let number_ptr = module.asc_new(&number.to_string()).unwrap();
     let converted: f64 = module.takes_ptr_returns_val("testToF64", number_ptr);
     assert_eq!(number, converted);
 
     // test BigInt conversion
     let number = "-922337203685077092345034";
-    let number_ptr = module.asc_new(number);
+    let number_ptr = module.asc_new(number).unwrap();
     let big_int_obj: AscPtr<AscBigInt> = module.invoke_export("testToBigInt", number_ptr);
-    let bytes: Vec<u8> = module.asc_get(big_int_obj);
+    let bytes: Vec<u8> = module.asc_get(big_int_obj).unwrap();
     assert_eq!(
         scalar::BigInt::from_str(number).unwrap(),
         scalar::BigInt::from_signed_bytes_le(&bytes)
@@ -257,17 +263,17 @@ async fn json_parsing() {
     // Parse invalid JSON and handle the error gracefully
     let s = "foo"; // Invalid because there are no quotes around `foo`
     let bytes: &[u8] = s.as_ref();
-    let bytes_ptr = module.asc_new(bytes);
+    let bytes_ptr = module.asc_new(bytes).unwrap();
     let return_value: AscPtr<AscString> = module.invoke_export("handleJsonError", bytes_ptr);
-    let output: String = module.asc_get(return_value);
+    let output: String = module.asc_get(return_value).unwrap();
     assert_eq!(output, "ERROR: true");
 
     // Parse valid JSON and get it back
     let s = "\"foo\""; // Valid because there are quotes around `foo`
     let bytes: &[u8] = s.as_ref();
-    let bytes_ptr = module.asc_new(bytes);
+    let bytes_ptr = module.asc_new(bytes).unwrap();
     let return_value: AscPtr<AscString> = module.invoke_export("handleJsonError", bytes_ptr);
-    let output: String = module.asc_get(return_value);
+    let output: String = module.asc_get(return_value).unwrap();
     assert_eq!(output, "OK: foo");
 }
 
@@ -282,9 +288,9 @@ async fn ipfs_cat() {
     std::thread::spawn(move || {
         runtime.enter(|| {
             let mut module = test_module("ipfsCat", mock_data_source("wasm_test/ipfs_cat.wasm"));
-            let arg = module.asc_new(&hash);
+            let arg = module.asc_new(&hash).unwrap();
             let converted: AscPtr<AscString> = module.invoke_export("ipfsCatString", arg);
-            let data: String = module.instance_ctx().asc_get(converted);
+            let data: String = module.instance_ctx().asc_get(converted).unwrap();
             assert_eq!(data, "42");
         })
     })
@@ -338,8 +344,8 @@ async fn ipfs_map() {
                     subgraph_id,
                     mock_data_source("wasm_test/ipfs_map.wasm"),
                 );
-                let value = module.asc_new(&hash);
-                let user_data = module.asc_new(USER_DATA);
+                let value = module.asc_new(&hash).unwrap();
+                let user_data = module.asc_new(USER_DATA).unwrap();
 
                 // Invoke the callback
                 let func = module.get_func("ipfsMap").get2().unwrap();
@@ -429,7 +435,7 @@ async fn ipfs_fail() {
         runtime.enter(|| {
             let mut module = test_module("ipfsFail", mock_data_source("wasm_test/ipfs_cat.wasm"));
 
-            let hash = module.asc_new("invalid hash");
+            let hash = module.asc_new("invalid hash").unwrap();
             assert!(module
                 .invoke_export::<_, AscString>("ipfsCat", hash,)
                 .is_null());
@@ -443,10 +449,10 @@ async fn ipfs_fail() {
 async fn crypto_keccak256() {
     let mut module = test_module("cryptoKeccak256", mock_data_source("wasm_test/crypto.wasm"));
     let input: &[u8] = "eth".as_ref();
-    let input: AscPtr<Uint8Array> = module.asc_new(input);
+    let input: AscPtr<Uint8Array> = module.asc_new(input).unwrap();
 
     let hash: AscPtr<Uint8Array> = module.invoke_export("hash", input);
-    let hash: Vec<u8> = module.asc_get(hash);
+    let hash: Vec<u8> = module.asc_get(hash).unwrap();
     assert_eq!(
         hex::encode(hash),
         "4f5b812789fc606be1b3b16908db13fc7a9adf7ca72641f84d75b47069d3d7f0"
@@ -462,23 +468,23 @@ async fn big_int_to_hex() {
 
     // Convert zero to hex
     let zero = BigInt::from_unsigned_u256(&U256::zero());
-    let zero: AscPtr<AscBigInt> = module.asc_new(&zero);
+    let zero: AscPtr<AscBigInt> = module.asc_new(&zero).unwrap();
     let zero_hex_ptr: AscPtr<AscString> = module.invoke_export("big_int_to_hex", zero);
-    let zero_hex_str: String = module.asc_get(zero_hex_ptr);
+    let zero_hex_str: String = module.asc_get(zero_hex_ptr).unwrap();
     assert_eq!(zero_hex_str, "0x0");
 
     // Convert 1 to hex
     let one = BigInt::from_unsigned_u256(&U256::one());
-    let one: AscPtr<AscBigInt> = module.asc_new(&one);
+    let one: AscPtr<AscBigInt> = module.asc_new(&one).unwrap();
     let one_hex_ptr: AscPtr<AscString> = module.invoke_export("big_int_to_hex", one);
-    let one_hex_str: String = module.asc_get(one_hex_ptr);
+    let one_hex_str: String = module.asc_get(one_hex_ptr).unwrap();
     assert_eq!(one_hex_str, "0x1");
 
     // Convert U256::max_value() to hex
     let u256_max = BigInt::from_unsigned_u256(&U256::max_value());
-    let u256_max: AscPtr<AscBigInt> = module.asc_new(&u256_max);
+    let u256_max: AscPtr<AscBigInt> = module.asc_new(&u256_max).unwrap();
     let u256_max_hex_ptr: AscPtr<AscString> = module.invoke_export("big_int_to_hex", u256_max);
-    let u256_max_hex_str: String = module.asc_get(u256_max_hex_ptr);
+    let u256_max_hex_str: String = module.asc_get(u256_max_hex_ptr).unwrap();
     assert_eq!(
         u256_max_hex_str,
         "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
@@ -494,56 +500,56 @@ async fn big_int_arithmetic() {
 
     // 0 + 1 = 1
     let zero = BigInt::from(0);
-    let zero: AscPtr<AscBigInt> = module.asc_new(&zero);
+    let zero: AscPtr<AscBigInt> = module.asc_new(&zero).unwrap();
     let one = BigInt::from(1);
-    let one: AscPtr<AscBigInt> = module.asc_new(&one);
+    let one: AscPtr<AscBigInt> = module.asc_new(&one).unwrap();
     let result_ptr: AscPtr<AscBigInt> = module.invoke_export2("plus", zero, one);
-    let result: BigInt = module.asc_get(result_ptr);
+    let result: BigInt = module.asc_get(result_ptr).unwrap();
     assert_eq!(result, BigInt::from(1));
 
     // 127 + 1 = 128
     let zero = BigInt::from(127);
-    let zero: AscPtr<AscBigInt> = module.asc_new(&zero);
+    let zero: AscPtr<AscBigInt> = module.asc_new(&zero).unwrap();
     let one = BigInt::from(1);
-    let one: AscPtr<AscBigInt> = module.asc_new(&one);
+    let one: AscPtr<AscBigInt> = module.asc_new(&one).unwrap();
     let result_ptr: AscPtr<AscBigInt> = module.invoke_export2("plus", zero, one);
-    let result: BigInt = module.asc_get(result_ptr);
+    let result: BigInt = module.asc_get(result_ptr).unwrap();
     assert_eq!(result, BigInt::from(128));
 
     // 5 - 10 = -5
     let five = BigInt::from(5);
-    let five: AscPtr<AscBigInt> = module.asc_new(&five);
+    let five: AscPtr<AscBigInt> = module.asc_new(&five).unwrap();
     let ten = BigInt::from(10);
-    let ten: AscPtr<AscBigInt> = module.asc_new(&ten);
+    let ten: AscPtr<AscBigInt> = module.asc_new(&ten).unwrap();
     let result_ptr: AscPtr<AscBigInt> = module.invoke_export2("minus", five, ten);
-    let result: BigInt = module.asc_get(result_ptr);
+    let result: BigInt = module.asc_get(result_ptr).unwrap();
     assert_eq!(result, BigInt::from(-5));
 
     // -20 * 5 = -100
     let minus_twenty = BigInt::from(-20);
-    let minus_twenty: AscPtr<AscBigInt> = module.asc_new(&minus_twenty);
+    let minus_twenty: AscPtr<AscBigInt> = module.asc_new(&minus_twenty).unwrap();
     let five = BigInt::from(5);
-    let five: AscPtr<AscBigInt> = module.asc_new(&five);
+    let five: AscPtr<AscBigInt> = module.asc_new(&five).unwrap();
     let result_ptr: AscPtr<AscBigInt> = module.invoke_export2("times", minus_twenty, five);
-    let result: BigInt = module.asc_get(result_ptr);
+    let result: BigInt = module.asc_get(result_ptr).unwrap();
     assert_eq!(result, BigInt::from(-100));
 
     // 5 / 2 = 2
     let five = BigInt::from(5);
-    let five: AscPtr<AscBigInt> = module.asc_new(&five);
+    let five: AscPtr<AscBigInt> = module.asc_new(&five).unwrap();
     let two = BigInt::from(2);
-    let two: AscPtr<AscBigInt> = module.asc_new(&two);
+    let two: AscPtr<AscBigInt> = module.asc_new(&two).unwrap();
     let result_ptr: AscPtr<AscBigInt> = module.invoke_export2("dividedBy", five, two);
-    let result: BigInt = module.asc_get(result_ptr);
+    let result: BigInt = module.asc_get(result_ptr).unwrap();
     assert_eq!(result, BigInt::from(2));
 
     // 5 % 2 = 1
     let five = BigInt::from(5);
-    let five: AscPtr<AscBigInt> = module.asc_new(&five);
+    let five: AscPtr<AscBigInt> = module.asc_new(&five).unwrap();
     let two = BigInt::from(2);
-    let two: AscPtr<AscBigInt> = module.asc_new(&two);
+    let two: AscPtr<AscBigInt> = module.asc_new(&two).unwrap();
     let result_ptr: AscPtr<AscBigInt> = module.invoke_export2("mod", five, two);
-    let result: BigInt = module.asc_get(result_ptr);
+    let result: BigInt = module.asc_get(result_ptr).unwrap();
     assert_eq!(result, BigInt::from(1));
 }
 
@@ -566,9 +572,9 @@ async fn bytes_to_base58() {
     );
     let bytes = hex::decode("12207D5A99F603F231D53A4F39D1521F98D2E8BB279CF29BEBFD0687DC98458E7F89")
         .unwrap();
-    let bytes_ptr = module.asc_new(bytes.as_slice());
+    let bytes_ptr = module.asc_new(bytes.as_slice()).unwrap();
     let result_ptr: AscPtr<AscString> = module.invoke_export("bytes_to_base58", bytes_ptr);
-    let base58: String = module.asc_get(result_ptr);
+    let base58: String = module.asc_get(result_ptr).unwrap();
     assert_eq!(base58, "QmWmyoMoctfbAaiEs2G46gpeUmhqFRDW6KWo64y5r581Vz");
 }
 
@@ -582,8 +588,8 @@ async fn data_source_create() {
             mock_data_source("wasm_test/data_source_create.wasm"),
         );
 
-        let name = module.asc_new(&name);
-        let params = module.asc_new(&*params);
+        let name = module.asc_new(&name).unwrap();
+        let params = module.asc_new(&*params).unwrap();
         module.instance_ctx_mut().ctx.state.enter_handler();
         module.invoke_export2_void("dataSourceCreate", name, params)?;
         module.instance_ctx_mut().ctx.state.exit_handler();
@@ -623,12 +629,12 @@ async fn ens_name_by_hash() {
     let hash = "0x7f0c1b04d1a4926f9c635a030eeb611d4c26e5e73291b32a1c7a4ac56935b5b3";
     let name = "dealdrafts";
     test_store::insert_ens_name(hash, name);
-    let val = module.asc_new(hash);
+    let val = module.asc_new(hash).unwrap();
     let converted: AscPtr<AscString> = module.invoke_export("nameByHash", val);
-    let data: String = module.asc_get(converted);
+    let data: String = module.asc_get(converted).unwrap();
     assert_eq!(data, name);
 
-    let hash = module.asc_new("impossible keccak hash");
+    let hash = module.asc_new("impossible keccak hash").unwrap();
     assert!(module
         .invoke_export::<_, AscString>("nameByHash", hash)
         .is_null());
@@ -654,7 +660,7 @@ async fn entity_store() {
     .unwrap();
 
     let get_user = move |module: &mut WasmInstance, id: &str| -> Option<Entity> {
-        let id = module.asc_new(id);
+        let id = module.asc_new(id).unwrap();
         let entity_ptr: AscPtr<AscEntity> = module.invoke_export("getUser", id);
         if entity_ptr.is_null() {
             None
@@ -668,8 +674,8 @@ async fn entity_store() {
     };
 
     let load_and_set_user_name = |module: &mut WasmInstance, id: &str, name: &str| {
-        let id_ptr = module.asc_new(id);
-        let name_ptr = module.asc_new(name);
+        let id_ptr = module.asc_new(id).unwrap();
+        let name_ptr = module.asc_new(name).unwrap();
         module
             .invoke_export2_void("loadAndSetUserName", id_ptr, name_ptr)
             .unwrap();

--- a/runtime/wasm/src/module/test/abi.rs
+++ b/runtime/wasm/src/module/test/abi.rs
@@ -36,10 +36,10 @@ async fn abi_array() {
         "3".to_owned(),
         "4".to_owned(),
     ];
-    let vec_obj: AscPtr<Array<AscPtr<AscString>>> = module.asc_new(&*vec);
+    let vec_obj: AscPtr<Array<AscPtr<AscString>>> = module.asc_new(&*vec).unwrap();
 
     let new_vec_obj: AscPtr<Array<AscPtr<AscString>>> = module.invoke_export("test_array", vec_obj);
-    let new_vec: Vec<String> = module.asc_get(new_vec_obj);
+    let new_vec: Vec<String> = module.asc_get(new_vec_obj).unwrap();
 
     assert_eq!(
         new_vec,
@@ -61,11 +61,11 @@ async fn abi_subarray() {
     );
 
     let vec: Vec<u8> = vec![1, 2, 3, 4];
-    let vec_obj: AscPtr<TypedArray<u8>> = module.asc_new(&*vec);
+    let vec_obj: AscPtr<TypedArray<u8>> = module.asc_new(&*vec).unwrap();
 
     let new_vec_obj: AscPtr<TypedArray<u8>> =
         module.invoke_export("byte_array_third_quarter", vec_obj);
-    let new_vec: Vec<u8> = module.asc_get(new_vec_obj);
+    let new_vec: Vec<u8> = module.asc_get(new_vec_obj).unwrap();
 
     assert_eq!(new_vec, vec![3])
 }
@@ -79,12 +79,12 @@ async fn abi_bytes_and_fixed_bytes() {
     let bytes1: Vec<u8> = vec![42, 45, 7, 245, 45];
     let bytes2: Vec<u8> = vec![3, 12, 0, 1, 255];
 
-    let bytes1_ptr = module.asc_new::<Uint8Array, _>(&*bytes1);
-    let bytes2_ptr = module.asc_new::<Uint8Array, _>(&*bytes2);
+    let bytes1_ptr = module.asc_new::<Uint8Array, _>(&*bytes1).unwrap();
+    let bytes2_ptr = module.asc_new::<Uint8Array, _>(&*bytes2).unwrap();
     let new_vec_obj: AscPtr<Uint8Array> = module.invoke_export2("concat", bytes1_ptr, bytes2_ptr);
 
     // This should be bytes1 and bytes2 concatenated.
-    let new_vec: Vec<u8> = module.asc_get(new_vec_obj);
+    let new_vec: Vec<u8> = module.asc_get(new_vec_obj).unwrap();
 
     let mut concated = bytes1.clone();
     concated.extend(bytes2.clone());
@@ -104,47 +104,47 @@ async fn abi_ethabi_token_identity() {
     let address = H160([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
     let token_address = Token::Address(address);
 
-    let token_address_ptr = module.asc_new(&token_address);
+    let token_address_ptr = module.asc_new(&token_address).unwrap();
     let new_address_obj: AscPtr<ArrayBuffer<u8>> =
         module.invoke_export("token_to_address", token_address_ptr);
 
     let new_token_ptr = module.invoke_export("token_from_address", new_address_obj);
-    let new_token = module.asc_get(new_token_ptr);
+    let new_token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(token_address, new_token);
 
     // Token::Bytes
     let token_bytes = Token::Bytes(vec![42, 45, 7, 245, 45]);
 
-    let token_bytes_ptr = module.asc_new(&token_bytes);
+    let token_bytes_ptr = module.asc_new(&token_bytes).unwrap();
     let new_bytes_obj: AscPtr<ArrayBuffer<u8>> =
         module.invoke_export("token_to_bytes", token_bytes_ptr);
 
     let new_token_ptr = module.invoke_export("token_from_bytes", new_bytes_obj);
-    let new_token = module.asc_get(new_token_ptr);
+    let new_token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(token_bytes, new_token);
 
     // Token::Int
     let int_token = Token::Int(U256([256, 453452345, 0, 42]));
 
-    let int_token_ptr = module.asc_new(&int_token);
+    let int_token_ptr = module.asc_new(&int_token).unwrap();
     let new_int_obj: AscPtr<ArrayBuffer<u8>> = module.invoke_export("token_to_int", int_token_ptr);
 
     let new_token_ptr = module.invoke_export("token_from_int", new_int_obj);
-    let new_token = module.asc_get(new_token_ptr);
+    let new_token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(int_token, new_token);
 
     // Token::Uint
     let uint_token = Token::Uint(U256([256, 453452345, 0, 42]));
 
-    let uint_token_ptr = module.asc_new(&uint_token);
+    let uint_token_ptr = module.asc_new(&uint_token).unwrap();
     let new_uint_obj: AscPtr<ArrayBuffer<u8>> =
         module.invoke_export("token_to_uint", uint_token_ptr);
 
     let new_token_ptr = module.invoke_export("token_from_uint", new_uint_obj);
-    let new_token = module.asc_get(new_token_ptr);
+    let new_token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(uint_token, new_token);
     assert_ne!(uint_token, int_token);
@@ -152,24 +152,24 @@ async fn abi_ethabi_token_identity() {
     // Token::Bool
     let token_bool = Token::Bool(true);
 
-    let token_bool_ptr = module.asc_new(&token_bool);
+    let token_bool_ptr = module.asc_new(&token_bool).unwrap();
     let func = module.get_func("token_to_bool").get1().unwrap();
     let boolean: i32 = func(token_bool_ptr.wasm_ptr()).unwrap();
 
     let new_token_ptr = module.takes_val_returns_ptr("token_from_bool", boolean);
-    let new_token = module.asc_get(new_token_ptr);
+    let new_token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(token_bool, new_token);
 
     // Token::String
     let token_string = Token::String("漢字Go🇧🇷".into());
 
-    let token_string_ptr = module.asc_new(&token_string);
+    let token_string_ptr = module.asc_new(&token_string).unwrap();
     let new_string_obj: AscPtr<AscString> =
         module.invoke_export("token_to_string", token_string_ptr);
 
     let new_token_ptr = module.invoke_export("token_from_string", new_string_obj);
-    let new_token = module.asc_get(new_token_ptr);
+    let new_token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(token_string, new_token);
 
@@ -177,12 +177,12 @@ async fn abi_ethabi_token_identity() {
     let token_array = Token::Array(vec![token_address, token_bytes, token_bool]);
     let token_array_nested = Token::Array(vec![token_string, token_array]);
 
-    let new_array_ptr = module.asc_new(&token_array_nested);
+    let new_array_ptr = module.asc_new(&token_array_nested).unwrap();
     let new_array_obj: AscEnumArray<EthereumValueKind> =
         module.invoke_export("token_to_array", new_array_ptr);
 
     let new_token_ptr = module.invoke_export("token_from_array", new_array_obj);
-    let new_token: Token = module.asc_get(new_token_ptr);
+    let new_token: Token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(new_token, token_array_nested);
 }
@@ -205,7 +205,7 @@ async fn abi_store_value() {
 
     // Value::String
     let string = "some string";
-    let string_ptr = module.asc_new(string);
+    let string_ptr = module.asc_new(string).unwrap();
     let new_value_ptr = module.invoke_export("value_from_string", string_ptr);
     let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::from(string));
@@ -218,13 +218,13 @@ async fn abi_store_value() {
 
     // Value::BigDecimal
     let big_decimal = BigDecimal::from_str("3.14159001").unwrap();
-    let big_decimal_ptr = module.asc_new(&big_decimal);
+    let big_decimal_ptr = module.asc_new(&big_decimal).unwrap();
     let new_value_ptr = module.invoke_export("value_from_big_decimal", big_decimal_ptr);
     let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::BigDecimal(big_decimal));
 
     let big_decimal = BigDecimal::new(10.into(), 5);
-    let big_decimal_ptr = module.asc_new(&big_decimal);
+    let big_decimal_ptr = module.asc_new(&big_decimal).unwrap();
     let new_value_ptr = module.invoke_export("value_from_big_decimal", big_decimal_ptr);
     let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::BigDecimal(1_000_000.into()));
@@ -238,7 +238,7 @@ async fn abi_store_value() {
 
     // Value::List
     let func = module.get_func("array_from_values").get2().unwrap();
-    let new_value_ptr: u32 = func(module.asc_new(string).wasm_ptr(), int).unwrap();
+    let new_value_ptr: u32 = func(module.asc_new(string).unwrap().wasm_ptr(), int).unwrap();
     let new_value_ptr = AscPtr::from(new_value_ptr);
     let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(
@@ -250,7 +250,7 @@ async fn abi_store_value() {
         Value::String("foo".to_owned()),
         Value::String("bar".to_owned()),
     ];
-    let array_ptr = module.asc_new(array);
+    let array_ptr = module.asc_new(array).unwrap();
     let new_value_ptr = module.invoke_export("value_from_array", array_ptr);
     let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(
@@ -263,14 +263,14 @@ async fn abi_store_value() {
 
     // Value::Bytes
     let bytes: &[u8] = &[0, 2, 5];
-    let bytes_ptr: AscPtr<Bytes> = module.asc_new(bytes);
+    let bytes_ptr: AscPtr<Bytes> = module.asc_new(bytes).unwrap();
     let new_value_ptr = module.invoke_export("value_from_bytes", bytes_ptr);
     let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::Bytes(bytes.into()));
 
     // Value::BigInt
     let bytes: &[u8] = &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
-    let bytes_ptr: AscPtr<Uint8Array> = module.asc_new(bytes);
+    let bytes_ptr: AscPtr<Uint8Array> = module.asc_new(bytes).unwrap();
     let new_value_ptr = module.invoke_export("value_from_bigint", bytes_ptr);
     let new_value: Value = module.try_asc_get(new_value_ptr).unwrap();
     assert_eq!(
@@ -285,11 +285,11 @@ async fn abi_h160() {
     let address = H160::zero();
 
     // As an `Uint8Array`
-    let array_buffer: AscPtr<Uint8Array> = module.asc_new(&address);
+    let array_buffer: AscPtr<Uint8Array> = module.asc_new(&address).unwrap();
     let new_address_obj: AscPtr<Uint8Array> = module.invoke_export("test_address", array_buffer);
 
     // This should have 1 added to the first and last byte.
-    let new_address: H160 = module.asc_get(new_address_obj);
+    let new_address: H160 = module.asc_get(new_address_obj).unwrap();
 
     assert_eq!(
         new_address,
@@ -301,10 +301,10 @@ async fn abi_h160() {
 async fn string() {
     let mut module = test_module("string", mock_data_source("wasm_test/abi_classes.wasm"));
     let string = "    漢字Double_Me🇧🇷  ";
-    let trimmed_string_ptr = module.asc_new(string);
+    let trimmed_string_ptr = module.asc_new(string).unwrap();
     let trimmed_string_obj: AscPtr<AscString> =
         module.invoke_export("repeat_twice", trimmed_string_ptr);
-    let doubled_string: String = module.asc_get(trimmed_string_obj);
+    let doubled_string: String = module.asc_get(trimmed_string_obj).unwrap();
     assert_eq!(doubled_string, string.repeat(2))
 }
 
@@ -314,18 +314,20 @@ async fn abi_big_int() {
 
     // Test passing in 0 and increment it by 1
     let old_uint = U256::zero();
-    let array_buffer: AscPtr<AscBigInt> = module.asc_new(&BigInt::from_unsigned_u256(&old_uint));
+    let array_buffer: AscPtr<AscBigInt> = module
+        .asc_new(&BigInt::from_unsigned_u256(&old_uint))
+        .unwrap();
     let new_uint_obj: AscPtr<AscBigInt> = module.invoke_export("test_uint", array_buffer);
-    let new_uint: BigInt = module.asc_get(new_uint_obj);
+    let new_uint: BigInt = module.asc_get(new_uint_obj).unwrap();
     assert_eq!(new_uint, BigInt::from(1 as i32));
     let new_uint = new_uint.to_unsigned_u256();
     assert_eq!(new_uint, U256([1, 0, 0, 0]));
 
     // Test passing in -50 and increment it by 1
     let old_uint = BigInt::from(-50);
-    let array_buffer: AscPtr<AscBigInt> = module.asc_new(&old_uint);
+    let array_buffer: AscPtr<AscBigInt> = module.asc_new(&old_uint).unwrap();
     let new_uint_obj: AscPtr<AscBigInt> = module.invoke_export("test_uint", array_buffer);
-    let new_uint: BigInt = module.asc_get(new_uint_obj);
+    let new_uint: BigInt = module.asc_get(new_uint_obj).unwrap();
     assert_eq!(new_uint, BigInt::from(-49 as i32));
     let new_uint_from_u256 = BigInt::from_signed_u256(&new_uint.to_signed_u256());
     assert_eq!(new_uint, new_uint_from_u256);
@@ -340,9 +342,9 @@ async fn big_int_to_string() {
 
     let big_int_str = "30145144166666665000000000000000000";
     let big_int = BigInt::from_str(big_int_str).unwrap();
-    let ptr: AscPtr<AscBigInt> = module.asc_new(&big_int);
+    let ptr: AscPtr<AscBigInt> = module.asc_new(&big_int).unwrap();
     let string_obj: AscPtr<AscString> = module.invoke_export("big_int_to_string", ptr);
-    let string: String = module.asc_get(string_obj);
+    let string: String = module.asc_get(string_obj).unwrap();
     assert_eq!(string, big_int_str);
 }
 

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -5,42 +5,49 @@ use graph::components::ethereum::{
     EthereumBlockData, EthereumCallData, EthereumEventData, EthereumTransactionData,
 };
 use graph::data::store;
-use graph::prelude::anyhow::{ensure, Error};
 use graph::prelude::serde_json;
 use graph::prelude::web3::types as web3;
 use graph::prelude::{BigDecimal, BigInt};
 
-use crate::asc_abi::class::*;
 use crate::asc_abi::{AscHeap, AscPtr, AscType, FromAscObj, ToAscObj, TryFromAscObj};
+use crate::{asc_abi::class::*, error::DeterministicHostError};
 
 use crate::UnresolvedContractCall;
 
 impl ToAscObj<Uint8Array> for web3::H160 {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Uint8Array {
+    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<Uint8Array, DeterministicHostError> {
         self.0.to_asc_obj(heap)
     }
 }
 
 impl FromAscObj<Uint8Array> for web3::H160 {
-    fn from_asc_obj<H: AscHeap>(typed_array: Uint8Array, heap: &H) -> Self {
-        web3::H160(<[u8; 20]>::from_asc_obj(typed_array, heap))
+    fn from_asc_obj<H: AscHeap>(
+        typed_array: Uint8Array,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
+        let data = <[u8; 20]>::from_asc_obj(typed_array, heap)?;
+        Ok(Self(data))
     }
 }
 
 impl FromAscObj<Uint8Array> for web3::H256 {
-    fn from_asc_obj<H: AscHeap>(typed_array: Uint8Array, heap: &H) -> Self {
-        web3::H256(<[u8; 32]>::from_asc_obj(typed_array, heap))
+    fn from_asc_obj<H: AscHeap>(
+        typed_array: Uint8Array,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
+        let data = <[u8; 32]>::from_asc_obj(typed_array, heap)?;
+        Ok(Self(data))
     }
 }
 
 impl ToAscObj<Uint8Array> for web3::H256 {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Uint8Array {
+    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<Uint8Array, DeterministicHostError> {
         self.0.to_asc_obj(heap)
     }
 }
 
 impl ToAscObj<AscBigInt> for web3::U128 {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscBigInt {
+    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscBigInt, DeterministicHostError> {
         let mut bytes: [u8; 16] = [0; 16];
         self.to_little_endian(&mut bytes);
         bytes.to_asc_obj(heap)
@@ -48,35 +55,44 @@ impl ToAscObj<AscBigInt> for web3::U128 {
 }
 
 impl ToAscObj<AscBigInt> for BigInt {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscBigInt {
+    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscBigInt, DeterministicHostError> {
         let bytes = self.to_signed_bytes_le();
         bytes.to_asc_obj(heap)
     }
 }
 
 impl FromAscObj<AscBigInt> for BigInt {
-    fn from_asc_obj<H: AscHeap>(array_buffer: AscBigInt, heap: &H) -> Self {
-        let bytes = <Vec<u8>>::from_asc_obj(array_buffer, heap);
-        BigInt::from_signed_bytes_le(&bytes)
+    fn from_asc_obj<H: AscHeap>(
+        array_buffer: AscBigInt,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
+        let bytes = <Vec<u8>>::from_asc_obj(array_buffer, heap)?;
+        Ok(BigInt::from_signed_bytes_le(&bytes))
     }
 }
 
 impl ToAscObj<AscBigDecimal> for BigDecimal {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscBigDecimal {
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscBigDecimal, DeterministicHostError> {
         // From the docs: "Note that a positive exponent indicates a negative power of 10",
         // so "exponent" is the opposite of what you'd expect.
         let (digits, negative_exp) = self.as_bigint_and_exponent();
-        AscBigDecimal {
-            exp: heap.asc_new(&BigInt::from(-negative_exp)),
-            digits: heap.asc_new(&BigInt::from(digits)),
-        }
+        Ok(AscBigDecimal {
+            exp: heap.asc_new(&BigInt::from(-negative_exp))?,
+            digits: heap.asc_new(&BigInt::from(digits))?,
+        })
     }
 }
 
 impl TryFromAscObj<AscBigDecimal> for BigDecimal {
-    fn try_from_asc_obj<H: AscHeap>(big_decimal: AscBigDecimal, heap: &H) -> Result<Self, Error> {
-        let digits: BigInt = heap.asc_get(big_decimal.digits);
-        let exp: BigInt = heap.asc_get(big_decimal.exp);
+    fn try_from_asc_obj<H: AscHeap>(
+        big_decimal: AscBigDecimal,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
+        let digits: BigInt = heap.asc_get(big_decimal.digits)?;
+        let exp: BigInt = heap.asc_get(big_decimal.exp)?;
 
         let bytes = exp.to_signed_bytes_le();
         let mut byte_array = if exp >= 0.into() { [0; 8] } else { [255; 8] };
@@ -87,95 +103,103 @@ impl TryFromAscObj<AscBigDecimal> for BigDecimal {
         let exp = -big_decimal.as_bigint_and_exponent().1;
         let min_exp: i64 = BigDecimal::MIN_EXP.into();
         let max_exp: i64 = BigDecimal::MAX_EXP.into();
-        ensure!(
-            min_exp <= exp && exp <= max_exp,
-            format!(
+        if exp < min_exp || max_exp < exp {
+            Err(DeterministicHostError(anyhow::anyhow!(
                 "big decimal exponent `{}` is outside the `{}` to `{}` range",
-                exp, min_exp, max_exp
-            )
-        );
-        Ok(big_decimal)
+                exp,
+                min_exp,
+                max_exp
+            )))
+        } else {
+            Ok(big_decimal)
+        }
     }
 }
 
 impl ToAscObj<AscEnum<EthereumValueKind>> for ethabi::Token {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscEnum<EthereumValueKind> {
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscEnum<EthereumValueKind>, DeterministicHostError> {
         use ethabi::Token::*;
 
         let kind = EthereumValueKind::get_kind(self);
         let payload = match self {
-            Address(address) => heap.asc_new::<AscAddress, _>(address).to_payload(),
+            Address(address) => heap.asc_new::<AscAddress, _>(address)?.to_payload(),
             FixedBytes(bytes) | Bytes(bytes) => {
-                heap.asc_new::<Uint8Array, _>(&**bytes).to_payload()
+                heap.asc_new::<Uint8Array, _>(&**bytes)?.to_payload()
             }
             Int(uint) => {
                 let n = BigInt::from_signed_u256(&uint);
-                heap.asc_new(&n).to_payload()
+                heap.asc_new(&n)?.to_payload()
             }
             Uint(uint) => {
                 let n = BigInt::from_unsigned_u256(&uint);
-                heap.asc_new(&n).to_payload()
+                heap.asc_new(&n)?.to_payload()
             }
             Bool(b) => *b as u64,
-            String(string) => heap.asc_new(&**string).to_payload(),
-            FixedArray(tokens) | Array(tokens) => heap.asc_new(&**tokens).to_payload(),
-            Tuple(tokens) => heap.asc_new(&**tokens).to_payload(),
+            String(string) => heap.asc_new(&**string)?.to_payload(),
+            FixedArray(tokens) | Array(tokens) => heap.asc_new(&**tokens)?.to_payload(),
+            Tuple(tokens) => heap.asc_new(&**tokens)?.to_payload(),
         };
 
-        AscEnum {
+        Ok(AscEnum {
             kind,
             _padding: 0,
             payload: EnumPayload(payload),
-        }
+        })
     }
 }
 
 impl FromAscObj<AscEnum<EthereumValueKind>> for ethabi::Token {
-    fn from_asc_obj<H: AscHeap>(asc_enum: AscEnum<EthereumValueKind>, heap: &H) -> Self {
+    fn from_asc_obj<H: AscHeap>(
+        asc_enum: AscEnum<EthereumValueKind>,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
         use ethabi::Token;
 
         let payload = asc_enum.payload;
-        match asc_enum.kind {
+        Ok(match asc_enum.kind {
             EthereumValueKind::Bool => Token::Bool(bool::from(payload)),
             EthereumValueKind::Address => {
                 let ptr: AscPtr<AscAddress> = AscPtr::from(payload);
-                Token::Address(heap.asc_get(ptr))
+                Token::Address(heap.asc_get(ptr)?)
             }
             EthereumValueKind::FixedBytes => {
                 let ptr: AscPtr<Uint8Array> = AscPtr::from(payload);
-                Token::FixedBytes(heap.asc_get(ptr))
+                Token::FixedBytes(heap.asc_get(ptr)?)
             }
             EthereumValueKind::Bytes => {
                 let ptr: AscPtr<Uint8Array> = AscPtr::from(payload);
-                Token::Bytes(heap.asc_get(ptr))
+                Token::Bytes(heap.asc_get(ptr)?)
             }
             EthereumValueKind::Int => {
                 let ptr: AscPtr<AscBigInt> = AscPtr::from(payload);
-                let n: BigInt = heap.asc_get(ptr);
+                let n: BigInt = heap.asc_get(ptr)?;
                 Token::Int(n.to_signed_u256())
             }
             EthereumValueKind::Uint => {
                 let ptr: AscPtr<AscBigInt> = AscPtr::from(payload);
-                let n: BigInt = heap.asc_get(ptr);
+                let n: BigInt = heap.asc_get(ptr)?;
                 Token::Uint(n.to_unsigned_u256())
             }
             EthereumValueKind::String => {
                 let ptr: AscPtr<AscString> = AscPtr::from(payload);
-                Token::String(heap.asc_get(ptr))
+                Token::String(heap.asc_get(ptr)?)
             }
             EthereumValueKind::FixedArray => {
                 let ptr: AscEnumArray<EthereumValueKind> = AscPtr::from(payload);
-                Token::FixedArray(heap.asc_get(ptr))
+                Token::FixedArray(heap.asc_get(ptr)?)
             }
             EthereumValueKind::Array => {
                 let ptr: AscEnumArray<EthereumValueKind> = AscPtr::from(payload);
-                Token::Array(heap.asc_get(ptr))
+                Token::Array(heap.asc_get(ptr)?)
             }
             EthereumValueKind::Tuple => {
                 let ptr: AscEnumArray<EthereumValueKind> = AscPtr::from(payload);
-                Token::Tuple(heap.asc_get(ptr))
+                Token::Tuple(heap.asc_get(ptr)?)
             }
-        }
+        })
     }
 }
 
@@ -183,14 +207,14 @@ impl TryFromAscObj<AscEnum<StoreValueKind>> for store::Value {
     fn try_from_asc_obj<H: AscHeap>(
         asc_enum: AscEnum<StoreValueKind>,
         heap: &H,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, DeterministicHostError> {
         use self::store::Value;
 
         let payload = asc_enum.payload;
         Ok(match asc_enum.kind {
             StoreValueKind::String => {
                 let ptr: AscPtr<AscString> = AscPtr::from(payload);
-                Value::String(heap.asc_get(ptr))
+                Value::String(heap.asc_get(ptr)?)
             }
             StoreValueKind::Int => Value::Int(i32::from(payload)),
             StoreValueKind::BigDecimal => {
@@ -205,12 +229,12 @@ impl TryFromAscObj<AscEnum<StoreValueKind>> for store::Value {
             StoreValueKind::Null => Value::Null,
             StoreValueKind::Bytes => {
                 let ptr: AscPtr<Bytes> = AscPtr::from(payload);
-                let array: Vec<u8> = heap.asc_get(ptr);
+                let array: Vec<u8> = heap.asc_get(ptr)?;
                 Value::Bytes(array.as_slice().into())
             }
             StoreValueKind::BigInt => {
                 let ptr: AscPtr<AscBigInt> = AscPtr::from(payload);
-                let array: Vec<u8> = heap.asc_get(ptr);
+                let array: Vec<u8> = heap.asc_get(ptr)?;
                 Value::BigInt(store::scalar::BigInt::from_signed_bytes_le(&array))
             }
         })
@@ -218,144 +242,159 @@ impl TryFromAscObj<AscEnum<StoreValueKind>> for store::Value {
 }
 
 impl ToAscObj<AscEnum<StoreValueKind>> for store::Value {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscEnum<StoreValueKind> {
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscEnum<StoreValueKind>, DeterministicHostError> {
         use self::store::Value;
 
         let payload = match self {
-            Value::String(string) => heap.asc_new(string.as_str()).into(),
+            Value::String(string) => heap.asc_new(string.as_str())?.into(),
             Value::Int(n) => EnumPayload::from(*n),
-            Value::BigDecimal(n) => heap.asc_new(n).into(),
+            Value::BigDecimal(n) => heap.asc_new(n)?.into(),
             Value::Bool(b) => EnumPayload::from(*b),
-            Value::List(array) => heap.asc_new(array.as_slice()).into(),
+            Value::List(array) => heap.asc_new(array.as_slice())?.into(),
             Value::Null => EnumPayload(0),
             Value::Bytes(bytes) => {
-                let bytes_obj: AscPtr<Uint8Array> = heap.asc_new(bytes.as_slice());
+                let bytes_obj: AscPtr<Uint8Array> = heap.asc_new(bytes.as_slice())?;
                 bytes_obj.into()
             }
             Value::BigInt(big_int) => {
-                let bytes_obj: AscPtr<Uint8Array> = heap.asc_new(&*big_int.to_signed_bytes_le());
+                let bytes_obj: AscPtr<Uint8Array> = heap.asc_new(&*big_int.to_signed_bytes_le())?;
                 bytes_obj.into()
             }
         };
 
-        AscEnum {
+        Ok(AscEnum {
             kind: StoreValueKind::get_kind(self),
             _padding: 0,
             payload,
-        }
+        })
     }
 }
 
 impl ToAscObj<AscLogParam> for ethabi::LogParam {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscLogParam {
-        AscLogParam {
-            name: heap.asc_new(self.name.as_str()),
-            value: heap.asc_new(&self.value),
-        }
+    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscLogParam, DeterministicHostError> {
+        Ok(AscLogParam {
+            name: heap.asc_new(self.name.as_str())?,
+            value: heap.asc_new(&self.value)?,
+        })
     }
 }
 
 impl ToAscObj<AscJson> for serde_json::Map<String, serde_json::Value> {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscJson {
-        AscTypedMap {
-            entries: heap.asc_new(&*self.iter().collect::<Vec<_>>()),
-        }
+    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscJson, DeterministicHostError> {
+        Ok(AscTypedMap {
+            entries: heap.asc_new(&*self.iter().collect::<Vec<_>>())?,
+        })
     }
 }
 
 impl ToAscObj<AscEntity> for HashMap<String, store::Value> {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscEntity {
-        AscTypedMap {
-            entries: heap.asc_new(&*self.iter().collect::<Vec<_>>()),
-        }
+    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscEntity, DeterministicHostError> {
+        Ok(AscTypedMap {
+            entries: heap.asc_new(&*self.iter().collect::<Vec<_>>())?,
+        })
     }
 }
 
 impl ToAscObj<AscEntity> for store::Entity {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscEntity {
-        AscTypedMap {
-            entries: heap.asc_new(&*self.iter().collect::<Vec<_>>()),
-        }
+    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscEntity, DeterministicHostError> {
+        Ok(AscTypedMap {
+            entries: heap.asc_new(&*self.iter().collect::<Vec<_>>())?,
+        })
     }
 }
 
 impl ToAscObj<AscEnum<JsonValueKind>> for serde_json::Value {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscEnum<JsonValueKind> {
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscEnum<JsonValueKind>, DeterministicHostError> {
         use serde_json::Value;
 
         let payload = match self {
             Value::Null => EnumPayload(0),
             Value::Bool(b) => EnumPayload::from(*b),
-            Value::Number(number) => heap.asc_new(&*number.to_string()).into(),
-            Value::String(string) => heap.asc_new(string.as_str()).into(),
-            Value::Array(array) => heap.asc_new(array.as_slice()).into(),
-            Value::Object(object) => heap.asc_new(object).into(),
+            Value::Number(number) => heap.asc_new(&*number.to_string())?.into(),
+            Value::String(string) => heap.asc_new(string.as_str())?.into(),
+            Value::Array(array) => heap.asc_new(array.as_slice())?.into(),
+            Value::Object(object) => heap.asc_new(object)?.into(),
         };
 
-        AscEnum {
+        Ok(AscEnum {
             kind: JsonValueKind::get_kind(self),
             _padding: 0,
             payload,
-        }
+        })
     }
 }
 
 impl ToAscObj<AscEthereumBlock> for EthereumBlockData {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscEthereumBlock {
-        AscEthereumBlock {
-            hash: heap.asc_new(&self.hash),
-            parent_hash: heap.asc_new(&self.parent_hash),
-            uncles_hash: heap.asc_new(&self.uncles_hash),
-            author: heap.asc_new(&self.author),
-            state_root: heap.asc_new(&self.state_root),
-            transactions_root: heap.asc_new(&self.transactions_root),
-            receipts_root: heap.asc_new(&self.receipts_root),
-            number: heap.asc_new(&BigInt::from(self.number)),
-            gas_used: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_used)),
-            gas_limit: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_limit)),
-            timestamp: heap.asc_new(&BigInt::from_unsigned_u256(&self.timestamp)),
-            difficulty: heap.asc_new(&BigInt::from_unsigned_u256(&self.difficulty)),
-            total_difficulty: heap.asc_new(&BigInt::from_unsigned_u256(&self.total_difficulty)),
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscEthereumBlock, DeterministicHostError> {
+        Ok(AscEthereumBlock {
+            hash: heap.asc_new(&self.hash)?,
+            parent_hash: heap.asc_new(&self.parent_hash)?,
+            uncles_hash: heap.asc_new(&self.uncles_hash)?,
+            author: heap.asc_new(&self.author)?,
+            state_root: heap.asc_new(&self.state_root)?,
+            transactions_root: heap.asc_new(&self.transactions_root)?,
+            receipts_root: heap.asc_new(&self.receipts_root)?,
+            number: heap.asc_new(&BigInt::from(self.number))?,
+            gas_used: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_used))?,
+            gas_limit: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_limit))?,
+            timestamp: heap.asc_new(&BigInt::from_unsigned_u256(&self.timestamp))?,
+            difficulty: heap.asc_new(&BigInt::from_unsigned_u256(&self.difficulty))?,
+            total_difficulty: heap.asc_new(&BigInt::from_unsigned_u256(&self.total_difficulty))?,
             size: self
                 .size
                 .map(|size| heap.asc_new(&BigInt::from_unsigned_u256(&size)))
-                .unwrap_or_else(|| AscPtr::null()),
-        }
+                .unwrap_or(Ok(AscPtr::null()))?,
+        })
     }
 }
 
 impl ToAscObj<AscEthereumTransaction> for EthereumTransactionData {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscEthereumTransaction {
-        AscEthereumTransaction {
-            hash: heap.asc_new(&self.hash),
-            index: heap.asc_new(&BigInt::from(self.index)),
-            from: heap.asc_new(&self.from),
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscEthereumTransaction, DeterministicHostError> {
+        Ok(AscEthereumTransaction {
+            hash: heap.asc_new(&self.hash)?,
+            index: heap.asc_new(&BigInt::from(self.index))?,
+            from: heap.asc_new(&self.from)?,
             to: self
                 .to
                 .map(|to| heap.asc_new(&to))
-                .unwrap_or_else(|| AscPtr::null()),
-            value: heap.asc_new(&BigInt::from_unsigned_u256(&self.value)),
-            gas_used: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_used)),
-            gas_price: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_price)),
-        }
+                .unwrap_or(Ok(AscPtr::null()))?,
+            value: heap.asc_new(&BigInt::from_unsigned_u256(&self.value))?,
+            gas_used: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_used))?,
+            gas_price: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_price))?,
+        })
     }
 }
 
 impl ToAscObj<AscEthereumTransaction_0_0_2> for EthereumTransactionData {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscEthereumTransaction_0_0_2 {
-        AscEthereumTransaction_0_0_2 {
-            hash: heap.asc_new(&self.hash),
-            index: heap.asc_new(&BigInt::from(self.index)),
-            from: heap.asc_new(&self.from),
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscEthereumTransaction_0_0_2, DeterministicHostError> {
+        Ok(AscEthereumTransaction_0_0_2 {
+            hash: heap.asc_new(&self.hash)?,
+            index: heap.asc_new(&BigInt::from(self.index))?,
+            from: heap.asc_new(&self.from)?,
             to: self
                 .to
                 .map(|to| heap.asc_new(&to))
-                .unwrap_or_else(|| AscPtr::null()),
-            value: heap.asc_new(&BigInt::from_unsigned_u256(&self.value)),
-            gas_used: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_used)),
-            gas_price: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_price)),
-            input: heap.asc_new(&*self.input.0),
-        }
+                .unwrap_or(Ok(AscPtr::null()))?,
+            value: heap.asc_new(&BigInt::from_unsigned_u256(&self.value))?,
+            gas_used: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_used))?,
+            gas_price: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_price))?,
+            input: heap.asc_new(&*self.input.0)?,
+        })
     }
 }
 
@@ -363,70 +402,85 @@ impl<T: AscType> ToAscObj<AscEthereumEvent<T>> for EthereumEventData
 where
     EthereumTransactionData: ToAscObj<T>,
 {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscEthereumEvent<T> {
-        AscEthereumEvent {
-            address: heap.asc_new(&self.address),
-            log_index: heap.asc_new(&BigInt::from_unsigned_u256(&self.log_index)),
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscEthereumEvent<T>, DeterministicHostError> {
+        Ok(AscEthereumEvent {
+            address: heap.asc_new(&self.address)?,
+            log_index: heap.asc_new(&BigInt::from_unsigned_u256(&self.log_index))?,
             transaction_log_index: heap
-                .asc_new(&BigInt::from_unsigned_u256(&self.transaction_log_index)),
+                .asc_new(&BigInt::from_unsigned_u256(&self.transaction_log_index))?,
             log_type: self
                 .log_type
                 .clone()
                 .map(|log_type| heap.asc_new(&log_type))
-                .unwrap_or_else(|| AscPtr::null()),
-            block: heap.asc_new(&self.block),
-            transaction: heap.asc_new::<T, EthereumTransactionData>(&self.transaction),
-            params: heap.asc_new(self.params.as_slice()),
-        }
+                .unwrap_or(Ok(AscPtr::null()))?,
+            block: heap.asc_new(&self.block)?,
+            transaction: heap.asc_new::<T, EthereumTransactionData>(&self.transaction)?,
+            params: heap.asc_new(self.params.as_slice())?,
+        })
     }
 }
 
 impl ToAscObj<AscEthereumCall> for EthereumCallData {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscEthereumCall {
-        AscEthereumCall {
-            address: heap.asc_new(&self.to),
-            block: heap.asc_new(&self.block),
-            transaction: heap.asc_new(&self.transaction),
-            inputs: heap.asc_new(self.inputs.as_slice()),
-            outputs: heap.asc_new(self.outputs.as_slice()),
-        }
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscEthereumCall, DeterministicHostError> {
+        Ok(AscEthereumCall {
+            address: heap.asc_new(&self.to)?,
+            block: heap.asc_new(&self.block)?,
+            transaction: heap.asc_new(&self.transaction)?,
+            inputs: heap.asc_new(self.inputs.as_slice())?,
+            outputs: heap.asc_new(self.outputs.as_slice())?,
+        })
     }
 }
 
 impl ToAscObj<AscEthereumCall_0_0_3> for EthereumCallData {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscEthereumCall_0_0_3 {
-        AscEthereumCall_0_0_3 {
-            to: heap.asc_new(&self.to),
-            from: heap.asc_new(&self.from),
-            block: heap.asc_new(&self.block),
-            transaction: heap.asc_new(&self.transaction),
-            inputs: heap.asc_new(self.inputs.as_slice()),
-            outputs: heap.asc_new(self.outputs.as_slice()),
-        }
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscEthereumCall_0_0_3, DeterministicHostError> {
+        Ok(AscEthereumCall_0_0_3 {
+            to: heap.asc_new(&self.to)?,
+            from: heap.asc_new(&self.from)?,
+            block: heap.asc_new(&self.block)?,
+            transaction: heap.asc_new(&self.transaction)?,
+            inputs: heap.asc_new(self.inputs.as_slice())?,
+            outputs: heap.asc_new(self.outputs.as_slice())?,
+        })
     }
 }
 
 impl FromAscObj<AscUnresolvedContractCall> for UnresolvedContractCall {
-    fn from_asc_obj<H: AscHeap>(asc_call: AscUnresolvedContractCall, heap: &H) -> Self {
-        UnresolvedContractCall {
-            contract_name: heap.asc_get(asc_call.contract_name),
-            contract_address: heap.asc_get(asc_call.contract_address),
-            function_name: heap.asc_get(asc_call.function_name),
+    fn from_asc_obj<H: AscHeap>(
+        asc_call: AscUnresolvedContractCall,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
+        Ok(UnresolvedContractCall {
+            contract_name: heap.asc_get(asc_call.contract_name)?,
+            contract_address: heap.asc_get(asc_call.contract_address)?,
+            function_name: heap.asc_get(asc_call.function_name)?,
             function_signature: None,
-            function_args: heap.asc_get(asc_call.function_args),
-        }
+            function_args: heap.asc_get(asc_call.function_args)?,
+        })
     }
 }
 
 impl FromAscObj<AscUnresolvedContractCall_0_0_4> for UnresolvedContractCall {
-    fn from_asc_obj<H: AscHeap>(asc_call: AscUnresolvedContractCall_0_0_4, heap: &H) -> Self {
-        UnresolvedContractCall {
-            contract_name: heap.asc_get(asc_call.contract_name),
-            contract_address: heap.asc_get(asc_call.contract_address),
-            function_name: heap.asc_get(asc_call.function_name),
-            function_signature: Some(heap.asc_get(asc_call.function_signature)),
-            function_args: heap.asc_get(asc_call.function_args),
-        }
+    fn from_asc_obj<H: AscHeap>(
+        asc_call: AscUnresolvedContractCall_0_0_4,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
+        Ok(UnresolvedContractCall {
+            contract_name: heap.asc_get(asc_call.contract_name)?,
+            contract_address: heap.asc_get(asc_call.contract_address)?,
+            function_name: heap.asc_get(asc_call.function_name)?,
+            function_signature: Some(heap.asc_get(asc_call.function_signature)?),
+            function_args: heap.asc_get(asc_call.function_args)?,
+        })
     }
 }
 
@@ -444,14 +498,17 @@ impl From<u32> for LogLevel {
 }
 
 impl ToAscObj<bool> for bool {
-    fn to_asc_obj<H: AscHeap>(&self, _heap: &mut H) -> bool {
-        *self
+    fn to_asc_obj<H: AscHeap>(&self, _heap: &mut H) -> Result<bool, DeterministicHostError> {
+        Ok(*self)
     }
 }
 
 impl<T: AscType> ToAscObj<AscWrapped<T>> for AscWrapped<T> {
-    fn to_asc_obj<H: AscHeap>(&self, _heap: &mut H) -> AscWrapped<T> {
-        *self
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        _heap: &mut H,
+    ) -> Result<AscWrapped<T>, DeterministicHostError> {
+        Ok(*self)
     }
 }
 
@@ -462,24 +519,27 @@ where
     VAsc: AscType,
     EAsc: AscType,
 {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscResult<VAsc, EAsc> {
-        match self {
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscResult<VAsc, EAsc>, DeterministicHostError> {
+        Ok(match self {
             Ok(value) => AscResult {
                 value: {
-                    let inner = heap.asc_new(value);
+                    let inner = heap.asc_new(value)?;
                     let wrapped = AscWrapped { inner };
-                    heap.asc_new(&wrapped)
+                    heap.asc_new(&wrapped)?
                 },
                 error: AscPtr::null(),
             },
             Err(e) => AscResult {
                 value: AscPtr::null(),
                 error: {
-                    let inner = heap.asc_new(e);
+                    let inner = heap.asc_new(e)?;
                     let wrapped = AscWrapped { inner };
-                    heap.asc_new(&wrapped)
+                    heap.asc_new(&wrapped)?
                 },
             },
-        }
+        })
     }
 }

--- a/runtime/wasm/src/to_from/mod.rs
+++ b/runtime/wasm/src/to_from/mod.rs
@@ -1,73 +1,98 @@
-use graph::prelude::anyhow::Error;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::FromIterator;
 
 use crate::asc_abi::class::*;
 use crate::asc_abi::{AscHeap, AscPtr, AscType, AscValue, FromAscObj, ToAscObj, TryFromAscObj};
+use crate::error::DeterministicHostError;
 
 ///! Implementations of `ToAscObj` and `FromAscObj` for Rust types.
 ///! Standard Rust types go in `mod.rs` and external types in `external.rs`.
 mod external;
 
 impl<T: AscValue> ToAscObj<TypedArray<T>> for [T] {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> TypedArray<T> {
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<TypedArray<T>, DeterministicHostError> {
         TypedArray::new(self, heap)
     }
 }
 
 impl<T: AscValue> FromAscObj<TypedArray<T>> for Vec<T> {
-    fn from_asc_obj<H: AscHeap>(typed_array: TypedArray<T>, heap: &H) -> Self {
+    fn from_asc_obj<H: AscHeap>(
+        typed_array: TypedArray<T>,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
         typed_array.to_vec(heap)
     }
 }
 
 impl<T: AscValue> FromAscObj<TypedArray<T>> for [T; 32] {
-    fn from_asc_obj<H: AscHeap>(typed_array: TypedArray<T>, heap: &H) -> Self {
+    fn from_asc_obj<H: AscHeap>(
+        typed_array: TypedArray<T>,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
         let mut array: [T; 32] = [T::default(); 32];
-        array.copy_from_slice(&typed_array.to_vec(heap));
-        array
+        let v = typed_array.to_vec(heap)?;
+        array.copy_from_slice(&v);
+        Ok(array)
     }
 }
 
 impl<T: AscValue> FromAscObj<TypedArray<T>> for [T; 20] {
-    fn from_asc_obj<H: AscHeap>(typed_array: TypedArray<T>, heap: &H) -> Self {
+    fn from_asc_obj<H: AscHeap>(
+        typed_array: TypedArray<T>,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
         let mut array: [T; 20] = [T::default(); 20];
-        array.copy_from_slice(&typed_array.to_vec(heap));
-        array
+        let v = typed_array.to_vec(heap)?;
+        array.copy_from_slice(&v);
+        Ok(array)
     }
 }
 
 impl<T: AscValue> FromAscObj<TypedArray<T>> for [T; 16] {
-    fn from_asc_obj<H: AscHeap>(typed_array: TypedArray<T>, heap: &H) -> Self {
+    fn from_asc_obj<H: AscHeap>(
+        typed_array: TypedArray<T>,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
         let mut array: [T; 16] = [T::default(); 16];
-        array.copy_from_slice(&typed_array.to_vec(heap));
-        array
+        let v = typed_array.to_vec(heap)?;
+        array.copy_from_slice(&v);
+        Ok(array)
     }
 }
 
 impl<T: AscValue> FromAscObj<TypedArray<T>> for [T; 4] {
-    fn from_asc_obj<H: AscHeap>(typed_array: TypedArray<T>, heap: &H) -> Self {
+    fn from_asc_obj<H: AscHeap>(
+        typed_array: TypedArray<T>,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
         let mut array: [T; 4] = [T::default(); 4];
-        array.copy_from_slice(&typed_array.to_vec(heap));
-        array
+        let v = typed_array.to_vec(heap)?;
+        array.copy_from_slice(&v);
+        Ok(array)
     }
 }
 
 impl ToAscObj<AscString> for str {
-    fn to_asc_obj<H: AscHeap>(&self, _: &mut H) -> AscString {
+    fn to_asc_obj<H: AscHeap>(&self, _: &mut H) -> Result<AscString, DeterministicHostError> {
         AscString::new(&self.encode_utf16().collect::<Vec<_>>())
     }
 }
 
 impl ToAscObj<AscString> for String {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscString {
+    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscString, DeterministicHostError> {
         self.as_str().to_asc_obj(heap)
     }
 }
 
 impl FromAscObj<AscString> for String {
-    fn from_asc_obj<H: AscHeap>(asc_string: AscString, _: &H) -> Self {
+    fn from_asc_obj<H: AscHeap>(
+        asc_string: AscString,
+        _: &H,
+    ) -> Result<Self, DeterministicHostError> {
         let mut string =
             String::from_utf16(&asc_string.content).expect("asc string was not UTF-16");
 
@@ -75,27 +100,37 @@ impl FromAscObj<AscString> for String {
         if string.contains("\u{0000}") {
             string = string.replace("\u{0000}", "");
         }
-        string
+        Ok(string)
     }
 }
 
 impl TryFromAscObj<AscString> for String {
-    fn try_from_asc_obj<H: AscHeap>(asc_string: AscString, heap: &H) -> Result<Self, Error> {
-        Ok(Self::from_asc_obj(asc_string, heap))
+    fn try_from_asc_obj<H: AscHeap>(
+        asc_string: AscString,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
+        Ok(Self::from_asc_obj(asc_string, heap)?)
     }
 }
 
 impl<C: AscType, T: ToAscObj<C>> ToAscObj<Array<AscPtr<C>>> for [T] {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Array<AscPtr<C>> {
-        let content: Vec<_> = self.iter().map(|x| heap.asc_new(x)).collect();
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<Array<AscPtr<C>>, DeterministicHostError> {
+        let content: Result<Vec<_>, _> = self.iter().map(|x| heap.asc_new(x)).collect();
+        let content = content?;
         Array::new(&*content, heap)
     }
 }
 
 impl<C: AscType, T: FromAscObj<C>> FromAscObj<Array<AscPtr<C>>> for Vec<T> {
-    fn from_asc_obj<H: AscHeap>(array: Array<AscPtr<C>>, heap: &H) -> Self {
+    fn from_asc_obj<H: AscHeap>(
+        array: Array<AscPtr<C>>,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
         array
-            .to_vec(heap)
+            .to_vec(heap)?
             .into_iter()
             .map(|x| heap.asc_get(x))
             .collect()
@@ -103,9 +138,12 @@ impl<C: AscType, T: FromAscObj<C>> FromAscObj<Array<AscPtr<C>>> for Vec<T> {
 }
 
 impl<C: AscType, T: TryFromAscObj<C>> TryFromAscObj<Array<AscPtr<C>>> for Vec<T> {
-    fn try_from_asc_obj<H: AscHeap>(array: Array<AscPtr<C>>, heap: &H) -> Result<Self, Error> {
+    fn try_from_asc_obj<H: AscHeap>(
+        array: Array<AscPtr<C>>,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
         array
-            .to_vec(heap)
+            .to_vec(heap)?
             .into_iter()
             .map(|x| heap.try_asc_get(x))
             .collect()
@@ -118,7 +156,7 @@ impl<K: AscType, V: AscType, T: TryFromAscObj<K>, U: TryFromAscObj<V>>
     fn try_from_asc_obj<H: AscHeap>(
         asc_entry: AscTypedMapEntry<K, V>,
         heap: &H,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, DeterministicHostError> {
         Ok((
             heap.try_asc_get(asc_entry.key)?,
             heap.try_asc_get(asc_entry.value)?,
@@ -129,18 +167,24 @@ impl<K: AscType, V: AscType, T: TryFromAscObj<K>, U: TryFromAscObj<V>>
 impl<'a, 'b, K: AscType, V: AscType, T: ToAscObj<K>, U: ToAscObj<V>>
     ToAscObj<AscTypedMapEntry<K, V>> for (&'a T, &'b U)
 {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> AscTypedMapEntry<K, V> {
-        AscTypedMapEntry {
-            key: heap.asc_new(self.0),
-            value: heap.asc_new(self.1),
-        }
+    fn to_asc_obj<H: AscHeap>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscTypedMapEntry<K, V>, DeterministicHostError> {
+        Ok(AscTypedMapEntry {
+            key: heap.asc_new(self.0)?,
+            value: heap.asc_new(self.1)?,
+        })
     }
 }
 
 impl<K: AscType, V: AscType, T: TryFromAscObj<K> + Hash + Eq, U: TryFromAscObj<V>>
     TryFromAscObj<AscTypedMap<K, V>> for HashMap<T, U>
 {
-    fn try_from_asc_obj<H: AscHeap>(asc_map: AscTypedMap<K, V>, heap: &H) -> Result<Self, Error> {
+    fn try_from_asc_obj<H: AscHeap>(
+        asc_map: AscTypedMap<K, V>,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError> {
         let entries: Vec<(T, U)> = heap.try_asc_get(asc_map.entries)?;
         Ok(HashMap::from_iter(entries.into_iter()))
     }


### PR DESCRIPTION
**Error Determinism**
  -  Introduced determinism in error types
   - Before this would set deterministic_host_trap, but access to this value may not be available in many cases where the error originates or may use shared references forcing atomics
   - anyhow errors are necessarily considered non-deterministic until proven otherwise.
   - Anyhow is dangerous for our use-case because it hides information by design. (This extends to any use-case which handles errors) There's not much that can be done here in the short term.
   - Lots of anyhow errors have been converted to deterministic ones (eg: json parsing, type conversions, math, and most other host exports are deterministic)
   - Note that like anyhow, panics do not carry determinism information. These must be treated as non-deterministic and should be avoided for error conditions arising out of the subgraph or the data it acts upon.

**Non-Panicky Errors**

- BigDecimal % 0 no longer panics but has DeterministicHostError instead
- Before the wasm was trusted to interact with the heap in-bounds, leading to panics - which with this change is a DeterministicHostError instead
- Same story for assertions on binary representations for AscValue which also are untrusted inputs
There's probably a lot more that can be done along these lines...