### PR TITLE
Unassign, not fail, pending subgraph on error

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1070,6 +1070,8 @@ pub trait Store: Send + Sync + 'static {
         node_id: &NodeId,
     ) -> Result<(), StoreError>;
 
+    fn unassign_subgraph(&self, id: &SubgraphDeploymentId) -> Result<(), StoreError>;
+
     /// Start an existing subgraph deployment. This will reset the state of
     /// the subgraph to a known good state. `ops` needs to contain all the
     /// operations on the subgraph of subgraphs to reset the metadata of the
@@ -1266,6 +1268,10 @@ impl Store for MockStore {
     }
 
     fn reassign_subgraph(&self, _: &SubgraphDeploymentId, _: &NodeId) -> Result<(), StoreError> {
+        unimplemented!()
+    }
+
+    fn unassign_subgraph(&self, _: &SubgraphDeploymentId) -> Result<(), StoreError> {
         unimplemented!()
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -170,6 +170,10 @@ impl Store for MockStore {
         unimplemented!()
     }
 
+    fn unassign_subgraph(&self, _: &SubgraphDeploymentId) -> Result<(), StoreError> {
+        unimplemented!()
+    }
+
     fn start_subgraph_deployment(
         &self,
         _logger: &Logger,

--- a/store/postgres/src/network_store.rs
+++ b/store/postgres/src/network_store.rs
@@ -210,6 +210,10 @@ impl StoreTrait for NetworkStore {
         self.store.reassign_subgraph(id, node)
     }
 
+    fn unassign_subgraph(&self, id: &SubgraphDeploymentId) -> Result<(), StoreError> {
+        self.store.unassign_subgraph(id)
+    }
+
     fn create_subgraph(&self, name: SubgraphName) -> Result<String, StoreError> {
         self.store.create_subgraph(name)
     }

--- a/store/postgres/src/sharded_store.rs
+++ b/store/postgres/src/sharded_store.rs
@@ -667,6 +667,14 @@ impl StoreTrait for ShardedStore {
         })
     }
 
+    fn unassign_subgraph(&self, id: &SubgraphDeploymentId) -> Result<(), StoreError> {
+        let pconn = self.primary_conn()?;
+        pconn.transaction(|| -> Result<_, StoreError> {
+            let changes = pconn.unassign_subgraph(id)?;
+            pconn.send_store_event(&StoreEvent::new(changes))
+        })
+    }
+
     fn status(&self, filter: status::Filter) -> Result<Vec<status::Info>, StoreError> {
         let deployments = match filter {
             status::Filter::SubgraphName(name) => {

--- a/tests/integration-tests/non-fatal-errors/test/test.js
+++ b/tests/integration-tests/non-fatal-errors/test/test.js
@@ -35,7 +35,7 @@ const waitForSubgraphToBeUnhealthy = async () =>
         });
 
         let health = result.data.indexingStatuses[0].health
-        if (result.data.indexingStatuses[0].synced && health == "unhealthy") {
+        if (health == "unhealthy") {
           resolve();
         } else if (health == "failed") {
           reject(new Error("Subgraph failed"));

--- a/tests/tests/tests.rs
+++ b/tests/tests/tests.rs
@@ -118,7 +118,6 @@ fn big_decimal() {
 #[test]
 fn non_fatal_errors() {
     let _m = TEST_MUTEX.lock();
-    std::env::set_var("GRAPH_DISABLE_FAIL_FAST", "yesplease");
     run_test("non-fatal-errors");
 }
 


### PR DESCRIPTION
It seems more consistent for a non-fatal error to always be transacted to the DB in the same way, but still we can unassign to prevent a subgraph that hasn't synced yet from moving forward after encountering an error.

This adds a `store.unassign` to remove the assignment for a subgraph id.