### PR TITLE
Set up foreign data wrappers for cross-shard communication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
- "memchr 2.3.4",
+ "memchr",
 ]
 
 [[package]]
@@ -152,22 +152,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
-dependencies = [
- "byteorder",
- "safemem 0.2.0",
-]
-
-[[package]]
-name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 dependencies = [
  "byteorder",
- "safemem 0.3.3",
+ "safemem",
 ]
 
 [[package]]
@@ -238,10 +228,10 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
 dependencies = [
- "byte-tools 0.3.1",
+ "byte-tools",
  "crypto-mac 0.7.0",
  "digest 0.8.1",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -272,24 +262,23 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
-dependencies = [
- "arrayref",
- "byte-tools 0.2.0",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding",
- "byte-tools 0.3.1",
+ "byte-tools",
  "byteorder",
  "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -298,7 +287,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
- "byte-tools 0.3.1",
+ "byte-tools",
 ]
 
 [[package]]
@@ -315,7 +304,7 @@ dependencies = [
  "dirs-next",
  "futures-core",
  "futures-util",
- "hex 0.4.3",
+ "hex",
  "http 0.2.1",
  "hyper 0.14.4",
  "hyper-unix-connector",
@@ -361,7 +350,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
 dependencies = [
- "memchr 2.3.4",
+ "memchr",
 ]
 
 [[package]]
@@ -375,12 +364,6 @@ name = "byte-slice-cast"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
-
-[[package]]
-name = "byte-tools"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 
 [[package]]
 name = "byte-tools"
@@ -505,7 +488,7 @@ dependencies = [
  "ascii",
  "byteorder",
  "either",
- "memchr 2.3.4",
+ "memchr",
  "unreachable",
 ]
 
@@ -561,6 +544,12 @@ name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "cranelift-bforest"
@@ -802,16 +791,6 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
-dependencies = [
- "constant_time_eq",
- "generic-array 0.9.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
@@ -825,6 +804,16 @@ name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.3.0",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array 0.14.4",
  "subtle 2.3.0",
@@ -1025,15 +1014,6 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
-name = "digest"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
-dependencies = [
- "generic-array 0.9.0",
-]
 
 [[package]]
 name = "digest"
@@ -1502,7 +1482,7 @@ dependencies = [
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr 2.3.4",
+ "memchr",
  "pin-project-lite 0.2.6",
  "pin-utils",
  "proc-macro-hack",
@@ -1515,15 +1495,6 @@ name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
-name = "generic-array"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "generic-array"
@@ -1553,6 +1524,17 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1630,7 +1612,7 @@ dependencies = [
  "futures 0.1.30",
  "futures 0.3.13",
  "graphql-parser",
- "hex 0.4.3",
+ "hex",
  "http 0.2.1",
  "isatty",
  "lazy_static",
@@ -1716,7 +1698,7 @@ dependencies = [
  "graph-graphql",
  "graph-mock",
  "graphql-parser",
- "hex 0.4.3",
+ "hex",
  "ipfs-api",
  "lazy_static",
  "lru_time_cache",
@@ -1825,7 +1807,7 @@ dependencies = [
  "graph-mock",
  "graph-runtime-derive",
  "graphql-parser",
- "hex 0.4.3",
+ "hex",
  "ipfs-api",
  "lazy_static",
  "never",
@@ -1923,7 +1905,7 @@ dependencies = [
  "graph-graphql",
  "graph-mock",
  "graphql-parser",
- "hex 0.4.3",
+ "hex",
  "hex-literal",
  "lazy_static",
  "lru_time_cache",
@@ -2040,12 +2022,6 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
-
-[[package]]
-name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
@@ -2058,12 +2034,12 @@ checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 
 [[package]]
 name = "hmac"
-version = "0.5.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac 0.5.2",
- "digest 0.7.6",
+ "crypto-mac 0.10.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -2290,7 +2266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24ef1fd95d34b4ff007d3f0590727b5cf33572cace09b42032fc817dc8b16557"
 dependencies = [
  "anyhow",
- "hex 0.4.3",
+ "hex",
  "hyper 0.14.4",
  "pin-project 1.0.5",
  "tokio 1.2.0",
@@ -2643,18 +2619,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "md5"
-version = "0.3.8"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
-
-[[package]]
-name = "memchr"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
-dependencies = [
- "libc",
-]
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -2867,7 +2834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "lexical-core",
- "memchr 2.3.4",
+ "memchr",
  "version_check 0.9.2",
 ]
 
@@ -2955,6 +2922,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -3159,18 +3132,18 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.7.24"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.7.24"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 dependencies = [
  "siphasher",
 ]
@@ -3247,46 +3220,44 @@ checksum = "f6519412c9e0d4be579b9f0618364d19cb434b324fc6ddb1b27b1e682c7105ed"
 
 [[package]]
 name = "postgres"
-version = "0.15.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115dde90ef51af573580c035857badbece2aa5cde3de1dfb3c932969ca92a6c5"
+checksum = "0f853fba627ed1f21392d329eeb03caf90dce57a65dfbd24274f4c39452ed3bb"
 dependencies = [
- "bytes 0.4.12",
- "fallible-iterator 0.1.6",
+ "bytes 1.0.1",
+ "fallible-iterator 0.2.0",
+ "futures 0.3.13",
  "log 0.4.11",
- "postgres-protocol",
- "postgres-shared",
- "socket2",
+ "tokio 1.2.0",
+ "tokio-postgres",
 ]
 
 [[package]]
 name = "postgres-protocol"
-version = "0.3.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2487e66455bf88a1b247bf08a3ce7fe5197ac6d67228d920b0ee6a0e97fd7312"
+checksum = "70e34ad3dc5c56d036b9418185ee97e14b6766d55c8ccf9dc18302ad4e6371d9"
 dependencies = [
- "base64 0.6.0",
+ "base64 0.13.0",
  "byteorder",
- "bytes 0.4.12",
- "fallible-iterator 0.1.6",
- "generic-array 0.9.0",
+ "bytes 1.0.1",
+ "fallible-iterator 0.2.0",
  "hmac",
  "md5",
- "memchr 1.0.2",
- "rand 0.3.23",
- "sha2 0.7.1",
+ "memchr",
+ "rand 0.8.3",
+ "sha2 0.9.3",
  "stringprep",
 ]
 
 [[package]]
-name = "postgres-shared"
-version = "0.4.2"
+name = "postgres-types"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffac35b3e0029b404c24a3b82149b4e904f293e8ca4a327eefa24d3ca50df36f"
+checksum = "5493d9d4613b88b12433aa12890e74e74cd93fdc1e08b7c2aed4768aaae8414c"
 dependencies = [
- "fallible-iterator 0.1.6",
- "hex 0.2.0",
- "phf",
+ "bytes 1.0.1",
+ "fallible-iterator 0.2.0",
  "postgres-protocol",
 ]
 
@@ -3432,7 +3403,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
- "memchr 2.3.4",
+ "memchr",
  "parking_lot 0.11.1",
  "protobuf",
  "thiserror",
@@ -3496,16 +3467,6 @@ checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -3555,11 +3516,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -3583,6 +3556,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,7 +3586,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -3622,6 +3614,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -3734,7 +3735,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "redox_syscall",
  "rust-argon2",
 ]
@@ -3757,7 +3758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "aho-corasick",
- "memchr 2.3.4",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -3897,12 +3898,6 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "safemem"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 
 [[package]]
 name = "safemem"
@@ -4151,7 +4146,7 @@ dependencies = [
  "block-buffer 0.7.3",
  "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -4162,18 +4157,6 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
-dependencies = [
- "block-buffer 0.3.3",
- "byte-tools 0.2.0",
- "digest 0.7.6",
- "fake-simd",
-]
-
-[[package]]
-name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
@@ -4181,7 +4164,20 @@ dependencies = [
  "block-buffer 0.7.3",
  "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -4191,10 +4187,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
 dependencies = [
  "block-buffer 0.7.3",
- "byte-tools 0.3.1",
+ "byte-tools",
  "digest 0.8.1",
  "keccak",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -4217,9 +4213,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.2.3"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 
 [[package]]
 name = "slab"
@@ -4666,7 +4662,7 @@ dependencies = [
  "iovec",
  "lazy_static",
  "libc",
- "memchr 2.3.4",
+ "memchr",
  "mio 0.6.22",
  "mio-uds",
  "num_cpus",
@@ -4684,7 +4680,7 @@ dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
  "libc",
- "memchr 2.3.4",
+ "memchr",
  "mio 0.7.9",
  "num_cpus",
  "once_cell",
@@ -4797,6 +4793,29 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.62",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc9f82c2bfb06a33dd0dfb44b07ca98fe72df19e681d80c78d05a1bac2138e2"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes 1.0.1",
+ "fallible-iterator 0.2.0",
+ "futures 0.3.13",
+ "log 0.4.11",
+ "parking_lot 0.11.1",
+ "percent-encoding 2.1.0",
+ "phf",
+ "pin-project-lite 0.2.6",
+ "postgres-protocol",
+ "postgres-types",
+ "socket2",
+ "tokio 1.2.0",
+ "tokio-util 0.6.3",
 ]
 
 [[package]]

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -204,7 +204,7 @@ async fn main() {
     let expensive_queries = read_expensive_queries().unwrap();
 
     let store_builder =
-        StoreBuilder::new(&logger, &node_id, &config, metrics_registry.cheap_clone());
+        StoreBuilder::new(&logger, &node_id, &config, metrics_registry.cheap_clone()).await;
 
     graph::spawn(
         futures::stream::FuturesOrdered::from_iter(stores_eth_networks.flatten().into_iter().map(

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -23,7 +23,7 @@ Inflector = "0.11.3"
 lazy_static = "1.1"
 lru_time_cache = "0.11"
 maybe-owned = "0.3.4"
-postgres = "0.15.2"
+postgres = "0.19.0"
 rand = "0.6.1"
 serde = "1.0"
 uuid = { version = "0.8.1", features = ["v4"] }

--- a/store/postgres/migrations/2021-03-11-010830_fdw/down.sql
+++ b/store/postgres/migrations/2021-03-11-010830_fdw/down.sql
@@ -1,0 +1,1 @@
+drop extension postgres_fdw;

--- a/store/postgres/migrations/2021-03-11-010830_fdw/up.sql
+++ b/store/postgres/migrations/2021-03-11-010830_fdw/up.sql
@@ -1,0 +1,1 @@
+create extension if not exists postgres_fdw;

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -1,6 +1,6 @@
-use diesel::pg::PgConnection;
 use diesel::prelude::RunQueryDsl;
 use diesel::sql_types::Text;
+use diesel::{pg::PgConnection, sql_query};
 use std::collections::{HashMap, HashSet};
 
 use graph::{data::subgraph::schema::POI_TABLE, prelude::StoreError};
@@ -89,4 +89,17 @@ pub fn supports_proof_of_indexing(
         .bind::<Text, _>(POI_TABLE)
         .load(conn)?;
     Ok(result.len() > 0)
+}
+
+pub fn current_servers(conn: &PgConnection) -> Result<Vec<String>, StoreError> {
+    #[derive(QueryableByName)]
+    struct Srv {
+        #[sql_type = "Text"]
+        srvname: String,
+    }
+    Ok(sql_query("select srvname from pg_foreign_server")
+        .get_results::<Srv>(conn)?
+        .into_iter()
+        .map(|srv| srv.srvname)
+        .collect())
 }

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -12,6 +12,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{collections::HashMap, sync::RwLock};
 
+//use postgres::config::Config;
+
 #[derive(Clone)]
 pub struct ConnectionPool {
     logger: Logger,

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -1,10 +1,9 @@
 use crate::functions::pg_notify;
 use diesel::pg::PgConnection;
 use diesel::select;
-use fallible_iterator::FallibleIterator;
 use lazy_static::lazy_static;
-use postgres::notification::Notification;
-use postgres::{Connection, TlsMode};
+use postgres::Notification;
+use postgres::{fallible_iterator::FallibleIterator, Client, NoTls};
 use std::env;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -123,11 +122,11 @@ impl NotificationListener {
             // We exit the process on panic so unwind safety is irrelevant.
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
                 // Connect to Postgres
-                let conn = Connection::connect(postgres_url, TlsMode::None)
+                let mut conn = Client::connect(postgres_url.as_str(), NoTls)
                     .expect("failed to connect notification listener to Postgres");
 
                 // Subscribe to the notification channel in Postgres
-                conn.execute(&format!("LISTEN {}", channel_name.0), &[])
+                conn.execute(format!("LISTEN {}", channel_name.0).as_str(), &[])
                     .expect("failed to listen to Postgres notifications");
 
                 // Wait until the listener has been started
@@ -135,11 +134,13 @@ impl NotificationListener {
 
                 // Read notifications until the thread is to be terminated
                 while !terminate.load(Ordering::SeqCst) {
-                    // Obtain a notifications iterator from Postgres
-                    let notifications = conn.notifications();
-
-                    // Read notifications until there hasn't been one for 500ms
-                    for notification in notifications
+                    // Obtain pending notifications from Postgres. We load
+                    // them all into memory, since for large notifications
+                    // we need to query the database again; avoiding this
+                    // load would require that we use a second database
+                    // connection to look up large notifications
+                    let notifications: Vec<_> = conn
+                        .notifications()
                         .timeout_iter(Duration::from_millis(500))
                         .iterator()
                         .filter_map(|item| match item {
@@ -149,20 +150,23 @@ impl NotificationListener {
                                 crit!(logger, "Error receiving message"; "error" => &msg);
                                 eprintln!(
                                     "Connection to Postgres lost while listening for events. \
-                                 Aborting to avoid inconsistent state. ({})",
+                             Aborting to avoid inconsistent state. ({})",
                                     msg
                                 );
                                 std::process::abort();
                             }
                         })
-                        .filter(|notification| notification.channel == channel_name.0)
-                    {
+                        .filter(|notification| notification.channel() == channel_name.0)
+                        .collect();
+
+                    // Read notifications until there hasn't been one for 500ms
+                    for notification in notifications {
                         // Terminate the thread if desired
                         if terminate.load(Ordering::SeqCst) {
                             break;
                         }
 
-                        match JsonNotification::parse(&notification, &conn) {
+                        match JsonNotification::parse(&notification, &mut conn) {
                             Ok(json_notification) => {
                                 // We'll assume here that if sending fails, this means that the
                                 // listener has already been dropped, the receiving
@@ -245,9 +249,9 @@ static LARGE_NOTIFICATION_THRESHOLD: usize = 7800;
 impl JsonNotification {
     pub fn parse(
         notification: &Notification,
-        conn: &Connection,
+        conn: &mut Client,
     ) -> Result<JsonNotification, StoreError> {
-        let value = serde_json::from_str(&notification.payload)?;
+        let value = serde_json::from_str(&notification.payload())?;
 
         match value {
             serde_json::Value::Number(n) => {
@@ -276,20 +280,20 @@ impl JsonNotification {
                         )
                     })?;
 
-                if payload_rows.is_empty() || payload_rows.get(0).is_empty() {
+                if payload_rows.is_empty() || payload_rows.get(0).is_none() {
                     return Err(anyhow!("No payload found for notification {}", payload_id))?;
                 }
-                let payload: String = payload_rows.get(0).get(0);
+                let payload: String = payload_rows.get(0).unwrap().get(0);
 
                 Ok(JsonNotification {
-                    process_id: notification.process_id,
-                    channel: notification.channel.clone(),
+                    process_id: notification.process_id(),
+                    channel: notification.channel().to_string(),
                     payload: serde_json::from_str(&payload)?,
                 })
             }
             serde_json::Value::Object(_) => Ok(JsonNotification {
-                process_id: notification.process_id,
-                channel: notification.channel.clone(),
+                process_id: notification.process_id(),
+                channel: notification.channel().to_string(),
                 payload: value,
             }),
             _ => Err(anyhow!("JSON notifications must be numbers or objects"))?,

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -443,7 +443,7 @@ fn build_store() -> (Arc<Store>, ConnectionPool, Config, Arc<SubscriptionManager
     let registry = Arc::new(MockMetricsRegistry::new());
     std::thread::spawn(move || {
         STORE_RUNTIME.lock().unwrap().block_on(async {
-            let builder = StoreBuilder::new(&*LOGGER, &*NODE_ID, &config, registry);
+            let builder = StoreBuilder::new(&*LOGGER, &*NODE_ID, &config, registry).await;
             let subscription_manager = builder.subscription_manager();
             let primary_pool = builder.primary_pool();
 


### PR DESCRIPTION
This PR sets up foreign data wrappers for cross-shard communication. For now, this doesn't do much other than expose `deployment_schemas` and `chains` in other shards, but using them will be important for cross-shard grafting and copying which will happen in future PR's.