### PR TITLE
Make graph-node startup more resilient in the face of misbehaving eth providers

### DIFF
--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -77,7 +77,7 @@ where
             }),
         );
 
-        let logger = logger.new(o!("network_name" => network_name.clone()));
+        let logger = logger.new(o!("provider" => eth_adapter.provider().to_string()));
 
         Ok(BlockIngestor {
             chain_store,

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -34,6 +34,7 @@ use web3::types::Filter;
 pub struct EthereumAdapter<T: web3::Transport> {
     logger: Logger,
     url_hostname: Arc<String>,
+    provider: String,
     web3: Arc<Web3<T>>,
     metrics: Arc<ProviderEthRpcMetrics>,
     is_ganache: bool,
@@ -87,6 +88,7 @@ impl<T: web3::Transport> CheapClone for EthereumAdapter<T> {
     fn cheap_clone(&self) -> Self {
         Self {
             logger: self.logger.clone(),
+            provider: self.provider.clone(),
             url_hostname: self.url_hostname.cheap_clone(),
             web3: self.web3.cheap_clone(),
             metrics: self.metrics.cheap_clone(),
@@ -103,6 +105,7 @@ where
 {
     pub async fn new(
         logger: Logger,
+        provider: String,
         url: &str,
         transport: T,
         provider_metrics: Arc<ProviderEthRpcMetrics>,
@@ -128,6 +131,7 @@ where
 
         EthereumAdapter {
             logger,
+            provider,
             url_hostname: Arc::new(hostname),
             web3,
             metrics: provider_metrics,
@@ -627,6 +631,10 @@ where
 {
     fn url_hostname(&self) -> &str {
         &self.url_hostname
+    }
+
+    fn provider(&self) -> &str {
+        &self.provider
     }
 
     fn net_identifiers(

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -596,6 +596,9 @@ impl BlockStreamMetrics {
 pub trait EthereumAdapter: Send + Sync + 'static {
     fn url_hostname(&self) -> &str;
 
+    /// The `provider.label` from the adapter's configuration
+    fn provider(&self) -> &str;
+
     /// Ask the Ethereum node for some identifying information about the Ethereum network it is
     /// connected to.
     fn net_identifiers(

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -593,6 +593,7 @@ impl BlockStreamMetrics {
 /// Implementations may be implemented against an in-process Ethereum node
 /// or a remote node over RPC.
 #[automock]
+#[async_trait]
 pub trait EthereumAdapter: Send + Sync + 'static {
     fn url_hostname(&self) -> &str;
 
@@ -601,9 +602,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
 
     /// Ask the Ethereum node for some identifying information about the Ethereum network it is
     /// connected to.
-    fn net_identifiers(
-        &self,
-    ) -> Box<dyn Future<Item = EthereumNetworkIdentifier, Error = Error> + Send>;
+    async fn net_identifiers(&self) -> Result<EthereumNetworkIdentifier, Error>;
 
     /// Get the latest block, including full transactions.
     fn latest_block(

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -19,7 +19,7 @@ use crate::prelude::*;
 
 pub type EventSignature = H256;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 /// A collection of attributes that (kind of) uniquely identify an Ethereum blockchain.
 pub struct EthereumNetworkIdentifier {
     pub net_version: String,

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -600,7 +600,6 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     /// connected to.
     fn net_identifiers(
         &self,
-        logger: &Logger,
     ) -> Box<dyn Future<Item = EthereumNetworkIdentifier, Error = Error> + Send>;
 
     /// Get the latest block, including full transactions.

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -501,7 +501,7 @@ async fn create_ethereum_networks(
         for provider in chain.providers {
             let capabilities = provider.node_capabilities();
 
-            let logger = logger.new(o!("provider" => provider.label));
+            let logger = logger.new(o!("provider" => provider.label.clone()));
             info!(
                 logger,
                 "Creating transport";
@@ -527,6 +527,7 @@ async fn create_ethereum_networks(
                 Arc::new(
                     graph_chain_ethereum::EthereumAdapter::new(
                         logger,
+                        provider.label,
                         &provider.url,
                         transport,
                         eth_rpc_metrics.clone(),

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -202,7 +202,7 @@ impl StoreBuilder {
     /// and a `BlockStore` for all chain related data
     pub fn network_store(
         self,
-        networks: Vec<(String, Option<EthereumNetworkIdentifier>)>,
+        networks: Vec<(String, Vec<EthereumNetworkIdentifier>)>,
     ) -> Arc<DieselStore> {
         let chain_head_update_listener = Arc::new(PostgresChainHeadUpdateListener::new(
             &self.logger,

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -202,7 +202,7 @@ impl StoreBuilder {
     /// and a `BlockStore` for all chain related data
     pub fn network_store(
         self,
-        networks: Vec<(String, EthereumNetworkIdentifier)>,
+        networks: Vec<(String, Option<EthereumNetworkIdentifier>)>,
     ) -> Arc<DieselStore> {
         let chain_head_update_listener = Arc::new(PostgresChainHeadUpdateListener::new(
             &self.logger,

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -454,8 +454,8 @@ fn build_store() -> (Arc<Store>, ConnectionPool, Config, Arc<SubscriptionManager
 
             (
                 builder.network_store(vec![
-                    (NETWORK_NAME.to_string(), ident.clone()),
-                    (FAKE_NETWORK_SHARED.to_string(), ident),
+                    (NETWORK_NAME.to_string(), Some(ident.clone())),
+                    (FAKE_NETWORK_SHARED.to_string(), Some(ident)),
                 ]),
                 primary_pool,
                 config,

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -454,8 +454,8 @@ fn build_store() -> (Arc<Store>, ConnectionPool, Config, Arc<SubscriptionManager
 
             (
                 builder.network_store(vec![
-                    (NETWORK_NAME.to_string(), Some(ident.clone())),
-                    (FAKE_NETWORK_SHARED.to_string(), Some(ident)),
+                    (NETWORK_NAME.to_string(), vec![ident.clone()]),
+                    (FAKE_NETWORK_SHARED.to_string(), vec![ident]),
                 ]),
                 primary_pool,
                 config,


### PR DESCRIPTION
Previously, an eth client that would not successfully respond to our `net_version` request (for example, by returning `429 Too Many Requests`) would block the startup of `graph-node` indefinitely. With this PR, if we can not get a valid response within 30s, we continue startup hoping that the `net_version` hasn't changed since the last run. If the misbehaving client is for a new chain, startup will still fail (though much more loudly than before)

This PR also fixes a bug introduced by various refactorings where we would not detect a change in net version because we were checking our database state against our database state ...