### PR TITLE
Asyncify blocking store operations used in async context

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1117,6 +1117,7 @@ pub trait SubgraphStore: Send + Sync + 'static {
     fn network_name(&self, subgraph_id: &SubgraphDeploymentId) -> Result<String, StoreError>;
 }
 
+#[async_trait]
 pub trait QueryStoreManager: Send + Sync + 'static {
     /// Get a new `QueryStore`. A `QueryStore` is tied to a DB replica, so if Graph Node is
     /// configured to use secondary DB servers the queries will be distributed between servers.
@@ -1127,7 +1128,7 @@ pub trait QueryStoreManager: Send + Sync + 'static {
     /// metadata about the deployment `id` (but not metadata about other deployments).
     ///
     /// If `for_subscription` is true, the main replica will always be used.
-    fn query_store(
+    async fn query_store(
         &self,
         target: QueryTarget,
         for_subscription: bool,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1011,12 +1011,14 @@ pub trait SubgraphStore: Send + Sync + 'static {
 
     /// Find the deployment for the current version of subgraph `name` and
     /// return details about it needed for executing queries
-    fn deployment_state_from_name(&self, name: SubgraphName)
-        -> Result<DeploymentState, StoreError>;
+    async fn deployment_state_from_name(
+        &self,
+        name: SubgraphName,
+    ) -> Result<DeploymentState, StoreError>;
 
     /// Find the deployment for the subgraph deployment `id` and
     /// return details about it needed for executing queries
-    fn deployment_state_from_id(
+    async fn deployment_state_from_id(
         &self,
         id: SubgraphDeploymentId,
     ) -> Result<DeploymentState, StoreError>;
@@ -1218,11 +1220,14 @@ impl SubgraphStore for MockStore {
         unimplemented!()
     }
 
-    fn deployment_state_from_name(&self, _: SubgraphName) -> Result<DeploymentState, StoreError> {
+    async fn deployment_state_from_name(
+        &self,
+        _: SubgraphName,
+    ) -> Result<DeploymentState, StoreError> {
         unimplemented!()
     }
 
-    fn deployment_state_from_id(
+    async fn deployment_state_from_id(
         &self,
         _: SubgraphDeploymentId,
     ) -> Result<DeploymentState, StoreError> {
@@ -1453,7 +1458,7 @@ pub trait QueryStore: Send + Sync {
 
     /// Find the current state for the subgraph deployment `id` and
     /// return details about it needed for executing queries
-    fn deployment_state(&self) -> Result<DeploymentState, QueryExecutionError>;
+    async fn deployment_state(&self) -> Result<DeploymentState, QueryExecutionError>;
 
     fn api_schema(&self) -> Result<Arc<ApiSchema>, QueryExecutionError>;
 

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -140,10 +140,7 @@ where
         // while the query is running. `self.store` can not be used after this
         // point, and everything needs to go through the `store` we are
         // setting up here
-        let store = self
-            .store
-            .query_store(target, false)
-            .map_err(|e| QueryExecutionError::from(e))?;
+        let store = self.store.query_store(target, false).await?;
         let state = store.deployment_state()?;
         let network = Some(store.network_name().to_string());
         let schema = store.api_schema()?;
@@ -264,7 +261,7 @@ where
         subscription: Subscription,
         target: QueryTarget,
     ) -> Result<SubscriptionResult, SubscriptionError> {
-        let store = self.store.query_store(target, true)?;
+        let store = self.store.query_store(target, true).await?;
         let schema = store.api_schema()?;
         let network = store.network_name().to_string();
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -851,7 +851,11 @@ fn query_complexity() {
 fn query_complexity_subscriptions() {
     run_test_sequentially(setup, |_, id| async move {
         let logger = Logger::root(slog::Discard, o!());
-        let store = STORE.clone().query_store(id.clone().into(), true).unwrap();
+        let store = STORE
+            .clone()
+            .query_store(id.clone().into(), true)
+            .await
+            .unwrap();
 
         let query = Query::new(
             graphql_parser::parse_query(
@@ -914,7 +918,11 @@ fn query_complexity_subscriptions() {
             None,
         );
 
-        let store = STORE.clone().query_store(id.clone().into(), true).unwrap();
+        let store = STORE
+            .clone()
+            .query_store(id.clone().into(), true)
+            .await
+            .unwrap();
 
         let options = SubscriptionExecutionOptions {
             logger,
@@ -1265,7 +1273,11 @@ fn cannot_filter_by_derved_relationship_fields() {
 fn subscription_gets_result_even_without_events() {
     run_test_sequentially(setup, |_, id| async move {
         let logger = Logger::root(slog::Discard, o!());
-        let store = STORE.clone().query_store(id.clone().into(), true).unwrap();
+        let store = STORE
+            .clone()
+            .query_store(id.clone().into(), true)
+            .await
+            .unwrap();
         let schema = STORE.api_schema(&id).unwrap();
 
         let query = Query::new(

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1558,6 +1558,7 @@ fn query_detects_reorg() {
             .into_static();
         let state = STORE
             .deployment_state_from_id(id.clone())
+            .await
             .expect("failed to get state");
 
         // Inject a fake initial state; c435c25decbc4ad7bbbadf8e0ced0ff2

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -122,11 +122,14 @@ impl SubgraphStore for MockStore {
         unimplemented!()
     }
 
-    fn deployment_state_from_name(&self, _: SubgraphName) -> Result<DeploymentState, StoreError> {
+    async fn deployment_state_from_name(
+        &self,
+        _: SubgraphName,
+    ) -> Result<DeploymentState, StoreError> {
         unimplemented!()
     }
 
-    fn deployment_state_from_id(
+    async fn deployment_state_from_id(
         &self,
         id: SubgraphDeploymentId,
     ) -> Result<DeploymentState, StoreError> {

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1053,12 +1053,12 @@ impl DeploymentStore {
         Ok(event)
     }
 
-    pub(crate) fn deployment_state_from_id(
+    pub(crate) async fn deployment_state_from_id(
         &self,
         id: SubgraphDeploymentId,
     ) -> Result<DeploymentState, StoreError> {
-        let conn = self.get_conn()?;
-        deployment::state(&conn, id)
+        self.with_conn(|conn, _| deployment::state(&conn, id).map_err(|e| e.into()))
+            .await
     }
 
     pub(crate) async fn fail_subgraph(

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -100,10 +100,11 @@ impl QueryStoreTrait for QueryStore {
             .await
     }
 
-    fn deployment_state(&self) -> Result<DeploymentState, QueryExecutionError> {
+    async fn deployment_state(&self) -> Result<DeploymentState, QueryExecutionError> {
         Ok(self
             .store
-            .deployment_state_from_id(self.site.deployment.clone())?)
+            .deployment_state_from_id(self.site.deployment.clone())
+            .await?)
     }
 
     fn api_schema(&self) -> Result<Arc<ApiSchema>, QueryExecutionError> {

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -152,18 +152,18 @@ impl SubgraphStoreTrait for Store {
             .revert_block_operations(subgraph_id, block_ptr_to)
     }
 
-    fn deployment_state_from_name(
+    async fn deployment_state_from_name(
         &self,
         name: graph::prelude::SubgraphName,
     ) -> Result<graph::prelude::DeploymentState, graph::prelude::StoreError> {
-        self.store.deployment_state_from_name(name)
+        self.store.deployment_state_from_name(name).await
     }
 
-    fn deployment_state_from_id(
+    async fn deployment_state_from_id(
         &self,
         id: graph::prelude::SubgraphDeploymentId,
     ) -> Result<graph::prelude::DeploymentState, graph::prelude::StoreError> {
-        self.store.deployment_state_from_id(id)
+        self.store.deployment_state_from_id(id).await
     }
 
     async fn fail_subgraph(

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1410,6 +1410,7 @@ fn throttle_subscription_delivers() {
             store
                 .clone()
                 .query_store(TEST_SUBGRAPH_ID.clone().into(), true)
+                .await
                 .unwrap(),
             TEST_SUBGRAPH_ID.clone(),
             Duration::from_millis(500),
@@ -1453,6 +1454,7 @@ fn throttle_subscription_throttles() {
             store
                 .clone()
                 .query_store(TEST_SUBGRAPH_ID.clone().into(), true)
+                .await
                 .unwrap(),
             TEST_SUBGRAPH_ID.clone(),
             Duration::from_secs(30),

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -993,6 +993,7 @@ async fn check_basic_revert(
     let subscription = subscribe(subgraph_id, entity_type);
     let state = store
         .deployment_state_from_id(subgraph_id.to_owned())
+        .await
         .expect("can get deployment state");
     assert_eq!(subgraph_id, &state.id);
 
@@ -1016,6 +1017,7 @@ async fn check_basic_revert(
 
     let state = store
         .deployment_state_from_id(subgraph_id.to_owned())
+        .await
         .expect("can get deployment state");
     assert_eq!(subgraph_id, &state.id);
 
@@ -1894,6 +1896,7 @@ fn reorg_tracking() {
             let subgraph_id = TEST_SUBGRAPH_ID.to_owned();
             let state = &$store
                 .deployment_state_from_id(subgraph_id.clone())
+                .await
                 .expect("can get deployment state");
             assert_eq!(&subgraph_id, &state.id, "subgraph_id");
             assert_eq!($reorg_count, state.reorg_count, "reorg_count");

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -515,7 +515,10 @@ fn fatal_vs_non_fatal() {
     }
 
     run_test_sequentially(setup, |store, id| async move {
-        let query_store = store.query_store(id.cheap_clone().into(), false).unwrap();
+        let query_store = store
+            .query_store(id.cheap_clone().into(), false)
+            .await
+            .unwrap();
 
         let error = || SubgraphError {
             subgraph_id: id.clone(),

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -442,7 +442,7 @@ fn build_store() -> (Arc<Store>, ConnectionPool, Config, Arc<SubscriptionManager
     .unwrap()
 }
 
-pub fn primary_connection() -> graph_store_postgres::layout_for_tests::Connection {
+pub fn primary_connection() -> graph_store_postgres::layout_for_tests::Connection<'static> {
     let conn = PRIMARY_POOL.get().unwrap();
     graph_store_postgres::layout_for_tests::Connection::new(conn)
 }

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -366,7 +366,9 @@ fn execute_subgraph_query_internal(
     ));
     let mut result = QueryResults::empty();
     let deployment = query.schema.id().clone();
-    let store = STORE.clone().query_store(deployment.into(), false).unwrap();
+    let store = rt
+        .block_on(STORE.clone().query_store(deployment.into(), false))
+        .unwrap();
     for (bc, (selection_set, error_policy)) in return_err!(query.block_constraint()) {
         let logger = logger.clone();
         let resolver = return_err!(rt.block_on(StoreResolver::at_block(


### PR DESCRIPTION
The store fns `deployment_state` and `query_store` are made async so that we avoid blocking DB queries in the async parts of query execution.