### PR TITLE
chains: change ethereum BlockHash logs back to hex format

### DIFF
--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -462,7 +462,7 @@ impl Clone for EthereumCallData {
 }
 
 /// A simple marker for byte arrays that are really block hashes
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Default, PartialEq, Eq, Hash)]
 pub struct BlockHash(pub Box<[u8]>);
 
 impl From<H256> for BlockHash {
@@ -472,6 +472,12 @@ impl From<H256> for BlockHash {
 }
 
 impl Display for BlockHash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "0x{}", hex::encode(&self.0))
+    }
+}
+
+impl fmt::Debug for BlockHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "0x{}", hex::encode(&self.0))
     }


### PR DESCRIPTION
At `master` this log is like this:

```
Apr 22 09:20:09.150 TRCE Subgraph pointer, number: 12289149, hash: Some(BlockHash([199, 141, 161, 107, 48, 115, 24, 183, 143, 41, 208, 195, 92, 3, 224, 68, 51, 67, 124, 214, 47, 99, 80, 137, 149, 221, 70, 31, 244, 51, 6, 190])), sgd: 52675, subgraph_id: QmZ2xEvr9MtPAGjuUQehKbGTo5178VhuQQpCjh7okdt8xr, component: SubgraphInstanceManager > BlockStream
```

It was using hex format before, we should go back to it. This happened because of [this change](https://github.com/graphprotocol/graph-node/commit/70f33788d64b15ca93e513651676a59477d282e2#diff-6169304ef93f023c417eb[…]61d35214ab9f8106c5b9ee1R417).

To fix the problem I've changed so we use the `Display` implementation instead of the `Debug` one, that's defined [here](https://github.com/graphprotocol/graph-node/blob/master/graph/src/components/ethereum/types.rs#L476).