### PR TITLE
Log non-fatal errors

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -929,6 +929,14 @@ where
         info!(&logger, "Applying {} entity operation(s)", mods.len());
     }
 
+    let err_count = block_state.deterministic_errors.len();
+    for (i, e) in block_state.deterministic_errors.iter().enumerate() {
+        error!(&logger, "Subgraph error {}/{}", i + 1, err_count;
+            "error" => e.to_string(),
+            "code" => LogCode::SubgraphSyncingFailure
+        );
+    }
+
     // Transact entity operations into the store and update the
     // subgraph's block stream pointer
     let _section = ctx.host_metrics.stopwatch.start_section("transact_block");


### PR DESCRIPTION
We don't want any errors to be silent in the logs.