### PR TITLE
Fix subgraph unhealthy check

### DIFF
--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -1157,7 +1157,7 @@ pub struct SubgraphError {
     pub block_ptr: Option<EthereumBlockPointer>,
     pub handler: Option<String>,
 
-    // `true` if we are certain the error is determinsitic. If in doubt, this is `false`.
+    // `true` if we are certain the error is deterministic. If in doubt, this is `false`.
     pub deterministic: bool,
 }
 

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -999,6 +999,7 @@ impl DeploymentStore {
                     &econn.conn,
                     &site.deployment,
                     deterministic_errors,
+                    block_ptr_to.block_number(),
                 )?;
             }
 

--- a/tests/integration-tests/non-fatal-errors/package.json
+++ b/tests/integration-tests/non-fatal-errors/package.json
@@ -5,8 +5,8 @@
     "build-contracts": "rm -rf abis bin && solcjs ../common/SimpleContract.sol --abi -o abis && mv abis/*Contract.abi abis/Contract.abi && solcjs ../common/SimpleContract.sol --bin -o bin && mv bin/*Contract.bin bin/Contract.bin",
     "codegen": "graph codegen",
     "test": "yarn build-contracts && truffle test --network test",
-    "create:test": "graph create test/remove-then-update --node http://localhost:18020/",
-    "deploy:test": "graph deploy test/remove-then-update --ipfs http://localhost:15001/ --node http://localhost:18020/"
+    "create:test": "graph create test/non-fatal-errors --node http://localhost:18020/",
+    "deploy:test": "graph deploy test/non-fatal-errors --ipfs http://localhost:15001/ --node http://localhost:18020/"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",

--- a/tests/integration-tests/non-fatal-errors/test/test.js
+++ b/tests/integration-tests/non-fatal-errors/test/test.js
@@ -11,7 +11,7 @@ const fetchSubgraphs = createApolloFetch({
   uri: "http://localhost:18030/graphql",
 });
 const fetchSubgraph = createApolloFetch({
-  uri: "http://localhost:18000/subgraphs/name/test/remove-then-update",
+  uri: "http://localhost:18000/subgraphs/name/test/non-fatal-errors",
 });
 
 const exec = (cmd) => {


### PR DESCRIPTION
Since https://github.com/graphprotocol/graph-node/pull/2121 we check for errors up to the subgraph current block, but when `insert_subgraph_errors` is called the subgraph pointer hasn't been advanced yet.  So `check_health` needs to be aware of the block it is checking. This slipped through because integration tests are always passing on CI as reported here https://github.com/graphprotocol/graph-node/issues/2159.