### PR TITLE
chain head listener: Use separate watchers per chain

### DIFF
--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -148,7 +148,7 @@ where
     S: SubgraphStore,
     C: ChainStore,
 {
-    pub fn new(
+    pub async fn new(
         subgraph_store: Arc<S>,
         chain_store: Arc<C>,
         eth_adapter: Arc<dyn EthereumAdapter>,
@@ -166,7 +166,7 @@ where
         BlockStream {
             state: BlockStreamState::BeginReconciliation,
             consecutive_err_count: 0,
-            chain_head_update_stream: chain_store.chain_head_updates(),
+            chain_head_update_stream: chain_store.chain_head_updates().await,
             ctx: BlockStreamContext {
                 subgraph_store,
                 chain_store,
@@ -788,6 +788,7 @@ where
     }
 }
 
+#[async_trait]
 impl<S, B, M> BlockStreamBuilderTrait for BlockStreamBuilder<S, B, M>
 where
     S: SubgraphStore,
@@ -796,7 +797,7 @@ where
 {
     type Stream = BlockStream<S, B::ChainStore>;
 
-    fn build(
+    async fn build(
         &self,
         logger: Logger,
         deployment_id: SubgraphDeploymentId,
@@ -850,6 +851,7 @@ where
             logger,
             metrics,
         )
+        .await
     }
 }
 

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -501,6 +501,7 @@ where
                 ctx.inputs.include_calls_in_blocks,
                 ctx.block_stream_metrics.clone(),
             )
+            .await
             .map_err(CancelableError::Error)
             .cancelable(&block_stream_canceler, || CancelableError::Cancel)
             .compat();

--- a/graph/src/components/ethereum/listener.rs
+++ b/graph/src/components/ethereum/listener.rs
@@ -25,8 +25,3 @@ pub struct ChainHeadUpdate {
 /// The updates have no payload, receivers should call `Store::chain_head_ptr`
 /// to check what the latest block is.
 pub type ChainHeadUpdateStream = Box<dyn Stream<Item = (), Error = ()> + Send>;
-
-pub trait ChainHeadUpdateListener {
-    // Subscribe to chain head updates for the given network.
-    fn subscribe(&self, network: String) -> ChainHeadUpdateStream;
-}

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -11,7 +11,7 @@ pub use self::adapter::{
     EthereumContractStateRequest, EthereumLogFilter, EthereumNetworkIdentifier,
     MockEthereumAdapter, ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
 };
-pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpdateStream};
+pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateStream};
 pub use self::network::{EthereumNetworkAdapters, EthereumNetworks, NodeCapabilities};
 pub use self::stream::{BlockStream, BlockStreamBuilder, BlockStreamEvent};
 pub use self::types::{

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -10,10 +10,12 @@ pub enum BlockStreamEvent {
 
 pub trait BlockStream: Stream<Item = BlockStreamEvent, Error = Error> {}
 
+#[async_trait]
+
 pub trait BlockStreamBuilder: Clone + Send + Sync + 'static {
     type Stream: BlockStream + Send + 'static;
 
-    fn build(
+    async fn build(
         &self,
         logger: Logger,
         deployment_id: SubgraphDeploymentId,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1238,6 +1238,7 @@ pub trait CallCache: Send + Sync + 'static {
 
 /// Common trait for blockchain store implementations.
 #[automock]
+#[async_trait]
 pub trait ChainStore: Send + Sync + 'static {
     /// Get a pointer to this blockchain's genesis block.
     fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error>;
@@ -1276,7 +1277,7 @@ pub trait ChainStore: Send + Sync + 'static {
     fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error>;
 
     /// Subscribe to chain head updates.
-    fn chain_head_updates(&self) -> ChainHeadUpdateStream;
+    async fn chain_head_updates(&self) -> ChainHeadUpdateStream;
 
     /// Get the current head block pointer for this chain.
     /// Any changes to the head block pointer will be to a block with a larger block number, never

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -81,13 +81,13 @@ pub mod prelude {
 
     pub use crate::components::ethereum::{
         BlockFinality, BlockStream, BlockStreamBuilder, BlockStreamEvent, BlockStreamMetrics,
-        ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpdateStream, EthereumAdapter,
-        EthereumAdapterError, EthereumBlock, EthereumBlockData, EthereumBlockFilter,
-        EthereumBlockPointer, EthereumBlockTriggerType, EthereumBlockWithCalls,
-        EthereumBlockWithTriggers, EthereumCall, EthereumCallData, EthereumCallFilter,
-        EthereumContractCall, EthereumContractCallError, EthereumEventData, EthereumLogFilter,
-        EthereumNetworkIdentifier, EthereumTransactionData, EthereumTrigger, LightEthereumBlock,
-        LightEthereumBlockExt, MappingTrigger, ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
+        ChainHeadUpdate, ChainHeadUpdateStream, EthereumAdapter, EthereumAdapterError,
+        EthereumBlock, EthereumBlockData, EthereumBlockFilter, EthereumBlockPointer,
+        EthereumBlockTriggerType, EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall,
+        EthereumCallData, EthereumCallFilter, EthereumContractCall, EthereumContractCallError,
+        EthereumEventData, EthereumLogFilter, EthereumNetworkIdentifier, EthereumTransactionData,
+        EthereumTrigger, LightEthereumBlock, LightEthereumBlockExt, MappingTrigger,
+        ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
     };
     pub use crate::components::graphql::{
         GraphQlRunner, QueryLoadManager, SubscriptionResultFuture,

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -44,10 +44,11 @@ impl MockBlockStreamBuilder {
     }
 }
 
+#[async_trait]
 impl BlockStreamBuilder for MockBlockStreamBuilder {
     type Stream = MockBlockStream;
 
-    fn build(
+    async fn build(
         &self,
         _logger: Logger,
         _deployment_id: SubgraphDeploymentId,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -19,6 +19,7 @@ mock! {
         fn network_name(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Option<String>, StoreError>;
     }
 
+    #[async_trait]
     trait ChainStore: Send + Sync + 'static {
         fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error>;
 
@@ -32,7 +33,7 @@ mock! {
 
         fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error>;
 
-        fn chain_head_updates(&self) -> ChainHeadUpdateStream;
+        async fn chain_head_updates(&self) -> ChainHeadUpdateStream;
 
         fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error>;
 

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -10,14 +10,14 @@ use diesel::sql_types::Text;
 use diesel::{insert_into, update};
 
 use graph::ensure;
+use graph::prelude::async_trait;
 use std::sync::Arc;
 use std::{collections::HashMap, convert::TryFrom};
 use std::{convert::TryInto, iter::FromIterator};
 
 use graph::prelude::{
-    web3::types::H256, BlockNumber, ChainHeadUpdateListener as _, ChainHeadUpdateStream, Error,
-    EthereumBlock, EthereumBlockPointer, EthereumNetworkIdentifier, Future, LightEthereumBlock,
-    Stream,
+    web3::types::H256, BlockNumber, ChainHeadUpdateStream, Error, EthereumBlock,
+    EthereumBlockPointer, EthereumNetworkIdentifier, Future, LightEthereumBlock, Stream,
 };
 
 use crate::{
@@ -1161,6 +1161,7 @@ impl ChainStore {
     }
 }
 
+#[async_trait]
 impl ChainStoreTrait for ChainStore {
     fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error> {
         Ok(self.genesis_block_ptr.clone())
@@ -1234,9 +1235,10 @@ impl ChainStoreTrait for ChainStore {
         Ok(missing)
     }
 
-    fn chain_head_updates(&self) -> ChainHeadUpdateStream {
+    async fn chain_head_updates(&self) -> ChainHeadUpdateStream {
         self.chain_head_update_listener
             .subscribe(self.chain.to_owned())
+            .await
     }
 
     fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error> {


### PR DESCRIPTION
As I've been able to reproduce locally, under a sufficent load of concurrent subgraphs and with many fast networks connected, there is a high probability of the mainnet chain head update being overwritten with that of another network before all subgraphs can read the update, to the point where the subgraphs can seem deadlocked. So this may very well be the cause for the subgraph deadlocks observed in prod.

The important change is in `chain_head_listener.rs`, which now demultiplexes the DB notifications into one watcher per network. This also does a bit of modernizing in `store_events.rs` and `notification_listener.rs` to use more of tokio 1.0 and futures 0.3.