### PR TITLE
docker: Make sure empty GRAPH_NODE_CONFIG does not trip us up

### DIFF
--- a/docker/start
+++ b/docker/start
@@ -59,6 +59,7 @@ run_graph_node() {
             --config "$GRAPH_NODE_CONFIG" \
             --ipfs "$ipfs"
     else
+        unset GRAPH_NODE_CONFIG
         postgres_port=${postgres_port:-5432}
         postgres_url="postgresql://$postgres_user:$postgres_pass@$postgres_host:$postgres_port/$postgres_db"
 


### PR DESCRIPTION
By default, GRAPH_NODE_CONFIG is set but empty, which the start script correctly interprets as to not use a configuration file; but argument parsing inside graph-node still thinks the variable is set. We explicitly unset the variable when running without a configuration file.

Fixes https://github.com/graphprotocol/graph-node/issues/2271

