### PR TITLE
Chunk application of entity modifications

### DIFF
--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -311,11 +311,7 @@ impl DeploymentStore {
             }
         }
 
-        // Apply modification groups:
-        // Each operation must respect the maximum number of bindings allowed in PostgreSQL queries,
-        // so we need to act in chunks whose size is defined by the number of entities times the
-        // number of attributes each entity type has.
-
+        // Apply modification groups.
         // Inserts:
         for (entity_type, mut entities) in inserts.into_iter() {
             count +=

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -38,7 +38,7 @@ use crate::relational_queries::FromEntityData;
 use crate::{connection_pool::ConnectionPool, detail};
 use crate::{dynds, primary::Site};
 
-const POSTGRES_MAX_BINDINGS_PER_STATEMENT: usize = u16::MAX as usize; // 65535
+const POSTGRES_MAX_PARAMETERS: usize = u16::MAX as usize; // 65535
 
 /// When connected to read replicas, this allows choosing which DB server to use for an operation.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -322,7 +322,7 @@ impl DeploymentStore {
         for (entity_type, mut entities) in inserts.into_iter() {
             let chunk_size = {
                 let num_fields = (*entities[0].1).len();
-                POSTGRES_MAX_BINDINGS_PER_STATEMENT / num_fields
+                POSTGRES_MAX_PARAMETERS / num_fields
             };
             for chunk in entities.chunks_mut(chunk_size) {
                 count +=
@@ -334,7 +334,7 @@ impl DeploymentStore {
         for (entity_type, mut entities) in overwrites.into_iter() {
             let chunk_size = {
                 let num_fields = (*entities[0].1).len();
-                POSTGRES_MAX_BINDINGS_PER_STATEMENT / num_fields
+                POSTGRES_MAX_PARAMETERS / num_fields
             };
             for chunk in entities.chunks_mut(chunk_size) {
                 // we do not update the count since the number of entities remains the same
@@ -344,7 +344,7 @@ impl DeploymentStore {
 
         // Removals
         for (entity_type, entity_keys) in removals.into_iter() {
-            let chunk_size = POSTGRES_MAX_BINDINGS_PER_STATEMENT / entity_keys.len(); // only ID is bound
+            let chunk_size = POSTGRES_MAX_PARAMETERS / entity_keys.len(); // only ID is bound
             for chunk in entity_keys.chunks(chunk_size) {
                 count -= self.remove_entities(&entity_type, chunk, conn, layout, ptr, &stopwatch)?
                     as i32;

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -565,7 +565,7 @@ impl Layout {
         &self,
         conn: &PgConnection,
         entity_type: &EntityType,
-        entities: &mut Vec<(EntityKey, Entity)>,
+        entities: &mut [(EntityKey, Entity)],
         block: BlockNumber,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
@@ -670,8 +670,8 @@ impl Layout {
     pub fn update(
         &self,
         conn: &PgConnection,
-        entity_type: EntityType,
-        mut entities: Vec<(EntityKey, Entity)>,
+        entity_type: &EntityType,
+        entities: &mut [(EntityKey, Entity)],
         block: BlockNumber,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
@@ -684,14 +684,14 @@ impl Layout {
         ClampRangeQuery::new(table, &entity_type, &entity_keys, block).execute(conn)?;
         section.end();
         let _section = stopwatch.start_section("update_modification_insert_query");
-        Ok(InsertQuery::new(table, &mut entities, block)?.execute(conn)?)
+        Ok(InsertQuery::new(table, entities, block)?.execute(conn)?)
     }
 
     pub fn delete(
         &self,
         conn: &PgConnection,
         entity_type: &EntityType,
-        entity_ids: &Vec<String>,
+        entity_ids: &[String],
         block: BlockNumber,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -574,7 +574,10 @@ impl Layout {
         let table = self.table_for_entity(entity_type)?;
         let _section = stopwatch.start_section("insert_modification_insert_query");
         let mut count = 0;
-        // we add 1 to account for the `block_range` bind parameter
+        // Each operation must respect the maximum number of bindings allowed in PostgreSQL queries,
+        // so we need to act in chunks whose size is defined by the number of entities times the
+        // number of attributes each entity type has.
+        // We add 1 to account for the `block_range` bind parameter
         let chunk_size = POSTGRES_MAX_PARAMETERS / (table.columns.len() + 1);
         for chunk in entities.chunks_mut(chunk_size) {
             count += InsertQuery::new(table, chunk, block)?
@@ -695,7 +698,11 @@ impl Layout {
 
         let _section = stopwatch.start_section("update_modification_insert_query");
         let mut count = 0;
-        // we add 1 to account for the `block_range` bind parameter
+
+        // Each operation must respect the maximum number of bindings allowed in PostgreSQL queries,
+        // so we need to act in chunks whose size is defined by the number of entities times the
+        // number of attributes each entity type has.
+        // We add 1 to account for the `block_range` bind parameter
         let chunk_size = POSTGRES_MAX_PARAMETERS / (table.columns.len() + 1);
         for chunk in entities.chunks_mut(chunk_size) {
             count += InsertQuery::new(table, chunk, block)?.execute(conn)?;

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -574,8 +574,8 @@ impl Layout {
         let table = self.table_for_entity(entity_type)?;
         let _section = stopwatch.start_section("insert_modification_insert_query");
         let mut count = 0;
-        // we add 1 to account for `block_range` bind parameter
-        let chunk_size = (POSTGRES_MAX_PARAMETERS / table.columns.len()) + 1;
+        // we add 1 to account for the `block_range` bind parameter
+        let chunk_size = POSTGRES_MAX_PARAMETERS / (table.columns.len() + 1);
         for chunk in entities.chunks_mut(chunk_size) {
             count += InsertQuery::new(table, chunk, block)?
                 .get_results(conn)
@@ -695,8 +695,8 @@ impl Layout {
 
         let _section = stopwatch.start_section("update_modification_insert_query");
         let mut count = 0;
-        // we add 1 to account for `block_range` bind parameter
-        let chunk_size = (POSTGRES_MAX_PARAMETERS / table.columns.len()) + 1;
+        // we add 1 to account for the `block_range` bind parameter
+        let chunk_size = POSTGRES_MAX_PARAMETERS / (table.columns.len() + 1);
         for chunk in entities.chunks_mut(chunk_size) {
             count += InsertQuery::new(table, chunk, block)?.execute(conn)?;
         }

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -576,8 +576,8 @@ impl Layout {
         let table = self.table_for_entity(entity_type)?;
         let _section = stopwatch.start_section("insert_modification_insert_query");
         let mut count = 0;
-        // we add 2 to account for `block_id` and `vid` fields
-        let chunk_size = (POSTGRES_MAX_PARAMETERS / table.columns.len()) + 2;
+        // we add 1 to account for `block_range` bind parameter
+        let chunk_size = (POSTGRES_MAX_PARAMETERS / table.columns.len()) + 1;
         for chunk in entities.chunks_mut(chunk_size) {
             count += InsertQuery::new(table, chunk, block)?
                 .get_results(conn)
@@ -697,10 +697,10 @@ impl Layout {
         }
         section.end();
 
-        // we add 2 to account for `block_id` and `vid` fields
         let _section = stopwatch.start_section("update_modification_insert_query");
         let mut count = 0;
-        let insert_chunk_size = (POSTGRES_MAX_PARAMETERS / table.columns.len()) + 2;
+        // we add 1 to account for `block_range` bind parameter
+        let insert_chunk_size = (POSTGRES_MAX_PARAMETERS / table.columns.len()) + 1;
         for insert_chunk in entities.chunks_mut(insert_chunk_size) {
             count += InsertQuery::new(table, insert_chunk, block)?.execute(conn)?;
         }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1235,7 +1235,7 @@ impl<'a, Conn> RunQueryDsl<Conn> for FindManyQuery<'a> {}
 #[derive(Debug)]
 pub struct InsertQuery<'a> {
     table: &'a Table,
-    entities: &'a Vec<(EntityKey, Entity)>,
+    entities: &'a [(EntityKey, Entity)],
     unique_columns: Vec<&'a Column>,
     block: BlockNumber,
 }
@@ -1243,7 +1243,7 @@ pub struct InsertQuery<'a> {
 impl<'a> InsertQuery<'a> {
     pub fn new(
         table: &'a Table,
-        entities: &'a mut Vec<(EntityKey, Entity)>,
+        entities: &'a mut [(EntityKey, Entity)],
         block: BlockNumber,
     ) -> Result<InsertQuery<'a>, StoreError> {
         for (entity_key, entity) in entities.iter_mut() {
@@ -1285,7 +1285,7 @@ impl<'a> InsertQuery<'a> {
     }
 
     /// Build the column name list using the subset of all keys among present entities.
-    fn unique_columns(table: &'a Table, entities: &'a Vec<(EntityKey, Entity)>) -> Vec<&'a Column> {
+    fn unique_columns(table: &'a Table, entities: &'a [(EntityKey, Entity)]) -> Vec<&'a Column> {
         let mut hashmap = HashMap::new();
         for (_key, entity) in entities.iter() {
             for column in &table.columns {

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -209,7 +209,7 @@ fn insert_entity(
             );
             (key, entity)
         })
-        .collect();
+        .collect::<Vec<(EntityKey, Entity)>>();
     let entity_type = EntityType::from(entity_type);
     let errmsg = format!(
         "Failed to insert entities {}[{:?}]",
@@ -233,7 +233,7 @@ fn update_entity(
     entity_type: &str,
     mut entities: Vec<Entity>,
 ) {
-    let entities_with_keys: Vec<(EntityKey, Entity)> = entities
+    let mut entities_with_keys: Vec<(EntityKey, Entity)> = entities
         .drain(..)
         .map(|entity| {
             let key = EntityKey::data(
@@ -254,8 +254,8 @@ fn update_entity(
     let updated = layout
         .update(
             &conn,
-            entity_type,
-            entities_with_keys.clone(),
+            &entity_type,
+            &mut entities_with_keys,
             0,
             &MOCK_STOPWATCH,
         )
@@ -538,7 +538,7 @@ fn update() {
         let entity_type = EntityType::from("Scalar");
         let mut entities = vec![(key, entity)];
         layout
-            .update(&conn, entity_type, entities.clone(), 0, &MOCK_STOPWATCH)
+            .update(&conn, &entity_type, &mut entities, 0, &MOCK_STOPWATCH)
             .expect("Failed to update");
 
         // The missing 'strings' will show up as Value::Null in the
@@ -596,13 +596,13 @@ fn update_many() {
             })
             .collect();
 
-        let entities = keys
+        let mut entities: Vec<(EntityKey, Entity)> = keys
             .into_iter()
             .zip(vec![one, two, three].into_iter())
             .collect();
 
         layout
-            .update(&conn, entity_type, entities, 0, &MOCK_STOPWATCH)
+            .update(&conn, &entity_type, &mut entities, 0, &MOCK_STOPWATCH)
             .expect("Failed to update");
 
         // check updates took effect
@@ -668,9 +668,9 @@ fn serialize_bigdecimal() {
                 entity.id().unwrap().clone(),
             );
             let entity_type = EntityType::from("Scalar");
-            let entities = vec![(key, entity.clone())];
+            let mut entities = vec![(key, entity.clone())];
             layout
-                .update(&conn, entity_type, entities, 0, &MOCK_STOPWATCH)
+                .update(&conn, &entity_type, &mut entities, 0, &MOCK_STOPWATCH)
                 .expect("Failed to update");
 
             let actual = layout

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -288,9 +288,9 @@ fn update() {
 
         let entity_id = entity.id().unwrap().clone();
         let entity_type = key.entity_type.clone();
-        let entities = vec![(key, entity)];
+        let mut entities = vec![(key, entity)];
         layout
-            .update(&conn, entity_type, entities.clone(), 1, &MOCK_STOPWATCH)
+            .update(&conn, &entity_type, &mut entities, 1, &MOCK_STOPWATCH)
             .expect("Failed to update");
 
         let actual = layout


### PR DESCRIPTION
This PR chunks the application of entity modifications as an attempt to fix #2330.

Given that the maximum number of PostgreSQL bind parameters per query is 65535, it makes sense to use N chunks where:
    
    chunk size =  65535 / number of fields per entity

Nonetheless, we must remain wary that parameters other than entity fields are also bound in each query, such as block numbers and auxiliary data.

Therefore, it would be reasonable for us to discuss ways to accommodate those extra bindings, probably by reducing `chunk size` by an arbitrary amount.
