### PR TITLE
node: ignore non-deterministic test

### DIFF
--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -29,6 +29,7 @@ fn node_fails_to_start_with_unnamed_ethereum_network() {
 }
 
 #[test]
+#[ignore = "non deterministic"]
 fn node_fails_to_start_with_invalid_ipfs() {
     assert_cli::Assert::main_binary()
         .with_args(&[


### PR DESCRIPTION
The test function `node_fails_to_start_with_invalid_ipfs` relies on
async and results in variable results, so we are ignoring it for now.

