### PR TITLE
store: Make sure SubgraphStore.locators returns all deployment instances

### DIFF
--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -780,3 +780,18 @@ pub fn update_entity_count(
         .execute(conn)?;
     Ok(())
 }
+
+/// Set the deployment's entity count to whatever `full_count_query` produces
+pub fn set_entity_count(
+    conn: &PgConnection,
+    site: &Site,
+    full_count_query: &str,
+) -> Result<(), StoreError> {
+    use subgraph_deployment as d;
+
+    let full_count_query = format!("({})", full_count_query);
+    update(d::table.filter(d::id.eq(site.id)))
+        .set(d::entity_count.eq(sql(&full_count_query)))
+        .execute(conn)?;
+    Ok(())
+}

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1181,7 +1181,7 @@ impl<'a> Connection<'a> {
         let used_by = s::table
             .inner_join(v::table.on(s::id.eq(v::subgraph)))
             .filter(v::deployment.eq(ds::subgraph))
-            .select(sql::<Array<Text>>("array_agg(name)"))
+            .select(sql::<Array<Text>>("array_agg(distinct name)"))
             .single_value();
 
         let unused = ds::table

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -322,8 +322,8 @@ impl Layout {
             .iter()
             .map(|table| {
                 format!(
-                    "select count(*) from \"{}\".\"{}\" where upper_inf(block_range)",
-                    &catalog.namespace, table.name
+                    "select count(*) from \"{}\".\"{}\" where block_range @> {}",
+                    &catalog.namespace, table.name, BLOCK_NUMBER_MAX
                 )
             })
             .collect::<Vec<_>>()

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -749,7 +749,7 @@ impl SubgraphStoreInner {
                 }
             }
             status::Filter::Deployments(deployments) => {
-                self.primary_conn()?.find_sites(deployments)?
+                self.primary_conn()?.find_sites(deployments, true)?
             }
         };
 
@@ -986,7 +986,7 @@ impl SubgraphStoreTrait for SubgraphStore {
     fn locators(&self, hash: &str) -> Result<Vec<DeploymentLocator>, StoreError> {
         Ok(self
             .primary_conn()?
-            .find_sites(vec![hash.to_string()])?
+            .find_sites(vec![hash.to_string()], false)?
             .iter()
             .map(|site| site.into())
             .collect())


### PR DESCRIPTION
We were filtering out inactive instances because that's what we look at for
deployment status, but for locators, we need to consider active and
inactive instances of a deployment.

