### PR TITLE
Fix has_non_fatal_errors

### DIFF
--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -515,12 +515,7 @@ fn fatal_vs_non_fatal() {
     }
 
     run_test_sequentially(setup, |store, id| async move {
-        let query_store = store
-            .query_store(
-                SubgraphDeploymentId::new("failUnfail").unwrap().into(),
-                false,
-            )
-            .unwrap();
+        let query_store = store.query_store(id.cheap_clone().into(), false).unwrap();
 
         let error = || SubgraphError {
             subgraph_id: id.clone(),


### PR DESCRIPTION
This is a bit subtle: When the instance manager calls `fail_subgraph` at block N, that block has not been transacted into the store, and is therefore N is beyond the subgraph head block.  But right now because the error is deterministic we'd consider it non-fatal. To fix this, `non_fatal_error` will not check if any determinstic error exists, but if one exists up to the subgraph head block and therefore is an error that has been transacted. The test demonstrates this situation.

Resolves #2093.