### PR TITLE
Rename EthereumBlockPointer and SubgraphDeploymentId

### DIFF
--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -88,7 +88,7 @@ struct BlockStreamContext<C> {
     chain_store: Arc<C>,
     eth_adapter: Arc<dyn EthereumAdapter>,
     node_id: NodeId,
-    subgraph_id: SubgraphDeploymentId,
+    subgraph_id: DeploymentHash,
     // This is not really a block number, but the (unsigned) difference
     // between two block numbers
     reorg_threshold: BlockNumber,
@@ -156,7 +156,7 @@ where
         chain_head_update_stream: ChainHeadUpdateStream,
         eth_adapter: Arc<dyn EthereumAdapter>,
         node_id: NodeId,
-        subgraph_id: SubgraphDeploymentId,
+        subgraph_id: DeploymentHash,
         log_filter: EthereumLogFilter,
         call_filter: EthereumCallFilter,
         block_filter: EthereumBlockFilter,

--- a/chain/ethereum/src/block_stream.rs
+++ b/chain/ethereum/src/block_stream.rs
@@ -70,7 +70,7 @@ enum ReconciliationStep {
     /// Revert the current block pointed at by the subgraph pointer. The pointer is to the current
     /// subgraph head, and a single block will be reverted so the new head will be the parent of the
     /// current one.
-    Revert(EthereumBlockPointer),
+    Revert(BlockPtr),
 
     /// Move forwards, processing one or more blocks. Second element is the block range size.
     ProcessDescendantBlocks(Vec<EthereumBlockWithTriggers>, BlockNumber),
@@ -142,7 +142,7 @@ enum NextBlocks {
     Blocks(VecDeque<EthereumBlockWithTriggers>, BlockNumber),
 
     /// Revert the current block pointed at by the subgraph pointer.
-    Revert(EthereumBlockPointer),
+    Revert(BlockPtr),
     Done,
 }
 
@@ -875,7 +875,7 @@ where
 // "test_reorg" fail point with the number of the block that should be reorged.
 #[cfg(debug_assertions)]
 #[allow(unused_variables)]
-fn test_reorg(ptr: EthereumBlockPointer) -> bool {
+fn test_reorg(ptr: BlockPtr) -> bool {
     fail_point!("test_reorg", |reorg_at| {
         use std::str::FromStr;
 

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -427,7 +427,7 @@ where
         logger: Logger,
         contract_address: Address,
         call_data: Bytes,
-        block_ptr: EthereumBlockPointer,
+        block_ptr: BlockPtr,
     ) -> impl Future<Item = Bytes, Error = EthereumContractCallError> + Send {
         let web3 = self.web3.clone();
 
@@ -597,7 +597,7 @@ where
         &self,
         logger: Logger,
         block_nums: Vec<BlockNumber>,
-    ) -> impl Stream<Item = EthereumBlockPointer, Error = Error> + Send {
+    ) -> impl Stream<Item = BlockPtr, Error = Error> + Send {
         let web3 = self.web3.clone();
 
         stream::iter_ok::<_, Error>(block_nums.into_iter().map(move |block_num| {
@@ -937,7 +937,7 @@ where
         logger: &Logger,
         chain_store: Arc<dyn ChainStore>,
         block_number: BlockNumber,
-    ) -> Box<dyn Future<Item = EthereumBlockPointer, Error = EthereumAdapterError> + Send> {
+    ) -> Box<dyn Future<Item = BlockPtr, Error = EthereumAdapterError> + Send> {
         Box::new(
             // When this method is called (from the subgraph registrar), we don't
             // know yet whether the block with the given number is final, it is
@@ -952,7 +952,7 @@ where
                     })
                 })
                 .from_err()
-                .map(move |block_hash| EthereumBlockPointer::from((block_hash, block_number))),
+                .map(move |block_hash| BlockPtr::from((block_hash, block_number))),
         )
     }
 
@@ -1080,7 +1080,7 @@ where
         logger: &Logger,
         _: Arc<SubgraphEthRpcMetrics>,
         chain_store: Arc<dyn ChainStore>,
-        block_ptr: EthereumBlockPointer,
+        block_ptr: BlockPtr,
     ) -> Box<dyn Future<Item = bool, Error = Error> + Send> {
         Box::new(
             self.block_hash_by_block_number(&logger, chain_store, block_ptr.number, true)
@@ -1337,7 +1337,7 @@ where
         logger: Logger,
         from: BlockNumber,
         to: BlockNumber,
-    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = Vec<BlockPtr>, Error = Error> + Send> {
         // Currently we can't go to the DB for this because there might be duplicate entries for
         // the same block number.
         debug!(&logger, "Requesting hashes for blocks [{}, {}]", from, to);

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -16,7 +16,7 @@ struct BlockWriterMetrics {
 impl BlockWriterMetrics {
     /// Creates new block writer metrics for a given subgraph.
     pub fn new(
-        subgraph_id: &SubgraphDeploymentId,
+        subgraph_id: &DeploymentHash,
         stopwatch: StopwatchMetrics,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
@@ -37,7 +37,7 @@ impl BlockWriterMetrics {
 /// Component that writes Ethereum blocks to the network subgraph store.
 pub struct BlockWriter {
     /// The network subgraph ID (e.g. `ethereum_mainnet_v0`).
-    subgraph_id: SubgraphDeploymentId,
+    subgraph_id: DeploymentHash,
 
     /// Logger.
     logger: Logger,
@@ -52,7 +52,7 @@ pub struct BlockWriter {
 impl BlockWriter {
     /// Creates a new block writer for the given subgraph ID.
     pub fn new(
-        subgraph_id: SubgraphDeploymentId,
+        subgraph_id: DeploymentHash,
         logger: &Logger,
         store: Arc<dyn WritableStore>,
         stopwatch: StopwatchMetrics,
@@ -93,7 +93,7 @@ impl BlockWriter {
 /// Internal context for writing a block.
 struct WriteContext {
     logger: Logger,
-    subgraph_id: SubgraphDeploymentId,
+    subgraph_id: DeploymentHash,
     store: Arc<dyn WritableStore>,
     cache: EntityCache,
     metrics: Arc<BlockWriterMetrics>,

--- a/chain/ethereum/src/network_indexer/block_writer.rs
+++ b/chain/ethereum/src/network_indexer/block_writer.rs
@@ -73,10 +73,7 @@ impl BlockWriter {
     }
 
     /// Writes a block to the store and updates the network subgraph block pointer.
-    pub fn write(
-        &self,
-        block: BlockWithOmmers,
-    ) -> impl Future<Item = EthereumBlockPointer, Error = Error> {
+    pub fn write(&self, block: BlockWithOmmers) -> impl Future<Item = BlockPtr, Error = Error> {
         let logger = self.logger.new(o!(
             "block" => format!("{}", block),
         ));
@@ -120,10 +117,7 @@ impl WriteContext {
     }
 
     /// Writes a block to the store.
-    fn write(
-        self,
-        block: BlockWithOmmers,
-    ) -> impl Future<Item = EthereumBlockPointer, Error = Error> {
+    fn write(self, block: BlockWithOmmers) -> impl Future<Item = BlockPtr, Error = Error> {
         debug!(self.logger, "Write block");
 
         let block = Arc::new(block);
@@ -153,7 +147,7 @@ impl WriteContext {
                     }
                     .modifications;
 
-                    let block_ptr = EthereumBlockPointer::from(&block_for_store.block);
+                    let block_ptr = BlockPtr::from(&block_for_store.block);
 
                     // Transact entity modifications into the store
                     let started = Instant::now();

--- a/chain/ethereum/src/network_indexer/convert.rs
+++ b/chain/ethereum/src/network_indexer/convert.rs
@@ -11,7 +11,7 @@ impl ToEntityId for Ommer {
 }
 
 impl ToEntityKey for Ommer {
-    fn to_entity_key(&self, subgraph_id: SubgraphDeploymentId) -> EntityKey {
+    fn to_entity_key(&self, subgraph_id: DeploymentHash) -> EntityKey {
         EntityKey::data(
             subgraph_id,
             BLOCK.to_string(),
@@ -27,7 +27,7 @@ impl ToEntityId for BlockWithOmmers {
 }
 
 impl ToEntityKey for &BlockWithOmmers {
-    fn to_entity_key(&self, subgraph_id: SubgraphDeploymentId) -> EntityKey {
+    fn to_entity_key(&self, subgraph_id: DeploymentHash) -> EntityKey {
         EntityKey::data(
             subgraph_id,
             BLOCK.to_string(),

--- a/chain/ethereum/src/network_indexer/metrics.rs
+++ b/chain/ethereum/src/network_indexer/metrics.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use graph::prelude::{
-    Aggregate, Counter, Gauge, MetricsRegistry, StopwatchMetrics, SubgraphDeploymentId,
+    Aggregate, Counter, DeploymentHash, Gauge, MetricsRegistry, StopwatchMetrics,
 };
 
 pub struct NetworkIndexerMetrics {
@@ -48,7 +48,7 @@ pub struct NetworkIndexerMetrics {
 
 impl NetworkIndexerMetrics {
     pub fn new(
-        subgraph_id: &SubgraphDeploymentId,
+        subgraph_id: &DeploymentHash,
         stopwatch: StopwatchMetrics,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -83,7 +83,7 @@ fn ensure_subgraph(
     logger: Logger,
     store: Arc<dyn SubgraphStore>,
     subgraph_name: SubgraphName,
-    subgraph_id: SubgraphDeploymentId,
+    subgraph_id: DeploymentHash,
     start_block: Option<BlockPtr>,
     network_name: String,
 ) -> EnsureSubgraphFuture {
@@ -450,7 +450,7 @@ pub struct Context {
     block_writer: Arc<BlockWriter>,
     event_sink: Sender<NetworkIndexerEvent>,
     subgraph_name: SubgraphName,
-    subgraph_id: SubgraphDeploymentId,
+    subgraph_id: DeploymentHash,
     start_block: Option<BlockPtr>,
     network_name: String,
 }
@@ -1136,7 +1136,7 @@ impl NetworkIndexer {
             subgraph_name.replace("/", "_"),
             NETWORK_INDEXER_VERSION
         );
-        let subgraph_id = SubgraphDeploymentId::new(id_str).expect("valid network subgraph ID");
+        let subgraph_id = DeploymentHash::new(id_str).expect("valid network subgraph ID");
         let subgraph_name = SubgraphName::new(subgraph_name).expect("valid network subgraph name");
 
         let logger = logger.new(o!(

--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 
 fn check_subgraph_exists(
     store: Arc<dyn SubgraphStore>,
-    subgraph_id: SubgraphDeploymentId,
+    subgraph_id: DeploymentHash,
 ) -> impl Future<Item = bool, Error = Error> {
     future::result(store.is_deployed(&subgraph_id))
 }
@@ -12,7 +12,7 @@ fn check_subgraph_exists(
 fn create_subgraph(
     store: Arc<dyn SubgraphStore>,
     subgraph_name: SubgraphName,
-    subgraph_id: SubgraphDeploymentId,
+    subgraph_id: DeploymentHash,
     start_block: Option<BlockPtr>,
     network_name: String,
 ) -> FutureResult<(), Error> {
@@ -48,7 +48,7 @@ fn create_subgraph(
 
 pub fn ensure_subgraph_exists(
     subgraph_name: SubgraphName,
-    subgraph_id: SubgraphDeploymentId,
+    subgraph_id: DeploymentHash,
     logger: Logger,
     store: Arc<dyn SubgraphStore>,
     start_block: Option<BlockPtr>,

--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -13,7 +13,7 @@ fn create_subgraph(
     store: Arc<dyn SubgraphStore>,
     subgraph_name: SubgraphName,
     subgraph_id: SubgraphDeploymentId,
-    start_block: Option<EthereumBlockPointer>,
+    start_block: Option<BlockPtr>,
     network_name: String,
 ) -> FutureResult<(), Error> {
     // Create a fake manifest
@@ -51,7 +51,7 @@ pub fn ensure_subgraph_exists(
     subgraph_id: SubgraphDeploymentId,
     logger: Logger,
     store: Arc<dyn SubgraphStore>,
-    start_block: Option<EthereumBlockPointer>,
+    start_block: Option<BlockPtr>,
     network_name: String,
 ) -> impl Future<Item = (), Error = Error> {
     debug!(logger, "Ensure that the network subgraph exists");

--- a/chain/ethereum/tests/network_indexer.rs
+++ b/chain/ethereum/tests/network_indexer.rs
@@ -43,7 +43,7 @@ fn remove_test_data(store: Arc<DieselStore>) {
 // Helper to run network indexer against test chains.
 fn run_network_indexer(
     store: Arc<DieselStore>,
-    start_block: Option<EthereumBlockPointer>,
+    start_block: Option<BlockPtr>,
     chains: Vec<Vec<BlockWithOmmers>>,
     timeout: Duration,
 ) -> impl Future<

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -16,7 +16,7 @@ lazy_static! {
 }
 
 pub struct SubgraphInstance<T: RuntimeHostBuilder> {
-    subgraph_id: SubgraphDeploymentId,
+    subgraph_id: DeploymentHash,
     network: String,
     host_builder: T,
 

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -1014,7 +1014,7 @@ where
 async fn update_proof_of_indexing(
     proof_of_indexing: ProofOfIndexing,
     stopwatch: &StopwatchMetrics,
-    deployment_id: &SubgraphDeploymentId,
+    deployment_id: &DeploymentHash,
     entity_cache: &mut EntityCache,
 ) -> Result<(), Error> {
     let _section_guard = stopwatch.start_section("update_proof_of_indexing");

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -613,7 +613,7 @@ where
                 None => unreachable!("The block stream stopped producing blocks"),
             };
 
-            let block_ptr = EthereumBlockPointer::from(&block.ethereum_block);
+            let block_ptr = BlockPtr::from(&block.ethereum_block);
 
             if block.triggers.len() > 0 {
                 subgraph_metrics
@@ -737,7 +737,7 @@ where
     let triggers = block.triggers;
     let block = block.ethereum_block;
 
-    let block_ptr = EthereumBlockPointer::from(&block);
+    let block_ptr = BlockPtr::from(&block);
     let logger = logger.new(o!(
         "block_number" => format!("{:?}", block_ptr.number),
         "block_hash" => format!("{}", block_ptr.hash)
@@ -755,7 +755,7 @@ where
 
     // Obtain current and new block pointer (after this block is processed)
     let light_block = Arc::new(block.light_block());
-    let block_ptr_after = EthereumBlockPointer::from(&block);
+    let block_ptr_after = BlockPtr::from(&block);
 
     let metrics = ctx.subgraph_metrics.clone();
 
@@ -1066,7 +1066,7 @@ async fn process_triggers(
     triggers: Vec<EthereumTrigger>,
 ) -> Result<BlockState, MappingError> {
     for trigger in triggers.into_iter() {
-        let block_ptr = EthereumBlockPointer::from(block.as_ref());
+        let block_ptr = BlockPtr::from(block.as_ref());
         let trigger_type = match trigger {
             EthereumTrigger::Log(_) => TriggerType::Event,
             EthereumTrigger::Call(_) => TriggerType::Call,

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -7,7 +7,7 @@ use graph::prelude::*;
 
 pub async fn load_dynamic_data_sources(
     store: Arc<dyn WritableStore>,
-    deployment_id: &SubgraphDeploymentId,
+    deployment_id: &DeploymentHash,
     logger: Logger,
     templates: Vec<DataSourceTemplate>,
 ) -> Result<Vec<DataSource>, Error> {

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -278,7 +278,7 @@ where
     async fn create_subgraph_version(
         &self,
         name: SubgraphName,
-        hash: SubgraphDeploymentId,
+        hash: DeploymentHash,
         node_id: NodeId,
     ) -> Result<(), SubgraphRegistrarError> {
         // We don't have a location for the subgraph yet; that will be
@@ -354,7 +354,7 @@ where
     /// subgraph syncing process.
     async fn reassign_subgraph(
         &self,
-        hash: &SubgraphDeploymentId,
+        hash: &DeploymentHash,
         node_id: &NodeId,
     ) -> Result<(), SubgraphRegistrarError> {
         let locations = self.store.locators(hash)?;
@@ -444,7 +444,7 @@ fn resolve_subgraph_chain_blocks(
     logger: &Logger,
 ) -> Box<
     dyn Future<
-            Item = (Option<BlockPtr>, Option<(SubgraphDeploymentId, BlockPtr)>),
+            Item = (Option<BlockPtr>, Option<(DeploymentHash, BlockPtr)>),
             Error = SubgraphRegistrarError,
         > + Send,
 > {

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -444,10 +444,7 @@ fn resolve_subgraph_chain_blocks(
     logger: &Logger,
 ) -> Box<
     dyn Future<
-            Item = (
-                Option<EthereumBlockPointer>,
-                Option<(SubgraphDeploymentId, EthereumBlockPointer)>,
-            ),
+            Item = (Option<BlockPtr>, Option<(SubgraphDeploymentId, BlockPtr)>),
             Error = SubgraphRegistrarError,
         > + Send,
 > {

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -14,7 +14,7 @@ fn insert_and_query(
     entities: Vec<(Entity, &str)>,
     query: &str,
 ) -> Result<QueryResult, StoreError> {
-    let subgraph_id = SubgraphDeploymentId::new(subgraph_id).unwrap();
+    let subgraph_id = DeploymentHash::new(subgraph_id).unwrap();
     let deployment = create_test_subgraph(&subgraph_id, schema);
 
     let insert_ops = entities

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -562,7 +562,7 @@ impl BlockStreamMetrics {
     pub fn new(
         registry: Arc<impl MetricsRegistry>,
         ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
-        deployment_id: &SubgraphDeploymentId,
+        deployment_id: &DeploymentHash,
         network: String,
         stopwatch: StopwatchMetrics,
     ) -> Self {

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -47,7 +47,7 @@ pub struct EthereumContractState {
 #[derive(Clone, Debug)]
 pub struct EthereumContractCall {
     pub address: Address,
-    pub block_ptr: EthereumBlockPointer,
+    pub block_ptr: BlockPtr,
     pub function: Function,
     pub args: Vec<Token>,
 }
@@ -639,7 +639,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         logger: Logger,
         from: BlockNumber,
         to: BlockNumber,
-    ) -> Box<dyn Future<Item = Vec<EthereumBlockPointer>, Error = Error> + Send>;
+    ) -> Box<dyn Future<Item = Vec<BlockPtr>, Error = Error> + Send>;
 
     /// Find a block by its hash.
     fn block_by_hash(
@@ -667,7 +667,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         logger: &Logger,
         chain_store: Arc<dyn ChainStore>,
         block_number: BlockNumber,
-    ) -> Box<dyn Future<Item = EthereumBlockPointer, Error = EthereumAdapterError> + Send>;
+    ) -> Box<dyn Future<Item = BlockPtr, Error = EthereumAdapterError> + Send>;
 
     /// Find a block by its number. The `block_is_final` flag indicates whether
     /// it is ok to remove blocks in the block cache with that number but with
@@ -713,7 +713,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         logger: &Logger,
         metrics: Arc<SubgraphEthRpcMetrics>,
         chain_store: Arc<dyn ChainStore>,
-        block_ptr: EthereumBlockPointer,
+        block_ptr: BlockPtr,
     ) -> Box<dyn Future<Item = bool, Error = Error> + Send>;
 
     fn calls_in_block(
@@ -785,7 +785,7 @@ fn parse_block_triggers(
     block_filter: EthereumBlockFilter,
     block: &EthereumBlockWithCalls,
 ) -> Vec<EthereumTrigger> {
-    let block_ptr = EthereumBlockPointer::from(&block.ethereum_block);
+    let block_ptr = BlockPtr::from(&block.ethereum_block);
     let trigger_every_block = block_filter.trigger_every_block;
     let call_filter = EthereumCallFilter::from(block_filter);
     let block_ptr2 = block_ptr.cheap_clone();
@@ -927,7 +927,7 @@ pub async fn blocks_with_triggers(
             eth.calls_in_block_range(&logger, subgraph_metrics.clone(), from, to, call_filter)
                 .map(|call| {
                     EthereumTrigger::Block(
-                        EthereumBlockPointer::from(&call),
+                        BlockPtr::from(&call),
                         EthereumBlockTriggerType::WithCallTo(call.to),
                     )
                 })

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -15,8 +15,8 @@ pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpda
 pub use self::network::{EthereumNetworkAdapters, EthereumNetworks, NodeCapabilities};
 pub use self::stream::{BlockStream, BlockStreamBuilder, BlockStreamEvent};
 pub use self::types::{
-    BlockFinality, BlockHash, EthereumBlock, EthereumBlockData, EthereumBlockPointer,
-    EthereumBlockTriggerType, EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall,
-    EthereumCallData, EthereumEventData, EthereumTransactionData, EthereumTrigger,
-    LightEthereumBlock, LightEthereumBlockExt, MappingTrigger,
+    BlockFinality, BlockHash, BlockPtr, EthereumBlock, EthereumBlockData, EthereumBlockTriggerType,
+    EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall, EthereumCallData,
+    EthereumEventData, EthereumTransactionData, EthereumTrigger, LightEthereumBlock,
+    LightEthereumBlockExt, MappingTrigger,
 };

--- a/graph/src/components/ethereum/stream.rs
+++ b/graph/src/components/ethereum/stream.rs
@@ -5,7 +5,7 @@ use crate::{components::store::DeploymentLocator, prelude::*};
 
 pub enum BlockStreamEvent {
     Block(EthereumBlockWithTriggers),
-    Revert(EthereumBlockPointer),
+    Revert(BlockPtr),
 }
 
 pub trait BlockStream: Stream<Item = BlockStreamEvent, Error = Error> {}

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -17,8 +17,8 @@ use web3::types::{
 };
 
 use crate::prelude::{
-    BlockNumber, CheapClone, EntityKey, MappingBlockHandler, MappingCallHandler,
-    MappingEventHandler, SubgraphDeploymentId, ToEntityKey,
+    BlockNumber, CheapClone, DeploymentHash, EntityKey, MappingBlockHandler, MappingCallHandler,
+    MappingEventHandler, ToEntityKey,
 };
 
 pub type LightEthereumBlock = Block<Transaction>;
@@ -653,7 +653,7 @@ impl From<BlockPtr> for BlockNumber {
 }
 
 impl ToEntityKey for BlockPtr {
-    fn to_entity_key(&self, subgraph: SubgraphDeploymentId) -> EntityKey {
+    fn to_entity_key(&self, subgraph: DeploymentHash) -> EntityKey {
         EntityKey::data(subgraph, "Block".into(), self.hash_hex())
     }
 }

--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -3,7 +3,7 @@ use futures::prelude::*;
 use crate::data::query::{CacheStatus, Query, QueryTarget};
 use crate::data::subscription::{Subscription, SubscriptionError, SubscriptionResult};
 use crate::data::{graphql::effort::LoadManager, query::QueryResults};
-use crate::prelude::SubgraphDeploymentId;
+use crate::prelude::DeploymentHash;
 
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -15,7 +15,7 @@ pub type SubscriptionResultFuture =
 
 pub enum GraphQlTarget {
     SubgraphName(String),
-    Deployment(SubgraphDeploymentId),
+    Deployment(DeploymentHash),
 }
 
 /// A component that can run GraphqL queries against a [Store](../store/trait.Store.html).

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -42,7 +42,7 @@ pub struct StopwatchMetrics {
 impl StopwatchMetrics {
     pub fn new(
         logger: Logger,
-        subgraph_id: SubgraphDeploymentId,
+        subgraph_id: DeploymentHash,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
         let mut inner = StopwatchInner {

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -155,7 +155,7 @@ pub trait RuntimeHostBuilder: Clone + Send + Sync + 'static {
     fn build(
         &self,
         network_name: String,
-        subgraph_id: SubgraphDeploymentId,
+        subgraph_id: DeploymentHash,
         data_source: DataSource,
         top_level_templates: Arc<Vec<DataSourceTemplate>>,
         mapping_request_sender: mpsc::Sender<Self::Req>,
@@ -167,7 +167,7 @@ pub trait RuntimeHostBuilder: Clone + Send + Sync + 'static {
     fn spawn_mapping(
         raw_module: Vec<u8>,
         logger: Logger,
-        subgraph_id: SubgraphDeploymentId,
+        subgraph_id: DeploymentHash,
         metrics: Arc<HostMetrics>,
     ) -> Result<mpsc::Sender<Self::Req>, anyhow::Error>;
 }

--- a/graph/src/components/subgraph/proof_of_indexing/mod.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/mod.rs
@@ -28,7 +28,7 @@ pub type SharedProofOfIndexing = Option<Arc<AtomicRefCell<ProofOfIndexing>>>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::{EthereumBlockPointer, SubgraphDeploymentId, Value};
+    use crate::prelude::{BlockPtr, SubgraphDeploymentId, Value};
     use maplit::hashmap;
     use online::ProofOfIndexingFinisher;
     use reference::*;
@@ -75,7 +75,7 @@ mod tests {
         }
 
         let block_number = (block_count - 1) as u64;
-        let block_ptr = EthereumBlockPointer::from((reference.block_hash, block_number));
+        let block_ptr = BlockPtr::from((reference.block_hash, block_number));
 
         // This region emulates the request
         let mut finisher =

--- a/graph/src/components/subgraph/proof_of_indexing/mod.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/mod.rs
@@ -28,7 +28,7 @@ pub type SharedProofOfIndexing = Option<Arc<AtomicRefCell<ProofOfIndexing>>>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::{BlockPtr, SubgraphDeploymentId, Value};
+    use crate::prelude::{BlockPtr, DeploymentHash, Value};
     use maplit::hashmap;
     use online::ProofOfIndexingFinisher;
     use reference::*;
@@ -106,7 +106,7 @@ mod tests {
         let mut cases = hashmap! {
             // Simple case of basically nothing
             "genesis" => PoI {
-                subgraph_id: SubgraphDeploymentId::new("test").unwrap(),
+                subgraph_id: DeploymentHash::new("test").unwrap(),
                 block_hash: H256::repeat_byte(1),
                 causality_regions: HashMap::new(),
                 indexer: None,
@@ -114,7 +114,7 @@ mod tests {
 
             // Add an event
             "one_event" => PoI {
-                subgraph_id: SubgraphDeploymentId::new("test").unwrap(),
+                subgraph_id: DeploymentHash::new("test").unwrap(),
                 block_hash: H256::repeat_byte(1),
                 causality_regions: hashmap! {
                     "eth".to_owned() => CausalityRegion {
@@ -137,7 +137,7 @@ mod tests {
 
             // Try adding a couple more blocks, including an empty block on the end
             "multiple_blocks" => PoI {
-                subgraph_id: SubgraphDeploymentId::new("b").unwrap(),
+                subgraph_id: DeploymentHash::new("b").unwrap(),
                 block_hash: H256::repeat_byte(3),
                 causality_regions: hashmap! {
                     "eth".to_owned() => CausalityRegion {
@@ -171,7 +171,7 @@ mod tests {
 
             // Try adding another causality region
             "causality_regions" => PoI {
-                subgraph_id: SubgraphDeploymentId::new("b").unwrap(),
+                subgraph_id: DeploymentHash::new("b").unwrap(),
                 block_hash: H256::repeat_byte(3),
                 causality_regions: hashmap! {
                     "eth".to_owned() => CausalityRegion {
@@ -229,7 +229,7 @@ mod tests {
 
             // Back to the one event case, but try adding some data.
             "data" => PoI {
-                subgraph_id: SubgraphDeploymentId::new("test").unwrap(),
+                subgraph_id: DeploymentHash::new("test").unwrap(),
                 block_hash: H256::repeat_byte(1),
                 causality_regions: hashmap! {
                     "eth".to_owned() => CausalityRegion {

--- a/graph/src/components/subgraph/proof_of_indexing/online.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/online.rs
@@ -3,7 +3,7 @@
 //! to the reference implementation, but this is updated incrementally
 
 use super::ProofOfIndexingEvent;
-use crate::prelude::{debug, BlockNumber, BlockPtr, Logger, SubgraphDeploymentId};
+use crate::prelude::{debug, BlockNumber, BlockPtr, DeploymentHash, Logger};
 use lazy_static::lazy_static;
 use stable_hash::crypto::{Blake3SeqNo, SetHasher};
 use stable_hash::prelude::*;
@@ -160,11 +160,7 @@ pub struct ProofOfIndexingFinisher {
 }
 
 impl ProofOfIndexingFinisher {
-    pub fn new(
-        block: &BlockPtr,
-        subgraph_id: &SubgraphDeploymentId,
-        indexer: &Option<Address>,
-    ) -> Self {
+    pub fn new(block: &BlockPtr, subgraph_id: &DeploymentHash, indexer: &Option<Address>) -> Self {
         let mut state = SetHasher::new();
 
         // Add the subgraph id

--- a/graph/src/components/subgraph/proof_of_indexing/online.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/online.rs
@@ -3,7 +3,7 @@
 //! to the reference implementation, but this is updated incrementally
 
 use super::ProofOfIndexingEvent;
-use crate::prelude::{debug, BlockNumber, EthereumBlockPointer, Logger, SubgraphDeploymentId};
+use crate::prelude::{debug, BlockNumber, BlockPtr, Logger, SubgraphDeploymentId};
 use lazy_static::lazy_static;
 use stable_hash::crypto::{Blake3SeqNo, SetHasher};
 use stable_hash::prelude::*;
@@ -161,7 +161,7 @@ pub struct ProofOfIndexingFinisher {
 
 impl ProofOfIndexingFinisher {
     pub fn new(
-        block: &EthereumBlockPointer,
+        block: &BlockPtr,
         subgraph_id: &SubgraphDeploymentId,
         indexer: &Option<Address>,
     ) -> Self {

--- a/graph/src/components/subgraph/proof_of_indexing/reference.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/reference.rs
@@ -1,5 +1,5 @@
 use super::ProofOfIndexingEvent;
-use crate::prelude::SubgraphDeploymentId;
+use crate::prelude::DeploymentHash;
 use stable_hash::prelude::*;
 use stable_hash::utils::AsBytes;
 use std::collections::HashMap;
@@ -12,7 +12,7 @@ use web3::types::{Address, H256};
 /// documentation as a side-benefit.
 pub struct PoI<'a> {
     pub causality_regions: HashMap<String, CausalityRegion<'a>>,
-    pub subgraph_id: SubgraphDeploymentId,
+    pub subgraph_id: DeploymentHash,
     pub block_hash: H256,
     pub indexer: Option<Address>,
 }

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -29,7 +29,7 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
     async fn create_subgraph_version(
         &self,
         name: SubgraphName,
-        hash: SubgraphDeploymentId,
+        hash: DeploymentHash,
         assignment_node_id: NodeId,
     ) -> Result<(), SubgraphRegistrarError>;
 
@@ -37,7 +37,7 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
 
     async fn reassign_subgraph(
         &self,
-        hash: &SubgraphDeploymentId,
+        hash: &DeploymentHash,
         node_id: &NodeId,
     ) -> Result<(), SubgraphRegistrarError>;
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -43,7 +43,7 @@ pub enum QueryExecutionError {
     MissingArgumentError(Pos, String),
     InvalidVariableTypeError(Pos, String),
     MissingVariableError(Pos, String),
-    ResolveEntityError(SubgraphDeploymentId, String, String, String),
+    ResolveEntityError(DeploymentHash, String, String, String),
     ResolveEntitiesError(String),
     OrderByNotSupportedError(String, String),
     OrderByNotSupportedForType(String),

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use crate::{
     data::graphql::shape_hash::shape_hash,
-    prelude::{q, SubgraphDeploymentId, SubgraphName},
+    prelude::{q, DeploymentHash, SubgraphName},
 };
 
 fn deserialize_number<'de, D>(deserializer: D) -> Result<q::Number, D::Error>
@@ -108,11 +108,11 @@ impl serde::ser::Serialize for QueryVariables {
 #[derive(Clone, Debug)]
 pub enum QueryTarget {
     Name(SubgraphName),
-    Deployment(SubgraphDeploymentId),
+    Deployment(DeploymentHash),
 }
 
-impl From<SubgraphDeploymentId> for QueryTarget {
-    fn from(id: SubgraphDeploymentId) -> Self {
+impl From<DeploymentHash> for QueryTarget {
+    fn from(id: DeploymentHash) -> Self {
         Self::Deployment(id)
     }
 }

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -1,7 +1,7 @@
 use super::error::{QueryError, QueryExecutionError};
 use crate::{
     data::graphql::SerializableValue,
-    prelude::{q, CacheWeight, SubgraphDeploymentId},
+    prelude::{q, CacheWeight, DeploymentHash},
 };
 use http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
@@ -182,7 +182,7 @@ pub struct QueryResult {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     errors: Vec<QueryError>,
     #[serde(skip_serializing)]
-    pub deployment: Option<SubgraphDeploymentId>,
+    pub deployment: Option<DeploymentHash>,
 }
 
 impl QueryResult {

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     components::store::{DeploymentLocator, EntityType},
     prelude::{q, s, CacheWeight, EntityKey, QueryExecutionError},
 };
-use crate::{data::subgraph::SubgraphDeploymentId, prelude::EntityChange};
+use crate::{data::subgraph::DeploymentHash, prelude::EntityChange};
 use anyhow::{anyhow, Error};
 use serde::de;
 use serde::{Deserialize, Serialize};
@@ -26,7 +26,7 @@ pub mod ethereum;
 pub enum SubscriptionFilter {
     /// Receive updates about all entities from the given deployment of the
     /// given type
-    Entities(SubgraphDeploymentId, EntityType),
+    Entities(DeploymentHash, EntityType),
     /// Subscripe to changes in deployment assignments
     Assignment,
 }
@@ -601,7 +601,7 @@ pub trait ToEntityId {
 
 /// A value that can be converted to an `Entity` key.
 pub trait ToEntityKey {
-    fn to_entity_key(&self, subgraph: SubgraphDeploymentId) -> EntityKey;
+    fn to_entity_key(&self, subgraph: DeploymentHash) -> EntityKey;
 }
 
 #[test]

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -9,7 +9,7 @@ use stable_hash::{SequenceNumber, StableHash, StableHasher};
 use std::str::FromStr;
 use std::{fmt, fmt::Display};
 
-use super::SubgraphDeploymentId;
+use super::DeploymentHash;
 use crate::components::{ethereum::BlockPtr, store::EntityType};
 use crate::data::graphql::TryFromValue;
 use crate::data::store::Value;
@@ -104,7 +104,7 @@ pub struct SubgraphDeploymentEntity {
     pub non_fatal_errors: Vec<SubgraphError>,
     pub earliest_block: Option<BlockPtr>,
     pub latest_block: Option<BlockPtr>,
-    pub graft_base: Option<SubgraphDeploymentId>,
+    pub graft_base: Option<DeploymentHash>,
     pub graft_block: Option<BlockPtr>,
     pub reorg_count: i32,
     pub current_reorg_depth: i32,
@@ -134,7 +134,7 @@ impl SubgraphDeploymentEntity {
         }
     }
 
-    pub fn graft(mut self, base: Option<(SubgraphDeploymentId, BlockPtr)>) -> Self {
+    pub fn graft(mut self, base: Option<(DeploymentHash, BlockPtr)>) -> Self {
         if let Some((subgraph, ptr)) = base {
             self.graft_base = Some(subgraph);
             self.graft_block = Some(ptr);
@@ -169,7 +169,7 @@ impl<'a> From<&'a super::SubgraphManifest> for SubgraphManifestEntity {
 
 #[derive(Debug)]
 pub struct SubgraphError {
-    pub subgraph_id: SubgraphDeploymentId,
+    pub subgraph_id: DeploymentHash,
     pub message: String,
     pub block_ptr: Option<BlockPtr>,
     pub handler: Option<String>,

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use std::{fmt, fmt::Display};
 
 use super::SubgraphDeploymentId;
-use crate::components::{ethereum::EthereumBlockPointer, store::EntityType};
+use crate::components::{ethereum::BlockPtr, store::EntityType};
 use crate::data::graphql::TryFromValue;
 use crate::data::store::Value;
 use crate::data::subgraph::SubgraphManifest;
@@ -102,10 +102,10 @@ pub struct SubgraphDeploymentEntity {
     pub synced: bool,
     pub fatal_error: Option<SubgraphError>,
     pub non_fatal_errors: Vec<SubgraphError>,
-    pub earliest_block: Option<EthereumBlockPointer>,
-    pub latest_block: Option<EthereumBlockPointer>,
+    pub earliest_block: Option<BlockPtr>,
+    pub latest_block: Option<BlockPtr>,
     pub graft_base: Option<SubgraphDeploymentId>,
-    pub graft_block: Option<EthereumBlockPointer>,
+    pub graft_block: Option<BlockPtr>,
     pub reorg_count: i32,
     pub current_reorg_depth: i32,
     pub max_reorg_depth: i32,
@@ -115,7 +115,7 @@ impl SubgraphDeploymentEntity {
     pub fn new(
         source_manifest: &SubgraphManifest,
         synced: bool,
-        earliest_block: Option<EthereumBlockPointer>,
+        earliest_block: Option<BlockPtr>,
     ) -> Self {
         Self {
             manifest: SubgraphManifestEntity::from(source_manifest),
@@ -134,7 +134,7 @@ impl SubgraphDeploymentEntity {
         }
     }
 
-    pub fn graft(mut self, base: Option<(SubgraphDeploymentId, EthereumBlockPointer)>) -> Self {
+    pub fn graft(mut self, base: Option<(SubgraphDeploymentId, BlockPtr)>) -> Self {
         if let Some((subgraph, ptr)) = base {
             self.graft_base = Some(subgraph);
             self.graft_block = Some(ptr);
@@ -171,7 +171,7 @@ impl<'a> From<&'a super::SubgraphManifest> for SubgraphManifestEntity {
 pub struct SubgraphError {
     pub subgraph_id: SubgraphDeploymentId,
     pub message: String,
-    pub block_ptr: Option<EthereumBlockPointer>,
+    pub block_ptr: Option<BlockPtr>,
     pub handler: Option<String>,
 
     // `true` if we are certain the error is deterministic. If in doubt, this is `false`.

--- a/graph/src/data/subgraph/status.rs
+++ b/graph/src/data/subgraph/status.rs
@@ -2,7 +2,7 @@
 
 use super::schema::{SubgraphError, SubgraphHealth};
 use crate::data::graphql::{object, IntoValue};
-use crate::prelude::{q, web3::types::H256, EthereumBlockPointer, Value};
+use crate::prelude::{q, web3::types::H256, BlockPtr, Value};
 
 pub enum Filter {
     /// Get all versions for the named subgraph
@@ -16,14 +16,14 @@ pub enum Filter {
 
 /// Light wrapper around `EthereumBlockPointer` that is compatible with GraphQL values.
 #[derive(Debug)]
-pub struct EthereumBlock(EthereumBlockPointer);
+pub struct EthereumBlock(BlockPtr);
 
 impl EthereumBlock {
     pub fn new(hash: H256, number: u64) -> Self {
-        EthereumBlock(EthereumBlockPointer::from((hash, number)))
+        EthereumBlock(BlockPtr::from((hash, number)))
     }
 
-    pub fn to_ptr(self) -> EthereumBlockPointer {
+    pub fn to_ptr(self) -> BlockPtr {
         self.0
     }
 
@@ -42,8 +42,8 @@ impl IntoValue for EthereumBlock {
     }
 }
 
-impl From<EthereumBlockPointer> for EthereumBlock {
-    fn from(ptr: EthereumBlockPointer) -> Self {
+impl From<BlockPtr> for EthereumBlock {
+    fn from(ptr: BlockPtr) -> Self {
         Self(ptr)
     }
 }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -84,9 +84,9 @@ pub mod prelude {
         Pin<Box<dyn futures03::Future<Output = Result<Ok, Err>> + Send + 'a>>;
 
     pub use crate::components::ethereum::{
-        BlockFinality, BlockStream, BlockStreamBuilder, BlockStreamEvent, BlockStreamMetrics,
-        ChainHeadUpdate, ChainHeadUpdateStream, EthereumAdapter, EthereumAdapterError,
-        EthereumBlock, EthereumBlockData, EthereumBlockFilter, EthereumBlockPointer,
+        BlockFinality, BlockPtr, BlockStream, BlockStreamBuilder, BlockStreamEvent,
+        BlockStreamMetrics, ChainHeadUpdate, ChainHeadUpdateStream, EthereumAdapter,
+        EthereumAdapterError, EthereumBlock, EthereumBlockData, EthereumBlockFilter,
         EthereumBlockTriggerType, EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall,
         EthereumCallData, EthereumCallFilter, EthereumContractCall, EthereumContractCallError,
         EthereumEventData, EthereumLogFilter, EthereumNetworkIdentifier, EthereumTransactionData,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -139,11 +139,10 @@ pub mod prelude {
     pub use crate::data::subgraph::schema::SubgraphDeploymentEntity;
     pub use crate::data::subgraph::{
         BlockHandlerFilter, CreateSubgraphResult, DataSource, DataSourceContext,
-        DataSourceTemplate, DeploymentState, Link, MappingABI, MappingBlockHandler,
-        MappingCallHandler, MappingEventHandler, SubgraphAssignmentProviderError,
-        SubgraphDeploymentId, SubgraphManifest, SubgraphManifestResolveError,
-        SubgraphManifestValidationError, SubgraphName, SubgraphRegistrarError,
-        UnvalidatedSubgraphManifest,
+        DataSourceTemplate, DeploymentHash, DeploymentState, Link, MappingABI, MappingBlockHandler,
+        MappingCallHandler, MappingEventHandler, SubgraphAssignmentProviderError, SubgraphManifest,
+        SubgraphManifestResolveError, SubgraphManifestValidationError, SubgraphName,
+        SubgraphRegistrarError, UnvalidatedSubgraphManifest,
     };
     pub use crate::data::subscription::{
         QueryResultStream, Subscription, SubscriptionError, SubscriptionResult,

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -6,14 +6,12 @@ use graph::{components::store::EntityType, mock::MockStore};
 use graph::{
     components::store::{DeploymentId, DeploymentLocator},
     prelude::{
-        Entity, EntityCache, EntityKey, EntityModification, SubgraphDeploymentId, SubgraphStore,
-        Value,
+        DeploymentHash, Entity, EntityCache, EntityKey, EntityModification, SubgraphStore, Value,
     },
 };
 
 lazy_static! {
-    static ref SUBGRAPH_ID: SubgraphDeploymentId =
-        SubgraphDeploymentId::new("entity_cache").unwrap();
+    static ref SUBGRAPH_ID: DeploymentHash = DeploymentHash::new("entity_cache").unwrap();
     static ref DEPLOYMENT: DeploymentLocator =
         DeploymentLocator::new(DeploymentId::new(-12), SUBGRAPH_ID.clone());
 }

--- a/graph/tests/manifest.rs
+++ b/graph/tests/manifest.rs
@@ -9,7 +9,7 @@ use graph::components::{
     store::EntityType,
 };
 use graph::prelude::{
-    anyhow, Entity, Link, SubgraphDeploymentId, SubgraphManifest, SubgraphManifestValidationError,
+    anyhow, DeploymentHash, Entity, Link, SubgraphManifest, SubgraphManifestValidationError,
     UnvalidatedSubgraphManifest,
 };
 
@@ -60,7 +60,7 @@ const MAPPING: &str = "export function handleGet(call: getCall): void {}";
 
 async fn resolve_manifest(text: &str) -> SubgraphManifest {
     let mut resolver = TextResolver::default();
-    let id = SubgraphDeploymentId::new("Qmmanifest").unwrap();
+    let id = DeploymentHash::new("Qmmanifest").unwrap();
 
     resolver.add(id.as_str(), text);
     resolver.add("/ipfs/Qmschema", GQL_SCHEMA);
@@ -74,7 +74,7 @@ async fn resolve_manifest(text: &str) -> SubgraphManifest {
 
 async fn resolve_unvalidated(text: &str) -> UnvalidatedSubgraphManifest {
     let mut resolver = TextResolver::default();
-    let id = SubgraphDeploymentId::new("Qmmanifest").unwrap();
+    let id = DeploymentHash::new("Qmmanifest").unwrap();
 
     resolver.add(id.as_str(), text);
     resolver.add("/ipfs/Qmschema", GQL_SCHEMA);
@@ -138,7 +138,7 @@ specVersion: 0.0.2
 
     test_store::STORE_RUNTIME.lock().unwrap().block_on(async {
         let unvalidated = resolve_unvalidated(YAML).await;
-        let subgraph = SubgraphDeploymentId::new("Qmbase").unwrap();
+        let subgraph = DeploymentHash::new("Qmbase").unwrap();
 
         //
         // Validation against subgraph that hasn't synced anything fails

--- a/graphql/src/execution/cache.rs
+++ b/graphql/src/execution/cache.rs
@@ -1,7 +1,7 @@
 use futures03::future::FutureExt;
 use futures03::future::Shared;
 use graph::{
-    prelude::{debug, futures03, CheapClone, EthereumBlockPointer, Logger, QueryResult},
+    prelude::{debug, futures03, BlockPtr, CheapClone, Logger, QueryResult},
     util::timed_rw_lock::TimedMutex,
 };
 use stable_hash::crypto::SetHasher;
@@ -84,7 +84,7 @@ impl<R: CheapClone> QueryCache<R> {
 
 #[derive(Debug)]
 struct CacheByBlock {
-    block: EthereumBlockPointer,
+    block: BlockPtr,
     max_weight: usize,
     weight: usize,
 
@@ -94,7 +94,7 @@ struct CacheByBlock {
 }
 
 impl CacheByBlock {
-    fn new(block: EthereumBlockPointer, max_weight: usize) -> Self {
+    fn new(block: BlockPtr, max_weight: usize) -> Self {
         CacheByBlock {
             block,
             max_weight,
@@ -148,7 +148,7 @@ impl QueryBlockCache {
     pub fn insert(
         &mut self,
         network: &str,
-        block_ptr: EthereumBlockPointer,
+        block_ptr: BlockPtr,
         key: QueryHash,
         result: Arc<QueryResult>,
         weight: usize,
@@ -230,7 +230,7 @@ impl QueryBlockCache {
     pub fn get(
         &self,
         network: &str,
-        block_ptr: &EthereumBlockPointer,
+        block_ptr: &BlockPtr,
         key: &QueryHash,
     ) -> Option<Arc<QueryResult>> {
         if let Some(cache) = self

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -138,7 +138,7 @@ struct HashableQuery<'a> {
     query_variables: &'a HashMap<String, q::Value>,
     query_fragments: &'a HashMap<String, q::FragmentDefinition>,
     selection_set: &'a q::SelectionSet,
-    block_ptr: &'a EthereumBlockPointer,
+    block_ptr: &'a BlockPtr,
 }
 
 /// Note that the use of StableHash here is a little bit loose. In particular,
@@ -190,7 +190,7 @@ impl StableHash for HashableQuery<'_> {
 fn cache_key(
     ctx: &ExecutionContext<impl Resolver>,
     selection_set: &q::SelectionSet,
-    block_ptr: &EthereumBlockPointer,
+    block_ptr: &BlockPtr,
 ) -> QueryHash {
     // It is very important that all data used for the query is included.
     // Otherwise, incorrect results may be returned.
@@ -354,7 +354,7 @@ pub async fn execute_root_selection_set<R: Resolver>(
     ctx: Arc<ExecutionContext<R>>,
     selection_set: Arc<q::SelectionSet>,
     root_type: Arc<s::ObjectType>,
-    block_ptr: Option<EthereumBlockPointer>,
+    block_ptr: Option<BlockPtr>,
 ) -> Arc<QueryResult> {
     // Cache the cache key to not have to calculate it twice - once for lookup
     // and once for insert.

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -134,7 +134,7 @@ impl Default for WeightedResult {
 }
 
 struct HashableQuery<'a> {
-    query_schema_id: &'a SubgraphDeploymentId,
+    query_schema_id: &'a DeploymentHash,
     query_variables: &'a HashMap<String, q::Value>,
     query_fragments: &'a HashMap<String, q::FragmentDefinition>,
     selection_set: &'a q::SelectionSet,

--- a/graphql/src/introspection/schema.rs
+++ b/graphql/src/introspection/schema.rs
@@ -3,7 +3,7 @@ use graphql_parser;
 use graph::data::graphql::ext::DocumentExt;
 use graph::data::graphql::ext::ObjectTypeExt;
 use graph::data::schema::{ApiSchema, Schema};
-use graph::data::subgraph::SubgraphDeploymentId;
+use graph::data::subgraph::DeploymentHash;
 use graph::prelude::s::{Document, ObjectType};
 
 use lazy_static::lazy_static;
@@ -121,7 +121,7 @@ lazy_static! {
         INTROSPECTION_DOCUMENT.get_root_query_type().unwrap();
 }
 
-pub fn introspection_schema(id: SubgraphDeploymentId) -> ApiSchema {
+pub fn introspection_schema(id: DeploymentHash) -> ApiSchema {
     ApiSchema::from_api_schema(Schema::new(id, INTROSPECTION_DOCUMENT.clone())).unwrap()
 }
 

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,4 +1,4 @@
-use graph::prelude::{q, CheapClone, EthereumBlockPointer, QueryExecutionError, QueryResult};
+use graph::prelude::{q, BlockPtr, CheapClone, QueryExecutionError, QueryResult};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -34,7 +34,7 @@ pub struct QueryExecutionOptions<R> {
 pub async fn execute_query<R>(
     query: Arc<Query>,
     selection_set: Option<q::SelectionSet>,
-    block_ptr: Option<EthereumBlockPointer>,
+    block_ptr: Option<BlockPtr>,
     options: QueryExecutionOptions<R>,
     nested_resolver: bool,
 ) -> Arc<QueryResult>

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -556,12 +556,12 @@ fn entity_validation() {
           # to store a thing with a null Cruft
           cruft: Cruft! @derivedFrom(field: \"thing\")
       }";
-        let subgraph = SubgraphDeploymentId::new("doesntmatter").unwrap();
+        let subgraph = DeploymentHash::new("doesntmatter").unwrap();
         let schema =
             graph::prelude::Schema::parse(DOCUMENT, subgraph).expect("Failed to parse test schema");
         let id = thing.id().unwrap_or("none".to_owned());
         let key = EntityKey::data(
-            SubgraphDeploymentId::new("doesntmatter").unwrap(),
+            DeploymentHash::new("doesntmatter").unwrap(),
             "Thing".to_owned(),
             id.to_owned(),
         );

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -261,7 +261,7 @@ fn build_order_direction(
 /// Parses the subgraph ID from the ObjectType directives.
 pub fn parse_subgraph_id<'a>(
     entity: impl Into<ObjectOrInterface<'a>>,
-) -> Result<SubgraphDeploymentId, QueryExecutionError> {
+) -> Result<DeploymentHash, QueryExecutionError> {
     let entity = entity.into();
     let entity_name = entity.name().clone();
     entity
@@ -279,7 +279,7 @@ pub fn parse_subgraph_id<'a>(
             _ => None,
         })
         .ok_or(())
-        .and_then(|id| SubgraphDeploymentId::new(id).map_err(|_| ()))
+        .and_then(|id| DeploymentHash::new(id).map_err(|_| ()))
         .map_err(|_| QueryExecutionError::SubgraphDeploymentIdError(entity_name.to_owned()))
 }
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -21,7 +21,7 @@ pub struct StoreResolver {
     logger: Logger,
     pub(crate) store: Arc<dyn QueryStore>,
     subscription_manager: Arc<dyn SubscriptionManager>,
-    pub(crate) block_ptr: Option<EthereumBlockPointer>,
+    pub(crate) block_ptr: Option<BlockPtr>,
     deployment: SubgraphDeploymentId,
     has_non_fatal_errors: bool,
     error_policy: ErrorPolicy,
@@ -102,7 +102,7 @@ impl StoreResolver {
         store: &dyn QueryStore,
         bc: BlockConstraint,
         subgraph: SubgraphDeploymentId,
-    ) -> Result<EthereumBlockPointer, QueryExecutionError> {
+    ) -> Result<BlockPtr, QueryExecutionError> {
         match bc {
             BlockConstraint::Number(number) => store
                 .block_ptr()
@@ -125,10 +125,7 @@ impl StoreResolver {
                         // always return an all zeroes hash when users specify
                         // a block number
                         // See 7a7b9708-adb7-4fc2-acec-88680cb07ec1
-                        Ok(EthereumBlockPointer::from((
-                            web3::types::H256::zero(),
-                            number as u64,
-                        )))
+                        Ok(BlockPtr::from((web3::types::H256::zero(), number as u64)))
                     }
                 }),
             BlockConstraint::Hash(hash) => {
@@ -143,7 +140,7 @@ impl StoreResolver {
                                     "no block with that hash found".to_owned(),
                                 )
                             })
-                            .map(|number| EthereumBlockPointer::from((hash, number as u64)))
+                            .map(|number| BlockPtr::from((hash, number as u64)))
                     })
             }
             BlockConstraint::Latest => store

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -22,7 +22,7 @@ pub struct StoreResolver {
     pub(crate) store: Arc<dyn QueryStore>,
     subscription_manager: Arc<dyn SubscriptionManager>,
     pub(crate) block_ptr: Option<BlockPtr>,
-    deployment: SubgraphDeploymentId,
+    deployment: DeploymentHash,
     has_non_fatal_errors: bool,
     error_policy: ErrorPolicy,
 }
@@ -36,7 +36,7 @@ impl StoreResolver {
     /// blocks
     pub fn for_subscription(
         logger: &Logger,
-        deployment: SubgraphDeploymentId,
+        deployment: DeploymentHash,
         store: Arc<dyn QueryStore>,
         subscription_manager: Arc<dyn SubscriptionManager>,
     ) -> Self {
@@ -64,7 +64,7 @@ impl StoreResolver {
         subscription_manager: Arc<dyn SubscriptionManager>,
         bc: BlockConstraint,
         error_policy: ErrorPolicy,
-        deployment: SubgraphDeploymentId,
+        deployment: DeploymentHash,
     ) -> Result<Self, QueryExecutionError> {
         let store_clone = store.cheap_clone();
         let deployment2 = deployment.clone();
@@ -101,7 +101,7 @@ impl StoreResolver {
     fn locate_block(
         store: &dyn QueryStore,
         bc: BlockConstraint,
-        subgraph: SubgraphDeploymentId,
+        subgraph: DeploymentHash,
     ) -> Result<BlockPtr, QueryExecutionError> {
         match bc {
             BlockConstraint::Number(number) => store

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use graph::data::graphql::{object, object_value, ObjectOrInterface};
 use graph::prelude::{
-    o, q, s, slog, tokio, ApiSchema, Logger, Query, QueryExecutionError, QueryResult, Schema,
-    SubgraphDeploymentId,
+    o, q, s, slog, tokio, ApiSchema, DeploymentHash, Logger, Query, QueryExecutionError,
+    QueryResult, Schema,
 };
 use graph_graphql::prelude::{
     api_schema, execute_query, ExecutionContext, Query as PreparedQuery, QueryExecutionOptions,
@@ -98,7 +98,7 @@ fn mock_schema() -> Schema {
                User: User
              }
              ",
-        SubgraphDeploymentId::new("mockschema").unwrap(),
+        DeploymentHash::new("mockschema").unwrap(),
     )
     .unwrap()
 }
@@ -1127,7 +1127,7 @@ type Parameter @entity {
 async fn successfully_runs_introspection_query_against_complex_schema() {
     let mut schema = Schema::parse(
         COMPLEX_SCHEMA,
-        SubgraphDeploymentId::new("complexschema").unwrap(),
+        DeploymentHash::new("complexschema").unwrap(),
     )
     .unwrap();
     schema.document = api_schema(&schema.document, &BTreeSet::new()).unwrap();
@@ -1237,7 +1237,7 @@ async fn successfully_runs_introspection_query_against_complex_schema() {
 async fn introspection_possible_types() {
     let mut schema = Schema::parse(
         COMPLEX_SCHEMA,
-        SubgraphDeploymentId::new("complexschema").unwrap(),
+        DeploymentHash::new("complexschema").unwrap(),
     )
     .unwrap();
     schema.document = api_schema(&schema.document, &BTreeSet::new()).unwrap();

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -18,7 +18,7 @@ use graph::{
     },
     prelude::{
         async_trait, futures03::stream::StreamExt, futures03::FutureExt, futures03::TryFutureExt,
-        o, q, serde_json, slog, tokio, Entity, EntityKey, EntityOperation, EthereumBlockPointer,
+        o, q, serde_json, slog, tokio, BlockPtr, Entity, EntityKey, EntityOperation,
         FutureExtension, GraphQlRunner as _, Logger, NodeId, Query, QueryError,
         QueryExecutionError, QueryLoadManager, QueryResult, QueryStoreManager, QueryVariables,
         Schema, SubgraphDeploymentEntity, SubgraphDeploymentId, SubgraphManifest, SubgraphName,
@@ -213,11 +213,7 @@ fn insert_test_entities(
         ]),
     ];
 
-    fn insert_at(
-        entities: Vec<Entity>,
-        deployment: &DeploymentLocator,
-        block_ptr: EthereumBlockPointer,
-    ) {
+    fn insert_at(entities: Vec<Entity>, deployment: &DeploymentLocator, block_ptr: BlockPtr) {
         let insert_ops = entities.into_iter().map(|data| EntityOperation::Set {
             key: EntityKey::data(
                 deployment.hash.clone(),

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -18,11 +18,11 @@ use graph::{
     },
     prelude::{
         async_trait, futures03::stream::StreamExt, futures03::FutureExt, futures03::TryFutureExt,
-        o, q, serde_json, slog, tokio, BlockPtr, Entity, EntityKey, EntityOperation,
-        FutureExtension, GraphQlRunner as _, Logger, NodeId, Query, QueryError,
+        o, q, serde_json, slog, tokio, BlockPtr, DeploymentHash, Entity, EntityKey,
+        EntityOperation, FutureExtension, GraphQlRunner as _, Logger, NodeId, Query, QueryError,
         QueryExecutionError, QueryLoadManager, QueryResult, QueryStoreManager, QueryVariables,
-        Schema, SubgraphDeploymentEntity, SubgraphDeploymentId, SubgraphManifest, SubgraphName,
-        SubgraphStore, SubgraphVersionSwitchingMode, Subscription, SubscriptionError, Value,
+        Schema, SubgraphDeploymentEntity, SubgraphManifest, SubgraphName, SubgraphStore,
+        SubgraphVersionSwitchingMode, Subscription, SubscriptionError, Value,
     },
 };
 use graph_graphql::{prelude::*, subscription::execute_subscription};
@@ -41,7 +41,7 @@ fn setup() -> DeploymentLocator {
 fn setup_with_features(id: &str, features: BTreeSet<SubgraphFeature>) -> DeploymentLocator {
     use test_store::block_store::{self, BLOCK_ONE, BLOCK_TWO, GENESIS_BLOCK};
 
-    let id = SubgraphDeploymentId::new(id).unwrap();
+    let id = DeploymentHash::new(id).unwrap();
 
     let chain = vec![&*GENESIS_BLOCK, &*BLOCK_ONE, &*BLOCK_TWO];
     block_store::set_chain(chain, NETWORK_NAME);
@@ -63,7 +63,7 @@ fn setup_with_features(id: &str, features: BTreeSet<SubgraphFeature>) -> Deploym
     insert_test_entities(STORE.subgraph_store().as_ref(), manifest)
 }
 
-fn test_schema(id: SubgraphDeploymentId) -> Schema {
+fn test_schema(id: DeploymentHash) -> Schema {
     Schema::parse(
         "
             type Musician @entity {
@@ -237,12 +237,12 @@ fn insert_test_entities(
     deployment
 }
 
-async fn execute_query_document(id: &SubgraphDeploymentId, query: q::Document) -> QueryResult {
+async fn execute_query_document(id: &DeploymentHash, query: q::Document) -> QueryResult {
     execute_query_document_with_variables(id, query, None).await
 }
 
 async fn execute_query_document_with_variables(
-    id: &SubgraphDeploymentId,
+    id: &DeploymentHash,
     query: q::Document,
     variables: Option<QueryVariables>,
 ) -> QueryResult {
@@ -1395,7 +1395,7 @@ fn can_use_nested_filter() {
 }
 
 async fn check_musicians_at(
-    id: &SubgraphDeploymentId,
+    id: &DeploymentHash,
     query: &str,
     block_var: Option<(&str, q::Value)>,
     expected: Result<Vec<&str>, &str>,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -17,7 +17,7 @@ mock! {
 
     #[async_trait]
     trait ChainStore: Send + Sync + 'static {
-        fn genesis_block_ptr(&self) -> Result<EthereumBlockPointer, Error>;
+        fn genesis_block_ptr(&self) -> Result<BlockPtr, Error>;
 
         fn upsert_blocks<B, E>(&self, blocks: B) -> Box<dyn Future<Item = (), Error = E> + Send + 'static>
         where
@@ -29,13 +29,13 @@ mock! {
 
         fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error>;
 
-        fn chain_head_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error>;
+        fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error>;
 
         fn blocks(&self, hashes: Vec<H256>) -> Result<Vec<LightEthereumBlock>, Error>;
 
         fn ancestor_block(
             &self,
-            block_ptr: EthereumBlockPointer,
+            block_ptr: BlockPtr,
             offset: BlockNumber,
         ) -> Result<Option<EthereumBlock>, Error>;
 
@@ -110,10 +110,7 @@ impl SubgraphStore for MockStore {
         todo!()
     }
 
-    fn least_block_ptr(
-        &self,
-        _: &SubgraphDeploymentId,
-    ) -> Result<Option<EthereumBlockPointer>, Error> {
+    fn least_block_ptr(&self, _: &SubgraphDeploymentId) -> Result<Option<BlockPtr>, Error> {
         unimplemented!()
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -8,11 +8,11 @@ mock! {
     pub Store {
         fn get_mock(&self, key: EntityKey) -> Result<Option<Entity>, QueryExecutionError>;
 
-        fn input_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<Schema>, StoreError>;
+        fn input_schema(&self, subgraph_id: &DeploymentHash) -> Result<Arc<Schema>, StoreError>;
 
-        fn api_schema(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Arc<ApiSchema>, StoreError>;
+        fn api_schema(&self, subgraph_id: &DeploymentHash) -> Result<Arc<ApiSchema>, StoreError>;
 
-        fn network_name(&self, subgraph_id: &SubgraphDeploymentId) -> Result<Option<String>, StoreError>;
+        fn network_name(&self, subgraph_id: &DeploymentHash) -> Result<Option<String>, StoreError>;
     }
 
     #[async_trait]
@@ -91,11 +91,11 @@ impl SubgraphStore for MockStore {
         unimplemented!()
     }
 
-    fn input_schema(&self, _: &SubgraphDeploymentId) -> Result<Arc<Schema>, StoreError> {
+    fn input_schema(&self, _: &DeploymentHash) -> Result<Arc<Schema>, StoreError> {
         unimplemented!()
     }
 
-    fn api_schema(&self, _: &SubgraphDeploymentId) -> Result<Arc<ApiSchema>, StoreError> {
+    fn api_schema(&self, _: &DeploymentHash) -> Result<Arc<ApiSchema>, StoreError> {
         unimplemented!()
     }
 
@@ -106,17 +106,17 @@ impl SubgraphStore for MockStore {
         todo!()
     }
 
-    fn is_deployed(&self, _: &SubgraphDeploymentId) -> Result<bool, Error> {
+    fn is_deployed(&self, _: &DeploymentHash) -> Result<bool, Error> {
         todo!()
     }
 
-    fn least_block_ptr(&self, _: &SubgraphDeploymentId) -> Result<Option<BlockPtr>, Error> {
+    fn least_block_ptr(&self, _: &DeploymentHash) -> Result<Option<BlockPtr>, Error> {
         unimplemented!()
     }
 
     fn writable_for_network_indexer(
         &self,
-        _: &SubgraphDeploymentId,
+        _: &DeploymentHash,
     ) -> Result<Arc<dyn graph::components::store::WritableStore>, StoreError> {
         unimplemented!()
     }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -382,7 +382,7 @@ async fn main() {
             let name = SubgraphName::new(name)
                 .expect("Subgraph name must contain only a-z, A-Z, 0-9, '-' and '_'");
             let subgraph_id =
-                SubgraphDeploymentId::new(hash).expect("Subgraph hash must be a valid IPFS hash");
+                DeploymentHash::new(hash).expect("Subgraph hash must be a valid IPFS hash");
 
             graph::spawn(
                 async move {

--- a/node/src/manager/commands/copy.rs
+++ b/node/src/manager/commands/copy.rs
@@ -6,7 +6,7 @@ use graph::{
     prelude::{
         anyhow::{anyhow, bail, Error},
         chrono::{DateTime, Duration, SecondsFormat, Utc},
-        ChainStore, EthereumBlockPointer, NodeId, QueryStoreManager,
+        BlockPtr, ChainStore, NodeId, QueryStoreManager,
     },
 };
 use graph_store_postgres::{
@@ -112,7 +112,7 @@ pub async fn create(
             src_number
         ),
     };
-    let base_ptr = EthereumBlockPointer::from((hash, src_number));
+    let base_ptr = BlockPtr::from((hash, src_number));
 
     let shard = Shard::new(shard)?;
     let node = NodeId::new(node.clone()).map_err(|()| anyhow!("invalid node id `{}`", node))?;

--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-use graph::prelude::{anyhow, BlockNumber, EthereumBlockPointer};
+use graph::prelude::{anyhow, BlockNumber, BlockPtr};
 use graph_store_postgres::SubgraphStore;
 
 use crate::manager::deployment;
@@ -13,7 +13,7 @@ pub fn run(
     block_number: BlockNumber,
 ) -> Result<(), anyhow::Error> {
     let id = deployment::as_hash(id)?;
-    let block_ptr_to = EthereumBlockPointer::try_from((block_hash.as_str(), block_number as i64))
+    let block_ptr_to = BlockPtr::try_from((block_hash.as_str(), block_number as i64))
         .map_err(|e| anyhow!("error converting to block pointer: {}", e))?;
 
     store.rewind(id, block_ptr_to)?;

--- a/node/src/manager/deployment.rs
+++ b/node/src/manager/deployment.rs
@@ -6,7 +6,7 @@ use graph::{
     data::subgraph::status,
     prelude::{
         anyhow::{self, anyhow, bail},
-        Error, SubgraphDeploymentId, SubgraphStore as _,
+        DeploymentHash, Error, SubgraphStore as _,
     },
 };
 use graph_store_postgres::{command_support::catalog as store_catalog, Shard, SubgraphStore};
@@ -150,6 +150,6 @@ pub fn locate(
     }
 }
 
-pub fn as_hash(hash: String) -> Result<SubgraphDeploymentId, Error> {
-    SubgraphDeploymentId::new(hash).map_err(|s| anyhow!("illegal deployment hash `{}`", s))
+pub fn as_hash(hash: String) -> Result<DeploymentHash, Error> {
+    DeploymentHash::new(hash).map_err(|s| anyhow!("illegal deployment hash `{}`", s))
 }

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -94,7 +94,7 @@ where
     fn spawn_mapping(
         raw_module: Vec<u8>,
         logger: Logger,
-        subgraph_id: SubgraphDeploymentId,
+        subgraph_id: DeploymentHash,
         metrics: Arc<HostMetrics>,
     ) -> Result<Sender<Self::Req>, Error> {
         let experimental_features = ExperimentalFeatures {
@@ -116,7 +116,7 @@ where
     fn build(
         &self,
         network_name: String,
-        subgraph_id: SubgraphDeploymentId,
+        subgraph_id: DeploymentHash,
         data_source: DataSource,
         templates: Arc<Vec<DataSourceTemplate>>,
         mapping_request_sender: Sender<MappingRequest>,
@@ -170,7 +170,7 @@ impl RuntimeHost {
         store: Arc<dyn crate::RuntimeStore>,
         call_cache: Arc<dyn EthereumCallCache>,
         network_name: String,
-        subgraph_id: SubgraphDeploymentId,
+        subgraph_id: DeploymentHash,
         data_source: DataSource,
         templates: Arc<Vec<DataSourceTemplate>>,
         mapping_request_sender: Sender<MappingRequest>,

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -67,7 +67,7 @@ impl IntoTrap for HostExportError {
 }
 
 pub(crate) struct HostExports {
-    pub(crate) subgraph_id: SubgraphDeploymentId,
+    pub(crate) subgraph_id: DeploymentHash,
     pub(crate) api_version: Version,
     data_source_name: String,
     data_source_address: Option<Address>,
@@ -97,7 +97,7 @@ impl std::fmt::Debug for HostExports {
 
 impl HostExports {
     pub(crate) fn new(
-        subgraph_id: SubgraphDeploymentId,
+        subgraph_id: DeploymentHash,
         data_source: &DataSource,
         data_source_network: String,
         templates: Arc<Vec<DataSourceTemplate>>,

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -17,7 +17,7 @@ lazy_static! {
 pub fn spawn_module(
     raw_module: Vec<u8>,
     logger: Logger,
-    subgraph_id: SubgraphDeploymentId,
+    subgraph_id: DeploymentHash,
     host_metrics: Arc<HostMetrics>,
     runtime: tokio::runtime::Handle,
     timeout: Option<Duration>,

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -38,7 +38,7 @@ fn test_valid_module_and_store_with_timeout(
         .ethereum_call_cache(NETWORK_NAME)
         .expect("call cache for test network");
     let metrics_registry = Arc::new(MockMetricsRegistry::new());
-    let deployment_id = SubgraphDeploymentId::new(subgraph_id).unwrap();
+    let deployment_id = DeploymentHash::new(subgraph_id).unwrap();
     let deployment = test_store::create_test_subgraph(
         &deployment_id,
         "type User @entity {
@@ -144,7 +144,7 @@ fn mock_abi() -> MappingABI {
 }
 
 fn mock_host_exports(
-    subgraph_id: SubgraphDeploymentId,
+    subgraph_id: DeploymentHash,
     data_source: DataSource,
     store: Arc<impl SubgraphStore>,
     call_cache: Arc<impl EthereumCallCache>,
@@ -339,7 +339,7 @@ fn make_thing(subgraph_id: &str, id: &str, value: &str) -> (String, EntityModifi
     data.set("value", value);
     data.set("extra", USER_DATA);
     let key = EntityKey::data(
-        SubgraphDeploymentId::new(subgraph_id).unwrap(),
+        DeploymentHash::new(subgraph_id).unwrap(),
         "Thing".to_string(),
         id.to_string(),
     );

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -184,7 +184,7 @@ where
         id: String,
         request: Request<Body>,
     ) -> GraphQLServiceResponse {
-        let res = SubgraphDeploymentId::new(id)
+        let res = DeploymentHash::new(id)
             .map_err(|id| GraphQLServerError::ClientError(format!("Invalid subgraph id `{}`", id)));
         match res {
             Err(_) => self.handle_not_found(),
@@ -408,7 +408,7 @@ mod tests {
     pub struct TestGraphQlRunner;
 
     lazy_static! {
-        static ref USERS: SubgraphDeploymentId = SubgraphDeploymentId::new("users").unwrap();
+        static ref USERS: DeploymentHash = DeploymentHash::new("users").unwrap();
     }
 
     #[async_trait]

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -86,7 +86,7 @@ mod test {
     use graph_mock::MockMetricsRegistry;
 
     lazy_static! {
-        static ref USERS: SubgraphDeploymentId = SubgraphDeploymentId::new("users").unwrap();
+        static ref USERS: DeploymentHash = DeploymentHash::new("users").unwrap();
     }
 
     #[test]

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -99,7 +99,7 @@ where
             .try_into()
             .unwrap();
 
-        let block = EthereumBlockPointer::from((block_hash, block_number));
+        let block = BlockPtr::from((block_hash, block_number));
 
         let indexer = argument_values
             .get_optional::<Address>("indexer")

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -84,7 +84,7 @@ where
         argument_values: &HashMap<&String, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         let deployment_id = argument_values
-            .get_required::<SubgraphDeploymentId>("subgraph")
+            .get_required::<DeploymentHash>("subgraph")
             .expect("Valid subgraphId required");
 
         let block_number: u64 = argument_values

--- a/server/index-node/src/schema.rs
+++ b/server/index-node/src/schema.rs
@@ -9,7 +9,7 @@ lazy_static! {
 
         Arc::new(
             ApiSchema::from_api_schema(Schema {
-                id: SubgraphDeploymentId::new("indexnode").unwrap(),
+                id: DeploymentHash::new("indexnode").unwrap(),
                 document,
                 interfaces_for_type,
                 types_for_interface,

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -38,7 +38,7 @@ struct SubgraphCreateParams {
 #[derive(Debug, Deserialize)]
 struct SubgraphDeployParams {
     name: SubgraphName,
-    ipfs_hash: SubgraphDeploymentId,
+    ipfs_hash: DeploymentHash,
     node_id: Option<NodeId>,
 }
 
@@ -49,7 +49,7 @@ struct SubgraphRemoveParams {
 
 #[derive(Debug, Deserialize)]
 struct SubgraphReassignParams {
-    ipfs_hash: SubgraphDeploymentId,
+    ipfs_hash: DeploymentHash,
     node_id: NodeId,
 }
 

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -171,7 +171,7 @@ pub struct GraphQlConnection<Q, S> {
     logger: Logger,
     graphql_runner: Arc<Q>,
     stream: WebSocketStream<S>,
-    deployment: SubgraphDeploymentId,
+    deployment: DeploymentHash,
 }
 
 impl<Q, S> GraphQlConnection<Q, S>
@@ -182,7 +182,7 @@ where
     /// Creates a new GraphQL subscription service.
     pub(crate) fn new(
         logger: &Logger,
-        deployment: SubgraphDeploymentId,
+        deployment: DeploymentHash,
         stream: WebSocketStream<S>,
         graphql_runner: Arc<Q>,
     ) -> Self {
@@ -200,7 +200,7 @@ where
         mut msg_sink: mpsc::UnboundedSender<WsMessage>,
         logger: Logger,
         connection_id: String,
-        deployment: SubgraphDeploymentId,
+        deployment: DeploymentHash,
         graphql_runner: Arc<Q>,
     ) -> Result<(), WsError> {
         let mut operations = Operations::new(msg_sink.clone());

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -43,7 +43,7 @@ where
         }
 
         fn target_from_id(id: &str) -> Option<QueryTarget> {
-            SubgraphDeploymentId::new(id)
+            DeploymentHash::new(id)
                 .ok()
                 .map(|id| QueryTarget::Deployment(id))
         }

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -5,7 +5,7 @@ use clap::App;
 use std::process::exit;
 use std::{fs, sync::Arc};
 
-use graph::prelude::{Schema, SubgraphDeploymentId};
+use graph::prelude::{DeploymentHash, Schema};
 use graph_store_postgres::{
     command_support::{Catalog, Column, ColumnType, Layout, Namespace},
     layout_for_tests::make_dummy_site,
@@ -135,7 +135,7 @@ pub fn main() {
     let namespace = args.value_of("db_schema").unwrap_or("subgraphs");
     let kind = args.value_of("generate").unwrap_or("ddl");
 
-    let subgraph = SubgraphDeploymentId::new("Qmasubgraph").unwrap();
+    let subgraph = DeploymentHash::new("Qmasubgraph").unwrap();
     let schema = ensure(fs::read_to_string(schema), "Can not read schema file");
     let schema = ensure(
         Schema::parse(&schema, subgraph.clone()),

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -7,7 +7,7 @@ use diesel::sql_types::{Integer, Range};
 use std::io::Write;
 use std::ops::{Bound, RangeBounds, RangeFrom};
 
-use graph::prelude::{BlockNumber, EthereumBlockPointer, BLOCK_NUMBER_MAX};
+use graph::prelude::{BlockNumber, BlockPtr, BLOCK_NUMBER_MAX};
 
 use crate::relational::Table;
 
@@ -67,7 +67,7 @@ pub(crate) fn first_block_in_range(
 /// `None` panic because that indicates that we want to perform an
 /// operation that does not record history, which should not happen
 /// with how we currently use relational schemas
-pub(crate) fn block_number(block_ptr: &EthereumBlockPointer) -> BlockNumber {
+pub(crate) fn block_number(block_ptr: &BlockPtr) -> BlockNumber {
     block_ptr.number
 }
 

--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -6,7 +6,7 @@ use std::{
 
 use graph::{
     components::store::BlockStore as BlockStoreTrait,
-    prelude::{error, warn, BlockNumber, EthereumBlockPointer, EthereumNetworkIdentifier, Logger},
+    prelude::{error, warn, BlockNumber, BlockPtr, EthereumNetworkIdentifier, Logger},
 };
 use graph::{components::store::CallCache as CallCacheTrait, prelude::StoreError};
 use graph::{
@@ -347,7 +347,7 @@ impl BlockStore {
         Ok(store)
     }
 
-    pub fn chain_head_pointers(&self) -> Result<HashMap<String, EthereumBlockPointer>, StoreError> {
+    pub fn chain_head_pointers(&self) -> Result<HashMap<String, BlockPtr>, StoreError> {
         let mut map = HashMap::new();
         let stores = self
             .stores

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -7,8 +7,8 @@ use graph::{
     constraint_violation,
     data::subgraph::schema::{SubgraphError, SubgraphManifestEntity},
     prelude::{
-        bigdecimal::ToPrimitive, BigDecimal, BlockPtr, StoreError, SubgraphDeploymentEntity,
-        SubgraphDeploymentId,
+        bigdecimal::ToPrimitive, BigDecimal, BlockPtr, DeploymentHash, StoreError,
+        SubgraphDeploymentEntity,
     },
 };
 use graph::{data::subgraph::status, prelude::web3::types::H256};
@@ -127,7 +127,7 @@ impl TryFrom<ErrorDetail> for SubgraphError {
             (Some(number), Some(hash)) => Some(BlockPtr::from((hash, number as u64))),
             _ => None,
         };
-        let subgraph_id = SubgraphDeploymentId::new(subgraph_id).map_err(|id| {
+        let subgraph_id = DeploymentHash::new(subgraph_id).map_err(|id| {
             StoreError::ConstraintViolation(format!("invalid subgraph id `{}` in fatal error", id))
         })?;
         Ok(SubgraphError {
@@ -321,7 +321,7 @@ impl TryFrom<StoredDeploymentEntity> for SubgraphDeploymentEntity {
 
         let graft_base = detail
             .graft_base
-            .map(|b| SubgraphDeploymentId::new(b))
+            .map(|b| DeploymentHash::new(b))
             .transpose()
             .map_err(|b| constraint_violation!("invalid graft base `{}`", b))?;
 

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -7,8 +7,8 @@ use graph::{
     constraint_violation,
     data::subgraph::schema::{SubgraphError, SubgraphManifestEntity},
     prelude::{
-        bigdecimal::ToPrimitive, BigDecimal, EthereumBlockPointer, StoreError,
-        SubgraphDeploymentEntity, SubgraphDeploymentId,
+        bigdecimal::ToPrimitive, BigDecimal, BlockPtr, StoreError, SubgraphDeploymentEntity,
+        SubgraphDeploymentId,
     },
 };
 use graph::{data::subgraph::status, prelude::web3::types::H256};
@@ -124,7 +124,7 @@ impl TryFrom<ErrorDetail> for SubgraphError {
         // has a hash. Conversely, it is also possible for an error to not have a
         // hash. In both cases, use a block pointer of `None`
         let block_ptr = match (block_number, block_hash) {
-            (Some(number), Some(hash)) => Some(EthereumBlockPointer::from((hash, number as u64))),
+            (Some(number), Some(hash)) => Some(BlockPtr::from((hash, number as u64))),
             _ => None,
         };
         let subgraph_id = SubgraphDeploymentId::new(subgraph_id).map_err(|id| {

--- a/store/postgres/src/dynds.rs
+++ b/store/postgres/src/dynds.rs
@@ -14,8 +14,8 @@ use graph::{
     constraint_violation,
     data::subgraph::Source,
     prelude::{
-        bigdecimal::ToPrimitive, web3::types::H160, BigDecimal, BlockNumber, BlockPtr, StoreError,
-        SubgraphDeploymentId,
+        bigdecimal::ToPrimitive, web3::types::H160, BigDecimal, BlockNumber, BlockPtr,
+        DeploymentHash, StoreError,
     },
 };
 
@@ -112,7 +112,7 @@ pub fn load(conn: &PgConnection, id: &str) -> Result<Vec<StoredDynamicDataSource
 
 pub(crate) fn insert(
     conn: &PgConnection,
-    deployment: &SubgraphDeploymentId,
+    deployment: &DeploymentHash,
     data_sources: Vec<StoredDynamicDataSource>,
     block_ptr: &BlockPtr,
 ) -> Result<usize, StoreError> {
@@ -209,7 +209,7 @@ pub(crate) fn copy(
 
 pub(crate) fn revert(
     conn: &PgConnection,
-    id: &SubgraphDeploymentId,
+    id: &DeploymentHash,
     block: BlockNumber,
 ) -> Result<(), StoreError> {
     use dynamic_ethereum_contract_data_source as decds;
@@ -219,7 +219,7 @@ pub(crate) fn revert(
     Ok(())
 }
 
-pub(crate) fn drop(conn: &PgConnection, id: &SubgraphDeploymentId) -> Result<usize, StoreError> {
+pub(crate) fn drop(conn: &PgConnection, id: &DeploymentHash) -> Result<usize, StoreError> {
     use dynamic_ethereum_contract_data_source as decds;
 
     delete(decds::table.filter(decds::deployment.eq(id.as_str())))

--- a/store/postgres/src/dynds.rs
+++ b/store/postgres/src/dynds.rs
@@ -14,8 +14,8 @@ use graph::{
     constraint_violation,
     data::subgraph::Source,
     prelude::{
-        bigdecimal::ToPrimitive, web3::types::H160, BigDecimal, BlockNumber, EthereumBlockPointer,
-        StoreError, SubgraphDeploymentId,
+        bigdecimal::ToPrimitive, web3::types::H160, BigDecimal, BlockNumber, BlockPtr, StoreError,
+        SubgraphDeploymentId,
     },
 };
 
@@ -114,7 +114,7 @@ pub(crate) fn insert(
     conn: &PgConnection,
     deployment: &SubgraphDeploymentId,
     data_sources: Vec<StoredDynamicDataSource>,
-    block_ptr: &EthereumBlockPointer,
+    block_ptr: &BlockPtr,
 ) -> Result<usize, StoreError> {
     use dynamic_ethereum_contract_data_source as decds;
 
@@ -166,7 +166,7 @@ pub(crate) fn copy(
     conn: &PgConnection,
     src: &Site,
     dst: &Site,
-    target_block: &EthereumBlockPointer,
+    target_block: &BlockPtr,
 ) -> Result<usize, StoreError> {
     use dynamic_ethereum_contract_data_source as decds;
 

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -51,7 +51,7 @@ impl QueryStoreTrait for QueryStore {
         Ok(self.store.exists_and_synced(&self.site.deployment)?)
     }
 
-    fn block_ptr(&self) -> Result<Option<EthereumBlockPointer>, Error> {
+    fn block_ptr(&self) -> Result<Option<BlockPtr>, Error> {
         self.store.block_ptr(&self.site)
     }
 

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -32,9 +32,9 @@ use graph::data::schema::{FulltextConfig, FulltextDefinition, Schema, SCHEMA_TYP
 use graph::data::store::BYTES_SCALAR;
 use graph::data::subgraph::schema::{POI_OBJECT, POI_TABLE};
 use graph::prelude::{
-    anyhow, info, BlockNumber, Entity, EntityChange, EntityCollection, EntityFilter, EntityKey,
-    EntityOrder, EntityRange, Logger, QueryExecutionError, StoreError, StoreEvent,
-    SubgraphDeploymentId, ValueType, BLOCK_NUMBER_MAX,
+    anyhow, info, BlockNumber, DeploymentHash, Entity, EntityChange, EntityCollection,
+    EntityFilter, EntityKey, EntityOrder, EntityRange, Logger, QueryExecutionError, StoreError,
+    StoreEvent, ValueType, BLOCK_NUMBER_MAX,
 };
 
 use crate::block_range::BLOCK_RANGE_COLUMN;
@@ -721,7 +721,7 @@ impl Layout {
     pub fn revert_block(
         &self,
         conn: &PgConnection,
-        subgraph_id: &SubgraphDeploymentId,
+        subgraph_id: &DeploymentHash,
         block: BlockNumber,
     ) -> Result<(StoreEvent, i32), StoreError> {
         let mut changes: Vec<EntityChange> = Vec::new();
@@ -777,7 +777,7 @@ impl Layout {
     /// is subject to reversion is only ever created but never updated
     pub fn revert_metadata(
         conn: &PgConnection,
-        subgraph: &SubgraphDeploymentId,
+        subgraph: &DeploymentHash,
         block: BlockNumber,
     ) -> Result<(), StoreError> {
         crate::dynds::revert(conn, &subgraph, block)?;
@@ -1340,7 +1340,7 @@ mod tests {
     const ID_TYPE: ColumnType = ColumnType::String;
 
     fn test_layout(gql: &str) -> Layout {
-        let subgraph = SubgraphDeploymentId::new("subgraph").unwrap();
+        let subgraph = DeploymentHash::new("subgraph").unwrap();
         let schema = Schema::parse(gql, subgraph.clone()).expect("Test schema invalid");
         let namespace = Namespace::new("sgd0815".to_owned()).unwrap();
         let catalog = Catalog::make_empty(namespace.clone()).expect("Can not create catalog");

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -9,8 +9,7 @@ use graph::{
     constraint_violation,
     data::subgraph::status,
     prelude::{
-        web3::types::Address, BlockPtr, CheapClone, QueryExecutionError, StoreError,
-        SubgraphDeploymentId,
+        web3::types::Address, BlockPtr, CheapClone, DeploymentHash, QueryExecutionError, StoreError,
     },
 };
 
@@ -109,7 +108,7 @@ impl StatusStore for Store {
 
     fn get_proof_of_indexing<'a>(
         self: Arc<Self>,
-        subgraph_id: &'a SubgraphDeploymentId,
+        subgraph_id: &'a DeploymentHash,
         indexer: &'a Option<Address>,
         block: BlockPtr,
     ) -> graph::prelude::DynTryFuture<'a, Option<[u8; 32]>> {

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -9,7 +9,7 @@ use graph::{
     constraint_violation,
     data::subgraph::status,
     prelude::{
-        web3::types::Address, CheapClone, EthereumBlockPointer, QueryExecutionError, StoreError,
+        web3::types::Address, BlockPtr, CheapClone, QueryExecutionError, StoreError,
         SubgraphDeploymentId,
     },
 };
@@ -111,7 +111,7 @@ impl StatusStore for Store {
         self: Arc<Self>,
         subgraph_id: &'a SubgraphDeploymentId,
         indexer: &'a Option<Address>,
-        block: EthereumBlockPointer,
+        block: BlockPtr,
     ) -> graph::prelude::DynTryFuture<'a, Option<[u8; 32]>> {
         self.subgraph_store
             .get_proof_of_indexing(subgraph_id, indexer, block)

--- a/store/postgres/tests/chain_head.rs
+++ b/store/postgres/tests/chain_head.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use graph::prelude::{anyhow::anyhow, anyhow::Error};
 use graph::prelude::{BlockNumber, QueryStoreManager};
 use graph::{cheap_clone::CheapClone, prelude::web3::types::H160};
-use graph::{components::store::BlockStore as _, prelude::SubgraphDeploymentId};
+use graph::{components::store::BlockStore as _, prelude::DeploymentHash};
 use graph::{components::store::ChainStore as _, prelude::EthereumCallCache as _};
 use graph_store_postgres::Store as DieselStore;
 use graph_store_postgres::{layout_for_tests::FAKE_NETWORK_SHARED, ChainStore as DieselChainStore};
@@ -169,7 +169,7 @@ fn long_chain_with_uncles() {
 #[test]
 fn block_number() {
     let chain = vec![&*GENESIS_BLOCK, &*BLOCK_ONE, &*BLOCK_TWO];
-    let subgraph = SubgraphDeploymentId::new("nonExistentSubgraph").unwrap();
+    let subgraph = DeploymentHash::new("nonExistentSubgraph").unwrap();
 
     run_test_async(chain, move |_, subgraph_store| {
         let subgraph = subgraph.cheap_clone();

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -63,8 +63,7 @@ macro_rules! block_pointer {
 }
 
 lazy_static! {
-    static ref TEST_SUBGRAPH_ID: SubgraphDeploymentId =
-        SubgraphDeploymentId::new("testsubgraph").unwrap();
+    static ref TEST_SUBGRAPH_ID: DeploymentHash = DeploymentHash::new("testsubgraph").unwrap();
     static ref TEST_SUBGRAPH_SCHEMA: Schema =
         Schema::parse(USER_GQL, TEST_SUBGRAPH_ID.clone()).expect("Failed to parse user schema");
     static ref BLOCKS: Vec<BlockPtr> = vec![
@@ -257,12 +256,12 @@ fn remove_test_data(store: Arc<DieselSubgraphStore>) {
 }
 
 fn create_grafted_subgraph(
-    subgraph_id: &SubgraphDeploymentId,
+    subgraph_id: &DeploymentHash,
     schema: &str,
     base_id: &str,
     base_block: BlockPtr,
 ) -> Result<DeploymentLocator, StoreError> {
-    let base = Some((SubgraphDeploymentId::new(base_id).unwrap(), base_block));
+    let base = Some((DeploymentHash::new(base_id).unwrap(), base_block));
     test_store::create_subgraph(subgraph_id, schema, base)
 }
 
@@ -324,7 +323,7 @@ fn graft() {
     run_test(move |store, _| -> Result<(), StoreError> {
         const SUBGRAPH: &str = "grafted";
 
-        let subgraph_id = SubgraphDeploymentId::new(SUBGRAPH).unwrap();
+        let subgraph_id = DeploymentHash::new(SUBGRAPH).unwrap();
 
         let deployment = create_grafted_subgraph(
             &subgraph_id,

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -58,7 +58,7 @@ const USER: &str = "User";
 
 macro_rules! block_pointer {
     ($hash:expr, $number:expr) => {{
-        EthereumBlockPointer::from((H256::from(hex!($hash)), $number as u64))
+        BlockPtr::from((H256::from(hex!($hash)), $number as u64))
     }};
 }
 
@@ -67,7 +67,7 @@ lazy_static! {
         SubgraphDeploymentId::new("testsubgraph").unwrap();
     static ref TEST_SUBGRAPH_SCHEMA: Schema =
         Schema::parse(USER_GQL, TEST_SUBGRAPH_ID.clone()).expect("Failed to parse user schema");
-    static ref BLOCKS: Vec<EthereumBlockPointer> = vec![
+    static ref BLOCKS: Vec<BlockPtr> = vec![
         block_pointer!(
             "bd34884280958002c51d3f7b5f853e6febeba33de0f40d15b0363006533c924f",
             0
@@ -260,7 +260,7 @@ fn create_grafted_subgraph(
     subgraph_id: &SubgraphDeploymentId,
     schema: &str,
     base_id: &str,
-    base_block: EthereumBlockPointer,
+    base_block: BlockPtr,
 ) -> Result<DeploymentLocator, StoreError> {
     let base = Some((SubgraphDeploymentId::new(base_id).unwrap(), base_block));
     test_store::create_subgraph(subgraph_id, schema, base)

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -2,9 +2,9 @@
 use diesel::connection::SimpleConnection as _;
 use diesel::pg::PgConnection;
 use graph::prelude::{
-    o, slog, web3::types::H256, Entity, EntityCollection, EntityFilter, EntityKey, EntityOrder,
-    EntityQuery, EntityRange, Logger, Schema, StopwatchMetrics, SubgraphDeploymentId, Value,
-    ValueType, BLOCK_NUMBER_MAX,
+    o, slog, web3::types::H256, DeploymentHash, Entity, EntityCollection, EntityFilter, EntityKey,
+    EntityOrder, EntityQuery, EntityRange, Logger, Schema, StopwatchMetrics, Value, ValueType,
+    BLOCK_NUMBER_MAX,
 };
 use graph_mock::MockMetricsRegistry;
 use hex_literal::hex;
@@ -117,8 +117,7 @@ const THINGS_GQL: &str = r#"
 "#;
 
 lazy_static! {
-    static ref THINGS_SUBGRAPH_ID: SubgraphDeploymentId =
-        SubgraphDeploymentId::new("things").unwrap();
+    static ref THINGS_SUBGRAPH_ID: DeploymentHash = DeploymentHash::new("things").unwrap();
     static ref NAMESPACE: Namespace = Namespace::new("sgd0815".to_string()).unwrap();
     static ref LARGE_INT: BigInt = BigInt::from(std::i64::MAX).pow(17);
     static ref LARGE_DECIMAL: BigDecimal =

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -7,9 +7,9 @@ use lazy_static::lazy_static;
 use std::{collections::BTreeMap, sync::Arc};
 
 use graph::prelude::{
-    o, slog, web3::types::H256, ChildMultiplicity, Entity, EntityCollection, EntityKey, EntityLink,
-    EntityOrder, EntityRange, EntityWindow, Logger, ParentLink, Schema, StopwatchMetrics,
-    SubgraphDeploymentId, Value, WindowAttribute, BLOCK_NUMBER_MAX,
+    o, slog, web3::types::H256, ChildMultiplicity, DeploymentHash, Entity, EntityCollection,
+    EntityKey, EntityLink, EntityOrder, EntityRange, EntityWindow, Logger, ParentLink, Schema,
+    StopwatchMetrics, Value, WindowAttribute, BLOCK_NUMBER_MAX,
 };
 use graph::{
     components::store::EntityType,
@@ -48,8 +48,7 @@ macro_rules! entity {
 }
 
 lazy_static! {
-    static ref THINGS_SUBGRAPH_ID: SubgraphDeploymentId =
-        SubgraphDeploymentId::new("things").unwrap();
+    static ref THINGS_SUBGRAPH_ID: DeploymentHash = DeploymentHash::new("things").unwrap();
     static ref LARGE_INT: BigInt = BigInt::from(std::i64::MAX).pow(17);
     static ref LARGE_DECIMAL: BigDecimal =
         BigDecimal::from(1) / BigDecimal::new(LARGE_INT.clone(), 1);

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -61,56 +61,56 @@ lazy_static! {
         SubgraphDeploymentId::new(TEST_SUBGRAPH_ID_STRING.as_str()).unwrap();
     static ref TEST_SUBGRAPH_SCHEMA: Schema =
         Schema::parse(USER_GQL, TEST_SUBGRAPH_ID.clone()).expect("Failed to parse user schema");
-    static ref TEST_BLOCK_0_PTR: EthereumBlockPointer = (
+    static ref TEST_BLOCK_0_PTR: BlockPtr = (
         H256::from(hex!(
             "bd34884280958002c51d3f7b5f853e6febeba33de0f40d15b0363006533c924f"
         )),
         0u64
     )
         .into();
-    static ref TEST_BLOCK_1_PTR: EthereumBlockPointer = (
+    static ref TEST_BLOCK_1_PTR: BlockPtr = (
         H256::from(hex!(
             "8511fa04b64657581e3f00e14543c1d522d5d7e771b54aa3060b662ade47da13"
         )),
         1u64
     )
         .into();
-    static ref TEST_BLOCK_2_PTR: EthereumBlockPointer = (
+    static ref TEST_BLOCK_2_PTR: BlockPtr = (
         H256::from(hex!(
             "b98fb783b49de5652097a989414c767824dff7e7fd765a63b493772511db81c1"
         )),
         2u64
     )
         .into();
-    static ref TEST_BLOCK_3_PTR: EthereumBlockPointer = (
+    static ref TEST_BLOCK_3_PTR: BlockPtr = (
         H256::from(hex!(
             "977c084229c72a0fa377cae304eda9099b6a2cb5d83b25cdf0f0969b69874255"
         )),
         3u64
     )
         .into();
-    static ref TEST_BLOCK_3A_PTR: EthereumBlockPointer = (
+    static ref TEST_BLOCK_3A_PTR: BlockPtr = (
         H256::from(hex!(
             "d163aec0592c7cb00c2700ab65dcaac93289f5d250b3b889b39198b07e1fbe4a"
         )),
         3u64
     )
         .into();
-    static ref TEST_BLOCK_4_PTR: EthereumBlockPointer = (
+    static ref TEST_BLOCK_4_PTR: BlockPtr = (
         H256::from(hex!(
             "007a03cdf635ebb66f5e79ae66cc90ca23d98031665649db056ff9c6aac2d74d"
         )),
         4u64
     )
         .into();
-    static ref TEST_BLOCK_4A_PTR: EthereumBlockPointer = (
+    static ref TEST_BLOCK_4A_PTR: BlockPtr = (
         H256::from(hex!(
             "8fab27e9e9285b0a39110f4d9877f05d0f43d2effa157e55f4dcc49c3cf8cbd7"
         )),
         4u64
     )
         .into();
-    static ref TEST_BLOCK_5_PTR: EthereumBlockPointer = (
+    static ref TEST_BLOCK_5_PTR: BlockPtr = (
         H256::from(hex!(
             "e8b3b02b936c4a4a331ac691ac9a86e197fb7731f14e3108602c87d4dac55160"
         )),
@@ -1871,7 +1871,7 @@ fn reorg_tracking() {
         store: &Arc<DieselSubgraphStore>,
         deployment: &DeploymentLocator,
         age: i32,
-        block: &EthereumBlockPointer,
+        block: &BlockPtr,
     ) {
         let test_entity_1 = create_test_entity(
             "1",

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -57,8 +57,8 @@ const USER: &str = "User";
 
 lazy_static! {
     static ref TEST_SUBGRAPH_ID_STRING: String = String::from("testsubgraph");
-    static ref TEST_SUBGRAPH_ID: SubgraphDeploymentId =
-        SubgraphDeploymentId::new(TEST_SUBGRAPH_ID_STRING.as_str()).unwrap();
+    static ref TEST_SUBGRAPH_ID: DeploymentHash =
+        DeploymentHash::new(TEST_SUBGRAPH_ID_STRING.as_str()).unwrap();
     static ref TEST_SUBGRAPH_SCHEMA: Schema =
         Schema::parse(USER_GQL, TEST_SUBGRAPH_ID.clone()).expect("Failed to parse user schema");
     static ref TEST_BLOCK_0_PTR: BlockPtr = (
@@ -293,7 +293,7 @@ fn remove_test_data(store: Arc<DieselSubgraphStore>) {
         .expect("deleting test entities succeeds");
 }
 
-fn get_entity_count(store: Arc<DieselStore>, subgraph_id: &SubgraphDeploymentId) -> u64 {
+fn get_entity_count(store: Arc<DieselStore>, subgraph_id: &DeploymentHash) -> u64 {
     let info = store
         .status(status::Filter::Deployments(vec![subgraph_id.to_string()]))
         .unwrap();
@@ -967,7 +967,7 @@ async fn check_events(
 
 // Subscribe to store events
 fn subscribe(
-    subgraph: &SubgraphDeploymentId,
+    subgraph: &DeploymentHash,
     entity_type: &str,
 ) -> StoreEventStream<impl Stream<Item = Arc<StoreEvent>, Error = ()> + Send> {
     let subscription = SUBSCRIPTION_MANAGER.subscribe(vec![SubscriptionFilter::Entities(
@@ -1257,7 +1257,7 @@ fn revert_block_with_dynamic_data_source_operations() {
             tag: 3,
             changes: HashSet::from_iter(
                 vec![EntityChange::Data {
-                    subgraph_id: SubgraphDeploymentId::new("testsubgraph").unwrap(),
+                    subgraph_id: DeploymentHash::new("testsubgraph").unwrap(),
                     entity_type: EntityType::new(USER.into()),
                 }]
                 .into_iter(),
@@ -1270,7 +1270,7 @@ fn revert_block_with_dynamic_data_source_operations() {
 #[test]
 fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
     run_test(|store, _, _| async move {
-        let subgraph_id = SubgraphDeploymentId::new("EntityChangeTestSubgraph").unwrap();
+        let subgraph_id = DeploymentHash::new("EntityChangeTestSubgraph").unwrap();
         let schema =
             Schema::parse(USER_GQL, subgraph_id.clone()).expect("Failed to parse user schema");
         let manifest = SubgraphManifest {

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -11,7 +11,7 @@ use graph::{
     prelude::SubgraphManifest,
     prelude::SubgraphName,
     prelude::SubgraphVersionSwitchingMode,
-    prelude::{CheapClone, NodeId, SubgraphDeploymentId, SubgraphStore as _},
+    prelude::{CheapClone, DeploymentHash, NodeId, SubgraphStore as _},
 };
 use graph_store_postgres::layout_for_tests::Connection as Primary;
 use graph_store_postgres::SubgraphStore;
@@ -43,7 +43,7 @@ fn unassigned(deployment: &DeploymentLocator) -> EntityChange {
 #[test]
 fn reassign_subgraph() {
     fn setup() -> DeploymentLocator {
-        let id = SubgraphDeploymentId::new("reassignSubgraph").unwrap();
+        let id = DeploymentHash::new("reassignSubgraph").unwrap();
         remove_subgraphs();
         create_test_subgraph(&id, SUBGRAPH_GQL)
     }
@@ -109,7 +109,7 @@ fn create_subgraph() {
         mode: SubgraphVersionSwitchingMode,
     ) -> (DeploymentLocator, HashSet<EntityChange>) {
         let name = SubgraphName::new(SUBGRAPH_NAME.to_string()).unwrap();
-        let id = SubgraphDeploymentId::new(id.to_string()).unwrap();
+        let id = DeploymentHash::new(id.to_string()).unwrap();
         let schema = Schema::parse(SUBGRAPH_GQL, id.clone()).unwrap();
 
         let manifest = SubgraphManifest {
@@ -297,10 +297,10 @@ fn status() {
     const OTHER: &str = "otherInfoSubgraph";
 
     fn setup() -> DeploymentLocator {
-        let id = SubgraphDeploymentId::new(NAME).unwrap();
+        let id = DeploymentHash::new(NAME).unwrap();
         remove_subgraphs();
         let deployment = create_test_subgraph(&id, SUBGRAPH_GQL);
-        create_test_subgraph(&SubgraphDeploymentId::new(OTHER).unwrap(), SUBGRAPH_GQL);
+        create_test_subgraph(&DeploymentHash::new(OTHER).unwrap(), SUBGRAPH_GQL);
         deployment
     }
 
@@ -404,7 +404,7 @@ fn version_info() {
     const NAME: &str = "versionInfoSubgraph";
 
     fn setup() -> DeploymentLocator {
-        let id = SubgraphDeploymentId::new(NAME).unwrap();
+        let id = DeploymentHash::new(NAME).unwrap();
         remove_subgraphs();
         block_store::set_chain(vec![], NETWORK_NAME);
         create_test_subgraph(&id, SUBGRAPH_GQL)
@@ -448,7 +448,7 @@ fn subgraph_error() {
     test_store::run_test_sequentially(
         || (),
         |store, _| async move {
-            let subgraph_id = SubgraphDeploymentId::new("testSubgraph").unwrap();
+            let subgraph_id = DeploymentHash::new("testSubgraph").unwrap();
             let deployment = test_store::create_test_subgraph(&subgraph_id, "type Foo { id: ID! }");
 
             let count = || -> usize {
@@ -500,7 +500,7 @@ fn subgraph_error() {
 #[test]
 fn fatal_vs_non_fatal() {
     fn setup() -> DeploymentLocator {
-        let id = SubgraphDeploymentId::new("failUnfail").unwrap();
+        let id = DeploymentHash::new("failUnfail").unwrap();
         remove_subgraphs();
         create_test_subgraph(&id, SUBGRAPH_GQL)
     }
@@ -538,7 +538,7 @@ fn fatal_vs_non_fatal() {
 #[test]
 fn fail_unfail() {
     fn setup() -> DeploymentLocator {
-        let id = SubgraphDeploymentId::new("failUnfail").unwrap();
+        let id = DeploymentHash::new("failUnfail").unwrap();
         remove_subgraphs();
         create_test_subgraph(&id, SUBGRAPH_GQL)
     }

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -146,9 +146,9 @@ pub fn place(name: &str) -> Result<Option<(Shard, Vec<NodeId>)>, String> {
 }
 
 pub fn create_subgraph(
-    subgraph_id: &SubgraphDeploymentId,
+    subgraph_id: &DeploymentHash,
     schema: &str,
-    base: Option<(SubgraphDeploymentId, BlockPtr)>,
+    base: Option<(DeploymentHash, BlockPtr)>,
 ) -> Result<DeploymentLocator, StoreError> {
     let schema = Schema::parse(schema, subgraph_id.clone()).unwrap();
 
@@ -184,11 +184,11 @@ pub fn create_subgraph(
     Ok(deployment)
 }
 
-pub fn create_test_subgraph(subgraph_id: &SubgraphDeploymentId, schema: &str) -> DeploymentLocator {
+pub fn create_test_subgraph(subgraph_id: &DeploymentHash, schema: &str) -> DeploymentLocator {
     create_subgraph(subgraph_id, schema, None).unwrap()
 }
 
-pub fn remove_subgraph(id: &SubgraphDeploymentId) {
+pub fn remove_subgraph(id: &DeploymentHash) {
     let name = {
         let mut name = id.to_string();
         name.truncate(32);
@@ -430,10 +430,7 @@ fn execute_subgraph_query_internal(
     result
 }
 
-pub async fn deployment_state(
-    store: &Store,
-    subgraph_id: &SubgraphDeploymentId,
-) -> DeploymentState {
+pub async fn deployment_state(store: &Store, subgraph_id: &DeploymentHash) -> DeploymentState {
     store
         .query_store(QueryTarget::Deployment(subgraph_id.to_owned()), false)
         .await

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -61,29 +61,29 @@ lazy_static! {
     pub static ref NODE_ID: NodeId = NodeId::new("test").unwrap();
     static ref SUBGRAPH_STORE: Arc<DieselSubgraphStore> = STORE.subgraph_store();
     static ref BLOCK_STORE: Arc<DieselBlcokStore> = STORE.block_store();
-    pub static ref GENESIS_PTR: EthereumBlockPointer = (
+    pub static ref GENESIS_PTR: BlockPtr = (
         H256::from(hex!(
             "bd34884280958002c51d3f7b5f853e6febeba33de0f40d15b0363006533c924f"
         )),
         0u64
     )
         .into();
-    pub static ref BLOCK_ONE: EthereumBlockPointer = (
+    pub static ref BLOCK_ONE: BlockPtr = (
         H256::from(hex!(
             "8511fa04b64657581e3f00e14543c1d522d5d7e771b54aa3060b662ade47da13"
         )),
         1u64
     )
         .into();
-    pub static ref BLOCKS: [EthereumBlockPointer; 4] = {
-        let two: EthereumBlockPointer = (
+    pub static ref BLOCKS: [BlockPtr; 4] = {
+        let two: BlockPtr = (
             H256::from(hex!(
                 "b98fb783b49de5652097a989414c767824dff7e7fd765a63b493772511db81c1"
             )),
             2u64,
         )
             .into();
-        let three: EthereumBlockPointer = (
+        let three: BlockPtr = (
             H256::from(hex!(
                 "977c084229c72a0fa377cae304eda9099b6a2cb5d83b25cdf0f0969b69874255"
             )),
@@ -148,7 +148,7 @@ pub fn place(name: &str) -> Result<Option<(Shard, Vec<NodeId>)>, String> {
 pub fn create_subgraph(
     subgraph_id: &SubgraphDeploymentId,
     schema: &str,
-    base: Option<(SubgraphDeploymentId, EthereumBlockPointer)>,
+    base: Option<(SubgraphDeploymentId, BlockPtr)>,
 ) -> Result<DeploymentLocator, StoreError> {
     let schema = Schema::parse(schema, subgraph_id.clone()).unwrap();
 
@@ -203,7 +203,7 @@ pub fn remove_subgraph(id: &SubgraphDeploymentId) {
 pub fn transact_errors(
     store: &Arc<Store>,
     deployment: &DeploymentLocator,
-    block_ptr_to: EthereumBlockPointer,
+    block_ptr_to: BlockPtr,
     errs: Vec<SubgraphError>,
 ) -> Result<(), StoreError> {
     let metrics_registry = Arc::new(MockMetricsRegistry::new());
@@ -228,7 +228,7 @@ pub fn transact_errors(
 pub fn transact_entity_operations(
     store: &Arc<DieselSubgraphStore>,
     deployment: &DeploymentLocator,
-    block_ptr_to: EthereumBlockPointer,
+    block_ptr_to: BlockPtr,
     ops: Vec<EntityOperation>,
 ) -> Result<(), StoreError> {
     transact_entities_and_dynamic_data_sources(store, deployment.clone(), block_ptr_to, vec![], ops)
@@ -237,7 +237,7 @@ pub fn transact_entity_operations(
 pub fn transact_entities_and_dynamic_data_sources(
     store: &Arc<DieselSubgraphStore>,
     deployment: DeploymentLocator,
-    block_ptr_to: EthereumBlockPointer,
+    block_ptr_to: BlockPtr,
     data_sources: Vec<&DataSource>,
     ops: Vec<EntityOperation>,
 ) -> Result<(), StoreError> {
@@ -267,11 +267,7 @@ pub fn transact_entities_and_dynamic_data_sources(
     )
 }
 
-pub fn revert_block(
-    store: &Arc<Store>,
-    deployment: &DeploymentLocator,
-    ptr: &EthereumBlockPointer,
-) {
+pub fn revert_block(store: &Arc<Store>, deployment: &DeploymentLocator, ptr: &BlockPtr) {
     store
         .subgraph_store()
         .writable(deployment)


### PR DESCRIPTION
These commits do nothing but renaming these two structs; there are no functional changes