### PR TITLE
Fix unused variable warning

### DIFF
--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -835,6 +835,7 @@ where
 // This always returns `false` in a normal build. A test may configure reorg by enabling
 // "test_reorg" fail point with the number of the block that should be reorged.
 #[cfg(debug_assertions)]
+#[allow(unused_variables)]
 fn test_reorg(ptr: EthereumBlockPointer) -> bool {
     fail_point!("test_reorg", |reorg_at| {
         use std::str::FromStr;


### PR DESCRIPTION
Depending if this is built with the `failpoints` feature turned on or not, it can trigger a warning.