### PR TITLE
Parallel trace_filter calls

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -21,11 +21,11 @@ those.
 - `ETHEREUM_TRACE_STREAM_STEP_SIZE`: `graph-node` queries traces for a given
   block range when a subgraph defines call handlers or block handlers with a
   call filter. The value of this variable controls the number of blocks to scan
-  in a single RPC request for traces from the Ethereum node.
+  in a single RPC request for traces from the Ethereum node. Defaults to 50.
 - `DISABLE_BLOCK_INGESTOR`: set to `true` to disable block ingestion. Leave
   unset or set to `false` to leave block ingestion enabled.
-- `ETHEREUM_BLOCK_BATCH_SIZE`: number of Ethereum blocks to request in parallel
-  (defaults to 50)
+- `ETHEREUM_BLOCK_BATCH_SIZE`: number of Ethereum blocks to request in parallel.
+  Also limits other parallel requests such such as trace_filter. Defaults to 10.
 - `GRAPH_ETHEREUM_MAX_BLOCK_RANGE_SIZE`: Maximum number of blocks to scan for
   triggers in each request (defaults to 1000).
 - `GRAPH_ETHEREUM_MAX_EVENT_ONLY_RANGE`: Maximum range size for `eth.getLogs`


### PR DESCRIPTION
This reduces the default range size to 50, so each request is less likely to timeout, but makes requests in parallel for a potential performance improvement.

