### PR TITLE
Log subgraph errors in a single line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
  "thiserror",
  "tokio 1.2.0",
  "tokio-util 0.6.3",
- "url 2.2.0",
+ "url 2.2.1",
  "winapi 0.3.9",
 ]
 

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -494,7 +494,7 @@ where
                         logger,
                         "Reverting block to get back to main chain";
                         "block_number" => format!("{}", subgraph_ptr.number),
-                        "block_hash" => format!("{}", subgraph_ptr.hash_as_h256())
+                        "block_hash" => format!("{}", subgraph_ptr.hash)
                     );
 
                     // We would like to revert the DB state to the parent of the current block.
@@ -627,16 +627,17 @@ where
 
                 // Handle unexpected stream errors by marking the subgraph as failed.
                 Err(e) => {
+                    let message = format!("{:#}", e).replace("\n", "\t");
                     error!(
                         &logger,
-                        "Subgraph instance failed to run: {}", e;
+                        "Subgraph instance failed to run: {}", message;
                         "id" => id_for_err.to_string(),
                         "code" => LogCode::SubgraphSyncingFailure
                     );
 
                     let error = SubgraphError {
                         subgraph_id: id_for_err.clone(),
-                        message: e.to_string(),
+                        message,
                         block_ptr: Some(block_ptr),
                         handler: None,
                         deterministic: e.is_deterministic(),
@@ -705,7 +706,7 @@ where
     let block_ptr = EthereumBlockPointer::from(&block);
     let logger = logger.new(o!(
         "block_number" => format!("{:?}", block_ptr.number),
-        "block_hash" => format!("{:?}", block_ptr.hash)
+        "block_hash" => format!("{}", block_ptr.hash)
     ));
 
     if triggers.len() == 1 {
@@ -923,8 +924,9 @@ where
 
     let err_count = block_state.deterministic_errors.len();
     for (i, e) in block_state.deterministic_errors.iter().enumerate() {
+        let message = format!("{:#}", e).replace("\n", "\t");
         error!(&logger, "Subgraph error {}/{}", i + 1, err_count;
-            "error" => e.to_string(),
+            "error" => message,
             "code" => LogCode::SubgraphSyncingFailure
         );
     }

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -3,7 +3,7 @@ use ethabi::LogParam;
 use serde::{Deserialize, Serialize};
 use stable_hash::prelude::*;
 use stable_hash::utils::AsBytes;
-use std::fmt::Write;
+use std::fmt::{Display, Write};
 use std::{cmp::Ordering, convert::TryFrom};
 use std::{fmt, str::FromStr};
 use web3::types::{
@@ -416,6 +416,12 @@ pub struct BlockHash(pub Box<[u8]>);
 impl From<H256> for BlockHash {
     fn from(hash: H256) -> Self {
         BlockHash(hash.as_bytes().into())
+    }
+}
+
+impl Display for BlockHash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "0x{}", hex::encode(&self.0))
     }
 }
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -242,15 +242,17 @@ impl WasmInstance {
         };
 
         if let Some(deterministic_error) = deterministic_error {
+            let message = format!("{:#}", deterministic_error).replace("\n", "\t");
+
             // Log the error and restore the updates snapshot, effectively reverting the handler.
             error!(&self.instance_ctx().ctx.logger,
                 "Handler skipped due to execution failure";
                 "handler" => handler,
-                "error" => format!("{:#}", deterministic_error)
+                "error" => &message,
             );
             let subgraph_error = SubgraphError {
                 subgraph_id: self.instance_ctx().ctx.host_exports.subgraph_id.clone(),
-                message: format!("{:#}", deterministic_error),
+                message,
                 block_ptr: Some(self.instance_ctx().ctx.block.block_ptr()),
                 handler: Some(handler.to_string()),
                 deterministic: true,

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -593,7 +593,7 @@ impl Layout {
                 return;
             }
 
-            let mut text = debug_query(&query).to_string().replace("\n", " ");
+            let mut text = debug_query(&query).to_string().replace("\n", "\t");
             // If the query + bind variables is more than MAXLEN, truncate it;
             // this will happen when queries have very large bind variables
             // (e.g., long arrays of string ids)


### PR DESCRIPTION
Stacktraces look nicer on separate lines, but that messes with how we sort logs based on the id tag. Not sure why this only became a problem now, maybe a slog dependency bump changed something.

Also log block hashes as hex strings.