### PR TITLE
Make block pointers less Ethereum specific

### DIFF
--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -1,8 +1,15 @@
 use lazy_static;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
-use graph::prelude::*;
-use web3::types::*;
+use graph::{
+    prelude::{
+        error, info, o, stream, tokio, trace, warn, web3::types::H256, BlockNumber, ChainStore,
+        ComponentLoggerConfig, ElasticComponentLoggerConfig, Error, EthereumAdapter,
+        EthereumAdapterError, EthereumBlock, Future, Future01CompatExt, LogCode, Logger,
+        LoggerFactory, MetricsRegistry, Stream,
+    },
+    prometheus::GaugeVec,
+};
 
 lazy_static! {
     // graph_node::config disallows setting this in a store with multiple
@@ -43,7 +50,7 @@ where
 {
     chain_store: Arc<S>,
     eth_adapter: Arc<dyn EthereumAdapter>,
-    ancestor_count: u64,
+    ancestor_count: BlockNumber,
     _network_name: String,
     logger: Logger,
     polling_interval: Duration,
@@ -56,7 +63,7 @@ where
     pub fn new(
         chain_store: Arc<S>,
         eth_adapter: Arc<dyn EthereumAdapter>,
-        ancestor_count: u64,
+        ancestor_count: BlockNumber,
         network_name: String,
         logger_factory: &LoggerFactory,
         polling_interval: Duration,

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -250,7 +250,7 @@ where
         );
         trace!(
             ctx.logger, "Subgraph pointer";
-            "hash" => format!("{:?}", subgraph_ptr.as_ref().map(|block| block.hash)),
+            "hash" => format!("{:?}", subgraph_ptr.as_ref().map(|block| &block.hash)),
             "number" => subgraph_ptr.as_ref().map(|block| block.number),
         );
 
@@ -475,7 +475,7 @@ where
                 Some(head_ancestor) => {
                     // We stopped one block short, so we'll compare the parent hash to the
                     // subgraph ptr.
-                    if head_ancestor.block.parent_hash == subgraph_ptr.hash {
+                    if head_ancestor.block.parent_hash == subgraph_ptr.hash_as_h256() {
                         // The subgraph ptr is an ancestor of the head block.
                         // We cannot use an RPC call here to find the first interesting block
                         // due to the race conditions previously mentioned,

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1222,7 +1222,7 @@ where
         // Check if we have it cached, if not do the call and cache.
         Box::new(
             match cache
-                .get_call(call.address, &call_data, call.block_ptr)
+                .get_call(call.address, &call_data, call.block_ptr.clone())
                 .map_err(|e| error!(logger, "call cache get error"; "error" => e.to_string()))
                 .ok()
                 .flatten()
@@ -1239,7 +1239,7 @@ where
                             logger.clone(),
                             call.address,
                             Bytes(call_data.clone()),
-                            call.block_ptr,
+                            call.block_ptr.clone(),
                         )
                         .map(move |result| {
                             let _ = cache

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -412,7 +412,7 @@ where
         let block_id = if self.is_ganache || *ETH_CALL_BY_NUMBER {
             BlockId::Number(block_ptr.number.into())
         } else {
-            BlockId::Hash(block_ptr.hash)
+            BlockId::Hash(block_ptr.hash_as_h256())
         };
 
         retry("eth_call RPC call", &logger)
@@ -932,10 +932,7 @@ where
                     })
                 })
                 .from_err()
-                .map(move |block_hash| EthereumBlockPointer {
-                    hash: block_hash,
-                    number: block_number,
-                }),
+                .map(move |block_hash| EthereumBlockPointer::from((block_hash, block_number))),
         )
     }
 
@@ -1072,7 +1069,7 @@ where
                         .ok_or_else(|| {
                             anyhow!("Ethereum node is missing block #{}", block_ptr.number)
                         })
-                        .map(|block_hash| block_hash == block_ptr.hash)
+                        .map(|block_hash| block_hash == block_ptr.hash_as_h256())
                 }),
         )
     }

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -322,10 +322,7 @@ fn load_parent_block_from_store(
         })
         .map(move |parent_hash: H256| {
             // Create a block pointer for the parent
-            EthereumBlockPointer {
-                number: block_ptr.number - 1,
-                hash: parent_hash,
-            }
+            EthereumBlockPointer::from((parent_hash, block_ptr.number - 1))
         }),
     )
 }

--- a/chain/ethereum/tests/network_indexer.rs
+++ b/chain/ethereum/tests/network_indexer.rs
@@ -217,7 +217,7 @@ fn create_mock_ethereum_adapter(
     let chains_for_block_by_number = chains.clone();
     adapter
         .expect_block_by_number()
-        .returning(move |_, number: u64| {
+        .returning(move |_, number| {
             let chains = chains_for_block_by_number.lock().unwrap();
             Box::new(future::result(
                 chains
@@ -226,7 +226,7 @@ fn create_mock_ethereum_adapter(
                     .map(|chain| {
                         chain
                             .iter()
-                            .find(|block| block.inner().number.unwrap().as_u64() == number)
+                            .find(|block| block.inner().number() == number)
                             .map(|block| block.clone().block.block)
                     }),
             ))

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -295,7 +295,7 @@ where
         })
     }
 
-    fn revert_data_sources(&mut self, reverted_block: u64) {
+    fn revert_data_sources(&mut self, reverted_block: BlockNumber) {
         // `hosts` is ordered by the creation block.
         // See also 8f1bca33-d3b7-4035-affc-fd6161a12448.
         while self

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -38,7 +38,7 @@ struct IndexingInputs<B, S, C> {
     deployment_id: SubgraphDeploymentId,
     features: BTreeSet<SubgraphFeature>,
     network_name: String,
-    start_blocks: Vec<u64>,
+    start_blocks: Vec<BlockNumber>,
     store: Arc<S>,
     chain_store: Arc<C>,
     eth_adapter: Arc<dyn EthereumAdapter>,

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -494,7 +494,7 @@ where
                         logger,
                         "Reverting block to get back to main chain";
                         "block_number" => format!("{}", subgraph_ptr.number),
-                        "block_hash" => format!("{}", subgraph_ptr.hash)
+                        "block_hash" => format!("{}", subgraph_ptr.hash_as_h256())
                     );
 
                     // We would like to revert the DB state to the parent of the current block.
@@ -505,7 +505,7 @@ where
                         .load_blocks(
                             logger.cheap_clone(),
                             ctx.inputs.chain_store.cheap_clone(),
-                            HashSet::from_iter(Some(subgraph_ptr.hash)),
+                            HashSet::from_iter(Some(subgraph_ptr.hash_as_h256())),
                         )
                         .collect()
                         .compat()

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -535,8 +535,8 @@ fn create_subgraph_version(
                 info!(
                     logger,
                     "Set subgraph start block";
-                    "block_number" => format!("{:?}", start_block.map(|block| block.number)),
-                    "block_hash" => format!("{:?}", start_block.map(|block| block.hash)),
+                    "block_number" => format!("{:?}", start_block.as_ref().map(|block| block.number)),
+                    "block_hash" => format!("{:?}", start_block.as_ref().map(|block| block.hash)),
                 );
 
                 info!(

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -472,11 +472,7 @@ fn resolve_subgraph_chain_blocks(
                     let base_block = base.block;
                     Box::new(
                         ethereum_adapter
-                            .block_pointer_from_number(
-                                &logger1,
-                                chain_store1.clone(),
-                                base.block as u64,
-                            )
+                            .block_pointer_from_number(&logger1, chain_store1.clone(), base.block)
                             .map(|ptr| Some((base.base, ptr)))
                             .map_err(move |_| {
                                 SubgraphRegistrarError::ManifestValidationError(vec![

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -536,7 +536,7 @@ fn create_subgraph_version(
                     logger,
                     "Set subgraph start block";
                     "block_number" => format!("{:?}", start_block.as_ref().map(|block| block.number)),
-                    "block_hash" => format!("{:?}", start_block.as_ref().map(|block| block.hash)),
+                    "block_hash" => format!("{:?}", start_block.as_ref().map(|block| &block.hash)),
                 );
 
                 info!(

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -802,12 +802,16 @@ fn parse_block_triggers(
     let block_ptr = EthereumBlockPointer::from(&block.ethereum_block);
     let trigger_every_block = block_filter.trigger_every_block;
     let call_filter = EthereumCallFilter::from(block_filter);
+    let block_ptr2 = block_ptr.clone();
     let mut triggers = block
         .calls
         .iter()
         .filter(move |call| call_filter.matches(call))
         .map(move |call| {
-            EthereumTrigger::Block(block_ptr, EthereumBlockTriggerType::WithCallTo(call.to))
+            EthereumTrigger::Block(
+                block_ptr2.clone(),
+                EthereumBlockTriggerType::WithCallTo(call.to),
+            )
         })
         .collect::<Vec<EthereumTrigger>>();
     if trigger_every_block {

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -802,7 +802,7 @@ fn parse_block_triggers(
     let block_ptr = EthereumBlockPointer::from(&block.ethereum_block);
     let trigger_every_block = block_filter.trigger_every_block;
     let call_filter = EthereumCallFilter::from(block_filter);
-    let block_ptr2 = block_ptr.clone();
+    let block_ptr2 = block_ptr.cheap_clone();
     let mut triggers = block
         .calls
         .iter()

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -15,7 +15,7 @@ pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpda
 pub use self::network::{EthereumNetworkAdapters, EthereumNetworks, NodeCapabilities};
 pub use self::stream::{BlockStream, BlockStreamBuilder, BlockStreamEvent};
 pub use self::types::{
-    BlockFinality, EthereumBlock, EthereumBlockData, EthereumBlockPointer,
+    BlockFinality, BlockHash, EthereumBlock, EthereumBlockData, EthereumBlockPointer,
     EthereumBlockTriggerType, EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall,
     EthereumCallData, EthereumEventData, EthereumTransactionData, EthereumTrigger,
     LightEthereumBlock, LightEthereumBlockExt,

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -18,7 +18,7 @@ pub trait BlockStreamBuilder: Clone + Send + Sync + 'static {
         logger: Logger,
         deployment_id: SubgraphDeploymentId,
         network_name: String,
-        start_blocks: Vec<u64>,
+        start_blocks: Vec<BlockNumber>,
         log_filter: EthereumLogFilter,
         call_filter: EthereumCallFilter,
         block_filter: EthereumBlockFilter,

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -11,7 +11,7 @@ use web3::types::{
     U128, U256, U64,
 };
 
-use crate::prelude::{BlockNumber, EntityKey, SubgraphDeploymentId, ToEntityKey};
+use crate::prelude::{BlockNumber, CheapClone, EntityKey, SubgraphDeploymentId, ToEntityKey};
 
 pub type LightEthereumBlock = Block<Transaction>;
 
@@ -427,6 +427,8 @@ pub struct EthereumBlockPointer {
     pub hash: BlockHash,
     pub number: BlockNumber,
 }
+
+impl CheapClone for EthereumBlockPointer {}
 
 impl StableHash for EthereumBlockPointer {
     fn stable_hash<H: StableHasher>(&self, mut sequence_number: H::Seq, state: &mut H) {

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -414,7 +414,7 @@ impl Clone for EthereumCallData {
 /// A block hash and block number from a specific Ethereum block.
 ///
 /// Maximum block number supported: 2^63 - 1
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EthereumBlockPointer {
     pub hash: H256,
     pub number: u64,

--- a/graph/src/components/server/index_node.rs
+++ b/graph/src/components/server/index_node.rs
@@ -2,15 +2,15 @@ use std::sync::Arc;
 
 use futures::prelude::*;
 
-use crate::prelude::Schema;
+use crate::prelude::{BlockNumber, Schema};
 
 #[derive(Debug)]
 /// This is only needed to support the explorer API
 pub struct VersionInfo {
     pub created_at: String,
     pub deployment_id: String,
-    pub latest_ethereum_block_number: Option<u64>,
-    pub total_ethereum_blocks_count: Option<u64>,
+    pub latest_ethereum_block_number: Option<BlockNumber>,
+    pub total_ethereum_blocks_count: Option<BlockNumber>,
     pub synced: bool,
     pub failed: bool,
     pub description: Option<String>,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -764,7 +764,7 @@ pub enum StoreError {
         "subgraph `{0}` has already processed block `{1}`; \
          there are most likely two (or more) nodes indexing this subgraph"
     )]
-    DuplicateBlockProcessing(SubgraphDeploymentId, u64),
+    DuplicateBlockProcessing(SubgraphDeploymentId, BlockNumber),
     /// An internal error where we expected the application logic to enforce
     /// some constraint, e.g., that subgraph names are unique, but found that
     /// constraint to not hold
@@ -823,7 +823,7 @@ pub struct StoredDynamicDataSource {
     pub name: String,
     pub source: Source,
     pub context: Option<String>,
-    pub creation_block: Option<u64>,
+    pub creation_block: Option<BlockNumber>,
 }
 
 impl From<&DataSource> for StoredDynamicDataSource {
@@ -1281,7 +1281,7 @@ pub trait ChainStore: Send + Sync + 'static {
     ///
     /// If the candidate new head block had one or more missing ancestors, returns
     /// `Ok(missing_blocks)`, where `missing_blocks` is a nonexhaustive list of missing blocks.
-    fn attempt_chain_head_update(&self, ancestor_count: u64) -> Result<Vec<H256>, Error>;
+    fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error>;
 
     /// Subscribe to chain head updates.
     fn chain_head_updates(&self) -> ChainHeadUpdateStream;
@@ -1304,7 +1304,7 @@ pub trait ChainStore: Send + Sync + 'static {
     fn ancestor_block(
         &self,
         block_ptr: EthereumBlockPointer,
-        offset: u64,
+        offset: BlockNumber,
     ) -> Result<Option<EthereumBlock>, Error>;
 
     /// Remove old blocks from the cache we maintain in the database and
@@ -1312,14 +1312,17 @@ pub trait ChainStore: Send + Sync + 'static {
     /// and the number of blocks deleted.
     /// We will never remove blocks that are within `ancestor_count` of
     /// the chain head.
-    fn cleanup_cached_blocks(&self, ancestor_count: u64) -> Result<(BlockNumber, usize), Error>;
+    fn cleanup_cached_blocks(
+        &self,
+        ancestor_count: BlockNumber,
+    ) -> Result<(BlockNumber, usize), Error>;
 
     /// Return the hashes of all blocks with the given number
-    fn block_hashes_by_block_number(&self, number: u64) -> Result<Vec<H256>, Error>;
+    fn block_hashes_by_block_number(&self, number: BlockNumber) -> Result<Vec<H256>, Error>;
 
     /// Confirm that block number `number` has hash `hash` and that the store
     /// may purge any other blocks with that number
-    fn confirm_block_hash(&self, number: u64, hash: &H256) -> Result<usize, Error>;
+    fn confirm_block_hash(&self, number: BlockNumber, hash: &H256) -> Result<usize, Error>;
 
     /// Find the block with `block_hash` and return the network name and number
     fn block_number(&self, block_hash: H256) -> Result<Option<(String, BlockNumber)>, StoreError>;

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -45,7 +45,7 @@ pub trait RuntimeHost: Send + Sync + Debug + 'static {
     fn matches_call(&self, call: &EthereumCall) -> bool;
 
     /// Returns true if the RuntimeHost has a handler for an Ethereum block.
-    fn matches_block(&self, call: &EthereumBlockTriggerType, block_number: u64) -> bool;
+    fn matches_block(&self, call: &EthereumBlockTriggerType, block_number: BlockNumber) -> bool;
 
     /// Process an Ethereum event and return a vector of entity operations.
     async fn process_log(
@@ -81,7 +81,7 @@ pub trait RuntimeHost: Send + Sync + Debug + 'static {
 
     /// Block number in which this host was created.
     /// Returns `None` for static data sources.
-    fn creation_block_number(&self) -> Option<u64>;
+    fn creation_block_number(&self) -> Option<BlockNumber>;
 }
 
 pub struct HostMetrics {

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -14,7 +14,7 @@ pub struct DataSourceTemplateInfo {
     pub template: DataSourceTemplate,
     pub params: Vec<String>,
     pub context: Option<DataSourceContext>,
-    pub creation_block: u64,
+    pub creation_block: BlockNumber,
 }
 
 #[derive(Debug)]
@@ -140,5 +140,5 @@ pub trait SubgraphInstance<H: RuntimeHost> {
         metrics: Arc<HostMetrics>,
     ) -> Result<Option<Arc<H>>, anyhow::Error>;
 
-    fn revert_data_sources(&mut self, reverted_block: u64);
+    fn revert_data_sources(&mut self, reverted_block: BlockNumber);
 }

--- a/graph/src/components/subgraph/proof_of_indexing/mod.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/mod.rs
@@ -75,10 +75,7 @@ mod tests {
         }
 
         let block_number = (block_count - 1) as u64;
-        let block_ptr = EthereumBlockPointer {
-            number: block_number,
-            hash: reference.block_hash,
-        };
+        let block_ptr = EthereumBlockPointer::from((reference.block_hash, block_number));
 
         // This region emulates the request
         let mut finisher =

--- a/graph/src/components/subgraph/proof_of_indexing/online.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/online.rs
@@ -31,7 +31,7 @@ pub struct BlockEventStream {
 ///
 /// struct Outer {
 ///    inners: Vec<Inner>,
-///    outer_num: i32   
+///    outer_num: i32
 /// }
 /// struct Inner {
 ///    inner_num: i32,
@@ -54,7 +54,7 @@ pub struct BlockEventStream {
 /// traverse_seq_no(&[
 ///    0, // Outer.inners
 ///    0, // Vec<Inner>[0]
-///    1, // Inner.inner_str    
+///    1, // Inner.inner_str
 ///])
 // Performance: Could write a specialized function for this easily, avoiding a bunch of clones of Blake3SeqNo
 fn traverse_seq_no(counts: &[usize]) -> Blake3SeqNo {
@@ -177,7 +177,7 @@ impl ProofOfIndexingFinisher {
         let block_hash_seq_no = traverse_seq_no(&[
             2, // PoI.block_hash
         ]);
-        AsBytes(block.hash.as_bytes()).stable_hash(block_hash_seq_no, &mut state);
+        AsBytes(block.hash_slice()).stable_hash(block_hash_seq_no, &mut state);
 
         // Add the indexer
         let indexer_seq_no = traverse_seq_no(&[

--- a/graph/src/components/subgraph/proof_of_indexing/online.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/online.rs
@@ -3,7 +3,7 @@
 //! to the reference implementation, but this is updated incrementally
 
 use super::ProofOfIndexingEvent;
-use crate::prelude::{debug, EthereumBlockPointer, Logger, SubgraphDeploymentId};
+use crate::prelude::{debug, BlockNumber, EthereumBlockPointer, Logger, SubgraphDeploymentId};
 use lazy_static::lazy_static;
 use stable_hash::crypto::{Blake3SeqNo, SetHasher};
 use stable_hash::prelude::*;
@@ -65,7 +65,7 @@ fn traverse_seq_no(counts: &[usize]) -> Blake3SeqNo {
 }
 
 impl BlockEventStream {
-    fn new(block_number: u64) -> Self {
+    fn new(block_number: BlockNumber) -> Self {
         let events = traverse_seq_no(&[
             1,                                // kvp -> v
             0,                                // CausalityRegion.blocks: Vec<Block>
@@ -101,7 +101,7 @@ impl BlockEventStream {
 
 #[derive(Default)]
 pub struct ProofOfIndexing {
-    block_number: u64,
+    block_number: BlockNumber,
     /// The POI is updated for each data source independently. This is necessary because
     /// some data sources (eg: IPFS files) may be unreliable and therefore cannot mix
     /// state with other data sources. This may also give us some freedom to change
@@ -116,7 +116,7 @@ impl fmt::Debug for ProofOfIndexing {
 }
 
 impl ProofOfIndexing {
-    pub fn new(block_number: u64) -> Self {
+    pub fn new(block_number: BlockNumber) -> Self {
         Self {
             block_number,
             per_causality_region: HashMap::new(),
@@ -154,7 +154,7 @@ impl ProofOfIndexing {
 }
 
 pub struct ProofOfIndexingFinisher {
-    block_number: u64,
+    block_number: BlockNumber,
     state: SetHasher,
     causality_count: usize,
 }

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -527,6 +527,12 @@ impl From<Address> for Bytes {
     }
 }
 
+impl From<web3::types::Bytes> for Bytes {
+    fn from(bytes: web3::types::Bytes) -> Bytes {
+        Bytes::from(bytes.0.as_slice())
+    }
+}
+
 impl Serialize for Bytes {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.to_string().serialize(serializer)

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -19,6 +19,8 @@ use std::str::FromStr;
 
 pub use num_bigint::Sign as BigIntSign;
 
+use crate::components::ethereum::BlockHash;
+
 /// All operations on `BigDecimal` return a normalized value.
 // Caveat: The exponent is currently an i64 and may overflow. See
 // https://github.com/akubera/bigdecimal-rs/issues/54.
@@ -530,6 +532,12 @@ impl From<Address> for Bytes {
 impl From<web3::types::Bytes> for Bytes {
     fn from(bytes: web3::types::Bytes) -> Bytes {
         Bytes::from(bytes.0.as_slice())
+    }
+}
+
+impl From<BlockHash> for Bytes {
+    fn from(hash: BlockHash) -> Self {
+        Bytes(hash.0)
     }
 }
 

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -464,7 +464,7 @@ pub struct Source {
     pub address: Option<Address>,
     pub abi: String,
     #[serde(rename = "startBlock", default)]
-    pub start_block: u64,
+    pub start_block: BlockNumber,
 }
 
 #[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Deserialize)]
@@ -674,7 +674,7 @@ pub struct BaseDataSource<M> {
     pub mapping: M,
     pub context: Option<DataSourceContext>,
     #[serde(skip)]
-    pub creation_block: Option<u64>,
+    pub creation_block: Option<BlockNumber>,
 }
 
 pub type UnresolvedDataSource = BaseDataSource<UnresolvedMapping>;
@@ -816,7 +816,7 @@ impl Graft {
                 self.base
             )),
             Ok(Some(ptr)) => {
-                if ptr.number < self.block as u64 {
+                if ptr.number < self.block {
                     gbi(format!(
                         "failed to graft onto `{}` at block {} since it has only processed block {}",
                         self.base, self.block, ptr.number
@@ -1038,7 +1038,7 @@ impl SubgraphManifest {
             .expect("Validated manifest does not have a network defined on any datasource")
     }
 
-    pub fn start_blocks(&self) -> Vec<u64> {
+    pub fn start_blocks(&self) -> Vec<BlockNumber> {
         self.data_sources
             .iter()
             .map(|data_source| data_source.source.start_block)

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -8,10 +8,13 @@ use rand::Rng;
 use stable_hash::{SequenceNumber, StableHash, StableHasher};
 use std::str::FromStr;
 use std::{fmt, fmt::Display};
-use web3::types::{Bytes, H256};
+use web3::types::H256;
 
 use super::SubgraphDeploymentId;
-use crate::components::{ethereum::EthereumBlockPointer, store::EntityType};
+use crate::components::{
+    ethereum::{BlockHash, EthereumBlockPointer},
+    store::EntityType,
+};
 use crate::data::graphql::TryFromValue;
 use crate::data::store::Value;
 use crate::data::subgraph::SubgraphManifest;
@@ -108,7 +111,7 @@ pub struct SubgraphDeploymentEntity {
     pub latest_ethereum_block_hash: Option<H256>,
     pub latest_ethereum_block_number: Option<BlockNumber>,
     pub graft_base: Option<SubgraphDeploymentId>,
-    pub graft_block_hash: Option<Bytes>,
+    pub graft_block_hash: Option<BlockHash>,
     pub graft_block_number: Option<BlockNumber>,
     pub reorg_count: i32,
     pub current_reorg_depth: i32,

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -108,7 +108,7 @@ pub struct SubgraphDeploymentEntity {
     pub latest_ethereum_block_hash: Option<H256>,
     pub latest_ethereum_block_number: Option<u64>,
     pub graft_base: Option<SubgraphDeploymentId>,
-    pub graft_block_hash: Option<H256>,
+    pub graft_block_hash: Option<Bytes>,
     pub graft_block_number: Option<u64>,
     pub reorg_count: i32,
     pub current_reorg_depth: i32,

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 use stable_hash::{SequenceNumber, StableHash, StableHasher};
 use std::str::FromStr;
 use std::{fmt, fmt::Display};
-use web3::types::*;
+use web3::types::{Bytes, H256};
 
 use super::SubgraphDeploymentId;
 use crate::components::{ethereum::EthereumBlockPointer, store::EntityType};
@@ -104,12 +104,12 @@ pub struct SubgraphDeploymentEntity {
     pub fatal_error: Option<SubgraphError>,
     pub non_fatal_errors: Vec<SubgraphError>,
     pub earliest_ethereum_block_hash: Option<H256>,
-    pub earliest_ethereum_block_number: Option<u64>,
+    pub earliest_ethereum_block_number: Option<BlockNumber>,
     pub latest_ethereum_block_hash: Option<H256>,
-    pub latest_ethereum_block_number: Option<u64>,
+    pub latest_ethereum_block_number: Option<BlockNumber>,
     pub graft_base: Option<SubgraphDeploymentId>,
     pub graft_block_hash: Option<Bytes>,
-    pub graft_block_number: Option<u64>,
+    pub graft_block_number: Option<BlockNumber>,
     pub reorg_count: i32,
     pub current_reorg_depth: i32,
     pub max_reorg_depth: i32,

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -8,7 +8,6 @@ use rand::Rng;
 use stable_hash::{SequenceNumber, StableHash, StableHasher};
 use std::str::FromStr;
 use std::{fmt, fmt::Display};
-use web3::types::H256;
 
 use super::SubgraphDeploymentId;
 use crate::components::{
@@ -106,9 +105,9 @@ pub struct SubgraphDeploymentEntity {
     pub synced: bool,
     pub fatal_error: Option<SubgraphError>,
     pub non_fatal_errors: Vec<SubgraphError>,
-    pub earliest_ethereum_block_hash: Option<H256>,
+    pub earliest_ethereum_block_hash: Option<BlockHash>,
     pub earliest_ethereum_block_number: Option<BlockNumber>,
-    pub latest_ethereum_block_hash: Option<H256>,
+    pub latest_ethereum_block_hash: Option<BlockHash>,
     pub latest_ethereum_block_number: Option<BlockNumber>,
     pub graft_base: Option<SubgraphDeploymentId>,
     pub graft_block_hash: Option<BlockHash>,
@@ -124,6 +123,10 @@ impl SubgraphDeploymentEntity {
         synced: bool,
         earliest_ethereum_block: Option<EthereumBlockPointer>,
     ) -> Self {
+        let (hash, number) = match earliest_ethereum_block {
+            None => (None, None),
+            Some(ptr) => (Some(ptr.hash), Some(ptr.number)),
+        };
         Self {
             manifest: SubgraphManifestEntity::from(source_manifest),
             failed: false,
@@ -131,10 +134,10 @@ impl SubgraphDeploymentEntity {
             synced,
             fatal_error: None,
             non_fatal_errors: vec![],
-            earliest_ethereum_block_hash: earliest_ethereum_block.clone().map(Into::into),
-            earliest_ethereum_block_number: earliest_ethereum_block.clone().map(Into::into),
-            latest_ethereum_block_hash: earliest_ethereum_block.clone().map(Into::into),
-            latest_ethereum_block_number: earliest_ethereum_block.map(Into::into),
+            earliest_ethereum_block_hash: hash.clone(),
+            earliest_ethereum_block_number: number,
+            latest_ethereum_block_hash: hash,
+            latest_ethereum_block_number: number,
             graft_base: None,
             graft_block_hash: None,
             graft_block_number: None,

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -128,9 +128,9 @@ impl SubgraphDeploymentEntity {
             synced,
             fatal_error: None,
             non_fatal_errors: vec![],
-            earliest_ethereum_block_hash: earliest_ethereum_block.map(Into::into),
-            earliest_ethereum_block_number: earliest_ethereum_block.map(Into::into),
-            latest_ethereum_block_hash: earliest_ethereum_block.map(Into::into),
+            earliest_ethereum_block_hash: earliest_ethereum_block.clone().map(Into::into),
+            earliest_ethereum_block_number: earliest_ethereum_block.clone().map(Into::into),
+            latest_ethereum_block_hash: earliest_ethereum_block.clone().map(Into::into),
             latest_ethereum_block_number: earliest_ethereum_block.map(Into::into),
             graft_base: None,
             graft_block_hash: None,
@@ -199,7 +199,7 @@ impl Display for SubgraphError {
         if let Some(handler) = &self.handler {
             write!(f, " in handler `{}`", handler)?;
         }
-        if let Some(block_ptr) = self.block_ptr {
+        if let Some(block_ptr) = &self.block_ptr {
             write!(f, " at block {}", block_ptr)?;
         }
         Ok(())

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -124,7 +124,7 @@ impl SubgraphDeploymentEntity {
             synced,
             fatal_error: None,
             non_fatal_errors: vec![],
-            earliest_block: earliest_block.clone(),
+            earliest_block: earliest_block.cheap_clone(),
             latest_block: earliest_block,
             graft_base: None,
             graft_block: None,

--- a/graph/src/data/subgraph/status.rs
+++ b/graph/src/data/subgraph/status.rs
@@ -27,7 +27,7 @@ impl EthereumBlock {
         self.0
     }
 
-    pub fn number(&self) -> u64 {
+    pub fn number(&self) -> i32 {
         self.0.number
     }
 }

--- a/graph/src/data/subgraph/status.rs
+++ b/graph/src/data/subgraph/status.rs
@@ -132,7 +132,7 @@ impl IntoValue for Info {
                 handler: handler,
                 block: object! {
                     __typename: "Block",
-                    number: block_ptr.map(|x| x.number),
+                    number: block_ptr.as_ref().map(|x| x.number),
                     hash: block_ptr.map(|x| q::Value::from(Value::Bytes(x.hash.as_ref().into()))),
                 },
                 deterministic: deterministic,

--- a/graph/src/data/subgraph/status.rs
+++ b/graph/src/data/subgraph/status.rs
@@ -20,7 +20,7 @@ pub struct EthereumBlock(EthereumBlockPointer);
 
 impl EthereumBlock {
     pub fn new(hash: H256, number: u64) -> Self {
-        EthereumBlock(EthereumBlockPointer { hash, number })
+        EthereumBlock(EthereumBlockPointer::from((hash, number)))
     }
 
     pub fn to_ptr(self) -> EthereumBlockPointer {
@@ -133,7 +133,7 @@ impl IntoValue for Info {
                 block: object! {
                     __typename: "Block",
                     number: block_ptr.as_ref().map(|x| x.number),
-                    hash: block_ptr.map(|x| q::Value::from(Value::Bytes(x.hash.as_ref().into()))),
+                    hash: block_ptr.map(|x| q::Value::from(Value::Bytes(x.hash.into()))),
                 },
                 deterministic: deterministic,
             }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -361,7 +361,7 @@ pub async fn execute_root_selection_set<R: Resolver>(
     let mut key: Option<QueryHash> = None;
 
     if R::CACHEABLE && (*CACHE_ALL || CACHED_SUBGRAPH_IDS.contains(ctx.query.schema.id())) {
-        if let (Some(block_ptr), Some(network)) = (block_ptr, &ctx.query.network) {
+        if let (Some(block_ptr), Some(network)) = (block_ptr.as_ref(), &ctx.query.network) {
             // JSONB and metadata queries use `BLOCK_NUMBER_MAX`. Ignore this case for two reasons:
             // - Metadata queries are not cacheable.
             // - Caching `BLOCK_NUMBER_MAX` would make this cache think all other blocks are old.

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -365,7 +365,7 @@ pub async fn execute_root_selection_set<R: Resolver>(
             // JSONB and metadata queries use `BLOCK_NUMBER_MAX`. Ignore this case for two reasons:
             // - Metadata queries are not cacheable.
             // - Caching `BLOCK_NUMBER_MAX` would make this cache think all other blocks are old.
-            if block_ptr.number != BLOCK_NUMBER_MAX as u64 {
+            if block_ptr.number != BLOCK_NUMBER_MAX {
                 // Calculate the hash outside of the lock
                 let cache_key = cache_key(&ctx, &selection_set, &block_ptr);
                 let shard = (cache_key[0] as usize) % QUERY_BLOCK_CACHE.len();

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -313,7 +313,7 @@ impl Query {
     pub fn log_cache_status(
         &self,
         selection_set: &q::SelectionSet,
-        block: u64,
+        block: BlockNumber,
         start: Instant,
         cache_status: String,
     ) {

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -70,7 +70,7 @@ where
         ctx.cheap_clone(),
         selection_set.cheap_clone(),
         query_type,
-        block_ptr,
+        block_ptr.clone(),
     )
     .await;
     let elapsed = start.elapsed();

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -93,6 +93,7 @@ impl StoreResolver {
 
     pub fn block_number(&self) -> BlockNumber {
         self.block_ptr
+            .as_ref()
             .map(|ptr| ptr.number as BlockNumber)
             .unwrap_or(BLOCK_NUMBER_MAX)
     }
@@ -167,6 +168,7 @@ impl StoreResolver {
         if object_type.is_meta() {
             let hash = self
                 .block_ptr
+                .as_ref()
                 .and_then(|ptr| {
                     // locate_block indicates that we do not have a block hash
                     // by setting the hash to `zero`
@@ -180,6 +182,7 @@ impl StoreResolver {
                 .unwrap_or(q::Value::Null);
             let number = self
                 .block_ptr
+                .as_ref()
                 .map(|ptr| q::Value::Int((ptr.number as i32).into()))
                 .unwrap_or(q::Value::Null);
             let mut map = BTreeMap::new();

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -109,7 +109,7 @@ impl StoreResolver {
                 .map_err(|e| StoreError::from(e).into())
                 .and_then(|ptr| {
                     let ptr = ptr.expect("we should have already checked that the subgraph exists");
-                    if ptr.number < number as u64 {
+                    if ptr.number < number {
                         Err(QueryExecutionError::ValueParseError(
                             "block.number".to_owned(),
                             format!(

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -173,10 +173,11 @@ impl StoreResolver {
                     // locate_block indicates that we do not have a block hash
                     // by setting the hash to `zero`
                     // See 7a7b9708-adb7-4fc2-acec-88680cb07ec1
-                    if ptr.hash == web3::types::H256::zero() {
+                    let hash_h256 = ptr.hash_as_h256();
+                    if hash_h256 == web3::types::H256::zero() {
                         None
                     } else {
-                        Some(q::Value::String(format!("0x{:x}", ptr.hash)))
+                        Some(q::Value::String(format!("0x{:x}", hash_h256)))
                     }
                 })
                 .unwrap_or(q::Value::Null);

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1763,7 +1763,7 @@ fn non_fatal_errors() {
             // Test error reverts.
             STORE
                 .subgraph_store()
-                .revert_block_operations(id.clone(), *BLOCK_ONE)
+                .revert_block_operations(id.clone(), BLOCK_ONE.clone())
                 .unwrap();
             let query = "query { musician(id: \"m1\") { id }  _meta { hasIndexingErrors } }";
             let query = graphql_parser::parse_query(query).unwrap().into_static();

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -52,7 +52,7 @@ impl BlockStreamBuilder for MockBlockStreamBuilder {
         _logger: Logger,
         _deployment_id: SubgraphDeploymentId,
         _network_name: String,
-        _start_blocks: Vec<u64>,
+        _start_blocks: Vec<BlockNumber>,
         _: EthereumLogFilter,
         _: EthereumCallFilter,
         _: EthereumBlockFilter,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -30,7 +30,7 @@ mock! {
 
         fn upsert_light_blocks(&self, blocks: Vec<LightEthereumBlock>) -> Result<(), Error>;
 
-        fn attempt_chain_head_update(&self, ancestor_count: u64) -> Result<Vec<H256>, Error>;
+        fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error>;
 
         fn chain_head_updates(&self) -> ChainHeadUpdateStream;
 
@@ -41,14 +41,14 @@ mock! {
         fn ancestor_block(
             &self,
             block_ptr: EthereumBlockPointer,
-            offset: u64,
+            offset: BlockNumber,
         ) -> Result<Option<EthereumBlock>, Error>;
 
-        fn cleanup_cached_blocks(&self, ancestor_count: u64) -> Result<(BlockNumber, usize), Error>;
+        fn cleanup_cached_blocks(&self, ancestor_count: BlockNumber) -> Result<(BlockNumber, usize), Error>;
 
-        fn block_hashes_by_block_number(&self, number: u64) -> Result<Vec<H256>, Error>;
+        fn block_hashes_by_block_number(&self, number: BlockNumber) -> Result<Vec<H256>, Error>;
 
-        fn confirm_block_hash(&self, number: u64, hash: &H256) -> Result<usize, Error>;
+        fn confirm_block_hash(&self, number: BlockNumber, hash: &H256) -> Result<usize, Error>;
 
         fn block_number(&self, block_hash: H256) -> Result<Option<(String, BlockNumber)>, StoreError>;
     }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -44,16 +44,16 @@ use store_builder::StoreBuilder;
 
 lazy_static! {
     // Default to an Ethereum reorg threshold to 50 blocks
-    static ref REORG_THRESHOLD: u64 = env::var("ETHEREUM_REORG_THRESHOLD")
+    static ref REORG_THRESHOLD: BlockNumber = env::var("ETHEREUM_REORG_THRESHOLD")
         .ok()
-        .map(|s| u64::from_str(&s)
+        .map(|s| BlockNumber::from_str(&s)
             .unwrap_or_else(|_| panic!("failed to parse env var ETHEREUM_REORG_THRESHOLD")))
         .unwrap_or(50);
 
     // Default to an ancestor count of 50 blocks
-    static ref ANCESTOR_COUNT: u64 = env::var("ETHEREUM_ANCESTOR_COUNT")
+    static ref ANCESTOR_COUNT: BlockNumber = env::var("ETHEREUM_ANCESTOR_COUNT")
         .ok()
-        .map(|s| u64::from_str(&s)
+        .map(|s| BlockNumber::from_str(&s)
              .unwrap_or_else(|_| panic!("failed to parse env var ETHEREUM_ANCESTOR_COUNT")))
         .unwrap_or(50);
 }

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -46,7 +46,7 @@ struct RuntimeHostConfig {
     data_source_network: String,
     data_source_name: String,
     data_source_context: Option<DataSourceContext>,
-    data_source_creation_block: Option<u64>,
+    data_source_creation_block: Option<BlockNumber>,
     contract: Source,
     templates: Arc<Vec<DataSourceTemplate>>,
 }
@@ -187,7 +187,7 @@ pub struct RuntimeHost {
     data_source_event_handlers: Vec<MappingEventHandler>,
     data_source_call_handlers: Vec<MappingCallHandler>,
     data_source_block_handlers: Vec<MappingBlockHandler>,
-    data_source_creation_block: Option<u64>,
+    data_source_creation_block: Option<BlockNumber>,
     mapping_request_sender: Sender<MappingRequest>,
     host_exports: Arc<HostExports>,
     metrics: Arc<HostMetrics>,
@@ -471,7 +471,8 @@ impl RuntimeHostTrait for RuntimeHost {
     fn matches_log(&self, log: &Log) -> bool {
         self.matches_log_address(log)
             && self.matches_log_signature(log)
-            && self.data_source_contract.start_block <= log.block_number.unwrap().as_u64()
+            && self.data_source_contract.start_block
+                <= BlockNumber::try_from(log.block_number.unwrap().as_u64()).unwrap()
     }
 
     fn matches_call(&self, call: &EthereumCall) -> bool {
@@ -483,7 +484,7 @@ impl RuntimeHostTrait for RuntimeHost {
     fn matches_block(
         &self,
         block_trigger_type: &EthereumBlockTriggerType,
-        block_number: u64,
+        block_number: BlockNumber,
     ) -> bool {
         self.matches_block_trigger(block_trigger_type)
             && self.data_source_contract.start_block <= block_number
@@ -738,7 +739,7 @@ impl RuntimeHostTrait for RuntimeHost {
         .await
     }
 
-    fn creation_block_number(&self) -> Option<u64> {
+    fn creation_block_number(&self) -> Option<BlockNumber> {
         self.data_source_creation_block
     }
 }

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -680,7 +680,7 @@ impl HostExports {
         name: String,
         params: Vec<String>,
         context: Option<DataSourceContext>,
-        creation_block: u64,
+        creation_block: BlockNumber,
     ) -> Result<(), HostExportError> {
         info!(
             logger,

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -105,10 +105,10 @@ where
             .get_optional::<Address>("indexer")
             .expect("Invalid indexer");
 
-        let poi_fut = self
-            .store
-            .clone()
-            .get_proof_of_indexing(&deployment_id, &indexer, block);
+        let poi_fut =
+            self.store
+                .clone()
+                .get_proof_of_indexing(&deployment_id, &indexer, block.clone());
         let poi = match futures::executor::block_on(poi_fut) {
             Ok(Some(poi)) => q::Value::String(format!("0x{}", hex::encode(&poi))),
             Ok(None) => q::Value::Null,

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -68,15 +68,7 @@ pub(crate) fn first_block_in_range(
 /// operation that does not record history, which should not happen
 /// with how we currently use relational schemas
 pub(crate) fn block_number(block_ptr: &EthereumBlockPointer) -> BlockNumber {
-    if block_ptr.number < std::i32::MAX as u64 {
-        block_ptr.number as i32
-    } else {
-        panic!(
-            "Block numbers bigger than {} are not supported, but received block number {}",
-            std::i32::MAX,
-            block_ptr.number
-        )
-    }
+    block_ptr.number
 }
 
 impl From<RangeFrom<BlockNumber>> for BlockRange {

--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -5,7 +5,7 @@ use std::{
 
 use graph::{
     components::store::BlockStore as BlockStoreTrait,
-    prelude::{error, EthereumBlockPointer, EthereumNetworkIdentifier, Logger},
+    prelude::{error, BlockNumber, EthereumBlockPointer, EthereumNetworkIdentifier, Logger},
 };
 use graph::{components::store::CallCache as CallCacheTrait, prelude::StoreError};
 use graph::{
@@ -274,7 +274,7 @@ impl BlockStore {
         Ok(map)
     }
 
-    pub fn chain_head_block(&self, chain: &str) -> Result<Option<u64>, StoreError> {
+    pub fn chain_head_block(&self, chain: &str) -> Result<Option<BlockNumber>, StoreError> {
         let store = self
             .store(chain)
             .ok_or_else(|| constraint_violation!("unknown network `{}`", chain))?;

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -1196,7 +1196,7 @@ impl ChainStore {
 
 impl ChainStoreTrait for ChainStore {
     fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error> {
-        Ok(self.genesis_block_ptr)
+        Ok(self.genesis_block_ptr.clone())
     }
 
     fn upsert_blocks<B, E>(
@@ -1233,7 +1233,7 @@ impl ChainStoreTrait for ChainStore {
             let conn = self.get_conn()?;
             conn.transaction(|| -> Result<(Vec<H256>, Option<(String, i64)>), Error> {
                 let candidate = self.storage.chain_head_candidate(&conn, &self.chain)?;
-                let (ptr, first_block) = match candidate {
+                let (ptr, first_block) = match &candidate {
                     None => return Ok((vec![], None)),
                     Some(ptr) => (ptr, 0.max(ptr.number.saturating_sub(ancestor_count))),
                 };

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -805,7 +805,7 @@ mod data {
                     );
 
                     let hash = sql_query(query)
-                        .bind::<Bytea, _>(&block_ptr.hash.0)
+                        .bind::<Bytea, _>(block_ptr.hash_slice())
                         .bind::<BigInt, _>(offset as i64)
                         .get_result::<BlockHashBytea>(conn)
                         .optional()?;

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -504,7 +504,7 @@ mod data {
             &self,
             conn: &PgConnection,
             chain: &str,
-            number: u64,
+            number: BlockNumber,
         ) -> Result<Vec<H256>, Error> {
             match self {
                 Storage::Shared => {
@@ -536,7 +536,7 @@ mod data {
             &self,
             conn: &PgConnection,
             chain: &str,
-            number: u64,
+            number: BlockNumber,
             hash: &H256,
         ) -> Result<usize, Error> {
             let number = number as i64;
@@ -751,7 +751,7 @@ mod data {
             &self,
             conn: &PgConnection,
             block_ptr: EthereumBlockPointer,
-            offset: u64,
+            offset: BlockNumber,
         ) -> Result<Option<EthereumBlock>, Error> {
             let data = match self {
                 Storage::Shared => {
@@ -1171,7 +1171,7 @@ impl ChainStore {
         Ok(HashMap::from_iter(pointers))
     }
 
-    pub fn chain_head_block(&self, chain: &str) -> Result<Option<u64>, StoreError> {
+    pub fn chain_head_block(&self, chain: &str) -> Result<Option<BlockNumber>, StoreError> {
         use public::ethereum_networks as n;
 
         let number: Option<i64> = n::table
@@ -1226,7 +1226,7 @@ impl ChainStoreTrait for ChainStore {
         Ok(())
     }
 
-    fn attempt_chain_head_update(&self, ancestor_count: u64) -> Result<Vec<H256>, Error> {
+    fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error> {
         use public::ethereum_networks as n;
 
         let (missing, ptr) = {
@@ -1299,7 +1299,7 @@ impl ChainStoreTrait for ChainStore {
     fn ancestor_block(
         &self,
         block_ptr: EthereumBlockPointer,
-        offset: u64,
+        offset: BlockNumber,
     ) -> Result<Option<EthereumBlock>, Error> {
         ensure!(
             block_ptr.number >= offset,
@@ -1312,7 +1312,10 @@ impl ChainStoreTrait for ChainStore {
         self.storage.ancestor_block(&conn, block_ptr, offset)
     }
 
-    fn cleanup_cached_blocks(&self, ancestor_count: u64) -> Result<(BlockNumber, usize), Error> {
+    fn cleanup_cached_blocks(
+        &self,
+        ancestor_count: BlockNumber,
+    ) -> Result<(BlockNumber, usize), Error> {
         use diesel::sql_types::Integer;
 
         #[derive(QueryableByName)]
@@ -1377,13 +1380,13 @@ impl ChainStoreTrait for ChainStore {
             .map_err(|e| e.into())
     }
 
-    fn block_hashes_by_block_number(&self, number: u64) -> Result<Vec<H256>, Error> {
+    fn block_hashes_by_block_number(&self, number: BlockNumber) -> Result<Vec<H256>, Error> {
         let conn = self.get_conn()?;
         self.storage
             .block_hashes_by_block_number(&conn, &self.chain, number)
     }
 
-    fn confirm_block_hash(&self, number: u64, hash: &H256) -> Result<usize, Error> {
+    fn confirm_block_hash(&self, number: BlockNumber, hash: &H256) -> Result<usize, Error> {
         let conn = self.get_conn()?;
         self.storage
             .confirm_block_hash(&conn, &self.chain, number, hash)
@@ -1467,7 +1470,7 @@ fn contract_call_id(
 pub mod test_support {
     use std::str::FromStr;
 
-    use graph::prelude::{web3::types::H256, EthereumBlock, EthereumBlockPointer};
+    use graph::prelude::{web3::types::H256, BlockNumber, EthereumBlock, EthereumBlockPointer};
 
     // Hash indicating 'no parent'
     pub const NO_PARENT: &str = "0000000000000000000000000000000000000000000000000000000000000000";
@@ -1475,7 +1478,7 @@ pub mod test_support {
     /// the block number, hash, and the hash of the parent block
     #[derive(Clone, Debug, PartialEq)]
     pub struct FakeBlock {
-        pub number: u64,
+        pub number: BlockNumber,
         pub hash: String,
         pub parent_hash: String,
     }
@@ -1489,7 +1492,7 @@ pub mod test_support {
             }
         }
 
-        pub fn make_no_parent(number: u64, hash: &str) -> Self {
+        pub fn make_no_parent(number: BlockNumber, hash: &str) -> Self {
             FakeBlock {
                 number,
                 hash: hash.to_owned(),

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -629,7 +629,7 @@ pub fn create_deployment(
         hash.as_ref().map(|hash| hash.0.as_slice())
     }
 
-    fn n(number: Option<u64>) -> SqlLiteral<Nullable<Numeric>> {
+    fn n(number: Option<BlockNumber>) -> SqlLiteral<Nullable<Numeric>> {
         match number {
             None => sql("null"),
             Some(number) => sql(&format!("{}::numeric", number)),

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -11,11 +11,13 @@ use diesel::{
     prelude::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl},
     sql_types::Nullable,
 };
-use graph::data::subgraph::{schema::SubgraphManifestEntity, SubgraphFeature};
-use graph::prelude::web3::types::Bytes;
 use graph::prelude::{
     anyhow, bigdecimal::ToPrimitive, hex, web3::types::H256, BigDecimal, BlockNumber,
     DeploymentState, EthereumBlockPointer, Schema, StoreError, SubgraphDeploymentId,
+};
+use graph::{
+    components::ethereum::BlockHash,
+    data::subgraph::{schema::SubgraphManifestEntity, SubgraphFeature},
 };
 use graph::{data::subgraph::schema::SubgraphError, prelude::SubgraphDeploymentEntity};
 use stable_hash::crypto::SetHasher;
@@ -625,8 +627,8 @@ pub fn create_deployment(
         hash.as_ref().map(|hash| hash.as_bytes())
     }
 
-    fn b(hash: &Option<Bytes>) -> Option<&[u8]> {
-        hash.as_ref().map(|hash| hash.0.as_slice())
+    fn b(hash: &Option<BlockHash>) -> Option<&[u8]> {
+        hash.as_ref().map(|hash| hash.0.as_ref())
     }
 
     fn n(number: Option<BlockNumber>) -> SqlLiteral<Nullable<Numeric>> {

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -398,12 +398,12 @@ fn insert_subgraph_error(conn: &PgConnection, error: SubgraphError) -> anyhow::R
         deterministic,
     } = error;
 
-    let block_num = match block_ptr {
+    let block_num = match &block_ptr {
         None => {
             assert_eq!(deterministic, false);
             crate::block_range::BLOCK_UNVERSIONED
         }
-        Some(block) => crate::block_range::block_number(&block),
+        Some(block) => crate::block_range::block_number(block),
     };
 
     insert_into(e::table)

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -623,10 +623,6 @@ pub fn create_deployment(
     use subgraph_deployment as d;
     use subgraph_manifest as m;
 
-    fn h(hash: &Option<H256>) -> Option<&[u8]> {
-        hash.as_ref().map(|hash| hash.as_bytes())
-    }
-
     fn b(hash: &Option<BlockHash>) -> Option<&[u8]> {
         hash.as_ref().map(|hash| hash.0.as_ref())
     }
@@ -674,9 +670,9 @@ pub fn create_deployment(
         d::health.eq(SubgraphHealth::Healthy),
         d::fatal_error.eq::<Option<String>>(None),
         d::non_fatal_errors.eq::<Vec<String>>(vec![]),
-        d::earliest_ethereum_block_hash.eq(h(&earliest_ethereum_block_hash)),
+        d::earliest_ethereum_block_hash.eq(b(&earliest_ethereum_block_hash)),
         d::earliest_ethereum_block_number.eq(n(earliest_ethereum_block_number)),
-        d::latest_ethereum_block_hash.eq(h(&latest_ethereum_block_hash)),
+        d::latest_ethereum_block_hash.eq(b(&latest_ethereum_block_hash)),
         d::latest_ethereum_block_number.eq(n(latest_ethereum_block_number)),
         d::entity_count.eq(sql("0")),
         d::graft_base.eq(graft_base.as_ref().map(|s| s.as_str())),

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -672,6 +672,7 @@ impl DeploymentStore {
         let site3 = site.clone();
         let site4 = site.clone();
         let store = self.clone();
+        let block2 = block.clone();
 
         async move {
             let entities = self
@@ -741,7 +742,7 @@ impl DeploymentStore {
                 })
                 .collect::<Result<HashMap<_, _>, anyhow::Error>>()?;
 
-            let mut finisher = ProofOfIndexingFinisher::new(&block, &site3.deployment, &indexer);
+            let mut finisher = ProofOfIndexingFinisher::new(&block2, &site3.deployment, &indexer);
             for (name, region) in by_causality_region.drain() {
                 finisher.add_causality_region(&name, &region);
             }
@@ -1047,11 +1048,11 @@ impl DeploymentStore {
                     &site.deployment,
                     &base_layout,
                     &base.deployment,
-                    block,
+                    block.clone(),
                 )?;
                 // Set the block ptr to the graft point to signal that we successfully
                 // performed the graft
-                deployment::forward_block_ptr(&conn, &site.deployment, block.clone())?;
+                deployment::forward_block_ptr(&conn, &site.deployment, block)?;
                 info!(logger, "Subgraph successfully initialized";
                     "time_ms" => start.elapsed().as_millis());
             }

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -915,7 +915,7 @@ impl DeploymentStore {
             // Don't revert past a graft point
             let info = self.subgraph_info_with_conn(&conn, &site.deployment)?;
             if let Some(graft_block) = info.graft_block {
-                if graft_block as u64 > block_ptr_to.number {
+                if graft_block > block_ptr_to.number {
                     return Err(anyhow!(
                         "Can not revert subgraph `{}` to block {} as it was \
                         grafted at block {} and reverting past a graft point \

--- a/store/postgres/src/dynds.rs
+++ b/store/postgres/src/dynds.rs
@@ -50,16 +50,6 @@ fn to_source(
     }
     let address = Some(H160::from_slice(address.as_slice()));
 
-    // Assume a missing start block is the same as 0
-    let start_block = start_block.to_u64().ok_or_else(|| {
-        constraint_violation!(
-            "Start block {:?} for dynamic data source {} in deployment {} is not a u64",
-            start_block,
-            vid,
-            deployment
-        )
-    })?;
-
     Ok(Source {
         address,
         abi,
@@ -98,7 +88,7 @@ pub fn load(conn: &PgConnection, id: &str) -> Result<Vec<StoredDynamicDataSource
     let mut data_sources: Vec<StoredDynamicDataSource> = Vec::new();
     for (vid, name, context, address, abi, start_block, creation_block) in dds.into_iter() {
         let source = to_source(id, vid, address, abi, start_block)?;
-        let creation_block = creation_block.to_u64();
+        let creation_block = creation_block.to_i32();
         let data_source = StoredDynamicDataSource {
             name,
             source,

--- a/store/postgres/src/dynds.rs
+++ b/store/postgres/src/dynds.rs
@@ -156,7 +156,7 @@ pub(crate) fn insert(
                 decds::abi.eq(abi),
                 decds::start_block.eq(start_block as i32),
                 decds::ethereum_block_number.eq(sql(&format!("{}::numeric", block_ptr.number))),
-                decds::ethereum_block_hash.eq(block_ptr.hash.as_bytes()),
+                decds::ethereum_block_hash.eq(block_ptr.hash_slice()),
             ))
         })
         .collect::<Result<_, _>>()?;

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -981,12 +981,7 @@ impl<'a> Connection<'a> {
                 detail.latest_ethereum_block_number.clone(),
             )?
             .map(|b| b.to_ptr())
-            .map(|ptr| {
-                (
-                    Some(Vec::from(ptr.hash.as_bytes())),
-                    Some(ptr.number as i32),
-                )
-            })
+            .map(|ptr| (Some(Vec::from(ptr.hash_slice())), Some(ptr.number as i32)))
             .unwrap_or((None, None));
             let entity_count = detail.entity_count.to_u64().unwrap_or(0) as i32;
 

--- a/store/postgres/tests/chain_head.rs
+++ b/store/postgres/tests/chain_head.rs
@@ -87,7 +87,7 @@ fn check_chain_head_update(
         let head_hash_act = store
             .chain_head_ptr()
             .expect("chain_head_ptr failed")
-            .map(|ebp| format!("{:x}", ebp.hash));
+            .map(|ebp| ebp.hash_hex());
         assert_eq!(head_hash_exp, head_hash_act);
         Ok(())
     })

--- a/store/postgres/tests/chain_head.rs
+++ b/store/postgres/tests/chain_head.rs
@@ -4,8 +4,8 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use graph::prelude::QueryStoreManager;
 use graph::prelude::{anyhow::anyhow, anyhow::Error};
+use graph::prelude::{BlockNumber, QueryStoreManager};
 use graph::{cheap_clone::CheapClone, prelude::web3::types::H160};
 use graph::{components::store::BlockStore as _, prelude::SubgraphDeploymentId};
 use graph::{components::store::ChainStore as _, prelude::EthereumCallCache as _};
@@ -20,7 +20,7 @@ use test_store::*;
 
 // The ancestor count we use for chain head updates. We keep this very small
 // to make setting up the tests easier
-const ANCESTOR_COUNT: u64 = 3;
+const ANCESTOR_COUNT: BlockNumber = 3;
 
 /// Test harness for running database integration tests.
 fn run_test<F>(chain: Chain, test: F)
@@ -248,7 +248,7 @@ fn block_hashes_by_number() {
 fn check_ancestor(
     store: &Arc<DieselChainStore>,
     child: &FakeBlock,
-    offset: u64,
+    offset: BlockNumber,
     exp: &FakeBlock,
 ) -> Result<(), Error> {
     let act = store
@@ -288,7 +288,7 @@ fn ancestor_block_simple() {
         check_ancestor(&store, &*BLOCK_THREE, 2, &*BLOCK_ONE)?;
 
         for offset in [6, 7, 8, 50].iter() {
-            let offset = offset.clone() as u64;
+            let offset = offset.clone();
             let res = store.ancestor_block(BLOCK_FIVE.block_ptr(), offset);
             assert!(res.is_err());
         }

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -157,7 +157,7 @@ fn insert_test_data(store: Arc<DieselSubgraphStore>) {
     transact_entity_operations(
         &store,
         TEST_SUBGRAPH_ID.clone(),
-        BLOCKS[0],
+        BLOCKS[0].clone(),
         vec![test_entity_1],
     )
     .unwrap();
@@ -185,7 +185,7 @@ fn insert_test_data(store: Arc<DieselSubgraphStore>) {
     transact_entity_operations(
         &store,
         TEST_SUBGRAPH_ID.clone(),
-        BLOCKS[1],
+        BLOCKS[1].clone(),
         vec![test_entity_2, test_entity_3_1],
     )
     .unwrap();
@@ -203,7 +203,7 @@ fn insert_test_data(store: Arc<DieselSubgraphStore>) {
     transact_entity_operations(
         &store,
         TEST_SUBGRAPH_ID.clone(),
-        BLOCKS[2],
+        BLOCKS[2].clone(),
         vec![test_entity_3_2],
     )
     .unwrap();
@@ -268,7 +268,7 @@ fn graft() {
             &subgraph_id,
             GRAFT_GQL,
             TEST_SUBGRAPH_ID.as_str(),
-            BLOCKS[1],
+            BLOCKS[1].clone(),
         );
         assert!(res.is_ok());
 
@@ -304,14 +304,15 @@ fn graft() {
             key: EntityKey::data(subgraph_id.clone(), USER.to_owned(), "3".to_owned()),
             data: shaq,
         };
-        transact_entity_operations(&store, subgraph_id.clone(), BLOCKS[2], vec![op]).unwrap();
+        transact_entity_operations(&store, subgraph_id.clone(), BLOCKS[2].clone(), vec![op])
+            .unwrap();
 
         store
-            .revert_block_operations(subgraph_id.clone(), BLOCKS[1])
+            .revert_block_operations(subgraph_id.clone(), BLOCKS[1].clone())
             .expect("We can revert a block we just created");
 
         let err = store
-            .revert_block_operations(subgraph_id.clone(), BLOCKS[0])
+            .revert_block_operations(subgraph_id.clone(), BLOCKS[0].clone())
             .expect_err("Reverting past graft point is not allowed");
 
         assert!(err.to_string().contains("Can not revert subgraph"));

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -184,7 +184,7 @@ fn insert_test_data(store: Arc<DieselSubgraphStore>) {
     transact_entity_operations(
         &store,
         TEST_SUBGRAPH_ID.clone(),
-        *GENESIS_PTR,
+        GENESIS_PTR.clone(),
         vec![test_entity_1],
     )
     .unwrap();
@@ -212,7 +212,7 @@ fn insert_test_data(store: Arc<DieselSubgraphStore>) {
     transact_entity_operations(
         &store,
         TEST_SUBGRAPH_ID.clone(),
-        *TEST_BLOCK_1_PTR,
+        TEST_BLOCK_1_PTR.clone(),
         vec![test_entity_2, test_entity_3_1],
     )
     .unwrap();
@@ -230,7 +230,7 @@ fn insert_test_data(store: Arc<DieselSubgraphStore>) {
     transact_entity_operations(
         &store,
         TEST_SUBGRAPH_ID.clone(),
-        *TEST_BLOCK_2_PTR,
+        TEST_BLOCK_2_PTR.clone(),
         vec![test_entity_3_2],
     )
     .unwrap();
@@ -309,7 +309,7 @@ fn delete_entity() {
         transact_entity_operations(
             &store.subgraph_store(),
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
+            TEST_BLOCK_3_PTR.clone(),
             vec![EntityOperation::Remove {
                 key: entity_key.clone(),
             }],
@@ -405,7 +405,7 @@ fn insert_entity() {
         transact_entity_operations(
             &store.subgraph_store(),
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
+            TEST_BLOCK_3_PTR.clone(),
             vec![test_entity],
         )
         .unwrap();
@@ -454,7 +454,7 @@ fn update_existing() {
         transact_entity_operations(
             &store.subgraph_store(),
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
+            TEST_BLOCK_3_PTR.clone(),
             vec![op],
         )
         .unwrap();
@@ -496,7 +496,7 @@ fn partially_update_existing() {
         transact_entity_operations(
             &store.subgraph_store(),
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
+            TEST_BLOCK_3_PTR.clone(),
             vec![EntityOperation::Set {
                 key: entity_key.clone(),
                 data: partial_entity.clone(),
@@ -1022,7 +1022,7 @@ async fn check_basic_revert(
     // Revert block 3
     store
         .subgraph_store()
-        .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_1_PTR)
+        .revert_block_operations(TEST_SUBGRAPH_ID.clone(), TEST_BLOCK_1_PTR.clone())
         .unwrap();
 
     let returned_entities = store
@@ -1081,7 +1081,7 @@ fn revert_block_with_delete() {
         transact_entity_operations(
             &store.subgraph_store(),
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
+            TEST_BLOCK_3_PTR.clone(),
             vec![EntityOperation::Remove { key: del_key }],
         )
         .unwrap();
@@ -1092,7 +1092,7 @@ fn revert_block_with_delete() {
         let count = get_entity_count(store.clone(), &TEST_SUBGRAPH_ID);
         store
             .subgraph_store()
-            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_2_PTR)
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), TEST_BLOCK_2_PTR.clone())
             .unwrap();
         assert_eq!(
             count + 1,
@@ -1147,7 +1147,7 @@ fn revert_block_with_partial_update() {
         transact_entity_operations(
             &store.subgraph_store(),
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
+            TEST_BLOCK_3_PTR.clone(),
             vec![EntityOperation::Set {
                 key: entity_key.clone(),
                 data: partial_entity.clone(),
@@ -1161,7 +1161,7 @@ fn revert_block_with_partial_update() {
         let count = get_entity_count(store.clone(), &TEST_SUBGRAPH_ID);
         store
             .subgraph_store()
-            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_2_PTR)
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), TEST_BLOCK_2_PTR.clone())
             .unwrap();
         assert_eq!(count, get_entity_count(store.clone(), &TEST_SUBGRAPH_ID));
 
@@ -1246,7 +1246,7 @@ fn revert_block_with_dynamic_data_source_operations() {
         transact_entities_and_dynamic_data_sources(
             &store,
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
+            TEST_BLOCK_3_PTR.clone(),
             vec![&data_source],
             ops,
         )
@@ -1273,7 +1273,7 @@ fn revert_block_with_dynamic_data_source_operations() {
 
         // Revert block that added the user and the dynamic data source
         store
-            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_2_PTR)
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), TEST_BLOCK_2_PTR.clone())
             .expect("revert block operations failed unexpectedly");
 
         // Verify that the user is the original again
@@ -1329,7 +1329,8 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
         };
 
         // Create SubgraphDeploymentEntity
-        let deployment = SubgraphDeploymentEntity::new(&manifest, false, Some(*TEST_BLOCK_0_PTR));
+        let deployment =
+            SubgraphDeploymentEntity::new(&manifest, false, Some(TEST_BLOCK_0_PTR.clone()));
         let name = SubgraphName::new("test/entity-changes-are-fired").unwrap();
         let node_id = NodeId::new("test").unwrap();
         store
@@ -1366,7 +1367,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
         transact_entity_operations(
             &store.subgraph_store(),
             subgraph_id.clone(),
-            *TEST_BLOCK_1_PTR,
+            TEST_BLOCK_1_PTR.clone(),
             added_entities
                 .iter()
                 .map(|(id, data)| EntityOperation::Set {
@@ -1396,7 +1397,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
         transact_entity_operations(
             &store.subgraph_store(),
             subgraph_id.clone(),
-            *TEST_BLOCK_2_PTR,
+            TEST_BLOCK_2_PTR.clone(),
             vec![update_op, delete_op],
         )
         .unwrap();
@@ -1466,7 +1467,7 @@ fn throttle_subscription_delivers() {
         transact_entity_operations(
             &store.subgraph_store(),
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
+            TEST_BLOCK_3_PTR.clone(),
             vec![user4],
         )
         .unwrap();
@@ -1510,7 +1511,7 @@ fn throttle_subscription_throttles() {
         transact_entity_operations(
             &store.subgraph_store(),
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
+            TEST_BLOCK_3_PTR.clone(),
             vec![user4],
         )
         .unwrap();
@@ -1603,7 +1604,7 @@ fn handle_large_string_with_index() {
             .subgraph_store()
             .transact_block_operations(
                 TEST_SUBGRAPH_ID.clone(),
-                *TEST_BLOCK_3_PTR,
+                TEST_BLOCK_3_PTR.clone(),
                 vec![
                     make_insert_op(ONE, &long_text),
                     make_insert_op(TWO, &other_text),
@@ -1804,7 +1805,7 @@ fn window() {
         transact_entity_operations(
             &store.subgraph_store(),
             TEST_SUBGRAPH_ID.clone(),
-            *TEST_BLOCK_3_PTR,
+            TEST_BLOCK_3_PTR.clone(),
             ops,
         )
         .expect("Failed to create test users");
@@ -1984,13 +1985,13 @@ fn reorg_tracking() {
 
         // Back to block 3
         store
-            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_3_PTR)
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), TEST_BLOCK_3_PTR.clone())
             .unwrap();
         check_state!(store, 1, 1, 3);
 
         // Back to block 2
         store
-            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_2_PTR)
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), TEST_BLOCK_2_PTR.clone())
             .unwrap();
         check_state!(store, 2, 2, 2);
 
@@ -2008,17 +2009,17 @@ fn reorg_tracking() {
 
         // Revert all the way back to block 2
         store
-            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_4_PTR)
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), TEST_BLOCK_4_PTR.clone())
             .unwrap();
         check_state!(store, 3, 2, 4);
 
         store
-            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_3_PTR)
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), TEST_BLOCK_3_PTR.clone())
             .unwrap();
         check_state!(store, 4, 2, 3);
 
         store
-            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), *TEST_BLOCK_2_PTR)
+            .revert_block_operations(TEST_SUBGRAPH_ID.clone(), TEST_BLOCK_2_PTR.clone())
             .unwrap();
         check_state!(store, 5, 3, 2);
     })

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -517,7 +517,7 @@ fn fatal_vs_non_fatal() {
         let error = || SubgraphError {
             subgraph_id: id.clone(),
             message: "test".to_string(),
-            block_ptr: Some(BLOCKS[1]),
+            block_ptr: Some(BLOCKS[1].clone()),
             handler: None,
             deterministic: true,
         };
@@ -560,7 +560,7 @@ fn fail_unfail() {
         let error = SubgraphError {
             subgraph_id: id.clone(),
             message: "test".to_string(),
-            block_ptr: Some(BLOCKS[1]),
+            block_ptr: Some(BLOCKS[1].clone()),
             handler: None,
             deterministic: true,
         };
@@ -580,8 +580,13 @@ fn fail_unfail() {
         store.subgraph_store().unfail(&id).unwrap();
 
         // Advance the block ptr to the block of the deleted error.
-        transact_entity_operations(&store.subgraph_store(), id.cheap_clone(), BLOCKS[1], vec![])
-            .unwrap();
+        transact_entity_operations(
+            &store.subgraph_store(),
+            id.cheap_clone(),
+            BLOCKS[1].clone(),
+            vec![],
+        )
+        .unwrap();
 
         // We still have no fatal errors.
         assert!(!query_store

--- a/store/test-store/src/block_store.rs
+++ b/store/test-store/src/block_store.rs
@@ -9,7 +9,7 @@ lazy_static! {
     // Genesis block
     pub static ref GENESIS_BLOCK: FakeBlock = FakeBlock {
         number: super::GENESIS_PTR.number,
-        hash: format!("{:x}", super::GENESIS_PTR.hash),
+        hash: super::GENESIS_PTR.hash_hex(),
         parent_hash: NO_PARENT.to_string()
     };
     pub static ref BLOCK_ONE: FakeBlock = GENESIS_BLOCK

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -450,7 +450,7 @@ fn build_store() -> (Arc<Store>, ConnectionPool, Config, Arc<SubscriptionManager
 
             let ident = EthereumNetworkIdentifier {
                 net_version: NETWORK_VERSION.to_owned(),
-                genesis_block_hash: GENESIS_PTR.hash,
+                genesis_block_hash: GENESIS_PTR.hash_as_h256(),
             };
 
             (


### PR DESCRIPTION
This PR changes `EthereumBlockPointer` so that the hash is `Bytes`(`Vec<u8>`) and the block number is a `BlockNumber` (`i32`). The PR does not rename the struct yet, but that should be a fairly easy change.