### PR TITLE
Fix not contains filter

### DIFF
--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -830,8 +830,14 @@ impl<'a> QueryFilter<'a> {
                 }
             }
             Value::List(_) => {
-                out.push_identifier(column.name.as_str())?;
-                out.push_sql(" @> ");
+                if negated {
+                    out.push_sql(" not ");
+                    out.push_identifier(column.name.as_str())?;
+                    out.push_sql(" && ");
+                } else {
+                    out.push_identifier(column.name.as_str())?;
+                    out.push_sql(" @> ");
+                }
                 QueryValue(value, &column.column_type).walk_ast(out)?;
             }
             Value::Null

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -745,6 +745,25 @@ fn check_find() {
             .check(vec![], drinks_query(vec!["beer", "water"]))
             .check(vec![], drinks_query(vec!["beer", "wine", "water"]));
 
+        // list not contains
+        let checker = checker
+            // User 3 do not have "beer" on its drinks list.
+            .check(
+                vec!["3"],
+                user_query().filter(EntityFilter::NotContains(
+                    "drinks".into(),
+                    vec!["beer"].into(),
+                )),
+            )
+            // Users 2 do not have "tea" on its drinks list.
+            .check(
+                vec!["2"],
+                user_query().filter(EntityFilter::NotContains(
+                    "drinks".into(),
+                    vec!["tea"].into(),
+                )),
+            );
+
         // string attributes
         let checker = checker
             .check(


### PR DESCRIPTION
Resolves #1766, resolves #1474

This fixes the `*_not_contains` graphQL operator from returning the same output as the `contains` operator.

The current code does not handle the negation of the `contains` filter, so the two operators produced the same result.

This PR contains two tests that handle populated lists, but empty lists and `null` values are still untested, as I think it would be best to discuss thoughts on how to handle those two possibilities for the absence of value.