### PR TITLE
Downgrade to tokio 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
+name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -239,7 +245,19 @@ dependencies = [
  "cfg-if 0.1.10",
  "constant_time_eq",
  "crypto-mac 0.8.0",
- "digest",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -248,7 +266,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -270,14 +297,14 @@ dependencies = [
  "hyper 0.14.5",
  "hyper-unix-connector",
  "log 0.4.11",
- "pin-project",
+ "pin-project 1.0.5",
  "serde",
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
  "thiserror",
  "tokio 1.4.0",
- "tokio-util",
+ "tokio-util 0.6.3",
  "url 2.2.1",
  "winapi 0.3.9",
 ]
@@ -319,6 +346,12 @@ name = "byte-slice-cast"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -755,7 +788,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -765,7 +798,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -962,11 +995,20 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -1187,6 +1229,12 @@ dependencies = [
  "syn 1.0.62",
  "synstructure",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fallible-iterator"
@@ -1425,6 +1473,15 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -1516,7 +1573,7 @@ dependencies = [
  "async-trait",
  "atomic_refcell",
  "bigdecimal",
- "bytes 1.0.1",
+ "bytes 0.5.6",
  "chrono",
  "diesel",
  "diesel_derives",
@@ -1555,7 +1612,7 @@ dependencies = [
  "test-store",
  "thiserror",
  "tiny-keccak 1.5.0",
- "tokio 1.4.0",
+ "tokio 0.2.25",
  "tokio-retry",
  "tokio-stream",
  "url 2.2.1",
@@ -1704,7 +1761,6 @@ dependencies = [
  "async-trait",
  "atomic_refcell",
  "bs58",
- "bytes 1.0.1",
  "defer",
  "ethabi 12.0.0-graph",
  "futures 0.1.31",
@@ -1736,7 +1792,7 @@ dependencies = [
  "graph-mock",
  "graphql-parser",
  "http 0.2.3",
- "hyper 0.14.5",
+ "hyper 0.13.10",
  "serde",
 ]
 
@@ -1749,7 +1805,7 @@ dependencies = [
  "graph-graphql",
  "graphql-parser",
  "http 0.2.3",
- "hyper 0.14.5",
+ "hyper 0.13.10",
  "serde",
 ]
 
@@ -1770,7 +1826,7 @@ dependencies = [
  "futures 0.1.31",
  "graph",
  "http 0.2.3",
- "hyper 0.14.5",
+ "hyper 0.13.10",
  "lazy_static",
  "serde",
 ]
@@ -1866,6 +1922,26 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.3",
+ "indexmap",
+ "slab 0.4.2",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "h2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
@@ -1879,7 +1955,7 @@ dependencies = [
  "indexmap",
  "slab 0.4.2",
  "tokio 1.4.0",
- "tokio-util",
+ "tokio-util 0.6.3",
  "tracing",
 ]
 
@@ -1926,7 +2002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac 0.10.0",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1961,6 +2037,16 @@ dependencies = [
  "futures 0.1.31",
  "http 0.1.21",
  "tokio-buf",
+]
+
+[[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes 0.5.6",
+ "http 0.2.3",
 ]
 
 [[package]]
@@ -2051,6 +2137,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.2.7",
+ "http 0.2.3",
+ "http-body 0.3.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.5",
+ "socket2 0.3.16",
+ "tokio 0.2.25",
+ "tower-service",
+ "tracing",
+ "want 0.3.0",
+]
+
+[[package]]
+name = "hyper"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
@@ -2065,7 +2175,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project 1.0.5",
  "socket2 0.4.0",
  "tokio 1.4.0",
  "tower-service",
@@ -2088,15 +2198,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "bytes 1.0.1",
- "hyper 0.14.5",
+ "bytes 0.5.6",
+ "hyper 0.13.10",
  "native-tls",
- "tokio 1.4.0",
- "tokio-native-tls",
+ "tokio 0.2.25",
+ "tokio-tls 0.3.1",
 ]
 
 [[package]]
@@ -2108,7 +2218,7 @@ dependencies = [
  "anyhow",
  "hex",
  "hyper 0.14.5",
- "pin-project",
+ "pin-project 1.0.5",
  "tokio 1.4.0",
 ]
 
@@ -2192,11 +2302,11 @@ dependencies = [
 
 [[package]]
 name = "input_buffer"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
+checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 0.5.6",
 ]
 
 [[package]]
@@ -2446,9 +2556,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
 dependencies = [
- "block-buffer",
- "digest",
- "opaque-debug",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -2533,9 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -2544,7 +2654,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log 0.4.11",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab 0.4.2",
  "winapi 0.2.8",
@@ -2571,14 +2681,14 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio 0.6.22",
+ "mio 0.6.23",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -2649,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -2752,6 +2862,12 @@ name = "once_cell"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -2953,11 +3069,31 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
+dependencies = [
+ "pin-project-internal 0.4.28",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.0.5",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -3247,6 +3383,19 @@ name = "radium"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "rand"
@@ -3557,19 +3706,19 @@ checksum = "05a51ad2b1c5c710fa89e6b1631068dab84ed687bc6a5fe061ad65da3d0c25b2"
 
 [[package]]
 name = "reqwest"
-version = "0.11.2"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
+checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
  "base64 0.13.0",
- "bytes 1.0.1",
+ "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http 0.2.3",
- "http-body 0.4.0",
- "hyper 0.14.5",
- "hyper-tls 0.5.0",
+ "http-body 0.3.1",
+ "hyper 0.13.10",
+ "hyper-tls 0.4.3",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -3582,8 +3731,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.4.0",
- "tokio-native-tls",
+ "tokio 0.2.25",
+ "tokio-tls 0.3.1",
  "url 2.2.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3888,15 +4037,14 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfebf75d25bd900fd1e7d11501efab59bc846dbc76196839663e6637bba9f25f"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer",
- "cfg-if 1.0.0",
- "cpuid-bool",
- "digest",
- "opaque-debug",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -3911,11 +4059,11 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpuid-bool",
- "digest",
- "opaque-debug",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -4364,7 +4512,7 @@ checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "mio 0.6.22",
+ "mio 0.6.23",
  "num_cpus",
  "tokio-codec",
  "tokio-current-thread",
@@ -4382,6 +4530,27 @@ dependencies = [
 
 [[package]]
 name = "tokio"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "iovec",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "mio 0.6.23",
+ "mio-uds",
+ "num_cpus",
+ "pin-project-lite 0.1.11",
+ "slab 0.4.2",
+ "tokio-macros 0.2.6",
+]
+
+[[package]]
+name = "tokio"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
@@ -4395,7 +4564,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite 0.2.6",
  "signal-hook-registry",
- "tokio-macros",
+ "tokio-macros 1.1.0",
  "winapi 0.3.9",
 ]
 
@@ -4431,7 +4600,7 @@ dependencies = [
  "futures 0.1.31",
  "iovec",
  "log 0.4.11",
- "mio 0.6.22",
+ "mio 0.6.23",
  "scoped-tls",
  "tokio 0.1.22",
  "tokio-executor",
@@ -4484,9 +4653,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.1.0"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4494,13 +4663,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
+name = "tokio-macros"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
- "native-tls",
- "tokio 1.4.0",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.62",
 ]
 
 [[package]]
@@ -4523,7 +4693,7 @@ dependencies = [
  "postgres-types",
  "socket2 0.4.0",
  "tokio 1.4.0",
- "tokio-util",
+ "tokio-util 0.6.3",
 ]
 
 [[package]]
@@ -4536,7 +4706,7 @@ dependencies = [
  "futures 0.1.31",
  "lazy_static",
  "log 0.4.11",
- "mio 0.6.22",
+ "mio 0.6.23",
  "num_cpus",
  "parking_lot 0.9.0",
  "slab 0.4.2",
@@ -4547,13 +4717,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+version = "0.2.0"
+source = "git+https://github.com/graphprotocol/rust-tokio-retry?branch=update-to-tokio-02#fc0e868bdc7ff79ac84cf502d4cec20c5ce5adaf"
 dependencies = [
- "pin-project",
- "rand 0.8.3",
- "tokio 1.4.0",
+ "futures 0.1.31",
+ "futures 0.3.13",
+ "rand 0.4.6",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -4565,7 +4735,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.6",
  "tokio 1.4.0",
- "tokio-util",
+ "tokio-util 0.6.3",
 ]
 
 [[package]]
@@ -4587,7 +4757,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
  "iovec",
- "mio 0.6.22",
+ "mio 0.6.23",
  "tokio-io",
  "tokio-reactor",
 ]
@@ -4643,15 +4813,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.14.0"
+name = "tokio-tls"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e96bb520beab540ab664bd5a9cfeaa1fcd846fa68c830b42e2c8963071251d2"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
- "futures-util",
+ "native-tls",
+ "tokio 0.2.25",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
+dependencies = [
+ "futures 0.3.13",
  "log 0.4.11",
- "pin-project",
- "tokio 1.4.0",
+ "pin-project 0.4.28",
+ "tokio 0.2.25",
  "tungstenite",
 ]
 
@@ -4664,7 +4844,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
  "log 0.4.11",
- "mio 0.6.22",
+ "mio 0.6.23",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
@@ -4681,7 +4861,7 @@ dependencies = [
  "iovec",
  "libc",
  "log 0.3.9",
- "mio 0.6.22",
+ "mio 0.6.23",
  "mio-uds",
  "tokio-core",
  "tokio-io",
@@ -4698,11 +4878,25 @@ dependencies = [
  "iovec",
  "libc",
  "log 0.4.11",
- "mio 0.6.22",
+ "mio 0.6.23",
  "mio-uds",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-core",
+ "futures-sink",
+ "log 0.4.11",
+ "pin-project-lite 0.1.11",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -4741,6 +4935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
+ "log 0.4.11",
  "pin-project-lite 0.1.11",
  "tracing-core",
 ]
@@ -4752,6 +4947,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project 1.0.5",
+ "tracing",
 ]
 
 [[package]]
@@ -4774,20 +4979,19 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.13.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8dada8c1a3aeca77d6b51a4f1314e0f4b8e438b7b1b71e3ddaca8080e4093"
+checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.11.0",
  "byteorder",
- "bytes 1.0.1",
+ "bytes 0.5.6",
  "http 0.2.3",
  "httparse",
  "input_buffer",
  "log 0.4.11",
- "rand 0.8.3",
+ "rand 0.7.3",
  "sha-1",
- "thiserror",
  "url 2.2.1",
  "utf-8",
 ]
@@ -5370,7 +5574,7 @@ dependencies = [
  "sha1",
  "tokio-core",
  "tokio-io",
- "tokio-tls",
+ "tokio-tls 0.2.1",
  "unicase 1.4.2",
  "url 1.7.2",
 ]

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -113,7 +113,7 @@ where
                 self.cleanup_cached_blocks()
             }
 
-            tokio::time::sleep(self.polling_interval).await;
+            tokio::time::delay_for(self.polling_interval).await;
         }
     }
 

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -661,7 +661,7 @@ impl<S: SubgraphStore, C: ChainStore> Stream for BlockStream<S, C> {
                             // Pause before trying again
                             let secs = (5 * self.consecutive_err_count).max(120) as u64;
                             state = BlockStreamState::RetryAfterDelay(Box::new(
-                                tokio::time::sleep(Duration::from_secs(secs))
+                                tokio::time::delay_for(Duration::from_secs(secs))
                                     .map(Ok)
                                     .boxed()
                                     .compat(),

--- a/chain/ethereum/tests/network_indexer.rs
+++ b/chain/ethereum/tests/network_indexer.rs
@@ -98,7 +98,7 @@ where
     let store = STORE.clone();
 
     // Lock regardless of poisoning. This also forces sequential test execution.
-    let runtime = match STORE_RUNTIME.lock() {
+    let mut runtime = match STORE_RUNTIME.lock() {
         Ok(guard) => guard,
         Err(err) => err.into_inner(),
     };

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -447,14 +447,11 @@ where
         // forward; this is easier than updating the existing block stream.
         //
         // This is a long-running and unfortunately a blocking future (see #905), so it is run in
-        // its own thread. It is also run with `task::unconstrained` because we have seen deadlocks
-        // occur without it, possibly caused by our use of legacy futures and tokio versions in the
-        // codebase and dependencies, which may not play well with the tokio 1.0 cooperative
-        // scheduling. It is also logical in terms of performance to run this with `unconstrained`,
-        // it has a dedicated OS thread so the OS will handle the preemption. See
-        // https://github.com/tokio-rs/tokio/issues/3493.
+        // its own thread. When upgrading to tokio 1.0 it would be logical to run this with
+        // `task::unconstrained`, since it has a dedicated OS thread so the OS will handle the
+        // preemption.
         graph::spawn_thread(deployment_id.to_string(), move || {
-            if let Err(e) = graph::block_on(task::unconstrained(run_subgraph(ctx))) {
+            if let Err(e) = graph::block_on(run_subgraph(ctx)) {
                 error!(
                     &logger,
                     "Subgraph instance failed to run: {}",

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -8,13 +8,13 @@ anyhow = "1.0"
 async-trait = "0.1.48"
 atomic_refcell = "0.1.7"
 bigdecimal = { version = "0.1.0", features = ["serde"] }
-bytes = "1.0.1"
+bytes = "0.5"
 diesel = { version = "1.4.6", features = ["postgres", "serde_json", "numeric", "r2d2"] }
 diesel_derives = "1.4"
 chrono = "0.4.19"
 Inflector = "0.11.3"
 isatty = "0.1.9"
-reqwest = { version = "0.11.2", features = ["json", "stream", "multipart"] }
+reqwest = { version = "0.10", features = ["json", "stream"] }
 
 # master contains changes such as
 # https://github.com/paritytech/ethabi/pull/140, which upstream does not want
@@ -46,9 +46,9 @@ slog-envlogger = "2.1.0"
 slog-term = "2.6.0"
 petgraph = "0.5.1"
 tiny-keccak = "1.5.0"
-tokio = { version = "1.4.0", features = ["time", "sync", "macros", "test-util", "rt-multi-thread"] }
+tokio = { version = "0.2.25", features = ["stream", "rt-threaded", "rt-util", "blocking", "time", "sync", "macros", "test-util", "net"] }
 tokio-stream = { version = "0.1.5", features = ["sync"] }
-tokio-retry = "0.3.0"
+tokio-retry = { git = "https://github.com/graphprotocol/rust-tokio-retry", branch = "update-to-tokio-02" }
 url = "2.2.1"
 prometheus = "0.12.0"
 priority-queue = "0.7.0"

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -653,7 +653,10 @@ where
         let mut pending_event: Option<StoreEvent> = None;
         let mut source = self.source.fuse();
         let mut had_err = false;
-        let mut delay = tokio::time::sleep(interval).unit_error().boxed().compat();
+        let mut delay = tokio::time::delay_for(interval)
+            .unit_error()
+            .boxed()
+            .compat();
         let logger = logger.clone();
 
         let source = Box::new(poll_fn(move || -> Poll<Option<Arc<StoreEvent>>, ()> {
@@ -680,7 +683,10 @@ where
                 // Timer errors are harmless. Treat them as if the timer had
                 // become ready.
                 Ok(Async::Ready(())) | Err(_) => {
-                    delay = tokio::time::sleep(interval).unit_error().boxed().compat();
+                    delay = tokio::time::delay_for(interval)
+                        .unit_error()
+                        .boxed()
+                        .compat();
                     true
                 }
             };

--- a/graph/src/data/graphql/effort.rs
+++ b/graph/src/data/graphql/effort.rs
@@ -562,12 +562,7 @@ impl QueryLoadManager for LoadManager {
         let start = Instant::now();
 
         // Unwrap: The semaphore is never closed.
-        let permit = self
-            .query_semaphore
-            .cheap_clone()
-            .acquire_owned()
-            .await
-            .unwrap();
+        let permit = self.query_semaphore.cheap_clone().acquire_owned().await;
         self.add_wait_time(start.elapsed());
         permit
     }

--- a/graph/src/task_spawn.rs
+++ b/graph/src/task_spawn.rs
@@ -59,9 +59,5 @@ pub fn block_on<T>(f: impl Future03<Output = T>) -> T {
 pub fn spawn_thread(name: String, f: impl 'static + FnOnce() + Send) {
     let conf = std::thread::Builder::new().name(name);
     let runtime = tokio::runtime::Handle::current();
-    conf.spawn(move || {
-        let _runtime_guard = runtime.enter();
-        f()
-    })
-    .unwrap();
+    conf.spawn(move || runtime.enter(f)).unwrap();
 }

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -1,6 +1,5 @@
 use crate::ext::futures::FutureExtension;
 use futures::prelude::*;
-use futures03::compat::Future01CompatExt;
 use futures03::{FutureExt, TryFutureExt};
 use slog::{debug, trace, warn, Logger};
 use std::fmt::Debug;
@@ -278,68 +277,64 @@ where
 
         attempt_count += 1;
 
-        try_it_with_timeout()
-            .then(move |result_with_timeout| {
-                let is_elapsed = result_with_timeout
-                    .as_ref()
-                    .err()
-                    .map(|e| e.is_elapsed())
-                    .unwrap_or(false);
+        try_it_with_timeout().then(move |result_with_timeout| {
+            let is_elapsed = result_with_timeout
+                .as_ref()
+                .err()
+                .map(|e| e.is_elapsed())
+                .unwrap_or(false);
 
-                if is_elapsed {
-                    if attempt_count >= log_after {
-                        debug!(
+            if is_elapsed {
+                if attempt_count >= log_after {
+                    debug!(
+                        logger,
+                        "Trying again after {} timed out (attempt #{})",
+                        &operation_name,
+                        attempt_count,
+                    );
+                }
+
+                // Wrap in Err to force retry
+                Err(result_with_timeout)
+            } else {
+                // Any error must now be an inner error.
+                // Unwrap the inner error so that the predicate doesn't need to think
+                // about timeout::Error.
+                let result = result_with_timeout.map_err(|e| e.into_inner().unwrap());
+
+                // If needs retry
+                if condition.check(&result) {
+                    if attempt_count >= warn_after {
+                        // This looks like it would be nice to de-duplicate, but if we try
+                        // to use log! slog complains about requiring a const for the log level
+                        // See also b05e1594-e408-4047-aefb-71fc60d70e8f
+                        warn!(
                             logger,
-                            "Trying again after {} timed out (attempt #{})",
+                            "Trying again after {} failed (attempt #{}) with result {:?}",
                             &operation_name,
                             attempt_count,
+                            result
+                        );
+                    } else if attempt_count >= log_after {
+                        // See also b05e1594-e408-4047-aefb-71fc60d70e8f
+                        debug!(
+                            logger,
+                            "Trying again after {} failed (attempt #{}) with result {:?}",
+                            &operation_name,
+                            attempt_count,
+                            result
                         );
                     }
 
                     // Wrap in Err to force retry
-                    Err(result_with_timeout)
+                    Err(result.map_err(TimeoutError::Inner))
                 } else {
-                    // Any error must now be an inner error.
-                    // Unwrap the inner error so that the predicate doesn't need to think
-                    // about timeout::Error.
-                    let result = result_with_timeout.map_err(|e| e.into_inner().unwrap());
-
-                    // If needs retry
-                    if condition.check(&result) {
-                        if attempt_count >= warn_after {
-                            // This looks like it would be nice to de-duplicate, but if we try
-                            // to use log! slog complains about requiring a const for the log level
-                            // See also b05e1594-e408-4047-aefb-71fc60d70e8f
-                            warn!(
-                                logger,
-                                "Trying again after {} failed (attempt #{}) with result {:?}",
-                                &operation_name,
-                                attempt_count,
-                                result
-                            );
-                        } else if attempt_count >= log_after {
-                            // See also b05e1594-e408-4047-aefb-71fc60d70e8f
-                            debug!(
-                                logger,
-                                "Trying again after {} failed (attempt #{}) with result {:?}",
-                                &operation_name,
-                                attempt_count,
-                                result
-                            );
-                        }
-
-                        // Wrap in Err to force retry
-                        Err(result.map_err(TimeoutError::Inner))
-                    } else {
-                        // Wrap in Ok to prevent retry
-                        Ok(result.map_err(TimeoutError::Inner))
-                    }
+                    // Wrap in Ok to prevent retry
+                    Ok(result.map_err(TimeoutError::Inner))
                 }
-            })
-            .compat()
+            }
+        })
     })
-    .boxed()
-    .compat()
     .then(|retry_result| {
         // Unwrap the inner result.
         // The outer Ok/Err is only used for retry control flow.
@@ -438,7 +433,8 @@ mod tests {
     #[test]
     fn test() {
         let logger = Logger::root(::slog::Discard, o!());
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let mut runtime = tokio::runtime::Builder::new()
+            .basic_scheduler()
             .enable_all()
             .build()
             .unwrap();
@@ -469,7 +465,8 @@ mod tests {
     #[test]
     fn limit_reached() {
         let logger = Logger::root(::slog::Discard, o!());
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let mut runtime = tokio::runtime::Builder::new()
+            .basic_scheduler()
             .enable_all()
             .build()
             .unwrap();
@@ -500,7 +497,8 @@ mod tests {
     #[test]
     fn limit_not_reached() {
         let logger = Logger::root(::slog::Discard, o!());
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let mut runtime = tokio::runtime::Builder::new()
+            .basic_scheduler()
             .enable_all()
             .build()
             .unwrap();

--- a/graph/src/util/jobs.rs
+++ b/graph/src/util/jobs.rs
@@ -85,7 +85,7 @@ impl Runner {
                 next = next.min(task.next_run);
             }
             let wait = next.saturating_duration_since(Instant::now());
-            tokio::time::sleep(wait).await;
+            tokio::time::delay_for(wait).await;
         }
         self.stop.store(false, Ordering::SeqCst);
         warn!(self.logger, "Received request to stop. Stopping runner");
@@ -116,7 +116,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(threaded_scheduler)]
     async fn jobs_run() {
         let count = Arc::new(Mutex::new(0));
         let job = CounterJob {
@@ -142,7 +142,7 @@ mod tests {
         stop.store(true, Ordering::SeqCst);
         // Wait for the runner to shut down
         while stop.load(Ordering::SeqCst) {
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            tokio::time::delay_for(Duration::from_millis(10)).await;
         }
     }
 }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -410,7 +410,6 @@ pub async fn execute_root_selection_set<R: Resolver>(
             Arc::new(tokio::sync::Semaphore::new(1))
                 .acquire_owned()
                 .await
-                .unwrap()
         };
 
         let logger = execute_ctx.logger.clone();

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -278,7 +278,7 @@ struct MockQueryLoadManager(Arc<tokio::sync::Semaphore>);
 impl QueryLoadManager for MockQueryLoadManager {
     async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit {
         // Unwrap: The semaphore is never closed.
-        self.0.clone().acquire_owned().await.unwrap()
+        self.0.clone().acquire_owned().await
     }
 
     fn record_work(&self, _shape_hash: u64, _duration: Duration, _cache_status: CacheStatus) {}

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -18,7 +18,6 @@ lazy_static = "1.4"
 uuid = { version = "0.8.1", features = ["v4"] }
 strum = "0.20.0"
 strum_macros = "0.20.1"
-bytes = "1.0"
 anyhow = "1.0"
 wasmtime = "0.26.0"
 defer = "0.1"

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -3,8 +3,8 @@ use crate::{
     module::IntoTrap,
     UnresolvedContractCall,
 };
-use bytes::Bytes;
 use ethabi::{Address, Token};
+use graph::bytes::Bytes;
 use graph::components::ethereum::*;
 use graph::components::store::EntityKey;
 use graph::components::subgraph::{ProofOfIndexingEvent, SharedProofOfIndexing};

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -350,7 +350,7 @@ impl WasmInstance {
                         None => break interrupt_handle.interrupt(), // Timed out.
 
                         Some(time) if time < minimum_wait => break interrupt_handle.interrupt(),
-                        Some(time) => tokio::time::sleep(time).await,
+                        Some(time) => tokio::time::delay_for(time).await,
                     }
                 }
             });

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -309,7 +309,7 @@ async fn json_parsing() {
     assert_eq!(output, "OK: foo");
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(threaded_scheduler)]
 async fn ipfs_cat() {
     let ipfs = IpfsClient::localhost();
     let hash = ipfs.add("42".into()).await.unwrap().hash;
@@ -318,12 +318,13 @@ async fn ipfs_cat() {
     // so we replicate what we do `spawn_module`.
     let runtime = tokio::runtime::Handle::current();
     std::thread::spawn(move || {
-        let _runtime_guard = runtime.enter();
-        let mut module = test_module("ipfsCat", mock_data_source("wasm_test/ipfs_cat.wasm"));
-        let arg = module.asc_new(&hash).unwrap();
-        let converted: AscPtr<AscString> = module.invoke_export("ipfsCatString", arg);
-        let data: String = module.instance_ctx().asc_get(converted).unwrap();
-        assert_eq!(data, "42");
+        runtime.enter(|| {
+            let mut module = test_module("ipfsCat", mock_data_source("wasm_test/ipfs_cat.wasm"));
+            let arg = module.asc_new(&hash).unwrap();
+            let converted: AscPtr<AscString> = module.invoke_export("ipfsCatString", arg);
+            let data: String = module.instance_ctx().asc_get(converted).unwrap();
+            assert_eq!(data, "42");
+        })
     })
     .join()
     .unwrap();
@@ -348,7 +349,7 @@ fn make_thing(subgraph_id: &str, id: &str, value: &str) -> (String, EntityModifi
     )
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(threaded_scheduler)]
 async fn ipfs_map() {
     const BAD_IPFS_HASH: &str = "bad-ipfs-hash";
 
@@ -370,34 +371,34 @@ async fn ipfs_map() {
         // so we replicate what we do `spawn_module`.
         let runtime = tokio::runtime::Handle::current();
         std::thread::spawn(move || {
-            let _runtime_guard = runtime.enter();
+            runtime.enter(|| {
+                let (mut module, store) = test_valid_module_and_store(
+                    subgraph_id,
+                    mock_data_source("wasm_test/ipfs_map.wasm"),
+                );
+                let value = module.asc_new(&hash).unwrap();
+                let user_data = module.asc_new(USER_DATA).unwrap();
 
-            let (mut module, store) = test_valid_module_and_store(
-                subgraph_id,
-                mock_data_source("wasm_test/ipfs_map.wasm"),
-            );
-            let value = module.asc_new(&hash).unwrap();
-            let user_data = module.asc_new(USER_DATA).unwrap();
+                // Invoke the callback
+                let func = module.get_func("ipfsMap").typed().unwrap().clone();
+                let _: () = func.call((value.wasm_ptr(), user_data.wasm_ptr()))?;
+                let mut mods = module
+                    .take_ctx()
+                    .ctx
+                    .state
+                    .entity_cache
+                    .as_modifications(store.as_ref())?
+                    .modifications;
 
-            // Invoke the callback
-            let func = module.get_func("ipfsMap").typed().unwrap().clone();
-            let _: () = func.call((value.wasm_ptr(), user_data.wasm_ptr()))?;
-            let mut mods = module
-                .take_ctx()
-                .ctx
-                .state
-                .entity_cache
-                .as_modifications(store.as_ref())?
-                .modifications;
-
-            // Bring the modifications into a predictable order (by entity_id)
-            mods.sort_by(|a, b| {
-                a.entity_key()
-                    .entity_id
-                    .partial_cmp(&b.entity_key().entity_id)
-                    .unwrap()
-            });
-            Ok(mods)
+                // Bring the modifications into a predictable order (by entity_id)
+                mods.sort_by(|a, b| {
+                    a.entity_key()
+                        .entity_id
+                        .partial_cmp(&b.entity_key().entity_id)
+                        .unwrap()
+                });
+                Ok(mods)
+            })
         })
         .join()
         .unwrap()
@@ -457,21 +458,21 @@ async fn ipfs_map() {
     assert!(errmsg.contains("Status(500)"));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(threaded_scheduler)]
 async fn ipfs_fail() {
     let runtime = tokio::runtime::Handle::current();
 
     // Ipfs host functions use `block_on` which must be called from a sync context,
     // so we replicate what we do `spawn_module`.
     std::thread::spawn(move || {
-        let _runtime_guard = runtime.enter();
+        runtime.enter(|| {
+            let mut module = test_module("ipfsFail", mock_data_source("wasm_test/ipfs_cat.wasm"));
 
-        let mut module = test_module("ipfsFail", mock_data_source("wasm_test/ipfs_cat.wasm"));
-
-        let hash = module.asc_new("invalid hash").unwrap();
-        assert!(module
-            .invoke_export::<_, AscString>("ipfsCat", hash,)
-            .is_null());
+            let hash = module.asc_new("invalid hash").unwrap();
+            assert!(module
+                .invoke_export::<_, AscString>("ipfsCat", hash,)
+                .is_null());
+        })
     })
     .join()
     .unwrap();

--- a/runtime/wasm/src/module/test/abi.rs
+++ b/runtime/wasm/src/module/test/abi.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(threaded_scheduler)]
 async fn unbounded_loop() {
     // Set handler timeout to 3 seconds.
     let module = test_valid_module_and_store_with_timeout(

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 futures = "0.1.21"
 graphql-parser = "0.3"
 http = "0.2"
-hyper = "0.14"
+hyper = "0.13"
 serde = "1.0"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -486,7 +486,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(threaded_scheduler)]
     async fn posting_valid_queries_yields_result_response() {
         let logger = Logger::root(slog::Discard, o!());
         let metrics_registry = Arc::new(MockMetricsRegistry::new());

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -12,7 +12,7 @@ use graph::prelude::*;
 use graph_server_http::test_utils;
 use graph_server_http::GraphQLServer as HyperGraphQLServer;
 
-use tokio::time::sleep;
+use tokio::time::delay_for;
 
 /// A simple stupid query runner for testing.
 pub struct TestGraphQlRunner;
@@ -91,7 +91,7 @@ mod test {
 
     #[test]
     fn rejects_empty_json() {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
         runtime
             .block_on(async {
                 let logger = Logger::root(slog::Discard, o!());
@@ -108,7 +108,7 @@ mod test {
                 // Launch the server to handle a single request
                 tokio::spawn(http_server.fuse().compat());
                 // Give some time for the server to start.
-                sleep(Duration::from_secs(2))
+                delay_for(Duration::from_secs(2))
                     .then(move |()| {
                         // Send an empty JSON POST request
                         let client = Client::new();
@@ -134,7 +134,7 @@ mod test {
 
     #[test]
     fn rejects_invalid_queries() {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
             let logger_factory = LoggerFactory::new(logger, None);
@@ -151,7 +151,7 @@ mod test {
             // Launch the server to handle a single request
             tokio::spawn(http_server.fuse().compat());
             // Give some time for the server to start.
-            sleep(Duration::from_secs(2))
+            delay_for(Duration::from_secs(2))
                 .then(move |()| {
                     // Send an broken query request
                     let client = Client::new();
@@ -216,7 +216,7 @@ mod test {
 
     #[test]
     fn accepts_valid_queries() {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
             let logger_factory = LoggerFactory::new(logger, None);
@@ -233,7 +233,7 @@ mod test {
             // Launch the server to handle a single request
             tokio::spawn(http_server.fuse().compat());
             // Give some time for the server to start.
-            sleep(Duration::from_secs(2))
+            delay_for(Duration::from_secs(2))
                 .then(move |()| {
                     // Send a valid example query
                     let client = Client::new();
@@ -263,7 +263,7 @@ mod test {
 
     #[test]
     fn accepts_valid_queries_with_variables() {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
         let _ = runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
             let logger_factory = LoggerFactory::new(logger, None);
@@ -280,7 +280,7 @@ mod test {
             // Launch the server to handle a single request
             tokio::spawn(http_server.fuse().compat());
             // Give some time for the server to start.
-            sleep(Duration::from_secs(2))
+            delay_for(Duration::from_secs(2))
                 .then(move |()| {
                     // Send a valid example query
                     let client = Client::new();

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -9,5 +9,5 @@ graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
 graphql-parser = "0.3"
 http = "0.2"
-hyper = "0.14"
+hyper = "0.13"
 serde = "1.0"

--- a/server/metrics/Cargo.toml
+++ b/server/metrics/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 futures = "0.1.21"
 graph = { path = "../../graph" }
 http = "0.2"
-hyper = { version = "0.14", features = ["server"] }
+hyper = "0.13"
 lazy_static = "1.2.0"
 serde = "1.0"

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -11,6 +11,6 @@ http = "0.2"
 lazy_static = "1.2.0"
 serde = "1.0"
 serde_derive = "1.0"
-tokio-tungstenite = "0.14"
+tokio-tungstenite = "0.10"
 uuid = { version = "0.7.2", features = ["v4"] }
 anyhow = "1.0"

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -83,7 +83,7 @@ where
         );
 
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
-        let socket = TcpListener::bind(&addr)
+        let mut socket = TcpListener::bind(&addr)
             .await
             .expect("Failed to bind WebSocket port");
 

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use graph::prelude::serde_json::{self, json};
 use graph::prelude::*;
-use graph::tokio_stream::wrappers::WatchStream;
 use graph_chain_ethereum::BlockIngestorMetrics;
 
 lazy_static! {
@@ -32,7 +31,7 @@ impl Watcher {
 
     fn send(&self) {
         // Unwrap: `self` holds a receiver.
-        self.sender.send(()).unwrap()
+        self.sender.broadcast(()).unwrap()
     }
 }
 
@@ -126,12 +125,7 @@ impl ChainHeadUpdateListener {
             .receiver
             .clone();
 
-        Box::new(
-            WatchStream::new(update_receiver)
-                .map(Result::<_, ()>::Ok)
-                .boxed()
-                .compat(),
-        )
+        Box::new(update_receiver.map(Result::<_, ()>::Ok).boxed().compat())
     }
 }
 

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -193,7 +193,11 @@ impl NotificationListener {
                                 // We'll assume here that if sending fails, this means that the
                                 // listener has already been dropped, the receiving
                                 // end is gone and we should terminate the listener loop
-                                if sender.clone().blocking_send(json_notification).is_err() {
+                                if Box::pin(sender.clone().send(json_notification))
+                                    .compat()
+                                    .wait()
+                                    .is_err()
+                                {
                                     break;
                                 }
                             }

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -92,7 +92,7 @@ where
     let store = STORE.subgraph_store();
 
     // Lock regardless of poisoning. This also forces sequential test execution.
-    let runtime = match STORE_RUNTIME.lock() {
+    let mut runtime = match STORE_RUNTIME.lock() {
         Ok(guard) => guard,
         Err(err) => err.into_inner(),
     };


### PR DESCRIPTION
Outside the chain head update issues that would have been worked around by #2378, the tokio 1.0 upgrade seems to be the cause for serious performance regressions in block processing time. So reverting it is necessary until we have time iron out these issues. Opened #2380 to track any future attempt at upgrading.