### PR TITLE
Use unconstrained tokio budget for `run_subgraph`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,9 +1310,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
@@ -1351,7 +1351,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "num_cpus",
 ]
 
@@ -1402,7 +1402,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1521,7 +1521,7 @@ dependencies = [
  "diesel",
  "diesel_derives",
  "ethabi 12.0.0-graph",
- "futures 0.1.30",
+ "futures 0.1.31",
  "futures 0.3.13",
  "graphql-parser",
  "hex",
@@ -1581,7 +1581,7 @@ dependencies = [
  "diesel",
  "dirs-next",
  "fail",
- "futures 0.1.30",
+ "futures 0.1.31",
  "graph",
  "graph-core",
  "graph-store-postgres",
@@ -1604,7 +1604,7 @@ dependencies = [
  "atomic_refcell",
  "bytes 0.5.6",
  "fail",
- "futures 0.1.30",
+ "futures 0.1.31",
  "futures 0.3.13",
  "graph",
  "graph-mock",
@@ -1629,7 +1629,7 @@ dependencies = [
  "anyhow",
  "crossbeam",
  "defer",
- "futures 0.1.30",
+ "futures 0.1.31",
  "graph",
  "graphql-parser",
  "indexmap",
@@ -1645,7 +1645,7 @@ dependencies = [
 name = "graph-mock"
 version = "0.22.0"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "graph",
  "graph-graphql",
  "graphql-parser",
@@ -1707,7 +1707,7 @@ dependencies = [
  "bytes 1.0.1",
  "defer",
  "ethabi 12.0.0-graph",
- "futures 0.1.30",
+ "futures 0.1.31",
  "graph",
  "graph-chain-arweave",
  "graph-core",
@@ -1730,7 +1730,7 @@ dependencies = [
 name = "graph-server-http"
 version = "0.22.0"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "graph",
  "graph-graphql",
  "graph-mock",
@@ -1767,7 +1767,7 @@ dependencies = [
 name = "graph-server-metrics"
 version = "0.22.0"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "graph",
  "http 0.2.3",
  "hyper 0.14.5",
@@ -1780,7 +1780,7 @@ name = "graph-server-websocket"
 version = "0.22.0"
 dependencies = [
  "anyhow",
- "futures 0.1.30",
+ "futures 0.1.31",
  "graph",
  "graphql-parser",
  "http 0.2.3",
@@ -1806,7 +1806,7 @@ dependencies = [
  "diesel-dynamic-schema",
  "diesel_migrations",
  "fallible-iterator 0.1.6",
- "futures 0.1.30",
+ "futures 0.1.31",
  "graph",
  "graph-chain-ethereum",
  "graph-graphql",
@@ -1855,7 +1855,7 @@ dependencies = [
  "byteorder",
  "bytes 0.4.12",
  "fnv",
- "futures 0.1.30",
+ "futures 0.1.31",
  "http 0.1.21",
  "indexmap",
  "log 0.4.11",
@@ -1958,7 +1958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.31",
  "http 0.1.21",
  "tokio-buf",
 ]
@@ -2026,7 +2026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.31",
  "futures-cpupool",
  "h2 0.1.26",
  "http 0.1.21",
@@ -2080,7 +2080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.31",
  "hyper 0.12.35",
  "native-tls",
  "tokio-io",
@@ -2274,7 +2274,7 @@ version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "log 0.4.11",
  "serde",
  "serde_derive",
@@ -4091,7 +4091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "530e1d624baae485bce12e6647acb76aafa253346ee8a16751974eed5a24b13d"
 dependencies = [
  "derive_state_machine_future",
- "futures 0.1.30",
+ "futures 0.1.31",
  "rent_to_own",
 ]
 
@@ -4363,7 +4363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.31",
  "mio 0.6.22",
  "num_cpus",
  "tokio-codec",
@@ -4407,7 +4407,7 @@ checksum = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 dependencies = [
  "bytes 0.4.12",
  "either",
- "futures 0.1.30",
+ "futures 0.1.31",
 ]
 
 [[package]]
@@ -4417,7 +4417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.31",
  "tokio-io",
 ]
 
@@ -4428,7 +4428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.31",
  "iovec",
  "log 0.4.11",
  "mio 0.6.22",
@@ -4446,7 +4446,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "tokio-executor",
 ]
 
@@ -4457,7 +4457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures 0.1.30",
+ "futures 0.1.31",
 ]
 
 [[package]]
@@ -4466,7 +4466,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "tokio-io",
  "tokio-threadpool",
 ]
@@ -4478,7 +4478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.31",
  "log 0.4.11",
 ]
 
@@ -4533,7 +4533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures 0.1.30",
+ "futures 0.1.31",
  "lazy_static",
  "log 0.4.11",
  "mio 0.6.22",
@@ -4575,7 +4575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
 dependencies = [
  "fnv",
- "futures 0.1.30",
+ "futures 0.1.31",
 ]
 
 [[package]]
@@ -4585,7 +4585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.31",
  "iovec",
  "mio 0.6.22",
  "tokio-io",
@@ -4601,7 +4601,7 @@ dependencies = [
  "crossbeam-deque 0.7.3",
  "crossbeam-queue 0.2.3",
  "crossbeam-utils 0.7.2",
- "futures 0.1.30",
+ "futures 0.1.31",
  "lazy_static",
  "log 0.4.11",
  "num_cpus",
@@ -4615,7 +4615,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "slab 0.3.0",
 ]
 
@@ -4626,7 +4626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures 0.1.30",
+ "futures 0.1.31",
  "slab 0.4.2",
  "tokio-executor",
 ]
@@ -4637,7 +4637,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "native-tls",
  "tokio-io",
 ]
@@ -4662,7 +4662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.31",
  "log 0.4.11",
  "mio 0.6.22",
  "tokio-codec",
@@ -4677,7 +4677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.31",
  "iovec",
  "libc",
  "log 0.3.9",
@@ -4694,7 +4694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.31",
  "iovec",
  "libc",
  "log 0.4.11",
@@ -4985,7 +4985,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "log 0.4.11",
  "try-lock",
 ]
@@ -5331,7 +5331,7 @@ dependencies = [
  "derive_more",
  "ethabi 12.0.0",
  "ethereum-types",
- "futures 0.1.30",
+ "futures 0.1.31",
  "hyper 0.12.35",
  "hyper-tls 0.3.2",
  "jsonrpc-core",
@@ -5363,7 +5363,7 @@ dependencies = [
  "bitflags 0.9.1",
  "byteorder",
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.31",
  "hyper 0.10.16",
  "native-tls",
  "rand 0.5.6",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 async-trait = "0.1.48"
 atomic_refcell = "0.1.7"
 bytes = "0.5"
-futures01 = { package="futures", version="0.1.29" }
+futures01 = { package="futures", version="0.1.31" }
 futures = { version="0.3.4", features=["compat"] }
 graph = { path = "../graph" }
 lazy_static = "1.2.0"

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -446,10 +446,8 @@ where
         // forward; this is easier than updating the existing block stream.
         //
         // This task has many calls to the store, so mark it as `blocking`.
-        // This call is the reason why the size of the blocking thread pool
-        // size must always be well above the number of deployed subgraphs.
-        graph::spawn_blocking(async move {
-            if let Err(e) = run_subgraph(ctx).await {
+        graph::spawn_thread(deployment_id.to_string(), move || {
+            if let Err(e) = graph::block_on(run_subgraph(ctx)) {
                 error!(
                     &logger,
                     "Subgraph instance failed to run: {}",

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -154,8 +154,3 @@ those.
   given the other load management configuration settings, but never
   actually decline to run a query, instead log about load management
   decisions. Set to `true` to turn simulation on, defaults to `false`
-- `GRAPH_MAX_BLOCKING_THREADS`:  Maximum number of blocking threads in the tokio blocking thread
-  pool. In an index node this should always be well above the number of subgraphs deployed to it,
-  because each subgraph permanently takes up one thread. Graphql queries are currently also run on
-  the blocking thread pool, but the DB connection pool size is usually the limiting factor for
-  queries. Defaults to 2000.

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -27,7 +27,7 @@ pub mod mock {
 /// Wrapper for spawning tasks that abort on panic, which is our default.
 mod task_spawn;
 pub use task_spawn::{
-    block_on, spawn, spawn_allow_panic, spawn_blocking, spawn_blocking_allow_panic,
+    block_on, spawn, spawn_allow_panic, spawn_blocking, spawn_blocking_allow_panic, spawn_thread,
 };
 
 pub use bytes;

--- a/graph/src/task_spawn.rs
+++ b/graph/src/task_spawn.rs
@@ -54,3 +54,14 @@ pub fn spawn_blocking_allow_panic<R: 'static + Send>(
 pub fn block_on<T>(f: impl Future03<Output = T>) -> T {
     tokio::runtime::Handle::current().block_on(f)
 }
+
+/// Spawns a thread with access to the tokio runtime. Panics if the thread cannot be spawned.
+pub fn spawn_thread(name: String, f: impl 'static + FnOnce() + Send) {
+    let conf = std::thread::Builder::new().name(name);
+    let runtime = tokio::runtime::Handle::current();
+    conf.spawn(move || {
+        let _runtime_guard = runtime.enter();
+        f()
+    })
+    .unwrap();
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -55,15 +55,6 @@ lazy_static! {
         .map(|s| BlockNumber::from_str(&s)
              .unwrap_or_else(|_| panic!("failed to parse env var ETHEREUM_ANCESTOR_COUNT")))
         .unwrap_or(50);
-
-    // Maximum number of blocking threads in the tokio blocking thread pool. This should always be
-    // well above the number of subgraphs deployed to an index node, because each subgraph takes up
-    // one thread. Defaults to 2000.
-    static ref MAX_BLOCKING_THREADS: usize = env::var("GRAPH_MAX_BLOCKING_THREADS")
-        .ok()
-        .map(|s| usize::from_str(&s)
-             .unwrap_or_else(|_| panic!("failed to parse env var ETHEREUM_ANCESTOR_COUNT")))
-        .unwrap_or(2000);
 }
 
 /// How long we will hold up node startup to get the net version and genesis
@@ -102,16 +93,8 @@ fn read_expensive_queries() -> Result<Vec<Arc<q::Document>>, std::io::Error> {
     Ok(queries)
 }
 
-fn main() {
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .max_blocking_threads(*MAX_BLOCKING_THREADS)
-        .build()
-        .unwrap()
-        .block_on(async { async_main().await })
-}
-
-async fn async_main() {
+#[tokio::main]
+async fn main() {
     env_logger::init();
 
     // Allow configuring fail points on debug builds. Used for integration tests.


### PR DESCRIPTION
This PR:

1. Reverts #2357, that was being done in lack of a better idea, and this is a better idea.
2. Updates futures 0.1.x from 0.1.30 to [0.1.31](https://github.com/rust-lang/futures-rs/pull/2359), which fixes a potential deadlock in `FuturesUnordered` when combined with the tokio cooperative scheduler, we use `FuturesUnordered` in the block stream so this may be affecting us.
3. While 2 might be sufficient to fix the deadlock, to be sure this disables cooperative scheduling for `run_subgraph`. It's being run in its own thread so there is nothing to gain from cooperative scheduling anyways.