### PR TITLE
node: Have `graphman` override configured pool sizes

### DIFF
--- a/graph/src/components/ethereum/network.rs
+++ b/graph/src/components/ethereum/network.rs
@@ -115,6 +115,11 @@ impl EthereumNetworkAdapters {
             .next()
             .map(|ethereum_network_adapter| &ethereum_network_adapter.adapter)
     }
+
+    pub fn remove(&mut self, provider: &str) {
+        self.adapters
+            .retain(|adapter| adapter.adapter.provider() != provider);
+    }
 }
 
 #[derive(Clone)]
@@ -143,6 +148,12 @@ impl EthereumNetworks {
             capabilities,
             adapter: adapter.clone(),
         });
+    }
+
+    pub fn remove(&mut self, name: &str, provider: &str) {
+        if let Some(adapters) = self.networks.get_mut(name) {
+            adapters.remove(provider);
+        }
     }
 
     pub fn extend(&mut self, other_networks: EthereumNetworks) {


### PR DESCRIPTION
In general, we don't want graphman to use the configured pool size to
reduce the risk of running out of database handles. Instead, `graphman`
uses a pool size of 3 by default for everything which should be plenty for
its purposes

I also tacked a small logging change that should make it easier to understand when we skip creating a block ingestor onto the PR
