### PR TITLE
Delete fatal error on unfail

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1080,15 +1080,15 @@ pub trait SubgraphStore: Send + Sync + 'static {
 
     fn unassign_subgraph(&self, id: &SubgraphDeploymentId) -> Result<(), StoreError>;
 
-    /// Start an existing subgraph deployment. This will reset the state of
-    /// the subgraph to a known good state. `ops` needs to contain all the
-    /// operations on the subgraph of subgraphs to reset the metadata of the
-    /// subgraph
+    /// Start an existing subgraph deployment.
     fn start_subgraph_deployment(
         &self,
         logger: &Logger,
         subgraph_id: &SubgraphDeploymentId,
     ) -> Result<(), StoreError>;
+
+    /// Remove the fatal error from a subgraph and check if it is healthy or unhealthy.
+    fn unfail(&self, subgraph_id: &SubgraphDeploymentId) -> Result<(), StoreError>;
 
     /// Load the dynamic data sources for the given deployment
     async fn load_dynamic_data_sources(
@@ -1275,6 +1275,10 @@ impl SubgraphStore for MockStore {
         _logger: &Logger,
         _subgraph_id: &SubgraphDeploymentId,
     ) -> Result<(), StoreError> {
+        unimplemented!()
+    }
+
+    fn unfail(&self, _: &SubgraphDeploymentId) -> Result<(), StoreError> {
         unimplemented!()
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -185,6 +185,10 @@ impl SubgraphStore for MockStore {
         unimplemented!()
     }
 
+    fn unfail(&self, _: &SubgraphDeploymentId) -> Result<(), StoreError> {
+        unimplemented!()
+    }
+
     fn is_deployment_synced(&self, _: &SubgraphDeploymentId) -> Result<bool, Error> {
         unimplemented!()
     }

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1128,10 +1128,12 @@ impl DeploymentStore {
         graft_base: Option<(Site, EthereumBlockPointer)>,
     ) -> Result<(), StoreError> {
         let econn = self.get_entity_conn(&site, ReplicaId::Main)?;
-        econn.transaction(|| {
-            deployment::unfail(&econn.conn, &site.deployment)?;
-            econn.start_subgraph(logger, graft_base)
-        })
+        econn.transaction(|| econn.start_subgraph(logger, graft_base))
+    }
+
+    pub(crate) fn unfail(&self, site: Arc<Site>) -> Result<(), StoreError> {
+        let econn = self.get_entity_conn(&site, ReplicaId::Main)?;
+        econn.transaction(|| deployment::unfail(&econn.conn, &site.deployment))
     }
 
     #[cfg(debug_assertions)]

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -195,6 +195,10 @@ impl SubgraphStoreTrait for Store {
         self.store.start_subgraph_deployment(logger, subgraph_id)
     }
 
+    fn unfail(&self, id: &SubgraphDeploymentId) -> Result<(), StoreError> {
+        self.store.unfail(id)
+    }
+
     fn is_deployment_synced(&self, id: &SubgraphDeploymentId) -> Result<bool, Error> {
         self.store.is_deployment_synced(id)
     }

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -745,6 +745,11 @@ impl SubgraphStoreTrait for SubgraphStore {
         store.start_subgraph(logger, site, graft_base)
     }
 
+    fn unfail(&self, id: &SubgraphDeploymentId) -> Result<(), StoreError> {
+        let (store, site) = self.store(id)?;
+        store.unfail(site)
+    }
+
     fn is_deployment_synced(&self, id: &SubgraphDeploymentId) -> Result<bool, Error> {
         let (store, _) = self.store(&id)?;
         Ok(store.exists_and_synced(&id)?)

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -12,7 +12,7 @@ use graph::{
     prelude::SubgraphManifest,
     prelude::SubgraphName,
     prelude::SubgraphVersionSwitchingMode,
-    prelude::{CheapClone, NodeId, SubgraphDeploymentId, SubgraphStore as _},
+    prelude::{o, slog, CheapClone, Logger, NodeId, SubgraphDeploymentId, SubgraphStore as _},
 };
 use graph_store_postgres::layout_for_tests::Connection as Primary;
 use graph_store_postgres::Store;
@@ -541,5 +541,52 @@ fn fatal_vs_non_fatal() {
             .has_non_fatal_errors(id.cheap_clone(), None)
             .await
             .unwrap());
+    })
+}
+
+#[test]
+fn fail_unfail() {
+    fn setup() -> SubgraphDeploymentId {
+        let id = SubgraphDeploymentId::new("failUnfail").unwrap();
+        remove_subgraphs();
+        create_test_subgraph(&id, SUBGRAPH_GQL);
+        id
+    }
+
+    run_test_sequentially(setup, |store, id| async move {
+        let logger = Logger::root(slog::Discard, o!());
+        let query_store = store
+            .query_store(id.cheap_clone().into(), false)
+            .await
+            .unwrap();
+
+        let error = SubgraphError {
+            subgraph_id: id.clone(),
+            message: "test".to_string(),
+            block_ptr: Some(BLOCKS[1]),
+            handler: None,
+            deterministic: true,
+        };
+
+        store.fail_subgraph(id.clone(), error).await.unwrap();
+
+        assert!(!query_store
+            .has_non_fatal_errors(id.cheap_clone(), None)
+            .await
+            .unwrap());
+
+        // This will unfail the subgraph and delete the fatal error.
+        store.start_subgraph_deployment(&logger, &id).unwrap();
+
+        // Advance the block ptr to the block of the deleted error.
+        transact_entity_operations(&store, id.cheap_clone(), BLOCKS[1], vec![]).unwrap();
+
+        // We still have no fatal errors.
+        assert!(!query_store
+            .has_non_fatal_errors(id.cheap_clone(), None)
+            .await
+            .unwrap());
+
+        test_store::remove_subgraphs();
     })
 }

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -12,7 +12,7 @@ use graph::{
     prelude::SubgraphManifest,
     prelude::SubgraphName,
     prelude::SubgraphVersionSwitchingMode,
-    prelude::{o, slog, CheapClone, Logger, NodeId, SubgraphDeploymentId, SubgraphStore as _},
+    prelude::{CheapClone, NodeId, SubgraphDeploymentId, SubgraphStore as _},
 };
 use graph_store_postgres::layout_for_tests::Connection as Primary;
 use graph_store_postgres::Store;
@@ -554,7 +554,6 @@ fn fail_unfail() {
     }
 
     run_test_sequentially(setup, |store, id| async move {
-        let logger = Logger::root(slog::Discard, o!());
         let query_store = store
             .query_store(id.cheap_clone().into(), false)
             .await
@@ -576,7 +575,7 @@ fn fail_unfail() {
             .unwrap());
 
         // This will unfail the subgraph and delete the fatal error.
-        store.start_subgraph_deployment(&logger, &id).unwrap();
+        store.unfail(&id).unwrap();
 
         // Advance the block ptr to the block of the deleted error.
         transact_entity_operations(&store, id.cheap_clone(), BLOCKS[1], vec![]).unwrap();


### PR DESCRIPTION
This fixes the `has_non_fatal_errors` check in the case described here https://github.com/graphprotocol/graph-node/pull/2121#issuecomment-767538602.

But unfortunately it means that errors will be recreated upon restart and it will again be hard to tell which errors are new.