### PR TITLE
Tokio 1.0, drop ipfs-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 0.2.1",
+ "http 0.2.3",
  "hyper 0.14.4",
  "hyper-unix-connector",
  "log 0.4.11",
@@ -596,7 +596,7 @@ dependencies = [
  "serde",
  "smallvec 1.6.1",
  "thiserror",
- "wasmparser 0.76.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1528,7 +1528,7 @@ dependencies = [
  "futures 0.3.13",
  "graphql-parser",
  "hex",
- "http 0.2.1",
+ "http 0.2.3",
  "isatty",
  "lazy_static",
  "maplit",
@@ -1562,8 +1562,7 @@ dependencies = [
  "tokio-retry",
  "tokio-stream",
  "url 2.2.1",
- "uuid 0.8.1",
- "wasmparser 0.63.1",
+ "wasmparser",
  "web3",
 ]
 
@@ -1611,7 +1610,6 @@ dependencies = [
  "futures 0.1.30",
  "futures 0.3.13",
  "graph",
- "graph-graphql",
  "graph-mock",
  "graphql-parser",
  "hex",
@@ -1644,7 +1642,6 @@ dependencies = [
  "pretty_assertions",
  "stable-hash",
  "test-store",
- "uuid 0.8.1",
 ]
 
 [[package]]
@@ -1741,7 +1738,7 @@ dependencies = [
  "graph-graphql",
  "graph-mock",
  "graphql-parser",
- "http 0.2.1",
+ "http 0.2.3",
  "hyper 0.14.4",
  "serde",
 ]
@@ -1754,7 +1751,7 @@ dependencies = [
  "graph",
  "graph-graphql",
  "graphql-parser",
- "http 0.2.1",
+ "http 0.2.3",
  "hyper 0.14.4",
  "serde",
 ]
@@ -1775,7 +1772,7 @@ version = "0.22.0"
 dependencies = [
  "futures 0.1.30",
  "graph",
- "http 0.2.1",
+ "http 0.2.3",
  "hyper 0.14.4",
  "lazy_static",
  "serde",
@@ -1789,7 +1786,7 @@ dependencies = [
  "futures 0.1.30",
  "graph",
  "graphql-parser",
- "http 0.2.1",
+ "http 0.2.3",
  "lazy_static",
  "serde",
  "serde_derive",
@@ -1881,7 +1878,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.1",
+ "http 0.2.3",
  "indexmap",
  "slab 0.4.2",
  "tokio 1.4.0",
@@ -1948,11 +1945,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
@@ -1976,7 +1973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
  "bytes 1.0.1",
- "http 0.2.1",
+ "http 0.2.3",
 ]
 
 [[package]]
@@ -2066,7 +2063,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.3.1",
- "http 0.2.1",
+ "http 0.2.3",
  "http-body 0.4.0",
  "httparse",
  "httpdate",
@@ -3566,7 +3563,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http 0.2.1",
+ "http 0.2.3",
  "http-body 0.4.0",
  "hyper 0.14.4",
  "hyper-tls 0.5.0",
@@ -3801,18 +3798,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4771,7 +4768,7 @@ dependencies = [
  "base64 0.13.0",
  "byteorder",
  "bytes 1.0.1",
- "http 0.2.1",
+ "http 0.2.3",
  "httparse",
  "input_buffer",
  "log 0.4.11",
@@ -5072,12 +5069,6 @@ checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
 name = "wasmparser"
-version = "0.63.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e4bce139034f66d49ad6071f6eda10f7188b0ad3cbfe080d673535ee30c23e"
-
-[[package]]
-name = "wasmparser"
 version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755a9a4afe3f6cccbbe6d7e965eef44cf260b001f93e547eba84255c1d0187d8"
@@ -5102,7 +5093,7 @@ dependencies = [
  "serde",
  "smallvec 1.6.1",
  "target-lexicon",
- "wasmparser 0.76.0",
+ "wasmparser",
  "wasmtime-cache",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -5144,7 +5135,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-wasm",
- "wasmparser 0.76.0",
+ "wasmparser",
  "wasmtime-environ",
 ]
 
@@ -5160,7 +5151,7 @@ dependencies = [
  "object 0.23.0",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.76.0",
+ "wasmparser",
  "wasmtime-environ",
 ]
 
@@ -5182,7 +5173,7 @@ dependencies = [
  "region",
  "serde",
  "thiserror",
- "wasmparser 0.76.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -5219,7 +5210,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.76.0",
+ "wasmparser",
  "wasmtime-cranelift",
  "wasmtime-debug",
  "wasmtime-environ",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,12 +162,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -223,18 +217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
-dependencies = [
- "byte-tools",
- "crypto-mac 0.7.0",
- "digest 0.8.1",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,19 +239,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "constant_time_eq",
  "crypto-mac 0.8.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.3",
+ "digest",
 ]
 
 [[package]]
@@ -278,16 +248,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "generic-array",
 ]
 
 [[package]]
@@ -309,14 +270,14 @@ dependencies = [
  "hyper 0.14.4",
  "hyper-unix-connector",
  "log 0.4.11",
- "pin-project 1.0.5",
+ "pin-project",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_urlencoded 0.7.0",
+ "serde_urlencoded",
  "thiserror",
- "tokio 1.2.0",
- "tokio-util 0.6.3",
+ "tokio 1.4.0",
+ "tokio-util",
  "url 2.2.1",
  "winapi 0.3.9",
 ]
@@ -331,12 +292,6 @@ dependencies = [
  "serde",
  "serde_with",
 ]
-
-[[package]]
-name = "bs58"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 
 [[package]]
 name = "bs58"
@@ -364,12 +319,6 @@ name = "byte-slice-cast"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -490,19 +439,6 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
-]
-
-[[package]]
-name = "common-multipart-rfc7578"
-version = "0.2.0-rc"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7471b7b1588b2cda44e0cdf3fd3da5706c1b46224dbf486c3daceb6655ec191c"
-dependencies = [
- "bytes 0.5.6",
- "futures 0.3.13",
- "http 0.2.1",
- "mime 0.3.16",
- "rand 0.5.6",
 ]
 
 [[package]]
@@ -809,22 +745,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.3",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.3.0",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -833,8 +759,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.3.0",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -924,12 +850,6 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.62",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
 
 [[package]]
 name = "defer"
@@ -1036,20 +956,11 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.3",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -1279,12 +1190,6 @@ dependencies = [
  "syn 1.0.62",
  "synstructure",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fallible-iterator"
@@ -1523,15 +1428,6 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -1623,7 +1519,7 @@ dependencies = [
  "async-trait",
  "atomic_refcell",
  "bigdecimal",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "chrono",
  "diesel",
  "diesel_derives",
@@ -1662,8 +1558,9 @@ dependencies = [
  "test-store",
  "thiserror",
  "tiny-keccak 1.5.0",
- "tokio 0.2.23",
+ "tokio 1.4.0",
  "tokio-retry",
+ "tokio-stream",
  "url 2.2.1",
  "uuid 0.8.1",
  "wasmparser 0.63.1",
@@ -1692,7 +1589,7 @@ dependencies = [
  "graph",
  "graph-core",
  "graph-store-postgres",
- "hyper 0.12.35",
+ "http 0.1.21",
  "jsonrpc-core",
  "lazy_static",
  "mockall",
@@ -1718,7 +1615,6 @@ dependencies = [
  "graph-mock",
  "graphql-parser",
  "hex",
- "ipfs-api",
  "lazy_static",
  "lru_time_cache",
  "pretty_assertions",
@@ -1788,7 +1684,6 @@ dependencies = [
  "graph-server-websocket",
  "graph-store-postgres",
  "graphql-parser",
- "ipfs-api",
  "lazy_static",
  "regex",
  "serde",
@@ -1814,8 +1709,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atomic_refcell",
- "bs58 0.4.0",
- "bytes 0.5.6",
+ "bs58",
+ "bytes 1.0.1",
  "defer",
  "ethabi 12.0.0-graph",
  "futures 0.1.30",
@@ -1827,7 +1722,6 @@ dependencies = [
  "graph-runtime-derive",
  "graphql-parser",
  "hex",
- "ipfs-api",
  "lazy_static",
  "never",
  "semver 0.10.0",
@@ -1848,7 +1742,7 @@ dependencies = [
  "graph-mock",
  "graphql-parser",
  "http 0.2.1",
- "hyper 0.13.9",
+ "hyper 0.14.4",
  "serde",
 ]
 
@@ -1861,7 +1755,7 @@ dependencies = [
  "graph-graphql",
  "graphql-parser",
  "http 0.2.1",
- "hyper 0.13.9",
+ "hyper 0.14.4",
  "serde",
 ]
 
@@ -1882,7 +1776,7 @@ dependencies = [
  "futures 0.1.30",
  "graph",
  "http 0.2.1",
- "hyper 0.13.9",
+ "hyper 0.14.4",
  "lazy_static",
  "serde",
 ]
@@ -1945,7 +1839,7 @@ dependencies = [
  "bollard",
  "futures 0.3.13",
  "port_check",
- "tokio 1.2.0",
+ "tokio 1.4.0",
  "tokio-stream",
 ]
 
@@ -1978,26 +1872,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.1",
- "indexmap",
- "slab 0.4.2",
- "tokio 0.2.23",
- "tokio-util 0.3.1",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "h2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
@@ -2010,8 +1884,8 @@ dependencies = [
  "http 0.2.1",
  "indexmap",
  "slab 0.4.2",
- "tokio 1.2.0",
- "tokio-util 0.6.3",
+ "tokio 1.4.0",
+ "tokio-util",
  "tracing",
 ]
 
@@ -2058,7 +1932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac 0.10.0",
- "digest 0.9.0",
+ "digest",
 ]
 
 [[package]]
@@ -2093,16 +1967,6 @@ dependencies = [
  "futures 0.1.30",
  "http 0.1.21",
  "tokio-buf",
-]
-
-[[package]]
-name = "http-body"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
-dependencies = [
- "bytes 0.5.6",
- "http 0.2.1",
 ]
 
 [[package]]
@@ -2193,30 +2057,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
-dependencies = [
- "bytes 0.5.6",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.2.7",
- "http 0.2.1",
- "http-body 0.3.1",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project 1.0.5",
- "socket2",
- "tokio 0.2.23",
- "tower-service",
- "tracing",
- "want 0.3.0",
-]
-
-[[package]]
-name = "hyper"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
@@ -2231,25 +2071,12 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
+ "pin-project",
  "socket2",
- "tokio 1.2.0",
+ "tokio 1.4.0",
  "tower-service",
  "tracing",
  "want 0.3.0",
-]
-
-[[package]]
-name = "hyper-multipart-rfc7578"
-version = "0.4.0-rc"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a71feb0ce26d0e28969633c06521716b07607f58f55dff84f30214b6c6d256a"
-dependencies = [
- "bytes 0.5.6",
- "common-multipart-rfc7578",
- "futures 0.3.13",
- "http 0.2.1",
- "hyper 0.13.9",
 ]
 
 [[package]]
@@ -2267,15 +2094,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 0.5.6",
- "hyper 0.13.9",
+ "bytes 1.0.1",
+ "hyper 0.14.4",
  "native-tls",
- "tokio 0.2.23",
- "tokio-tls 0.3.1",
+ "tokio 1.4.0",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -2287,8 +2114,8 @@ dependencies = [
  "anyhow",
  "hex",
  "hyper 0.14.4",
- "pin-project 1.0.5",
- "tokio 1.2.0",
+ "pin-project",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -2370,11 +2197,11 @@ dependencies = [
 
 [[package]]
 name = "input_buffer"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
+checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
 ]
 
 [[package]]
@@ -2393,29 +2220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "ipfs-api"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93cd854b7d68085b438401625317dc38b88a7c586cdea09ccdbe19cb49ac55b"
-dependencies = [
- "bytes 0.5.6",
- "dirs 2.0.2",
- "failure",
- "futures 0.3.13",
- "http 0.2.1",
- "hyper 0.13.9",
- "hyper-multipart-rfc7578",
- "hyper-tls 0.4.3",
- "parity-multiaddr",
- "serde",
- "serde_json",
- "serde_urlencoded 0.6.1",
- "tokio 0.2.23",
- "tokio-util 0.2.0",
- "walkdir",
 ]
 
 [[package]]
@@ -2512,12 +2316,6 @@ dependencies = [
  "tokio-codec",
  "unicase 2.6.0",
 ]
-
-[[package]]
-name = "keccak"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kernel32-sys"
@@ -2833,9 +2631,9 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "native-tls"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2957,12 +2755,6 @@ checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -3013,39 +2805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 dependencies = [
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "parity-multiaddr"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77055f9e81921a8cc7bebeb6cded3d128931d51f1e3dd6251f0770a6d431477"
-dependencies = [
- "arrayref",
- "bs58 0.3.1",
- "byteorder",
- "data-encoding",
- "parity-multihash",
- "percent-encoding 2.1.0",
- "serde",
- "static_assertions",
- "unsigned-varint",
- "url 2.2.1",
-]
-
-[[package]]
-name = "parity-multihash"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1cd2ba02391b81367bec529fb209019d718684fdc8ad6a712c2b536e46f775"
-dependencies = [
- "blake2",
- "bytes 0.5.6",
- "rand 0.7.3",
- "sha-1",
- "sha2 0.8.2",
- "sha3",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -3194,31 +2953,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
-dependencies = [
- "pin-project-internal 0.4.27",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal 1.0.5",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
- "syn 1.0.62",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -3272,7 +3011,7 @@ dependencies = [
  "fallible-iterator 0.2.0",
  "futures 0.3.13",
  "log 0.4.11",
- "tokio 1.2.0",
+ "tokio 1.4.0",
  "tokio-postgres",
 ]
 
@@ -3290,7 +3029,7 @@ dependencies = [
  "md5",
  "memchr",
  "rand 0.8.3",
- "sha2 0.9.3",
+ "sha2",
  "stringprep",
 ]
 
@@ -3508,19 +3247,6 @@ name = "radium"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "rand"
@@ -3831,19 +3557,19 @@ checksum = "05a51ad2b1c5c710fa89e6b1631068dab84ed687bc6a5fe061ad65da3d0c25b2"
 
 [[package]]
 name = "reqwest"
-version = "0.10.8"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
+checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
 dependencies = [
- "base64 0.12.3",
- "bytes 0.5.6",
+ "base64 0.13.0",
+ "bytes 1.0.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http 0.2.1",
- "http-body 0.3.1",
- "hyper 0.13.9",
- "hyper-tls 0.4.3",
+ "http-body 0.4.0",
+ "hyper 0.14.4",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -3852,11 +3578,12 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.2.6",
  "serde",
- "serde_urlencoded 0.6.1",
- "tokio 0.2.23",
- "tokio-tls 0.3.1",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio 1.4.0",
+ "tokio-native-tls",
  "url 2.2.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4115,18 +3842,6 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
-dependencies = [
- "dtoa",
- "itoa",
- "serde",
- "url 2.2.1",
-]
-
-[[package]]
-name = "serde_urlencoded"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
@@ -4173,14 +3888,15 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.8.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+checksum = "dfebf75d25bd900fd1e7d11501efab59bc846dbc76196839663e6637bba9f25f"
 dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4191,40 +3907,15 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha2"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpuid-bool",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha3"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
-dependencies = [
- "block-buffer 0.7.3",
- "byte-tools",
- "digest 0.8.1",
- "keccak",
- "opaque-debug 0.2.3",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4475,12 +4166,6 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-
-[[package]]
-name = "subtle"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
@@ -4590,18 +4275,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4687,30 +4372,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.23"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "libc",
- "memchr",
- "mio 0.6.22",
- "mio-uds",
- "num_cpus",
- "pin-project-lite 0.1.11",
- "slab 0.4.2",
- "tokio-macros 0.2.6",
-]
-
-[[package]]
-name = "tokio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
@@ -4721,7 +4385,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite 0.2.6",
  "signal-hook-registry",
- "tokio-macros 1.1.0",
+ "tokio-macros",
  "winapi 0.3.9",
 ]
 
@@ -4810,17 +4474,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
- "syn 1.0.62",
-]
-
-[[package]]
-name = "tokio-macros"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
@@ -4828,6 +4481,16 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.62",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -4849,8 +4512,8 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "socket2",
- "tokio 1.2.0",
- "tokio-util 0.6.3",
+ "tokio 1.4.0",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4874,13 +4537,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-retry"
-version = "0.2.0"
-source = "git+https://github.com/graphprotocol/rust-tokio-retry?branch=update-to-tokio-02#fc0e868bdc7ff79ac84cf502d4cec20c5ce5adaf"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
- "futures 0.1.30",
- "futures 0.3.13",
- "rand 0.4.6",
- "tokio 0.2.23",
+ "pin-project",
+ "rand 0.8.3",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -4891,7 +4554,8 @@ checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.6",
- "tokio 1.2.0",
+ "tokio 1.4.0",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4969,25 +4633,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio 0.2.23",
-]
-
-[[package]]
 name = "tokio-tungstenite"
-version = "0.10.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
+checksum = "1e96bb520beab540ab664bd5a9cfeaa1fcd846fa68c830b42e2c8963071251d2"
 dependencies = [
- "futures 0.3.13",
+ "futures-util",
  "log 0.4.11",
- "pin-project 0.4.27",
- "tokio 0.2.23",
+ "pin-project",
+ "tokio 1.4.0",
  "tungstenite",
 ]
 
@@ -5043,34 +4697,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "futures-sink",
- "log 0.4.11",
- "pin-project-lite 0.1.11",
- "tokio 0.2.23",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "futures-sink",
- "log 0.4.11",
- "pin-project-lite 0.1.11",
- "tokio 0.2.23",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
@@ -5080,7 +4706,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project-lite 0.2.6",
- "tokio 1.2.0",
+ "tokio 1.4.0",
 ]
 
 [[package]]
@@ -5105,7 +4731,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
- "log 0.4.11",
  "pin-project-lite 0.1.11",
  "tracing-core",
 ]
@@ -5117,16 +4742,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
-dependencies = [
- "pin-project 0.4.27",
- "tracing",
 ]
 
 [[package]]
@@ -5149,19 +4764,20 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.10.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
+checksum = "5fe8dada8c1a3aeca77d6b51a4f1314e0f4b8e438b7b1b71e3ddaca8080e4093"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.13.0",
  "byteorder",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "http 0.2.1",
  "httparse",
  "input_buffer",
  "log 0.4.11",
- "rand 0.7.3",
+ "rand 0.8.3",
  "sha-1",
+ "thiserror",
  "url 2.2.1",
  "utf-8",
 ]
@@ -5258,12 +4874,6 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
-
-[[package]]
-name = "unsigned-varint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67332660eb59a6f1eb24ff1220c9e8d01738a8503c6002e30bcfe4bd9f2b4a9"
 
 [[package]]
 name = "untrusted"
@@ -5518,7 +5128,7 @@ dependencies = [
  "libc",
  "log 0.4.11",
  "serde",
- "sha2 0.9.3",
+ "sha2",
  "toml",
  "winapi 0.3.9",
  "zstd",
@@ -5753,7 +5363,7 @@ dependencies = [
  "sha1",
  "tokio-core",
  "tokio-io",
- "tokio-tls 0.2.1",
+ "tokio-tls",
  "unicase 1.4.2",
  "url 1.7.2",
 ]

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 - The `GRAPH_ETH_CALL_BY_NUMBER` environment variable has been removed. Graph Node requires an
   Ethereum client that support EIP-1898, which all major clients support.
+- Added support for IPFS versions larger than 0.4.
 
 ## 0.22.0
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To build and run this project you need to have the following installed on your s
 
 - Rust (latest stable) – [How to install Rust](https://www.rust-lang.org/en-US/install.html)
 - PostgreSQL – [PostgreSQL Downloads](https://www.postgresql.org/download/)
-- IPFS – [Installing IPFS](https://docs.ipfs.io/install/) (currently only [v0.4.x](https://github.com/ipfs/go-ipfs/releases/tag/v0.4.23) is supported)
+- IPFS – [Installing IPFS](https://docs.ipfs.io/install/)
 
 For Ethereum network data, you can either run your own Ethereum node or use an Ethereum node provider of your choice.
 

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 chrono = "0.4"
 futures = "0.1.21"
-http = "0.1" # must be compatible with the version rust-web3 uses
+http = "0.1.21" # must be compatible with the version rust-web3 uses
 jsonrpc-core = "14.2.0"
 graph = { path = "../../graph" }
 lazy_static = "1.2.0"

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 chrono = "0.4"
 futures = "0.1.21"
-hyper = "0.12.25" # must be compatible with the version rust-web3 uses
+http = "0.1" # must be compatible with the version rust-web3 uses
 jsonrpc-core = "14.2.0"
 graph = { path = "../../graph" }
 lazy_static = "1.2.0"

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -113,7 +113,7 @@ where
                 self.cleanup_cached_blocks()
             }
 
-            tokio::time::delay_for(self.polling_interval).await;
+            tokio::time::sleep(self.polling_interval).await;
         }
     }
 

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -654,8 +654,9 @@ impl<S: SubgraphStore, C: ChainStore> Stream for BlockStream<S, C> {
                             // Pause before trying again
                             let secs = (5 * self.consecutive_err_count).max(120) as u64;
                             state = BlockStreamState::RetryAfterDelay(Box::new(
-                                tokio::time::delay_for(Duration::from_secs(secs))
+                                tokio::time::sleep(Duration::from_secs(secs))
                                     .map(Ok)
+                                    .boxed()
                                     .compat(),
                             ));
                             break Err(e);

--- a/chain/ethereum/src/config.rs
+++ b/chain/ethereum/src/config.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use config::{Config, File};
-use hyper::header::{HeaderMap, HeaderName, HeaderValue};
+use http::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Deserializer};
 
 use graph::prelude::*;

--- a/chain/ethereum/tests/network_indexer.rs
+++ b/chain/ethereum/tests/network_indexer.rs
@@ -98,7 +98,7 @@ where
     let store = STORE.clone();
 
     // Lock regardless of poisoning. This also forces sequential test execution.
-    let mut runtime = match STORE_RUNTIME.lock() {
+    let runtime = match STORE_RUNTIME.lock() {
         Ok(guard) => guard,
         Err(err) => err.into_inner(),
     };

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,6 @@ bytes = "0.5"
 futures01 = { package="futures", version="0.1.29" }
 futures = { version="0.3.4", features=["compat"] }
 graph = { path = "../graph" }
-graph-graphql = { path = "../graphql" }
 lazy_static = "1.2.0"
 lru_time_cache = "0.11"
 semver = "0.10.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,6 @@ futures01 = { package="futures", version="0.1.29" }
 futures = { version="0.3.4", features=["compat"] }
 graph = { path = "../graph" }
 graph-graphql = { path = "../graphql" }
-ipfs-api = { version = "=0.7.1", features = ["hyper-tls"] }
 lazy_static = "1.2.0"
 lru_time_cache = "0.11"
 semver = "0.10.0"

--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -186,7 +186,7 @@ impl LinkResolverTrait for LinkResolver {
 
         let (stat, client) = select_fastest_client_with_stat(
             self.clients.cheap_clone(),
-            logger.clone(),
+            logger.cheap_clone(),
             path.clone(),
             self.timeout,
             self.retry,
@@ -243,7 +243,7 @@ impl LinkResolverTrait for LinkResolver {
 
         let (stat, client) = select_fastest_client_with_stat(
             self.clients.cheap_clone(),
-            logger.clone(),
+            logger.cheap_clone(),
             path.to_string(),
             self.timeout,
             self.retry,

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -8,13 +8,13 @@ anyhow = "1.0"
 async-trait = "0.1.48"
 atomic_refcell = "0.1.6"
 bigdecimal = { version = "0.1.0", features = ["serde"] }
-bytes = "1.0"
+bytes = "1.0.1"
 diesel = { version = "1.4.6", features = ["postgres", "serde_json", "numeric", "r2d2"] }
 diesel_derives = "1.4"
-chrono = "0.4"
+chrono = "0.4.19"
 Inflector = "0.11.3"
-isatty = "0.1"
-reqwest = { version = "0.11", features = ["json", "stream", "multipart"] }
+isatty = "0.1.9"
+reqwest = { version = "0.11.2", features = ["json", "stream", "multipart"] }
 
 # master contains changes such as
 # https://github.com/paritytech/ethabi/pull/140, which upstream does not want
@@ -23,18 +23,18 @@ reqwest = { version = "0.11", features = ["json", "stream", "multipart"] }
 # ethabi, but long term we want to find a way to drop our fork.
 ethabi = { git = "https://github.com/graphprotocol/ethabi.git", branch = "master" }
 hex = "0.4.3"
-http = "0.2"
+http = "0.2.3"
 futures = "0.1.21"
-graphql-parser = "0.3"
+graphql-parser = "0.3.0"
 lazy_static = "1.4.0"
-mockall = "0.8"
+mockall = "0.8.3"
 num-bigint = { version = "^0.2.6", features = ["serde"] }
 num_cpus = "1.13.0"
-num-traits = "0.2"
+num-traits = "0.2.14"
 rand = "0.6.1"
 semver = "0.10.0"
-serde = { version = "1.0", features = ["rc"] }
-serde_derive = "1.0"
+serde = { version = "1.0.125", features = ["rc"] }
+serde_derive = "1.0.125"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 serde_yaml = "0.8"
 slog = { version = "2.5.2", features = ["release_max_level_trace", "max_level_trace"] }
@@ -48,14 +48,13 @@ petgraph = "0.5.1"
 tiny-keccak = "1.5.0"
 tokio = { version = "1.4.0", features = ["time", "sync", "macros", "test-util", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.5", features = ["sync"] }
-tokio-retry = "0.3"
+tokio-retry = "0.3.0"
 url = "2.2.1"
 prometheus = "0.12.0"
 priority-queue = "0.7.0"
 futures03 = { version = "0.3.1", package = "futures", features = ["compat"] }
-uuid = { version = "0.8.1", features = ["v4"] }
-wasmparser = "0.63.1"
-thiserror = "1.0"
+wasmparser = "0.76.0"
+thiserror = "1.0.24"
 parking_lot = "0.11.1"
 
 # Our fork contains a small but hacky patch.

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -8,13 +8,13 @@ anyhow = "1.0"
 async-trait = "0.1.48"
 atomic_refcell = "0.1.6"
 bigdecimal = { version = "0.1.0", features = ["serde"] }
-bytes = "0.5"
+bytes = "1.0"
 diesel = { version = "1.4.6", features = ["postgres", "serde_json", "numeric", "r2d2"] }
 diesel_derives = "1.4"
 chrono = "0.4"
 Inflector = "0.11.3"
 isatty = "0.1"
-reqwest = "0.10"
+reqwest = { version = "0.11", features = ["json", "stream", "multipart"] }
 
 # master contains changes such as
 # https://github.com/paritytech/ethabi/pull/140, which upstream does not want
@@ -46,8 +46,9 @@ slog-envlogger = "2.1.0"
 slog-term = "2.6.0"
 petgraph = "0.5.1"
 tiny-keccak = "1.5.0"
-tokio = { version = "0.2.22", features = ["stream", "rt-threaded", "rt-util", "blocking", "time", "sync", "macros", "test-util"] }
-tokio-retry = { git = "https://github.com/graphprotocol/rust-tokio-retry", branch = "update-to-tokio-02" }
+tokio = { version = "1.4.0", features = ["time", "sync", "macros", "test-util", "rt-multi-thread"] }
+tokio-stream = { version = "0.1.5", features = ["sync"] }
+tokio-retry = "0.3"
 url = "2.2.1"
 prometheus = "0.12.0"
 priority-queue = "0.7.0"

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -653,7 +653,7 @@ where
         let mut pending_event: Option<StoreEvent> = None;
         let mut source = self.source.fuse();
         let mut had_err = false;
-        let mut delay = tokio::time::delay_for(interval).unit_error().compat();
+        let mut delay = tokio::time::sleep(interval).unit_error().boxed().compat();
         let logger = logger.clone();
 
         let source = Box::new(poll_fn(move || -> Poll<Option<Arc<StoreEvent>>, ()> {
@@ -680,7 +680,7 @@ where
                 // Timer errors are harmless. Treat them as if the timer had
                 // become ready.
                 Ok(Async::Ready(())) | Err(_) => {
-                    delay = tokio::time::delay_for(interval).unit_error().compat();
+                    delay = tokio::time::sleep(interval).unit_error().boxed().compat();
                     true
                 }
             };

--- a/graph/src/data/graphql/effort.rs
+++ b/graph/src/data/graphql/effort.rs
@@ -560,7 +560,14 @@ impl LoadManager {
 impl QueryLoadManager for LoadManager {
     async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit {
         let start = Instant::now();
-        let permit = self.query_semaphore.cheap_clone().acquire_owned().await;
+
+        // Unwrap: The semaphore is never closed.
+        let permit = self
+            .query_semaphore
+            .cheap_clone()
+            .acquire_owned()
+            .await
+            .unwrap();
         self.add_wait_time(start.elapsed());
         permit
     }

--- a/graph/src/ipfs_client.rs
+++ b/graph/src/ipfs_client.rs
@@ -1,0 +1,114 @@
+use crate::prelude::CheapClone;
+use anyhow::Error;
+use bytes::Bytes;
+use futures03::Stream;
+use http::Uri;
+use reqwest::multipart;
+use serde::Deserialize;
+use std::{str::FromStr, sync::Arc};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ObjectStatResponse {
+    pub hash: String,
+    pub num_links: u64,
+    pub block_size: u64,
+    pub links_size: u64,
+    pub data_size: u64,
+    pub cumulative_size: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct AddResponse {
+    pub name: String,
+    pub hash: String,
+    pub size: String,
+}
+
+#[derive(Clone)]
+pub struct IpfsClient {
+    base: Arc<Uri>,
+    client: Arc<reqwest::Client>,
+}
+
+impl CheapClone for IpfsClient {
+    fn cheap_clone(&self) -> Self {
+        IpfsClient {
+            base: self.base.cheap_clone(),
+            client: self.client.cheap_clone(),
+        }
+    }
+}
+
+impl IpfsClient {
+    pub fn new(base: &str) -> Result<Self, Error> {
+        Ok(IpfsClient {
+            client: Arc::new(reqwest::Client::new()),
+            base: Arc::new(Uri::from_str(base)?),
+        })
+    }
+
+    pub fn localhost() -> Self {
+        IpfsClient {
+            client: Arc::new(reqwest::Client::new()),
+            base: Arc::new(Uri::from_str("http://localhost:5001").unwrap()),
+        }
+    }
+
+    /// Calls `object stat`.
+    pub async fn object_stat(&self, path: String) -> Result<ObjectStatResponse, reqwest::Error> {
+        self.call(self.url("object/stat", path), None)
+            .await?
+            .json()
+            .await
+    }
+
+    /// Download the entire contents.
+    pub async fn cat_all(&self, cid: String) -> Result<Bytes, reqwest::Error> {
+        self.call(self.url("cat", cid), None).await?.bytes().await
+    }
+
+    pub async fn cat(
+        &self,
+        cid: String,
+    ) -> Result<impl Stream<Item = Result<Bytes, reqwest::Error>>, reqwest::Error> {
+        Ok(self.call(self.url("cat", cid), None).await?.bytes_stream())
+    }
+
+    pub async fn test(&self) -> Result<(), reqwest::Error> {
+        self.call(format!("{}api/v0/version", self.base), None)
+            .await
+            .map(|_| ())
+    }
+
+    pub async fn add(&self, data: Vec<u8>) -> Result<AddResponse, reqwest::Error> {
+        let form = multipart::Form::new().part("path", multipart::Part::bytes(data));
+
+        self.call(format!("{}api/v0/add", self.base), Some(form))
+            .await?
+            .json()
+            .await
+    }
+
+    fn url(&self, route: &'static str, arg: String) -> String {
+        // URL security: We control the base and the route, user-supplied input goes only into the
+        // query parameters.
+        format!("{}api/v0/{}?arg={}", self.base, route, arg)
+    }
+
+    async fn call(
+        &self,
+        url: String,
+        form: Option<multipart::Form>,
+    ) -> Result<reqwest::Response, reqwest::Error> {
+        let mut req = self.client.post(&url);
+        if let Some(form) = form {
+            req = req.multipart(form);
+        }
+        req.send()
+            .await
+            .map(|res| res.error_for_status())
+            .and_then(|x| x)
+    }
+}

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -16,6 +16,8 @@ pub mod log;
 /// `CheapClone` trait.
 pub mod cheap_clone;
 
+pub mod ipfs_client;
+
 /// Module with mocks for different parts of the system.
 pub mod mock {
     pub use crate::components::ethereum::MockEthereumAdapter;
@@ -32,6 +34,7 @@ pub use bytes;
 pub use prometheus;
 pub use semver;
 pub use stable_hash;
+pub use tokio_stream;
 pub use url;
 
 /// A prelude that makes all system component traits and data types available.

--- a/graph/src/util/jobs.rs
+++ b/graph/src/util/jobs.rs
@@ -85,7 +85,7 @@ impl Runner {
                 next = next.min(task.next_run);
             }
             let wait = next.saturating_duration_since(Instant::now());
-            tokio::time::delay_for(wait).await;
+            tokio::time::sleep(wait).await;
         }
         self.stop.store(false, Ordering::SeqCst);
         warn!(self.logger, "Received request to stop. Stopping runner");
@@ -116,7 +116,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn jobs_run() {
         let count = Arc::new(Mutex::new(0));
         let job = CounterJob {
@@ -142,7 +142,7 @@ mod tests {
         stop.store(true, Ordering::SeqCst);
         // Wait for the runner to shut down
         while stop.load(Ordering::SeqCst) {
-            tokio::time::delay_for(Duration::from_millis(10)).await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }
 }

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -11,7 +11,6 @@ graphql-parser = "0.3"
 indexmap = "1.6"
 Inflector = "0.11.3"
 lazy_static = "1.2.0"
-uuid = { version = "0.8.1", features = ["v4"] }
 stable-hash = { git = "https://github.com/graphprotocol/stable-hash" }
 once_cell = "1.7.2"
 defer = "0.1"

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -406,7 +406,7 @@ pub async fn execute_root_selection_set<R: Resolver>(
         let _permit = if !nested_resolver {
             execute_ctx.load_manager.query_permit().await
         } else {
-            // Acquire a dummy semaphore.
+            // Acquire a dummy semaphore. Unwrap: a semaphore that was just created can be acquired.
             Arc::new(tokio::sync::Semaphore::new(1))
                 .acquire_owned()
                 .await

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -410,6 +410,7 @@ pub async fn execute_root_selection_set<R: Resolver>(
             Arc::new(tokio::sync::Semaphore::new(1))
                 .acquire_owned()
                 .await
+                .unwrap()
         };
 
         let logger = execute_ctx.logger.clone();

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -277,7 +277,8 @@ struct MockQueryLoadManager(Arc<tokio::sync::Semaphore>);
 #[async_trait]
 impl QueryLoadManager for MockQueryLoadManager {
     async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit {
-        self.0.clone().acquire_owned().await
+        // Unwrap: The semaphore is never closed.
+        self.0.clone().acquire_owned().await.unwrap()
     }
 
     fn record_work(&self, _shape_hash: u64, _duration: Duration, _cache_status: CacheStatus) {}

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,7 +18,6 @@ env_logger = "0.8.2"
 git-testament = "0.1"
 graphql-parser = "0.3"
 futures = { version = "0.3.1", features = ["compat"] }
-ipfs-api = { version = "=0.7.1", features = ["hyper-tls"] }
 lazy_static = "1.2.0"
 url = "2.2.1"
 crossbeam-channel = "0.5.0"

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4"
 uuid = { version = "0.8.1", features = ["v4"] }
 strum = "0.20.0"
 strum_macros = "0.20.1"
-bytes = "0.5"
+bytes = "1.0"
 anyhow = "1.0"
 wasmtime = "0.25.0"
 defer = "0.1"
@@ -29,5 +29,4 @@ graphql-parser = "0.3"
 graph-core = { path = "../../core" }
 graph-mock = { path = "../../mock" }
 test-store = { path = "../../store/test-store" }
-ipfs-api = { version = "=0.7.1", features = ["hyper-tls"] }
 graph-chain-arweave = { path = "../../chain/arweave" }

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -37,76 +37,76 @@ pub fn spawn_module(
     let conf =
         thread::Builder::new().name(format!("mapping-{}-{}", &subgraph_id, uuid::Uuid::new_v4()));
     conf.spawn(move || {
-        runtime.enter(|| {
-            // Pass incoming triggers to the WASM module and return entity changes;
-            // Stop when canceled because all RuntimeHosts and their senders were dropped.
-            match mapping_request_receiver
-                .map_err(|()| unreachable!())
-                .for_each(move |request| {
-                    let MappingRequest {
-                        ctx,
-                        trigger,
-                        result_sender,
-                    } = request;
-                    let logger = ctx.logger.cheap_clone();
+        let _runtime_guard = runtime.enter();
 
-                    // Start the WASM module runtime.
-                    let section = host_metrics.stopwatch.start_section("module_init");
-                    let module = WasmInstance::from_valid_module_with_ctx(
-                        valid_module.cheap_clone(),
-                        ctx,
-                        host_metrics.cheap_clone(),
-                        timeout,
-                        experimental_features.clone(),
-                    )?;
-                    section.end();
+        // Pass incoming triggers to the WASM module and return entity changes;
+        // Stop when canceled because all RuntimeHosts and their senders were dropped.
+        match mapping_request_receiver
+            .map_err(|()| unreachable!())
+            .for_each(move |request| {
+                let MappingRequest {
+                    ctx,
+                    trigger,
+                    result_sender,
+                } = request;
+                let logger = ctx.logger.cheap_clone();
 
-                    let section = host_metrics.stopwatch.start_section("run_handler");
-                    if *LOG_TRIGGER_DATA {
-                        debug!(logger, "trigger data: {:?}", trigger);
+                // Start the WASM module runtime.
+                let section = host_metrics.stopwatch.start_section("module_init");
+                let module = WasmInstance::from_valid_module_with_ctx(
+                    valid_module.cheap_clone(),
+                    ctx,
+                    host_metrics.cheap_clone(),
+                    timeout,
+                    experimental_features.clone(),
+                )?;
+                section.end();
+
+                let section = host_metrics.stopwatch.start_section("run_handler");
+                if *LOG_TRIGGER_DATA {
+                    debug!(logger, "trigger data: {:?}", trigger);
+                }
+                let result = match trigger {
+                    MappingTrigger::Log {
+                        transaction,
+                        log,
+                        params,
+                        handler,
+                    } => module.handle_ethereum_log(
+                        handler.handler.as_str(),
+                        transaction,
+                        log,
+                        params,
+                    ),
+                    MappingTrigger::Call {
+                        transaction,
+                        call,
+                        inputs,
+                        outputs,
+                        handler,
+                    } => module.handle_ethereum_call(
+                        handler.handler.as_str(),
+                        transaction,
+                        call,
+                        inputs,
+                        outputs,
+                    ),
+                    MappingTrigger::Block { handler } => {
+                        module.handle_ethereum_block(handler.handler.as_str())
                     }
-                    let result = match trigger {
-                        MappingTrigger::Log {
-                            transaction,
-                            log,
-                            params,
-                            handler,
-                        } => module.handle_ethereum_log(
-                            handler.handler.as_str(),
-                            transaction,
-                            log,
-                            params,
-                        ),
-                        MappingTrigger::Call {
-                            transaction,
-                            call,
-                            inputs,
-                            outputs,
-                            handler,
-                        } => module.handle_ethereum_call(
-                            handler.handler.as_str(),
-                            transaction,
-                            call,
-                            inputs,
-                            outputs,
-                        ),
-                        MappingTrigger::Block { handler } => {
-                            module.handle_ethereum_block(handler.handler.as_str())
-                        }
-                    };
-                    section.end();
+                };
+                section.end();
 
-                    result_sender
-                        .send(result)
-                        .map_err(|_| anyhow::anyhow!("WASM module result receiver dropped."))
-                })
-                .wait()
-            {
-                Ok(()) => debug!(logger, "Subgraph stopped, WASM runtime thread terminated"),
-                Err(e) => debug!(logger, "WASM runtime thread terminated abnormally";
+                result_sender
+                    .send(result)
+                    .map_err(|_| anyhow::anyhow!("WASM module result receiver dropped."))
+            })
+            .wait()
+        {
+            Ok(()) => debug!(logger, "Subgraph stopped, WASM runtime thread terminated"),
+            Err(e) => debug!(logger, "WASM runtime thread terminated abnormally";
                                     "error" => e.to_string()),
-            }
-        })
+        }
     })
     .map(|_| ())
     .context("Spawning WASM runtime thread failed")?;

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -350,7 +350,7 @@ impl WasmInstance {
                         None => break interrupt_handle.interrupt(), // Timed out.
 
                         Some(time) if time < minimum_wait => break interrupt_handle.interrupt(),
-                        Some(time) => tokio::time::delay_for(time).await,
+                        Some(time) => tokio::time::sleep(time).await,
                     }
                 }
             });

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -1,14 +1,13 @@
 use ethabi::{Contract, Token};
 use hex;
 use std::collections::{BTreeMap, HashMap};
-use std::io::Cursor;
 use std::str::FromStr;
 
 use crate::host_exports::HostExports;
-use graph::components::store::*;
 use graph::data::store::scalar;
 use graph::data::subgraph::*;
 use graph::mock::MockEthereumAdapter;
+use graph::{components::store::*, ipfs_client::IpfsClient};
 use graph_chain_arweave::adapter::ArweaveAdapter;
 use graph_core;
 use graph_core::three_box::ThreeBoxAdapter;
@@ -184,9 +183,7 @@ fn mock_host_exports(
         network,
         Arc::new(templates),
         mock_ethereum_adapter,
-        Arc::new(graph_core::LinkResolver::from(
-            ipfs_api::IpfsClient::default(),
-        )),
+        Arc::new(graph_core::LinkResolver::from(IpfsClient::localhost())),
         store,
         call_cache,
         arweave_adapter,
@@ -312,25 +309,24 @@ async fn json_parsing() {
     assert_eq!(output, "OK: foo");
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn ipfs_cat() {
-    let ipfs = Arc::new(ipfs_api::IpfsClient::default());
-    let hash = ipfs.add(Cursor::new("42")).await.unwrap().hash;
+    let ipfs = IpfsClient::localhost();
+    let hash = ipfs.add("42".into()).await.unwrap().hash;
 
     // Ipfs host functions use `block_on` which must be called from a sync context,
     // so we replicate what we do `spawn_module`.
     let runtime = tokio::runtime::Handle::current();
     std::thread::spawn(move || {
-        runtime.enter(|| {
-            let mut module = test_module("ipfsCat", mock_data_source("wasm_test/ipfs_cat.wasm"));
-            let arg = module.asc_new(&hash).unwrap();
-            let converted: AscPtr<AscString> = module.invoke_export("ipfsCatString", arg);
-            let data: String = module.instance_ctx().asc_get(converted).unwrap();
-            assert_eq!(data, "42");
-        })
+        let _runtime_guard = runtime.enter();
+        let mut module = test_module("ipfsCat", mock_data_source("wasm_test/ipfs_cat.wasm"));
+        let arg = module.asc_new(&hash).unwrap();
+        let converted: AscPtr<AscString> = module.invoke_export("ipfsCatString", arg);
+        let data: String = module.instance_ctx().asc_get(converted).unwrap();
+        assert_eq!(data, "42");
     })
     .join()
-    .unwrap()
+    .unwrap();
 }
 
 // The user_data value we use with calls to ipfs_map
@@ -352,56 +348,56 @@ fn make_thing(subgraph_id: &str, id: &str, value: &str) -> (String, EntityModifi
     )
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn ipfs_map() {
     const BAD_IPFS_HASH: &str = "bad-ipfs-hash";
 
-    let ipfs = Arc::new(ipfs_api::IpfsClient::default());
+    let ipfs = IpfsClient::localhost();
     let subgraph_id = "ipfsMap";
 
     async fn run_ipfs_map(
-        ipfs: Arc<ipfs_api::IpfsClient>,
+        ipfs: IpfsClient,
         subgraph_id: &'static str,
         json_string: String,
     ) -> Result<Vec<EntityModification>, anyhow::Error> {
         let hash = if json_string == BAD_IPFS_HASH {
             "Qm".to_string()
         } else {
-            ipfs.add(Cursor::new(json_string)).await.unwrap().hash
+            ipfs.add(json_string.into()).await.unwrap().hash
         };
 
         // Ipfs host functions use `block_on` which must be called from a sync context,
         // so we replicate what we do `spawn_module`.
         let runtime = tokio::runtime::Handle::current();
         std::thread::spawn(move || {
-            runtime.enter(|| {
-                let (mut module, store) = test_valid_module_and_store(
-                    subgraph_id,
-                    mock_data_source("wasm_test/ipfs_map.wasm"),
-                );
-                let value = module.asc_new(&hash).unwrap();
-                let user_data = module.asc_new(USER_DATA).unwrap();
+            let _runtime_guard = runtime.enter();
 
-                // Invoke the callback
-                let func = module.get_func("ipfsMap").typed().unwrap().clone();
-                let _: () = func.call((value.wasm_ptr(), user_data.wasm_ptr()))?;
-                let mut mods = module
-                    .take_ctx()
-                    .ctx
-                    .state
-                    .entity_cache
-                    .as_modifications(store.as_ref())?
-                    .modifications;
+            let (mut module, store) = test_valid_module_and_store(
+                subgraph_id,
+                mock_data_source("wasm_test/ipfs_map.wasm"),
+            );
+            let value = module.asc_new(&hash).unwrap();
+            let user_data = module.asc_new(USER_DATA).unwrap();
 
-                // Bring the modifications into a predictable order (by entity_id)
-                mods.sort_by(|a, b| {
-                    a.entity_key()
-                        .entity_id
-                        .partial_cmp(&b.entity_key().entity_id)
-                        .unwrap()
-                });
-                Ok(mods)
-            })
+            // Invoke the callback
+            let func = module.get_func("ipfsMap").typed().unwrap().clone();
+            let _: () = func.call((value.wasm_ptr(), user_data.wasm_ptr()))?;
+            let mut mods = module
+                .take_ctx()
+                .ctx
+                .state
+                .entity_cache
+                .as_modifications(store.as_ref())?
+                .modifications;
+
+            // Bring the modifications into a predictable order (by entity_id)
+            mods.sort_by(|a, b| {
+                a.entity_key()
+                    .entity_id
+                    .partial_cmp(&b.entity_key().entity_id)
+                    .unwrap()
+            });
+            Ok(mods)
         })
         .join()
         .unwrap()
@@ -458,27 +454,27 @@ async fn ipfs_map() {
         .await
         .unwrap_err()
         .to_string();
-    assert!(errmsg.contains("ApiError"));
+    assert!(errmsg.contains("Status(500)"));
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn ipfs_fail() {
     let runtime = tokio::runtime::Handle::current();
 
     // Ipfs host functions use `block_on` which must be called from a sync context,
     // so we replicate what we do `spawn_module`.
     std::thread::spawn(move || {
-        runtime.enter(|| {
-            let mut module = test_module("ipfsFail", mock_data_source("wasm_test/ipfs_cat.wasm"));
+        let _runtime_guard = runtime.enter();
 
-            let hash = module.asc_new("invalid hash").unwrap();
-            assert!(module
-                .invoke_export::<_, AscString>("ipfsCat", hash,)
-                .is_null());
-        })
+        let mut module = test_module("ipfsFail", mock_data_source("wasm_test/ipfs_cat.wasm"));
+
+        let hash = module.asc_new("invalid hash").unwrap();
+        assert!(module
+            .invoke_export::<_, AscString>("ipfsCat", hash,)
+            .is_null());
     })
     .join()
-    .unwrap()
+    .unwrap();
 }
 
 #[tokio::test]

--- a/runtime/wasm/src/module/test/abi.rs
+++ b/runtime/wasm/src/module/test/abi.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn unbounded_loop() {
     // Set handler timeout to 3 seconds.
     let module = test_valid_module_and_store_with_timeout(

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 futures = "0.1.21"
 graphql-parser = "0.3"
 http = "0.2"
-hyper = "0.13"
+hyper = "0.14"
 serde = "1.0"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -486,7 +486,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn posting_valid_queries_yields_result_response() {
         let logger = Logger::root(slog::Discard, o!());
         let metrics_registry = Arc::new(MockMetricsRegistry::new());

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -12,7 +12,7 @@ use graph::prelude::*;
 use graph_server_http::test_utils;
 use graph_server_http::GraphQLServer as HyperGraphQLServer;
 
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 /// A simple stupid query runner for testing.
 pub struct TestGraphQlRunner;
@@ -91,7 +91,7 @@ mod test {
 
     #[test]
     fn rejects_empty_json() {
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime
             .block_on(async {
                 let logger = Logger::root(slog::Discard, o!());
@@ -108,7 +108,7 @@ mod test {
                 // Launch the server to handle a single request
                 tokio::spawn(http_server.fuse().compat());
                 // Give some time for the server to start.
-                delay_for(Duration::from_secs(2))
+                sleep(Duration::from_secs(2))
                     .then(move |()| {
                         // Send an empty JSON POST request
                         let client = Client::new();
@@ -134,7 +134,7 @@ mod test {
 
     #[test]
     fn rejects_invalid_queries() {
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
             let logger_factory = LoggerFactory::new(logger, None);
@@ -151,7 +151,7 @@ mod test {
             // Launch the server to handle a single request
             tokio::spawn(http_server.fuse().compat());
             // Give some time for the server to start.
-            delay_for(Duration::from_secs(2))
+            sleep(Duration::from_secs(2))
                 .then(move |()| {
                     // Send an broken query request
                     let client = Client::new();
@@ -216,7 +216,7 @@ mod test {
 
     #[test]
     fn accepts_valid_queries() {
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
             let logger_factory = LoggerFactory::new(logger, None);
@@ -233,7 +233,7 @@ mod test {
             // Launch the server to handle a single request
             tokio::spawn(http_server.fuse().compat());
             // Give some time for the server to start.
-            delay_for(Duration::from_secs(2))
+            sleep(Duration::from_secs(2))
                 .then(move |()| {
                     // Send a valid example query
                     let client = Client::new();
@@ -263,7 +263,7 @@ mod test {
 
     #[test]
     fn accepts_valid_queries_with_variables() {
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
         let _ = runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
             let logger_factory = LoggerFactory::new(logger, None);
@@ -280,7 +280,7 @@ mod test {
             // Launch the server to handle a single request
             tokio::spawn(http_server.fuse().compat());
             // Give some time for the server to start.
-            delay_for(Duration::from_secs(2))
+            sleep(Duration::from_secs(2))
                 .then(move |()| {
                     // Send a valid example query
                     let client = Client::new();

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -9,5 +9,5 @@ graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
 graphql-parser = "0.3"
 http = "0.2"
-hyper = "0.13"
+hyper = "0.14"
 serde = "1.0"

--- a/server/metrics/Cargo.toml
+++ b/server/metrics/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 futures = "0.1.21"
 graph = { path = "../../graph" }
 http = "0.2"
-hyper = "0.13"
+hyper = { version = "0.14", features = ["server"] }
 lazy_static = "1.2.0"
 serde = "1.0"

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -11,6 +11,6 @@ http = "0.2"
 lazy_static = "1.2.0"
 serde = "1.0"
 serde_derive = "1.0"
-tokio-tungstenite = "0.10"
+tokio-tungstenite = "0.14"
 uuid = { version = "0.7.2", features = ["v4"] }
 anyhow = "1.0"

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -7,7 +7,7 @@ use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::env;
 use std::str::FromStr;
-use tokio::prelude::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_tungstenite::tungstenite::{Error as WsError, Message as WsMessage};
 use tokio_tungstenite::WebSocketStream;
 use uuid::Uuid;
@@ -45,9 +45,9 @@ impl IncomingMessage {
     pub fn from_ws_message(msg: WsMessage) -> Result<Self, WsError> {
         let text = msg.into_text()?;
         serde_json::from_str(text.as_str()).map_err(|e| {
-            WsError::Protocol(
+            WsError::Http(http::Response::new(Some(
                 format!("Invalid GraphQL over WebSocket message: {}: {}", text, e).into(),
-            )
+            )))
         })
     }
 }
@@ -94,8 +94,11 @@ fn send_message(
     sink: &mpsc::UnboundedSender<WsMessage>,
     msg: OutgoingMessage,
 ) -> Result<(), WsError> {
-    sink.unbounded_send(msg.into())
-        .map_err(|_| WsError::Http(StatusCode::INTERNAL_SERVER_ERROR))
+    sink.unbounded_send(msg.into()).map_err(|_| {
+        let mut response = http::Response::new(None);
+        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+        WsError::Http(response)
+    })
 }
 
 /// Helper function to send error messages.
@@ -105,7 +108,11 @@ fn send_error_string(
     error: String,
 ) -> Result<(), WsError> {
     sink.unbounded_send(OutgoingMessage::from_error_string(operation_id, error).into())
-        .map_err(|_| WsError::Http(StatusCode::INTERNAL_SERVER_ERROR))
+        .map_err(|_| {
+            let mut response = http::Response::new(None);
+            *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            WsError::Http(response)
+        })
 }
 
 /// Responsible for recording operation ids and stopping them.

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -83,14 +83,13 @@ where
         );
 
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
-        let mut socket = TcpListener::bind(&addr)
+        let socket = TcpListener::bind(&addr)
             .await
             .expect("Failed to bind WebSocket port");
 
-        let mut incoming = socket.incoming();
-        while let Some(stream_res) = incoming.next().await {
-            let stream = match stream_res {
-                Ok(stream) => stream,
+        loop {
+            let stream = match socket.accept().await {
+                Ok((stream, _)) => stream,
                 Err(e) => {
                     trace!(self.logger, "Connection error: {}", e);
                     continue;

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -92,7 +92,7 @@ where
     let store = STORE.subgraph_store();
 
     // Lock regardless of poisoning. This also forces sequential test execution.
-    let mut runtime = match STORE_RUNTIME.lock() {
+    let runtime = match STORE_RUNTIME.lock() {
         Ok(guard) => guard,
         Err(err) => err.into_inner(),
     };


### PR DESCRIPTION
This upgrades us to Tokio 1.0 and hyper 0.14. It also removes the ipfs-api dependency, we now implement our own `IpfsClient` based on reqwest. This gains us compatibility with IPFS versions > 0.4. Resolves #1799.

Relevant changes in tokio 1.0:
- `delay_for` renamed to `sleep`. But `sleep` is not `Unpin`, which required some lifetime gymnastics in `link_resolver.rs` and `util/futures.rs`.
- `tokio` doesn't export `Stream` directly, that was moved to `tokio-stream`. So some code that didn't really need stream adapters, such as the places where we wait on an `interval`, was refactored.
- The `runtime::Builder`, `tokio::test` and `tokio::main` APIs changed slightly.
- The semaphore now returns `Result`, but in our uses it will never error. 
- `runtime.enter()` now uses drop guard style instead of closure style.

Read with whitespace diff disabled.