### PR TITLE
node: Add `graphman query`

### DIFF
--- a/node/src/manager/commands/mod.rs
+++ b/node/src/manager/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod copy;
 pub mod info;
 pub mod listen;
+pub mod query;
 pub mod remove;
 pub mod rewind;
 pub mod txn_speed;

--- a/node/src/manager/commands/query.rs
+++ b/node/src/manager/commands/query.rs
@@ -1,0 +1,62 @@
+use std::iter::FromIterator;
+use std::{collections::HashMap, sync::Arc};
+
+use graph::{
+    data::query::QueryTarget,
+    prelude::{
+        anyhow::{self, anyhow},
+        q, serde_json, GraphQlRunner as _, Query, QueryVariables, SubgraphDeploymentId,
+        SubgraphName,
+    },
+};
+use graph_graphql::prelude::GraphQlRunner;
+use graph_store_postgres::Store;
+
+use crate::manager::PanicSubscriptionManager;
+
+pub async fn run(
+    runner: Arc<GraphQlRunner<Store, PanicSubscriptionManager>>,
+    target: String,
+    query: String,
+    vars: Vec<String>,
+) -> Result<(), anyhow::Error> {
+    let target = if target.starts_with("Qm") {
+        let id = SubgraphDeploymentId::new(target)
+            .map_err(|id| anyhow!("illegal deployment id `{}`", id))?;
+        QueryTarget::Deployment(id)
+    } else {
+        let name = SubgraphName::new(target.clone())
+            .map_err(|()| anyhow!("illegal subgraph name `{}`", target))?;
+        QueryTarget::Name(name)
+    };
+
+    let document = graphql_parser::parse_query(&query)?.into_static();
+    let vars: Vec<(String, q::Value)> = vars
+        .into_iter()
+        .map(|v| {
+            let mut pair = v.splitn(2, '=').map(|s| s.to_string());
+            let key = pair.next();
+            let value = pair
+                .next()
+                .map(|s| q::Value::String(s))
+                .unwrap_or(q::Value::Null);
+            match key {
+                Some(key) => Ok((key, value)),
+                None => Err(anyhow!(
+                    "malformed variable `{}`, it must be of the form `key=value`",
+                    v
+                )),
+            }
+        })
+        .collect::<Result<_, _>>()?;
+    let query = Query::new(
+        document,
+        Some(QueryVariables::new(HashMap::from_iter(vars))),
+    );
+
+    let res = runner.run_query(query, target, false).await;
+    let json = serde_json::to_string(&res)?;
+    println!("{}", json);
+
+    Ok(())
+}

--- a/node/src/manager/mod.rs
+++ b/node/src/manager/mod.rs
@@ -1,4 +1,18 @@
+use graph::{
+    components::store::SubscriptionManager,
+    prelude::{StoreEventStreamBox, SubscriptionFilter},
+};
+
 pub mod catalog;
 pub mod commands;
 pub mod deployment;
 mod display;
+
+/// A dummy subscription manager that always panics
+pub struct PanicSubscriptionManager;
+
+impl SubscriptionManager for PanicSubscriptionManager {
+    fn subscribe(&self, _: Vec<SubscriptionFilter>) -> StoreEventStreamBox {
+        panic!("we were never meant to call `subscribe`");
+    }
+}


### PR DESCRIPTION
This makes it possible to execute a GraphQL query with

```
graphman query sub/graph '{ .. GraphQL .. }' var1=val1 ...
```

By passing `GRAPH_LOG_QUERY_TIMING=gql,sql GRAPH_LOG=debug` in the environment, the command will log a lot of info about query execution.

For now, it's probably best to not run this against production directly though. Amongst other things, the code sets up notification listeners as a side-effect of creating the store.