### PR TITLE
chain head listener: Fix race condition

### DIFF
--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -148,7 +148,7 @@ where
     S: SubgraphStore,
     C: ChainStore,
 {
-    pub async fn new(
+    pub fn new(
         subgraph_store: Arc<S>,
         chain_store: Arc<C>,
         eth_adapter: Arc<dyn EthereumAdapter>,
@@ -166,7 +166,7 @@ where
         BlockStream {
             state: BlockStreamState::BeginReconciliation,
             consecutive_err_count: 0,
-            chain_head_update_stream: chain_store.chain_head_updates().await,
+            chain_head_update_stream: chain_store.chain_head_updates(),
             ctx: BlockStreamContext {
                 subgraph_store,
                 chain_store,
@@ -797,7 +797,7 @@ where
 {
     type Stream = BlockStream<S, B::ChainStore>;
 
-    async fn build(
+    fn build(
         &self,
         logger: Logger,
         deployment_id: SubgraphDeploymentId,
@@ -851,7 +851,6 @@ where
             logger,
             metrics,
         )
-        .await
     }
 }
 

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -501,7 +501,6 @@ where
                 ctx.inputs.include_calls_in_blocks,
                 ctx.block_stream_metrics.clone(),
             )
-            .await
             .map_err(CancelableError::Error)
             .cancelable(&block_stream_canceler, || CancelableError::Cancel)
             .compat();

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -10,12 +10,10 @@ pub enum BlockStreamEvent {
 
 pub trait BlockStream: Stream<Item = BlockStreamEvent, Error = Error> {}
 
-#[async_trait]
-
 pub trait BlockStreamBuilder: Clone + Send + Sync + 'static {
     type Stream: BlockStream + Send + 'static;
 
-    async fn build(
+    fn build(
         &self,
         logger: Logger,
         deployment_id: SubgraphDeploymentId,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1277,7 +1277,7 @@ pub trait ChainStore: Send + Sync + 'static {
     fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error>;
 
     /// Subscribe to chain head updates.
-    async fn chain_head_updates(&self) -> ChainHeadUpdateStream;
+    fn chain_head_updates(&self) -> ChainHeadUpdateStream;
 
     /// Get the current head block pointer for this chain.
     /// Any changes to the head block pointer will be to a block with a larger block number, never

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -31,6 +31,7 @@ pub use task_spawn::{
 };
 
 pub use bytes;
+pub use parking_lot;
 pub use prometheus;
 pub use semver;
 pub use stable_hash;

--- a/mock/src/block_stream.rs
+++ b/mock/src/block_stream.rs
@@ -44,11 +44,10 @@ impl MockBlockStreamBuilder {
     }
 }
 
-#[async_trait]
 impl BlockStreamBuilder for MockBlockStreamBuilder {
     type Stream = MockBlockStream;
 
-    async fn build(
+    fn build(
         &self,
         _logger: Logger,
         _deployment_id: SubgraphDeploymentId,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -33,7 +33,7 @@ mock! {
 
         fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error>;
 
-        async fn chain_head_updates(&self) -> ChainHeadUpdateStream;
+        fn chain_head_updates(&self) -> ChainHeadUpdateStream;
 
         fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error>;
 

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -1235,10 +1235,9 @@ impl ChainStoreTrait for ChainStore {
         Ok(missing)
     }
 
-    async fn chain_head_updates(&self) -> ChainHeadUpdateStream {
+    fn chain_head_updates(&self) -> ChainHeadUpdateStream {
         self.chain_head_update_listener
             .subscribe(self.chain.to_owned())
-            .await
     }
 
     fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error> {


### PR DESCRIPTION
This is a correction to #2365. There is a race condition in the `else` branch where the watcher could be overwritten, and a subscriber might end up with a receiver that has no sender and would error.

This keeps it simple by using a Mutex, and switching to a sync Mutex since that's what tokio recommends for short critical sections.