### PR TITLE
graph, store: Simplify the changes we send with StoreEvent

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -460,10 +460,6 @@ pub enum EntityChange {
         subgraph_id: SubgraphDeploymentId,
         /// Entity type name of the changed entity.
         entity_type: EntityType,
-        /// ID of the changed entity.
-        entity_id: String,
-        /// Operation that caused the change.
-        operation: EntityChangeOperation,
     },
     Assignment {
         subgraph_id: SubgraphDeploymentId,
@@ -472,12 +468,10 @@ pub enum EntityChange {
 }
 
 impl EntityChange {
-    pub fn for_data(key: EntityKey, operation: EntityChangeOperation) -> Self {
+    pub fn for_data(key: EntityKey) -> Self {
         Self::Data {
             subgraph_id: key.subgraph_id,
             entity_type: key.entity_type,
-            entity_id: key.entity_id,
-            operation,
         }
     }
 
@@ -527,11 +521,8 @@ impl<'a> FromIterator<&'a EntityModification> for StoreEvent {
             .map(|op| {
                 use self::EntityModification::*;
                 match op {
-                    Insert { key, .. } | Overwrite { key, .. } => {
-                        EntityChange::for_data(key.clone(), EntityChangeOperation::Set)
-                    }
-                    Remove { key } => {
-                        EntityChange::for_data(key.clone(), EntityChangeOperation::Removed)
+                    Insert { key, .. } | Overwrite { key, .. } | Remove { key } => {
+                        EntityChange::for_data(key.clone())
                     }
                 }
             })

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -32,9 +32,9 @@ use graph::data::schema::{FulltextConfig, FulltextDefinition, Schema, SCHEMA_TYP
 use graph::data::store::BYTES_SCALAR;
 use graph::data::subgraph::schema::{POI_OBJECT, POI_TABLE};
 use graph::prelude::{
-    anyhow, info, BlockNumber, Entity, EntityChange, EntityChangeOperation, EntityCollection,
-    EntityFilter, EntityKey, EntityOrder, EntityRange, EthereumBlockPointer, Logger,
-    QueryExecutionError, StoreError, StoreEvent, SubgraphDeploymentId, ValueType, BLOCK_NUMBER_MAX,
+    anyhow, info, BlockNumber, Entity, EntityChange, EntityCollection, EntityFilter, EntityKey,
+    EntityOrder, EntityRange, EthereumBlockPointer, Logger, QueryExecutionError, StoreError,
+    StoreEvent, SubgraphDeploymentId, ValueType, BLOCK_NUMBER_MAX,
 };
 
 use crate::block_range::BLOCK_RANGE_COLUMN;
@@ -701,19 +701,15 @@ impl Layout {
             let deleted = removed
                 .into_iter()
                 .filter(|id| !unclamped.contains(id))
-                .map(|id| EntityChange::Data {
+                .map(|_| EntityChange::Data {
                     subgraph_id: subgraph_id.clone(),
                     entity_type: table.object.clone(),
-                    entity_id: id,
-                    operation: EntityChangeOperation::Removed,
                 });
             changes.extend(deleted);
             // EntityChange for versions that we just updated or inserted
-            let set = unclamped.into_iter().map(|id| EntityChange::Data {
+            let set = unclamped.into_iter().map(|_| EntityChange::Data {
                 subgraph_id: subgraph_id.clone(),
                 entity_type: table.object.clone(),
-                entity_id: id,
-                operation: EntityChangeOperation::Set,
             });
             changes.extend(set);
         }

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -928,16 +928,10 @@ fn find() {
     });
 }
 
-fn make_entity_change(
-    entity_type: &str,
-    entity_id: &str,
-    op: EntityChangeOperation,
-) -> EntityChange {
+fn make_entity_change(entity_type: &str) -> EntityChange {
     EntityChange::Data {
         subgraph_id: TEST_SUBGRAPH_ID.clone(),
         entity_type: EntityType::new(entity_type.to_owned()),
-        entity_id: entity_id.to_owned(),
-        operation: op,
     }
 }
 
@@ -1052,11 +1046,7 @@ async fn check_basic_revert(
 #[test]
 fn revert_block_basic_user() {
     run_test(|store| async move {
-        let expected = StoreEvent::new(vec![make_entity_change(
-            USER,
-            "3",
-            EntityChangeOperation::Set,
-        )]);
+        let expected = StoreEvent::new(vec![make_entity_change(USER)]);
 
         let count = get_entity_count(store.clone(), &TEST_SUBGRAPH_ID);
         check_basic_revert(store.clone(), expected, &TEST_SUBGRAPH_ID, USER).await;
@@ -1115,11 +1105,7 @@ fn revert_block_with_delete() {
         assert_eq!(&test_value, returned_name.unwrap());
 
         // Check that the subscription notified us of the changes
-        let expected = StoreEvent::new(vec![make_entity_change(
-            USER,
-            "2",
-            EntityChangeOperation::Set,
-        )]);
+        let expected = StoreEvent::new(vec![make_entity_change(USER)]);
 
         // The last event is the one for the reversion
         check_events(subscription, vec![expected]).await
@@ -1176,11 +1162,7 @@ fn revert_block_with_partial_update() {
         assert_eq!(reverted_entity, original_entity);
 
         // Check that the subscription notified us of the changes
-        let expected = StoreEvent::new(vec![make_entity_change(
-            USER,
-            "1",
-            EntityChangeOperation::Set,
-        )]);
+        let expected = StoreEvent::new(vec![make_entity_change(USER)]);
 
         check_events(subscription, vec![expected]).await
     })
@@ -1299,8 +1281,6 @@ fn revert_block_with_dynamic_data_source_operations() {
                 vec![EntityChange::Data {
                     subgraph_id: SubgraphDeploymentId::new("testsubgraph").unwrap(),
                     entity_type: EntityType::new(USER.into()),
-                    entity_id: "1".into(),
-                    operation: EntityChangeOperation::Set,
                 }]
                 .into_iter(),
             ),
@@ -1409,28 +1389,20 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
                 EntityChange::Data {
                     subgraph_id: subgraph_id.clone(),
                     entity_type: user_type.clone(),
-                    entity_id: added_entities[0].clone().0,
-                    operation: EntityChangeOperation::Set,
                 },
                 EntityChange::Data {
                     subgraph_id: subgraph_id.clone(),
                     entity_type: user_type.clone(),
-                    entity_id: added_entities[1].clone().0,
-                    operation: EntityChangeOperation::Set,
                 },
             ]),
             StoreEvent::new(vec![
                 EntityChange::Data {
                     subgraph_id: subgraph_id.clone(),
                     entity_type: user_type.clone(),
-                    entity_id: "1".to_owned(),
-                    operation: EntityChangeOperation::Set,
                 },
                 EntityChange::Data {
                     subgraph_id: subgraph_id.clone(),
                     entity_type: user_type.clone(),
-                    entity_id: added_entities[1].clone().0,
-                    operation: EntityChangeOperation::Removed,
                 },
             ]),
         ];
@@ -1472,11 +1444,7 @@ fn throttle_subscription_delivers() {
         )
         .unwrap();
 
-        let expected = StoreEvent::new(vec![make_entity_change(
-            USER,
-            "4",
-            EntityChangeOperation::Set,
-        )]);
+        let expected = StoreEvent::new(vec![make_entity_change(USER)]);
 
         check_events(subscription, vec![expected]).await
     })


### PR DESCRIPTION
We only pay attention to the EntityType in StoreEvent, but not the entity id or the change operation. This change will significantly reduce the size of notifications that we send.

