### PR TITLE
Rebase web3, use upstream ethabi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a2f58b0bb10c380af2b26e57212856b8c9a59e0925b4c20f4a174a49734eaf7"
+
+[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +100,17 @@ dependencies = [
  "failure",
  "failure_derive",
  "serde_json",
+]
+
+[[package]]
+name = "async-native-tls"
+version = "0.3.3"
+source = "git+https://github.com/async-email/async-native-tls.git?rev=b5b5562d6cea77f913d4cbe448058c031833bf17#b5b5562d6cea77f913d4cbe448058c031833bf17"
+dependencies = [
+ "native-tls",
+ "thiserror",
+ "tokio 1.4.0",
+ "url",
 ]
 
 [[package]]
@@ -152,16 +169,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
-
-[[package]]
-name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -196,24 +203,20 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
-
-[[package]]
-name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
-version = "0.17.4"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
+checksum = "1f682656975d3a682daff957be4ddeb65d6ad656737cd821f2d00685ae466af1"
 dependencies = [
- "either",
+ "funty",
  "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -223,7 +226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.5.2",
  "constant_time_eq",
 ]
 
@@ -234,7 +237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9ff35b701f3914bdb8fad3368d822c766ef2858b2583198e41639b936f09d3f"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.5.2",
  "cc",
  "cfg-if 0.1.10",
  "constant_time_eq",
@@ -248,8 +251,15 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bollard"
@@ -266,10 +276,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 0.2.3",
+ "http 0.2.4",
  "hyper 0.14.5",
  "hyper-unix-connector",
- "log 0.4.11",
+ "log",
  "pin-project",
  "serde",
  "serde_derive",
@@ -278,7 +288,7 @@ dependencies = [
  "thiserror",
  "tokio 1.4.0",
  "tokio-util",
- "url 2.2.1",
+ "url",
  "winapi 0.3.9",
 ]
 
@@ -316,9 +326,9 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byte-slice-cast"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
+checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
 
 [[package]]
 name = "byteorder"
@@ -392,7 +402,7 @@ checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term 0.11.0",
  "atty",
- "bitflags 1.2.1",
+ "bitflags",
  "strsim 0.8.0",
  "textwrap",
  "unicode-width",
@@ -405,7 +415,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -414,7 +424,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -530,7 +540,7 @@ dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
  "gimli",
- "log 0.4.11",
+ "log",
  "regalloc",
  "serde",
  "smallvec 1.6.1",
@@ -573,7 +583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae11da9ca99f987c29e3eb39ebe10e9b879ecca30f3aeaee13db5e8e02b80fb6"
 dependencies = [
  "cranelift-codegen",
- "log 0.4.11",
+ "log",
  "smallvec 1.6.1",
  "target-lexicon",
 ]
@@ -598,7 +608,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "itertools",
- "log 0.4.11",
+ "log",
  "serde",
  "smallvec 1.6.1",
  "thiserror",
@@ -896,7 +906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "047bfc4d5c3bd2ef6ca6f981941046113524b9a9f9a7cbdfdd7ff40f58e6f542"
 dependencies = [
  "bigdecimal",
- "bitflags 1.2.1",
+ "bitflags",
  "byteorder",
  "diesel_derives",
  "num-bigint",
@@ -1056,7 +1066,7 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
  "humantime 1.3.0",
- "log 0.4.11",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -1069,7 +1079,7 @@ checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
  "humantime 2.0.1",
- "log 0.4.11",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -1103,36 +1113,25 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "12.0.0-graph"
-source = "git+https://github.com/graphprotocol/ethabi.git#35977d1ce69d4c2db652c502d70e4e53a7aa9897"
-dependencies = [
- "ethereum-types",
- "rustc-hex",
- "serde",
- "serde_json",
- "tiny-keccak 1.5.0",
- "uint",
-]
-
-[[package]]
-name = "ethabi"
-version = "12.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
+checksum = "c52991643379afc90bfe2df3c64d53983e59c35a82ba6e75c997cfc2880d8524"
 dependencies = [
+ "anyhow",
  "ethereum-types",
- "rustc-hex",
+ "hex",
  "serde",
  "serde_json",
- "tiny-keccak 1.5.0",
+ "sha3",
+ "thiserror",
  "uint",
 ]
 
 [[package]]
 name = "ethbloom"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a6567e6fd35589fea0c63b94b4cf2e55573e413901bdbe60ab15cf0e25e5df"
+checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
 dependencies = [
  "crunchy",
  "fixed-hash",
@@ -1143,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473aecff686bd8e7b9db0165cbbb53562376b39bf35b427f0c60446a9e1634b0"
+checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -1162,7 +1161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
 dependencies = [
  "lazy_static",
- "log 0.4.11",
+ "log",
  "rand 0.7.3",
 ]
 
@@ -1207,7 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fdbe0d94371f9ce939b555dd342d0686cc4c0cadbcd4b61d70af5ff97eb4126"
 dependencies = [
  "env_logger 0.7.1",
- "log 0.4.11",
+ "log",
 ]
 
 [[package]]
@@ -1218,12 +1217,12 @@ checksum = "31586bda1b136406162e381a3185a506cdfc1631708dd40cba2f6628d8634499"
 
 [[package]]
 name = "fixed-hash"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand 0.7.3",
+ "rand 0.8.3",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1277,7 +1276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -1298,7 +1297,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "fuchsia-zircon-sys",
 ]
 
@@ -1307,6 +1306,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -1397,6 +1402,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,7 +1425,7 @@ dependencies = [
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
- "slab 0.4.2",
+ "slab",
 ]
 
 [[package]]
@@ -1430,7 +1441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -1482,7 +1493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "526ad4c79ca35ec046176e89787409f1d75d9cd51fa9258c01ca206d4fba9340"
 dependencies = [
  "chrono",
- "log 0.4.11",
+ "log",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.62",
@@ -1503,7 +1514,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "fnv",
- "log 0.4.11",
+ "log",
  "regex",
 ]
 
@@ -1520,12 +1531,12 @@ dependencies = [
  "chrono",
  "diesel",
  "diesel_derives",
- "ethabi 12.0.0-graph",
+ "ethabi",
  "futures 0.1.31",
  "futures 0.3.13",
  "graphql-parser",
  "hex",
- "http 0.2.3",
+ "http 0.2.4",
  "isatty",
  "lazy_static",
  "maplit",
@@ -1558,7 +1569,7 @@ dependencies = [
  "tokio 1.4.0",
  "tokio-retry",
  "tokio-stream",
- "url 2.2.1",
+ "url",
  "wasmparser",
  "web3",
 ]
@@ -1585,8 +1596,8 @@ dependencies = [
  "graph",
  "graph-core",
  "graph-store-postgres",
- "http 0.1.21",
- "jsonrpc-core",
+ "http 0.2.4",
+ "jsonrpc-core 17.0.0",
  "lazy_static",
  "mockall",
  "pretty_assertions",
@@ -1685,7 +1696,7 @@ dependencies = [
  "shellexpand",
  "structopt",
  "toml",
- "url 2.2.1",
+ "url",
 ]
 
 [[package]]
@@ -1706,7 +1717,7 @@ dependencies = [
  "bs58",
  "bytes 1.0.1",
  "defer",
- "ethabi 12.0.0-graph",
+ "ethabi",
  "futures 0.1.31",
  "graph",
  "graph-chain-arweave",
@@ -1735,7 +1746,7 @@ dependencies = [
  "graph-graphql",
  "graph-mock",
  "graphql-parser",
- "http 0.2.3",
+ "http 0.2.4",
  "hyper 0.14.5",
  "serde",
 ]
@@ -1748,7 +1759,7 @@ dependencies = [
  "graph",
  "graph-graphql",
  "graphql-parser",
- "http 0.2.3",
+ "http 0.2.4",
  "hyper 0.14.5",
  "serde",
 ]
@@ -1769,7 +1780,7 @@ version = "0.22.0"
 dependencies = [
  "futures 0.1.31",
  "graph",
- "http 0.2.3",
+ "http 0.2.4",
  "hyper 0.14.5",
  "lazy_static",
  "serde",
@@ -1783,7 +1794,7 @@ dependencies = [
  "futures 0.1.31",
  "graph",
  "graphql-parser",
- "http 0.2.3",
+ "http 0.2.4",
  "lazy_static",
  "serde",
  "serde_derive",
@@ -1858,8 +1869,8 @@ dependencies = [
  "futures 0.1.31",
  "http 0.1.21",
  "indexmap",
- "log 0.4.11",
- "slab 0.4.2",
+ "log",
+ "slab",
  "string",
  "tokio-io",
 ]
@@ -1875,9 +1886,9 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.3",
+ "http 0.2.4",
  "indexmap",
- "slab 0.4.2",
+ "slab",
  "tokio 1.4.0",
  "tokio-util",
  "tracing",
@@ -1888,6 +1899,31 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "headers"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
+dependencies = [
+ "base64 0.13.0",
+ "bitflags",
+ "bytes 1.0.1",
+ "headers-core",
+ "http 0.2.4",
+ "mime",
+ "sha-1",
+ "time",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.4",
+]
 
 [[package]]
 name = "heck"
@@ -1942,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -1970,7 +2006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
  "bytes 1.0.1",
- "http 0.2.3",
+ "http 0.2.4",
 ]
 
 [[package]]
@@ -2002,25 +2038,6 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.10.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
-dependencies = [
- "base64 0.9.3",
- "httparse",
- "language-tags",
- "log 0.3.9",
- "mime 0.2.6",
- "num_cpus",
- "time",
- "traitobject",
- "typeable",
- "unicase 1.4.2",
- "url 1.7.2",
-]
-
-[[package]]
-name = "hyper"
 version = "0.12.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
@@ -2034,7 +2051,7 @@ dependencies = [
  "httparse",
  "iovec",
  "itoa",
- "log 0.4.11",
+ "log",
  "net2",
  "rustc_version",
  "time",
@@ -2045,7 +2062,7 @@ dependencies = [
  "tokio-reactor",
  "tokio-tcp",
  "tokio-threadpool",
- "tokio-timer 0.2.13",
+ "tokio-timer",
  "want 0.2.0",
 ]
 
@@ -2060,7 +2077,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.3.1",
- "http 0.2.3",
+ "http 0.2.4",
  "http-body 0.4.0",
  "httparse",
  "httpdate",
@@ -2074,16 +2091,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.3.2"
+name = "hyper-proxy"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
+checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
 dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "hyper 0.12.35",
+ "bytes 1.0.1",
+ "futures 0.3.13",
+ "headers",
+ "http 0.2.4",
+ "hyper 0.14.5",
+ "hyper-tls",
  "native-tls",
- "tokio-io",
+ "tokio 1.4.0",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2132,17 +2154,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
@@ -2154,18 +2165,18 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
+checksum = "df170efa359aebdd5cb7fe78edcc67107748e4737bdca8a8fb40d15ea7a877ed"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "impl-rlp"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
  "rlp",
 ]
@@ -2275,7 +2286,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
 dependencies = [
  "futures 0.1.31",
- "log 0.4.11",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonrpc-core"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07569945133257ff557eb37b015497104cea61a2c9edaf126c1cbd6e8332397f"
+dependencies = [
+ "futures 0.3.13",
+ "log",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2288,12 +2312,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da906d682799df05754480dac1b9e70ec92e12c19ebafd2662a5ea1c9fd6522"
 dependencies = [
  "hyper 0.12.35",
- "jsonrpc-core",
+ "jsonrpc-core 14.2.0",
  "jsonrpc-server-utils",
- "log 0.4.11",
+ "log",
  "net2",
  "parking_lot 0.10.2",
- "unicase 2.6.0",
+ "unicase",
 ]
 
 [[package]]
@@ -2304,13 +2328,19 @@ checksum = "56cbfb462e7f902e21121d9f0d1c2b77b2c5b642e1a4e8f4ebfa2e15b94402bb"
 dependencies = [
  "bytes 0.4.12",
  "globset",
- "jsonrpc-core",
+ "jsonrpc-core 14.2.0",
  "lazy_static",
- "log 0.4.11",
+ "log",
  "tokio 0.1.22",
  "tokio-codec",
- "unicase 2.6.0",
+ "unicase",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kernel32-sys"
@@ -2321,12 +2351,6 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
-
-[[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -2346,8 +2370,8 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 dependencies = [
- "arrayvec",
- "bitflags 1.2.1",
+ "arrayvec 0.5.2",
+ "bitflags",
  "cfg-if 0.1.10",
  "ryu",
  "static_assertions",
@@ -2381,15 +2405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
 dependencies = [
  "scopeguard",
-]
-
-[[package]]
-name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.11",
 ]
 
 [[package]]
@@ -2498,15 +2513,6 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-dependencies = [
- "log 0.3.9",
-]
-
-[[package]]
-name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
@@ -2517,8 +2523,8 @@ version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
- "mime 0.3.16",
- "unicase 2.6.0",
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -2543,10 +2549,10 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.11",
+ "log",
  "miow 0.2.1",
  "net2",
- "slab 0.4.2",
+ "slab",
  "winapi 0.2.8",
 ]
 
@@ -2557,7 +2563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
 dependencies = [
  "libc",
- "log 0.4.11",
+ "log",
  "miow 0.3.6",
  "ntapi",
  "winapi 0.3.9",
@@ -2637,7 +2643,7 @@ checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.11",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -2672,7 +2678,7 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "lexical-core",
  "memchr",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -2765,7 +2771,7 @@ version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
@@ -2809,11 +2815,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
+checksum = "731f4d179ed52b1c7eeb29baf29c604ea9301b889b23ce93660220a5465d5c6f"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.0",
  "bitvec",
  "byte-slice-cast",
  "serde",
@@ -2900,12 +2906,6 @@ name = "paste"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -3010,7 +3010,7 @@ dependencies = [
  "bytes 1.0.1",
  "fallible-iterator 0.2.0",
  "futures 0.3.13",
- "log 0.4.11",
+ "log",
  "tokio 1.4.0",
  "tokio-postgres",
 ]
@@ -3102,9 +3102,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.7.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
+checksum = "2415937401cb030a2a0a4d922483f945fa068f52a7dbb22ce0fe5f2b6f6adace"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -3133,7 +3133,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.62",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -3144,7 +3144,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -3237,29 +3237,16 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
 dependencies = [
- "log 0.4.11",
+ "log",
  "parking_lot 0.11.1",
  "scheduled-thread-pool",
 ]
 
 [[package]]
 name = "radium"
-version = "0.3.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
-name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "cloudabi 0.0.3",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "winapi 0.3.9",
-]
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -3505,7 +3492,7 @@ version = "0.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
 dependencies = [
- "log 0.4.11",
+ "log",
  "rustc-hash",
  "serde",
  "smallvec 1.6.1",
@@ -3534,7 +3521,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "libc",
  "mach",
  "winapi 0.3.9",
@@ -3566,25 +3553,25 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http 0.2.3",
+ "http 0.2.4",
  "http-body 0.4.0",
  "hyper 0.14.5",
- "hyper-tls 0.5.0",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.11",
- "mime 0.3.16",
+ "log",
+ "mime",
  "mime_guess",
  "native-tls",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project-lite 0.2.6",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.4.0",
  "tokio-native-tls",
- "url 2.2.1",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3608,10 +3595,11 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
+checksum = "e54369147e3e7796c9b885c7304db87ca3d09a0a98f72843d532868675bbfba8"
 dependencies = [
+ "bytes 1.0.1",
  "rustc-hex",
 ]
 
@@ -3661,12 +3649,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3693,12 +3675,6 @@ checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
  "parking_lot 0.11.1",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 
 [[package]]
 name = "scopeguard"
@@ -3739,7 +3715,8 @@ dependencies = [
 [[package]]
 name = "secp256k1"
 version = "0.20.1"
-source = "git+https://github.com/rust-bitcoin/rust-secp256k1#4ae0e7ebd1c01f686e0ee5bf31f184b418929cf8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733b114f058f260c0af7591434eef4272ae1a8ec2751766d3cb89c6df8d5e450"
 dependencies = [
  "secp256k1-sys",
 ]
@@ -3747,7 +3724,8 @@ dependencies = [
 [[package]]
 name = "secp256k1-sys"
 version = "0.4.0"
-source = "git+https://github.com/rust-bitcoin/rust-secp256k1#4ae0e7ebd1c01f686e0ee5bf31f184b418929cf8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e4b6455ee49f5901c8985b88f98fb0a0e1d90a6661f5a03f4888bd987dad29"
 dependencies = [
  "cc",
 ]
@@ -3758,7 +3736,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3900,12 +3878,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
-
-[[package]]
 name = "sha2"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3915,6 +3887,18 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpuid-bool",
  "digest",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "keccak",
  "opaque-debug",
 ]
 
@@ -3941,12 +3925,6 @@ name = "siphasher"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
-
-[[package]]
-name = "slab"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 
 [[package]]
 name = "slab"
@@ -3978,7 +3956,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "906a1a0bc43fed692df4b82a5e2fbfc3733db8dad8bb514ab27a4f23ad04f5c0"
 dependencies = [
- "log 0.4.11",
+ "log",
  "regex",
  "slog",
  "slog-async",
@@ -4004,7 +3982,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8228ab7302adbf4fcb37e66f3cda78003feb521e7fd9e3847ec117a7784d0f5a"
 dependencies = [
- "log 0.4.11",
+ "log",
  "slog",
  "slog-scope",
 ]
@@ -4057,6 +4035,21 @@ checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "soketto"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c71ed3d54db0a699f4948e1bb3e45b450fa31fe602621dee6680361d569c88"
+dependencies = [
+ "base64 0.12.3",
+ "bytes 0.5.6",
+ "futures 0.3.13",
+ "httparse",
+ "log",
+ "rand 0.7.3",
+ "sha-1",
 ]
 
 [[package]]
@@ -4221,6 +4214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,9 +4374,9 @@ dependencies = [
  "tokio-sync",
  "tokio-tcp",
  "tokio-threadpool",
- "tokio-timer 0.2.13",
+ "tokio-timer",
  "tokio-udp",
- "tokio-uds 0.2.7",
+ "tokio-uds",
 ]
 
 [[package]]
@@ -4393,6 +4392,7 @@ dependencies = [
  "mio 0.7.9",
  "num_cpus",
  "once_cell",
+ "parking_lot 0.11.1",
  "pin-project-lite 0.2.6",
  "signal-hook-registry",
  "tokio-macros",
@@ -4419,25 +4419,6 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
  "tokio-io",
-]
-
-[[package]]
-name = "tokio-core"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "iovec",
- "log 0.4.11",
- "mio 0.6.22",
- "scoped-tls",
- "tokio 0.1.22",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "tokio-timer 0.2.13",
 ]
 
 [[package]]
@@ -4479,7 +4460,7 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "log 0.4.11",
+ "log",
 ]
 
 [[package]]
@@ -4514,9 +4495,9 @@ dependencies = [
  "bytes 1.0.1",
  "fallible-iterator 0.2.0",
  "futures 0.3.13",
- "log 0.4.11",
+ "log",
  "parking_lot 0.11.1",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "phf",
  "pin-project-lite 0.2.6",
  "postgres-protocol",
@@ -4535,11 +4516,11 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
  "lazy_static",
- "log 0.4.11",
+ "log",
  "mio 0.6.22",
  "num_cpus",
  "parking_lot 0.9.0",
- "slab 0.4.2",
+ "slab",
  "tokio-executor",
  "tokio-io",
  "tokio-sync",
@@ -4603,20 +4584,10 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
  "lazy_static",
- "log 0.4.11",
+ "log",
  "num_cpus",
- "slab 0.4.2",
+ "slab",
  "tokio-executor",
-]
-
-[[package]]
-name = "tokio-timer"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc"
-dependencies = [
- "futures 0.1.31",
- "slab 0.3.0",
 ]
 
 [[package]]
@@ -4627,19 +4598,8 @@ checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
- "slab 0.4.2",
+ "slab",
  "tokio-executor",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
-dependencies = [
- "futures 0.1.31",
- "native-tls",
- "tokio-io",
 ]
 
 [[package]]
@@ -4649,7 +4609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e96bb520beab540ab664bd5a9cfeaa1fcd846fa68c830b42e2c8963071251d2"
 dependencies = [
  "futures-util",
- "log 0.4.11",
+ "log",
  "pin-project",
  "tokio 1.4.0",
  "tungstenite",
@@ -4663,28 +4623,11 @@ checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "log 0.4.11",
+ "log",
  "mio 0.6.22",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-uds"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "iovec",
- "libc",
- "log 0.3.9",
- "mio 0.6.22",
- "mio-uds",
- "tokio-core",
- "tokio-io",
 ]
 
 [[package]]
@@ -4697,7 +4640,7 @@ dependencies = [
  "futures 0.1.31",
  "iovec",
  "libc",
- "log 0.4.11",
+ "log",
  "mio 0.6.22",
  "mio-uds",
  "tokio-codec",
@@ -4713,8 +4656,9 @@ checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
 dependencies = [
  "bytes 1.0.1",
  "futures-core",
+ "futures-io",
  "futures-sink",
- "log 0.4.11",
+ "log",
  "pin-project-lite 0.2.6",
  "tokio 1.4.0",
 ]
@@ -4755,12 +4699,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
 name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4781,22 +4719,16 @@ dependencies = [
  "base64 0.13.0",
  "byteorder",
  "bytes 1.0.1",
- "http 0.2.3",
+ "http 0.2.4",
  "httparse",
  "input_buffer",
- "log 0.4.11",
+ "log",
  "rand 0.8.3",
  "sha-1",
  "thiserror",
- "url 2.2.1",
+ "url",
  "utf-8",
 ]
-
-[[package]]
-name = "typeable"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
@@ -4806,23 +4738,14 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uint"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
+checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
 dependencies = [
  "byteorder",
  "crunchy",
- "rustc-hex",
+ "hex",
  "static_assertions",
-]
-
-[[package]]
-name = "unicase"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-dependencies = [
- "version_check 0.1.5",
 ]
 
 [[package]]
@@ -4831,7 +4754,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -4893,25 +4816,14 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.0",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -4952,12 +4864,6 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-
-[[package]]
-name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
@@ -4986,7 +4892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
  "futures 0.1.31",
- "log 0.4.11",
+ "log",
  "try-lock",
 ]
 
@@ -4996,7 +4902,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.11",
+ "log",
  "try-lock",
 ]
 
@@ -5032,7 +4938,7 @@ checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.11",
+ "log",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.62",
@@ -5100,7 +5006,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "libc",
- "log 0.4.11",
+ "log",
  "paste",
  "psm",
  "region",
@@ -5132,7 +5038,7 @@ dependencies = [
  "errno",
  "file-per-thread-logger",
  "libc",
- "log 0.4.11",
+ "log",
  "serde",
  "sha2",
  "toml",
@@ -5183,7 +5089,7 @@ dependencies = [
  "cranelift-wasm",
  "gimli",
  "indexmap",
- "log 0.4.11",
+ "log",
  "more-asserts",
  "region",
  "serde",
@@ -5217,7 +5123,7 @@ dependencies = [
  "cranelift-native",
  "cranelift-wasm",
  "gimli",
- "log 0.4.11",
+ "log",
  "more-asserts",
  "object 0.23.0",
  "rayon",
@@ -5281,7 +5187,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "libc",
- "log 0.4.11",
+ "log",
  "mach",
  "memoffset 0.6.3",
  "more-asserts",
@@ -5323,56 +5229,36 @@ dependencies = [
 
 [[package]]
 name = "web3"
-version = "0.10.0-graph"
-source = "git+https://github.com/graphprotocol/rust-web3#2ffcc3adb208d8be0e078601b8ded9e5c6290843"
+version = "0.15.0-graph"
+source = "git+https://github.com/graphprotocol/rust-web3?branch=leo/test-rebase-upstream-master#6df4b7108997600dfff66d1063b7762adde9946b"
 dependencies = [
- "arrayvec",
- "base64 0.12.3",
+ "arrayvec 0.5.2",
+ "async-native-tls",
+ "base64 0.13.0",
  "derive_more",
- "ethabi 12.0.0",
+ "ethabi",
  "ethereum-types",
- "futures 0.1.31",
- "hyper 0.12.35",
- "hyper-tls 0.3.2",
- "jsonrpc-core",
- "log 0.4.11",
- "native-tls",
- "parking_lot 0.10.2",
+ "futures 0.3.13",
+ "futures-timer",
+ "headers",
+ "hex",
+ "hyper 0.14.5",
+ "hyper-proxy",
+ "hyper-tls",
+ "jsonrpc-core 17.0.0",
+ "log",
+ "parking_lot 0.11.1",
+ "pin-project",
  "rlp",
- "rustc-hex",
  "secp256k1",
  "serde",
  "serde_json",
+ "soketto",
  "tiny-keccak 2.0.2",
- "tokio-core",
- "tokio-io",
- "tokio-timer 0.1.2",
- "tokio-uds 0.1.7",
- "url 2.2.1",
- "websocket",
- "zeroize",
-]
-
-[[package]]
-name = "websocket"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9faed2bff8af2ea6b9f8b917d3d00b467583f6781fe3def174a9e33c879703"
-dependencies = [
- "base64 0.9.3",
- "bitflags 0.9.1",
- "byteorder",
- "bytes 0.4.12",
- "futures 0.1.31",
- "hyper 0.10.16",
- "native-tls",
- "rand 0.5.6",
- "sha1",
- "tokio-core",
- "tokio-io",
- "tokio-tls",
- "unicase 1.4.2",
- "url 1.7.2",
+ "tokio 1.4.0",
+ "tokio-stream",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -5438,6 +5324,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5445,12 +5337,6 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
 
 [[package]]
 name = "zstd"

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 [dependencies]
 chrono = "0.4"
 futures = "0.1.21"
-http = "0.1.21" # must be compatible with the version rust-web3 uses
-jsonrpc-core = "14.2.0"
+http = "0.2.4"
+jsonrpc-core = "17.0.0"
 graph = { path = "../../graph" }
 lazy_static = "1.2.0"
 state_machine_future = "0.2"

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -20,7 +20,7 @@ use graph::prelude::{
         },
     },
     BlockNumber, ChainStore, CheapClone, DynTryFuture, Error, EthereumCallCache, Logger,
-    TimeoutError,
+    TimeoutError, TryFutureExt,
 };
 use graph::{
     components::ethereum::{EthereumAdapter as EthereumAdapterTrait, *},
@@ -122,7 +122,6 @@ where
         let is_ganache = web3
             .web3()
             .client_version()
-            .compat()
             .await
             .map(|s| s.contains("TestRPC"))
             .unwrap_or(false);
@@ -169,9 +168,8 @@ where
                 let start = Instant::now();
                 let subgraph_metrics = subgraph_metrics.clone();
                 let provider_metrics = eth.metrics.clone();
-                eth.web3
-                    .trace()
-                    .filter(trace_filter)
+                Box::pin(eth.web3.trace().filter(trace_filter))
+                    .compat()
                     .map(move |traces| {
                         if traces.len() > 0 {
                             if to == from {
@@ -258,16 +256,18 @@ where
                     .build();
 
                 // Request logs from client
-                eth_adapter.web3.eth().logs(log_filter).then(move |result| {
-                    let elapsed = start.elapsed().as_secs_f64();
-                    provider_metrics.observe_request(elapsed, "eth_getLogs");
-                    subgraph_metrics.observe_request(elapsed, "eth_getLogs");
-                    if result.is_err() {
-                        provider_metrics.add_error("eth_getLogs");
-                        subgraph_metrics.add_error("eth_getLogs");
-                    }
-                    result
-                })
+                Box::pin(eth_adapter.web3.eth().logs(log_filter))
+                    .compat()
+                    .then(move |result| {
+                        let elapsed = start.elapsed().as_secs_f64();
+                        provider_metrics.observe_request(elapsed, "eth_getLogs");
+                        subgraph_metrics.observe_request(elapsed, "eth_getLogs");
+                        if result.is_err() {
+                            provider_metrics.add_error("eth_getLogs");
+                            subgraph_metrics.add_error("eth_getLogs");
+                        }
+                        result
+                    })
             })
     }
 
@@ -442,115 +442,120 @@ where
             .run(move || {
                 let req = CallRequest {
                     from: None,
-                    to: contract_address,
+                    to: Some(contract_address),
                     gas: None,
                     gas_price: None,
                     value: None,
                     data: Some(call_data.clone()),
                 };
-                web3.eth().call(req, Some(block_id)).then(|result| {
-                    // Try to check if the call was reverted. The JSON-RPC response for reverts is
-                    // not standardized, so we have ad-hoc checks for each of Geth, Parity and
-                    // Ganache.
+                Box::pin(web3.eth().call(req, Some(block_id)))
+                    .compat()
+                    .then(|result| {
+                        // Try to check if the call was reverted. The JSON-RPC response for reverts is
+                        // not standardized, so we have ad-hoc checks for each of Geth, Parity and
+                        // Ganache.
 
-                    // 0xfe is the "designated bad instruction" of the EVM, and Solidity uses it for
-                    // asserts.
-                    const PARITY_BAD_INSTRUCTION_FE: &str = "Bad instruction fe";
+                        // 0xfe is the "designated bad instruction" of the EVM, and Solidity uses it for
+                        // asserts.
+                        const PARITY_BAD_INSTRUCTION_FE: &str = "Bad instruction fe";
 
-                    // 0xfd is REVERT, but on some contracts, and only on older blocks,
-                    // this happens. Makes sense to consider it a revert as well.
-                    const PARITY_BAD_INSTRUCTION_FD: &str = "Bad instruction fd";
+                        // 0xfd is REVERT, but on some contracts, and only on older blocks,
+                        // this happens. Makes sense to consider it a revert as well.
+                        const PARITY_BAD_INSTRUCTION_FD: &str = "Bad instruction fd";
 
-                    const PARITY_BAD_JUMP_PREFIX: &str = "Bad jump";
-                    const PARITY_STACK_LIMIT_PREFIX: &str = "Out of stack";
+                        const PARITY_BAD_JUMP_PREFIX: &str = "Bad jump";
+                        const PARITY_STACK_LIMIT_PREFIX: &str = "Out of stack";
 
-                    const GANACHE_VM_EXECUTION_ERROR: i64 = -32000;
-                    const GANACHE_REVERT_MESSAGE: &str =
-                        "VM Exception while processing transaction: revert";
-                    const PARITY_VM_EXECUTION_ERROR: i64 = -32015;
-                    const PARITY_REVERT_PREFIX: &str = "Reverted 0x";
+                        const GANACHE_VM_EXECUTION_ERROR: i64 = -32000;
+                        const GANACHE_REVERT_MESSAGE: &str =
+                            "VM Exception while processing transaction: revert";
+                        const PARITY_VM_EXECUTION_ERROR: i64 = -32015;
+                        const PARITY_REVERT_PREFIX: &str = "Reverted 0x";
 
-                    // Deterministic Geth execution errors. We might need to expand this as
-                    // subgraphs come across other errors. See
-                    // https://github.com/ethereum/go-ethereum/blob/cd57d5cd38ef692de8fbedaa56598b4e9fbfbabc/core/vm/errors.go
-                    const GETH_EXECUTION_ERRORS: &[&str] = &[
-                        "execution reverted",
-                        "invalid jump destination",
-                        "invalid opcode",
-                        // Ethereum says 1024 is the stack sizes limit, so this is deterministic.
-                        "stack limit reached 1024",
-                    ];
+                        // Deterministic Geth execution errors. We might need to expand this as
+                        // subgraphs come across other errors. See
+                        // https://github.com/ethereum/go-ethereum/blob/cd57d5cd38ef692de8fbedaa56598b4e9fbfbabc/core/vm/errors.go
+                        const GETH_EXECUTION_ERRORS: &[&str] = &[
+                            "execution reverted",
+                            "invalid jump destination",
+                            "invalid opcode",
+                            // Ethereum says 1024 is the stack sizes limit, so this is deterministic.
+                            "stack limit reached 1024",
+                        ];
 
-                    let as_solidity_revert_with_reason = |bytes: &[u8]| {
-                        let solidity_revert_function_selector =
-                            &tiny_keccak::keccak256(b"Error(string)")[..4];
+                        let as_solidity_revert_with_reason = |bytes: &[u8]| {
+                            let solidity_revert_function_selector =
+                                &tiny_keccak::keccak256(b"Error(string)")[..4];
 
-                        match bytes.len() >= 4 && &bytes[..4] == solidity_revert_function_selector {
-                            false => None,
-                            true => ethabi::decode(&[ParamType::String], &bytes[4..])
-                                .ok()
-                                .and_then(|tokens| tokens[0].clone().to_string()),
-                        }
-                    };
-
-                    match result {
-                        // A successful response.
-                        Ok(bytes) => Ok(bytes),
-
-                        // Check for Geth revert.
-                        Err(web3::Error::Rpc(rpc_error))
-                            if GETH_EXECUTION_ERRORS
-                                .iter()
-                                .any(|e| rpc_error.message.contains(e)) =>
-                        {
-                            Err(EthereumContractCallError::Revert(rpc_error.message))
-                        }
-
-                        // Check for Parity revert.
-                        Err(web3::Error::Rpc(ref rpc_error))
-                            if rpc_error.code.code() == PARITY_VM_EXECUTION_ERROR =>
-                        {
-                            match rpc_error.data.as_ref().and_then(|d| d.as_str()) {
-                                Some(data)
-                                    if data.starts_with(PARITY_REVERT_PREFIX)
-                                        || data.starts_with(PARITY_BAD_JUMP_PREFIX)
-                                        || data.starts_with(PARITY_STACK_LIMIT_PREFIX)
-                                        || data == PARITY_BAD_INSTRUCTION_FE
-                                        || data == PARITY_BAD_INSTRUCTION_FD =>
-                                {
-                                    let reason = if data == PARITY_BAD_INSTRUCTION_FE {
-                                        PARITY_BAD_INSTRUCTION_FE.to_owned()
-                                    } else {
-                                        let payload = data.trim_start_matches(PARITY_REVERT_PREFIX);
-                                        hex::decode(payload)
-                                            .ok()
-                                            .and_then(|payload| {
-                                                as_solidity_revert_with_reason(&payload)
-                                            })
-                                            .unwrap_or("no reason".to_owned())
-                                    };
-                                    Err(EthereumContractCallError::Revert(reason))
-                                }
-
-                                // The VM execution error was not identified as a revert.
-                                _ => Err(EthereumContractCallError::Web3Error(web3::Error::Rpc(
-                                    rpc_error.clone(),
-                                ))),
+                            match bytes.len() >= 4
+                                && &bytes[..4] == solidity_revert_function_selector
+                            {
+                                false => None,
+                                true => ethabi::decode(&[ParamType::String], &bytes[4..])
+                                    .ok()
+                                    .and_then(|tokens| tokens[0].clone().into_string()),
                             }
-                        }
+                        };
 
-                        // Check for Ganache revert.
-                        Err(web3::Error::Rpc(ref rpc_error))
-                            if rpc_error.code.code() == GANACHE_VM_EXECUTION_ERROR
-                                && rpc_error.message.starts_with(GANACHE_REVERT_MESSAGE) =>
-                        {
-                            Err(EthereumContractCallError::Revert(rpc_error.message.clone()))
-                        }
+                        match result {
+                            // A successful response.
+                            Ok(bytes) => Ok(bytes),
 
-                        // The error was not identified as a revert.
-                        Err(err) => Err(EthereumContractCallError::Web3Error(err)),
-                    }
-                })
+                            // Check for Geth revert.
+                            Err(web3::Error::Rpc(rpc_error))
+                                if GETH_EXECUTION_ERRORS
+                                    .iter()
+                                    .any(|e| rpc_error.message.contains(e)) =>
+                            {
+                                Err(EthereumContractCallError::Revert(rpc_error.message))
+                            }
+
+                            // Check for Parity revert.
+                            Err(web3::Error::Rpc(ref rpc_error))
+                                if rpc_error.code.code() == PARITY_VM_EXECUTION_ERROR =>
+                            {
+                                match rpc_error.data.as_ref().and_then(|d| d.as_str()) {
+                                    Some(data)
+                                        if data.starts_with(PARITY_REVERT_PREFIX)
+                                            || data.starts_with(PARITY_BAD_JUMP_PREFIX)
+                                            || data.starts_with(PARITY_STACK_LIMIT_PREFIX)
+                                            || data == PARITY_BAD_INSTRUCTION_FE
+                                            || data == PARITY_BAD_INSTRUCTION_FD =>
+                                    {
+                                        let reason = if data == PARITY_BAD_INSTRUCTION_FE {
+                                            PARITY_BAD_INSTRUCTION_FE.to_owned()
+                                        } else {
+                                            let payload =
+                                                data.trim_start_matches(PARITY_REVERT_PREFIX);
+                                            hex::decode(payload)
+                                                .ok()
+                                                .and_then(|payload| {
+                                                    as_solidity_revert_with_reason(&payload)
+                                                })
+                                                .unwrap_or("no reason".to_owned())
+                                        };
+                                        Err(EthereumContractCallError::Revert(reason))
+                                    }
+
+                                    // The VM execution error was not identified as a revert.
+                                    _ => Err(EthereumContractCallError::Web3Error(
+                                        web3::Error::Rpc(rpc_error.clone()),
+                                    )),
+                                }
+                            }
+
+                            // Check for Ganache revert.
+                            Err(web3::Error::Rpc(ref rpc_error))
+                                if rpc_error.code.code() == GANACHE_VM_EXECUTION_ERROR
+                                    && rpc_error.message.starts_with(GANACHE_REVERT_MESSAGE) =>
+                            {
+                                Err(EthereumContractCallError::Revert(rpc_error.message.clone()))
+                            }
+
+                            // The error was not identified as a revert.
+                            Err(err) => Err(EthereumContractCallError::Web3Error(err)),
+                        }
+                    })
             })
             .map_err(|e| e.into_inner().unwrap_or(EthereumContractCallError::Timeout))
     }
@@ -569,8 +574,8 @@ where
                 .limit(*REQUEST_RETRIES)
                 .timeout_secs(*JSON_RPC_TIMEOUT)
                 .run(move || {
-                    web3.eth()
-                        .block_with_txs(BlockId::Hash(hash))
+                    Box::pin(web3.eth().block_with_txs(BlockId::Hash(hash)))
+                        .compat()
                         .from_err::<Error>()
                         .and_then(move |block| {
                             block.ok_or_else(|| {
@@ -599,14 +604,17 @@ where
                 .no_limit()
                 .timeout_secs(*JSON_RPC_TIMEOUT)
                 .run(move || {
-                    web3.eth()
-                        .block(BlockId::Number(Web3BlockNumber::Number(block_num.into())))
-                        .from_err::<Error>()
-                        .and_then(move |block| {
-                            block.ok_or_else(|| {
-                                anyhow!("Ethereum node did not find block {:?}", block_num)
-                            })
+                    Box::pin(
+                        web3.eth()
+                            .block(BlockId::Number(Web3BlockNumber::Number(block_num.into()))),
+                    )
+                    .compat()
+                    .from_err::<Error>()
+                    .and_then(move |block| {
+                        block.ok_or_else(|| {
+                            anyhow!("Ethereum node did not find block {:?}", block_num)
                         })
+                    })
                 })
                 .from_err()
         }))
@@ -637,25 +645,26 @@ where
         let net_version_future = retry("net_version RPC call", &logger)
             .no_limit()
             .timeout_secs(20)
-            .run(move || web3.net().version().from_err());
+            .run(move || Box::pin(web3.net().version()).compat().from_err());
 
         let web3 = self.web3.clone();
         let gen_block_hash_future = retry("eth_getBlockByNumber(0, false) RPC call", &logger)
             .no_limit()
             .timeout_secs(30)
             .run(move || {
-                web3.eth()
-                    .block(BlockId::Number(Web3BlockNumber::Number(0.into())))
-                    .from_err()
-                    .and_then(|gen_block_opt| {
-                        future::result(
-                            gen_block_opt
-                                .and_then(|gen_block| gen_block.hash)
-                                .ok_or_else(|| {
-                                    anyhow!("Ethereum node could not find genesis block")
-                                }),
-                        )
-                    })
+                Box::pin(
+                    web3.eth()
+                        .block(BlockId::Number(Web3BlockNumber::Number(0.into()))),
+                )
+                .compat()
+                .from_err()
+                .and_then(|gen_block_opt| {
+                    future::result(
+                        gen_block_opt
+                            .and_then(|gen_block| gen_block.hash)
+                            .ok_or_else(|| anyhow!("Ethereum node could not find genesis block")),
+                    )
+                })
             });
 
         net_version_future
@@ -686,15 +695,19 @@ where
                 .no_limit()
                 .timeout_secs(*JSON_RPC_TIMEOUT)
                 .run(move || {
-                    web3.eth()
-                        .block(Web3BlockNumber::Latest.into())
-                        .map_err(|e| anyhow!("could not get latest block from Ethereum: {}", e))
-                        .from_err()
-                        .and_then(|block_opt| {
-                            block_opt.ok_or_else(|| {
-                                anyhow!("no latest block returned from Ethereum").into()
-                            })
-                        })
+                    Box::pin(
+                        web3.eth()
+                            .block(Web3BlockNumber::Latest.into())
+                            .map_err(|e| {
+                                anyhow!("could not get latest block from Ethereum: {}", e)
+                            }),
+                    )
+                    .compat()
+                    .from_err()
+                    .and_then(|block_opt| {
+                        block_opt
+                            .ok_or_else(|| anyhow!("no latest block returned from Ethereum").into())
+                    })
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
@@ -716,15 +729,19 @@ where
                 .no_limit()
                 .timeout_secs(*JSON_RPC_TIMEOUT)
                 .run(move || {
-                    web3.eth()
-                        .block_with_txs(Web3BlockNumber::Latest.into())
-                        .map_err(|e| anyhow!("could not get latest block from Ethereum: {}", e))
-                        .from_err()
-                        .and_then(|block_opt| {
-                            block_opt.ok_or_else(|| {
-                                anyhow!("no latest block returned from Ethereum").into()
-                            })
-                        })
+                    Box::pin(
+                        web3.eth()
+                            .block_with_txs(Web3BlockNumber::Latest.into())
+                            .map_err(|e| {
+                                anyhow!("could not get latest block from Ethereum: {}", e)
+                            }),
+                    )
+                    .compat()
+                    .from_err()
+                    .and_then(|block_opt| {
+                        block_opt
+                            .ok_or_else(|| anyhow!("no latest block returned from Ethereum").into())
+                    })
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
@@ -765,8 +782,8 @@ where
                 .limit(*REQUEST_RETRIES)
                 .timeout_secs(*JSON_RPC_TIMEOUT)
                 .run(move || {
-                    web3.eth()
-                        .block_with_txs(BlockId::Hash(block_hash))
+                    Box::pin(web3.eth().block_with_txs(BlockId::Hash(block_hash)))
+                        .compat()
                         .from_err()
                 })
                 .map_err(move |e| {
@@ -790,9 +807,12 @@ where
                 .no_limit()
                 .timeout_secs(*JSON_RPC_TIMEOUT)
                 .run(move || {
-                    web3.eth()
-                        .block_with_txs(BlockId::Number(block_number.into()))
-                        .from_err()
+                    Box::pin(
+                        web3.eth()
+                            .block_with_txs(BlockId::Number(block_number.into())),
+                    )
+                    .compat()
+                    .from_err()
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
@@ -843,9 +863,8 @@ where
                             let logger = logger.clone();
                             let tx_hash = tx.hash;
 
-                            batching_web3
-                                .eth()
-                                .transaction_receipt(tx_hash)
+                            Box::pin(batching_web3.eth().transaction_receipt(tx_hash))
+                                .compat()
                                 .from_err()
                                 .map_err(EthereumAdapterError::Unknown)
                                 .and_then(move |receipt_opt| {
@@ -899,9 +918,8 @@ where
                         })
                         .collect::<Vec<_>>();
 
-                    batching_web3
-                        .transport()
-                        .submit_batch()
+                    Box::pin(batching_web3.transport().submit_batch())
+                        .compat()
                         .from_err()
                         .map_err(EthereumAdapterError::Unknown)
                         .and_then(move |_| {
@@ -1001,8 +1019,8 @@ where
                     .no_limit()
                     .timeout_secs(*JSON_RPC_TIMEOUT)
                     .run(move || {
-                        web3.eth()
-                            .block(BlockId::Number(block_number.into()))
+                        Box::pin(web3.eth().block(BlockId::Number(block_number.into())))
+                            .compat()
                             .from_err()
                             .map(|block_opt| block_opt.map(|block| block.hash).flatten())
                     })
@@ -1046,8 +1064,8 @@ where
                     .no_limit()
                     .timeout_secs(60)
                     .run(move || {
-                        web3.eth()
-                            .uncle(block_hash.clone().into(), index.into())
+                        Box::pin(web3.eth().uncle(block_hash.clone().into(), index.into()))
+                            .compat()
                             .map_err(move |e| {
                                 anyhow!(
                                     "could not get uncle {} for block {:?} ({} uncles): {}",

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -11,4 +11,4 @@ mod transport;
 pub use self::block_ingestor::{BlockIngestor, BlockIngestorMetrics, CLEANUP_BLOCKS};
 pub use self::block_stream::{BlockStream, BlockStreamBuilder};
 pub use self::ethereum_adapter::EthereumAdapter;
-pub use self::transport::{EventLoopHandle, Transport};
+pub use self::transport::Transport;

--- a/chain/ethereum/src/transport.rs
+++ b/chain/ethereum/src/transport.rs
@@ -1,12 +1,11 @@
 use jsonrpc_core::types::Call;
-use serde_json::Value;
-use std::env;
+use jsonrpc_core::Value;
 
-pub use web3::transports::EventLoopHandle;
 use web3::transports::{http, ipc, ws};
 use web3::RequestId;
 
 use graph::prelude::*;
+use std::future::Future;
 
 use super::config::ETHEREUM_CONFIG;
 
@@ -20,16 +19,18 @@ pub enum Transport {
 
 impl Transport {
     /// Creates an IPC transport.
-    pub fn new_ipc(ipc: &str) -> (EventLoopHandle, Self) {
+    pub async fn new_ipc(ipc: &str) -> Self {
         ipc::Ipc::new(ipc)
-            .map(|(event_loop, transport)| (event_loop, Transport::IPC(transport)))
+            .await
+            .map(|transport| Transport::IPC(transport))
             .expect("Failed to connect to Ethereum IPC")
     }
 
     /// Creates a WebSocket transport.
-    pub fn new_ws(ws: &str) -> (EventLoopHandle, Self) {
+    pub async fn new_ws(ws: &str) -> Self {
         ws::WebSocket::new(ws)
-            .map(|(event_loop, transport)| (event_loop, Transport::WS(transport)))
+            .await
+            .map(|transport| Transport::WS(transport))
             .expect("Failed to connect to Ethereum WS")
     }
 
@@ -37,22 +38,18 @@ impl Transport {
     ///
     /// Note: JSON-RPC over HTTP doesn't always support subscribing to new
     /// blocks (one such example is Infura's HTTP endpoint).
-    pub fn new_rpc(rpc: &str) -> (EventLoopHandle, Self) {
-        let max_parallel_http: usize = env::var_os("ETHEREUM_RPC_MAX_PARALLEL_REQUESTS")
-            .map(|s| s.to_str().unwrap().parse().unwrap())
-            .unwrap_or(64);
-
+    pub fn new_rpc(rpc: &str) -> Self {
         let cfg = ETHEREUM_CONFIG.rpc.get(rpc);
         let headers = cfg.map(|cfg| cfg.http_headers.clone()).unwrap_or_default();
 
-        http::Http::with_max_parallel_and_headers(rpc, max_parallel_http, headers)
-            .map(|(event_loop, transport)| (event_loop, Transport::RPC(transport)))
+        http::Http::with_headers(rpc, headers)
+            .map(|transport| Transport::RPC(transport))
             .expect("Failed to connect to Ethereum RPC")
     }
 }
 
 impl web3::Transport for Transport {
-    type Out = Box<dyn Future<Item = Value, Error = web3::error::Error> + Send>;
+    type Out = Box<dyn Future<Output = Result<Value, web3::error::Error>> + Send + Unpin>;
 
     fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {
         match self {
@@ -73,8 +70,9 @@ impl web3::Transport for Transport {
 
 impl web3::BatchTransport for Transport {
     type Batch = Box<
-        dyn Future<Item = Vec<Result<Value, web3::error::Error>>, Error = web3::error::Error>
-            + Send,
+        dyn Future<Output = Result<Vec<Result<Value, web3::error::Error>>, web3::error::Error>>
+            + Send
+            + Unpin,
     >;
 
     fn send_batch<T>(&self, requests: T) -> Self::Batch

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -15,13 +15,7 @@ chrono = "0.4.19"
 Inflector = "0.11.3"
 isatty = "0.1.9"
 reqwest = { version = "0.11.2", features = ["json", "stream", "multipart"] }
-
-# master contains changes such as
-# https://github.com/paritytech/ethabi/pull/140, which upstream does not want
-# and we should try to implement on top of ethabi instead of inside it, and
-# tuple support which isn't upstreamed yet. For now, we shall deviate from
-# ethabi, but long term we want to find a way to drop our fork.
-ethabi = { git = "https://github.com/graphprotocol/ethabi.git", branch = "master" }
+ethabi = "14.0"
 hex = "0.4.3"
 http = "0.2.3"
 futures = "0.1.21"
@@ -57,8 +51,9 @@ wasmparser = "0.77.0"
 thiserror = "1.0.24"
 parking_lot = "0.11.1"
 
-# Our fork contains a small but hacky patch.
-web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "master" }
+# Our fork contains patches for custom http headers and to make some block fields optional.
+# Without the "arbitrary_precision" feature, we get the error `data did not match any variant of untagged enum Response`.
+web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "leo/test-rebase-upstream-master", features = ["arbitrary_precision"] }
 
 [dev-dependencies]
 test-store = { path = "../store/test-store" }

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -380,7 +380,7 @@ impl From<&'_ Transaction> for EthereumTransactionData {
         EthereumTransactionData {
             hash: tx.hash,
             index: tx.transaction_index.unwrap().as_u64().into(),
-            from: tx.from,
+            from: tx.from.unwrap(),
             to: tx.to,
             value: tx.value,
             gas_used: tx.gas,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -540,15 +540,11 @@ async fn create_ethereum_networks(
 
             use crate::config::Transport::*;
 
-            let (transport_event_loop, transport) = match provider.transport {
+            let transport = match provider.transport {
                 Rpc => Transport::new_rpc(&provider.url),
-                Ipc => Transport::new_ipc(&provider.url),
-                Ws => Transport::new_ws(&provider.url),
+                Ipc => Transport::new_ipc(&provider.url).await,
+                Ws => Transport::new_ws(&provider.url).await,
             };
-
-            // If we drop the event loop the transport will stop working.
-            // For now it's fine to just leak it.
-            std::mem::forget(transport_event_loop);
 
             let supports_eip_1898 = !provider.features.contains("no_eip1898");
 

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.48"
 atomic_refcell = "0.1.7"
-ethabi = { git = "https://github.com/graphprotocol/ethabi.git", branch = "master" }
+ethabi = "14.0"
 futures = "0.1.21"
 hex = "0.4.3"
 graph = { path = "../../graph" }


### PR DESCRIPTION
I've rebased web3 to the upstream master in the `leo/test-rebase-upstream-master` branch, if this change is successful that can be made the new master. The primary goal is to have web3 use tokio 1.0, mixing tokio 1.0 with 0.1 might be the potential cause of the deadlocks we're seeing after upgrading to tokio 1.0. Our ethabi patches have been upstreamed (thanks @vkgnosis), so we can switch back to upstream ethabi.

This leaves the jsonrpc server as the only outdated tokio, which is sufficiently isolated to not cause problems.

Read with whitespace diff disabled.