### PR TITLE
ES: Fix memory leak and logs not flushing

### DIFF
--- a/graph/src/log/elastic.rs
+++ b/graph/src/log/elastic.rs
@@ -205,7 +205,7 @@ impl ElasticDrain {
 
                 // Do nothing if there are no logs to flush
                 if logs_to_send.is_empty() {
-                    return;
+                    continue;
                 }
 
                 debug!(


### PR DESCRIPTION
This was issue was introduced in #2334, where as soon as there are no logs to flush, the log task would end. I don't think this is the end of our logging issues, but it should resolve the memory leak of logs accumulating endlessly.