### PR TITLE
Change how subgraph_deployment is organized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "81cddc5f91628367664cc7c69714ff08deee8a3efc54623011c772544d7b2767"
 
 [[package]]
 name = "arc-swap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.41"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cddc5f91628367664cc7c69714ff08deee8a3efc54623011c772544d7b2767"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "arc-swap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
+checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
 dependencies = [
  "lazy_static",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,9 +4857,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1981ad97df782ab506a1f43bf82c967326960d278acf3bf8279809648c3ff3ea"
+checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,10 +927,11 @@ checksum = "647605a6345d5e89c3950a36a638c56478af9b414c55c6f2477c73b115f9acde"
 
 [[package]]
 name = "derive_more"
-version = "0.99.11"
+version = "0.99.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
+checksum = "f82b1b72f1263f214c0f823371768776c4f5841b942c9883aa8e5ec584fd0ba6"
 dependencies = [
+ "convert_case",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.62",

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -12,7 +12,7 @@ graph = { path = "../../graph" }
 lazy_static = "1.2.0"
 state_machine_future = "0.2"
 serde = "1.0"
-config = { version = "0.10", features = ["toml"], default-features = false }
+config = { version = "0.11", features = ["toml"], default-features = false }
 dirs = "3.0"
 anyhow = "1.0"
 fail = "0.4"

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -77,7 +77,7 @@ where
             }),
         );
 
-        let logger = logger.new(o!("network_name" => network_name.clone()));
+        let logger = logger.new(o!("provider" => eth_adapter.provider().to_string()));
 
         Ok(BlockIngestor {
             chain_store,

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -34,6 +34,7 @@ use web3::types::Filter;
 pub struct EthereumAdapter<T: web3::Transport> {
     logger: Logger,
     url_hostname: Arc<String>,
+    provider: String,
     web3: Arc<Web3<T>>,
     metrics: Arc<ProviderEthRpcMetrics>,
     is_ganache: bool,
@@ -87,6 +88,7 @@ impl<T: web3::Transport> CheapClone for EthereumAdapter<T> {
     fn cheap_clone(&self) -> Self {
         Self {
             logger: self.logger.clone(),
+            provider: self.provider.clone(),
             url_hostname: self.url_hostname.cheap_clone(),
             web3: self.web3.cheap_clone(),
             metrics: self.metrics.cheap_clone(),
@@ -103,6 +105,7 @@ where
 {
     pub async fn new(
         logger: Logger,
+        provider: String,
         url: &str,
         transport: T,
         provider_metrics: Arc<ProviderEthRpcMetrics>,
@@ -128,6 +131,7 @@ where
 
         EthereumAdapter {
             logger,
+            provider,
             url_hostname: Arc::new(hostname),
             web3,
             metrics: provider_metrics,
@@ -627,6 +631,10 @@ where
 {
     fn url_hostname(&self) -> &str {
         &self.url_hostname
+    }
+
+    fn provider(&self) -> &str {
+        &self.provider
     }
 
     fn net_identifiers(

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.22.0"
 edition = "2018"
 
 [dependencies]
-async-trait = "0.1.41"
+async-trait = "0.1.48"
 atomic_refcell = "0.1.6"
 bytes = "0.5"
 futures01 = { package="futures", version="0.1.29" }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,7 +76,7 @@ RUN apt-get update \
  && apt-get install -y libpq-dev ca-certificates netcat
 
 ADD docker/wait_for docker/start /usr/local/bin/
-COPY --from=graph-node-build /usr/local/cargo/bin/graph-node /usr/local/cargo/bin/graphman /usr/local/bin
+COPY --from=graph-node-build /usr/local/cargo/bin/graph-node /usr/local/cargo/bin/graphman /usr/local/bin/
 COPY --from=graph-node-build /etc/image-info /etc/image-info
 COPY docker/Dockerfile /Dockerfile
 CMD start

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1.41"
+async-trait = "0.1.48"
 atomic_refcell = "0.1.6"
 bigdecimal = { version = "0.1.0", features = ["serde"] }
 bytes = "0.5"

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -596,6 +596,9 @@ impl BlockStreamMetrics {
 pub trait EthereumAdapter: Send + Sync + 'static {
     fn url_hostname(&self) -> &str;
 
+    /// The `provider.label` from the adapter's configuration
+    fn provider(&self) -> &str;
+
     /// Ask the Ethereum node for some identifying information about the Ethereum network it is
     /// connected to.
     fn net_identifiers(

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -593,6 +593,7 @@ impl BlockStreamMetrics {
 /// Implementations may be implemented against an in-process Ethereum node
 /// or a remote node over RPC.
 #[automock]
+#[async_trait]
 pub trait EthereumAdapter: Send + Sync + 'static {
     fn url_hostname(&self) -> &str;
 
@@ -601,9 +602,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
 
     /// Ask the Ethereum node for some identifying information about the Ethereum network it is
     /// connected to.
-    fn net_identifiers(
-        &self,
-    ) -> Box<dyn Future<Item = EthereumNetworkIdentifier, Error = Error> + Send>;
+    async fn net_identifiers(&self) -> Result<EthereumNetworkIdentifier, Error>;
 
     /// Get the latest block, including full transactions.
     fn latest_block(

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -19,7 +19,7 @@ use crate::prelude::*;
 
 pub type EventSignature = H256;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 /// A collection of attributes that (kind of) uniquely identify an Ethereum blockchain.
 pub struct EthereumNetworkIdentifier {
     pub net_version: String,

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -600,7 +600,6 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     /// connected to.
     fn net_identifiers(
         &self,
-        logger: &Logger,
     ) -> Box<dyn Future<Item = EthereumNetworkIdentifier, Error = Error> + Send>;
 
     /// Get the latest block, including full transactions.

--- a/graph/src/log/elastic.rs
+++ b/graph/src/log/elastic.rs
@@ -208,7 +208,7 @@ impl ElasticDrain {
                         return;
                     }
 
-                    trace!(
+                    debug!(
                         flush_logger,
                         "Flushing {} logs to Elasticsearch",
                         logs_to_send.len()
@@ -371,7 +371,7 @@ impl Drain for ElasticDrain {
 pub fn elastic_logger(config: ElasticDrainConfig, error_logger: Logger) -> Logger {
     let elastic_drain = ElasticDrain::new(config, error_logger).fuse();
     let async_drain = slog_async::Async::new(elastic_drain)
-        .chan_size(10000)
+        .chan_size(20000)
         .build()
         .fuse();
     Logger::root(async_drain, o!())

--- a/graph/src/log/mod.rs
+++ b/graph/src/log/mod.rs
@@ -51,7 +51,7 @@ pub fn logger(show_debug: bool) -> Logger {
         )
         .build();
     let drain = slog_async::Async::new(drain)
-        .chan_size(10000)
+        .chan_size(20000)
         .build()
         .fuse();
     Logger::root(drain, o!())

--- a/graph/src/log/split.rs
+++ b/graph/src/log/split.rs
@@ -70,7 +70,7 @@ where
 {
     let split_drain = SplitDrain::new(drain1.fuse(), drain2.fuse()).fuse();
     let async_drain = slog_async::Async::new(split_drain)
-        .chan_size(10000)
+        .chan_size(20000)
         .build()
         .fuse();
     Logger::root(async_drain, o!())

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -501,7 +501,7 @@ async fn create_ethereum_networks(
         for provider in chain.providers {
             let capabilities = provider.node_capabilities();
 
-            let logger = logger.new(o!("provider" => provider.label));
+            let logger = logger.new(o!("provider" => provider.label.clone()));
             info!(
                 logger,
                 "Creating transport";
@@ -527,6 +527,7 @@ async fn create_ethereum_networks(
                 Arc::new(
                     graph_chain_ethereum::EthereumAdapter::new(
                         logger,
+                        provider.label,
                         &provider.url,
                         transport,
                         eth_rpc_metrics.clone(),

--- a/node/src/manager/commands/listen.rs
+++ b/node/src/manager/commands/listen.rs
@@ -1,0 +1,63 @@
+use std::io::Write;
+use std::sync::Arc;
+
+use futures::compat::Future01CompatExt;
+//use futures::future;
+use graph::{
+    components::store::{EntityType, SubscriptionManager as _},
+    prelude::{anyhow, serde_json, Error, Stream, SubgraphDeploymentId, SubscriptionFilter},
+};
+use graph_store_postgres::SubscriptionManager;
+
+async fn listen(
+    mgr: Arc<SubscriptionManager>,
+    filter: Vec<SubscriptionFilter>,
+) -> Result<(), Error> {
+    let events = mgr.subscribe(filter);
+    println!("press ctrl-c to stop");
+    let res = events
+        .inspect(move |event| {
+            serde_json::to_writer_pretty(std::io::stdout(), event)
+                .expect("event can be serialized to JSON");
+            writeln!(std::io::stdout(), "").unwrap();
+            std::io::stdout().flush().unwrap();
+        })
+        .collect()
+        .compat()
+        .await;
+
+    match res {
+        Ok(_) => {
+            println!("stream finished")
+        }
+        Err(()) => {
+            eprintln!("stream failed")
+        }
+    }
+    Ok(())
+}
+
+pub async fn assignments(mgr: Arc<SubscriptionManager>) -> Result<(), Error> {
+    println!("waiting for assignment events");
+    listen(mgr, vec![SubscriptionFilter::Assignment]).await?;
+
+    Ok(())
+}
+
+pub async fn entities(
+    mgr: Arc<SubscriptionManager>,
+    deployment: String,
+    entity_types: Vec<String>,
+) -> Result<(), Error> {
+    let deployment = SubgraphDeploymentId::new(deployment)
+        .map_err(|s| anyhow!("illegal deployment hash `{}`", s))?;
+    let filter: Vec<_> = entity_types
+        .into_iter()
+        .map(|et| SubscriptionFilter::Entities(deployment.clone(), EntityType::new(et)))
+        .collect();
+
+    println!("waiting for store events from {}", deployment);
+    listen(mgr, filter).await?;
+
+    Ok(())
+}

--- a/node/src/manager/commands/mod.rs
+++ b/node/src/manager/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod assign;
 pub mod config;
 pub mod info;
+pub mod listen;
 pub mod remove;
 pub mod txn_speed;
 pub mod unused_deployments;

--- a/node/src/manager/commands/unused_deployments.rs
+++ b/node/src/manager/commands/unused_deployments.rs
@@ -58,7 +58,11 @@ pub fn record(store: Arc<SubgraphStore>) -> Result<(), Error> {
     let recorded = store.record_unused_deployments()?;
 
     for deployment in store.list_unused_deployments(unused::Filter::New)? {
-        if recorded.iter().find(|r| r.id == deployment.id).is_some() {
+        if recorded
+            .iter()
+            .find(|r| r.deployment == deployment.id)
+            .is_some()
+        {
             add_row(&mut list, deployment);
         }
     }

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -202,7 +202,7 @@ impl StoreBuilder {
     /// and a `BlockStore` for all chain related data
     pub fn network_store(
         self,
-        networks: Vec<(String, Option<EthereumNetworkIdentifier>)>,
+        networks: Vec<(String, Vec<EthereumNetworkIdentifier>)>,
     ) -> Arc<DieselStore> {
         let chain_head_update_listener = Arc::new(PostgresChainHeadUpdateListener::new(
             &self.logger,

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -202,7 +202,7 @@ impl StoreBuilder {
     /// and a `BlockStore` for all chain related data
     pub fn network_store(
         self,
-        networks: Vec<(String, EthereumNetworkIdentifier)>,
+        networks: Vec<(String, Option<EthereumNetworkIdentifier>)>,
     ) -> Arc<DieselStore> {
         let chain_head_update_listener = Arc::new(PostgresChainHeadUpdateListener::new(
             &self.logger,

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.22.0"
 edition = "2018"
 
 [dependencies]
-async-trait = "0.1.41"
+async-trait = "0.1.48"
 atomic_refcell = "0.1.6"
 ethabi = { git = "https://github.com/graphprotocol/ethabi.git", branch = "master" }
 futures = "0.1.21"

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -780,9 +780,13 @@ impl WasmInstanceContext {
         id_ptr: AscPtr<AscString>,
         data_ptr: AscPtr<AscEntity>,
     ) -> Result<(), HostExportError> {
+        let stopwatch = &self.host_metrics.stopwatch;
+        stopwatch.start_section("host_export_store_set__wasm_instance_context_store_set");
+
         let entity = self.asc_get(entity_ptr)?;
         let id = self.asc_get(id_ptr)?;
         let data = self.try_asc_get(data_ptr)?;
+
         self.ctx.host_exports.store_set(
             &self.ctx.logger,
             &mut self.ctx.state,
@@ -790,6 +794,7 @@ impl WasmInstanceContext {
             entity,
             id,
             data,
+            stopwatch,
         )?;
         Ok(())
     }

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -439,6 +439,11 @@ impl WasmInstance {
 
                     // Happens when calling a host fn in Wasm start.
                     if instance.is_none() {
+                        error!(
+                            ctx.borrow().as_ref().unwrap().logger,
+                            "contract calls in globals are deprecated"
+                        );
+
                         *instance = Some(
                             WasmInstanceContext::from_caller(
                                 caller,

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.22.0"
 edition = "2018"
 
 [dependencies]
-async-trait = "0.1.41"
+async-trait = "0.1.48"
 blake3 = "0.3.7"
 derive_more = { version = "0.99.13" }
 diesel = { version = "1.4.6", features = ["postgres", "serde_json", "numeric", "r2d2"] }

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.41"
 blake3 = "0.3.7"
-derive_more = { version = "0.99.11" }
+derive_more = { version = "0.99.13" }
 diesel = { version = "1.4.6", features = ["postgres", "serde_json", "numeric", "r2d2"] }
 # We use diesel-dynamic-schema straight from git as the project has not
 # made a release as a crate yet

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -150,6 +150,7 @@ pub fn main() {
         "Failed to construct catalog",
     );
     let site = Site {
+        id: 1,
         deployment: subgraph,
         shard: PRIMARY_SHARD.clone(),
         namespace: namespace,

--- a/store/postgres/migrations/2021-03-11-231340_subgraph_deployment_changes/down.sql
+++ b/store/postgres/migrations/2021-03-11-231340_subgraph_deployment_changes/down.sql
@@ -1,0 +1,5 @@
+do $$
+begin
+  raise 'This migration is irreversible';
+end
+$$;

--- a/store/postgres/migrations/2021-03-11-231340_subgraph_deployment_changes/up.sql
+++ b/store/postgres/migrations/2021-03-11-231340_subgraph_deployment_changes/up.sql
@@ -1,0 +1,6 @@
+alter table subgraphs.subgraph_deployment
+      drop column block_range;
+alter table subgraphs.subgraph_deployment
+      rename column id to deployment;
+alter table subgraphs.subgraph_deployment
+      add column id int;

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -1312,8 +1312,8 @@ impl ChainStoreTrait for ChainStore {
                   from subgraphs.subgraph_deployment d,
                        subgraphs.subgraph_deployment_assignment a,
                        deployment_schemas ds
-                 where ds.subgraph = d.id
-                   and a.id = d.id
+                 where ds.subgraph = d.deployment
+                   and a.id = d.deployment
                    and not d.failed
                    and ds.network = $2) a;";
         let ancestor_count = i32::try_from(ancestor_count)

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -310,17 +310,20 @@ impl DeploymentStore {
                 }
             }
         }
+
         // apply modification groups
         for (entity_type, entities) in inserts.iter_mut() {
-            count += self.insert_entities(entity_type, entities, conn, layout, ptr, &stopwatch)?;
+            count +=
+                self.insert_entities(entity_type, entities, conn, layout, ptr, &stopwatch)? as i32
         }
         for (entity_type, entities) in overwrites.iter_mut() {
-            count +=
-                self.overwrite_entities(entity_type, entities, conn, layout, ptr, &stopwatch)?;
+            // not updating count since the number of entities remains the same
+            self.overwrite_entities(entity_type, entities, conn, layout, ptr, &stopwatch)?;
         }
         for (entity_type, entity_keys) in removals.into_iter() {
-            count +=
-                self.remove_entities(entity_type, entity_keys, conn, layout, ptr, &stopwatch)?;
+            count -=
+                self.remove_entities(entity_type, entity_keys, conn, layout, ptr, &stopwatch)?
+                    as i32;
         }
         Ok(count)
     }
@@ -333,7 +336,7 @@ impl DeploymentStore {
         layout: &Layout,
         ptr: &EthereumBlockPointer,
         stopwatch: &StopwatchMetrics,
-    ) -> Result<i32, StoreError> {
+    ) -> Result<usize, StoreError> {
         let section = stopwatch.start_section("check_interface_entity_uniqueness");
         for (key, _) in data.iter() {
             // WARNING: This will potentially execute 2 queries for each entity key.
@@ -342,9 +345,7 @@ impl DeploymentStore {
         section.end();
 
         let _section = stopwatch.start_section("apply_entity_modifications_insert");
-        layout
-            .insert(conn, entity_type, data, block_number(ptr))
-            .map(|_| 1)
+        layout.insert(conn, entity_type, data, block_number(ptr))
     }
 
     fn overwrite_entities(
@@ -355,7 +356,7 @@ impl DeploymentStore {
         layout: &Layout,
         ptr: &EthereumBlockPointer,
         stopwatch: &StopwatchMetrics,
-    ) -> Result<i32, StoreError> {
+    ) -> Result<usize, StoreError> {
         let section = stopwatch.start_section("check_interface_entity_uniqueness");
         for (key, _) in data.iter() {
             // WARNING: This will potentially execute 2 queries for each entity key.
@@ -364,9 +365,7 @@ impl DeploymentStore {
         section.end();
 
         let _section = stopwatch.start_section("apply_entity_modifications_update");
-        layout
-            .update(conn, entity_type, data, block_number(ptr))
-            .map(|_| 0)
+        layout.update(conn, entity_type, data, block_number(ptr))
     }
 
     fn remove_entities(
@@ -377,12 +376,10 @@ impl DeploymentStore {
         layout: &Layout,
         ptr: &EthereumBlockPointer,
         stopwatch: &StopwatchMetrics,
-    ) -> Result<i32, StoreError> {
+    ) -> Result<usize, StoreError> {
         let _section = stopwatch.start_section("apply_entity_modifications_delete");
         layout
             .delete(conn, entity_type, &entity_keys, block_number(ptr))
-            // This conversion is ok since n will only be 0 or 1
-            .map(|n| -(n as i32))
             .map_err(|_error| anyhow!("Failed to remove entities: {:?}", entity_keys).into())
     }
 

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -164,7 +164,7 @@ impl DeploymentStore {
             if replace || !exists {
                 deployment::create_deployment(
                     &conn,
-                    &site.deployment,
+                    &site,
                     deployment,
                     exists,
                     replace,
@@ -865,7 +865,7 @@ impl DeploymentStore {
             )?;
             deployment::update_entity_count(
                 &conn,
-                &site.deployment,
+                site.as_ref(),
                 layout.count_query.as_str(),
                 count,
             )?;
@@ -944,7 +944,7 @@ impl DeploymentStore {
 
             deployment::update_entity_count(
                 &conn,
-                &site.deployment,
+                site.as_ref(),
                 layout.count_query.as_str(),
                 count,
             )?;

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -345,7 +345,7 @@ impl DeploymentStore {
         section.end();
 
         let _section = stopwatch.start_section("apply_entity_modifications_insert");
-        layout.insert(conn, entity_type, data, block_number(ptr))
+        layout.insert(conn, entity_type, data, block_number(ptr), stopwatch)
     }
 
     fn overwrite_entities(
@@ -365,7 +365,7 @@ impl DeploymentStore {
         section.end();
 
         let _section = stopwatch.start_section("apply_entity_modifications_update");
-        layout.update(conn, entity_type, data, block_number(ptr))
+        layout.update(conn, entity_type, data, block_number(ptr), stopwatch)
     }
 
     fn remove_entities(
@@ -379,7 +379,13 @@ impl DeploymentStore {
     ) -> Result<usize, StoreError> {
         let _section = stopwatch.start_section("apply_entity_modifications_delete");
         layout
-            .delete(conn, entity_type, &entity_keys, block_number(ptr))
+            .delete(
+                conn,
+                entity_type,
+                &entity_keys,
+                block_number(ptr),
+                stopwatch,
+            )
             .map_err(|_error| anyhow!("Failed to remove entities: {:?}", entity_keys).into())
     }
 

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -72,7 +72,7 @@ pub mod command_support {
         pub use crate::primary::Connection;
         pub use crate::primary::{
             deployment_schemas, ens_names, subgraph, subgraph_deployment_assignment,
-            subgraph_version,
+            subgraph_version, Site,
         };
     }
     pub use crate::primary::Namespace;

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -235,6 +235,7 @@ impl ToSql<Text, Pg> for Namespace {
 /// the database namespace for the deployment as that information is only
 /// stored in the primary database
 pub struct Site {
+    pub id: i32,
     /// The subgraph deployment
     pub deployment: SubgraphDeploymentId,
     /// The name of the database shard
@@ -260,6 +261,7 @@ impl TryFrom<Schema> for Site {
         })?;
         let shard = Shard::new(schema.shard)?;
         Ok(Self {
+            id: schema.id,
             deployment,
             namespace,
             shard,
@@ -637,16 +639,16 @@ impl<'a> Connection<'a> {
         }
 
         // Create a schema for the deployment.
-        let schemas: Vec<String> = diesel::insert_into(ds::table)
+        let schemas: Vec<(i32, String)> = diesel::insert_into(ds::table)
             .values((
                 ds::subgraph.eq(subgraph.as_str()),
                 ds::shard.eq(shard.as_str()),
                 ds::version.eq(v::Relational),
                 ds::network.eq(network.as_str()),
             ))
-            .returning(ds::name)
+            .returning((ds::id, ds::name))
             .get_results(conn)?;
-        let namespace = schemas
+        let (id, namespace) = schemas
             .first()
             .cloned()
             .ok_or_else(|| anyhow!("failed to read schema name for {} back", subgraph))?;
@@ -655,6 +657,7 @@ impl<'a> Connection<'a> {
         })?;
 
         Ok(Site {
+            id,
             deployment: subgraph.clone(),
             namespace,
             shard,

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -978,7 +978,7 @@ impl<'a> Connection<'a> {
 
         for detail in details {
             let (latest_hash, latest_number) = block(
-                &detail.id,
+                &detail.deployment,
                 "latest_ethereum_block",
                 detail.latest_ethereum_block_hash.clone(),
                 detail.latest_ethereum_block_number.clone(),
@@ -988,7 +988,7 @@ impl<'a> Connection<'a> {
             .unwrap_or((None, None));
             let entity_count = detail.entity_count.to_u64().unwrap_or(0) as i32;
 
-            update(u::table.filter(u::id.eq(&detail.id)))
+            update(u::table.filter(u::id.eq(&detail.deployment)))
                 .set((
                     u::entity_count.eq(entity_count),
                     u::latest_ethereum_block_hash.eq(latest_hash),

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -42,7 +42,7 @@ impl QueryStoreTrait for QueryStore {
             .store
             .get_replica_conn(self.replica_id)
             .map_err(|e| QueryExecutionError::StoreError(e.into()))?;
-        self.store.execute_query(&conn, &self.site, query)
+        self.store.execute_query(&conn, self.site.clone(), query)
     }
 
     /// Return true if the deployment with the given id is fully synced,

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -565,7 +565,7 @@ impl Layout {
         block: BlockNumber,
     ) -> Result<usize, StoreError> {
         let table = self.table_for_entity(entity_type)?;
-        Ok(InsertQuery::new(table, &entity_type, entities, block)?
+        Ok(InsertQuery::new(table, entities, block)?
             .get_results(conn)
             .map(|ids| ids.len())?)
     }
@@ -671,7 +671,7 @@ impl Layout {
         let table = self.table_for_entity(&entity_type)?;
         let entity_keys: Vec<&EntityKey> = entities.iter().map(|(key, _)| key).collect();
         ClampRangeQuery::new(table, &entity_type, &entity_keys, block).execute(conn)?;
-        Ok(InsertQuery::new(table, entity_type, entities, block)?
+        Ok(InsertQuery::new(table, entities, block)?
             .get_results(conn)
             .map(|ids| ids.len())?)
     }

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -671,7 +671,9 @@ impl Layout {
         let table = self.table_for_entity(&entity_type)?;
         let entity_keys: Vec<&EntityKey> = entities.iter().map(|(key, _)| key).collect();
         ClampRangeQuery::new(table, &entity_type, &entity_keys, block).execute(conn)?;
-        Ok(InsertQuery::new(table, entity_type, entities, block)?.execute(conn)?)
+        Ok(InsertQuery::new(table, entity_type, entities, block)?
+            .get_results(conn)
+            .map(|ids| ids.len())?)
     }
 
     pub fn delete(
@@ -683,7 +685,11 @@ impl Layout {
     ) -> Result<usize, StoreError> {
         let table = self.table_for_entity(&entity_type)?;
         let entity_keys: Vec<&EntityKey> = entity_keys.iter().collect();
-        Ok(ClampRangeQuery::new(table, &entity_type, &entity_keys, block).execute(conn)?)
+        Ok(
+            ClampRangeQuery::new(table, &entity_type, &entity_keys, block)
+                .get_results(conn)
+                .map(|ids| ids.len())?,
+        )
     }
 
     pub fn revert_block(

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1327,6 +1327,7 @@ mod tests {
         let namespace = Namespace::new("sgd0815".to_owned()).unwrap();
         let catalog = Catalog::make_empty(namespace.clone()).expect("Can not create catalog");
         let site = Site {
+            id: 1,
             deployment: subgraph,
             shard: PRIMARY_SHARD.clone(),
             namespace: namespace,

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -680,9 +680,7 @@ impl Layout {
         ClampRangeQuery::new(table, &entity_type, &entity_keys, block).execute(conn)?;
         section.end();
         let _section = stopwatch.start_section("update_modification_insert_query");
-        Ok(InsertQuery::new(table, &mut entities, block)?
-            .get_results(conn)
-            .map(|ids| ids.len())?)
+        Ok(InsertQuery::new(table, &mut entities, block)?.execute(conn)?)
     }
 
     pub fn delete(
@@ -695,9 +693,7 @@ impl Layout {
     ) -> Result<usize, StoreError> {
         let table = self.table_for_entity(&entity_type)?;
         let _section = stopwatch.start_section("delete_modification_clamp_range_query");
-        Ok(ClampRangeQuery::new(table, &entity_type, entity_ids, block)
-            .get_results(conn)
-            .map(|ids| ids.len())?)
+        Ok(ClampRangeQuery::new(table, &entity_type, entity_ids, block).execute(conn)?)
     }
 
     pub fn revert_block(

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -564,7 +564,7 @@ impl Layout {
         entities: &mut Vec<(EntityKey, Entity)>,
         block: BlockNumber,
     ) -> Result<usize, StoreError> {
-        let table = self.table_for_entity(&entity_type)?;
+        let table = self.table_for_entity(entity_type)?;
         Ok(InsertQuery::new(table, &entity_type, entities, block)?
             .get_results(conn)
             .map(|ids| ids.len())?)

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1351,10 +1351,10 @@ impl<'a> QueryId for InsertQuery<'a> {
     const HAS_STATIC_QUERY_ID: bool = false;
 }
 
-impl<'a> LoadQuery<PgConnection, RevertEntityData> for InsertQuery<'a> {
-    fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
+impl<'a> LoadQuery<PgConnection, ReturnedEntityData> for InsertQuery<'a> {
+    fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<ReturnedEntityData>> {
         conn.query_by_name(&self)
-            .map(|data| RevertEntityData::bytes_as_str(&self.table, data))
+            .map(|data| ReturnedEntityData::bytes_as_str(&self.table, data))
     }
 }
 
@@ -2551,15 +2551,15 @@ impl<'a, Conn> RunQueryDsl<Conn> for ClampRangeQuery<'a> {}
 /// Helper struct for returning the id's touched by the RevertRemove and
 /// RevertExtend queries
 #[derive(QueryableByName, PartialEq, Eq, Hash)]
-pub struct RevertEntityData {
+pub struct ReturnedEntityData {
     #[sql_type = "Text"]
     pub id: String,
 }
 
-impl RevertEntityData {
+impl ReturnedEntityData {
     /// Convert primary key ids from Postgres' internal form to the format we
     /// use by stripping `\\x` off the front of bytes strings
-    fn bytes_as_str(table: &Table, mut data: Vec<RevertEntityData>) -> Vec<RevertEntityData> {
+    fn bytes_as_str(table: &Table, mut data: Vec<ReturnedEntityData>) -> Vec<ReturnedEntityData> {
         match table.primary_key().column_type.id_type() {
             IdType::String => data,
             IdType::Bytes => {
@@ -2607,10 +2607,10 @@ impl<'a> QueryId for RevertRemoveQuery<'a> {
     const HAS_STATIC_QUERY_ID: bool = false;
 }
 
-impl<'a> LoadQuery<PgConnection, RevertEntityData> for RevertRemoveQuery<'a> {
-    fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
+impl<'a> LoadQuery<PgConnection, ReturnedEntityData> for RevertRemoveQuery<'a> {
+    fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<ReturnedEntityData>> {
         conn.query_by_name(&self)
-            .map(|data| RevertEntityData::bytes_as_str(&self.table, data))
+            .map(|data| ReturnedEntityData::bytes_as_str(&self.table, data))
     }
 }
 
@@ -2678,10 +2678,10 @@ impl<'a> QueryId for RevertClampQuery<'a> {
     const HAS_STATIC_QUERY_ID: bool = false;
 }
 
-impl<'a> LoadQuery<PgConnection, RevertEntityData> for RevertClampQuery<'a> {
-    fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
+impl<'a> LoadQuery<PgConnection, ReturnedEntityData> for RevertClampQuery<'a> {
+    fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<ReturnedEntityData>> {
         conn.query_by_name(&self)
-            .map(|data| RevertEntityData::bytes_as_str(&self.table, data))
+            .map(|data| ReturnedEntityData::bytes_as_str(&self.table, data))
     }
 }
 
@@ -2734,10 +2734,10 @@ impl<'a> QueryId for DeleteByPrefixQuery<'a> {
     const HAS_STATIC_QUERY_ID: bool = false;
 }
 
-impl<'a> LoadQuery<PgConnection, RevertEntityData> for DeleteByPrefixQuery<'a> {
-    fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
+impl<'a> LoadQuery<PgConnection, ReturnedEntityData> for DeleteByPrefixQuery<'a> {
+    fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<ReturnedEntityData>> {
         conn.query_by_name(&self)
-            .map(|data| RevertEntityData::bytes_as_str(&self.table, data))
+            .map(|data| ReturnedEntityData::bytes_as_str(&self.table, data))
     }
 }
 

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1240,7 +1240,6 @@ pub struct InsertQuery<'a> {
 impl<'a> InsertQuery<'a> {
     pub fn new(
         table: &'a Table,
-        _entity_type: &'a EntityType,
         entities: &'a mut Vec<(EntityKey, Entity)>,
         block: BlockNumber,
     ) -> Result<InsertQuery<'a>, StoreError> {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -12,7 +12,7 @@ use diesel::result::{Error as DieselError, QueryResult};
 use diesel::sql_types::{Array, Binary, Bool, Integer, Jsonb, Range, Text};
 use diesel::Connection;
 use lazy_static::lazy_static;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryFrom;
 use std::env;
 use std::fmt::{self, Display};
@@ -1284,15 +1284,15 @@ impl<'a> InsertQuery<'a> {
 
     /// Build the column name list using the subset of all keys among present entities.
     fn unique_columns(table: &'a Table, entities: &'a Vec<(EntityKey, Entity)>) -> Vec<&'a Column> {
-        let mut btreemap = BTreeMap::new();
+        let mut hashmap = HashMap::new();
         for (_key, entity) in entities.iter() {
             for column in &table.columns {
                 if entity.get(&column.field).is_some() {
-                    btreemap.entry(column.name.as_str()).or_insert(column);
+                    hashmap.entry(column.name.as_str()).or_insert(column);
                 }
             }
         }
-        btreemap.into_iter().map(|(_key, value)| value).collect()
+        hashmap.into_iter().map(|(_key, value)| value).collect()
     }
 }
 

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1337,6 +1337,10 @@ impl<'a> QueryFragment<Pg> for InsertQuery<'a> {
                 out.push_sql(",\n");
             }
         }
+        out.push_sql("\nreturning ");
+        out.push_sql(PRIMARY_KEY_COLUMN);
+        out.push_sql("::text");
+
         Ok(())
     }
 }
@@ -1345,6 +1349,13 @@ impl<'a> QueryId for InsertQuery<'a> {
     type QueryId = ();
 
     const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a> LoadQuery<PgConnection, RevertEntityData> for InsertQuery<'a> {
+    fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<RevertEntityData>> {
+        conn.query_by_name(&self)
+            .map(|data| RevertEntityData::bytes_as_str(&self.table, data))
+    }
 }
 
 impl<'a, Conn> RunQueryDsl<Conn> for InsertQuery<'a> {}

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2536,6 +2536,11 @@ impl<'a> QueryFragment<Pg> for ClampRangeQuery<'a> {
         out.push_sql(" and (");
         out.push_sql(BLOCK_RANGE_CURRENT);
         out.push_sql(")");
+
+        out.push_sql("\nreturning ");
+        out.push_sql(PRIMARY_KEY_COLUMN);
+        out.push_sql("::text");
+
         Ok(())
     }
 }
@@ -2544,6 +2549,13 @@ impl<'a> QueryId for ClampRangeQuery<'a> {
     type QueryId = ();
 
     const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a> LoadQuery<PgConnection, ReturnedEntityData> for ClampRangeQuery<'a> {
+    fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<ReturnedEntityData>> {
+        conn.query_by_name(&self)
+            .map(|data| ReturnedEntityData::bytes_as_str(&self.table, data))
+    }
 }
 
 impl<'a, Conn> RunQueryDsl<Conn> for ClampRangeQuery<'a> {}

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -16,7 +16,11 @@ use graph::{
     components::store::EntityType,
     data::store::scalar::{BigDecimal, BigInt, Bytes},
 };
-use graph_store_postgres::layout_for_tests::{Layout, Namespace, STRING_PREFIX_SIZE};
+use graph_store_postgres::{
+    command_support::catalog::Site,
+    layout_for_tests::{Layout, Namespace, STRING_PREFIX_SIZE},
+    PRIMARY_SHARD,
+};
 
 use test_store::*;
 
@@ -395,11 +399,16 @@ fn insert_pets(conn: &PgConnection, layout: &Layout) {
 
 fn insert_test_data(conn: &PgConnection) -> Layout {
     let schema = Schema::parse(THINGS_GQL, THINGS_SUBGRAPH_ID.clone()).unwrap();
-
+    let site = Site {
+        deployment: THINGS_SUBGRAPH_ID.clone(),
+        shard: PRIMARY_SHARD.clone(),
+        namespace: NAMESPACE.clone(),
+        network: NETWORK_NAME.to_string(),
+    };
     let query = format!("create schema {}", NAMESPACE.as_str());
     conn.batch_execute(&*query).unwrap();
 
-    Layout::create_relational_schema(&conn, &schema, NAMESPACE.to_owned())
+    Layout::create_relational_schema(&conn, Arc::new(site), &schema)
         .expect("Failed to create relational schema")
 }
 

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -400,6 +400,7 @@ fn insert_pets(conn: &PgConnection, layout: &Layout) {
 fn insert_test_data(conn: &PgConnection) -> Layout {
     let schema = Schema::parse(THINGS_GQL, THINGS_SUBGRAPH_ID.clone()).unwrap();
     let site = Site {
+        id: 1,
         deployment: THINGS_SUBGRAPH_ID.clone(),
         shard: PRIMARY_SHARD.clone(),
         namespace: NAMESPACE.clone(),

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -118,6 +118,7 @@ fn create_schema(conn: &PgConnection) -> Layout {
     conn.batch_execute(&*query).unwrap();
 
     let site = Site {
+        id: 1,
         deployment: THINGS_SUBGRAPH_ID.clone(),
         shard: PRIMARY_SHARD.clone(),
         namespace: NAMESPACE.clone(),

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -454,8 +454,8 @@ fn build_store() -> (Arc<Store>, ConnectionPool, Config, Arc<SubscriptionManager
 
             (
                 builder.network_store(vec![
-                    (NETWORK_NAME.to_string(), ident.clone()),
-                    (FAKE_NETWORK_SHARED.to_string(), ident),
+                    (NETWORK_NAME.to_string(), Some(ident.clone())),
+                    (FAKE_NETWORK_SHARED.to_string(), Some(ident)),
                 ]),
                 primary_pool,
                 config,

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -454,8 +454,8 @@ fn build_store() -> (Arc<Store>, ConnectionPool, Config, Arc<SubscriptionManager
 
             (
                 builder.network_store(vec![
-                    (NETWORK_NAME.to_string(), Some(ident.clone())),
-                    (FAKE_NETWORK_SHARED.to_string(), Some(ident)),
+                    (NETWORK_NAME.to_string(), vec![ident.clone()]),
+                    (FAKE_NETWORK_SHARED.to_string(), vec![ident]),
                 ]),
                 primary_pool,
                 config,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,4 +9,4 @@ tokio = {version = "1.2.0", features = ["rt", "macros", "process"]}
 tokio-stream = "0.1"
 futures = "0.3.13"
 port_check = "0.1.5"
-anyhow = "1.0.38"
+anyhow = "1.0.39"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,4 +9,4 @@ tokio = {version = "1.2.0", features = ["rt", "macros", "process"]}
 tokio-stream = "0.1"
 futures = "0.3.13"
 port_check = "0.1.5"
-anyhow = "1.0.39"
+anyhow = "1.0.40"


### PR DESCRIPTION
This PR is a steptowards using the same `id` as the primary key as `deployment_schemas`. It sits on top of #2266 since the former can easily be rolled back in the hosted service if anything goes wrong. This PR contains an irreversible migration and should therefore be rolled out by itself.