### PR TITLE
store: Save the network to which a subgraph belongs in the primary

### DIFF
--- a/store/postgres/migrations/2021-01-14-175654_add_network_to_deployment_schemas/down.sql
+++ b/store/postgres/migrations/2021-01-14-175654_add_network_to_deployment_schemas/down.sql
@@ -1,0 +1,2 @@
+alter table deployment_schemas
+  drop column network;

--- a/store/postgres/migrations/2021-01-14-175654_add_network_to_deployment_schemas/up.sql
+++ b/store/postgres/migrations/2021-01-14-175654_add_network_to_deployment_schemas/up.sql
@@ -1,0 +1,7 @@
+alter table deployment_schemas
+  add column network text references ethereum_networks(name);
+
+update deployment_schemas ds
+   set network = d.network
+  from subgraphs.subgraph_deployment_detail d
+ where d.id = ds.subgraph;

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -113,6 +113,7 @@ table! {
         shard -> Text,
         /// The subgraph layout scheme used for this subgraph
         version -> crate::primary::DeploymentSchemaVersionMapping,
+        network -> Nullable<Text>,
     }
 }
 
@@ -162,6 +163,7 @@ struct Schema {
     /// The version currently in use. Always `Relational`, attempts to load
     /// schemas from the database with `Split` produce an error
     version: DeploymentSchemaVersion,
+    pub network: Option<String>,
 }
 
 #[derive(Clone, Queryable, QueryableByName, Debug)]
@@ -603,6 +605,7 @@ impl Connection {
         &self,
         shard: Shard,
         subgraph: &SubgraphDeploymentId,
+        network_name: &str,
     ) -> Result<Site, StoreError> {
         use deployment_schemas as ds;
         use DeploymentSchemaVersion as v;
@@ -619,6 +622,7 @@ impl Connection {
                 ds::subgraph.eq(subgraph.as_str()),
                 ds::shard.eq(shard.as_str()),
                 ds::version.eq(v::Relational),
+                ds::network.eq(network_name),
             ))
             .returning(ds::name)
             .get_results(conn)?;

--- a/store/postgres/src/sharded_store.rs
+++ b/store/postgres/src/sharded_store.rs
@@ -224,7 +224,7 @@ impl ShardedStore {
         // TODO: Check this for behavior on failure
         let site = self
             .primary_conn()?
-            .allocate_site(shard.clone(), &schema.id)?;
+            .allocate_site(shard.clone(), &schema.id, &network_name)?;
 
         let graft_site = deployment
             .graft_base

--- a/store/test-store/src/block_store.rs
+++ b/store/test-store/src/block_store.rs
@@ -101,6 +101,8 @@ pub fn remove() {
     use db_schema::ethereum_blocks as b;
     use db_schema::ethereum_networks as n;
 
+    crate::store::remove_subgraphs();
+
     let conn = super::PRIMARY_POOL
         .get()
         .expect("Failed to connect to Postgres");


### PR DESCRIPTION
For some of the upcoming changes, we need to know the network for each subgraph, rather than leave that as an `Option` - we already know that, but don't store it in the primary. This change just records a subgraph's network in the primary in `deployment_schemas` and fills in the data for existing deployments.

For non-sharded setups, that's the end of the story. For sharded setups (which it is safe to assume is only hosted at this point), we will need to manually fill `deployment_schemas.network` for existing deployments that are not in the primary shard. 

A follow-up PR will then make `deployment_schemas.network` not nullable, and use it rather than `ethereum_contract_data_source.network` which is somewhat hard to get to.