### PR TITLE
Fix hanging when starting over 512 subgraphs

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -242,8 +242,7 @@ where
                     let sender = sender.clone();
                     let logger = logger.clone();
 
-                    // Blocking due to store interactions. Won't be blocking after #905.
-                    graph::spawn_blocking(
+                    graph::spawn(
                         start_subgraph(id, provider.clone(), logger).map(move |()| drop(sender)),
                     );
                 }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -27,7 +27,7 @@ pub mod mock {
 /// Wrapper for spawning tasks that abort on panic, which is our default.
 mod task_spawn;
 pub use task_spawn::{
-    block_on, spawn, spawn_allow_panic, spawn_blocking, spawn_blocking_allow_panic,
+    block_on, spawn, spawn_allow_panic, spawn_blocking, spawn_blocking_allow_panic, spawn_thread,
 };
 
 pub use bytes;

--- a/graph/src/task_spawn.rs
+++ b/graph/src/task_spawn.rs
@@ -54,3 +54,14 @@ pub fn spawn_blocking_allow_panic<R: 'static + Send>(
 pub fn block_on<T>(f: impl Future03<Output = T>) -> T {
     tokio::runtime::Handle::current().block_on(f)
 }
+
+/// Spawns a thread with access to the tokio runtime. Panics if the thread cannot be spawned.
+pub fn spawn_thread(name: String, f: impl 'static + FnOnce() + Send) {
+    let conf = std::thread::Builder::new().name(name);
+    let runtime = tokio::runtime::Handle::current();
+    conf.spawn(move || {
+        let _runtime_guard = runtime.enter();
+        f()
+    })
+    .unwrap();
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -93,10 +93,7 @@ fn read_expensive_queries() -> Result<Vec<Arc<q::Document>>, std::io::Error> {
     Ok(queries)
 }
 
-// Saturating the blocking threads can cause all sorts of issues, so set a large maximum.
-// Ideally we'd use semaphores to not use more blocking threads than DB connections,
-// but for now this is necessary.
-#[tokio::main(worker_threads = 2000)]
+#[tokio::main]
 async fn main() {
     env_logger::init();
 


### PR DESCRIPTION
This issue was introduced when upgrading to tokio 1.0, the `#[tokio::main]` syntax changed and the number of blocking threads was inadvertently lowered from 2000 to the default 512. I was able to reproduce the issue locally. This fixes the root cause which is the incorrect use of the blocking thread pool. At least in the critical locations, we still use it incorrectly in others, #905 tracks getting this right in all places.

There are at least two ways we where using the blocking thread pool incorrectly:
- The code path to start a subgraph had a few nested calls to `spawn_blocking`. This leads to a "double dip" deadlock, the nested calls are waiting on the callers to release a blocking threads, but the callers are of course waiting on the nested call to complete.
- We were using `spawn_blocking` for the task that calls `run_subgraph`. Tasks that run indeterminately should not be put on the blocking thread pool, because that could exhaust the available threads. Ideally we'd make it so that `run_subgraph` doesn't do blocking calls, but the quick fix is to use an OS thread. I added `graph::spawn_thread` to make this convenient.