### PR TITLE
Drop support for old Geth revert format, detect stack limit

### DIFF
--- a/tests/tests/common/docker.rs
+++ b/tests/tests/common/docker.rs
@@ -115,14 +115,7 @@ impl TestContainerService {
 
         container::Config {
             image: Some(GANACHE_IMAGE),
-            cmd: Some(vec![
-                "-d",
-                "-l",
-                "100000000000",
-                "-g",
-                "1",
-                "--noVMErrorsOnRPCResponse",
-            ]),
+            cmd: Some(vec!["-d", "-l", "100000000000", "-g", "1"]),
             host_config: Some(host_config),
             ..Default::default()
         }


### PR DESCRIPTION
The old format is not returned by Geth since the Berlin fork. A few subgraphs have hit the `stack limit reached` error, which is deterministic.