### PR TITLE
Use a synthetic primary key for subgraph_deployment

### DIFF
--- a/store/postgres/migrations/2021-03-12-014815_subgraph_deployment_pkey/down.sql
+++ b/store/postgres/migrations/2021-03-12-014815_subgraph_deployment_pkey/down.sql
@@ -1,0 +1,5 @@
+do $$
+begin
+  raise 'This migration is irreversible';
+end
+$$;

--- a/store/postgres/migrations/2021-03-12-014815_subgraph_deployment_pkey/up.sql
+++ b/store/postgres/migrations/2021-03-12-014815_subgraph_deployment_pkey/up.sql
@@ -1,0 +1,14 @@
+update subgraphs.subgraph_deployment d
+   set id = ds.id
+  from deployment_schemas ds
+ where ds.subgraph = d.deployment
+   and d.id is null;
+
+alter table subgraphs.subgraph_deployment
+      drop constraint subgraph_deployment_pkey;
+
+alter table subgraphs.subgraph_deployment
+      add primary key(id);
+
+alter table subgraphs.subgraph_deployment
+      drop column vid;

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -4,7 +4,7 @@
 use diesel::{
     connection::SimpleConnection,
     dsl::{delete, insert_into, select, sql, update},
-    sql_types::{Integer, Text},
+    sql_types::Integer,
 };
 use diesel::{expression::SqlLiteral, pg::PgConnection, sql_types::Numeric};
 use diesel::{
@@ -48,8 +48,7 @@ impl From<SubgraphHealth> for graph::data::subgraph::schema::SubgraphHealth {
 }
 
 table! {
-    subgraphs.subgraph_deployment (vid) {
-        vid -> BigInt,
+    subgraphs.subgraph_deployment (id) {
         id -> Integer,
         deployment -> Text,
         manifest -> Text,
@@ -738,13 +737,13 @@ pub fn update_entity_count(
            set entity_count =
                  coalesce((nullif(entity_count, -1)) + $1,
                           ({full_count_query}))
-         where deployment = $2
+         where id = $2
         ",
         full_count_query = full_count_query
     );
     Ok(diesel::sql_query(query)
         .bind::<Integer, _>(count)
-        .bind::<Text, _>(site.deployment.as_str())
+        .bind::<Integer, _>(site.id)
         .execute(conn)
         .map(|_| ())?)
 }

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -25,7 +25,6 @@ type Bytes = Vec<u8>;
 // don't need all the fields
 #[allow(dead_code)]
 pub struct DeploymentDetail {
-    vid: i64,
     id: i32,
     pub deployment: String,
     manifest: String,


### PR DESCRIPTION
This PR switches the primary key for `subgraph_deployment` to be the same as the pk for `deployment_schemas`. It does the bare minimum necessary to arrange for that in the database, but does not yet contain the code changes required to move away from identifying deployments internally by their IPFS hash. That will come in a future PR.

This PR sits on top of #2267 since manual intervention is needed in the sharded setup in the hosted service between these two PR's.