### PR TITLE
Copy subgraphs between shards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,7 @@ dependencies = [
  "bigdecimal",
  "bitflags 1.2.1",
  "byteorder",
+ "chrono",
  "diesel_derives",
  "num-bigint",
  "num-integer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "atty",
  "bitflags 1.2.1",
  "strsim 0.8.0",
+ "term_size",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -4399,6 +4400,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4428,6 +4439,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "term_size",
  "unicode-width",
 ]
 

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -1,14 +1,11 @@
 use lazy_static;
 use std::{sync::Arc, time::Duration};
 
-use graph::{
-    prelude::{
-        error, info, o, stream, tokio, trace, warn, web3::types::H256, BlockNumber, ChainStore,
-        ComponentLoggerConfig, ElasticComponentLoggerConfig, Error, EthereumAdapter,
-        EthereumAdapterError, EthereumBlock, Future, Future01CompatExt, LogCode, Logger,
-        LoggerFactory, MetricsRegistry, Stream,
-    },
-    prometheus::GaugeVec,
+use graph::prelude::{
+    error, info, o, stream, tokio, trace, warn, web3::types::H256, BlockNumber, ChainStore,
+    ComponentLoggerConfig, ElasticComponentLoggerConfig, Error, EthereumAdapter,
+    EthereumAdapterError, EthereumBlock, Future, Future01CompatExt, LogCode, Logger, LoggerFactory,
+    Stream,
 };
 
 lazy_static! {
@@ -18,30 +15,6 @@ lazy_static! {
         .ok()
         .map(|s| s.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
-}
-
-pub struct BlockIngestorMetrics {
-    chain_head_number: Box<GaugeVec>,
-}
-
-impl BlockIngestorMetrics {
-    pub fn new(registry: Arc<dyn MetricsRegistry>) -> Self {
-        Self {
-            chain_head_number: registry
-                .new_gauge_vec(
-                    "ethereum_chain_head_number",
-                    "Block number of the most recent block synced from Ethereum",
-                    vec![String::from("network")],
-                )
-                .unwrap(),
-        }
-    }
-
-    pub fn set_chain_head_number(&self, network_name: &str, chain_head_number: i64) {
-        self.chain_head_number
-            .with_label_values(vec![network_name].as_slice())
-            .set(chain_head_number as f64);
-    }
 }
 
 pub struct BlockIngestor<S>

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -4,7 +4,10 @@ use std::mem;
 use std::time::Duration;
 
 use graph::components::{
-    ethereum::{blocks_with_triggers, triggers_in_block, EthereumNetworks, NodeCapabilities},
+    ethereum::{
+        blocks_with_triggers, triggers_in_block, ChainHeadUpdateListener, EthereumNetworks,
+        NodeCapabilities,
+    },
     store::{BlockStore, DeploymentLocator, WritableStore},
 };
 use graph::prelude::{
@@ -150,6 +153,7 @@ where
     pub fn new(
         subgraph_store: Arc<dyn WritableStore>,
         chain_store: Arc<C>,
+        chain_head_update_stream: ChainHeadUpdateStream,
         eth_adapter: Arc<dyn EthereumAdapter>,
         node_id: NodeId,
         subgraph_id: SubgraphDeploymentId,
@@ -165,7 +169,7 @@ where
         BlockStream {
             state: BlockStreamState::BeginReconciliation,
             consecutive_err_count: 0,
-            chain_head_update_stream: chain_store.chain_head_updates(),
+            chain_head_update_stream,
             ctx: BlockStreamContext {
                 subgraph_store,
                 chain_store,
@@ -748,6 +752,7 @@ impl<C: ChainStore> Stream for BlockStream<C> {
 pub struct BlockStreamBuilder<B, M> {
     subgraph_store: Arc<dyn SubgraphStore>,
     block_store: Arc<B>,
+    chain_head_update_listener: Arc<dyn ChainHeadUpdateListener>,
     eth_networks: EthereumNetworks,
     node_id: NodeId,
     reorg_threshold: BlockNumber,
@@ -759,6 +764,7 @@ impl<B, M> Clone for BlockStreamBuilder<B, M> {
         BlockStreamBuilder {
             subgraph_store: self.subgraph_store.clone(),
             block_store: self.block_store.clone(),
+            chain_head_update_listener: self.chain_head_update_listener.clone(),
             eth_networks: self.eth_networks.clone(),
             node_id: self.node_id.clone(),
             reorg_threshold: self.reorg_threshold,
@@ -775,6 +781,7 @@ where
     pub fn new(
         subgraph_store: Arc<dyn SubgraphStore>,
         block_store: Arc<B>,
+        chain_head_update_listener: Arc<dyn ChainHeadUpdateListener>,
         eth_networks: EthereumNetworks,
         node_id: NodeId,
         reorg_threshold: BlockNumber,
@@ -783,6 +790,7 @@ where
         BlockStreamBuilder {
             subgraph_store,
             block_store,
+            chain_head_update_listener,
             eth_networks,
             node_id,
             reorg_threshold,
@@ -824,6 +832,10 @@ where
             ))
             .clone();
 
+        let chain_head_update_stream = self
+            .chain_head_update_listener
+            .subscribe(network_name.clone());
+
         let requirements = NodeCapabilities {
             archive: false,
             traces: include_calls_in_blocks,
@@ -843,6 +855,7 @@ where
                 .writable(&deployment)
                 .expect(&format!("no store for deployment `{}`", deployment.hash)),
             chain_store,
+            chain_head_update_stream,
             eth_adapter.clone(),
             self.node_id.clone(),
             deployment.hash,

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use graph::components::{
     ethereum::{blocks_with_triggers, triggers_in_block, EthereumNetworks, NodeCapabilities},
-    store::{BlockStore, WritableStore},
+    store::{BlockStore, DeploymentLocator, WritableStore},
 };
 use graph::prelude::{
     BlockStream as BlockStreamTrait, BlockStreamBuilder as BlockStreamBuilderTrait, *,
@@ -802,7 +802,7 @@ where
     fn build(
         &self,
         logger: Logger,
-        deployment_id: SubgraphDeploymentId,
+        deployment: DeploymentLocator,
         network_name: String,
         start_blocks: Vec<BlockNumber>,
         log_filter: EthereumLogFilter,
@@ -840,12 +840,12 @@ where
         // Create the actual subgraph-specific block stream
         BlockStream::new(
             self.subgraph_store
-                .writable(&deployment_id)
-                .expect(&format!("no store for deployment `{}`", deployment_id)),
+                .writable(&deployment)
+                .expect(&format!("no store for deployment `{}`", deployment.hash)),
             chain_store,
             eth_adapter.clone(),
             self.node_id.clone(),
-            deployment_id,
+            deployment.hash,
             log_filter,
             call_filter,
             block_filter,

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -239,7 +239,7 @@ where
                 return Box::new(future::err(e)) as Box<dyn Future<Item = _, Error = _> + Send>
             }
         };
-        let subgraph_ptr = match ctx.subgraph_store.block_ptr(&ctx.subgraph_id) {
+        let subgraph_ptr = match ctx.subgraph_store.block_ptr() {
             Ok(ptr) => ptr,
             Err(e) => {
                 return Box::new(future::err(e)) as Box<dyn Future<Item = _, Error = _> + Send>
@@ -569,7 +569,7 @@ where
     /// caught up to the head block pointer.
     fn update_subgraph_synced_status(&self) -> Result<(), Error> {
         let head_ptr_opt = self.chain_store.chain_head_ptr()?;
-        let subgraph_ptr = self.subgraph_store.block_ptr(&self.subgraph_id)?;
+        let subgraph_ptr = self.subgraph_store.block_ptr()?;
 
         if head_ptr_opt != subgraph_ptr || head_ptr_opt.is_none() || subgraph_ptr.is_none() {
             // Not synced yet
@@ -580,7 +580,7 @@ where
             // Stop recording time-to-sync metrics.
             self.metrics.stopwatch.disable();
 
-            self.subgraph_store.deployment_synced(&self.subgraph_id)
+            self.subgraph_store.deployment_synced()
         }
     }
 }

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -839,7 +839,9 @@ where
 
         // Create the actual subgraph-specific block stream
         BlockStream::new(
-            self.subgraph_store.writable(&deployment_id),
+            self.subgraph_store
+                .writable(&deployment_id)
+                .expect(&format!("no store for deployment `{}`", deployment_id)),
             chain_store,
             eth_adapter.clone(),
             self.node_id.clone(),

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -839,7 +839,7 @@ where
 
         // Create the actual subgraph-specific block stream
         BlockStream::new(
-            self.subgraph_store.writable(),
+            self.subgraph_store.writable(&deployment_id),
             chain_store,
             eth_adapter.clone(),
             self.node_id.clone(),

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -8,7 +8,7 @@ mod ethereum_adapter;
 pub mod network_indexer;
 mod transport;
 
-pub use self::block_ingestor::{BlockIngestor, BlockIngestorMetrics, CLEANUP_BLOCKS};
+pub use self::block_ingestor::{BlockIngestor, CLEANUP_BLOCKS};
 pub use self::block_stream::{BlockStream, BlockStreamBuilder};
 pub use self::ethereum_adapter::EthereumAdapter;
 pub use self::transport::{EventLoopHandle, Transport};

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -143,7 +143,6 @@ impl WriteContext {
                     let cache = context.cache;
                     let metrics = context.metrics;
                     let store = context.store;
-                    let subgraph_id = context.subgraph_id;
 
                     let stopwatch = metrics.stopwatch.clone();
 
@@ -161,7 +160,6 @@ impl WriteContext {
                     future::result(
                         store
                             .transact_block_operations(
-                                subgraph_id.clone(),
                                 block_ptr.clone(),
                                 modifications,
                                 stopwatch,

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -147,7 +147,7 @@ impl WriteContext {
                     let stopwatch = metrics.stopwatch.clone();
 
                     // Collect all entity modifications to be made
-                    let modifications = match cache.as_modifications(store.as_ref()) {
+                    let modifications = match cache.as_modifications() {
                         Ok(mods) => mods,
                         Err(e) => return future::err(e.into()),
                     }

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use graph::prelude::*;
+use graph::{components::store::WritableStore, prelude::*};
 
 use super::*;
 
@@ -43,7 +43,7 @@ pub struct BlockWriter {
     logger: Logger,
 
     /// Store that manages the network subgraph.
-    store: Arc<dyn SubgraphStore>,
+    store: Arc<dyn WritableStore>,
 
     /// Metrics for analyzing the block writer performance.
     metrics: Arc<BlockWriterMetrics>,
@@ -54,7 +54,7 @@ impl BlockWriter {
     pub fn new(
         subgraph_id: SubgraphDeploymentId,
         logger: &Logger,
-        store: Arc<dyn SubgraphStore>,
+        store: Arc<dyn WritableStore>,
         stopwatch: StopwatchMetrics,
         metrics_registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
@@ -97,7 +97,7 @@ impl BlockWriter {
 struct WriteContext {
     logger: Logger,
     subgraph_id: SubgraphDeploymentId,
-    store: Arc<dyn SubgraphStore>,
+    store: Arc<dyn WritableStore>,
     cache: EntityCache,
     metrics: Arc<BlockWriterMetrics>,
 }

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -105,7 +105,7 @@ fn load_local_head(context: &Context) -> LocalHeadFuture {
         future::result(
             context
                 .store
-                .writable(&context.subgraph_id)
+                .writable_for_network_indexer(&context.subgraph_id)
                 .map_err(Error::from)
                 .and_then(|store| store.block_ptr())
         )
@@ -1166,7 +1166,7 @@ impl NetworkIndexer {
         ));
 
         let writable = store
-            .writable(&subgraph_id)
+            .writable_for_network_indexer(&subgraph_id)
             .expect("can get writable store");
         let block_writer = Arc::new(BlockWriter::new(
             subgraph_id.clone(),

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -107,7 +107,7 @@ fn load_local_head(context: &Context) -> LocalHeadFuture {
                 .store
                 .writable(&context.subgraph_id)
                 .map_err(Error::from)
-                .and_then(|store| store.block_ptr(&context.subgraph_id))
+                .and_then(|store| store.block_ptr())
         )
     ))
 }
@@ -341,7 +341,6 @@ fn revert_local_head(context: &Context, local_head: EthereumBlockPointer) -> Rev
 
     let writable = context.writable.clone();
     let event_sink = context.event_sink.clone();
-    let subgraph_id = context.subgraph_id.clone();
 
     let logger_for_complete = context.logger.clone();
 
@@ -358,7 +357,7 @@ fn revert_local_head(context: &Context, local_head: EthereumBlockPointer) -> Rev
             .and_then(move |parent_block| {
                 future::result(
                     writable
-                        .revert_block_operations(subgraph_id.clone(), parent_block.clone())
+                        .revert_block_operations(parent_block.clone())
                         .map_err(|e| e.into())
                         .map(|_| (local_head, parent_block)),
                 )

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -102,7 +102,7 @@ fn load_local_head(context: &Context) -> LocalHeadFuture {
         context.metrics,
         load_local_head,
         load_local_head_problems,
-        future::result(context.store.clone().block_ptr(&context.subgraph_id))
+        future::result(context.store.writable().block_ptr(&context.subgraph_id))
     ))
 }
 
@@ -289,7 +289,7 @@ fn load_parent_block_from_store(
         future::result(
             context
                 .store
-                .clone()
+                .writable()
                 .get(block_ptr.to_entity_key(context.subgraph_id.clone()))
                 .map_err(|e| e.into())
                 .and_then(|entity| {
@@ -353,7 +353,7 @@ fn revert_local_head(context: &Context, local_head: EthereumBlockPointer) -> Rev
             .and_then(move |parent_block| {
                 future::result(
                     store
-                        .clone()
+                        .writable()
                         .revert_block_operations(subgraph_id.clone(), parent_block.clone())
                         .map_err(|e| e.into())
                         .map(|_| (local_head, parent_block)),
@@ -1164,7 +1164,7 @@ impl NetworkIndexer {
         let block_writer = Arc::new(BlockWriter::new(
             subgraph_id.clone(),
             &logger,
-            store.clone(),
+            store.writable(),
             stopwatch,
             metrics_registry.clone(),
         ));

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -102,7 +102,12 @@ fn load_local_head(context: &Context) -> LocalHeadFuture {
         context.metrics,
         load_local_head,
         load_local_head_problems,
-        future::result(context.store.writable().block_ptr(&context.subgraph_id))
+        future::result(
+            context
+                .store
+                .writable(&context.subgraph_id)
+                .block_ptr(&context.subgraph_id)
+        )
     ))
 }
 
@@ -289,7 +294,7 @@ fn load_parent_block_from_store(
         future::result(
             context
                 .store
-                .writable()
+                .writable(&context.subgraph_id)
                 .get(block_ptr.to_entity_key(context.subgraph_id.clone()))
                 .map_err(|e| e.into())
                 .and_then(|entity| {
@@ -353,7 +358,7 @@ fn revert_local_head(context: &Context, local_head: EthereumBlockPointer) -> Rev
             .and_then(move |parent_block| {
                 future::result(
                     store
-                        .writable()
+                        .writable(&subgraph_id)
                         .revert_block_operations(subgraph_id.clone(), parent_block.clone())
                         .map_err(|e| e.into())
                         .map(|_| (local_head, parent_block)),
@@ -1164,7 +1169,7 @@ impl NetworkIndexer {
         let block_writer = Arc::new(BlockWriter::new(
             subgraph_id.clone(),
             &logger,
-            store.writable(),
+            store.writable(&subgraph_id),
             stopwatch,
             metrics_registry.clone(),
         ));

--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -1,9 +1,10 @@
 use super::*;
 use futures::future::FutureResult;
+use graph::components::store::WritableStore;
 use std::collections::BTreeSet;
 
 fn check_subgraph_exists(
-    store: Arc<dyn SubgraphStore>,
+    store: Arc<dyn WritableStore>,
     subgraph_id: SubgraphDeploymentId,
 ) -> impl Future<Item = bool, Error = Error> {
     future::result(store.is_deployed(&subgraph_id))
@@ -57,7 +58,7 @@ pub fn ensure_subgraph_exists(
 
     let logger_for_created = logger.clone();
 
-    check_subgraph_exists(store.clone(), subgraph_id.clone())
+    check_subgraph_exists(store.writable(), subgraph_id.clone())
         .from_err()
         .and_then(move |subgraph_exists| {
             if subgraph_exists {

--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -41,7 +41,8 @@ fn create_subgraph(
                 network_name,
                 SubgraphVersionSwitchingMode::Instant,
             )
-            .map_err(|e| e.into()),
+            .map_err(|e| e.into())
+            .map(|_| ()),
     )
 }
 

--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -1,10 +1,9 @@
 use super::*;
 use futures::future::FutureResult;
-use graph::components::store::WritableStore;
 use std::collections::BTreeSet;
 
 fn check_subgraph_exists(
-    store: Arc<dyn WritableStore>,
+    store: Arc<dyn SubgraphStore>,
     subgraph_id: SubgraphDeploymentId,
 ) -> impl Future<Item = bool, Error = Error> {
     future::result(store.is_deployed(&subgraph_id))
@@ -58,7 +57,7 @@ pub fn ensure_subgraph_exists(
 
     let logger_for_created = logger.clone();
 
-    check_subgraph_exists(store.writable(&subgraph_id), subgraph_id.clone())
+    check_subgraph_exists(store.clone(), subgraph_id.clone())
         .from_err()
         .and_then(move |subgraph_exists| {
             if subgraph_exists {

--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -58,7 +58,7 @@ pub fn ensure_subgraph_exists(
 
     let logger_for_created = logger.clone();
 
-    check_subgraph_exists(store.writable(), subgraph_id.clone())
+    check_subgraph_exists(store.writable(&subgraph_id), subgraph_id.clone())
         .from_err()
         .and_then(move |subgraph_exists| {
             if subgraph_exists {

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -210,7 +210,7 @@ where
     ) {
         let logger = self.logger_factory.subgraph_logger(&id);
 
-        let writable = self.subgraph_store.writable();
+        let writable = self.subgraph_store.writable(&id);
 
         match Self::start_subgraph_inner(
             logger.clone(),

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -923,7 +923,7 @@ where
         entity_lfu_cache: mut cache,
     } = block_state
         .entity_cache
-        .as_modifications(ctx.inputs.store.as_ref())
+        .as_modifications()
         .map_err(|e| BlockProcessingError::Unknown(e.into()))?;
     section.end();
 

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -210,14 +210,12 @@ where
     ) {
         let logger = self.logger_factory.subgraph_logger(&id);
 
-        let writable = self.subgraph_store.writable(&id);
-
         match Self::start_subgraph_inner(
             logger.clone(),
             self.instances.clone(),
             self.host_builder.clone(),
             self.block_stream_builder.clone(),
-            writable,
+            self.subgraph_store.clone(),
             self.block_store.cheap_clone(),
             self.eth_networks.clone(),
             id,
@@ -298,7 +296,7 @@ where
         instances: SharedInstanceKeepAliveMap,
         host_builder: impl RuntimeHostBuilder,
         stream_builder: B,
-        store: Arc<dyn WritableStore>,
+        store: Arc<dyn SubgraphStore>,
         block_store: Arc<BS>,
         eth_networks: EthereumNetworks,
         subgraph_id: SubgraphDeploymentId,
@@ -306,6 +304,8 @@ where
         registry: Arc<M>,
         link_resolver: Arc<L>,
     ) -> Result<(), Error> {
+        let store = store.writable(&subgraph_id)?;
+
         let manifest = {
             info!(logger, "Resolve subgraph files using IPFS");
 

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -210,7 +210,7 @@ where
         loc: DeploymentLocator,
         manifest: serde_yaml::Mapping,
     ) {
-        let logger = self.logger_factory.subgraph_logger(&loc.hash);
+        let logger = self.logger_factory.subgraph_logger(&loc);
 
         graph::spawn(async move {
             match Self::start_subgraph_inner(
@@ -240,7 +240,7 @@ where
     }
 
     fn stop_subgraph(&self, loc: DeploymentLocator) {
-        let logger = self.logger_factory.subgraph_logger(&loc.hash);
+        let logger = self.logger_factory.subgraph_logger(&loc);
         info!(logger, "Stop subgraph");
 
         // Drop the cancel guard to shut down the subgraph now

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -212,6 +212,11 @@ where
     ) {
         let logger = self.logger_factory.subgraph_logger(&loc);
 
+        // Perform the actual work of starting the subgraph in a separate
+        // task. If the subgraph is a graft or a copy, starting it will
+        // perform the actual work of grafting/copying, which can take
+        // hours. Running it in the background makes sure the instance
+        // manager does not hang because of that work.
         graph::spawn(async move {
             match Self::start_subgraph_inner(
                 logger.clone(),
@@ -311,9 +316,9 @@ where
         let store = store.writable(&deployment)?;
 
         // Start the subgraph deployment before reading dynamic data
-        // sources; if the subgraph is a copy, starting it will do the
-        // copying and dynamic data sources won't show up until after
-        // copying is done
+        // sources; if the subgraph is a graft or a copy, starting it will
+        // do the copying and dynamic data sources won't show up until after
+        // that is done
         {
             let store = store.clone();
             let logger = logger.clone();

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -20,10 +20,7 @@ pub async fn load_dynamic_data_sources(
     );
     let mut data_sources: Vec<DataSource> = vec![];
 
-    for stored in store
-        .load_dynamic_data_sources(deployment_id.clone())
-        .await?
-    {
+    for stored in store.load_dynamic_data_sources().await? {
         let StoredDynamicDataSource {
             name,
             source,

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -7,7 +7,7 @@ use graph::prelude::*;
 
 pub async fn load_dynamic_data_sources(
     store: Arc<dyn WritableStore>,
-    deployment_id: SubgraphDeploymentId,
+    deployment_id: &SubgraphDeploymentId,
     logger: Logger,
     templates: Vec<DataSourceTemplate>,
 ) -> Result<Vec<DataSource>, Error> {

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::time::Instant;
 
-use graph::components::store::StoredDynamicDataSource;
+use graph::components::store::{StoredDynamicDataSource, WritableStore};
 use graph::prelude::*;
 
 pub async fn load_dynamic_data_sources(
-    store: &impl SubgraphStore,
+    store: Arc<dyn WritableStore>,
     deployment_id: SubgraphDeploymentId,
     logger: Logger,
     templates: Vec<DataSourceTemplate>,

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -41,7 +41,7 @@ where
     I: SubgraphInstanceManager,
 {
     async fn start(&self, loc: DeploymentLocator) -> Result<(), SubgraphAssignmentProviderError> {
-        let logger = self.logger_factory.subgraph_logger(&loc.hash);
+        let logger = self.logger_factory.subgraph_logger(&loc);
 
         // If subgraph ID already in set
         if !self.subgraphs_running.lock().unwrap().insert(loc.id) {

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -167,7 +167,8 @@ where
                     .map(|change| match change {
                         EntityChange::Data { .. } => unreachable!(),
                         EntityChange::Assignment {
-                            deployment ,                      operation,
+                            deployment,
+                            operation,
                         } => (deployment.clone(), operation.clone()),
                     })
                     .collect::<Vec<_>>();
@@ -358,9 +359,18 @@ where
     ) -> Result<(), SubgraphRegistrarError> {
         let locations = self.store.locators(hash)?;
         let deployment = match locations.len() {
-            0 => return Err(SubgraphRegistrarError::StoreError(anyhow!("boo").into())),
+            0 => return Err(SubgraphRegistrarError::DeploymentNotFound(hash.to_string())),
             1 => locations[0].clone(),
-            _ => return Err(SubgraphRegistrarError::StoreError(anyhow!("boo").into())),
+            _ => {
+                return Err(SubgraphRegistrarError::StoreError(
+                    anyhow!(
+                        "there are {} different deployments with id {}",
+                        locations.len(),
+                        hash.as_str()
+                    )
+                    .into(),
+                ))
+            }
         };
         self.store.reassign_subgraph(&deployment, node_id)?;
 

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -15,7 +15,7 @@ fn insert_and_query(
     query: &str,
 ) -> Result<QueryResult, StoreError> {
     let subgraph_id = SubgraphDeploymentId::new(subgraph_id).unwrap();
-    create_test_subgraph(&subgraph_id, schema);
+    let deployment = create_test_subgraph(&subgraph_id, schema);
 
     let insert_ops = entities
         .into_iter()
@@ -30,7 +30,7 @@ fn insert_and_query(
 
     transact_entity_operations(
         &STORE.subgraph_store(),
-        subgraph_id.clone(),
+        &deployment,
         GENESIS_PTR.clone(),
         insert_ops.collect::<Vec<_>>(),
     )?;

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = "0.1.48"
 atomic_refcell = "0.1.7"
 bigdecimal = { version = "0.1.0", features = ["serde"] }
 bytes = "0.5"
-diesel = { version = "1.4.6", features = ["postgres", "serde_json", "numeric", "r2d2"] }
+diesel = { version = "1.4.6", features = ["postgres", "serde_json", "numeric", "r2d2", "chrono"] }
 diesel_derives = "1.4"
 chrono = "0.4.19"
 Inflector = "0.11.3"

--- a/graph/src/components/ethereum/listener.rs
+++ b/graph/src/components/ethereum/listener.rs
@@ -25,3 +25,8 @@ pub struct ChainHeadUpdate {
 /// The updates have no payload, receivers should call `Store::chain_head_ptr`
 /// to check what the latest block is.
 pub type ChainHeadUpdateStream = Box<dyn Stream<Item = (), Error = ()> + Send>;
+
+pub trait ChainHeadUpdateListener: Send + Sync + 'static {
+    // Subscribe to chain head updates for the given network.
+    fn subscribe(&self, network: String) -> ChainHeadUpdateStream;
+}

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -11,7 +11,7 @@ pub use self::adapter::{
     EthereumContractStateRequest, EthereumLogFilter, EthereumNetworkIdentifier,
     MockEthereumAdapter, ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
 };
-pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateStream};
+pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpdateStream};
 pub use self::network::{EthereumNetworkAdapters, EthereumNetworks, NodeCapabilities};
 pub use self::stream::{BlockStream, BlockStreamBuilder, BlockStreamEvent};
 pub use self::types::{

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use futures::Stream;
 
-use crate::prelude::*;
+use crate::{components::store::DeploymentLocator, prelude::*};
 
 pub enum BlockStreamEvent {
     Block(EthereumBlockWithTriggers),
@@ -16,7 +16,7 @@ pub trait BlockStreamBuilder: Clone + Send + Sync + 'static {
     fn build(
         &self,
         logger: Logger,
-        deployment_id: SubgraphDeploymentId,
+        deployment: DeploymentLocator,
         network_name: String,
         start_blocks: Vec<BlockNumber>,
         log_filter: EthereumLogFilter,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -875,9 +875,6 @@ pub trait SubgraphStore: Send + Sync + 'static {
     /// Queries the store for entities that match the store query.
     fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError>;
 
-    /// Queries the store for a single entity matching the store query.
-    fn find_one(&self, query: EntityQuery) -> Result<Option<Entity>, QueryExecutionError>;
-
     /// Find the reverse of keccak256 for `hash` through looking it up in the
     /// rainbow table.
     fn find_ens_name(&self, _hash: &str) -> Result<Option<String>, QueryExecutionError>;
@@ -1064,10 +1061,6 @@ impl SubgraphStore for MockStore {
     }
 
     fn find(&self, _query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
-        unimplemented!()
-    }
-
-    fn find_one(&self, _query: EntityQuery) -> Result<Option<Entity>, QueryExecutionError> {
         unimplemented!()
     }
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -909,7 +909,18 @@ pub trait SubgraphStore: Send + Sync + 'static {
     /// adding a root query type etc. to it
     fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<ApiSchema>, StoreError>;
 
+    /// Return a `WritableStore` that is used for indexing subgraphs. Only
+    /// code that is part of indexing a subgraph should ever use this.
     fn writable(&self, id: &SubgraphDeploymentId) -> Result<Arc<dyn WritableStore>, StoreError>;
+
+    /// The network indexer does not follow the normal flow of how subgraphs
+    /// are indexed, and therefore needs a special way to get a
+    /// `WritableStore`. This method should not be used outside of that, and
+    /// `writable` should be used instead
+    fn writable_for_network_indexer(
+        &self,
+        id: &SubgraphDeploymentId,
+    ) -> Result<Arc<dyn WritableStore>, StoreError>;
 
     /// Return the minimum block pointer of all deployments with this `id`
     /// that we would use to query or copy from; in particular, this will
@@ -1076,6 +1087,13 @@ impl SubgraphStore for MockStore {
         &self,
         _: &SubgraphDeploymentId,
     ) -> Result<Option<EthereumBlockPointer>, Error> {
+        unimplemented!()
+    }
+
+    fn writable_for_network_indexer(
+        &self,
+        _: &SubgraphDeploymentId,
+    ) -> Result<Arc<dyn WritableStore>, StoreError> {
         unimplemented!()
     }
 }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -910,6 +910,15 @@ pub trait SubgraphStore: Send + Sync + 'static {
     fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<ApiSchema>, StoreError>;
 
     fn writable(&self, id: &SubgraphDeploymentId) -> Result<Arc<dyn WritableStore>, StoreError>;
+
+    /// Return the minimum block pointer of all deployments with this `id`
+    /// that we would use to query or copy from; in particular, this will
+    /// ignore any instances of this deployment that are in the process of
+    /// being set up
+    fn least_block_ptr(
+        &self,
+        id: &SubgraphDeploymentId,
+    ) -> Result<Option<EthereumBlockPointer>, Error>;
 }
 
 #[async_trait]
@@ -1060,6 +1069,13 @@ impl SubgraphStore for MockStore {
     }
 
     fn is_deployed(&self, _: &SubgraphDeploymentId) -> Result<bool, Error> {
+        unimplemented!()
+    }
+
+    fn least_block_ptr(
+        &self,
+        _: &SubgraphDeploymentId,
+    ) -> Result<Option<EthereumBlockPointer>, Error> {
         unimplemented!()
     }
 }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1298,11 +1298,6 @@ pub trait StatusStore: Send + Sync + 'static {
         subgraph_id: &str,
     ) -> Result<(Option<String>, Option<String>), StoreError>;
 
-    fn supports_proof_of_indexing<'a>(
-        self: Arc<Self>,
-        subgraph_id: &'a SubgraphDeploymentId,
-    ) -> DynTryFuture<'a, bool>;
-
     /// A value of None indicates that the table is not available. Re-deploying
     /// the subgraph fixes this. It is undesirable to force everything to
     /// re-sync from scratch, so existing deployments will continue without a

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -918,20 +918,6 @@ pub trait SubgraphStore: Send + Sync + 'static {
         block_ptr_to: EthereumBlockPointer,
     ) -> Result<(), StoreError>;
 
-    /// Find the deployment for the current version of subgraph `name` and
-    /// return details about it needed for executing queries
-    async fn deployment_state_from_name(
-        &self,
-        name: SubgraphName,
-    ) -> Result<DeploymentState, StoreError>;
-
-    /// Find the deployment for the subgraph deployment `id` and
-    /// return details about it needed for executing queries
-    async fn deployment_state_from_id(
-        &self,
-        id: SubgraphDeploymentId,
-    ) -> Result<DeploymentState, StoreError>;
-
     /// Set subgraph status to failed with the given error as the cause.
     async fn fail_subgraph(
         &self,
@@ -1127,20 +1113,6 @@ impl SubgraphStore for MockStore {
         _subgraph_id: SubgraphDeploymentId,
         _block_ptr_to: EthereumBlockPointer,
     ) -> Result<(), StoreError> {
-        unimplemented!()
-    }
-
-    async fn deployment_state_from_name(
-        &self,
-        _: SubgraphName,
-    ) -> Result<DeploymentState, StoreError> {
-        unimplemented!()
-    }
-
-    async fn deployment_state_from_id(
-        &self,
-        _: SubgraphDeploymentId,
-    ) -> Result<DeploymentState, StoreError> {
         unimplemented!()
     }
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -861,18 +861,6 @@ pub trait SubgraphStore: Send + Sync + 'static {
         subgraph_id: &'a SubgraphDeploymentId,
     ) -> DynTryFuture<'a, bool>;
 
-    /// A value of None indicates that the table is not available. Re-deploying
-    /// the subgraph fixes this. It is undesirable to force everything to
-    /// re-sync from scratch, so existing deployments will continue without a
-    /// Proof of Indexing. Once all subgraphs have been re-deployed the Option
-    /// can be removed.
-    fn get_proof_of_indexing<'a>(
-        self: Arc<Self>,
-        subgraph_id: &'a SubgraphDeploymentId,
-        indexer: &'a Option<Address>,
-        block: EthereumBlockPointer,
-    ) -> DynTryFuture<'a, Option<[u8; 32]>>;
-
     /// Looks up an entity using the given store key at the latest block.
     fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError>;
 
@@ -1060,15 +1048,6 @@ impl SubgraphStore for MockStore {
         self: Arc<Self>,
         _subgraph_id: &'a SubgraphDeploymentId,
     ) -> DynTryFuture<'a, bool> {
-        unimplemented!();
-    }
-
-    fn get_proof_of_indexing<'a>(
-        self: Arc<Self>,
-        _subgraph_id: &'a SubgraphDeploymentId,
-        _indexer: &'a Option<Address>,
-        _block: EthereumBlockPointer,
-    ) -> DynTryFuture<'a, Option<[u8; 32]>> {
         unimplemented!();
     }
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1541,10 +1541,7 @@ impl EntityCache {
     /// to the current state is actually needed.
     ///
     /// Also returns the updated `LfuCache`.
-    pub fn as_modifications(
-        mut self,
-        store: &(impl WritableStore + ?Sized),
-    ) -> Result<ModificationsAndCache, QueryExecutionError> {
+    pub fn as_modifications(mut self) -> Result<ModificationsAndCache, QueryExecutionError> {
         assert!(!self.in_handler);
 
         // The first step is to make sure all entities being set are in `self.current`.
@@ -1566,7 +1563,7 @@ impl EntityCache {
         }
 
         for (subgraph_id, keys) in missing_by_subgraph {
-            for (entity_type, entities) in store.get_many(keys)? {
+            for (entity_type, entities) in self.store.get_many(keys)? {
                 for entity in entities {
                     let key = EntityKey {
                         subgraph_id: subgraph_id.clone(),

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -872,9 +872,6 @@ pub trait SubgraphStore: Send + Sync + 'static {
         ids_for_type: BTreeMap<&EntityType, Vec<&str>>,
     ) -> Result<BTreeMap<EntityType, Vec<Entity>>, StoreError>;
 
-    /// Queries the store for entities that match the store query.
-    fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError>;
-
     /// Find the reverse of keccak256 for `hash` through looking it up in the
     /// rainbow table.
     fn find_ens_name(&self, _hash: &str) -> Result<Option<String>, QueryExecutionError>;
@@ -1058,10 +1055,6 @@ impl SubgraphStore for MockStore {
         ids_for_type: BTreeMap<&EntityType, Vec<&str>>,
     ) -> Result<BTreeMap<EntityType, Vec<Entity>>, StoreError> {
         self.get_many_mock(subgraph_id, ids_for_type)
-    }
-
-    fn find(&self, _query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
-        unimplemented!()
     }
 
     fn find_ens_name(&self, _hash: &str) -> Result<Option<String>, QueryExecutionError> {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1271,9 +1271,6 @@ pub trait ChainStore: Send + Sync + 'static {
     /// `Ok(missing_blocks)`, where `missing_blocks` is a nonexhaustive list of missing blocks.
     fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error>;
 
-    /// Subscribe to chain head updates.
-    fn chain_head_updates(&self) -> ChainHeadUpdateStream;
-
     /// Get the current head block pointer for this chain.
     /// Any changes to the head block pointer will be to a block with a larger block number, never
     /// to a block with a smaller or equal block number.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1345,10 +1345,7 @@ pub trait QueryStore: Send + Sync {
 
     fn is_deployment_synced(&self) -> Result<bool, Error>;
 
-    fn block_ptr(
-        &self,
-        subgraph_id: SubgraphDeploymentId,
-    ) -> Result<Option<EthereumBlockPointer>, Error>;
+    fn block_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error>;
 
     fn block_number(&self, block_hash: H256) -> Result<Option<BlockNumber>, StoreError>;
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1352,11 +1352,7 @@ pub trait QueryStore: Send + Sync {
     fn wait_stats(&self) -> &PoolWaitStats;
 
     /// If `block` is `None`, assumes the latest block.
-    async fn has_non_fatal_errors(
-        &self,
-        id: SubgraphDeploymentId,
-        block: Option<BlockNumber>,
-    ) -> Result<bool, StoreError>;
+    async fn has_non_fatal_errors(&self, block: Option<BlockNumber>) -> Result<bool, StoreError>;
 
     /// Find the current state for the subgraph deployment `id` and
     /// return details about it needed for executing queries

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -872,6 +872,8 @@ pub struct DeploymentLocator {
     pub hash: SubgraphDeploymentId,
 }
 
+impl CheapClone for DeploymentLocator {}
+
 impl slog::Value for DeploymentLocator {
     fn serialize(
         &self,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -990,10 +990,6 @@ pub trait SubgraphStore: Send + Sync + 'static {
     /// Return the GraphQL schema that was derived from the user's schema by
     /// adding a root query type etc. to it
     fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<ApiSchema>, StoreError>;
-
-    /// Return the name of the network that the subgraph is indexing from. The
-    /// names returned are things like `mainnet` or `ropsten`
-    fn network_name(&self, subgraph_id: &SubgraphDeploymentId) -> Result<String, StoreError>;
 }
 
 #[async_trait]
@@ -1161,10 +1157,6 @@ impl SubgraphStore for MockStore {
     }
 
     fn api_schema(&self, _: &SubgraphDeploymentId) -> Result<Arc<ApiSchema>, StoreError> {
-        unimplemented!()
-    }
-
-    fn network_name(&self, _: &SubgraphDeploymentId) -> Result<String, StoreError> {
         unimplemented!()
     }
 }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -904,7 +904,7 @@ pub trait SubgraphStore: Send + Sync + 'static {
     /// adding a root query type etc. to it
     fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<ApiSchema>, StoreError>;
 
-    fn writable(&self) -> Arc<dyn WritableStore>;
+    fn writable(&self, id: &SubgraphDeploymentId) -> Arc<dyn WritableStore>;
 }
 
 #[async_trait]
@@ -1080,7 +1080,7 @@ impl SubgraphStore for MockStore {
         unimplemented!()
     }
 
-    fn writable(&self) -> Arc<dyn WritableStore> {
+    fn writable(&self, _: &SubgraphDeploymentId) -> Arc<dyn WritableStore> {
         Arc::new(MockStore::new())
     }
 }

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -1,6 +1,6 @@
-use crate::data::subgraph::schema::SubgraphError;
 use crate::prelude::*;
 use crate::util::lfu_cache::LfuCache;
+use crate::{components::store::WritableStore, data::subgraph::schema::SubgraphError};
 
 #[derive(Clone, Debug)]
 pub struct DataSourceTemplateInfo {
@@ -25,7 +25,7 @@ pub struct BlockState {
 
 impl BlockState {
     pub fn new(
-        store: Arc<dyn SubgraphStore>,
+        store: Arc<dyn WritableStore>,
         lfu_cache: LfuCache<EntityKey, Option<Entity>>,
     ) -> Self {
         BlockState {

--- a/graph/src/components/subgraph/instance_manager.rs
+++ b/graph/src/components/subgraph/instance_manager.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::prelude::SubgraphDeploymentId;
+use crate::components::store::DeploymentLocator;
 
 /// A `SubgraphInstanceManager` loads and manages subgraph instances.
 ///
@@ -11,8 +11,8 @@ use crate::prelude::SubgraphDeploymentId;
 pub trait SubgraphInstanceManager: Send + Sync + 'static {
     async fn start_subgraph(
         self: Arc<Self>,
-        id: SubgraphDeploymentId,
+        deployment: DeploymentLocator,
         manifest: serde_yaml::Mapping,
     );
-    fn stop_subgraph(&self, id: SubgraphDeploymentId);
+    fn stop_subgraph(&self, deployment: DeploymentLocator);
 }

--- a/graph/src/components/subgraph/provider.rs
+++ b/graph/src/components/subgraph/provider.rs
@@ -1,10 +1,16 @@
 use async_trait::async_trait;
 
-use crate::prelude::*;
+use crate::{components::store::DeploymentLocator, prelude::*};
 
 /// Common trait for subgraph providers.
 #[async_trait]
 pub trait SubgraphAssignmentProvider: Send + Sync + 'static {
-    async fn start(&self, id: SubgraphDeploymentId) -> Result<(), SubgraphAssignmentProviderError>;
-    async fn stop(&self, id: SubgraphDeploymentId) -> Result<(), SubgraphAssignmentProviderError>;
+    async fn start(
+        &self,
+        deployment: DeploymentLocator,
+    ) -> Result<(), SubgraphAssignmentProviderError>;
+    async fn stop(
+        &self,
+        deployment: DeploymentLocator,
+    ) -> Result<(), SubgraphAssignmentProviderError>;
 }

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -37,7 +37,7 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
 
     async fn reassign_subgraph(
         &self,
-        hash: SubgraphDeploymentId,
-        node_id: NodeId,
+        hash: &SubgraphDeploymentId,
+        node_id: &NodeId,
     ) -> Result<(), SubgraphRegistrarError>;
 }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::store::EntityType,
+    components::store::{DeploymentLocator, EntityType},
     prelude::{q, s, CacheWeight, EntityKey, QueryExecutionError},
 };
 use crate::{data::subgraph::SubgraphDeploymentId, prelude::EntityChange};
@@ -95,11 +95,11 @@ impl<'de> de::Deserialize<'de> for NodeId {
 #[serde(tag = "type")]
 pub enum AssignmentEvent {
     Add {
-        subgraph_id: SubgraphDeploymentId,
+        deployment: DeploymentLocator,
         node_id: NodeId,
     },
     Remove {
-        subgraph_id: SubgraphDeploymentId,
+        deployment: DeploymentLocator,
         node_id: NodeId,
     },
 }

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -753,6 +753,7 @@ impl Graft {
             vec![SubgraphManifestValidationError::GraftBaseInvalid(msg)]
         }
 
+        let store = store.writable();
         match store.block_ptr(&self.base) {
             Err(e) => gbi(e.to_string()),
             Ok(None) => gbi(format!(

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -755,6 +755,12 @@ impl Graft {
             vec![SubgraphManifestValidationError::GraftBaseInvalid(msg)]
         }
 
+        // We are being defensive here: we don't know which specific
+        // instance of a subgraph we will use as the base for the graft,
+        // since the notion of which of these instances is active can change
+        // between this check and when the graft actually happens when the
+        // subgraph is started. We therefore check that any instance of the
+        // base subgraph is suitable.
         match store.least_block_ptr(&self.base) {
             Err(e) => gbi(e.to_string()),
             Ok(None) => gbi(format!(

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -753,11 +753,7 @@ impl Graft {
             vec![SubgraphManifestValidationError::GraftBaseInvalid(msg)]
         }
 
-        let store = match store.writable(&self.base) {
-            Ok(store) => store,
-            Err(e) => return gbi(e.to_string()),
-        };
-        match store.block_ptr() {
+        match store.least_block_ptr(&self.base) {
             Err(e) => gbi(e.to_string()),
             Ok(None) => gbi(format!(
                 "failed to graft onto `{}` since it has not processed any blocks",

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -1102,6 +1102,13 @@ pub struct DeploymentState {
     pub latest_ethereum_block_number: BlockNumber,
 }
 
+impl DeploymentState {
+    /// Is this subgraph deployed and has it processed any blocks?
+    pub fn is_deployed(&self) -> bool {
+        self.latest_ethereum_block_number > 0
+    }
+}
+
 #[derive(Debug, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(non_camel_case_types)]
 pub enum SubgraphFeature {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -19,8 +19,10 @@ use thiserror::Error;
 use wasmparser;
 use web3::types::{Address, H256};
 
-use crate::components::link_resolver::LinkResolver;
-use crate::components::store::{StoreError, SubgraphStore};
+use crate::components::{
+    link_resolver::LinkResolver,
+    store::{DeploymentLocator, StoreError, SubgraphStore},
+};
 use crate::data::graphql::TryFromValue;
 use crate::data::query::QueryExecutionError;
 use crate::data::schema::{Schema, SchemaImportError, SchemaValidationError};
@@ -343,7 +345,7 @@ pub enum SubgraphAssignmentProviderError {
     #[error("Subgraph with ID {0} already running")]
     AlreadyRunning(SubgraphDeploymentId),
     #[error("Subgraph with ID {0} is not running")]
-    NotRunning(SubgraphDeploymentId),
+    NotRunning(DeploymentLocator),
     #[error("Subgraph provider error: {0}")]
     Unknown(anyhow::Error),
 }

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -753,7 +753,7 @@ impl Graft {
             vec![SubgraphManifestValidationError::GraftBaseInvalid(msg)]
         }
 
-        let store = store.writable();
+        let store = store.writable(&self.base);
         match store.block_ptr(&self.base) {
             Err(e) => gbi(e.to_string()),
             Ok(None) => gbi(format!(

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -757,7 +757,7 @@ impl Graft {
             Ok(store) => store,
             Err(e) => return gbi(e.to_string()),
         };
-        match store.block_ptr(&self.base) {
+        match store.block_ptr() {
             Err(e) => gbi(e.to_string()),
             Ok(None) => gbi(format!(
                 "failed to graft onto `{}` since it has not processed any blocks",

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -753,7 +753,10 @@ impl Graft {
             vec![SubgraphManifestValidationError::GraftBaseInvalid(msg)]
         }
 
-        let store = store.writable(&self.base);
+        let store = match store.writable(&self.base) {
+            Ok(store) => store,
+            Err(e) => return gbi(e.to_string()),
+        };
         match store.block_ptr(&self.base) {
             Err(e) => gbi(e.to_string()),
             Ok(None) => gbi(format!(

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -155,12 +155,6 @@ pub struct SubgraphManifestEntity {
     pub schema: String,
 }
 
-impl SubgraphManifestEntity {
-    pub fn id(subgraph_id: &SubgraphDeploymentId) -> String {
-        format!("{}-manifest", subgraph_id)
-    }
-}
-
 impl<'a> From<&'a super::SubgraphManifest> for SubgraphManifestEntity {
     fn from(manifest: &'a super::SubgraphManifest) -> Self {
         Self {

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -51,6 +51,7 @@ pub mod prelude {
     pub use anyhow::{anyhow, Context as _, Error};
     pub use async_trait::async_trait;
     pub use bigdecimal;
+    pub use chrono;
     pub use ethabi;
     pub use futures::future;
     pub use futures::prelude::*;

--- a/graph/src/log/factory.rs
+++ b/graph/src/log/factory.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::data::subgraph::SubgraphDeploymentId;
+use crate::components::store::DeploymentLocator;
 use crate::log::elastic::*;
 use crate::log::split::*;
 use slog::*;
@@ -76,10 +76,10 @@ impl LoggerFactory {
     }
 
     /// Creates a subgraph logger with Elasticsearch support.
-    pub fn subgraph_logger(&self, subgraph_id: &SubgraphDeploymentId) -> Logger {
+    pub fn subgraph_logger(&self, loc: &DeploymentLocator) -> Logger {
         let term_logger = self
             .parent
-            .new(o!("subgraph_id" => subgraph_id.to_string()));
+            .new(o!("subgraph_id" => loc.hash.to_string(), "sgd" => loc.id.to_string()));
 
         self.elastic_config
             .clone()
@@ -92,7 +92,7 @@ impl LoggerFactory {
                             index: String::from("subgraph-logs"),
                             document_type: String::from("log"),
                             custom_id_key: String::from("subgraphId"),
-                            custom_id_value: subgraph_id.to_string(),
+                            custom_id_value: loc.hash.to_string(),
                             flush_interval: Duration::from_secs(5),
                         },
                         term_logger.clone(),

--- a/graph/src/util/mod.rs
+++ b/graph/src/util/mod.rs
@@ -9,6 +9,8 @@ pub mod security;
 
 pub mod lfu_cache;
 
+pub mod timed_cache;
+
 pub mod error;
 
 pub mod stats;

--- a/graph/src/util/timed_cache.rs
+++ b/graph/src/util/timed_cache.rs
@@ -1,0 +1,70 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+    time::{Duration, Instant},
+};
+
+/// Caching of values for a specified amount of time
+#[derive(Debug)]
+struct CacheEntry<T> {
+    value: Arc<T>,
+    expires: Instant,
+}
+
+/// A cache that keeps entries live for a fixed amount of time. It is assumed
+/// that all that data that could possibly wind up in the cache is very small,
+/// and that expired entries are replaced by an updated entry whenever expiry
+/// is detected. In other words, the cache does not ever remove entries.
+#[derive(Debug)]
+pub struct TimedCache<T> {
+    ttl: Duration,
+    entries: RwLock<HashMap<String, CacheEntry<T>>>,
+}
+
+impl<T> TimedCache<T> {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            entries: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Return the entry for `key` if it exists and is not expired yet, and
+    /// return `None` otherwise. Note that expired entries stay in the cache
+    /// as it is assumed that, after returning `None`, the caller will
+    /// immediately overwrite that entry with a call to `set`
+    pub fn get(&self, key: &str) -> Option<Arc<T>> {
+        self.get_at(key, Instant::now())
+    }
+
+    fn get_at(&self, key: &str, now: Instant) -> Option<Arc<T>> {
+        match self.entries.read().unwrap().get(key) {
+            Some(CacheEntry { value, expires }) if *expires >= now => Some(value.clone()),
+            _ => None,
+        }
+    }
+
+    /// Associate `key` with `value` in the cache. The `value` will be
+    /// valid for `self.ttl` duration
+    pub fn set(&self, key: String, value: Arc<T>) {
+        self.set_at(key, value, Instant::now())
+    }
+
+    fn set_at(&self, key: String, value: Arc<T>, now: Instant) {
+        let entry = CacheEntry {
+            value,
+            expires: now + self.ttl,
+        };
+        self.entries.write().unwrap().insert(key, entry);
+    }
+}
+
+#[test]
+fn cache() {
+    const KEY: &str = "one";
+    let cache = TimedCache::<String>::new(Duration::from_millis(10));
+    let now = Instant::now();
+    cache.set_at(KEY.to_string(), Arc::new("value".to_string()), now);
+    assert!(cache.get_at(KEY, now + Duration::from_millis(5)).is_some());
+    assert!(cache.get_at(KEY, now + Duration::from_millis(15)).is_none());
+}

--- a/graph/src/util/timed_cache.rs
+++ b/graph/src/util/timed_cache.rs
@@ -74,6 +74,22 @@ impl<K, V> TimedCache<K, V> {
         };
         self.entries.write().unwrap().insert(key, entry);
     }
+
+    pub fn clear(&self) {
+        self.entries.write().unwrap().clear();
+    }
+
+    pub fn find<F>(&self, pred: F) -> Option<Arc<V>>
+    where
+        F: Fn(&V) -> bool,
+    {
+        self.entries
+            .read()
+            .unwrap()
+            .values()
+            .find(move |entry| pred(entry.value.as_ref()))
+            .map(|entry| entry.value.clone())
+    }
 }
 
 #[test]

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -6,11 +7,14 @@ use graph::prelude::{
 };
 use graph::{components::store::EntityType, mock::MockStore};
 
-fn make_band(id: &'static str, data: Vec<(&str, Value)>) -> (EntityKey, Entity) {
-    let subgraph_id = SubgraphDeploymentId::new("entity_cache").unwrap();
+lazy_static! {
+    static ref SUBGRAPH_ID: SubgraphDeploymentId =
+        SubgraphDeploymentId::new("entity_cache").unwrap();
+}
 
+fn make_band(id: &'static str, data: Vec<(&str, Value)>) -> (EntityKey, Entity) {
     (
-        EntityKey::data(subgraph_id.clone(), "Band".to_string(), id.into()),
+        EntityKey::data(SUBGRAPH_ID.clone(), "Band".to_string(), id.into()),
         Entity::from(data),
     )
 }
@@ -22,7 +26,7 @@ fn sort_by_entity_key(mut mods: Vec<EntityModification>) -> Vec<EntityModificati
 
 #[test]
 fn empty_cache_modifications() {
-    let store = MockStore::new().writable();
+    let store = MockStore::new().writable(&*SUBGRAPH_ID);
     let cache = EntityCache::new(store.clone());
     let result = cache.as_modifications(&*store);
     assert_eq!(result.unwrap().modifications, vec![]);

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -28,7 +28,7 @@ fn sort_by_entity_key(mut mods: Vec<EntityModification>) -> Vec<EntityModificati
 fn empty_cache_modifications() {
     let store = MockStore::new().writable(&*SUBGRAPH_ID).unwrap();
     let cache = EntityCache::new(store.clone());
-    let result = cache.as_modifications(&*store);
+    let result = cache.as_modifications();
     assert_eq!(result.unwrap().modifications, vec![]);
 }
 
@@ -57,7 +57,7 @@ fn insert_modifications() {
     );
     cache.set(sigurros_key.clone(), sigurros_data.clone());
 
-    let result = cache.as_modifications(&*store);
+    let result = cache.as_modifications();
     assert_eq!(
         sort_by_entity_key(result.unwrap().modifications),
         sort_by_entity_key(vec![
@@ -124,7 +124,7 @@ fn overwrite_modifications() {
     );
     cache.set(sigurros_key.clone(), sigurros_data.clone());
 
-    let result = cache.as_modifications(&*store);
+    let result = cache.as_modifications();
     assert_eq!(
         sort_by_entity_key(result.unwrap().modifications),
         sort_by_entity_key(vec![
@@ -190,7 +190,7 @@ fn consecutive_modifications() {
 
     // We expect a single overwrite modification for the above that leaves "id"
     // and "name" untouched, sets "founded" and removes the "label" field.
-    let result = cache.as_modifications(&*store);
+    let result = cache.as_modifications();
     assert_eq!(
         sort_by_entity_key(result.unwrap().modifications),
         sort_by_entity_key(vec![EntityModification::Overwrite {

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -2,14 +2,20 @@ use lazy_static::lazy_static;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use graph::prelude::{
-    Entity, EntityCache, EntityKey, EntityModification, SubgraphDeploymentId, SubgraphStore, Value,
-};
 use graph::{components::store::EntityType, mock::MockStore};
+use graph::{
+    components::store::{DeploymentId, DeploymentLocator},
+    prelude::{
+        Entity, EntityCache, EntityKey, EntityModification, SubgraphDeploymentId, SubgraphStore,
+        Value,
+    },
+};
 
 lazy_static! {
     static ref SUBGRAPH_ID: SubgraphDeploymentId =
         SubgraphDeploymentId::new("entity_cache").unwrap();
+    static ref DEPLOYMENT: DeploymentLocator =
+        DeploymentLocator::new(DeploymentId::new(-12), SUBGRAPH_ID.clone());
 }
 
 fn make_band(id: &'static str, data: Vec<(&str, Value)>) -> (EntityKey, Entity) {
@@ -26,7 +32,7 @@ fn sort_by_entity_key(mut mods: Vec<EntityModification>) -> Vec<EntityModificati
 
 #[test]
 fn empty_cache_modifications() {
-    let store = MockStore::new().writable(&*SUBGRAPH_ID).unwrap();
+    let store = MockStore::new().writable(&*DEPLOYMENT).unwrap();
     let cache = EntityCache::new(store.clone());
     let result = cache.as_modifications();
     assert_eq!(result.unwrap().modifications, vec![]);

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -26,7 +26,7 @@ fn sort_by_entity_key(mut mods: Vec<EntityModification>) -> Vec<EntityModificati
 
 #[test]
 fn empty_cache_modifications() {
-    let store = MockStore::new().writable(&*SUBGRAPH_ID);
+    let store = MockStore::new().writable(&*SUBGRAPH_ID).unwrap();
     let cache = EntityCache::new(store.clone());
     let result = cache.as_modifications(&*store);
     assert_eq!(result.unwrap().modifications, vec![]);

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use graph::prelude::{
-    Entity, EntityCache, EntityKey, EntityModification, SubgraphDeploymentId, Value,
+    Entity, EntityCache, EntityKey, EntityModification, SubgraphDeploymentId, SubgraphStore, Value,
 };
 use graph::{components::store::EntityType, mock::MockStore};
 
@@ -22,7 +22,7 @@ fn sort_by_entity_key(mut mods: Vec<EntityModification>) -> Vec<EntityModificati
 
 #[test]
 fn empty_cache_modifications() {
-    let store = Arc::new(MockStore::new());
+    let store = MockStore::new().writable();
     let cache = EntityCache::new(store.clone());
     let result = cache.as_modifications(&*store);
     assert_eq!(result.unwrap().modifications, vec![]);

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -40,7 +40,7 @@ fn insert_modifications() {
     // operation as an insert.
     store
         .expect_get_many_mock()
-        .returning(|_, _| Ok(BTreeMap::new()));
+        .returning(|_| Ok(BTreeMap::new()));
 
     let store = Arc::new(store);
     let mut cache = EntityCache::new(store.clone());
@@ -79,7 +79,7 @@ fn overwrite_modifications() {
 
     // Pre-populate the store with entities so that the cache treats
     // every set operation as an overwrite.
-    store.expect_get_many_mock().returning(|_, _| {
+    store.expect_get_many_mock().returning(|_| {
         let mut map = BTreeMap::new();
 
         map.insert(
@@ -146,7 +146,7 @@ fn consecutive_modifications() {
 
     // Pre-populate the store with data so that we can test setting a field to
     // `Value::Null`.
-    store.expect_get_many_mock().returning(|_, _| {
+    store.expect_get_many_mock().returning(|_| {
         let mut map = BTreeMap::new();
 
         map.insert(

--- a/graph/tests/manifest.rs
+++ b/graph/tests/manifest.rs
@@ -143,7 +143,7 @@ specVersion: 0.0.2
         //
         // Validation against subgraph that hasn't synced anything fails
         //
-        test_store::create_test_subgraph(&subgraph, GQL_SCHEMA);
+        let deployment = test_store::create_test_subgraph(&subgraph, GQL_SCHEMA);
         // This check is awkward since the test manifest has other problems
         // that the validation complains about as setting up a valid manifest
         // would be a bit more work; we just want to make sure that
@@ -163,7 +163,7 @@ specVersion: 0.0.2
 
         let mut thing = Entity::new();
         thing.set("id", "datthing");
-        test_store::insert_entities(subgraph, vec![(EntityType::from("Thing"), thing)])
+        test_store::insert_entities(&deployment, vec![(EntityType::from("Thing"), thing)])
             .expect("Can insert a thing");
 
         // Validation against subgraph that has not reached the graft point fails

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -105,7 +105,7 @@ impl StoreResolver {
     ) -> Result<EthereumBlockPointer, QueryExecutionError> {
         match bc {
             BlockConstraint::Number(number) => store
-                .block_ptr(subgraph.clone())
+                .block_ptr()
                 .map_err(|e| StoreError::from(e).into())
                 .and_then(|ptr| {
                     let ptr = ptr.expect("we should have already checked that the subgraph exists");
@@ -147,7 +147,7 @@ impl StoreResolver {
                     })
             }
             BlockConstraint::Latest => store
-                .block_ptr(subgraph.clone())
+                .block_ptr()
                 .map_err(|e| StoreError::from(e).into())
                 .and_then(|ptr| {
                     let ptr = ptr.expect("we should have already checked that the subgraph exists");

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -13,7 +13,7 @@ use crate::query::ext::BlockConstraint;
 use crate::schema::ast as sast;
 use crate::{prelude::*, schema::api::ErrorPolicy};
 
-use crate::store::query::{collect_entities_from_query_field, parse_subgraph_id};
+use crate::store::query::collect_entities_from_query_field;
 
 /// A resolver that fetches entities from a `Store`.
 #[derive(Clone)]
@@ -289,14 +289,12 @@ impl Resolver for StoreResolver {
         let entities = collect_entities_from_query_field(schema, object_type, field);
 
         // Subscribe to the store and return the entity change stream
-        let deployment_id = parse_subgraph_id(object_type)?;
         Ok(self
             .subscription_manager
             .subscribe(entities)
             .throttle_while_syncing(
                 &self.logger,
                 self.store.clone(),
-                deployment_id,
                 *SUBSCRIPTION_THROTTLE_INTERVAL,
             ))
     }

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -76,7 +76,7 @@ impl StoreResolver {
         .and_then(|x| x)?; // Propagate panics.
 
         let has_non_fatal_errors = store
-            .has_non_fatal_errors(deployment.clone(), Some(block_ptr.block_number()))
+            .has_non_fatal_errors(Some(block_ptr.block_number()))
             .await?;
 
         let resolver = StoreResolver {

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1571,6 +1571,7 @@ fn query_detects_reorg() {
         // Revert one block
         STORE
             .subgraph_store()
+            .writable()
             .revert_block_operations(id.clone(), GENESIS_PTR.clone())
             .unwrap();
         // A query is still fine since we implicitly query at block 0; we were
@@ -1759,6 +1760,7 @@ fn non_fatal_errors() {
             // Test error reverts.
             STORE
                 .subgraph_store()
+                .writable()
                 .revert_block_operations(id.clone(), BLOCK_ONE.clone())
                 .unwrap();
             let query = "query { musician(id: \"m1\") { id }  _meta { hasIndexingErrors } }";

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1572,6 +1572,7 @@ fn query_detects_reorg() {
         STORE
             .subgraph_store()
             .writable(&id)
+            .expect("can get writable")
             .revert_block_operations(id.clone(), GENESIS_PTR.clone())
             .unwrap();
         // A query is still fine since we implicitly query at block 0; we were
@@ -1761,6 +1762,7 @@ fn non_fatal_errors() {
             STORE
                 .subgraph_store()
                 .writable(&id)
+                .expect("can get writable")
                 .revert_block_operations(id.clone(), BLOCK_ONE.clone())
                 .unwrap();
             let query = "query { musician(id: \"m1\") { id }  _meta { hasIndexingErrors } }";

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -26,7 +26,7 @@ use graph::{
 };
 use graph_graphql::{prelude::*, subscription::execute_subscription};
 use test_store::{
-    execute_subgraph_query_with_complexity, execute_subgraph_query_with_deadline,
+    deployment_state, execute_subgraph_query_with_complexity, execute_subgraph_query_with_deadline,
     run_test_sequentially, transact_entity_operations, transact_errors, BLOCK_ONE, GENESIS_PTR,
     LOAD_MANAGER, LOGGER, STORE, SUBSCRIPTION_MANAGER,
 };
@@ -1553,11 +1553,7 @@ fn query_detects_reorg() {
         let query = graphql_parser::parse_query(query)
             .expect("invalid test query")
             .into_static();
-        let state = STORE
-            .subgraph_store()
-            .deployment_state_from_id(id.clone())
-            .await
-            .expect("failed to get state");
+        let state = deployment_state(STORE.as_ref(), &id).await;
 
         // Inject a fake initial state; c435c25decbc4ad7bbbadf8e0ced0ff2
         *graph_graphql::test_support::INITIAL_DEPLOYMENT_STATE_FOR_TESTS

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1571,7 +1571,7 @@ fn query_detects_reorg() {
         // Revert one block
         STORE
             .subgraph_store()
-            .writable()
+            .writable(&id)
             .revert_block_operations(id.clone(), GENESIS_PTR.clone())
             .unwrap();
         // A query is still fine since we implicitly query at block 0; we were
@@ -1760,7 +1760,7 @@ fn non_fatal_errors() {
             // Test error reverts.
             STORE
                 .subgraph_store()
-                .writable()
+                .writable(&id)
                 .revert_block_operations(id.clone(), BLOCK_ONE.clone())
                 .unwrap();
             let query = "query { musician(id: \"m1\") { id }  _meta { hasIndexingErrors } }";

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -1,6 +1,6 @@
 use futures::sync::mpsc::{channel, Receiver, Sender};
 
-use graph::prelude::*;
+use graph::{components::store::DeploymentLocator, prelude::*};
 
 pub struct MockBlockStream {
     chain_head_update_sink: Sender<ChainHeadUpdate>,
@@ -50,7 +50,7 @@ impl BlockStreamBuilder for MockBlockStreamBuilder {
     fn build(
         &self,
         _logger: Logger,
-        _deployment_id: SubgraphDeploymentId,
+        _deployment: DeploymentLocator,
         _network_name: String,
         _start_blocks: Vec<BlockNumber>,
         _: EthereumLogFilter,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -29,8 +29,6 @@ mock! {
 
         fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error>;
 
-        fn chain_head_updates(&self) -> ChainHeadUpdateStream;
-
         fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error>;
 
         fn blocks(&self, hashes: Vec<H256>) -> Result<Vec<LightEthereumBlock>, Error>;

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -124,25 +124,6 @@ impl SubgraphStore for MockStore {
         unimplemented!()
     }
 
-    async fn deployment_state_from_name(
-        &self,
-        _: SubgraphName,
-    ) -> Result<DeploymentState, StoreError> {
-        unimplemented!()
-    }
-
-    async fn deployment_state_from_id(
-        &self,
-        id: SubgraphDeploymentId,
-    ) -> Result<DeploymentState, StoreError> {
-        Ok(DeploymentState {
-            id,
-            reorg_count: 0,
-            max_reorg_depth: 0,
-            latest_ethereum_block_number: 0,
-        })
-    }
-
     async fn fail_subgraph(
         &self,
         _: SubgraphDeploymentId,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -1,7 +1,7 @@
 use mockall::predicate::*;
 use mockall::*;
 
-use graph::prelude::*;
+use graph::{components::store::DeploymentLocator, prelude::*};
 use web3::types::H256;
 
 mock! {
@@ -65,7 +65,7 @@ impl SubgraphStore for MockStore {
         _: NodeId,
         _: String,
         _: SubgraphVersionSwitchingMode,
-    ) -> Result<(), StoreError> {
+    ) -> Result<DeploymentLocator, StoreError> {
         unimplemented!()
     }
 
@@ -77,15 +77,15 @@ impl SubgraphStore for MockStore {
         unimplemented!()
     }
 
-    fn reassign_subgraph(&self, _: &SubgraphDeploymentId, _: &NodeId) -> Result<(), StoreError> {
+    fn reassign_subgraph(&self, _: &DeploymentLocator, _: &NodeId) -> Result<(), StoreError> {
         unimplemented!()
     }
 
-    fn assigned_node(&self, _: &SubgraphDeploymentId) -> Result<Option<NodeId>, StoreError> {
+    fn assigned_node(&self, _: &DeploymentLocator) -> Result<Option<NodeId>, StoreError> {
         unimplemented!()
     }
 
-    fn assignments(&self, _: &NodeId) -> Result<Vec<SubgraphDeploymentId>, StoreError> {
+    fn assignments(&self, _: &NodeId) -> Result<Vec<DeploymentLocator>, StoreError> {
         unimplemented!()
     }
 
@@ -103,7 +103,7 @@ impl SubgraphStore for MockStore {
 
     fn writable(
         &self,
-        _: &SubgraphDeploymentId,
+        _: &DeploymentLocator,
     ) -> Result<Arc<dyn graph::components::store::WritableStore>, StoreError> {
         todo!()
     }
@@ -123,6 +123,10 @@ impl SubgraphStore for MockStore {
         &self,
         _: &SubgraphDeploymentId,
     ) -> Result<Arc<dyn graph::components::store::WritableStore>, StoreError> {
+        unimplemented!()
+    }
+
+    fn locators(&self, _: &str) -> Result<Vec<DeploymentLocator>, StoreError> {
         unimplemented!()
     }
 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -87,10 +87,6 @@ impl SubgraphStore for MockStore {
         unimplemented!()
     }
 
-    fn find_one(&self, _query: EntityQuery) -> Result<Option<Entity>, QueryExecutionError> {
-        unimplemented!()
-    }
-
     fn find_ens_name(&self, _hash: &str) -> Result<Option<String>, QueryExecutionError> {
         unimplemented!()
     }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -101,7 +101,10 @@ impl SubgraphStore for MockStore {
         unimplemented!()
     }
 
-    fn writable(&self) -> Arc<dyn graph::components::store::WritableStore> {
+    fn writable(
+        &self,
+        _: &SubgraphDeploymentId,
+    ) -> Arc<dyn graph::components::store::WritableStore> {
         todo!()
     }
 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -189,8 +189,4 @@ impl SubgraphStore for MockStore {
     fn api_schema(&self, _: &SubgraphDeploymentId) -> Result<Arc<ApiSchema>, StoreError> {
         unimplemented!()
     }
-
-    fn network_name(&self, _: &SubgraphDeploymentId) -> Result<String, StoreError> {
-        unimplemented!()
-    }
 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -104,7 +104,11 @@ impl SubgraphStore for MockStore {
     fn writable(
         &self,
         _: &SubgraphDeploymentId,
-    ) -> Arc<dyn graph::components::store::WritableStore> {
+    ) -> Result<Arc<dyn graph::components::store::WritableStore>, StoreError> {
+        todo!()
+    }
+
+    fn is_deployed(&self, _: &SubgraphDeploymentId) -> Result<bool, Error> {
         todo!()
     }
 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -111,4 +111,11 @@ impl SubgraphStore for MockStore {
     fn is_deployed(&self, _: &SubgraphDeploymentId) -> Result<bool, Error> {
         todo!()
     }
+
+    fn least_block_ptr(
+        &self,
+        _: &SubgraphDeploymentId,
+    ) -> Result<Option<EthereumBlockPointer>, Error> {
+        unimplemented!()
+    }
 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -6,7 +6,7 @@ use graph::components::store::EntityType;
 use graph::components::store::StoredDynamicDataSource;
 use graph::data::subgraph::schema::SubgraphError;
 use graph::prelude::*;
-use web3::types::{Address, H256};
+use web3::types::H256;
 
 mock! {
     pub Store {
@@ -80,15 +80,6 @@ impl SubgraphStore for MockStore {
         self: Arc<Self>,
         _subgraph_id: &'a SubgraphDeploymentId,
     ) -> DynTryFuture<'a, bool> {
-        unimplemented!()
-    }
-
-    fn get_proof_of_indexing<'a>(
-        self: Arc<Self>,
-        _subgraph_id: &'a SubgraphDeploymentId,
-        _indexer: &'a Option<Address>,
-        _block: EthereumBlockPointer,
-    ) -> DynTryFuture<'a, Option<[u8; 32]>> {
         unimplemented!()
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -1,10 +1,6 @@
 use mockall::predicate::*;
 use mockall::*;
-use std::collections::BTreeMap;
 
-use graph::components::store::EntityType;
-use graph::components::store::StoredDynamicDataSource;
-use graph::data::subgraph::schema::SubgraphError;
 use graph::prelude::*;
 use web3::types::H256;
 
@@ -57,61 +53,7 @@ mock! {
 
 #[async_trait]
 impl SubgraphStore for MockStore {
-    fn block_ptr(
-        &self,
-        _subgraph_id: &SubgraphDeploymentId,
-    ) -> Result<Option<EthereumBlockPointer>, Error> {
-        unimplemented!()
-    }
-
-    fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError> {
-        self.get_mock(key)
-    }
-
-    fn get_many(
-        &self,
-        _subgraph_id: &SubgraphDeploymentId,
-        _ids_for_type: BTreeMap<&EntityType, Vec<&str>>,
-    ) -> Result<BTreeMap<EntityType, Vec<Entity>>, StoreError> {
-        unimplemented!()
-    }
-
-    fn supports_proof_of_indexing<'a>(
-        self: Arc<Self>,
-        _subgraph_id: &'a SubgraphDeploymentId,
-    ) -> DynTryFuture<'a, bool> {
-        unimplemented!()
-    }
-
     fn find_ens_name(&self, _hash: &str) -> Result<Option<String>, QueryExecutionError> {
-        unimplemented!()
-    }
-
-    fn transact_block_operations(
-        &self,
-        _subgraph_id: SubgraphDeploymentId,
-        _block_ptr_to: EthereumBlockPointer,
-        _mods: Vec<EntityModification>,
-        _stopwatch: StopwatchMetrics,
-        _data_sources: Vec<StoredDynamicDataSource>,
-        _deterministic_errors: Vec<SubgraphError>,
-    ) -> Result<(), StoreError> {
-        unimplemented!()
-    }
-
-    fn revert_block_operations(
-        &self,
-        _subgraph_id: SubgraphDeploymentId,
-        _block_ptr_to: EthereumBlockPointer,
-    ) -> Result<(), StoreError> {
-        unimplemented!()
-    }
-
-    async fn fail_subgraph(
-        &self,
-        _: SubgraphDeploymentId,
-        _: SubgraphError,
-    ) -> Result<(), StoreError> {
         unimplemented!()
     }
 
@@ -139,37 +81,6 @@ impl SubgraphStore for MockStore {
         unimplemented!()
     }
 
-    fn unassign_subgraph(&self, _: &SubgraphDeploymentId) -> Result<(), StoreError> {
-        unimplemented!()
-    }
-
-    fn start_subgraph_deployment(
-        &self,
-        _logger: &Logger,
-        _subgraph_id: &SubgraphDeploymentId,
-    ) -> Result<(), StoreError> {
-        unimplemented!()
-    }
-
-    fn unfail(&self, _: &SubgraphDeploymentId) -> Result<(), StoreError> {
-        unimplemented!()
-    }
-
-    fn is_deployment_synced(&self, _: &SubgraphDeploymentId) -> Result<bool, Error> {
-        unimplemented!()
-    }
-
-    fn deployment_synced(&self, _: &SubgraphDeploymentId) -> Result<(), Error> {
-        unimplemented!()
-    }
-
-    async fn load_dynamic_data_sources(
-        &self,
-        _: SubgraphDeploymentId,
-    ) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
-        unimplemented!()
-    }
-
     fn assigned_node(&self, _: &SubgraphDeploymentId) -> Result<Option<NodeId>, StoreError> {
         unimplemented!()
     }
@@ -188,5 +99,9 @@ impl SubgraphStore for MockStore {
 
     fn api_schema(&self, _: &SubgraphDeploymentId) -> Result<Arc<ApiSchema>, StoreError> {
         unimplemented!()
+    }
+
+    fn writable(&self) -> Arc<dyn graph::components::store::WritableStore> {
+        todo!()
     }
 }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -83,10 +83,6 @@ impl SubgraphStore for MockStore {
         unimplemented!()
     }
 
-    fn find(&self, _query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
-        unimplemented!()
-    }
-
     fn find_ens_name(&self, _hash: &str) -> Result<Option<String>, QueryExecutionError> {
         unimplemented!()
     }

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -118,4 +118,11 @@ impl SubgraphStore for MockStore {
     ) -> Result<Option<EthereumBlockPointer>, Error> {
         unimplemented!()
     }
+
+    fn writable_for_network_indexer(
+        &self,
+        _: &SubgraphDeploymentId,
+    ) -> Result<Arc<dyn graph::components::store::WritableStore>, StoreError> {
+        unimplemented!()
+    }
 }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -36,7 +36,7 @@ graph-store-postgres = { path = "../store/postgres" }
 regex = "1.4.5"
 serde = { version = "1.0.117", features = ["derive", "rc"] }
 serde_regex = "1.1.0"
-structopt = "0.3.20"
+structopt = { version = "0.3.20", features = ["wrap_help"] }
 toml = "0.5.7"
 shellexpand = "2.1.0"
 diesel = "1.4.6"

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -105,11 +105,15 @@ pub enum Command {
         id: String,
         /// The name of the node that should index the deployment
         node: String,
+        /// The shard of the deployment if `id` itself is ambiguous
+        shard: Option<String>,
     },
     /// Unassign a deployment
     Unassign {
         /// The id of the deployment to unassign
         id: String,
+        /// The shard of the deployment if `id` itself is ambiguous
+        shard: Option<String>,
     },
     Rewind {
         id: String,
@@ -213,6 +217,8 @@ pub enum CopyCommand {
         shard: String,
         /// The name of the node that should index the copy
         node: String,
+        /// The shard of the `src` subgraph in case that is ambiguous
+        src_shard: Option<String>,
     },
     /// Activate the copy of a deployment.
     ///
@@ -395,8 +401,10 @@ async fn main() {
             }
         }
         Remove { name } => commands::remove::run(ctx.subgraph_store(), name),
-        Unassign { id } => commands::assign::unassign(ctx.subgraph_store(), id),
-        Reassign { id, node } => commands::assign::reassign(ctx.subgraph_store(), id, node),
+        Unassign { id, shard } => commands::assign::unassign(ctx.subgraph_store(), id, shard),
+        Reassign { id, node, shard } => {
+            commands::assign::reassign(ctx.subgraph_store(), id, node, shard)
+        }
         Rewind {
             id,
             block_hash,
@@ -423,7 +431,8 @@ async fn main() {
                     shard,
                     node,
                     offset,
-                } => commands::copy::create(ctx.store(), src, shard, node, offset).await,
+                    src_shard,
+                } => commands::copy::create(ctx.store(), src, src_shard, shard, node, offset).await,
                 Activate { deployment, shard } => {
                     commands::copy::activate(ctx.subgraph_store(), deployment, shard)
                 }

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -436,7 +436,7 @@ async fn main() {
                 Activate { deployment, shard } => {
                     commands::copy::activate(ctx.subgraph_store(), deployment, shard)
                 }
-                List => commands::copy::list(ctx.primary_pool()),
+                List => commands::copy::list(ctx.pools()),
                 Status { dst } => commands::copy::status(ctx.pools(), dst),
             }
         }

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -213,6 +213,17 @@ pub enum CopyCommand {
         /// The name of the node that should index the copy
         node: String,
     },
+    /// Activate the copy of a deployment.
+    ///
+    /// This will route queries to that specific copy (with some delay); the
+    /// previously active copy will become inactive. Only copies that have
+    /// progressed at least as far as the original should be activated.
+    Activate {
+        /// The IPFS hash of the deployment to activate
+        deployment: String,
+        /// The name of the database shard that holds the copy
+        shard: String,
+    },
 }
 
 impl From<Opt> for config::Opt {
@@ -396,6 +407,9 @@ async fn main() {
                     node,
                     offset,
                 } => commands::copy::create(ctx.store(), src, shard, node, offset).await,
+                Activate { deployment, shard } => {
+                    commands::copy::activate(ctx.subgraph_store(), deployment, shard)
+                }
             }
         }
     };

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -206,6 +206,8 @@ pub struct Shard {
     pub weight: usize,
     #[serde(default)]
     pub pool_size: PoolSize,
+    #[serde(default = "PoolSize::five")]
+    pub fdw_pool_size: PoolSize,
     #[serde(default)]
     pub replicas: BTreeMap<String, Replica>,
 }
@@ -248,6 +250,7 @@ impl Shard {
             connection: postgres_url.clone(),
             weight: opt.postgres_host_weights.get(0).cloned().unwrap_or(1),
             pool_size,
+            fdw_pool_size: PoolSize::five(),
             replicas,
         })
     }
@@ -268,6 +271,10 @@ impl Default for PoolSize {
 }
 
 impl PoolSize {
+    fn five() -> Self {
+        Self::Fixed(5)
+    }
+
     fn validate(&self, connection: &str) -> Result<()> {
         use PoolSize::*;
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -229,11 +229,8 @@ async fn main() {
             graphql_runner.clone(),
             node_id.clone(),
         );
-        let subscription_server = GraphQLSubscriptionServer::new(
-            &logger,
-            graphql_runner.clone(),
-            network_store.subgraph_store(),
-        );
+        let subscription_server =
+            GraphQLSubscriptionServer::new(&logger, graphql_runner.clone(), network_store.clone());
 
         let mut index_node_server = IndexNodeServer::new(
             &logger_factory,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -210,6 +210,7 @@ async fn main() {
         let (eth_networks, idents) = connect_networks(&logger, eth_networks).await;
 
         let subscription_manager = store_builder.subscription_manager();
+        let chain_head_update_listener = store_builder.chain_head_update_listener();
         let network_store = store_builder.network_store(idents);
         let load_manager = Arc::new(LoadManager::new(
             &logger,
@@ -295,6 +296,7 @@ async fn main() {
         let block_stream_builder = BlockStreamBuilder::new(
             network_store.subgraph_store(),
             network_store.block_store(),
+            chain_head_update_listener.clone(),
             eth_networks.clone(),
             node_id.clone(),
             *REORG_THRESHOLD,

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -5,8 +5,12 @@ use graph_store_postgres::SubgraphStore;
 
 use crate::manager::deployment::locate;
 
-pub fn unassign(store: Arc<SubgraphStore>, hash: String) -> Result<(), Error> {
-    let deployment = locate(store.as_ref(), hash)?;
+pub fn unassign(
+    store: Arc<SubgraphStore>,
+    hash: String,
+    shard: Option<String>,
+) -> Result<(), Error> {
+    let deployment = locate(store.as_ref(), hash, shard)?;
 
     println!("unassigning {}", deployment);
     store.writable(&deployment)?.unassign_subgraph()?;
@@ -14,9 +18,14 @@ pub fn unassign(store: Arc<SubgraphStore>, hash: String) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn reassign(store: Arc<SubgraphStore>, hash: String, node: String) -> Result<(), Error> {
+pub fn reassign(
+    store: Arc<SubgraphStore>,
+    hash: String,
+    node: String,
+    shard: Option<String>,
+) -> Result<(), Error> {
     let node = NodeId::new(node.clone()).map_err(|()| anyhow!("illegal node id `{}`", node))?;
-    let deployment = locate(store.as_ref(), hash)?;
+    let deployment = locate(store.as_ref(), hash, shard)?;
 
     println!("reassigning {} to {}", deployment, node.as_str());
     store.reassign_subgraph(&deployment, &node)?;

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -8,7 +8,7 @@ pub fn unassign(store: Arc<SubgraphStore>, id: String) -> Result<(), Error> {
         SubgraphDeploymentId::new(id).map_err(|id| anyhow!("illegal deployment id `{}`", id))?;
 
     println!("unassigning {}", id.as_str());
-    store.writable(&id).unassign_subgraph(&id)?;
+    store.writable(&id)?.unassign_subgraph(&id)?;
 
     Ok(())
 }

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -8,7 +8,7 @@ pub fn unassign(store: Arc<SubgraphStore>, id: String) -> Result<(), Error> {
         SubgraphDeploymentId::new(id).map_err(|id| anyhow!("illegal deployment id `{}`", id))?;
 
     println!("unassigning {}", id.as_str());
-    store.writable().unassign_subgraph(&id)?;
+    store.writable(&id).unassign_subgraph(&id)?;
 
     Ok(())
 }

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -8,7 +8,7 @@ pub fn unassign(store: Arc<SubgraphStore>, id: String) -> Result<(), Error> {
         SubgraphDeploymentId::new(id).map_err(|id| anyhow!("illegal deployment id `{}`", id))?;
 
     println!("unassigning {}", id.as_str());
-    store.unassign_subgraph(&id)?;
+    store.writable().unassign_subgraph(&id)?;
 
     Ok(())
 }

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -8,7 +8,7 @@ pub fn unassign(store: Arc<SubgraphStore>, id: String) -> Result<(), Error> {
         SubgraphDeploymentId::new(id).map_err(|id| anyhow!("illegal deployment id `{}`", id))?;
 
     println!("unassigning {}", id.as_str());
-    store.writable(&id)?.unassign_subgraph(&id)?;
+    store.writable(&id)?.unassign_subgraph()?;
 
     Ok(())
 }

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -1,31 +1,9 @@
 use std::sync::Arc;
 
-use graph::{
-    components::store::DeploymentLocator,
-    prelude::{
-        anyhow::{anyhow, bail},
-        Error, NodeId, SubgraphStore as _,
-    },
-};
+use graph::prelude::{anyhow::anyhow, Error, NodeId, SubgraphStore as _};
 use graph_store_postgres::SubgraphStore;
 
-fn locate(store: &SubgraphStore, hash: String) -> Result<DeploymentLocator, Error> {
-    let locators = store.locators(&hash)?;
-
-    match locators.len() {
-        0 => {
-            bail!("no matching assignment");
-        }
-        1 => Ok(locators[0].clone()),
-        _ => {
-            bail!(
-                "deployment hash `{}` is ambiguous: {} locations found",
-                hash,
-                locators.len()
-            );
-        }
-    }
-}
+use crate::manager::deployment::locate;
 
 pub fn unassign(store: Arc<SubgraphStore>, hash: String) -> Result<(), Error> {
     let deployment = locate(store.as_ref(), hash)?;

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -1,25 +1,47 @@
 use std::sync::Arc;
 
-use graph::prelude::{anyhow, Error, NodeId, SubgraphDeploymentId, SubgraphStore as _};
+use graph::{
+    components::store::DeploymentLocator,
+    prelude::{
+        anyhow::{anyhow, bail},
+        Error, NodeId, SubgraphStore as _,
+    },
+};
 use graph_store_postgres::SubgraphStore;
 
-pub fn unassign(store: Arc<SubgraphStore>, id: String) -> Result<(), Error> {
-    let id =
-        SubgraphDeploymentId::new(id).map_err(|id| anyhow!("illegal deployment id `{}`", id))?;
+fn locate(store: &SubgraphStore, hash: String) -> Result<DeploymentLocator, Error> {
+    let locators = store.locators(&hash)?;
 
-    println!("unassigning {}", id.as_str());
-    store.writable(&id)?.unassign_subgraph()?;
+    match locators.len() {
+        0 => {
+            bail!("no matching assignment");
+        }
+        1 => Ok(locators[0].clone()),
+        _ => {
+            bail!(
+                "deployment hash `{}` is ambiguous: {} locations found",
+                hash,
+                locators.len()
+            );
+        }
+    }
+}
+
+pub fn unassign(store: Arc<SubgraphStore>, hash: String) -> Result<(), Error> {
+    let deployment = locate(store.as_ref(), hash)?;
+
+    println!("unassigning {}", deployment);
+    store.writable(&deployment)?.unassign_subgraph()?;
 
     Ok(())
 }
 
-pub fn reassign(store: Arc<SubgraphStore>, id: String, node: String) -> Result<(), Error> {
-    let id =
-        SubgraphDeploymentId::new(id).map_err(|id| anyhow!("illegal deployment id `{}`", id))?;
+pub fn reassign(store: Arc<SubgraphStore>, hash: String, node: String) -> Result<(), Error> {
     let node = NodeId::new(node.clone()).map_err(|()| anyhow!("illegal node id `{}`", node))?;
+    let deployment = locate(store.as_ref(), hash)?;
 
-    println!("reassigning {} to {}", id.as_str(), node.as_str());
-    store.reassign_subgraph(&id, &node)?;
+    println!("reassigning {} to {}", deployment, node.as_str());
+    store.reassign_subgraph(&deployment, &node)?;
 
     Ok(())
 }

--- a/node/src/manager/commands/copy.rs
+++ b/node/src/manager/commands/copy.rs
@@ -90,7 +90,7 @@ pub async fn create(
 
     let src_ptr = query_store.block_ptr()?.ok_or_else(|| anyhow!("subgraph {} has not indexed any blocks yet and can not be used as the source of a copy", src))?;
     let src_number = if src_ptr.number <= block_offset {
-        bail!("subgraph {} has only indexed {} blocks, but we need at least {} blocks before we can copy from it", src, src_ptr.number, block_offset);
+        bail!("subgraph {} has only indexed up to block {}, but we need at least block {} before we can copy from it", src, src_ptr.number, block_offset);
     } else {
         src_ptr.number - block_offset
     };
@@ -114,7 +114,6 @@ pub async fn create(
     };
     let base_ptr = EthereumBlockPointer::from((hash, src_number));
 
-    // let chain_store = store.block_store().chain_head_block(chain)
     let shard = Shard::new(shard)?;
     let node = NodeId::new(node.clone()).map_err(|()| anyhow!("invalid node id `{}`", node))?;
 

--- a/node/src/manager/commands/copy.rs
+++ b/node/src/manager/commands/copy.rs
@@ -49,13 +49,14 @@ struct CopyTableState {
 pub async fn create(
     store: Arc<Store>,
     src: String,
+    src_shard: Option<String>,
     shard: String,
     node: String,
     block_offset: u32,
 ) -> Result<(), Error> {
     let block_offset = block_offset as i32;
     let subgraph_store = store.subgraph_store();
-    let src = deployment::locate(subgraph_store.as_ref(), src)?;
+    let src = deployment::locate(subgraph_store.as_ref(), src, src_shard)?;
     let query_store = store.query_store(src.hash.clone().into(), true).await?;
     let network = query_store.network_name();
 

--- a/node/src/manager/commands/copy.rs
+++ b/node/src/manager/commands/copy.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use graph::{
+    components::store::BlockStore as _,
+    prelude::{
+        anyhow::{anyhow, bail, Error},
+        ChainStore, EthereumBlockPointer, NodeId, QueryStoreManager,
+    },
+};
+use graph_store_postgres::{Shard, Store};
+
+use crate::manager::deployment;
+
+pub async fn create(
+    store: Arc<Store>,
+    src: String,
+    shard: String,
+    node: String,
+    block_offset: u32,
+) -> Result<(), Error> {
+    let block_offset = block_offset as i32;
+    let subgraph_store = store.subgraph_store();
+    let src = deployment::locate(subgraph_store.as_ref(), src)?;
+    let query_store = store.query_store(src.hash.clone().into(), true).await?;
+    let network = query_store.network_name();
+
+    let src_ptr = query_store.block_ptr()?.ok_or_else(|| anyhow!("subgraph {} has not indexed any blocks yet and can not be used as the source of a copy", src))?;
+    let src_number = if src_ptr.number <= block_offset {
+        bail!("subgraph {} has only indexed {} blocks, but we need at least {} blocks before we can copy from it", src, src_ptr.number, block_offset);
+    } else {
+        src_ptr.number - block_offset
+    };
+
+    let chain_store = store
+        .block_store()
+        .chain_store(&network)
+        .ok_or_else(|| anyhow!("could not find chain store for network {}", network))?;
+    let hashes = chain_store.block_hashes_by_block_number(src_number)?;
+    let hash = match hashes.len() {
+        0 => bail!(
+            "could not find a block with number {} in our cache",
+            src_number
+        ),
+        1 => hashes[0],
+        n => bail!(
+            "the cache contains {} hashes for block number {}",
+            n,
+            src_number
+        ),
+    };
+    let base_ptr = EthereumBlockPointer::from((hash, src_number));
+
+    // let chain_store = store.block_store().chain_head_block(chain)
+    let shard = Shard::new(shard)?;
+    let node = NodeId::new(node.clone()).map_err(|()| anyhow!("invalid node id `{}`", node))?;
+
+    let dst = subgraph_store.copy_deployment(&src, shard, node, base_ptr)?;
+
+    println!("created deployment {} as copy of {}", dst, src);
+    Ok(())
+}

--- a/node/src/manager/commands/mod.rs
+++ b/node/src/manager/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod assign;
 pub mod config;
+pub mod copy;
 pub mod info;
 pub mod listen;
 pub mod remove;

--- a/node/src/manager/deployment.rs
+++ b/node/src/manager/deployment.rs
@@ -27,7 +27,7 @@ impl Deployment {
         let query = ds::table
             .inner_join(v::table.on(v::deployment.eq(ds::subgraph)))
             .inner_join(s::table.on(v::subgraph.eq(s::id)))
-            .left_outer_join(a::table.on(a::id.eq(ds::subgraph)))
+            .left_outer_join(a::table.on(a::id.eq(ds::id)))
             .select((
                 s::name,
                 sql::<Text>(

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -246,26 +246,6 @@ impl StoreBuilder {
             self.chains,
             networks,
         )
-        /*
-        let networks = networks
-            .into_iter()
-            .map(|(name, ident)| {
-                let shard = self.chains.get(&name).unwrap_or(&*PRIMARY_SHARD).clone();
-                (name, ident, shard)
-            })
-            .collect();
-
-        let logger = self.logger.new(o!("component" => "BlockStore"));
-
-        let block_store = Arc::new(
-            DieselBlockStore::new(logger, networks, self.pools.clone())
-                .expect("Creating the BlockStore works"),
-        );
-
-        Arc::new(DieselStore::new(
-            self.subgraph_store.cheap_clone(),
-            block_store,
-        ))*/
     }
 
     pub fn subscription_manager(&self) -> Arc<SubscriptionManager> {

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -168,6 +168,10 @@ impl StoreBuilder {
             "we can determine the pool size for store {}",
             name
         ));
+        let fdw_pool_size = shard.fdw_pool_size.size_for(node, name).expect(&format!(
+            "we can determine the fdw pool size for store {}",
+            name
+        ));
         info!(
             logger,
             "Connecting to Postgres";
@@ -180,6 +184,7 @@ impl StoreBuilder {
             "main",
             shard.connection.to_owned(),
             pool_size,
+            Some(fdw_pool_size),
             &logger,
             registry.cheap_clone(),
         )
@@ -218,6 +223,7 @@ impl StoreBuilder {
                         pool,
                         replica.connection.clone(),
                         pool_size,
+                        None,
                         &logger,
                         registry.cheap_clone(),
                     )

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -43,7 +43,7 @@ impl StoreBuilder {
         ));
 
         let (store, pools) =
-            Self::make_sharded_store_and_primary_pool(logger, node, config, registry.cheap_clone());
+            Self::make_subgraph_store_and_pools(logger, node, config, registry.cheap_clone());
 
         // Perform setup for all the pools
         let details = pools
@@ -80,7 +80,7 @@ impl StoreBuilder {
     /// Make a `ShardedStore` across all configured shards, and also return
     /// the main connection pools for each shard, but not any pools for
     /// replicas
-    fn make_sharded_store_and_primary_pool(
+    fn make_subgraph_store_and_pools(
         logger: &Logger,
         node: &NodeId,
         config: &Config,
@@ -118,15 +118,15 @@ impl StoreBuilder {
     }
 
     // Somehow, rustc gets this wrong; the function is used in
-    // `manager::make_store`
+    // `manager::Context.subgraph_store`
     #[allow(dead_code)]
-    pub fn make_sharded_store(
+    pub fn make_subgraph_store(
         logger: &Logger,
         node: &NodeId,
         config: &Config,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Arc<SubgraphStore> {
-        Self::make_sharded_store_and_primary_pool(logger, node, config, registry).0
+        Self::make_subgraph_store_and_pools(logger, node, config, registry).0
     }
 
     /// Create a connection pool for the main database of hte primary shard

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -372,7 +372,7 @@ async fn ipfs_map() {
         let runtime = tokio::runtime::Handle::current();
         std::thread::spawn(move || {
             runtime.enter(|| {
-                let (mut module, store) = test_valid_module_and_store(
+                let (mut module, _) = test_valid_module_and_store(
                     subgraph_id,
                     mock_data_source("wasm_test/ipfs_map.wasm"),
                 );
@@ -382,13 +382,12 @@ async fn ipfs_map() {
                 // Invoke the callback
                 let func = module.get_func("ipfsMap").typed().unwrap().clone();
                 let _: () = func.call((value.wasm_ptr(), user_data.wasm_ptr()))?;
-                let subgraph_id = SubgraphDeploymentId::new(subgraph_id).unwrap();
                 let mut mods = module
                     .take_ctx()
                     .ctx
                     .state
                     .entity_cache
-                    .as_modifications(store.writable(&subgraph_id)?.as_ref())?
+                    .as_modifications()?
                     .modifications;
 
                 // Bring the modifications into a predictable order (by entity_id)
@@ -727,10 +726,7 @@ async fn entity_store() {
         &mut module.instance_ctx_mut().ctx.state.entity_cache,
         EntityCache::new(writable.clone()),
     );
-    let mut mods = cache
-        .as_modifications(writable.as_ref())
-        .unwrap()
-        .modifications;
+    let mut mods = cache.as_modifications().unwrap().modifications;
     assert_eq!(1, mods.len());
     match mods.pop().unwrap() {
         EntityModification::Overwrite { data, .. } => {
@@ -751,7 +747,7 @@ async fn entity_store() {
         .ctx
         .state
         .entity_cache
-        .as_modifications(writable.as_ref())
+        .as_modifications()
         .unwrap()
         .modifications;
     assert_eq!(1, mods.len());

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -209,7 +209,7 @@ fn mock_context(
             store.clone(),
             call_cache,
         )),
-        state: BlockState::new(store, Default::default()),
+        state: BlockState::new(store.writable(), Default::default()),
         proof_of_indexing: None,
     }
 }
@@ -387,7 +387,7 @@ async fn ipfs_map() {
                     .ctx
                     .state
                     .entity_cache
-                    .as_modifications(store.as_ref())?
+                    .as_modifications(store.writable().as_ref())?
                     .modifications;
 
                 // Bring the modifications into a predictable order (by entity_id)
@@ -721,12 +721,13 @@ async fn entity_store() {
     load_and_set_user_name(&mut module, "steve", "Steve-O");
 
     // We need to empty the cache for the next test
+    let writable = store.writable();
     let cache = std::mem::replace(
         &mut module.instance_ctx_mut().ctx.state.entity_cache,
-        EntityCache::new(store.clone()),
+        EntityCache::new(writable.clone()),
     );
     let mut mods = cache
-        .as_modifications(store.as_ref())
+        .as_modifications(writable.as_ref())
         .unwrap()
         .modifications;
     assert_eq!(1, mods.len());
@@ -749,7 +750,7 @@ async fn entity_store() {
         .ctx
         .state
         .entity_cache
-        .as_modifications(store.as_ref())
+        .as_modifications(store.writable().as_ref())
         .unwrap()
         .modifications;
     assert_eq!(1, mods.len());

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -209,7 +209,7 @@ fn mock_context(
             store.clone(),
             call_cache,
         )),
-        state: BlockState::new(store.writable(&subgraph_id), Default::default()),
+        state: BlockState::new(store.writable(&subgraph_id).unwrap(), Default::default()),
         proof_of_indexing: None,
     }
 }
@@ -388,7 +388,7 @@ async fn ipfs_map() {
                     .ctx
                     .state
                     .entity_cache
-                    .as_modifications(store.writable(&subgraph_id).as_ref())?
+                    .as_modifications(store.writable(&subgraph_id)?.as_ref())?
                     .modifications;
 
                 // Bring the modifications into a predictable order (by entity_id)
@@ -722,7 +722,7 @@ async fn entity_store() {
     load_and_set_user_name(&mut module, "steve", "Steve-O");
 
     // We need to empty the cache for the next test
-    let writable = store.writable(&subgraph_id);
+    let writable = store.writable(&subgraph_id).unwrap();
     let cache = std::mem::replace(
         &mut module.instance_ctx_mut().ctx.state.entity_cache,
         EntityCache::new(writable.clone()),

--- a/server/index-node/src/explorer.rs
+++ b/server/index-node/src/explorer.rs
@@ -75,9 +75,9 @@ lazy_static! {
 #[derive(Debug)]
 pub struct Explorer<S> {
     store: Arc<S>,
-    versions: TimedCache<q::Value>,
-    version_infos: TimedCache<VersionInfo>,
-    entity_counts: TimedCache<q::Value>,
+    versions: TimedCache<String, q::Value>,
+    version_infos: TimedCache<String, VersionInfo>,
+    entity_counts: TimedCache<String, q::Value>,
 }
 
 impl<S> Explorer<S>

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -138,7 +138,7 @@ impl<R: SubgraphRegistrar> JsonRpcServer<R> {
 
         match self
             .registrar
-            .reassign_subgraph(params.ipfs_hash.clone(), params.node_id.clone())
+            .reassign_subgraph(&params.ipfs_hash, &params.node_id)
             .await
         {
             Ok(_) => Ok(Value::Null),

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -171,7 +171,7 @@ pub struct GraphQlConnection<Q, S> {
     logger: Logger,
     graphql_runner: Arc<Q>,
     stream: WebSocketStream<S>,
-    schema: Arc<ApiSchema>,
+    deployment: SubgraphDeploymentId,
 }
 
 impl<Q, S> GraphQlConnection<Q, S>
@@ -182,7 +182,7 @@ where
     /// Creates a new GraphQL subscription service.
     pub(crate) fn new(
         logger: &Logger,
-        schema: Arc<ApiSchema>,
+        deployment: SubgraphDeploymentId,
         stream: WebSocketStream<S>,
         graphql_runner: Arc<Q>,
     ) -> Self {
@@ -191,7 +191,7 @@ where
             logger: logger.new(o!("component" => "GraphQlConnection")),
             graphql_runner,
             stream,
-            schema,
+            deployment,
         }
     }
 
@@ -200,7 +200,7 @@ where
         mut msg_sink: mpsc::UnboundedSender<WsMessage>,
         logger: Logger,
         connection_id: String,
-        schema: Arc<ApiSchema>,
+        deployment: SubgraphDeploymentId,
         graphql_runner: Arc<Q>,
     ) -> Result<(), WsError> {
         let mut operations = Operations::new(msg_sink.clone());
@@ -298,7 +298,7 @@ where
                     };
 
                     // Construct a subscription
-                    let target = QueryTarget::Deployment(schema.schema.id.clone());
+                    let target = QueryTarget::Deployment(deployment.clone());
                     let subscription = Subscription {
                         // Subscriptions currently do not benefit from the generational cache
                         // anyways, so don't bother passing a network.
@@ -406,7 +406,7 @@ where
             msg_sink,
             self.logger.clone(),
             self.id.clone(),
-            self.schema.clone(),
+            self.deployment.clone(),
             self.graphql_runner.clone(),
         );
 

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -175,7 +175,7 @@ where
                             .unwrap());
                     }
 
-                *accept_subgraph_id.lock().unwrap() = Some(state);
+                *accept_subgraph_id.lock().unwrap() = Some(state.id);
                 response.headers_mut().insert(
                     "Sec-WebSocket-Protocol",
                     HeaderValue::from_static("graphql-ws"),

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -99,7 +99,6 @@ where
             let logger2 = self.logger.clone();
             let graphql_runner = self.graphql_runner.clone();
             let store = self.store.clone();
-            let store2 = self.store.clone();
 
             // Subgraph that the request is resolved to (if any)
             let subgraph_id = Arc::new(Mutex::new(None));
@@ -173,22 +172,10 @@ where
                         // Obtain the subgraph ID or name that we resolved the request to
                         let subgraph_id = subgraph_id.lock().unwrap().clone().unwrap();
 
-                        // Get the subgraph schema
-                        let schema = match store2.api_schema(&subgraph_id) {
-                            Ok(schema) => schema,
-                            Err(e) => {
-                                error!(logger2, "Failed to establish WS connection, could not find schema";
-                                                "subgraph" => subgraph_id.to_string(),
-                                                "error" => e.to_string(),
-                                );
-                                return;
-                            }
-                        };
-
                         // Spawn a GraphQL over WebSocket connection
                         let service = GraphQlConnection::new(
                             &logger2,
-                            schema,
+                            subgraph_id,
                             ws_stream,
                             graphql_runner.clone(),
                         );

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -7,8 +7,8 @@ use std::{fs, sync::Arc};
 
 use graph::prelude::{Schema, SubgraphDeploymentId};
 use graph_store_postgres::{
-    command_support::{catalog::Site, Catalog, Column, ColumnType, Layout, Namespace},
-    PRIMARY_SHARD,
+    command_support::{Catalog, Column, ColumnType, Layout, Namespace},
+    layout_for_tests::make_dummy_site,
 };
 
 pub fn usage(msg: &str) -> ! {
@@ -149,13 +149,7 @@ pub fn main() {
         Catalog::make_empty(namespace.clone()),
         "Failed to construct catalog",
     );
-    let site = Site {
-        id: 1,
-        deployment: subgraph,
-        shard: PRIMARY_SHARD.clone(),
-        namespace: namespace,
-        network: "anet".to_string(),
-    };
+    let site = make_dummy_site(subgraph, namespace, "anet".to_string());
     let layout = ensure(
         Layout::new(Arc::new(site), &schema, catalog, false),
         "Failed to construct Mapping",

--- a/store/postgres/migrations/2021-03-16-001809_assignment_deployment/down.sql
+++ b/store/postgres/migrations/2021-03-16-001809_assignment_deployment/down.sql
@@ -1,0 +1,5 @@
+do $$
+begin
+  raise 'This migration is irreversible';
+end
+$$;

--- a/store/postgres/migrations/2021-03-16-001809_assignment_deployment/up.sql
+++ b/store/postgres/migrations/2021-03-16-001809_assignment_deployment/up.sql
@@ -1,0 +1,19 @@
+alter table subgraphs.subgraph_deployment_assignment
+      add column new_id int;
+
+update subgraphs.subgraph_deployment_assignment a
+   set new_id = ds.id
+  from deployment_schemas ds
+ where ds.subgraph = a.id;
+
+alter table subgraphs.subgraph_deployment_assignment
+      drop column id,
+      drop column vid,
+      drop column block_range,
+      drop column cost;
+
+alter table subgraphs.subgraph_deployment_assignment
+      rename column new_id to id;
+
+alter table subgraphs.subgraph_deployment_assignment
+      add primary key(id);

--- a/store/postgres/migrations/2021-03-16-165131_subgraph_manifest/down.sql
+++ b/store/postgres/migrations/2021-03-16-165131_subgraph_manifest/down.sql
@@ -1,0 +1,5 @@
+do $$
+begin
+  raise 'This migration is irreversible';
+end
+$$;

--- a/store/postgres/migrations/2021-03-16-165131_subgraph_manifest/up.sql
+++ b/store/postgres/migrations/2021-03-16-165131_subgraph_manifest/up.sql
@@ -1,0 +1,27 @@
+alter table subgraphs.subgraph_manifest
+      add column new_id int
+          references subgraphs.subgraph_deployment(id) on delete cascade;
+
+update subgraphs.subgraph_manifest m
+   set new_id = d.id
+  from subgraphs.subgraph_deployment d
+ where d.manifest = m.id;
+
+alter table subgraphs.subgraph_manifest
+      drop column id,
+      drop column vid,
+      drop column block_range;
+
+alter table subgraphs.subgraph_manifest
+      rename column new_id to id;
+
+alter table subgraphs.subgraph_manifest
+      add primary key(id);
+
+alter table subgraphs.subgraph_deployment
+      drop column manifest;
+
+drop index subgraphs.attr_4_1_subgraph_manifest_spec_version;
+drop index subgraphs.attr_4_2_subgraph_manifest_description;
+drop index subgraphs.attr_4_3_subgraph_manifest_repository;
+drop index subgraphs.attr_4_4_subgraph_manifest_schema;

--- a/store/postgres/migrations/2021-03-19-161012_unused_deployments_pk/down.sql
+++ b/store/postgres/migrations/2021-03-19-161012_unused_deployments_pk/down.sql
@@ -1,0 +1,5 @@
+do $$
+begin
+  raise 'This migration is irreversible';
+end
+$$;

--- a/store/postgres/migrations/2021-03-19-161012_unused_deployments_pk/up.sql
+++ b/store/postgres/migrations/2021-03-19-161012_unused_deployments_pk/up.sql
@@ -1,0 +1,20 @@
+alter table unused_deployments
+      add column new_id int
+          references subgraphs.subgraph_deployment(id) on delete cascade;
+
+create temp sequence unused_pk;
+
+update unused_deployments
+   set new_id = nextval('unused_pk');
+
+alter table unused_deployments
+      rename column id to deployment;
+
+alter table unused_deployments
+      rename column new_id to id;
+
+alter table unused_deployments
+      drop constraint unused_deployments_pkey;
+
+alter table unused_deployments
+      add primary key(id);

--- a/store/postgres/migrations/2021-03-19-161012_unused_deployments_pk/up.sql
+++ b/store/postgres/migrations/2021-03-19-161012_unused_deployments_pk/up.sql
@@ -1,6 +1,5 @@
 alter table unused_deployments
-      add column new_id int
-          references subgraphs.subgraph_deployment(id) on delete cascade;
+      add column new_id int;
 
 create temp sequence unused_pk;
 

--- a/store/postgres/migrations/2021-03-19-161012_unused_deployments_pk/up.sql
+++ b/store/postgres/migrations/2021-03-19-161012_unused_deployments_pk/up.sql
@@ -1,10 +1,10 @@
 alter table unused_deployments
       add column new_id int;
 
-create temp sequence unused_pk;
-
+-- Recover the deployment_schemas.id from existing unused_deployments
+-- entries
 update unused_deployments
-   set new_id = nextval('unused_pk');
+   set new_id = replace(namespace, 'sgd', '')::int;
 
 alter table unused_deployments
       rename column id to deployment;

--- a/store/postgres/migrations/2021-03-20-001347_deployment_schemas_active/down.sql
+++ b/store/postgres/migrations/2021-03-20-001347_deployment_schemas_active/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/store/postgres/migrations/2021-03-20-001347_deployment_schemas_active/up.sql
+++ b/store/postgres/migrations/2021-03-20-001347_deployment_schemas_active/up.sql
@@ -1,0 +1,12 @@
+alter table deployment_schemas
+      add column active bool;
+
+update deployment_schemas
+   set active = true;
+
+alter table deployment_schemas
+      alter column active set not null;
+
+-- we only allow one active entry per IPFS hash
+create unique index deployment_schemas_deployment_active
+       on deployment_schemas(subgraph) where active;

--- a/store/postgres/migrations/2021-03-24-220541_deployment_schemas_deployment_shard/down.sql
+++ b/store/postgres/migrations/2021-03-24-220541_deployment_schemas_deployment_shard/down.sql
@@ -1,0 +1,4 @@
+drop constraint deployment_schemas_subgraph_shard_uq;
+
+create unique index deployment_schemas_subgraph_key
+       on deployment_schemas(subgraph);

--- a/store/postgres/migrations/2021-03-24-220541_deployment_schemas_deployment_shard/up.sql
+++ b/store/postgres/migrations/2021-03-24-220541_deployment_schemas_deployment_shard/up.sql
@@ -1,0 +1,5 @@
+alter table deployment_schemas
+      drop constraint deployment_schemas_subgraph_key;
+
+create unique index deployment_schemas_subgraph_shard_uq
+       on deployment_schemas(subgraph, shard);

--- a/store/postgres/src/advisory_lock.rs
+++ b/store/postgres/src/advisory_lock.rs
@@ -1,0 +1,36 @@
+//! Helpers for using advisory locks. We centralize all use of these locks
+//! in this module to make it easier to see what they are used for.
+
+use diesel::{sql_query, PgConnection, RunQueryDsl};
+
+/// Get a lock for running migrations. Return whether we were the first ones
+/// to get the lock and should therefore run migrations. Blocks until we get
+/// the lock.
+///
+/// # Panics
+///
+/// If the query to get the lock causes an error
+pub(crate) fn lock_migration(conn: &PgConnection) -> bool {
+    #[derive(QueryableByName)]
+    struct LockResult {
+        #[sql_type = "diesel::sql_types::Bool"]
+        migrate: bool,
+    }
+
+    let lock = sql_query("select pg_try_advisory_lock(1) as migrate, pg_advisory_lock(2)")
+        .get_result::<LockResult>(conn)
+        .expect("we can try to get advisory locks 1 and 2");
+
+    lock.migrate
+}
+
+/// Release the migration lock.
+///
+/// # Panics
+///
+/// If the query to release the lock causes an error
+pub(crate) fn unlock_migration(conn: &PgConnection) {
+    sql_query("select pg_advisory_unlock(1), pg_advisory_unlock(2)")
+        .execute(conn)
+        .expect("we can unlock the advisory locks");
+}

--- a/store/postgres/src/advisory_lock.rs
+++ b/store/postgres/src/advisory_lock.rs
@@ -1,7 +1,21 @@
 //! Helpers for using advisory locks. We centralize all use of these locks
 //! in this module to make it easier to see what they are used for.
+//!
+//! The [Postgres
+//! documentation](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS)
+//! has more details on advisory locks.
+//!
+//! We use the following 64 bit locks:
+//!   * 1,2: to synchronize on migratons
+//!
+//! We use the following 2x 32-bit locks
+//!   * 1, n: to lock copying of the deployment with id n in the destination
+//!           shard
 
 use diesel::{sql_query, PgConnection, RunQueryDsl};
+use graph::prelude::StoreError;
+
+use crate::command_support::catalog::Site;
 
 /// Get a lock for running migrations. Return whether we were the first ones
 /// to get the lock and should therefore run migrations. Blocks until we get
@@ -33,4 +47,18 @@ pub(crate) fn unlock_migration(conn: &PgConnection) {
     sql_query("select pg_advisory_unlock(1), pg_advisory_unlock(2)")
         .execute(conn)
         .expect("we can unlock the advisory locks");
+}
+
+pub(crate) fn lock_copying(conn: &PgConnection, dst: &Site) -> Result<(), StoreError> {
+    sql_query(&format!("select pg_advisory_lock(1, {})", dst.id))
+        .execute(conn)
+        .map(|_| ())
+        .map_err(StoreError::from)
+}
+
+pub(crate) fn unlock_copying(conn: &PgConnection, dst: &Site) -> Result<(), StoreError> {
+    sql_query(&format!("select pg_advisory_unlock(1, {})", dst.id))
+        .execute(conn)
+        .map(|_| ())
+        .map_err(StoreError::from)
 }

--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -15,8 +15,7 @@ use graph::{
 };
 
 use crate::{
-    chain_head_listener::ChainHeadUpdateSender, connection_pool::ConnectionPool,
-    ChainHeadUpdateListener, ChainStore,
+    chain_head_listener::ChainHeadUpdateSender, connection_pool::ConnectionPool, ChainStore,
 };
 use crate::{subgraph_store::PRIMARY_SHARD, Shard};
 
@@ -167,7 +166,6 @@ pub struct BlockStore {
     stores: RwLock<HashMap<String, Arc<ChainStore>>>,
     pools: HashMap<Shard, ConnectionPool>,
     primary: ConnectionPool,
-    chain_head_update_listener: Arc<ChainHeadUpdateListener>,
 }
 
 impl BlockStore {
@@ -188,7 +186,6 @@ impl BlockStore {
         chains: Vec<(String, Vec<EthereumNetworkIdentifier>, Shard)>,
         // shard -> pool
         pools: HashMap<Shard, ConnectionPool>,
-        chain_head_update_listener: Arc<ChainHeadUpdateListener>,
     ) -> Result<Self, StoreError> {
         let primary = pools
             .get(&PRIMARY_SHARD)
@@ -201,7 +198,6 @@ impl BlockStore {
             stores: RwLock::new(HashMap::new()),
             pools,
             primary,
-            chain_head_update_listener,
         };
 
         fn reduce_idents(
@@ -337,7 +333,6 @@ impl BlockStore {
             chain.storage.clone(),
             &ident,
             status,
-            self.chain_head_update_listener.clone(),
             sender,
             pool,
         );

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -1322,7 +1322,7 @@ impl ChainStoreTrait for ChainStore {
                        subgraphs.subgraph_deployment_assignment a,
                        deployment_schemas ds
                  where ds.subgraph = d.deployment
-                   and a.id = d.deployment
+                   and a.id = d.id
                    and not d.failed
                    and ds.network = $2) a;";
         let ancestor_count = i32::try_from(ancestor_count)

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -147,7 +147,9 @@ impl ForeignServer {
                 "create view {nsp}.deployment_schemas as
                         select * from public.deployment_schemas;
                  create view {nsp}.chains as
-                        select * from public.chains",
+                        select * from public.chains;
+                 create view {nsp}.active_copies as
+                        select * from public.active_copies;",
                 nsp = Self::PRIMARY_PUBLIC
             )
         } else {

--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -383,7 +383,7 @@ impl TableState {
     }
 
     fn record_progress(
-        &self,
+        &mut self,
         conn: &PgConnection,
         elapsed: Duration,
         first_batch: bool,
@@ -392,8 +392,7 @@ impl TableState {
 
         // This conversion will become a problem if a copy takes longer than
         // 300B years
-        let elapsed = i64::try_from(elapsed.as_millis()).unwrap_or(0);
-        let duration_ms = self.duration_ms + elapsed;
+        self.duration_ms += i64::try_from(elapsed.as_millis()).unwrap_or(0);
 
         if first_batch {
             // Reset started_at so that finished_at - started_at is an
@@ -409,7 +408,7 @@ impl TableState {
         let values = (
             cts::next_vid.eq(self.next_vid),
             cts::batch_size.eq(self.batch_size),
-            cts::duration_ms.eq(duration_ms),
+            cts::duration_ms.eq(self.duration_ms),
         );
         update(
             cts::table

--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -43,9 +43,9 @@ table! {
         dst -> Integer,
         target_block_hash -> Binary,
         target_block_number -> Integer,
-        started_at -> Date,
-        finished_at -> Nullable<Date>,
-        cancelled_at -> Nullable<Date>,
+        started_at -> Timestamptz,
+        finished_at -> Nullable<Timestamptz>,
+        cancelled_at -> Nullable<Timestamptz>,
     }
 }
 
@@ -58,8 +58,8 @@ table! {
         next_vid -> BigInt,
         target_vid -> BigInt,
         batch_size -> BigInt,
-        started_at -> Date,
-        finished_at -> Nullable<Date>,
+        started_at -> Timestamptz,
+        finished_at -> Nullable<Timestamptz>,
         // Measures just the time we spent working, not any wait time for
         // connections or the like
         duration_ms -> BigInt,

--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -27,7 +27,8 @@ use graph::{
     prelude::{info, BlockNumber, EthereumBlockPointer, Logger, StoreError},
 };
 
-use crate::{connection_pool::ConnectionPool, primary::Site, relational::Layout};
+use crate::primary::{DeploymentId, Site};
+use crate::{connection_pool::ConnectionPool, relational::Layout};
 use crate::{relational::Table, relational_queries as rq};
 
 const INITIAL_BATCH_SIZE: i64 = 10_000;
@@ -90,7 +91,7 @@ impl CopyState {
         let state = match cs::table
             .filter(cs::dst.eq(dst.site.id))
             .select((cs::src, cs::target_block_hash, cs::target_block_number))
-            .first::<(i32, Vec<u8>, BlockNumber)>(conn)
+            .first::<(DeploymentId, Vec<u8>, BlockNumber)>(conn)
             .optional()?
         {
             Some((src_id, hash, number)) => {
@@ -298,7 +299,7 @@ impl TableState {
             layout: &Layout,
             kind: &str,
             entity_type: &EntityType,
-            dst: i32,
+            dst: DeploymentId,
             id: i32,
         ) -> Result<Arc<Table>, StoreError> {
             layout

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1081,7 +1081,10 @@ impl DeploymentStore {
             // that actually need to be copied from the source are compatible
             // with the corresponding tables in `self`
             let copy_conn = crate::copy::Connection::new(self.conn.clone());
-            copy_conn.copy_data(logger, src.clone(), dst.clone(), block.clone())?;
+            let status = copy_conn.copy_data(logger, src.clone(), dst.clone(), block.clone())?;
+            if status == crate::copy::Status::Cancelled {
+                return Ok(());
+            }
 
             let conn = self.get_conn()?;
             conn.transaction(|| -> Result<(), StoreError> {

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1090,8 +1090,14 @@ impl DeploymentStore {
             // as adding new tables in `self`; we only need to check that tables
             // that actually need to be copied from the source are compatible
             // with the corresponding tables in `self`
-            let copy_conn = crate::copy::Connection::new(self.conn.clone());
-            let status = copy_conn.copy_data(logger, src.clone(), dst.clone(), block.clone())?;
+            let copy_conn = crate::copy::Connection::new(
+                logger,
+                self.conn.clone(),
+                src.clone(),
+                dst.clone(),
+                block.clone(),
+            )?;
+            let status = copy_conn.copy_data()?;
             if status == crate::copy::Status::Cancelled {
                 return Ok(());
             }

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -195,6 +195,14 @@ impl DeploymentStore {
         })
     }
 
+    pub(crate) fn load_deployment(
+        &self,
+        site: &Site,
+    ) -> Result<SubgraphDeploymentEntity, StoreError> {
+        let conn = self.get_conn()?;
+        detail::deployment_entity(&conn, site)
+    }
+
     // Remove the data and metadata for the deployment `site`. This operation
     // is not reversible
     pub(crate) fn drop_deployment(&self, site: &Site) -> Result<(), StoreError> {

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1109,6 +1109,11 @@ impl DeploymentStore {
                 info!(logger, "Copied {} dynamic data sources", count;
                       "time_ms" => start.elapsed().as_millis());
 
+                // Copy errors across
+                let count = deployment::copy_errors(&conn, &src.site, &dst.site, &block)?;
+                info!(logger, "Copied {} existing errors", count;
+                      "time_ms" => start.elapsed().as_millis());
+
                 // Rewind the subgraph so that entity versions that are
                 // clamped in the future (beyond `block`) become valid for
                 // all blocks after `block`. `revert_block` gets rid of

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1099,7 +1099,7 @@ impl DeploymentStore {
             )?;
             let status = copy_conn.copy_data()?;
             if status == crate::copy::Status::Cancelled {
-                return Ok(());
+                return Err(StoreError::Canceled);
             }
 
             let conn = self.get_conn()?;

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1056,6 +1056,16 @@ impl DeploymentStore {
         deployment::graft_pending(&conn, id)
     }
 
+    /// Bring the subgraph into a state where we can start or resume
+    /// indexing.
+    ///
+    /// If `graft_src` is `Some(..)`, copy data from that subgraph. It
+    /// should only be `Some(..)` if we know we still need to copy data. The
+    /// code is idempotent so that a copy process that has been interrupted
+    /// can be resumed seamlessly, but the code sets the block pointer back
+    /// to the graph point, so that calling this needlessly with `Some(..)`
+    /// will remove any progress that might have been made since the last
+    /// time the deployment was started.
     pub(crate) fn start_subgraph(
         &self,
         logger: &Logger,

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -807,6 +807,8 @@ impl DeploymentStore {
         layout.find_many(&conn, ids_for_type, BLOCK_NUMBER_MAX)
     }
 
+    // Only used by tests
+    #[cfg(debug_assertions)]
     pub(crate) fn find(
         &self,
         site: Arc<Site>,

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -23,9 +23,9 @@ use graph::components::subgraph::ProofOfIndexingFinisher;
 use graph::data::subgraph::schema::{SubgraphError, POI_OBJECT};
 use graph::prelude::{
     anyhow, debug, futures03, info, o, web3, ApiSchema, BlockNumber, CheapClone, DeploymentState,
-    DynTryFuture, Entity, EntityKey, EntityModification, EntityQuery, EntityRange, Error,
-    EthereumBlockPointer, Logger, QueryExecutionError, Schema, StopwatchMetrics, StoreError,
-    StoreEvent, SubgraphDeploymentId, Value, BLOCK_NUMBER_MAX,
+    DynTryFuture, Entity, EntityKey, EntityModification, EntityQuery, Error, EthereumBlockPointer,
+    Logger, QueryExecutionError, Schema, StopwatchMetrics, StoreError, StoreEvent,
+    SubgraphDeploymentId, Value, BLOCK_NUMBER_MAX,
 };
 
 use graph_graphql::prelude::api_schema;
@@ -816,24 +816,6 @@ impl DeploymentStore {
             .get_conn()
             .map_err(|e| QueryExecutionError::StoreError(e.into()))?;
         self.execute_query(&conn, site, query)
-    }
-
-    pub(crate) fn find_one(
-        &self,
-        site: Arc<Site>,
-        mut query: EntityQuery,
-    ) -> Result<Option<Entity>, QueryExecutionError> {
-        query.range = EntityRange::first(1);
-
-        let conn = self
-            .get_conn()
-            .map_err(|e| QueryExecutionError::StoreError(e.into()))?;
-
-        let mut results = self.execute_query(&conn, site, query)?;
-        match results.len() {
-            0 | 1 => Ok(results.pop()),
-            n => panic!("find_one query found {} results", n),
-        }
     }
 
     pub(crate) fn transact_block_operations(

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -14,8 +14,11 @@ use graph::{data::subgraph::status, prelude::web3::types::H256};
 use std::convert::TryFrom;
 use std::{ops::Bound, sync::Arc};
 
-use crate::deployment::{subgraph_deployment, subgraph_error, SubgraphHealth as HealthType};
 use crate::primary::Site;
+use crate::{
+    deployment::{subgraph_deployment, subgraph_error, SubgraphHealth as HealthType},
+    primary::DeploymentId,
+};
 
 type Bytes = Vec<u8>;
 
@@ -25,7 +28,7 @@ type Bytes = Vec<u8>;
 // don't need all the fields
 #[allow(dead_code)]
 pub struct DeploymentDetail {
-    id: i32,
+    pub id: DeploymentId,
     pub deployment: String,
     pub failed: bool,
     health: HealthType,

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -27,7 +27,6 @@ type Bytes = Vec<u8>;
 pub struct DeploymentDetail {
     id: i32,
     pub deployment: String,
-    manifest: String,
     pub failed: bool,
     health: HealthType,
     pub synced: bool,
@@ -143,7 +142,6 @@ impl<'a> TryFrom<DetailAndError<'a>> for status::Info {
 
         let DeploymentDetail {
             deployment,
-            manifest: _,
             failed: _,
             health,
             synced,

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -52,7 +52,9 @@ pub mod layout_for_tests {
     pub use crate::block_range::*;
     pub use crate::block_store::FAKE_NETWORK_SHARED;
     pub use crate::chain_store::test_support as chain_support;
-    pub use crate::primary::{Connection, Namespace, EVENT_TAP, EVENT_TAP_ENABLED};
+    pub use crate::primary::{
+        make_dummy_site, Connection, Namespace, EVENT_TAP, EVENT_TAP_ENABLED,
+    };
     pub use crate::relational::*;
 }
 

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -23,6 +23,7 @@ extern crate postgres;
 extern crate serde;
 extern crate uuid;
 
+mod advisory_lock;
 mod block_range;
 mod block_store;
 mod catalog;

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -72,9 +72,10 @@ pub use self::subgraph_store::{unused, DeploymentPlacer, Shard, SubgraphStore, P
 /// be used in 'normal' graph-node code
 pub mod command_support {
     pub mod catalog {
+        pub use crate::copy::{copy_state, copy_table_state};
         pub use crate::primary::Connection;
         pub use crate::primary::{
-            deployment_schemas, ens_names, subgraph, subgraph_deployment_assignment,
+            active_copies, deployment_schemas, ens_names, subgraph, subgraph_deployment_assignment,
             subgraph_version, Site,
         };
     }

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -814,11 +814,6 @@ impl<'a> Connection<'a> {
             .collect()
     }
 
-    pub fn find_existing_site(&self, subgraph: &SubgraphDeploymentId) -> Result<Site, StoreError> {
-        self.find_site(subgraph)?
-            .ok_or_else(|| StoreError::DeploymentNotFound(subgraph.to_string()))
-    }
-
     pub fn sites(&self) -> Result<Vec<Site>, StoreError> {
         use deployment_schemas as ds;
 

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -839,7 +839,7 @@ impl<'a> Connection<'a> {
         self.create_site(shard, src.deployment.clone(), src.network.clone(), false)
     }
 
-    pub fn activate(&self, deployment: &DeploymentLocator) -> Result<(), StoreError> {
+    pub(crate) fn activate(&self, deployment: &DeploymentLocator) -> Result<(), StoreError> {
         use deployment_schemas as ds;
 
         // We need to tread lightly so we do not violate the unique constraint on

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -93,8 +93,8 @@ table! {
     active_copies(dst) {
         src -> Integer,
         dst -> Integer,
-        queued_at -> Date,
-        cancelled_at -> Nullable<Date>,
+        queued_at -> Timestamptz,
+        cancelled_at -> Nullable<Timestamptz>,
     }
 }
 

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -721,7 +721,7 @@ impl<'a> Connection<'a> {
 
         let conn = self.0.as_ref();
 
-        if let Some(schema) = self.find_site(subgraph)? {
+        if let Some(schema) = self.find_active_site(subgraph)? {
             return Ok(schema);
         }
 
@@ -774,9 +774,13 @@ impl<'a> Connection<'a> {
         })
     }
 
-    pub fn find_site(&self, subgraph: &SubgraphDeploymentId) -> Result<Option<Site>, StoreError> {
+    pub fn find_active_site(
+        &self,
+        subgraph: &SubgraphDeploymentId,
+    ) -> Result<Option<Site>, StoreError> {
         let schema = deployment_schemas::table
             .filter(deployment_schemas::subgraph.eq(subgraph.to_string()))
+            .filter(deployment_schemas::active.eq(true))
             .first::<Schema>(self.0.as_ref())
             .optional()?;
         if let Some(Schema { version, .. }) = schema {

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -789,9 +789,7 @@ impl<'a> Connection<'a> {
     /// return all sites
     pub fn find_sites(&self, ids: Vec<String>) -> Result<Vec<Site>, StoreError> {
         let schemas = if ids.is_empty() {
-            deployment_schemas::table
-                .filter(deployment_schemas::subgraph.eq_any(ids))
-                .load::<Schema>(self.0.as_ref())?
+            deployment_schemas::table.load::<Schema>(self.0.as_ref())?
         } else {
             deployment_schemas::table
                 .filter(deployment_schemas::subgraph.eq_any(ids))

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -108,7 +108,7 @@ impl QueryStoreTrait for QueryStore {
     }
 
     fn api_schema(&self) -> Result<Arc<ApiSchema>, QueryExecutionError> {
-        let info = self.store.subgraph_info(&self.site.deployment)?;
+        let info = self.store.subgraph_info(&self.site)?;
         Ok(info.api)
     }
 

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -47,9 +47,8 @@ impl QueryStoreTrait for QueryStore {
 
     /// Return true if the deployment with the given id is fully synced,
     /// and return false otherwise. Errors from the store are passed back up
-    fn is_deployment_synced(&self, id: &SubgraphDeploymentId) -> Result<bool, Error> {
-        assert_eq!(&self.site.deployment, id);
-        Ok(self.store.exists_and_synced(id)?)
+    fn is_deployment_synced(&self) -> Result<bool, Error> {
+        Ok(self.store.exists_and_synced(&self.site.deployment)?)
     }
 
     fn block_ptr(

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -51,11 +51,7 @@ impl QueryStoreTrait for QueryStore {
         Ok(self.store.exists_and_synced(&self.site.deployment)?)
     }
 
-    fn block_ptr(
-        &self,
-        subgraph_id: SubgraphDeploymentId,
-    ) -> Result<Option<EthereumBlockPointer>, Error> {
-        assert_eq!(&self.site.deployment, &subgraph_id);
+    fn block_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error> {
         self.store.block_ptr(&self.site)
     }
 

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -83,11 +83,8 @@ impl QueryStoreTrait for QueryStore {
         self.store.wait_stats(self.replica_id)
     }
 
-    async fn has_non_fatal_errors(
-        &self,
-        id: SubgraphDeploymentId,
-        block: Option<BlockNumber>,
-    ) -> Result<bool, StoreError> {
+    async fn has_non_fatal_errors(&self, block: Option<BlockNumber>) -> Result<bool, StoreError> {
+        let id = self.site.deployment.clone();
         self.store
             .with_conn(move |conn, _| {
                 crate::deployment::has_non_fatal_errors(conn, &id, block).map_err(|e| e.into())

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1335,7 +1335,7 @@ fn is_object_type(field_type: &q::Type, enums: &EnumMap) -> bool {
 mod tests {
     use super::*;
 
-    use crate::PRIMARY_SHARD;
+    use crate::layout_for_tests::make_dummy_site;
 
     const ID_TYPE: ColumnType = ColumnType::String;
 
@@ -1344,13 +1344,7 @@ mod tests {
         let schema = Schema::parse(gql, subgraph.clone()).expect("Test schema invalid");
         let namespace = Namespace::new("sgd0815".to_owned()).unwrap();
         let catalog = Catalog::make_empty(namespace.clone()).expect("Can not create catalog");
-        let site = Site {
-            id: 1,
-            deployment: subgraph,
-            shard: PRIMARY_SHARD.clone(),
-            namespace: namespace,
-            network: "anet".to_string(),
-        };
+        let site = make_dummy_site(subgraph, namespace, "anet".to_string());
         Layout::new(Arc::new(site), &schema, catalog, false).expect("Failed to construct Layout")
     }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -107,15 +107,6 @@ impl StatusStore for Store {
         self.subgraph_store.versions_for_subgraph_id(subgraph_id)
     }
 
-    fn supports_proof_of_indexing<'a>(
-        self: Arc<Self>,
-        subgraph_id: &'a SubgraphDeploymentId,
-    ) -> graph::prelude::DynTryFuture<'a, bool> {
-        self.subgraph_store
-            .clone()
-            .supports_proof_of_indexing(subgraph_id)
-    }
-
     fn get_proof_of_indexing<'a>(
         self: Arc<Self>,
         subgraph_id: &'a SubgraphDeploymentId,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -123,7 +123,6 @@ impl StatusStore for Store {
         block: EthereumBlockPointer,
     ) -> graph::prelude::DynTryFuture<'a, Option<[u8; 32]>> {
         self.subgraph_store
-            .clone()
             .get_proof_of_indexing(subgraph_id, indexer, block)
     }
 }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -4,10 +4,7 @@ use std::sync::Arc;
 use graph::{
     components::{
         server::index_node::VersionInfo,
-        store::{
-            BlockStore as BlockStoreTrait, QueryStoreManager, StatusStore,
-            SubgraphStore as SubgraphStoreTrait,
-        },
+        store::{BlockStore as BlockStoreTrait, QueryStoreManager, StatusStore},
     },
     constraint_violation,
     data::subgraph::status,

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -297,6 +297,7 @@ impl SubgraphStoreInner {
         }
     }
 
+    /// Return the active `Site` for this deployment hash
     fn site(&self, id: &SubgraphDeploymentId) -> Result<Arc<Site>, StoreError> {
         if let Some(site) = self.sites.read().unwrap().get(id) {
             return Ok(site.clone());
@@ -304,7 +305,7 @@ impl SubgraphStoreInner {
 
         let conn = self.primary_conn()?;
         let site = conn
-            .find_site(id)?
+            .find_active_site(id)?
             .ok_or_else(|| StoreError::DeploymentNotFound(id.to_string()))?;
         let site = Arc::new(site);
 
@@ -333,6 +334,8 @@ impl SubgraphStoreInner {
         Ok(site)
     }
 
+    /// Return the store and site for the active deployment of this
+    /// deployment hash
     fn store(
         &self,
         id: &SubgraphDeploymentId,

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -706,11 +706,6 @@ impl SubgraphStoreTrait for SubgraphStore {
         store.find(site, query)
     }
 
-    fn find_one(&self, query: EntityQuery) -> Result<Option<Entity>, QueryExecutionError> {
-        let (store, site) = self.store(&query.subgraph_id)?;
-        store.find_one(site, query)
-    }
-
     fn find_ens_name(&self, hash: &str) -> Result<Option<String>, QueryExecutionError> {
         Ok(self.primary_conn()?.find_ens_name(hash)?)
     }

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -22,8 +22,8 @@ use graph::{
     prelude::SubgraphDeploymentEntity,
     prelude::{
         futures03::future::join_all, lazy_static, o, web3::types::Address, ApiSchema, DynTryFuture,
-        Entity, EntityKey, EntityModification, EntityQuery, Error, EthereumBlockPointer, Logger,
-        NodeId, QueryExecutionError, Schema, StopwatchMetrics, StoreError, SubgraphDeploymentId,
+        Entity, EntityKey, EntityModification, Error, EthereumBlockPointer, Logger, NodeId,
+        QueryExecutionError, Schema, StopwatchMetrics, StoreError, SubgraphDeploymentId,
         SubgraphName, SubgraphStore as SubgraphStoreTrait, SubgraphVersionSwitchingMode,
     },
 };
@@ -207,7 +207,7 @@ impl SubgraphStore {
         self: Arc<Self>,
         id: &'a SubgraphDeploymentId,
     ) -> DynTryFuture<'a, bool> {
-        self.writable().supports_proof_of_indexing(id)
+        self.writable(id).supports_proof_of_indexing(id)
     }
 }
 
@@ -728,7 +728,10 @@ impl SubgraphStoreInner {
 
     // Only used by tests
     #[cfg(debug_assertions)]
-    pub fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
+    pub fn find(
+        &self,
+        query: graph::prelude::EntityQuery,
+    ) -> Result<Vec<Entity>, QueryExecutionError> {
         let (store, site) = self.store(&query.subgraph_id)?;
         store.find(site, query)
     }
@@ -817,7 +820,7 @@ impl SubgraphStoreTrait for SubgraphStore {
         Ok(info.api)
     }
 
-    fn writable(&self) -> Arc<dyn store::WritableStore> {
+    fn writable(&self, _id: &SubgraphDeploymentId) -> Arc<dyn store::WritableStore> {
         Arc::new(WritableStore {
             store: self.clone(),
         })

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -294,6 +294,13 @@ impl SubgraphStoreInner {
         self.sites.clear();
     }
 
+    // Only needed for tests
+    #[cfg(debug_assertions)]
+    pub fn shard(&self, deployment: &DeploymentLocator) -> Result<Shard, StoreError> {
+        self.find_site(deployment.id.into())
+            .map(|site| site.shard.clone())
+    }
+
     fn cache_active(&self, site: &Arc<Site>) {
         if site.active {
             self.sites.set(site.deployment.clone(), site.clone());

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -660,6 +660,16 @@ impl SubgraphStore {
         let event = store.rewind(site, block_ptr_to)?;
         self.send_store_event(&event)
     }
+
+    pub(crate) fn get_proof_of_indexing<'a>(
+        self: Arc<Self>,
+        id: &'a SubgraphDeploymentId,
+        indexer: &'a Option<Address>,
+        block: EthereumBlockPointer,
+    ) -> DynTryFuture<'a, Option<[u8; 32]>> {
+        let (store, site) = self.store(&id).unwrap();
+        store.clone().get_proof_of_indexing(site, indexer, block)
+    }
 }
 
 #[async_trait::async_trait]
@@ -675,16 +685,6 @@ impl SubgraphStoreTrait for SubgraphStore {
     ) -> DynTryFuture<'a, bool> {
         let (store, site) = self.store(&id).unwrap();
         store.clone().supports_proof_of_indexing(site)
-    }
-
-    fn get_proof_of_indexing<'a>(
-        self: Arc<Self>,
-        id: &'a SubgraphDeploymentId,
-        indexer: &'a Option<Address>,
-        block: EthereumBlockPointer,
-    ) -> DynTryFuture<'a, Option<[u8; 32]>> {
-        let (store, site) = self.store(&id).unwrap();
-        store.clone().get_proof_of_indexing(site, indexer, block)
     }
 
     fn get(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError> {

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -837,6 +837,14 @@ impl SubgraphStoreTrait for SubgraphStore {
             Err(e) => Err(e.into()),
         }
     }
+
+    fn least_block_ptr(
+        &self,
+        id: &SubgraphDeploymentId,
+    ) -> Result<Option<EthereumBlockPointer>, Error> {
+        let (store, site) = self.store(id)?;
+        store.block_ptr(site.as_ref())
+    }
 }
 
 struct WritableStore {

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -610,7 +610,7 @@ impl SubgraphStore {
             let id = SubgraphDeploymentId::new(deployment_id.clone())
                 .map_err(|id| constraint_violation!("illegal deployment id {}", id))?;
             let (store, site) = self.store(&id)?;
-            let statuses = store.deployment_statuses(&vec![site])?;
+            let statuses = store.deployment_statuses(&vec![site.clone()])?;
             let status = statuses
                 .first()
                 .ok_or_else(|| StoreError::DeploymentNotFound(deployment_id.clone()))?;
@@ -620,7 +620,7 @@ impl SubgraphStore {
                 .ok_or_else(|| constraint_violation!("no chain info for {}", deployment_id))?;
             let latest_ethereum_block_number =
                 chain.latest_block.as_ref().map(|ref block| block.number());
-            let subgraph_info = store.subgraph_info(&id)?;
+            let subgraph_info = store.subgraph_info(site.as_ref())?;
             let network = self.network_name(&id)?;
 
             let info = VersionInfo {
@@ -916,14 +916,14 @@ impl SubgraphStoreTrait for SubgraphStore {
     }
 
     fn input_schema(&self, id: &SubgraphDeploymentId) -> Result<Arc<Schema>, StoreError> {
-        let (store, _) = self.store(&id)?;
-        let info = store.subgraph_info(id)?;
+        let (store, site) = self.store(&id)?;
+        let info = store.subgraph_info(site.as_ref())?;
         Ok(info.input)
     }
 
     fn api_schema(&self, id: &SubgraphDeploymentId) -> Result<Arc<ApiSchema>, StoreError> {
-        let (store, _) = self.store(&id)?;
-        let info = store.subgraph_info(id)?;
+        let (store, site) = self.store(&id)?;
+        let info = store.subgraph_info(&site)?;
         Ok(info.api)
     }
 

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -495,7 +495,7 @@ impl SubgraphStoreInner {
                 node
             )));
         }
-        let mut deployment = src_store.load_deployment(src.as_ref())?;
+        let deployment = src_store.load_deployment(src.as_ref())?;
         if deployment.failed {
             return Err(StoreError::Unknown(anyhow!(
                 "can not copy deployment {} because it has failed",
@@ -504,14 +504,21 @@ impl SubgraphStoreInner {
         }
 
         // Transmogrify the deployment into a new one
-        deployment.fatal_error = None;
-        deployment.non_fatal_errors = vec![];
-        deployment.reorg_count = 0;
-        deployment.max_reorg_depth = 0;
-        deployment.current_reorg_depth = 0;
-        deployment.latest_block = deployment.earliest_block.clone();
-        deployment.graft_base = Some(src.deployment.clone());
-        deployment.graft_block = Some(block);
+        let deployment = SubgraphDeploymentEntity {
+            manifest: deployment.manifest,
+            failed: false,
+            health: deployment.health,
+            synced: false,
+            fatal_error: None,
+            non_fatal_errors: vec![],
+            earliest_block: deployment.earliest_block.clone(),
+            latest_block: deployment.earliest_block,
+            graft_base: Some(src.deployment.clone()),
+            graft_block: Some(block),
+            reorg_count: 0,
+            current_reorg_depth: 0,
+            max_reorg_depth: 0,
+        };
 
         let graft_base = self.layout(&src.deployment)?;
 

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -202,16 +202,6 @@ impl SubgraphStore {
     ) -> DynTryFuture<'a, Option<[u8; 32]>> {
         self.inner.clone().get_proof_of_indexing(id, indexer, block)
     }
-
-    pub(crate) fn supports_proof_of_indexing<'a>(
-        self: Arc<Self>,
-        id: &'a SubgraphDeploymentId,
-    ) -> DynTryFuture<'a, bool> {
-        match self.writable(id) {
-            Ok(writable) => writable.supports_proof_of_indexing(),
-            Err(e) => Box::pin(std::future::ready(Err(e.into()))),
-        }
-    }
 }
 
 impl std::ops::Deref for SubgraphStore {

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -845,6 +845,13 @@ impl SubgraphStoreTrait for SubgraphStore {
         }))
     }
 
+    fn writable_for_network_indexer(
+        &self,
+        id: &SubgraphDeploymentId,
+    ) -> Result<Arc<dyn WritableStoreTrait>, StoreError> {
+        self.writable(id)
+    }
+
     fn is_deployed(&self, id: &SubgraphDeploymentId) -> Result<bool, Error> {
         match self.site(id) {
             Ok(_) => Ok(true),

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -611,7 +611,7 @@ impl SubgraphStore {
             let latest_ethereum_block_number =
                 chain.latest_block.as_ref().map(|ref block| block.number());
             let subgraph_info = store.subgraph_info(site.as_ref())?;
-            let network = self.network_name(&id)?;
+            let network = site.network.clone();
 
             let info = VersionInfo {
                 created_at,
@@ -894,11 +894,6 @@ impl SubgraphStoreTrait for SubgraphStore {
         let (store, site) = self.store(&id)?;
         let info = store.subgraph_info(&site)?;
         Ok(info.api)
-    }
-
-    fn network_name(&self, id: &SubgraphDeploymentId) -> Result<String, StoreError> {
-        let (_, site) = self.store(&id)?;
-        Ok(site.network.to_string())
     }
 }
 

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -670,6 +670,13 @@ impl SubgraphStore {
         let (store, site) = self.store(&id).unwrap();
         store.clone().get_proof_of_indexing(site, indexer, block)
     }
+
+    // Only used by tests
+    #[cfg(debug_assertions)]
+    pub fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
+        let (store, site) = self.store(&query.subgraph_id)?;
+        store.find(site, query)
+    }
 }
 
 #[async_trait::async_trait]
@@ -699,11 +706,6 @@ impl SubgraphStoreTrait for SubgraphStore {
     ) -> Result<BTreeMap<EntityType, Vec<Entity>>, StoreError> {
         let (store, site) = self.store(&id)?;
         store.get_many(site, ids_for_type)
-    }
-
-    fn find(&self, query: EntityQuery) -> Result<Vec<Entity>, QueryExecutionError> {
-        let (store, site) = self.store(&query.subgraph_id)?;
-        store.find(site, query)
     }
 
     fn find_ens_name(&self, hash: &str) -> Result<Option<String>, QueryExecutionError> {

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -308,12 +308,12 @@ fn graft() {
 
         store
             .writable(&subgraph_id)?
-            .revert_block_operations(subgraph_id.clone(), BLOCKS[1].clone())
+            .revert_block_operations(BLOCKS[1].clone())
             .expect("We can revert a block we just created");
 
         let err = store
             .writable(&subgraph_id)?
-            .revert_block_operations(subgraph_id.clone(), BLOCKS[0].clone())
+            .revert_block_operations(BLOCKS[0].clone())
             .expect_err("Reverting past graft point is not allowed");
 
         assert!(err.to_string().contains("Can not revert subgraph"));

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -307,12 +307,12 @@ fn graft() {
             .unwrap();
 
         store
-            .writable()
+            .writable(&subgraph_id)
             .revert_block_operations(subgraph_id.clone(), BLOCKS[1].clone())
             .expect("We can revert a block we just created");
 
         let err = store
-            .writable()
+            .writable(&subgraph_id)
             .revert_block_operations(subgraph_id.clone(), BLOCKS[0].clone())
             .expect_err("Reverting past graft point is not allowed");
 

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -307,10 +307,12 @@ fn graft() {
             .unwrap();
 
         store
+            .writable()
             .revert_block_operations(subgraph_id.clone(), BLOCKS[1].clone())
             .expect("We can revert a block we just created");
 
         let err = store
+            .writable()
             .revert_block_operations(subgraph_id.clone(), BLOCKS[0].clone())
             .expect_err("Reverting past graft point is not allowed");
 

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -259,7 +259,7 @@ fn remove_test_data(store: Arc<DieselSubgraphStore>) {
 
 #[test]
 fn graft() {
-    run_test(move |store| -> Result<(), ()> {
+    run_test(move |store| -> Result<(), StoreError> {
         const SUBGRAPH: &str = "grafted";
 
         let subgraph_id = SubgraphDeploymentId::new(SUBGRAPH).unwrap();
@@ -307,12 +307,12 @@ fn graft() {
             .unwrap();
 
         store
-            .writable(&subgraph_id)
+            .writable(&subgraph_id)?
             .revert_block_operations(subgraph_id.clone(), BLOCKS[1].clone())
             .expect("We can revert a block we just created");
 
         let err = store
-            .writable(&subgraph_id)
+            .writable(&subgraph_id)?
             .revert_block_operations(subgraph_id.clone(), BLOCKS[0].clone())
             .expect_err("Reverting past graft point is not allowed");
 

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -17,9 +17,8 @@ use graph::{
     data::store::scalar::{BigDecimal, BigInt, Bytes},
 };
 use graph_store_postgres::{
-    command_support::catalog::Site,
+    layout_for_tests::make_dummy_site,
     layout_for_tests::{Layout, Namespace, STRING_PREFIX_SIZE},
-    PRIMARY_SHARD,
 };
 
 use test_store::*;
@@ -399,13 +398,11 @@ fn insert_pets(conn: &PgConnection, layout: &Layout) {
 
 fn insert_test_data(conn: &PgConnection) -> Layout {
     let schema = Schema::parse(THINGS_GQL, THINGS_SUBGRAPH_ID.clone()).unwrap();
-    let site = Site {
-        id: 1,
-        deployment: THINGS_SUBGRAPH_ID.clone(),
-        shard: PRIMARY_SHARD.clone(),
-        namespace: NAMESPACE.clone(),
-        network: NETWORK_NAME.to_string(),
-    };
+    let site = make_dummy_site(
+        THINGS_SUBGRAPH_ID.clone(),
+        NAMESPACE.clone(),
+        NETWORK_NAME.to_string(),
+    );
     let query = format!("create schema {}", NAMESPACE.as_str());
     conn.batch_execute(&*query).unwrap();
 

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -16,9 +16,8 @@ use graph::{
     data::store::scalar::{BigDecimal, BigInt},
 };
 use graph_store_postgres::{
-    command_support::catalog::Site,
+    layout_for_tests::make_dummy_site,
     layout_for_tests::{Layout, Namespace},
-    PRIMARY_SHARD,
 };
 
 use test_store::*;
@@ -117,13 +116,11 @@ fn create_schema(conn: &PgConnection) -> Layout {
     let query = format!("create schema {}", NAMESPACE.as_str());
     conn.batch_execute(&*query).unwrap();
 
-    let site = Site {
-        id: 1,
-        deployment: THINGS_SUBGRAPH_ID.clone(),
-        shard: PRIMARY_SHARD.clone(),
-        namespace: NAMESPACE.clone(),
-        network: NETWORK_NAME.to_string(),
-    };
+    let site = make_dummy_site(
+        THINGS_SUBGRAPH_ID.clone(),
+        NAMESPACE.clone(),
+        NETWORK_NAME.to_string(),
+    );
     Layout::create_relational_schema(&conn, Arc::new(site), &schema)
         .expect("Failed to create relational schema")
 }

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1398,7 +1398,6 @@ fn throttle_subscription_delivers() {
                 .query_store(deployment.hash.clone().into(), true)
                 .await
                 .unwrap(),
-            deployment.hash.clone(),
             Duration::from_millis(500),
         );
 
@@ -1438,7 +1437,6 @@ fn throttle_subscription_throttles() {
                 .query_store(deployment.hash.clone().into(), true)
                 .await
                 .unwrap(),
-            deployment.hash.clone(),
             Duration::from_secs(30),
         );
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1263,7 +1263,7 @@ fn revert_block_with_dynamic_data_source_operations() {
         let loaded_dds = subgraph_store
             .writable(&*TEST_SUBGRAPH_ID)
             .expect("can get writable")
-            .load_dynamic_data_sources(TEST_SUBGRAPH_ID.clone())
+            .load_dynamic_data_sources()
             .await
             .unwrap();
         assert_eq!(1, loaded_dds.len());
@@ -1287,7 +1287,7 @@ fn revert_block_with_dynamic_data_source_operations() {
         let loaded_dds = subgraph_store
             .writable(&*TEST_SUBGRAPH_ID)
             .expect("can get writable")
-            .load_dynamic_data_sources(TEST_SUBGRAPH_ID.clone())
+            .load_dynamic_data_sources()
             .await
             .unwrap();
         assert_eq!(0, loaded_dds.len());
@@ -1590,7 +1590,6 @@ fn handle_large_string_with_index() {
             .writable(&*TEST_SUBGRAPH_ID)
             .expect("can get writable")
             .transact_block_operations(
-                TEST_SUBGRAPH_ID.clone(),
                 TEST_BLOCK_3_PTR.clone(),
                 vec![
                     make_insert_op(ONE, &long_text),

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -194,10 +194,8 @@ fn create_subgraph() {
         assert!(pending.is_none());
 
         // Sync deployment
-        store
-            .writable()
-            .deployment_synced(&SubgraphDeploymentId::new(ID2).unwrap())
-            .unwrap();
+        let id = SubgraphDeploymentId::new(ID2).unwrap();
+        store.writable(&id).deployment_synced(&id).unwrap();
 
         // Deploying again still overwrites current
         let mut expected = deploy_event(ID3);
@@ -261,10 +259,8 @@ fn create_subgraph() {
         assert!(pending.is_none());
 
         // Deploy when current is synced leaves current alone and adds pending
-        store
-            .writable()
-            .deployment_synced(&SubgraphDeploymentId::new(ID2).unwrap())
-            .unwrap();
+        let id = SubgraphDeploymentId::new(ID2).unwrap();
+        store.writable(&id).deployment_synced(&id).unwrap();
         let expected = deploy_event(ID3);
 
         let events = deploy(store.as_ref(), ID3, MODE);
@@ -384,7 +380,7 @@ fn status() {
 
         store
             .subgraph_store()
-            .writable()
+            .writable(&id)
             .fail_subgraph(id.clone(), error)
             .await
             .unwrap();
@@ -526,7 +522,7 @@ fn fatal_vs_non_fatal() {
 
         store
             .subgraph_store()
-            .writable()
+            .writable(&id)
             .fail_subgraph(id.clone(), error())
             .await
             .unwrap();
@@ -568,12 +564,8 @@ fn fail_unfail() {
             deterministic: true,
         };
 
-        store
-            .subgraph_store()
-            .writable()
-            .fail_subgraph(id.clone(), error)
-            .await
-            .unwrap();
+        let writable = store.subgraph_store().writable(&id);
+        writable.fail_subgraph(id.clone(), error).await.unwrap();
 
         assert!(!query_store
             .has_non_fatal_errors(id.cheap_clone(), None)
@@ -581,7 +573,7 @@ fn fail_unfail() {
             .unwrap());
 
         // This will unfail the subgraph and delete the fatal error.
-        store.subgraph_store().writable().unfail(&id).unwrap();
+        writable.unfail(&id).unwrap();
 
         // Advance the block ptr to the block of the deleted error.
         transact_entity_operations(

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -195,6 +195,7 @@ fn create_subgraph() {
 
         // Sync deployment
         store
+            .writable()
             .deployment_synced(&SubgraphDeploymentId::new(ID2).unwrap())
             .unwrap();
 
@@ -261,6 +262,7 @@ fn create_subgraph() {
 
         // Deploy when current is synced leaves current alone and adds pending
         store
+            .writable()
             .deployment_synced(&SubgraphDeploymentId::new(ID2).unwrap())
             .unwrap();
         let expected = deploy_event(ID3);
@@ -382,6 +384,7 @@ fn status() {
 
         store
             .subgraph_store()
+            .writable()
             .fail_subgraph(id.clone(), error)
             .await
             .unwrap();
@@ -523,6 +526,7 @@ fn fatal_vs_non_fatal() {
 
         store
             .subgraph_store()
+            .writable()
             .fail_subgraph(id.clone(), error())
             .await
             .unwrap();
@@ -566,6 +570,7 @@ fn fail_unfail() {
 
         store
             .subgraph_store()
+            .writable()
             .fail_subgraph(id.clone(), error)
             .await
             .unwrap();
@@ -576,7 +581,7 @@ fn fail_unfail() {
             .unwrap());
 
         // This will unfail the subgraph and delete the fatal error.
-        store.subgraph_store().unfail(&id).unwrap();
+        store.subgraph_store().writable().unfail(&id).unwrap();
 
         // Advance the block ptr to the block of the deleted error.
         transact_entity_operations(

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -155,7 +155,7 @@ fn create_subgraph() {
         store
             .writable(&id)
             .expect("can get writable")
-            .deployment_synced(&id)
+            .deployment_synced()
             .unwrap();
     }
 
@@ -390,7 +390,7 @@ fn status() {
             .subgraph_store()
             .writable(&id)
             .expect("can get writable")
-            .fail_subgraph(id.clone(), error)
+            .fail_subgraph(error)
             .await
             .unwrap();
         let infos = store
@@ -533,7 +533,7 @@ fn fatal_vs_non_fatal() {
             .subgraph_store()
             .writable(&id)
             .expect("can get writable")
-            .fail_subgraph(id.clone(), error())
+            .fail_subgraph(error())
             .await
             .unwrap();
 
@@ -578,7 +578,7 @@ fn fail_unfail() {
             .subgraph_store()
             .writable(&id)
             .expect("can get writable");
-        writable.fail_subgraph(id.clone(), error).await.unwrap();
+        writable.fail_subgraph(error).await.unwrap();
 
         assert!(!query_store
             .has_non_fatal_errors(id.cheap_clone(), None)
@@ -586,7 +586,7 @@ fn fail_unfail() {
             .unwrap());
 
         // This will unfail the subgraph and delete the fatal error.
-        writable.unfail(&id).unwrap();
+        writable.unfail().unwrap();
 
         // Advance the block ptr to the block of the deleted error.
         transact_entity_operations(

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -527,17 +527,11 @@ fn fatal_vs_non_fatal() {
             .await
             .unwrap();
 
-        assert!(!query_store
-            .has_non_fatal_errors(deployment.hash.cheap_clone(), None)
-            .await
-            .unwrap());
+        assert!(!query_store.has_non_fatal_errors(None).await.unwrap());
 
         transact_errors(&store, &deployment, BLOCKS[1].clone(), vec![error()]).unwrap();
 
-        assert!(query_store
-            .has_non_fatal_errors(deployment.hash.cheap_clone(), None)
-            .await
-            .unwrap());
+        assert!(query_store.has_non_fatal_errors(None).await.unwrap());
     })
 }
 
@@ -569,10 +563,7 @@ fn fail_unfail() {
             .expect("can get writable");
         writable.fail_subgraph(error).await.unwrap();
 
-        assert!(!query_store
-            .has_non_fatal_errors(deployment.hash.cheap_clone(), None)
-            .await
-            .unwrap());
+        assert!(!query_store.has_non_fatal_errors(None).await.unwrap());
 
         // This will unfail the subgraph and delete the fatal error.
         writable.unfail().unwrap();
@@ -587,10 +578,7 @@ fn fail_unfail() {
         .unwrap();
 
         // We still have no fatal errors.
-        assert!(!query_store
-            .has_non_fatal_errors(deployment.hash.cheap_clone(), None)
-            .await
-            .unwrap());
+        assert!(!query_store.has_non_fatal_errors(None).await.unwrap());
 
         test_store::remove_subgraphs();
     })

--- a/store/test-store/README.md
+++ b/store/test-store/README.md
@@ -1,0 +1,57 @@
+# Setting up for running tests
+
+This document describes what needs to be done to run tests against a
+Postgres database.
+
+## Initial setup
+
+Before starting, you will need to set up a database user `graph` and give
+it the password `graph` by running `createuser -W graph`.
+
+You also need to arrange for `psql` and similar tools to connect to
+Postgres automatically as the `postgres` user.
+
+For that, add this line as the first non-comment line to
+`$PGDATA/pg_hba.conf`:
+```
+local   all             postgres                                peer map=admin
+```
+
+and add these lines to `data/pg_ident.conf`:
+```
+admin           postgres                postgres
+admin           <your username>         postgres
+```
+
+You might also want to set `log_statement = 'all'` to
+`$PGDATA/postgresql.conf`. That will cause Postgres to log all SQL
+statements that the tests send it which can sometimes be very helpful when
+tests fail.
+
+After making all these changes, restart Postgres to make sure it actually
+uses these settings.
+
+## Resetting the test databases
+
+The script `db-reset` will (re)create databases in the test cluster. This
+script can be used to remove old databases and/or broken databases schemas
+and cause `cargo test` to create the schema from scratch on the next test
+run.
+
+Note that `db-reset` will completely delete the databases `graph-test` and
+`graph-sgd` in the databases cluster that a plain invocation of `psql`
+connects to.
+
+## Running tests
+
+Before running tests set the environment variable `GRAPH_NODE_TEST_CONFIG`
+to point either at `config.simple.toml` or `config.sharded.toml`.
+
+Run tests with `cargo test --workspace --exclude graph-tests`; this will
+run all unit and integration tests. The `graph-tests` crate contains more
+extensive integration tests that depend on running docker containers; that
+setup is outside the scope of the document, and we therefore exclude them
+from running for basic usage.
+
+When you switch from one of the test configurations to another, you will
+need to clean out the test databases by running `db-reset`.

--- a/store/test-store/config.sharded.toml
+++ b/store/test-store/config.sharded.toml
@@ -1,15 +1,20 @@
-# A simple store configuration: we use one database for everything
-# This is equivalent to the old way of configuring the store for tests
-# by just setting the environment variable THEGRAPH_STORE_POSTGRES_DIESEL_URL
-
+# A sharded setup that uses two databases
 [store]
 [store.primary]
 connection = "postgresql://graph:graph@127.0.0.1:5432/graph-test"
-pool_size = 10
+pool_size = [ { size = 10 } ]
+[store.sgd]
+connection = "postgresql://graph:graph@127.0.0.1:5432/graph-sgd"
+pool_size = [ { size = 10 } ]
 
 [deployment]
 [[deployment.rule]]
-store = "primary"
+match = { name = "abi.*|grafted" }
+shard="primary"
+indexers = [ "default" ]
+
+[[deployment.rule]]
+shard = "sgd"
 indexers = [ "default" ]
 
 [chains]
@@ -18,13 +23,13 @@ ingestor = "default"
 # The tests do not talk to ethereum clients; we use valid free client
 # endpoints as an example
 [chains.fake_network]
-shard = "primary"
+shard = "sgd"
 provider = [
   { label = "penguin", url="https://main-light.eth.linkpool.io/", features = [] }
 ]
 
 [chains.fake_network_shared]
-shard = "primary"
+shard = "sgd"
 provider = [
   { label = "owl", url="https://rinkeby-light.eth.linkpool.io/", features = [] }
 ]

--- a/store/test-store/db-reset
+++ b/store/test-store/db-reset
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+resetdb() {
+    host=$(hostname -s)
+    db=$1
+    echo "Reset $db"
+    dropdb $db && createdb -O graph $db
+    psql -q -X $db <<EOF
+create extension pg_trgm;
+create extension pg_stat_statements;
+create extension btree_gist;
+create extension postgres_fdw;
+grant usage on foreign data wrapper postgres_fdw to graph;
+EOF
+}
+
+resetdb graph-test
+resetdb graph-sgd

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -178,7 +178,7 @@ fn create_subgraph(
         SubgraphVersionSwitchingMode::Instant,
     )?;
     SUBGRAPH_STORE
-        .writable()
+        .writable(&subgraph_id)
         .start_subgraph_deployment(&*LOGGER, &subgraph_id)
 }
 
@@ -218,14 +218,17 @@ pub fn transact_errors(
         subgraph_id.clone(),
         metrics_registry.clone(),
     );
-    store.subgraph_store().writable().transact_block_operations(
-        subgraph_id,
-        block_ptr_to,
-        Vec::new(),
-        stopwatch_metrics,
-        Vec::new(),
-        errs,
-    )
+    store
+        .subgraph_store()
+        .writable(&subgraph_id)
+        .transact_block_operations(
+            subgraph_id,
+            block_ptr_to,
+            Vec::new(),
+            stopwatch_metrics,
+            Vec::new(),
+            errs,
+        )
 }
 
 /// Convenience to transact EntityOperation instead of EntityModification
@@ -245,7 +248,7 @@ pub fn transact_entities_and_dynamic_data_sources(
     data_sources: Vec<&DataSource>,
     ops: Vec<EntityOperation>,
 ) -> Result<(), StoreError> {
-    let store = store.writable();
+    let store = store.writable(&subgraph_id);
     let mut entity_cache = EntityCache::new(store.clone());
     entity_cache.append(ops);
     let mods = entity_cache

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -6,7 +6,8 @@ use graph::data::subgraph::schema::SubgraphError;
 use graph::log;
 use graph::prelude::{QueryStoreManager as _, SubgraphStore as _, *};
 use graph::{
-    components::store::EntityType, components::store::StoredDynamicDataSource, prelude::NodeId,
+    components::store::EntityType, components::store::StatusStore,
+    components::store::StoredDynamicDataSource, data::subgraph::status, prelude::NodeId,
 };
 use graph_graphql::prelude::{
     execute_query, Query as PreparedQuery, QueryExecutionOptions, StoreResolver,
@@ -376,7 +377,12 @@ fn execute_subgraph_query_internal(
         _ => unreachable!("tests do not use this"),
     };
     let schema = SUBGRAPH_STORE.api_schema(&id).unwrap();
-    let network = Some(SUBGRAPH_STORE.network_name(&id).unwrap());
+    let status = StatusStore::status(
+        STORE.as_ref(),
+        status::Filter::Deployments(vec![id.to_string()]),
+    )
+    .unwrap();
+    let network = Some(status[0].chains[0].network.clone());
     let query = return_err!(PreparedQuery::new(
         &logger,
         schema,

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -179,7 +179,7 @@ fn create_subgraph(
     )?;
     SUBGRAPH_STORE
         .writable(&subgraph_id)?
-        .start_subgraph_deployment(&*LOGGER, &subgraph_id)
+        .start_subgraph_deployment(&*LOGGER)
 }
 
 pub fn create_test_subgraph(subgraph_id: &SubgraphDeploymentId, schema: &str) {
@@ -222,7 +222,6 @@ pub fn transact_errors(
         .subgraph_store()
         .writable(&subgraph_id)?
         .transact_block_operations(
-            subgraph_id,
             block_ptr_to,
             Vec::new(),
             stopwatch_metrics,
@@ -266,7 +265,6 @@ pub fn transact_entities_and_dynamic_data_sources(
         .map(|ds| StoredDynamicDataSource::from(ds))
         .collect();
     store.transact_block_operations(
-        subgraph_id,
         block_ptr_to,
         mods,
         stopwatch_metrics,
@@ -284,7 +282,7 @@ pub fn revert_block(
         .subgraph_store()
         .writable(subgraph_id)
         .expect("can get writable")
-        .revert_block_operations(subgraph_id.clone(), ptr.clone())
+        .revert_block_operations(ptr.clone())
         .unwrap();
 }
 

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -251,7 +251,7 @@ pub fn transact_entities_and_dynamic_data_sources(
     let mut entity_cache = EntityCache::new(store.clone());
     entity_cache.append(ops);
     let mods = entity_cache
-        .as_modifications(store.as_ref())
+        .as_modifications()
         .expect("failed to convert to modifications")
         .modifications;
     let metrics_registry = Arc::new(MockMetricsRegistry::new());

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -178,7 +178,7 @@ fn create_subgraph(
         SubgraphVersionSwitchingMode::Instant,
     )?;
     SUBGRAPH_STORE
-        .writable(&subgraph_id)
+        .writable(&subgraph_id)?
         .start_subgraph_deployment(&*LOGGER, &subgraph_id)
 }
 
@@ -220,7 +220,7 @@ pub fn transact_errors(
     );
     store
         .subgraph_store()
-        .writable(&subgraph_id)
+        .writable(&subgraph_id)?
         .transact_block_operations(
             subgraph_id,
             block_ptr_to,
@@ -248,7 +248,7 @@ pub fn transact_entities_and_dynamic_data_sources(
     data_sources: Vec<&DataSource>,
     ops: Vec<EntityOperation>,
 ) -> Result<(), StoreError> {
-    let store = store.writable(&subgraph_id);
+    let store = store.writable(&subgraph_id)?;
     let mut entity_cache = EntityCache::new(store.clone());
     entity_cache.append(ops);
     let mods = entity_cache
@@ -273,6 +273,19 @@ pub fn transact_entities_and_dynamic_data_sources(
         data_sources,
         Vec::new(),
     )
+}
+
+pub fn revert_block(
+    store: &Arc<Store>,
+    subgraph_id: &SubgraphDeploymentId,
+    ptr: &EthereumBlockPointer,
+) {
+    store
+        .subgraph_store()
+        .writable(subgraph_id)
+        .expect("can get writable")
+        .revert_block_operations(subgraph_id.clone(), ptr.clone())
+        .unwrap();
 }
 
 pub fn insert_ens_name(hash: &str, name: &str) {

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -177,7 +177,9 @@ fn create_subgraph(
         NETWORK_NAME.to_string(),
         SubgraphVersionSwitchingMode::Instant,
     )?;
-    SUBGRAPH_STORE.start_subgraph_deployment(&*LOGGER, &subgraph_id)
+    SUBGRAPH_STORE
+        .writable()
+        .start_subgraph_deployment(&*LOGGER, &subgraph_id)
 }
 
 pub fn create_test_subgraph(subgraph_id: &SubgraphDeploymentId, schema: &str) {
@@ -216,7 +218,7 @@ pub fn transact_errors(
         subgraph_id.clone(),
         metrics_registry.clone(),
     );
-    store.subgraph_store().transact_block_operations(
+    store.subgraph_store().writable().transact_block_operations(
         subgraph_id,
         block_ptr_to,
         Vec::new(),
@@ -243,6 +245,7 @@ pub fn transact_entities_and_dynamic_data_sources(
     data_sources: Vec<&DataSource>,
     ops: Vec<EntityOperation>,
 ) -> Result<(), StoreError> {
+    let store = store.writable();
     let mut entity_cache = EntityCache::new(store.clone());
     entity_cache.append(ops);
     let mods = entity_cache

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -193,7 +193,9 @@ pub fn remove_subgraph(id: &SubgraphDeploymentId) {
         SubgraphName::new(name).unwrap()
     };
     SUBGRAPH_STORE.remove_subgraph(name).unwrap();
-    SUBGRAPH_STORE.remove_deployment(id).unwrap();
+    for detail in SUBGRAPH_STORE.record_unused_deployments().unwrap() {
+        SUBGRAPH_STORE.remove_deployment(detail.id).unwrap();
+    }
 }
 
 pub fn create_grafted_subgraph(

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -417,6 +417,19 @@ fn execute_subgraph_query_internal(
     result
 }
 
+pub async fn deployment_state(
+    store: &Store,
+    subgraph_id: &SubgraphDeploymentId,
+) -> DeploymentState {
+    store
+        .query_store(QueryTarget::Deployment(subgraph_id.to_owned()), false)
+        .await
+        .expect("could get a query store")
+        .deployment_state()
+        .await
+        .expect("can get deployment state")
+}
+
 pub fn store_is_sharded() -> bool {
     CONFIG.stores.len() > 1
 }

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -58,7 +58,7 @@ lazy_static! {
     pub static ref STORE: Arc<Store> = STORE_POOL_CONFIG.0.clone();
     static ref CONFIG: Config = STORE_POOL_CONFIG.2.clone();
     pub static ref SUBSCRIPTION_MANAGER: Arc<SubscriptionManager> = STORE_POOL_CONFIG.3.clone();
-    static ref NODE_ID: NodeId = NodeId::new("test").unwrap();
+    pub static ref NODE_ID: NodeId = NodeId::new("test").unwrap();
     static ref SUBGRAPH_STORE: Arc<DieselSubgraphStore> = STORE.subgraph_store();
     static ref BLOCK_STORE: Arc<DieselBlcokStore> = STORE.block_store();
     pub static ref GENESIS_PTR: EthereumBlockPointer = (
@@ -145,7 +145,7 @@ pub fn place(name: &str) -> Result<Option<(Shard, Vec<NodeId>)>, String> {
     CONFIG.deployment.place(name, NETWORK_NAME)
 }
 
-fn create_subgraph(
+pub fn create_subgraph(
     subgraph_id: &SubgraphDeploymentId,
     schema: &str,
     base: Option<(SubgraphDeploymentId, EthereumBlockPointer)>,
@@ -198,16 +198,6 @@ pub fn remove_subgraph(id: &SubgraphDeploymentId) {
     for detail in SUBGRAPH_STORE.record_unused_deployments().unwrap() {
         SUBGRAPH_STORE.remove_deployment(detail.id).unwrap();
     }
-}
-
-pub fn create_grafted_subgraph(
-    subgraph_id: &SubgraphDeploymentId,
-    schema: &str,
-    base_id: &str,
-    base_block: EthereumBlockPointer,
-) -> Result<DeploymentLocator, StoreError> {
-    let base = Some((SubgraphDeploymentId::new(base_id).unwrap(), base_block));
-    create_subgraph(subgraph_id, schema, base)
 }
 
 pub fn transact_errors(
@@ -459,6 +449,15 @@ pub async fn deployment_state(
 
 pub fn store_is_sharded() -> bool {
     CONFIG.stores.len() > 1
+}
+
+pub fn all_shards() -> Vec<Shard> {
+    CONFIG
+        .stores
+        .keys()
+        .map(|shard| Shard::new(shard.clone()))
+        .collect::<Result<Vec<_>, _>>()
+        .expect("all configured shard names are valid")
 }
 
 fn build_store() -> (Arc<Store>, ConnectionPool, Config, Arc<SubscriptionManager>) {


### PR DESCRIPTION
With this PR, subgraphs can be copied from one shard to another shard. The system can now deal with multiple copies of the same deployment hash existing side by side. These copies need to be in different shards (there's little point in having the same data duplicated in the same database), and only one of these copies (the 'active' one) will be used to respond to queries.

Copying is initiated by running `graphman copy create ...`, and queries can be switched to the copy with `graphman copy activate ..` once the copy has finished. Behind the scenes, copying uses most of the grafting machinery from #2293. In addition, all operations make sure that they now uniquely identify the precise copy of a deployment using a `DeploymentLocator` on the write path for a subgraph (encapsulated in a `WritableStore`) For queries, the `QueryStore` automatically picks the active copy of a subgraph. Within the store, deployments are now identified by the `id` of the `deployment_schemas` table; `DeploymentLocator` encapsulates that so that the rest of the code can be oblivious to that.

The system is limited to 5 active copy/graft operations per index pod. In the future, it might be better to limit this systemwide. The limit is hardcoded, but it would be easy to make that configurable in `graph-node.toml`

While a copy/graft is under way, progress is printed approximately every 3-5 minutes; the progress message looks like
```
INFO Copied 68.36% of `UpdateOperator` entities (150000/219432 entity versions), 36.60% of overall data, 
         dst: sgd139, subgraph_id: QmXB2mf78FTeXPFT7R7LUiUGNxypTbDnoMXYGu7oRAfh9z, 
         component: SubgraphInstanceManager
```
A copy/graft can be cancelled by unassigning the destination deployment. That will (with some delay of up to 5 minutes) lead to the copy process stopping, and the subgraph being stopped.

A list of active copies can be generated with `graphman copy list`:
```
------------------------------------------------------------------------------
deployment           | QmQx9BPnarDU29c1vroiWCBd4wrZuMpngvA6peuSB2Kzy6
action               | sgd120 -> sgd141 (shard_1)
started              | 2021-04-06T00:17:41+00:00
progress             | 12.51% done, 310000/2477526
------------------------------------------------------------------------------
deployment           | QmRuorV4Ck1sVdpfpAAwfYXnf3cfSkbDwZvvzWud9SH8Dg
action               | sgd130 -> sgd145 (shard_1)
queued               | 2021-04-06T00:18:16+00:00
------------------------------------------------------------------------------
deployment           | QmRpG1kMLJxnruvCScfs4JYPeHJEnJk1ZsEdhpfqaGPUHs
action               | sgd19 -> sgd146 (shard_1)
cancel requested     | 2021-04-06T00:22:30+00:00
------------------------------------------------------------------------------
deployment           | QmSsv4sJNwyEkSmwWgErmHS4tneAuVEoChSRNcyXSE1mjG
action               | sgd43 -> sgd142 (shard_1)
cancelled            | 2021-04-06T00:22:56+00:00
```
The details of a copy operation can be printed with `graphman copy status <dst>` which prints something like
```
src          | 122
dst          | 144
target block | 12152039
duration     | 25m
status       | .

         entity type           |   next   |  target  |  batch   | duration
--------------------------------------------------------------------------
> Loan                         |   637909 |  1283075 |   144322 |      19m
. Poi$                         |        0 |   108543 |    10000 |      0ms
✓ Pool                         |   113975 |   113974 |   160000 |     112s
✓ Proxy                        |       22 |       21 |    20000 |     40ms
```

To help clarify the distinction between internal and external identifier of a deployment, I plan on renaming `SubgraphDeploymentId` to `DeploymentHash`. Since this is a very boring, but very intrusive change, I will do that in a separate PR; that's the reason why a lot of code now has variables `hash: SubgraphDeploymentId`.

This PR sits on top of #2293.

 