### PR TITLE
Increase log buffer

### DIFF
--- a/graph/src/log/elastic.rs
+++ b/graph/src/log/elastic.rs
@@ -208,7 +208,7 @@ impl ElasticDrain {
                         return;
                     }
 
-                    trace!(
+                    debug!(
                         flush_logger,
                         "Flushing {} logs to Elasticsearch",
                         logs_to_send.len()
@@ -371,7 +371,7 @@ impl Drain for ElasticDrain {
 pub fn elastic_logger(config: ElasticDrainConfig, error_logger: Logger) -> Logger {
     let elastic_drain = ElasticDrain::new(config, error_logger).fuse();
     let async_drain = slog_async::Async::new(elastic_drain)
-        .chan_size(10000)
+        .chan_size(20000)
         .build()
         .fuse();
     Logger::root(async_drain, o!())

--- a/graph/src/log/mod.rs
+++ b/graph/src/log/mod.rs
@@ -51,7 +51,7 @@ pub fn logger(show_debug: bool) -> Logger {
         )
         .build();
     let drain = slog_async::Async::new(drain)
-        .chan_size(10000)
+        .chan_size(20000)
         .build()
         .fuse();
     Logger::root(drain, o!())

--- a/graph/src/log/split.rs
+++ b/graph/src/log/split.rs
@@ -70,7 +70,7 @@ where
 {
     let split_drain = SplitDrain::new(drain1.fuse(), drain2.fuse()).fuse();
     let async_drain = slog_async::Async::new(split_drain)
-        .chan_size(10000)
+        .chan_size(20000)
         .build()
         .fuse();
     Logger::root(async_drain, o!())


### PR DESCRIPTION
It's already big, but I've seen messages lost due to buffer overflow in the hosted service. Also increase the log level of the ES log count, to see if we are sending requests that are too big.