### PR TITLE
Do not retry `ipfs.cat` indefinitely

### DIFF
--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -142,6 +142,17 @@ pub struct LinkResolver {
     retry: bool,
 }
 
+impl CheapClone for LinkResolver {
+    fn cheap_clone(&self) -> Self {
+        LinkResolver {
+            clients: self.clients.cheap_clone(),
+            cache: self.cache.cheap_clone(),
+            timeout: self.timeout,
+            retry: self.retry,
+        }
+    }
+}
+
 impl From<IpfsClient> for LinkResolver {
     fn from(client: IpfsClient) -> Self {
         vec![client].into()

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -14,7 +14,7 @@ pub struct SubgraphAssignmentProvider<L, I> {
 
 impl<L, I> SubgraphAssignmentProvider<L, I>
 where
-    L: LinkResolver,
+    L: LinkResolver + CheapClone,
     I: SubgraphInstanceManager,
 {
     pub fn new(logger_factory: &LoggerFactory, link_resolver: Arc<L>, instance_manager: I) -> Self {
@@ -25,7 +25,7 @@ where
         SubgraphAssignmentProvider {
             logger_factory,
             subgraphs_running: Arc::new(Mutex::new(HashSet::new())),
-            link_resolver,
+            link_resolver: Arc::new(link_resolver.as_ref().cheap_clone().with_retries()),
             instance_manager: Arc::new(instance_manager),
         }
     }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,6 +1,6 @@
 use futures::future::join_all;
 use git_testament::{git_testament, render_testament};
-use graph::{ipfs_client::IpfsClient, prelude::LinkResolver as _, prometheus::Registry};
+use graph::{ipfs_client::IpfsClient, prometheus::Registry};
 use lazy_static::lazy_static;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -179,7 +179,7 @@ async fn main() {
 
     // Convert the clients into a link resolver. Since we want to get past
     // possible temporary DNS failures, make the resolver retry
-    let link_resolver = Arc::new(LinkResolver::from(ipfs_clients).with_retries());
+    let link_resolver = Arc::new(LinkResolver::from(ipfs_clients));
 
     // Set up Prometheus registry
     let prometheus_registry = Arc::new(Registry::new());
@@ -385,7 +385,7 @@ async fn main() {
         // Create IPFS-based subgraph provider
         let subgraph_provider = IpfsSubgraphAssignmentProvider::new(
             &logger_factory,
-            link_resolver.clone(),
+            link_resolver.cheap_clone(),
             subgraph_instance_manager,
         );
 
@@ -400,7 +400,7 @@ async fn main() {
         // Create named subgraph provider for resolving subgraph name->ID mappings
         let subgraph_registrar = Arc::new(IpfsSubgraphRegistrar::new(
             &logger_factory,
-            link_resolver,
+            link_resolver.cheap_clone(),
             Arc::new(subgraph_provider),
             network_store.subgraph_store(),
             subscription_manager,


### PR DESCRIPTION
I believe #2324 accidentally applied infinite retries to the link resolver used by the runtime, this was meant to apply only to the assignment provider.