### PR TITLE
Downgrade to tokio 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,12 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a2f58b0bb10c380af2b26e57212856b8c9a59e0925b4c20f4a174a49734eaf7"
-
-[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,17 +94,6 @@ dependencies = [
  "failure",
  "failure_derive",
  "serde_json",
-]
-
-[[package]]
-name = "async-native-tls"
-version = "0.3.3"
-source = "git+https://github.com/async-email/async-native-tls.git?rev=b5b5562d6cea77f913d4cbe448058c031833bf17#b5b5562d6cea77f913d4cbe448058c031833bf17"
-dependencies = [
- "native-tls",
- "thiserror",
- "tokio 1.4.0",
- "url",
 ]
 
 [[package]]
@@ -169,6 +152,16 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+dependencies = [
+ "byteorder",
+ "safemem",
+]
+
+[[package]]
+name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
@@ -209,20 +202,24 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+
+[[package]]
+name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
-version = "0.20.2"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f682656975d3a682daff957be4ddeb65d6ad656737cd821f2d00685ae466af1"
+checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
 dependencies = [
- "funty",
+ "either",
  "radium",
- "tap",
- "wyz",
 ]
 
 [[package]]
@@ -232,7 +229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -243,7 +240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9ff35b701f3914bdb8fad3368d822c766ef2858b2583198e41639b936f09d3f"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec",
  "cc",
  "cfg-if 0.1.10",
  "constant_time_eq",
@@ -257,7 +254,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5",
+ "block-padding",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
@@ -269,7 +266,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
  "generic-array 0.14.4",
 ]
 
@@ -281,12 +277,6 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bollard"
@@ -306,7 +296,7 @@ dependencies = [
  "http 0.2.4",
  "hyper 0.14.5",
  "hyper-unix-connector",
- "log",
+ "log 0.4.11",
  "pin-project 1.0.5",
  "serde",
  "serde_derive",
@@ -315,7 +305,7 @@ dependencies = [
  "thiserror",
  "tokio 1.4.0",
  "tokio-util 0.6.3",
- "url",
+ "url 2.2.1",
  "winapi 0.3.9",
 ]
 
@@ -353,9 +343,9 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.0.0"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
 name = "byte-tools"
@@ -435,7 +425,7 @@ checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term 0.11.0",
  "atty",
- "bitflags",
+ "bitflags 1.2.1",
  "strsim 0.8.0",
  "textwrap",
  "unicode-width",
@@ -448,7 +438,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
 ]
 
 [[package]]
@@ -457,7 +447,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
 ]
 
 [[package]]
@@ -573,7 +563,7 @@ dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
  "gimli",
- "log",
+ "log 0.4.11",
  "regalloc",
  "serde",
  "smallvec 1.6.1",
@@ -616,7 +606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae11da9ca99f987c29e3eb39ebe10e9b879ecca30f3aeaee13db5e8e02b80fb6"
 dependencies = [
  "cranelift-codegen",
- "log",
+ "log 0.4.11",
  "smallvec 1.6.1",
  "target-lexicon",
 ]
@@ -641,7 +631,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "itertools",
- "log",
+ "log 0.4.11",
  "serde",
  "smallvec 1.6.1",
  "thiserror",
@@ -939,7 +929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "047bfc4d5c3bd2ef6ca6f981941046113524b9a9f9a7cbdfdd7ff40f58e6f542"
 dependencies = [
  "bigdecimal",
- "bitflags",
+ "bitflags 1.2.1",
  "byteorder",
  "diesel_derives",
  "num-bigint",
@@ -1108,7 +1098,7 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
  "humantime 1.3.0",
- "log",
+ "log 0.4.11",
  "regex",
  "termcolor",
 ]
@@ -1121,7 +1111,7 @@ checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
  "humantime 2.0.1",
- "log",
+ "log 0.4.11",
  "regex",
  "termcolor",
 ]
@@ -1155,25 +1145,36 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52991643379afc90bfe2df3c64d53983e59c35a82ba6e75c997cfc2880d8524"
+version = "12.0.0-graph"
+source = "git+https://github.com/graphprotocol/ethabi.git?branch=master#35977d1ce69d4c2db652c502d70e4e53a7aa9897"
 dependencies = [
- "anyhow",
  "ethereum-types",
- "hex",
+ "rustc-hex",
  "serde",
  "serde_json",
- "sha3",
- "thiserror",
+ "tiny-keccak 1.5.0",
+ "uint",
+]
+
+[[package]]
+name = "ethabi"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
+dependencies = [
+ "ethereum-types",
+ "rustc-hex",
+ "serde",
+ "serde_json",
+ "tiny-keccak 1.5.0",
  "uint",
 ]
 
 [[package]]
 name = "ethbloom"
-version = "0.11.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
+checksum = "71a6567e6fd35589fea0c63b94b4cf2e55573e413901bdbe60ab15cf0e25e5df"
 dependencies = [
  "crunchy",
  "fixed-hash",
@@ -1184,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.11.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
+checksum = "473aecff686bd8e7b9db0165cbbb53562376b39bf35b427f0c60446a9e1634b0"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -1203,7 +1204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
 dependencies = [
  "lazy_static",
- "log",
+ "log 0.4.11",
  "rand 0.7.3",
 ]
 
@@ -1254,7 +1255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fdbe0d94371f9ce939b555dd342d0686cc4c0cadbcd4b61d70af5ff97eb4126"
 dependencies = [
  "env_logger 0.7.1",
- "log",
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -1265,12 +1266,12 @@ checksum = "31586bda1b136406162e381a3185a506cdfc1631708dd40cba2f6628d8634499"
 
 [[package]]
 name = "fixed-hash"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
  "byteorder",
- "rand 0.8.3",
+ "rand 0.7.3",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1324,7 +1325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
 dependencies = [
  "matches",
- "percent-encoding",
+ "percent-encoding 2.1.0",
 ]
 
 [[package]]
@@ -1345,7 +1346,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "fuchsia-zircon-sys",
 ]
 
@@ -1354,12 +1355,6 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -1450,12 +1445,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-
-[[package]]
 name = "futures-util"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,7 +1462,7 @@ dependencies = [
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
- "slab",
+ "slab 0.4.2",
 ]
 
 [[package]]
@@ -1498,7 +1487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -1550,7 +1539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "526ad4c79ca35ec046176e89787409f1d75d9cd51fa9258c01ca206d4fba9340"
 dependencies = [
  "chrono",
- "log",
+ "log 0.4.11",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.62",
@@ -1571,7 +1560,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "fnv",
- "log",
+ "log 0.4.11",
  "regex",
 ]
 
@@ -1588,7 +1577,7 @@ dependencies = [
  "chrono",
  "diesel",
  "diesel_derives",
- "ethabi",
+ "ethabi 12.0.0-graph",
  "futures 0.1.31",
  "futures 0.3.13",
  "graphql-parser",
@@ -1626,7 +1615,7 @@ dependencies = [
  "tokio 0.2.25",
  "tokio-retry",
  "tokio-stream",
- "url",
+ "url 2.2.1",
  "wasmparser",
  "web3",
 ]
@@ -1653,8 +1642,8 @@ dependencies = [
  "graph",
  "graph-core",
  "graph-store-postgres",
- "http 0.2.4",
- "jsonrpc-core 17.0.0",
+ "http 0.1.21",
+ "jsonrpc-core",
  "lazy_static",
  "mockall",
  "pretty_assertions",
@@ -1753,7 +1742,7 @@ dependencies = [
  "shellexpand",
  "structopt",
  "toml",
- "url",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -1773,7 +1762,7 @@ dependencies = [
  "atomic_refcell",
  "bs58",
  "defer",
- "ethabi",
+ "ethabi 12.0.0-graph",
  "futures 0.1.31",
  "graph",
  "graph-chain-arweave",
@@ -1925,8 +1914,8 @@ dependencies = [
  "futures 0.1.31",
  "http 0.1.21",
  "indexmap",
- "log",
- "slab",
+ "log 0.4.11",
+ "slab 0.4.2",
  "string",
  "tokio-io",
 ]
@@ -1944,7 +1933,7 @@ dependencies = [
  "futures-util",
  "http 0.2.4",
  "indexmap",
- "slab",
+ "slab 0.4.2",
  "tokio 0.2.25",
  "tokio-util 0.3.1",
  "tracing",
@@ -1964,7 +1953,7 @@ dependencies = [
  "futures-util",
  "http 0.2.4",
  "indexmap",
- "slab",
+ "slab 0.4.2",
  "tokio 1.4.0",
  "tokio-util 0.6.3",
  "tracing",
@@ -1975,31 +1964,6 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "headers"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
-dependencies = [
- "base64 0.13.0",
- "bitflags",
- "bytes 1.0.1",
- "headers-core",
- "http 0.2.4",
- "mime",
- "sha-1 0.9.4",
- "time",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http 0.2.4",
-]
 
 [[package]]
 name = "heck"
@@ -2124,6 +2088,25 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
+version = "0.10.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
+dependencies = [
+ "base64 0.9.3",
+ "httparse",
+ "language-tags",
+ "log 0.3.9",
+ "mime 0.2.6",
+ "num_cpus",
+ "time",
+ "traitobject",
+ "typeable",
+ "unicase 1.4.2",
+ "url 1.7.2",
+]
+
+[[package]]
+name = "hyper"
 version = "0.12.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
@@ -2137,7 +2120,7 @@ dependencies = [
  "httparse",
  "iovec",
  "itoa",
- "log",
+ "log 0.4.11",
  "net2",
  "rustc_version",
  "time",
@@ -2148,7 +2131,7 @@ dependencies = [
  "tokio-reactor",
  "tokio-tcp",
  "tokio-threadpool",
- "tokio-timer",
+ "tokio-timer 0.2.13",
  "want 0.2.0",
 ]
 
@@ -2201,21 +2184,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-proxy"
-version = "0.9.1"
+name = "hyper-tls"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 dependencies = [
- "bytes 1.0.1",
- "futures 0.3.13",
- "headers",
- "http 0.2.4",
- "hyper 0.14.5",
- "hyper-tls 0.5.0",
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "hyper 0.12.35",
  "native-tls",
- "tokio 1.4.0",
- "tokio-native-tls",
- "tower-service",
+ "tokio-io",
 ]
 
 [[package]]
@@ -2228,20 +2206,7 @@ dependencies = [
  "hyper 0.13.10",
  "native-tls",
  "tokio 0.2.25",
- "tokio-tls",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes 1.0.1",
- "hyper 0.14.5",
- "native-tls",
- "tokio 1.4.0",
- "tokio-native-tls",
+ "tokio-tls 0.3.1",
 ]
 
 [[package]]
@@ -2277,6 +2242,17 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
@@ -2288,18 +2264,18 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.5.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df170efa359aebdd5cb7fe78edcc67107748e4737bdca8a8fb40d15ea7a877ed"
+checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "impl-rlp"
-version = "0.3.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+checksum = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
 dependencies = [
  "rlp",
 ]
@@ -2409,20 +2385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
 dependencies = [
  "futures 0.1.31",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "jsonrpc-core"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07569945133257ff557eb37b015497104cea61a2c9edaf126c1cbd6e8332397f"
-dependencies = [
- "futures 0.3.13",
- "log",
+ "log 0.4.11",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2435,12 +2398,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da906d682799df05754480dac1b9e70ec92e12c19ebafd2662a5ea1c9fd6522"
 dependencies = [
  "hyper 0.12.35",
- "jsonrpc-core 14.2.0",
+ "jsonrpc-core",
  "jsonrpc-server-utils",
- "log",
+ "log 0.4.11",
  "net2",
  "parking_lot 0.10.2",
- "unicase",
+ "unicase 2.6.0",
 ]
 
 [[package]]
@@ -2451,19 +2414,13 @@ checksum = "56cbfb462e7f902e21121d9f0d1c2b77b2c5b642e1a4e8f4ebfa2e15b94402bb"
 dependencies = [
  "bytes 0.4.12",
  "globset",
- "jsonrpc-core 14.2.0",
+ "jsonrpc-core",
  "lazy_static",
- "log",
+ "log 0.4.11",
  "tokio 0.1.22",
  "tokio-codec",
- "unicase",
+ "unicase 2.6.0",
 ]
-
-[[package]]
-name = "keccak"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kernel32-sys"
@@ -2474,6 +2431,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -2493,8 +2456,8 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 dependencies = [
- "arrayvec 0.5.2",
- "bitflags",
+ "arrayvec",
+ "bitflags 1.2.1",
  "cfg-if 0.1.10",
  "ryu",
  "static_assertions",
@@ -2528,6 +2491,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+dependencies = [
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -2636,6 +2608,15 @@ dependencies = [
 
 [[package]]
 name = "mime"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
+dependencies = [
+ "log 0.3.9",
+]
+
+[[package]]
+name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
@@ -2646,8 +2627,8 @@ version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
- "mime",
- "unicase",
+ "mime 0.3.16",
+ "unicase 2.6.0",
 ]
 
 [[package]]
@@ -2672,10 +2653,10 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log",
+ "log 0.4.11",
  "miow 0.2.2",
  "net2",
- "slab",
+ "slab 0.4.2",
  "winapi 0.2.8",
 ]
 
@@ -2686,7 +2667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
 dependencies = [
  "libc",
- "log",
+ "log 0.4.11",
  "miow 0.3.6",
  "ntapi",
  "winapi 0.3.9",
@@ -2766,7 +2747,7 @@ checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
- "log",
+ "log 0.4.11",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -2801,7 +2782,7 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "lexical-core",
  "memchr",
- "version_check",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -2900,7 +2881,7 @@ version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
@@ -2944,11 +2925,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.1.0"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f4d179ed52b1c7eeb29baf29c604ea9301b889b23ce93660220a5465d5c6f"
+checksum = "a4b26b16c7687c3075982af47719e481815df30bc544f7a6690763a25ca16e9d"
 dependencies = [
- "arrayvec 0.7.0",
+ "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "serde",
@@ -3035,6 +3016,12 @@ name = "paste"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -3159,7 +3146,7 @@ dependencies = [
  "bytes 1.0.1",
  "fallible-iterator 0.2.0",
  "futures 0.3.13",
- "log",
+ "log 0.4.11",
  "tokio 1.4.0",
  "tokio-postgres",
 ]
@@ -3251,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.9.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2415937401cb030a2a0a4d922483f945fa068f52a7dbb22ce0fe5f2b6f6adace"
+checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -3282,7 +3269,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.62",
- "version_check",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -3293,7 +3280,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "version_check",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -3386,16 +3373,16 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
 dependencies = [
- "log",
+ "log 0.4.11",
  "parking_lot 0.11.1",
  "scheduled-thread-pool",
 ]
 
 [[package]]
 name = "radium"
-version = "0.6.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
@@ -3407,6 +3394,19 @@ dependencies = [
  "libc",
  "rand_core 0.3.1",
  "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
+dependencies = [
+ "cloudabi 0.0.3",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
  "winapi 0.3.9",
 ]
 
@@ -3654,7 +3654,7 @@ version = "0.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
 dependencies = [
- "log",
+ "log 0.4.11",
  "rustc-hash",
  "serde",
  "smallvec 1.6.1",
@@ -3683,7 +3683,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "libc",
  "mach",
  "winapi 0.3.9",
@@ -3722,18 +3722,18 @@ dependencies = [
  "ipnet",
  "js-sys",
  "lazy_static",
- "log",
- "mime",
+ "log 0.4.11",
+ "mime 0.3.16",
  "mime_guess",
  "native-tls",
- "percent-encoding",
+ "percent-encoding 2.1.0",
  "pin-project-lite 0.2.6",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 0.2.25",
- "tokio-tls",
- "url",
+ "tokio-tls 0.3.1",
+ "url 2.2.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3757,11 +3757,10 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.5.0"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54369147e3e7796c9b885c7304db87ca3d09a0a98f72843d532868675bbfba8"
+checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
 dependencies = [
- "bytes 1.0.1",
  "rustc-hex",
 ]
 
@@ -3811,6 +3810,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3837,6 +3842,12 @@ checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
  "parking_lot 0.11.1",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 
 [[package]]
 name = "scopeguard"
@@ -3877,8 +3888,7 @@ dependencies = [
 [[package]]
 name = "secp256k1"
 version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733b114f058f260c0af7591434eef4272ae1a8ec2751766d3cb89c6df8d5e450"
+source = "git+https://github.com/rust-bitcoin/rust-secp256k1#63f4de78cee376c409fedc92d5a1aff9202caf6a"
 dependencies = [
  "secp256k1-sys",
 ]
@@ -3886,8 +3896,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-sys"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e4b6455ee49f5901c8985b88f98fb0a0e1d90a6661f5a03f4888bd987dad29"
+source = "git+https://github.com/rust-bitcoin/rust-secp256k1#63f4de78cee376c409fedc92d5a1aff9202caf6a"
 dependencies = [
  "cc",
 ]
@@ -3898,7 +3907,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4039,17 +4048,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.9.4"
+name = "sha1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfebf75d25bd900fd1e7d11501efab59bc846dbc76196839663e6637bba9f25f"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if 1.0.0",
- "cpuid-bool",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
@@ -4061,18 +4063,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
  "opaque-debug 0.3.0",
 ]
 
@@ -4099,6 +4089,12 @@ name = "siphasher"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
+
+[[package]]
+name = "slab"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 
 [[package]]
 name = "slab"
@@ -4130,7 +4126,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "906a1a0bc43fed692df4b82a5e2fbfc3733db8dad8bb514ab27a4f23ad04f5c0"
 dependencies = [
- "log",
+ "log 0.4.11",
  "regex",
  "slog",
  "slog-async",
@@ -4156,7 +4152,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8228ab7302adbf4fcb37e66f3cda78003feb521e7fd9e3847ec117a7784d0f5a"
 dependencies = [
- "log",
+ "log 0.4.11",
  "slog",
  "slog-scope",
 ]
@@ -4209,21 +4205,6 @@ checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "soketto"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c71ed3d54db0a699f4948e1bb3e45b450fa31fe602621dee6680361d569c88"
-dependencies = [
- "base64 0.12.3",
- "bytes 0.5.6",
- "futures 0.3.13",
- "httparse",
- "log",
- "rand 0.7.3",
- "sha-1 0.9.4",
 ]
 
 [[package]]
@@ -4388,12 +4369,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "target-lexicon"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4548,9 +4523,9 @@ dependencies = [
  "tokio-sync",
  "tokio-tcp",
  "tokio-threadpool",
- "tokio-timer",
+ "tokio-timer 0.2.13",
  "tokio-udp",
- "tokio-uds",
+ "tokio-uds 0.2.7",
 ]
 
 [[package]]
@@ -4570,7 +4545,7 @@ dependencies = [
  "mio-uds",
  "num_cpus",
  "pin-project-lite 0.1.11",
- "slab",
+ "slab 0.4.2",
  "tokio-macros 0.2.6",
 ]
 
@@ -4587,7 +4562,6 @@ dependencies = [
  "mio 0.7.9",
  "num_cpus",
  "once_cell",
- "parking_lot 0.11.1",
  "pin-project-lite 0.2.6",
  "signal-hook-registry",
  "tokio-macros 1.1.0",
@@ -4614,6 +4588,25 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
  "tokio-io",
+]
+
+[[package]]
+name = "tokio-core"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87b1395334443abca552f63d4f61d0486f12377c2ba8b368e523f89e828cffd4"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "iovec",
+ "log 0.4.11",
+ "mio 0.6.23",
+ "scoped-tls",
+ "tokio 0.1.22",
+ "tokio-executor",
+ "tokio-io",
+ "tokio-reactor",
+ "tokio-timer 0.2.13",
 ]
 
 [[package]]
@@ -4655,7 +4648,7 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "log",
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -4681,16 +4674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio 1.4.0",
-]
-
-[[package]]
 name = "tokio-postgres"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4701,9 +4684,9 @@ dependencies = [
  "bytes 1.0.1",
  "fallible-iterator 0.2.0",
  "futures 0.3.13",
- "log",
+ "log 0.4.11",
  "parking_lot 0.11.1",
- "percent-encoding",
+ "percent-encoding 2.1.0",
  "phf",
  "pin-project-lite 0.2.6",
  "postgres-protocol",
@@ -4722,11 +4705,11 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
  "lazy_static",
- "log",
+ "log 0.4.11",
  "mio 0.6.23",
  "num_cpus",
  "parking_lot 0.9.0",
- "slab",
+ "slab 0.4.2",
  "tokio-executor",
  "tokio-io",
  "tokio-sync",
@@ -4790,10 +4773,20 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
  "lazy_static",
- "log",
+ "log 0.4.11",
  "num_cpus",
- "slab",
+ "slab 0.4.2",
  "tokio-executor",
+]
+
+[[package]]
+name = "tokio-timer"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc"
+dependencies = [
+ "futures 0.1.31",
+ "slab 0.3.0",
 ]
 
 [[package]]
@@ -4804,8 +4797,19 @@ checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
- "slab",
+ "slab 0.4.2",
  "tokio-executor",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
+dependencies = [
+ "futures 0.1.31",
+ "native-tls",
+ "tokio-io",
 ]
 
 [[package]]
@@ -4825,7 +4829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
 dependencies = [
  "futures 0.3.13",
- "log",
+ "log 0.4.11",
  "pin-project 0.4.28",
  "tokio 0.2.25",
  "tungstenite",
@@ -4839,11 +4843,28 @@ checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "log",
+ "log 0.4.11",
  "mio 0.6.23",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
+]
+
+[[package]]
+name = "tokio-uds"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "iovec",
+ "libc",
+ "log 0.3.9",
+ "mio 0.6.23",
+ "mio-uds",
+ "tokio-core",
+ "tokio-io",
 ]
 
 [[package]]
@@ -4856,7 +4877,7 @@ dependencies = [
  "futures 0.1.31",
  "iovec",
  "libc",
- "log",
+ "log 0.4.11",
  "mio 0.6.23",
  "mio-uds",
  "tokio-codec",
@@ -4873,7 +4894,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "log",
+ "log 0.4.11",
  "pin-project-lite 0.1.11",
  "tokio 0.2.25",
 ]
@@ -4886,9 +4907,8 @@ checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
 dependencies = [
  "bytes 1.0.1",
  "futures-core",
- "futures-io",
  "futures-sink",
- "log",
+ "log 0.4.11",
  "pin-project-lite 0.2.6",
  "tokio 1.4.0",
 ]
@@ -4915,7 +4935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
- "log",
+ "log 0.4.11",
  "pin-project-lite 0.1.11",
  "tracing-core",
 ]
@@ -4938,6 +4958,12 @@ dependencies = [
  "pin-project 1.0.5",
  "tracing",
 ]
+
+[[package]]
+name = "traitobject"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "treeline"
@@ -4963,12 +4989,18 @@ dependencies = [
  "http 0.2.4",
  "httparse",
  "input_buffer",
- "log",
+ "log 0.4.11",
  "rand 0.7.3",
- "sha-1 0.8.2",
- "url",
+ "sha-1",
+ "url 2.2.1",
  "utf-8",
 ]
+
+[[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
@@ -4978,14 +5010,23 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uint"
-version = "0.9.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
+checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
 dependencies = [
  "byteorder",
  "crunchy",
- "hex",
+ "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+dependencies = [
+ "version_check 0.1.5",
 ]
 
 [[package]]
@@ -4994,7 +5035,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -5056,14 +5097,25 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
+]
+
+[[package]]
+name = "url"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.2.0",
  "matches",
- "percent-encoding",
+ "percent-encoding 2.1.0",
 ]
 
 [[package]]
@@ -5104,6 +5156,12 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
+[[package]]
+name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
@@ -5132,7 +5190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
  "futures 0.1.31",
- "log",
+ "log 0.4.11",
  "try-lock",
 ]
 
@@ -5142,7 +5200,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log",
+ "log 0.4.11",
  "try-lock",
 ]
 
@@ -5178,7 +5236,7 @@ checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log",
+ "log 0.4.11",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.62",
@@ -5246,7 +5304,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "libc",
- "log",
+ "log 0.4.11",
  "paste",
  "psm",
  "region",
@@ -5278,7 +5336,7 @@ dependencies = [
  "errno",
  "file-per-thread-logger",
  "libc",
- "log",
+ "log 0.4.11",
  "serde",
  "sha2",
  "toml",
@@ -5329,7 +5387,7 @@ dependencies = [
  "cranelift-wasm",
  "gimli",
  "indexmap",
- "log",
+ "log 0.4.11",
  "more-asserts",
  "region",
  "serde",
@@ -5363,7 +5421,7 @@ dependencies = [
  "cranelift-native",
  "cranelift-wasm",
  "gimli",
- "log",
+ "log 0.4.11",
  "more-asserts",
  "object 0.23.0",
  "rayon",
@@ -5427,7 +5485,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "libc",
- "log",
+ "log 0.4.11",
  "mach",
  "memoffset 0.6.3",
  "more-asserts",
@@ -5469,36 +5527,56 @@ dependencies = [
 
 [[package]]
 name = "web3"
-version = "0.15.0-graph"
-source = "git+https://github.com/graphprotocol/rust-web3?branch=leo/test-rebase-upstream-master#6df4b7108997600dfff66d1063b7762adde9946b"
+version = "0.10.0-graph"
+source = "git+https://github.com/graphprotocol/rust-web3?branch=master#2ffcc3adb208d8be0e078601b8ded9e5c6290843"
 dependencies = [
- "arrayvec 0.5.2",
- "async-native-tls",
- "base64 0.13.0",
+ "arrayvec",
+ "base64 0.12.3",
  "derive_more",
- "ethabi",
+ "ethabi 12.0.0",
  "ethereum-types",
- "futures 0.3.13",
- "futures-timer",
- "headers",
- "hex",
- "hyper 0.14.5",
- "hyper-proxy",
- "hyper-tls 0.5.0",
- "jsonrpc-core 17.0.0",
- "log",
- "parking_lot 0.11.1",
- "pin-project 1.0.5",
+ "futures 0.1.31",
+ "hyper 0.12.35",
+ "hyper-tls 0.3.2",
+ "jsonrpc-core",
+ "log 0.4.11",
+ "native-tls",
+ "parking_lot 0.10.2",
  "rlp",
+ "rustc-hex",
  "secp256k1",
  "serde",
  "serde_json",
- "soketto",
  "tiny-keccak 2.0.2",
- "tokio 1.4.0",
- "tokio-stream",
- "tokio-util 0.6.3",
- "url",
+ "tokio-core",
+ "tokio-io",
+ "tokio-timer 0.1.2",
+ "tokio-uds 0.1.7",
+ "url 2.2.1",
+ "websocket",
+ "zeroize",
+]
+
+[[package]]
+name = "websocket"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9faed2bff8af2ea6b9f8b917d3d00b467583f6781fe3def174a9e33c879703"
+dependencies = [
+ "base64 0.9.3",
+ "bitflags 0.9.1",
+ "byteorder",
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "hyper 0.10.16",
+ "native-tls",
+ "rand 0.5.6",
+ "sha1",
+ "tokio-core",
+ "tokio-io",
+ "tokio-tls 0.2.1",
+ "unicase 1.4.2",
+ "url 1.7.2",
 ]
 
 [[package]]
@@ -5564,12 +5642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
-
-[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5577,6 +5649,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
+name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -242,7 +248,19 @@ dependencies = [
  "cfg-if 0.1.10",
  "constant_time_eq",
  "crypto-mac 0.8.0",
- "digest",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding 0.1.5",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -251,8 +269,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
- "generic-array",
+ "block-padding 0.2.1",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -280,14 +307,14 @@ dependencies = [
  "hyper 0.14.5",
  "hyper-unix-connector",
  "log",
- "pin-project",
+ "pin-project 1.0.5",
  "serde",
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
  "thiserror",
  "tokio 1.4.0",
- "tokio-util",
+ "tokio-util 0.6.3",
  "url",
  "winapi 0.3.9",
 ]
@@ -329,6 +356,12 @@ name = "byte-slice-cast"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -765,7 +798,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -775,7 +808,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -972,11 +1005,20 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -1186,6 +1228,12 @@ dependencies = [
  "syn 1.0.62",
  "synstructure",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fallible-iterator"
@@ -1436,6 +1484,15 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -1527,7 +1584,7 @@ dependencies = [
  "async-trait",
  "atomic_refcell",
  "bigdecimal",
- "bytes 1.0.1",
+ "bytes 0.5.6",
  "chrono",
  "diesel",
  "diesel_derives",
@@ -1566,7 +1623,7 @@ dependencies = [
  "test-store",
  "thiserror",
  "tiny-keccak 1.5.0",
- "tokio 1.4.0",
+ "tokio 0.2.25",
  "tokio-retry",
  "tokio-stream",
  "url",
@@ -1715,7 +1772,6 @@ dependencies = [
  "async-trait",
  "atomic_refcell",
  "bs58",
- "bytes 1.0.1",
  "defer",
  "ethabi",
  "futures 0.1.31",
@@ -1747,7 +1803,7 @@ dependencies = [
  "graph-mock",
  "graphql-parser",
  "http 0.2.4",
- "hyper 0.14.5",
+ "hyper 0.13.10",
  "serde",
 ]
 
@@ -1760,7 +1816,7 @@ dependencies = [
  "graph-graphql",
  "graphql-parser",
  "http 0.2.4",
- "hyper 0.14.5",
+ "hyper 0.13.10",
  "serde",
 ]
 
@@ -1781,7 +1837,7 @@ dependencies = [
  "futures 0.1.31",
  "graph",
  "http 0.2.4",
- "hyper 0.14.5",
+ "hyper 0.13.10",
  "lazy_static",
  "serde",
 ]
@@ -1877,6 +1933,26 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.4",
+ "indexmap",
+ "slab",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "h2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
@@ -1890,7 +1966,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio 1.4.0",
- "tokio-util",
+ "tokio-util 0.6.3",
  "tracing",
 ]
 
@@ -1912,7 +1988,7 @@ dependencies = [
  "headers-core",
  "http 0.2.4",
  "mime",
- "sha-1",
+ "sha-1 0.9.4",
  "time",
 ]
 
@@ -1962,7 +2038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac 0.10.0",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1997,6 +2073,16 @@ dependencies = [
  "futures 0.1.31",
  "http 0.1.21",
  "tokio-buf",
+]
+
+[[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes 0.5.6",
+ "http 0.2.4",
 ]
 
 [[package]]
@@ -2068,6 +2154,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.2.7",
+ "http 0.2.4",
+ "http-body 0.3.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.5",
+ "socket2 0.3.16",
+ "tokio 0.2.25",
+ "tower-service",
+ "tracing",
+ "want 0.3.0",
+]
+
+[[package]]
+name = "hyper"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
@@ -2082,7 +2192,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project 1.0.5",
  "socket2 0.4.0",
  "tokio 1.4.0",
  "tower-service",
@@ -2101,11 +2211,24 @@ dependencies = [
  "headers",
  "http 0.2.4",
  "hyper 0.14.5",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "native-tls",
  "tokio 1.4.0",
  "tokio-native-tls",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+dependencies = [
+ "bytes 0.5.6",
+ "hyper 0.13.10",
+ "native-tls",
+ "tokio 0.2.25",
+ "tokio-tls",
 ]
 
 [[package]]
@@ -2130,7 +2253,7 @@ dependencies = [
  "anyhow",
  "hex",
  "hyper 0.14.5",
- "pin-project",
+ "pin-project 1.0.5",
  "tokio 1.4.0",
 ]
 
@@ -2203,11 +2326,11 @@ dependencies = [
 
 [[package]]
 name = "input_buffer"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
+checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 0.5.6",
 ]
 
 [[package]]
@@ -2461,9 +2584,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
 dependencies = [
- "block-buffer",
- "digest",
- "opaque-debug",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -2539,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -2550,7 +2673,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -2577,14 +2700,14 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio 0.6.22",
+ "mio 0.6.23",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -2655,9 +2778,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -2758,6 +2881,12 @@ name = "once_cell"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -2953,11 +3082,31 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
+dependencies = [
+ "pin-project-internal 0.4.28",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.0.5",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -3247,6 +3396,19 @@ name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "rand"
@@ -3544,19 +3706,19 @@ checksum = "05a51ad2b1c5c710fa89e6b1631068dab84ed687bc6a5fe061ad65da3d0c25b2"
 
 [[package]]
 name = "reqwest"
-version = "0.11.2"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
+checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
  "base64 0.13.0",
- "bytes 1.0.1",
+ "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http 0.2.4",
- "http-body 0.4.0",
- "hyper 0.14.5",
- "hyper-tls",
+ "http-body 0.3.1",
+ "hyper 0.13.10",
+ "hyper-tls 0.4.3",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -3569,8 +3731,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.4.0",
- "tokio-native-tls",
+ "tokio 0.2.25",
+ "tokio-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3866,15 +4028,27 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfebf75d25bd900fd1e7d11501efab59bc846dbc76196839663e6637bba9f25f"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpuid-bool",
- "digest",
- "opaque-debug",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -3883,11 +4057,11 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpuid-bool",
- "digest",
- "opaque-debug",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -3896,10 +4070,10 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
  "keccak",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -4049,7 +4223,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.7.3",
- "sha-1",
+ "sha-1 0.9.4",
 ]
 
 [[package]]
@@ -4363,7 +4537,7 @@ checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "mio 0.6.22",
+ "mio 0.6.23",
  "num_cpus",
  "tokio-codec",
  "tokio-current-thread",
@@ -4377,6 +4551,27 @@ dependencies = [
  "tokio-timer",
  "tokio-udp",
  "tokio-uds",
+]
+
+[[package]]
+name = "tokio"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "iovec",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "mio 0.6.23",
+ "mio-uds",
+ "num_cpus",
+ "pin-project-lite 0.1.11",
+ "slab",
+ "tokio-macros 0.2.6",
 ]
 
 [[package]]
@@ -4395,7 +4590,7 @@ dependencies = [
  "parking_lot 0.11.1",
  "pin-project-lite 0.2.6",
  "signal-hook-registry",
- "tokio-macros",
+ "tokio-macros 1.1.0",
  "winapi 0.3.9",
 ]
 
@@ -4465,6 +4660,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.62",
+]
+
+[[package]]
+name = "tokio-macros"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
@@ -4504,7 +4710,7 @@ dependencies = [
  "postgres-types",
  "socket2 0.4.0",
  "tokio 1.4.0",
- "tokio-util",
+ "tokio-util 0.6.3",
 ]
 
 [[package]]
@@ -4517,7 +4723,7 @@ dependencies = [
  "futures 0.1.31",
  "lazy_static",
  "log",
- "mio 0.6.22",
+ "mio 0.6.23",
  "num_cpus",
  "parking_lot 0.9.0",
  "slab",
@@ -4528,13 +4734,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+version = "0.2.0"
+source = "git+https://github.com/graphprotocol/rust-tokio-retry?branch=update-to-tokio-02#fc0e868bdc7ff79ac84cf502d4cec20c5ce5adaf"
 dependencies = [
- "pin-project",
- "rand 0.8.3",
- "tokio 1.4.0",
+ "futures 0.1.31",
+ "futures 0.3.13",
+ "rand 0.4.6",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -4546,7 +4752,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.6",
  "tokio 1.4.0",
- "tokio-util",
+ "tokio-util 0.6.3",
 ]
 
 [[package]]
@@ -4568,7 +4774,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
  "iovec",
- "mio 0.6.22",
+ "mio 0.6.23",
  "tokio-io",
  "tokio-reactor",
 ]
@@ -4603,15 +4809,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.14.0"
+name = "tokio-tls"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e96bb520beab540ab664bd5a9cfeaa1fcd846fa68c830b42e2c8963071251d2"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
- "futures-util",
+ "native-tls",
+ "tokio 0.2.25",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
+dependencies = [
+ "futures 0.3.13",
  "log",
- "pin-project",
- "tokio 1.4.0",
+ "pin-project 0.4.28",
+ "tokio 0.2.25",
  "tungstenite",
 ]
 
@@ -4624,7 +4840,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
  "log",
- "mio 0.6.22",
+ "mio 0.6.23",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
@@ -4641,11 +4857,25 @@ dependencies = [
  "iovec",
  "libc",
  "log",
- "mio 0.6.22",
+ "mio 0.6.23",
  "mio-uds",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.1.11",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -4685,6 +4915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
+ "log",
  "pin-project-lite 0.1.11",
  "tracing-core",
 ]
@@ -4696,6 +4927,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project 1.0.5",
+ "tracing",
 ]
 
 [[package]]
@@ -4712,20 +4953,19 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.13.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8dada8c1a3aeca77d6b51a4f1314e0f4b8e438b7b1b71e3ddaca8080e4093"
+checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.11.0",
  "byteorder",
- "bytes 1.0.1",
+ "bytes 0.5.6",
  "http 0.2.4",
  "httparse",
  "input_buffer",
  "log",
- "rand 0.8.3",
- "sha-1",
- "thiserror",
+ "rand 0.7.3",
+ "sha-1 0.8.2",
  "url",
  "utf-8",
 ]
@@ -5244,11 +5484,11 @@ dependencies = [
  "hex",
  "hyper 0.14.5",
  "hyper-proxy",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "jsonrpc-core 17.0.0",
  "log",
  "parking_lot 0.11.1",
- "pin-project",
+ "pin-project 1.0.5",
  "rlp",
  "secp256k1",
  "serde",
@@ -5257,7 +5497,7 @@ dependencies = [
  "tiny-keccak 2.0.2",
  "tokio 1.4.0",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.3",
  "url",
 ]
 

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 [dependencies]
 chrono = "0.4"
 futures = "0.1.21"
-http = "0.2.4"
-jsonrpc-core = "17.0.0"
+http = "0.1.21" # must be compatible with the version rust-web3 uses
+jsonrpc-core = "14.2.0"
 graph = { path = "../../graph" }
 lazy_static = "1.2.0"
 state_machine_future = "0.2"

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -113,7 +113,7 @@ where
                 self.cleanup_cached_blocks()
             }
 
-            tokio::time::sleep(self.polling_interval).await;
+            tokio::time::delay_for(self.polling_interval).await;
         }
     }
 

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -661,7 +661,7 @@ impl<S: SubgraphStore, C: ChainStore> Stream for BlockStream<S, C> {
                             // Pause before trying again
                             let secs = (5 * self.consecutive_err_count).max(120) as u64;
                             state = BlockStreamState::RetryAfterDelay(Box::new(
-                                tokio::time::sleep(Duration::from_secs(secs))
+                                tokio::time::delay_for(Duration::from_secs(secs))
                                     .map(Ok)
                                     .boxed()
                                     .compat(),

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -11,4 +11,4 @@ mod transport;
 pub use self::block_ingestor::{BlockIngestor, BlockIngestorMetrics, CLEANUP_BLOCKS};
 pub use self::block_stream::{BlockStream, BlockStreamBuilder};
 pub use self::ethereum_adapter::EthereumAdapter;
-pub use self::transport::Transport;
+pub use self::transport::{EventLoopHandle, Transport};

--- a/chain/ethereum/tests/network_indexer.rs
+++ b/chain/ethereum/tests/network_indexer.rs
@@ -98,7 +98,7 @@ where
     let store = STORE.clone();
 
     // Lock regardless of poisoning. This also forces sequential test execution.
-    let runtime = match STORE_RUNTIME.lock() {
+    let mut runtime = match STORE_RUNTIME.lock() {
         Ok(guard) => guard,
         Err(err) => err.into_inner(),
     };

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -447,14 +447,11 @@ where
         // forward; this is easier than updating the existing block stream.
         //
         // This is a long-running and unfortunately a blocking future (see #905), so it is run in
-        // its own thread. It is also run with `task::unconstrained` because we have seen deadlocks
-        // occur without it, possibly caused by our use of legacy futures and tokio versions in the
-        // codebase and dependencies, which may not play well with the tokio 1.0 cooperative
-        // scheduling. It is also logical in terms of performance to run this with `unconstrained`,
-        // it has a dedicated OS thread so the OS will handle the preemption. See
-        // https://github.com/tokio-rs/tokio/issues/3493.
+        // its own thread. When upgrading to tokio 1.0 it would be logical to run this with
+        // `task::unconstrained`, since it has a dedicated OS thread so the OS will handle the
+        // preemption.
         graph::spawn_thread(deployment_id.to_string(), move || {
-            if let Err(e) = graph::block_on(task::unconstrained(run_subgraph(ctx))) {
+            if let Err(e) = graph::block_on(run_subgraph(ctx)) {
                 error!(
                     &logger,
                     "Subgraph instance failed to run: {}",

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -8,13 +8,13 @@ anyhow = "1.0"
 async-trait = "0.1.48"
 atomic_refcell = "0.1.7"
 bigdecimal = { version = "0.1.0", features = ["serde"] }
-bytes = "1.0.1"
+bytes = "0.5"
 diesel = { version = "1.4.6", features = ["postgres", "serde_json", "numeric", "r2d2"] }
 diesel_derives = "1.4"
 chrono = "0.4.19"
 Inflector = "0.11.3"
 isatty = "0.1.9"
-reqwest = { version = "0.11.2", features = ["json", "stream", "multipart"] }
+reqwest = { version = "0.10", features = ["json", "stream"] }
 ethabi = "14.0"
 hex = "0.4.3"
 http = "0.2.3"
@@ -40,9 +40,9 @@ slog-envlogger = "2.1.0"
 slog-term = "2.6.0"
 petgraph = "0.5.1"
 tiny-keccak = "1.5.0"
-tokio = { version = "1.4.0", features = ["time", "sync", "macros", "test-util", "rt-multi-thread"] }
+tokio = { version = "0.2.25", features = ["stream", "rt-threaded", "rt-util", "blocking", "time", "sync", "macros", "test-util", "net"] }
 tokio-stream = { version = "0.1.5", features = ["sync"] }
-tokio-retry = "0.3.0"
+tokio-retry = { git = "https://github.com/graphprotocol/rust-tokio-retry", branch = "update-to-tokio-02" }
 url = "2.2.1"
 prometheus = "0.12.0"
 priority-queue = "0.7.0"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -15,7 +15,13 @@ chrono = "0.4.19"
 Inflector = "0.11.3"
 isatty = "0.1.9"
 reqwest = { version = "0.10", features = ["json", "stream"] }
-ethabi = "14.0"
+
+# master contains changes such as
+# https://github.com/paritytech/ethabi/pull/140, which upstream does not want
+# and we should try to implement on top of ethabi instead of inside it, and
+# tuple support which isn't upstreamed yet. For now, we shall deviate from
+# ethabi, but long term we want to find a way to drop our fork.
+ethabi = { git = "https://github.com/graphprotocol/ethabi.git", branch = "master" }
 hex = "0.4.3"
 http = "0.2.3"
 futures = "0.1.21"
@@ -51,9 +57,8 @@ wasmparser = "0.77.0"
 thiserror = "1.0.24"
 parking_lot = "0.11.1"
 
-# Our fork contains patches for custom http headers and to make some block fields optional.
-# Without the "arbitrary_precision" feature, we get the error `data did not match any variant of untagged enum Response`.
-web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "leo/test-rebase-upstream-master", features = ["arbitrary_precision"] }
+# Our fork contains a small but hacky patch.
+web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "master" }
 
 [dev-dependencies]
 test-store = { path = "../store/test-store" }

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -16,11 +16,7 @@ Inflector = "0.11.3"
 isatty = "0.1.9"
 reqwest = { version = "0.10", features = ["json", "stream"] }
 
-# master contains changes such as
-# https://github.com/paritytech/ethabi/pull/140, which upstream does not want
-# and we should try to implement on top of ethabi instead of inside it, and
-# tuple support which isn't upstreamed yet. For now, we shall deviate from
-# ethabi, but long term we want to find a way to drop our fork.
+# We could use ethabi 0.14, but first web3 needs to be updated.
 ethabi = { git = "https://github.com/graphprotocol/ethabi.git", branch = "master" }
 hex = "0.4.3"
 http = "0.2.3"
@@ -57,7 +53,9 @@ wasmparser = "0.77.0"
 thiserror = "1.0.24"
 parking_lot = "0.11.1"
 
-# Our fork contains a small but hacky patch.
+# We have an updated version on:
+# `branch = "leo/test-rebase-upstream-master", features = ["arbitrary_precision"]`
+# but we'd need to update to tokio 1.0 first.
 web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "master" }
 
 [dev-dependencies]

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -380,7 +380,7 @@ impl From<&'_ Transaction> for EthereumTransactionData {
         EthereumTransactionData {
             hash: tx.hash,
             index: tx.transaction_index.unwrap().as_u64().into(),
-            from: tx.from.unwrap(),
+            from: tx.from,
             to: tx.to,
             value: tx.value,
             gas_used: tx.gas,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -653,7 +653,10 @@ where
         let mut pending_event: Option<StoreEvent> = None;
         let mut source = self.source.fuse();
         let mut had_err = false;
-        let mut delay = tokio::time::sleep(interval).unit_error().boxed().compat();
+        let mut delay = tokio::time::delay_for(interval)
+            .unit_error()
+            .boxed()
+            .compat();
         let logger = logger.clone();
 
         let source = Box::new(poll_fn(move || -> Poll<Option<Arc<StoreEvent>>, ()> {
@@ -680,7 +683,10 @@ where
                 // Timer errors are harmless. Treat them as if the timer had
                 // become ready.
                 Ok(Async::Ready(())) | Err(_) => {
-                    delay = tokio::time::sleep(interval).unit_error().boxed().compat();
+                    delay = tokio::time::delay_for(interval)
+                        .unit_error()
+                        .boxed()
+                        .compat();
                     true
                 }
             };

--- a/graph/src/data/graphql/effort.rs
+++ b/graph/src/data/graphql/effort.rs
@@ -562,12 +562,7 @@ impl QueryLoadManager for LoadManager {
         let start = Instant::now();
 
         // Unwrap: The semaphore is never closed.
-        let permit = self
-            .query_semaphore
-            .cheap_clone()
-            .acquire_owned()
-            .await
-            .unwrap();
+        let permit = self.query_semaphore.cheap_clone().acquire_owned().await;
         self.add_wait_time(start.elapsed());
         permit
     }

--- a/graph/src/task_spawn.rs
+++ b/graph/src/task_spawn.rs
@@ -59,9 +59,5 @@ pub fn block_on<T>(f: impl Future03<Output = T>) -> T {
 pub fn spawn_thread(name: String, f: impl 'static + FnOnce() + Send) {
     let conf = std::thread::Builder::new().name(name);
     let runtime = tokio::runtime::Handle::current();
-    conf.spawn(move || {
-        let _runtime_guard = runtime.enter();
-        f()
-    })
-    .unwrap();
+    conf.spawn(move || runtime.enter(f)).unwrap();
 }

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -1,6 +1,5 @@
 use crate::ext::futures::FutureExtension;
 use futures::prelude::*;
-use futures03::compat::Future01CompatExt;
 use futures03::{FutureExt, TryFutureExt};
 use slog::{debug, trace, warn, Logger};
 use std::fmt::Debug;
@@ -278,68 +277,64 @@ where
 
         attempt_count += 1;
 
-        try_it_with_timeout()
-            .then(move |result_with_timeout| {
-                let is_elapsed = result_with_timeout
-                    .as_ref()
-                    .err()
-                    .map(|e| e.is_elapsed())
-                    .unwrap_or(false);
+        try_it_with_timeout().then(move |result_with_timeout| {
+            let is_elapsed = result_with_timeout
+                .as_ref()
+                .err()
+                .map(|e| e.is_elapsed())
+                .unwrap_or(false);
 
-                if is_elapsed {
-                    if attempt_count >= log_after {
-                        debug!(
+            if is_elapsed {
+                if attempt_count >= log_after {
+                    debug!(
+                        logger,
+                        "Trying again after {} timed out (attempt #{})",
+                        &operation_name,
+                        attempt_count,
+                    );
+                }
+
+                // Wrap in Err to force retry
+                Err(result_with_timeout)
+            } else {
+                // Any error must now be an inner error.
+                // Unwrap the inner error so that the predicate doesn't need to think
+                // about timeout::Error.
+                let result = result_with_timeout.map_err(|e| e.into_inner().unwrap());
+
+                // If needs retry
+                if condition.check(&result) {
+                    if attempt_count >= warn_after {
+                        // This looks like it would be nice to de-duplicate, but if we try
+                        // to use log! slog complains about requiring a const for the log level
+                        // See also b05e1594-e408-4047-aefb-71fc60d70e8f
+                        warn!(
                             logger,
-                            "Trying again after {} timed out (attempt #{})",
+                            "Trying again after {} failed (attempt #{}) with result {:?}",
                             &operation_name,
                             attempt_count,
+                            result
+                        );
+                    } else if attempt_count >= log_after {
+                        // See also b05e1594-e408-4047-aefb-71fc60d70e8f
+                        debug!(
+                            logger,
+                            "Trying again after {} failed (attempt #{}) with result {:?}",
+                            &operation_name,
+                            attempt_count,
+                            result
                         );
                     }
 
                     // Wrap in Err to force retry
-                    Err(result_with_timeout)
+                    Err(result.map_err(TimeoutError::Inner))
                 } else {
-                    // Any error must now be an inner error.
-                    // Unwrap the inner error so that the predicate doesn't need to think
-                    // about timeout::Error.
-                    let result = result_with_timeout.map_err(|e| e.into_inner().unwrap());
-
-                    // If needs retry
-                    if condition.check(&result) {
-                        if attempt_count >= warn_after {
-                            // This looks like it would be nice to de-duplicate, but if we try
-                            // to use log! slog complains about requiring a const for the log level
-                            // See also b05e1594-e408-4047-aefb-71fc60d70e8f
-                            warn!(
-                                logger,
-                                "Trying again after {} failed (attempt #{}) with result {:?}",
-                                &operation_name,
-                                attempt_count,
-                                result
-                            );
-                        } else if attempt_count >= log_after {
-                            // See also b05e1594-e408-4047-aefb-71fc60d70e8f
-                            debug!(
-                                logger,
-                                "Trying again after {} failed (attempt #{}) with result {:?}",
-                                &operation_name,
-                                attempt_count,
-                                result
-                            );
-                        }
-
-                        // Wrap in Err to force retry
-                        Err(result.map_err(TimeoutError::Inner))
-                    } else {
-                        // Wrap in Ok to prevent retry
-                        Ok(result.map_err(TimeoutError::Inner))
-                    }
+                    // Wrap in Ok to prevent retry
+                    Ok(result.map_err(TimeoutError::Inner))
                 }
-            })
-            .compat()
+            }
+        })
     })
-    .boxed()
-    .compat()
     .then(|retry_result| {
         // Unwrap the inner result.
         // The outer Ok/Err is only used for retry control flow.
@@ -438,7 +433,8 @@ mod tests {
     #[test]
     fn test() {
         let logger = Logger::root(::slog::Discard, o!());
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let mut runtime = tokio::runtime::Builder::new()
+            .basic_scheduler()
             .enable_all()
             .build()
             .unwrap();
@@ -469,7 +465,8 @@ mod tests {
     #[test]
     fn limit_reached() {
         let logger = Logger::root(::slog::Discard, o!());
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let mut runtime = tokio::runtime::Builder::new()
+            .basic_scheduler()
             .enable_all()
             .build()
             .unwrap();
@@ -500,7 +497,8 @@ mod tests {
     #[test]
     fn limit_not_reached() {
         let logger = Logger::root(::slog::Discard, o!());
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let mut runtime = tokio::runtime::Builder::new()
+            .basic_scheduler()
             .enable_all()
             .build()
             .unwrap();

--- a/graph/src/util/jobs.rs
+++ b/graph/src/util/jobs.rs
@@ -85,7 +85,7 @@ impl Runner {
                 next = next.min(task.next_run);
             }
             let wait = next.saturating_duration_since(Instant::now());
-            tokio::time::sleep(wait).await;
+            tokio::time::delay_for(wait).await;
         }
         self.stop.store(false, Ordering::SeqCst);
         warn!(self.logger, "Received request to stop. Stopping runner");
@@ -116,7 +116,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(threaded_scheduler)]
     async fn jobs_run() {
         let count = Arc::new(Mutex::new(0));
         let job = CounterJob {
@@ -142,7 +142,7 @@ mod tests {
         stop.store(true, Ordering::SeqCst);
         // Wait for the runner to shut down
         while stop.load(Ordering::SeqCst) {
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            tokio::time::delay_for(Duration::from_millis(10)).await;
         }
     }
 }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -410,7 +410,6 @@ pub async fn execute_root_selection_set<R: Resolver>(
             Arc::new(tokio::sync::Semaphore::new(1))
                 .acquire_owned()
                 .await
-                .unwrap()
         };
 
         let logger = execute_ctx.logger.clone();

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -278,7 +278,7 @@ struct MockQueryLoadManager(Arc<tokio::sync::Semaphore>);
 impl QueryLoadManager for MockQueryLoadManager {
     async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit {
         // Unwrap: The semaphore is never closed.
-        self.0.clone().acquire_owned().await.unwrap()
+        self.0.clone().acquire_owned().await
     }
 
     fn record_work(&self, _shape_hash: u64, _duration: Duration, _cache_status: CacheStatus) {}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -540,11 +540,15 @@ async fn create_ethereum_networks(
 
             use crate::config::Transport::*;
 
-            let transport = match provider.transport {
+            let (transport_event_loop, transport) = match provider.transport {
                 Rpc => Transport::new_rpc(&provider.url),
-                Ipc => Transport::new_ipc(&provider.url).await,
-                Ws => Transport::new_ws(&provider.url).await,
+                Ipc => Transport::new_ipc(&provider.url),
+                Ws => Transport::new_ws(&provider.url),
             };
+
+            // If we drop the event loop the transport will stop working.
+            // For now it's fine to just leak it.
+            std::mem::forget(transport_event_loop);
 
             let supports_eip_1898 = !provider.features.contains("no_eip1898");
 

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -18,7 +18,6 @@ lazy_static = "1.4"
 uuid = { version = "0.8.1", features = ["v4"] }
 strum = "0.20.0"
 strum_macros = "0.20.1"
-bytes = "1.0"
 anyhow = "1.0"
 wasmtime = "0.26.0"
 defer = "0.1"

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.48"
 atomic_refcell = "0.1.7"
-ethabi = "14.0"
+ethabi = { git = "https://github.com/graphprotocol/ethabi.git", branch = "master" }
 futures = "0.1.21"
 hex = "0.4.3"
 graph = { path = "../../graph" }

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -3,7 +3,7 @@ use crate::{
     module::IntoTrap,
     UnresolvedContractCall,
 };
-use bytes::Bytes;
+use graph::bytes::Bytes;
 use ethabi::{Address, Token};
 use graph::components::ethereum::*;
 use graph::components::store::EntityKey;

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -3,8 +3,8 @@ use crate::{
     module::IntoTrap,
     UnresolvedContractCall,
 };
-use graph::bytes::Bytes;
 use ethabi::{Address, Token};
+use graph::bytes::Bytes;
 use graph::components::ethereum::*;
 use graph::components::store::EntityKey;
 use graph::components::subgraph::{ProofOfIndexingEvent, SharedProofOfIndexing};

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -350,7 +350,7 @@ impl WasmInstance {
                         None => break interrupt_handle.interrupt(), // Timed out.
 
                         Some(time) if time < minimum_wait => break interrupt_handle.interrupt(),
-                        Some(time) => tokio::time::sleep(time).await,
+                        Some(time) => tokio::time::delay_for(time).await,
                     }
                 }
             });

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -309,7 +309,7 @@ async fn json_parsing() {
     assert_eq!(output, "OK: foo");
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(threaded_scheduler)]
 async fn ipfs_cat() {
     let ipfs = IpfsClient::localhost();
     let hash = ipfs.add("42".into()).await.unwrap().hash;
@@ -318,12 +318,13 @@ async fn ipfs_cat() {
     // so we replicate what we do `spawn_module`.
     let runtime = tokio::runtime::Handle::current();
     std::thread::spawn(move || {
-        let _runtime_guard = runtime.enter();
-        let mut module = test_module("ipfsCat", mock_data_source("wasm_test/ipfs_cat.wasm"));
-        let arg = module.asc_new(&hash).unwrap();
-        let converted: AscPtr<AscString> = module.invoke_export("ipfsCatString", arg);
-        let data: String = module.instance_ctx().asc_get(converted).unwrap();
-        assert_eq!(data, "42");
+        runtime.enter(|| {
+            let mut module = test_module("ipfsCat", mock_data_source("wasm_test/ipfs_cat.wasm"));
+            let arg = module.asc_new(&hash).unwrap();
+            let converted: AscPtr<AscString> = module.invoke_export("ipfsCatString", arg);
+            let data: String = module.instance_ctx().asc_get(converted).unwrap();
+            assert_eq!(data, "42");
+        })
     })
     .join()
     .unwrap();
@@ -348,7 +349,7 @@ fn make_thing(subgraph_id: &str, id: &str, value: &str) -> (String, EntityModifi
     )
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(threaded_scheduler)]
 async fn ipfs_map() {
     const BAD_IPFS_HASH: &str = "bad-ipfs-hash";
 
@@ -370,34 +371,34 @@ async fn ipfs_map() {
         // so we replicate what we do `spawn_module`.
         let runtime = tokio::runtime::Handle::current();
         std::thread::spawn(move || {
-            let _runtime_guard = runtime.enter();
+            runtime.enter(|| {
+                let (mut module, store) = test_valid_module_and_store(
+                    subgraph_id,
+                    mock_data_source("wasm_test/ipfs_map.wasm"),
+                );
+                let value = module.asc_new(&hash).unwrap();
+                let user_data = module.asc_new(USER_DATA).unwrap();
 
-            let (mut module, store) = test_valid_module_and_store(
-                subgraph_id,
-                mock_data_source("wasm_test/ipfs_map.wasm"),
-            );
-            let value = module.asc_new(&hash).unwrap();
-            let user_data = module.asc_new(USER_DATA).unwrap();
+                // Invoke the callback
+                let func = module.get_func("ipfsMap").typed().unwrap().clone();
+                let _: () = func.call((value.wasm_ptr(), user_data.wasm_ptr()))?;
+                let mut mods = module
+                    .take_ctx()
+                    .ctx
+                    .state
+                    .entity_cache
+                    .as_modifications(store.as_ref())?
+                    .modifications;
 
-            // Invoke the callback
-            let func = module.get_func("ipfsMap").typed().unwrap().clone();
-            let _: () = func.call((value.wasm_ptr(), user_data.wasm_ptr()))?;
-            let mut mods = module
-                .take_ctx()
-                .ctx
-                .state
-                .entity_cache
-                .as_modifications(store.as_ref())?
-                .modifications;
-
-            // Bring the modifications into a predictable order (by entity_id)
-            mods.sort_by(|a, b| {
-                a.entity_key()
-                    .entity_id
-                    .partial_cmp(&b.entity_key().entity_id)
-                    .unwrap()
-            });
-            Ok(mods)
+                // Bring the modifications into a predictable order (by entity_id)
+                mods.sort_by(|a, b| {
+                    a.entity_key()
+                        .entity_id
+                        .partial_cmp(&b.entity_key().entity_id)
+                        .unwrap()
+                });
+                Ok(mods)
+            })
         })
         .join()
         .unwrap()
@@ -457,21 +458,21 @@ async fn ipfs_map() {
     assert!(errmsg.contains("Status(500)"));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(threaded_scheduler)]
 async fn ipfs_fail() {
     let runtime = tokio::runtime::Handle::current();
 
     // Ipfs host functions use `block_on` which must be called from a sync context,
     // so we replicate what we do `spawn_module`.
     std::thread::spawn(move || {
-        let _runtime_guard = runtime.enter();
+        runtime.enter(|| {
+            let mut module = test_module("ipfsFail", mock_data_source("wasm_test/ipfs_cat.wasm"));
 
-        let mut module = test_module("ipfsFail", mock_data_source("wasm_test/ipfs_cat.wasm"));
-
-        let hash = module.asc_new("invalid hash").unwrap();
-        assert!(module
-            .invoke_export::<_, AscString>("ipfsCat", hash,)
-            .is_null());
+            let hash = module.asc_new("invalid hash").unwrap();
+            assert!(module
+                .invoke_export::<_, AscString>("ipfsCat", hash,)
+                .is_null());
+        })
     })
     .join()
     .unwrap();

--- a/runtime/wasm/src/module/test/abi.rs
+++ b/runtime/wasm/src/module/test/abi.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(threaded_scheduler)]
 async fn unbounded_loop() {
     // Set handler timeout to 3 seconds.
     let module = test_valid_module_and_store_with_timeout(

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 futures = "0.1.21"
 graphql-parser = "0.3"
 http = "0.2"
-hyper = "0.14"
+hyper = "0.13"
 serde = "1.0"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -486,7 +486,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(threaded_scheduler)]
     async fn posting_valid_queries_yields_result_response() {
         let logger = Logger::root(slog::Discard, o!());
         let metrics_registry = Arc::new(MockMetricsRegistry::new());

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -12,7 +12,7 @@ use graph::prelude::*;
 use graph_server_http::test_utils;
 use graph_server_http::GraphQLServer as HyperGraphQLServer;
 
-use tokio::time::sleep;
+use tokio::time::delay_for;
 
 /// A simple stupid query runner for testing.
 pub struct TestGraphQlRunner;
@@ -91,7 +91,7 @@ mod test {
 
     #[test]
     fn rejects_empty_json() {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
         runtime
             .block_on(async {
                 let logger = Logger::root(slog::Discard, o!());
@@ -108,7 +108,7 @@ mod test {
                 // Launch the server to handle a single request
                 tokio::spawn(http_server.fuse().compat());
                 // Give some time for the server to start.
-                sleep(Duration::from_secs(2))
+                delay_for(Duration::from_secs(2))
                     .then(move |()| {
                         // Send an empty JSON POST request
                         let client = Client::new();
@@ -134,7 +134,7 @@ mod test {
 
     #[test]
     fn rejects_invalid_queries() {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
             let logger_factory = LoggerFactory::new(logger, None);
@@ -151,7 +151,7 @@ mod test {
             // Launch the server to handle a single request
             tokio::spawn(http_server.fuse().compat());
             // Give some time for the server to start.
-            sleep(Duration::from_secs(2))
+            delay_for(Duration::from_secs(2))
                 .then(move |()| {
                     // Send an broken query request
                     let client = Client::new();
@@ -216,7 +216,7 @@ mod test {
 
     #[test]
     fn accepts_valid_queries() {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
             let logger_factory = LoggerFactory::new(logger, None);
@@ -233,7 +233,7 @@ mod test {
             // Launch the server to handle a single request
             tokio::spawn(http_server.fuse().compat());
             // Give some time for the server to start.
-            sleep(Duration::from_secs(2))
+            delay_for(Duration::from_secs(2))
                 .then(move |()| {
                     // Send a valid example query
                     let client = Client::new();
@@ -263,7 +263,7 @@ mod test {
 
     #[test]
     fn accepts_valid_queries_with_variables() {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
         let _ = runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
             let logger_factory = LoggerFactory::new(logger, None);
@@ -280,7 +280,7 @@ mod test {
             // Launch the server to handle a single request
             tokio::spawn(http_server.fuse().compat());
             // Give some time for the server to start.
-            sleep(Duration::from_secs(2))
+            delay_for(Duration::from_secs(2))
                 .then(move |()| {
                     // Send a valid example query
                     let client = Client::new();

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -9,5 +9,5 @@ graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
 graphql-parser = "0.3"
 http = "0.2"
-hyper = "0.14"
+hyper = "0.13"
 serde = "1.0"

--- a/server/metrics/Cargo.toml
+++ b/server/metrics/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 futures = "0.1.21"
 graph = { path = "../../graph" }
 http = "0.2"
-hyper = { version = "0.14", features = ["server"] }
+hyper = "0.13"
 lazy_static = "1.2.0"
 serde = "1.0"

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -11,6 +11,6 @@ http = "0.2"
 lazy_static = "1.2.0"
 serde = "1.0"
 serde_derive = "1.0"
-tokio-tungstenite = "0.14"
+tokio-tungstenite = "0.10"
 uuid = { version = "0.7.2", features = ["v4"] }
 anyhow = "1.0"

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -83,7 +83,7 @@ where
         );
 
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
-        let socket = TcpListener::bind(&addr)
+        let mut socket = TcpListener::bind(&addr)
             .await
             .expect("Failed to bind WebSocket port");
 

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use graph::prelude::serde_json::{self, json};
 use graph::prelude::*;
-use graph::tokio_stream::wrappers::WatchStream;
 use graph_chain_ethereum::BlockIngestorMetrics;
 
 lazy_static! {
@@ -32,7 +31,7 @@ impl Watcher {
 
     fn send(&self) {
         // Unwrap: `self` holds a receiver.
-        self.sender.send(()).unwrap()
+        self.sender.broadcast(()).unwrap()
     }
 }
 
@@ -126,12 +125,7 @@ impl ChainHeadUpdateListener {
             .receiver
             .clone();
 
-        Box::new(
-            WatchStream::new(update_receiver)
-                .map(Result::<_, ()>::Ok)
-                .boxed()
-                .compat(),
-        )
+        Box::new(update_receiver.map(Result::<_, ()>::Ok).boxed().compat())
     }
 }
 

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -182,7 +182,11 @@ impl NotificationListener {
                                 // We'll assume here that if sending fails, this means that the
                                 // listener has already been dropped, the receiving
                                 // end is gone and we should terminate the listener loop
-                                if sender.clone().blocking_send(json_notification).is_err() {
+                                if Box::pin(sender.clone().send(json_notification))
+                                    .compat()
+                                    .wait()
+                                    .is_err()
+                                {
                                     break;
                                 }
                             }

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -92,7 +92,7 @@ where
     let store = STORE.subgraph_store();
 
     // Lock regardless of poisoning. This also forces sequential test execution.
-    let runtime = match STORE_RUNTIME.lock() {
+    let mut runtime = match STORE_RUNTIME.lock() {
         Ok(guard) => guard,
         Err(err) => err.into_inner(),
     };


### PR DESCRIPTION
We are having prod issues that are related to a recent code change, and the tokio 1.0 upgrade is the prime suspect. This reverts to tokio 0.2, and fully reverts #2362 since we cannot update web3 if we remain in tokio 0.2. Note that this is not a total revert of #2334 but only the necessary changes to get back on 0.2.