### PR TITLE
Have a fallback timeout for chain head updates

### DIFF
--- a/graph/src/components/ethereum/listener.rs
+++ b/graph/src/components/ethereum/listener.rs
@@ -1,4 +1,3 @@
-use futures::Stream;
 use serde::de::{Deserializer, Error as DeserializerError};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -21,7 +20,3 @@ pub struct ChainHeadUpdate {
     pub head_block_hash: H256,
     pub head_block_number: u64,
 }
-
-/// The updates have no payload, receivers should call `Store::chain_head_ptr`
-/// to check what the latest block is.
-pub type ChainHeadUpdateStream = Box<dyn Stream<Item = (), Error = ()> + Send>;

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -11,7 +11,7 @@ pub use self::adapter::{
     EthereumContractStateRequest, EthereumLogFilter, EthereumNetworkIdentifier,
     MockEthereumAdapter, ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
 };
-pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateStream};
+pub use self::listener::ChainHeadUpdate;
 pub use self::network::{EthereumNetworkAdapters, EthereumNetworks, NodeCapabilities};
 pub use self::stream::{BlockStream, BlockStreamBuilder, BlockStreamEvent};
 pub use self::types::{

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1277,7 +1277,7 @@ pub trait ChainStore: Send + Sync + 'static {
     fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error>;
 
     /// Subscribe to chain head updates.
-    fn chain_head_updates(&self) -> ChainHeadUpdateStream;
+    fn chain_head_updates(&self) -> tokio::sync::watch::Receiver<()>;
 
     /// Get the current head block pointer for this chain.
     /// Any changes to the head block pointer will be to a block with a larger block number, never

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -35,6 +35,7 @@ pub use parking_lot;
 pub use prometheus;
 pub use semver;
 pub use stable_hash;
+pub use tokio;
 pub use tokio_stream;
 pub use url;
 
@@ -82,13 +83,13 @@ pub mod prelude {
 
     pub use crate::components::ethereum::{
         BlockFinality, BlockStream, BlockStreamBuilder, BlockStreamEvent, BlockStreamMetrics,
-        ChainHeadUpdate, ChainHeadUpdateStream, EthereumAdapter, EthereumAdapterError,
-        EthereumBlock, EthereumBlockData, EthereumBlockFilter, EthereumBlockPointer,
-        EthereumBlockTriggerType, EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall,
-        EthereumCallData, EthereumCallFilter, EthereumContractCall, EthereumContractCallError,
-        EthereumEventData, EthereumLogFilter, EthereumNetworkIdentifier, EthereumTransactionData,
-        EthereumTrigger, LightEthereumBlock, LightEthereumBlockExt, MappingTrigger,
-        ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
+        ChainHeadUpdate, EthereumAdapter, EthereumAdapterError, EthereumBlock, EthereumBlockData,
+        EthereumBlockFilter, EthereumBlockPointer, EthereumBlockTriggerType,
+        EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall, EthereumCallData,
+        EthereumCallFilter, EthereumContractCall, EthereumContractCallError, EthereumEventData,
+        EthereumLogFilter, EthereumNetworkIdentifier, EthereumTransactionData, EthereumTrigger,
+        LightEthereumBlock, LightEthereumBlockExt, MappingTrigger, ProviderEthRpcMetrics,
+        SubgraphEthRpcMetrics,
     };
     pub use crate::components::graphql::{
         GraphQlRunner, QueryLoadManager, SubscriptionResultFuture,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -33,7 +33,7 @@ mock! {
 
         fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error>;
 
-        fn chain_head_updates(&self) -> ChainHeadUpdateStream;
+        fn chain_head_updates(&self) -> tokio::sync::watch::Receiver<()>;
 
         fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error>;
 

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -16,8 +16,8 @@ use std::{collections::HashMap, convert::TryFrom};
 use std::{convert::TryInto, iter::FromIterator};
 
 use graph::prelude::{
-    web3::types::H256, BlockNumber, ChainHeadUpdateStream, Error, EthereumBlock,
-    EthereumBlockPointer, EthereumNetworkIdentifier, Future, LightEthereumBlock, Stream,
+    web3::types::H256, BlockNumber, Error, EthereumBlock, EthereumBlockPointer,
+    EthereumNetworkIdentifier, Future, LightEthereumBlock, Stream,
 };
 
 use crate::{
@@ -1235,7 +1235,7 @@ impl ChainStoreTrait for ChainStore {
         Ok(missing)
     }
 
-    fn chain_head_updates(&self) -> ChainHeadUpdateStream {
+    fn chain_head_updates(&self) -> graph::tokio::sync::watch::Receiver<()> {
         self.chain_head_update_listener
             .subscribe(self.chain.to_owned())
     }


### PR DESCRIPTION
We believe chain head updates not going through are the cause for some issues seen in production, so introduce a fallback so that things can still work while we debug.