### PR TITLE
Add CORS for all HTTP responses

### DIFF
--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -3,6 +3,10 @@ use crate::{
     data::graphql::SerializableValue,
     prelude::{q, CacheWeight, SubgraphDeploymentId},
 };
+use http::header::{
+    ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
+    CONTENT_TYPE,
+};
 use serde::ser::*;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -158,10 +162,10 @@ impl QueryResults {
             serde_json::to_string(self).expect("Failed to serialize GraphQL response to JSON");
         http::Response::builder()
             .status(status_code)
-            .header("Access-Control-Allow-Origin", "*")
-            .header("Access-Control-Allow-Headers", "Content-Type, User-Agent")
-            .header("Access-Control-Allow-Methods", "GET, OPTIONS, POST")
-            .header("Content-Type", "application/json")
+            .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+            .header(ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type, User-Agent")
+            .header(ACCESS_CONTROL_ALLOW_METHODS, "GET, OPTIONS, POST")
+            .header(CONTENT_TYPE, "application/json")
             .body(T::from(json))
             .unwrap()
     }

--- a/graph/src/log/elastic.rs
+++ b/graph/src/log/elastic.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use chrono::prelude::{SecondsFormat, Utc};
 use futures03::TryFutureExt;
+use http::header::CONTENT_TYPE;
 use reqwest;
 use reqwest::Client;
 use serde::ser::Serializer as SerdeSerializer;
@@ -265,11 +266,11 @@ impl ElasticDrain {
                     let header = match config.general.username {
                         Some(username) => client
                             .post(batch_url)
-                            .header("Content-Type", "application/json")
+                            .header(CONTENT_TYPE, "application/json")
                             .basic_auth(username, config.general.password.clone()),
                         None => client
                             .post(batch_url)
-                            .header("Content-Type", "application/json"),
+                            .header(CONTENT_TYPE, "application/json"),
                     };
                     header
                         .body(batch_body)

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 use graph::prelude::*;
 use graph::{components::server::query::GraphQLServerError, data::query::QueryTarget};
 use http::header;
+use http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, LOCATION};
 use hyper::service::Service;
 use hyper::{Body, Method, Request, Response, StatusCode};
 
@@ -119,6 +120,7 @@ where
     async fn index(self) -> GraphQLServiceResult {
         Ok(Response::builder()
             .status(200)
+            .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
             .body(Body::from(String::from(
                 "Access deployed subgraphs by deployment ID at \
                 /subgraphs/id/<ID> or by name at /subgraphs/name/<NAME>",
@@ -131,6 +133,7 @@ where
         async move {
             Ok(Response::builder()
                 .status(200)
+                .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                 .body(Body::from(contents))
                 .unwrap())
         }
@@ -142,6 +145,7 @@ where
         async {
             Ok(Response::builder()
                 .status(200)
+                .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                 .body(Body::from(contents))
                 .unwrap())
         }
@@ -231,7 +235,8 @@ where
             .map(|loc_header_val| {
                 Response::builder()
                     .status(StatusCode::FOUND)
-                    .header(header::LOCATION, loc_header_val)
+                    .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                    .header(LOCATION, loc_header_val)
                     .body(Body::from("Redirecting..."))
                     .unwrap()
             })
@@ -242,6 +247,7 @@ where
         async {
             Ok(Response::builder()
                 .status(StatusCode::NOT_FOUND)
+                .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                 .body(Body::from("Not found"))
                 .unwrap())
         }
@@ -338,6 +344,7 @@ where
                 Err(err @ GraphQLServerError::ClientError(_)) => Ok(Response::builder()
                     .status(400)
                     .header("Content-Type", "text/plain")
+                    .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                     .body(Body::from(err.to_string()))
                     .unwrap()),
                 Err(err @ GraphQLServerError::QueryError(_)) => {
@@ -346,6 +353,7 @@ where
                     Ok(Response::builder()
                         .status(400)
                         .header("Content-Type", "text/plain")
+                        .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                         .body(Body::from(format!("Query error: {}", err)))
                         .unwrap())
                 }
@@ -355,6 +363,7 @@ where
                     Ok(Response::builder()
                         .status(500)
                         .header("Content-Type", "text/plain")
+                        .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                         .body(Body::from(format!("Internal server error: {}", err)))
                         .unwrap())
                 }

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -8,7 +8,10 @@ use std::time::Instant;
 use graph::prelude::*;
 use graph::{components::server::query::GraphQLServerError, data::query::QueryTarget};
 use http::header;
-use http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, LOCATION};
+use http::header::{
+    ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
+    CONTENT_TYPE, LOCATION,
+};
 use hyper::service::Service;
 use hyper::{Body, Method, Request, Response, StatusCode};
 
@@ -217,9 +220,9 @@ where
         async {
             Ok(Response::builder()
                 .status(200)
-                .header("Access-Control-Allow-Origin", "*")
-                .header("Access-Control-Allow-Headers", "Content-Type, User-Agent")
-                .header("Access-Control-Allow-Methods", "GET, OPTIONS, POST")
+                .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                .header(ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type, User-Agent")
+                .header(ACCESS_CONTROL_ALLOW_METHODS, "GET, OPTIONS, POST")
                 .body(Body::from(""))
                 .unwrap())
         }
@@ -343,7 +346,7 @@ where
                 Ok(response) => Ok(response),
                 Err(err @ GraphQLServerError::ClientError(_)) => Ok(Response::builder()
                     .status(400)
-                    .header("Content-Type", "text/plain")
+                    .header(CONTENT_TYPE, "text/plain")
                     .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                     .body(Body::from(err.to_string()))
                     .unwrap()),
@@ -352,7 +355,7 @@ where
 
                     Ok(Response::builder()
                         .status(400)
-                        .header("Content-Type", "text/plain")
+                        .header(CONTENT_TYPE, "text/plain")
                         .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                         .body(Body::from(format!("Query error: {}", err)))
                         .unwrap())
@@ -362,7 +365,7 @@ where
 
                     Ok(Response::builder()
                         .status(500)
-                        .header("Content-Type", "text/plain")
+                        .header(CONTENT_TYPE, "text/plain")
                         .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                         .body(Body::from(format!("Internal server error: {}", err)))
                         .unwrap())

--- a/server/http/src/test_utils.rs
+++ b/server/http/src/test_utils.rs
@@ -60,6 +60,7 @@ pub fn assert_error_response(
         .clone()
 }
 
+#[track_caller]
 pub fn assert_expected_headers(response: &Response<Body>) {
     assert_eq!(
         response

--- a/server/http/tests/response.rs
+++ b/server/http/tests/response.rs
@@ -8,6 +8,7 @@ use std::collections::BTreeMap;
 fn generates_200_for_query_results() {
     let data = BTreeMap::new();
     let query_result = QueryResults::from(data).as_http_response();
+    test_utils::assert_expected_headers(&query_result);
     test_utils::assert_successful_response(query_result);
 }
 
@@ -15,6 +16,7 @@ fn generates_200_for_query_results() {
 fn generates_valid_json_for_an_empty_result() {
     let data = BTreeMap::new();
     let query_result = QueryResults::from(data).as_http_response();
+    test_utils::assert_expected_headers(&query_result);
     let data = test_utils::assert_successful_response(query_result);
     assert!(data.is_empty());
 }

--- a/server/index-node/src/explorer.rs
+++ b/server/index-node/src/explorer.rs
@@ -2,7 +2,10 @@
 //! in this file is private API and experimental and subject to change at
 //! any time
 use http::{Response, StatusCode};
-use hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN;
+use hyper::header::{
+    ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
+    CONTENT_TYPE,
+};
 use hyper::Body;
 use std::{
     collections::HashMap,
@@ -234,7 +237,7 @@ where
 fn handle_not_found() -> Result<Response<Body>, GraphQLServerError> {
     Ok(Response::builder()
         .status(StatusCode::NOT_FOUND)
-        .header("Content-Type", "text/plain")
+        .header(CONTENT_TYPE, "text/plain")
         .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
         .body(Body::from("Not found\n"))
         .unwrap())
@@ -246,10 +249,10 @@ fn as_http_response(value: &q::Value) -> http::Response<Body> {
         .expect("Failed to serialize response to JSON");
     http::Response::builder()
         .status(status_code)
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Access-Control-Allow-Headers", "Content-Type, User-Agent")
-        .header("Access-Control-Allow-Methods", "GET, OPTIONS, POST")
-        .header("Content-Type", "application/json")
+        .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type, User-Agent")
+        .header(ACCESS_CONTROL_ALLOW_METHODS, "GET, OPTIONS, POST")
+        .header(CONTENT_TYPE, "application/json")
         .body(Body::from(json))
         .unwrap()
 }

--- a/server/index-node/src/explorer.rs
+++ b/server/index-node/src/explorer.rs
@@ -2,6 +2,7 @@
 //! in this file is private API and experimental and subject to change at
 //! any time
 use http::{Response, StatusCode};
+use hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN;
 use hyper::Body;
 use std::{
     collections::HashMap,
@@ -234,6 +235,7 @@ fn handle_not_found() -> Result<Response<Body>, GraphQLServerError> {
     Ok(Response::builder()
         .status(StatusCode::NOT_FOUND)
         .header("Content-Type", "text/plain")
+        .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
         .body(Body::from("Not found\n"))
         .unwrap())
 }

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -1,4 +1,7 @@
-use http::header::{self, ACCESS_CONTROL_ALLOW_ORIGIN, LOCATION};
+use http::header::{
+    self, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
+    CONTENT_TYPE, LOCATION,
+};
 use hyper::service::Service;
 use hyper::{Body, Method, Request, Response, StatusCode};
 use std::task::Context;
@@ -129,9 +132,9 @@ where
     fn handle_graphql_options(_request: Request<Body>) -> Response<Body> {
         Response::builder()
             .status(200)
-            .header("Access-Control-Allow-Origin", "*")
-            .header("Access-Control-Allow-Headers", "Content-Type, User-Agent")
-            .header("Access-Control-Allow-Methods", "GET, OPTIONS, POST")
+            .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+            .header(ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type, User-Agent")
+            .header(ACCESS_CONTROL_ALLOW_METHODS, "GET, OPTIONS, POST")
             .body(Body::from(""))
             .unwrap()
     }
@@ -157,7 +160,7 @@ where
         Response::builder()
             .status(StatusCode::NOT_FOUND)
             .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .header("Content-Type", "text/plain")
+            .header(CONTENT_TYPE, "text/plain")
             .body(Body::from("Not found\n"))
             .unwrap()
     }
@@ -228,7 +231,7 @@ where
 
                         Ok(Response::builder()
                             .status(400)
-                            .header("Content-Type", "text/plain")
+                            .header(CONTENT_TYPE, "text/plain")
                             .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                             .body(Body::from(format!("Invalid request: {}", err)))
                             .unwrap())
@@ -238,7 +241,7 @@ where
 
                         Ok(Response::builder()
                             .status(400)
-                            .header("Content-Type", "text/plain")
+                            .header(CONTENT_TYPE, "text/plain")
                             .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                             .body(Body::from(format!("Query error: {}", err)))
                             .unwrap())
@@ -248,7 +251,7 @@ where
 
                         Ok(Response::builder()
                             .status(500)
-                            .header("Content-Type", "text/plain")
+                            .header(CONTENT_TYPE, "text/plain")
                             .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                             .body(Body::from(format!("Internal server error: {}", err)))
                             .unwrap())

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -1,4 +1,4 @@
-use http::header;
+use http::header::{self, ACCESS_CONTROL_ALLOW_ORIGIN, LOCATION};
 use hyper::service::Service;
 use hyper::{Body, Method, Request, Response, StatusCode};
 use std::task::Context;
@@ -62,6 +62,7 @@ where
     /// Serves a static file.
     fn serve_file(contents: &'static str) -> Response<Body> {
         Response::builder()
+            .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
             .status(200)
             .body(Body::from(contents))
             .unwrap()
@@ -70,6 +71,7 @@ where
     fn index() -> Response<Body> {
         Response::builder()
             .status(200)
+            .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
             .body(Body::from("OK"))
             .unwrap()
     }
@@ -143,7 +145,8 @@ where
             .map(|loc_header_val| {
                 Response::builder()
                     .status(StatusCode::FOUND)
-                    .header(header::LOCATION, loc_header_val)
+                    .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                    .header(LOCATION, loc_header_val)
                     .body(Body::from("Redirecting..."))
                     .unwrap()
             })
@@ -153,6 +156,7 @@ where
     pub(crate) fn handle_not_found() -> Response<Body> {
         Response::builder()
             .status(StatusCode::NOT_FOUND)
+            .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
             .header("Content-Type", "text/plain")
             .body(Body::from("Not found\n"))
             .unwrap()
@@ -225,6 +229,7 @@ where
                         Ok(Response::builder()
                             .status(400)
                             .header("Content-Type", "text/plain")
+                            .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                             .body(Body::from(format!("Invalid request: {}", err)))
                             .unwrap())
                     }
@@ -234,6 +239,7 @@ where
                         Ok(Response::builder()
                             .status(400)
                             .header("Content-Type", "text/plain")
+                            .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                             .body(Body::from(format!("Query error: {}", err)))
                             .unwrap())
                     }
@@ -243,6 +249,7 @@ where
                         Ok(Response::builder()
                             .status(500)
                             .header("Content-Type", "text/plain")
+                            .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                             .body(Body::from(format!("Internal server error: {}", err)))
                             .unwrap())
                     }

--- a/server/metrics/src/lib.rs
+++ b/server/metrics/src/lib.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use anyhow::Error;
 use graph::prometheus::{Encoder, Registry, TextEncoder};
 use hyper;
+use hyper::header::{ACCESS_CONTROL_ALLOW_ORIGIN, CONTENT_TYPE};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Response, Server};
 use thiserror::Error;
@@ -75,7 +76,8 @@ impl MetricsServerTrait for PrometheusMetricsServer {
                     futures03::future::ok::<_, Error>(
                         Response::builder()
                             .status(200)
-                            .header(hyper::header::CONTENT_TYPE, encoder.format_type())
+                            .header(CONTENT_TYPE, encoder.format_type())
+                            .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                             .body(Body::from(buffer))
                             .unwrap(),
                     )

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -1,4 +1,5 @@
 use graph::prelude::{SubscriptionServer as SubscriptionServerTrait, *};
+use http::header::ACCESS_CONTROL_ALLOW_ORIGIN;
 use http::{HeaderValue, Response, StatusCode};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Mutex;
@@ -128,6 +129,7 @@ where
 
                     Response::builder()
                         .status(StatusCode::INTERNAL_SERVER_ERROR)
+			.header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                         .body(None)
                         .unwrap()
                 })
@@ -135,6 +137,7 @@ where
                     subgraph_id_opt.ok_or_else(|| {
                         Response::builder()
                             .status(StatusCode::NOT_FOUND)
+			    .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                             .body(None)
                             .unwrap()
                     })
@@ -148,6 +151,7 @@ where
                         );
                         return Err(Response::builder()
                             .status(StatusCode::NOT_FOUND)
+                            .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                             .body(None)
                             .unwrap());
                     }


### PR DESCRIPTION
Resolves #2193

This PR inserts `Access-Control-Alllow-Origin: *` on all response headers.

Also, all header names were refactored to constants so the type checker can protect us from possible typing mistakes. 