### PR TITLE
Deprecate calling `ethereum.call` to initialize a global

### DIFF
--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -439,6 +439,11 @@ impl WasmInstance {
 
                     // Happens when calling a host fn in Wasm start.
                     if instance.is_none() {
+                        error!(
+                            ctx.borrow().as_ref().unwrap().logger,
+                            "contract calls in globals are deprecated"
+                        );
+
                         *instance = Some(
                             WasmInstanceContext::from_caller(
                                 caller,


### PR DESCRIPTION
This is a strange thing to do anyways and hopefully nobody is doing it and we can quickly remove this. The goal is to make things a bit simpler for multiblockchain if chain specific host exports don't need to worry about being called to initialize a global variable.

The first commit clarifies some outdated comments.