### PR TITLE
docs: Added up to date network options for Ethereum data source

### DIFF
--- a/docs/subgraph-manifest.md
+++ b/docs/subgraph-manifest.md
@@ -1,5 +1,5 @@
 # Subgraph Manifest
-##### v.0.0.1
+##### v.0.0.2
 
 ## 1.1 Overview
 The subgraph manifest specifies all the information required to index and query a specific subgraph. This is the entry point to your subgraph.
@@ -33,7 +33,7 @@ Any data format that has a well-defined 1:1 mapping with the [IPLD Canonical For
 | --- | --- | --- |
 | **kind** | *String | The type of data source. Possible values: *ethereum/contract*.|
 | **name** | *String* | The name of the source data. Will be used to generate APIs in the mapping and also for self-documentation purposes. |
-| **network** | *String* | For blockchains, this describes which network the subgraph targets. For Ethereum, this could be, for example, "mainnet" or "rinkeby". |
+| **network** | *String* | For blockchains, this describes which network the subgraph targets. For Ethereum, this can be any of "mainnet", "rinkeby", "kovan", "ropsten", "goerli", "poa-core", "poa-sokol", "xdai", "matic", "mumbai", "fantom", "bsc" or "clover". Developers could look for an up to date list in the graph-cli [*code*](https://github.com/graphprotocol/graph-cli/blob/master/src/commands/init.js#L43-L57).|
 | **source** | [*EthereumContractSource*](#151-ethereumcontractsource) | The source data on a blockchain such as Ethereum. |
 | **mapping** | [*Mapping*](#152-mapping) | The transformation logic applied to the data prior to being indexed. |
 


### PR DESCRIPTION
First PR raised in this project, having read the contribution guidelines and attempts to align to previous PRs and commits as best as I saw from history. Please do let me know if you'd like me to do any further revisions to any part.

I was looking to build and deploy a subgraph for BSC and could not find the network information required for the data source inside the subgraph-manifest docs. I found the information I needed on discord as an adhoc answer to my specfic question, but also wanted to find the source information for the options available. I eventually found this inside https://github.com/graphprotocol/graph-cli/blob/master/src/commands/init.js#L43-L57, which I have linked to in this tiny update. 

I would have loved to have this information easily available, and I am hoping it may help the next person. Hopefully you'll agree and we can update this part of the docs. I haven't looked at the rest of the manifest, but would also like to keep this first PR small.

Excited to contribute a tiny part to your great project.

