### PR TITLE
Downgrade noisy logs to trace

### DIFF
--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -215,7 +215,7 @@ impl RuntimeHost {
         let handler = trigger.handler_name().to_string();
 
         let extras = trigger.logging_extras();
-        debug!(
+        trace!(
             logger, "Start processing Ethereum trigger";
             &extras,
             "trigger_type" => trigger_type,
@@ -257,6 +257,7 @@ impl RuntimeHost {
             "trigger_type" => trigger_type,
             "total_ms" => elapsed.as_millis(),
             "handler" => handler,
+            "data_source" => &self.data_source.name,
         );
 
         result

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -377,7 +377,7 @@ impl HostExports {
             ))),
         };
 
-        debug!(logger, "Contract call finished";
+        trace!(logger, "Contract call finished";
               "address" => &unresolved_call.contract_address.to_string(),
               "contract" => &unresolved_call.contract_name,
               "function" => &unresolved_call.function_name,


### PR DESCRIPTION
Don't know what others think, but the 'start' and 'done' logs are basically redundant, but the 'done' includes the timing so I downgraded the 'start' to trace level. Also the contract call log isn't very useful so I downgraded it to 'trace' as well. The goal is to make logs a bit more scrollable and readable at debug level, which is what the hosted service uses.