### PR TITLE
Allow network to opt out of eip-1898

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## next - unreleased
 
+- The `GRAPH_ETH_CALL_BY_NUMBER` environment variable has been removed. Graph Node requires an
+  Ethereum client that support EIP-1898, which all major clients support.
+
 ## 0.22.0
 
 ### Feature: Block store sharding

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -10,7 +10,7 @@ use graph_store_postgres::{DeploymentPlacer, Shard as ShardName, PRIMARY_SHARD};
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::read_to_string;
 use url::Url;
 
@@ -465,10 +465,10 @@ pub struct Provider {
     #[serde(default)]
     pub transport: Transport,
     pub url: String,
-    pub features: Vec<String>,
+    pub features: BTreeSet<String>,
 }
 
-const PROVIDER_FEATURES: [&str; 2] = ["traces", "archive"];
+const PROVIDER_FEATURES: [&str; 3] = ["traces", "archive", "no_eip1898"];
 
 impl Provider {
     fn validate(&self) -> Result<()> {
@@ -498,8 +498,8 @@ impl Provider {
 
     pub fn node_capabilities(&self) -> NodeCapabilities {
         NodeCapabilities {
-            archive: self.features.iter().any(|f| f == "archive"),
-            traces: self.features.iter().any(|f| f == "traces"),
+            archive: self.features.contains("archive"),
+            traces: self.features.contains("traces"),
         }
     }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -56,18 +56,6 @@ lazy_static! {
         .map(|s| BlockNumber::from_str(&s)
              .unwrap_or_else(|_| panic!("failed to parse env var ETHEREUM_ANCESTOR_COUNT")))
         .unwrap_or(50);
-
-    // Comma separated network names that do not support EIP-1898 (calls by block hash). The only
-    // network known to not support it is fuse, once all known networks support eip 1898 this env
-    // var can be removed.
-    static ref NO_EIP_1898_SUPPORT: Vec<String> = {
-        std::env::var("GRAPH_NO_EIP_1898_SUPPORT").map(|s| {
-            s.split(',')
-             .map(|s| s.to_owned())
-             .collect()
-        })
-        .unwrap_or_default()
-    };
 }
 
 /// How long we will hold up node startup to get the net version and genesis
@@ -563,7 +551,7 @@ async fn create_ethereum_networks(
             // For now it's fine to just leak it.
             std::mem::forget(transport_event_loop);
 
-            let supports_eip_1898 = !NO_EIP_1898_SUPPORT.contains(&name);
+            let supports_eip_1898 = !provider.features.contains("no_eip1898");
 
             parsed_networks.insert(
                 name.to_string(),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -56,6 +56,18 @@ lazy_static! {
         .map(|s| BlockNumber::from_str(&s)
              .unwrap_or_else(|_| panic!("failed to parse env var ETHEREUM_ANCESTOR_COUNT")))
         .unwrap_or(50);
+
+    // Comma separated network names that do not support EIP-1898 (calls by block hash). The only
+    // network known to not support it is fuse, once all known networks support eip 1898 this env
+    // var can be removed.
+    static ref NO_EIP_1898_SUPPORT: Vec<String> = {
+        std::env::var("GRAPH_NO_EIP_1898_SUPPORT").map(|s| {
+            s.split(',')
+             .map(|s| s.to_owned())
+             .collect()
+        })
+        .unwrap_or_default()
+    };
 }
 
 /// How long we will hold up node startup to get the net version and genesis
@@ -551,6 +563,8 @@ async fn create_ethereum_networks(
             // For now it's fine to just leak it.
             std::mem::forget(transport_event_loop);
 
+            let supports_eip_1898 = !NO_EIP_1898_SUPPORT.contains(&name);
+
             parsed_networks.insert(
                 name.to_string(),
                 capabilities,
@@ -561,6 +575,7 @@ async fn create_ethereum_networks(
                         &provider.url,
                         transport,
                         eth_rpc_metrics.clone(),
+                        supports_eip_1898,
                     )
                     .await,
                 ) as Arc<dyn EthereumAdapter>,


### PR DESCRIPTION
This is necessary support fuse until their OpenEthereum version is updated.

I removed the previous global escape hatch `GRAPH_ETH_CALL_BY_NUMBER` since with OpenEthereum 3.2 released, indexers should now all have access to an EIP-1898 compatible node.