### PR TITLE
store: Allow enforcing a timeout for SQL queries

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -100,6 +100,9 @@ those.
 - `GRAPH_GRAPHQL_MAX_OPERATIONS_PER_CONNECTION`: maximum number of GraphQL
   operations per WebSocket connection. Any operation created after the limit
   will return an error to the client. Default: unlimited.
+- `GRAPH_SQL_STATEMENT_TIMEOUT`: the maximum number of seconds an
+  individual SQL query is allowed to take during GraphQL
+  execution. Default: unlimited
 
 ## Miscellaneous
 


### PR DESCRIPTION
This isn't great since the timeout is set through an environment variable - it would be better to derive it from the overall timeout for GraphQL queries, but that's a little more work.