### PR TITLE
Make the BlockIngestor independent from Ethereum (was: Simplify ingestion logic)

### DIFF
--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -2,7 +2,7 @@ use lazy_static;
 use std::{sync::Arc, time::Duration};
 
 use graph::{
-    blockchain::{Blockchain, EthereumAdapterError, IngestorAdapter},
+    blockchain::{Blockchain, IngestorAdapter, IngestorError},
     prelude::{
         info, o, tokio, trace, warn, BlockNumber, ComponentLoggerConfig,
         ElasticComponentLoggerConfig, Error, LogCode, Logger, LoggerFactory,
@@ -67,14 +67,14 @@ where
         loop {
             match self.do_poll().await {
                 // Some polls will fail due to transient issues
-                Err(err @ EthereumAdapterError::BlockUnavailable(_)) => {
+                Err(err @ IngestorError::BlockUnavailable(_)) => {
                     trace!(
                         self.logger,
                         "Trying again after block polling failed: {}",
                         err
                     );
                 }
-                Err(EthereumAdapterError::Unknown(inner_err)) => {
+                Err(IngestorError::Unknown(inner_err)) => {
                     warn!(
                         self.logger,
                         "Trying again after block polling failed: {}", inner_err
@@ -112,7 +112,7 @@ where
         }
     }
 
-    async fn do_poll(&self) -> Result<(), EthereumAdapterError> {
+    async fn do_poll(&self) -> Result<(), IngestorError> {
         trace!(self.logger, "BlockIngestor::do_poll");
 
         // Get chain head ptr from store

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -2,10 +2,10 @@ use lazy_static;
 use std::{sync::Arc, time::Duration};
 
 use graph::{
-    blockchain::{Blockchain, IngestorAdapter},
+    blockchain::{Blockchain, EthereumAdapterError, IngestorAdapter},
     prelude::{
         info, o, tokio, trace, warn, BlockNumber, ComponentLoggerConfig,
-        ElasticComponentLoggerConfig, Error, EthereumAdapterError, LogCode, Logger, LoggerFactory,
+        ElasticComponentLoggerConfig, Error, LogCode, Logger, LoggerFactory,
     },
 };
 

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -214,7 +214,9 @@ where
         self.chain_store.upsert_block(block).await?;
 
         self.chain_store
+            .clone()
             .attempt_chain_head_update(self.ancestor_count)
+            .await
             .map_err(|e| {
                 error!(self.logger, "failed to update chain head");
                 EthereumAdapterError::Unknown(e)

--- a/chain/ethereum/src/block_ingestor.rs
+++ b/chain/ethereum/src/block_ingestor.rs
@@ -211,7 +211,7 @@ where
         &self,
         block: EthereumBlock,
     ) -> Result<Option<H256>, EthereumAdapterError> {
-        self.chain_store.upsert_block(block)?;
+        self.chain_store.upsert_block(block).await?;
 
         self.chain_store
             .attempt_chain_head_update(self.ancestor_count)

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -1,0 +1,188 @@
+use std::{pin::Pin, sync::Arc, task::Context};
+
+use anyhow::Error;
+use graph::{
+    blockchain::{
+        block_stream::{
+            BlockStream, BlockStreamEvent, BlockWithTriggers, ScanTriggersError, TriggersAdapter,
+        },
+        Block, Blockchain, DataSource, IngestorAdapter, Manifest, TriggerFilter,
+    },
+    prelude::{async_trait, serde_yaml, BlockPtr, DeploymentHash, LinkResolver, Logger},
+    runtime::{AscType, DeterministicHostError},
+    tokio_stream::Stream,
+};
+
+struct Chain;
+
+impl Blockchain for Chain {
+    type Block = DummyBlock;
+
+    type DataSource = DummyDataSource;
+
+    type DataSourceTemplate = DummyDataSourceTemplate;
+
+    type Manifest = DummyManifest;
+
+    type TriggersAdapter = DummyTriggerAdapter;
+
+    type BlockStream = DummyBlockStream;
+
+    type TriggerData = DummyTriggerData;
+
+    type MappingTrigger = DummyMappingTrigger;
+
+    type TriggerFilter = DummyTriggerFilter;
+
+    type NodeCapabilities = DummyNodeCapabilities;
+
+    type IngestorAdapter = DummyIngestorAdapter;
+
+    fn reorg_threshold() -> u32 {
+        todo!()
+    }
+
+    fn triggers_adapter(
+        &self,
+        _network: &str,
+        _capabilities: Self::NodeCapabilities,
+    ) -> Arc<Self::TriggersAdapter> {
+        todo!()
+    }
+
+    fn new_block_stream(
+        &self,
+        _current_head: BlockPtr,
+        _filter: Self::TriggerFilter,
+    ) -> Result<Self::BlockStream, Error> {
+        todo!()
+    }
+}
+
+struct DummyBlock;
+
+impl Block for DummyBlock {
+    fn ptr(&self) -> BlockPtr {
+        todo!()
+    }
+
+    fn parent_ptr(&self) -> Option<BlockPtr> {
+        todo!()
+    }
+}
+
+struct DummyDataSource;
+
+impl DataSource<Chain> for DummyDataSource {
+    fn match_and_decode(
+        &self,
+        _trigger: &DummyTriggerData,
+        _block: &DummyBlock,
+        _logger: &Logger,
+    ) -> Result<Option<DummyMappingTrigger>, Error> {
+        todo!()
+    }
+}
+
+struct DummyDataSourceTemplate;
+
+struct DummyManifest;
+
+#[async_trait]
+impl Manifest<Chain> for DummyManifest {
+    async fn resolve_from_raw(
+        _id: DeploymentHash,
+        _raw: serde_yaml::Mapping,
+        _resolver: &impl LinkResolver,
+        _logger: &Logger,
+    ) -> Result<Self, Error> {
+        todo!()
+    }
+
+    fn data_sources(&self) -> &[DummyDataSource] {
+        todo!()
+    }
+
+    fn templates(&self) -> &[DummyDataSourceTemplate] {
+        todo!()
+    }
+}
+
+struct DummyTriggerAdapter;
+
+#[async_trait]
+impl TriggersAdapter<Chain> for DummyTriggerAdapter {
+    async fn scan_triggers(
+        &self,
+        _chain_base: BlockPtr,
+        _step_size: u32,
+        _filter: DummyTriggerFilter,
+    ) -> Result<Vec<BlockWithTriggers<Chain>>, ScanTriggersError> {
+        todo!()
+    }
+
+    async fn triggers_in_block(
+        &self,
+        _block: DummyBlock,
+        _filter: DummyTriggerFilter,
+    ) -> Result<BlockWithTriggers<Chain>, Error> {
+        todo!()
+    }
+}
+
+struct DummyBlockStream;
+
+impl Stream for DummyBlockStream {
+    type Item = Result<BlockStreamEvent<Chain>, Error>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        todo!()
+    }
+}
+
+impl BlockStream<Chain> for DummyBlockStream {}
+
+struct DummyTriggerData;
+
+struct DummyMappingTrigger;
+
+impl AscType for DummyMappingTrigger {
+    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+        todo!()
+    }
+
+    fn from_asc_bytes(_asc_obj: &[u8]) -> Result<Self, DeterministicHostError> {
+        todo!()
+    }
+}
+
+struct DummyTriggerFilter;
+
+impl Default for DummyTriggerFilter {
+    fn default() -> Self {
+        todo!()
+    }
+}
+
+impl TriggerFilter<Chain> for DummyTriggerFilter {
+    fn extend<'a>(&mut self, _data_sources: impl Iterator<Item = &'a DummyDataSource>) {
+        todo!()
+    }
+}
+
+struct DummyNodeCapabilities;
+
+struct DummyIngestorAdapter;
+
+impl IngestorAdapter<Chain> for DummyIngestorAdapter {
+    fn head_block(&self) -> DummyBlock {
+        todo!()
+    }
+
+    fn ingest_block(&self, _block: &DummyBlock) -> Result<(), Error> {
+        todo!()
+    }
+}

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -253,4 +253,12 @@ impl IngestorAdapterTrait<Chain> for IngestorAdapter {
                 EthereumAdapterError::Unknown(e)
             })
     }
+
+    fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error> {
+        self.chain_store.chain_head_ptr()
+    }
+
+    fn cleanup_cached_blocks(&self) -> Result<Option<(i32, usize)>, Error> {
+        self.chain_store.cleanup_cached_blocks(self.ancestor_count)
+    }
 }

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -6,13 +6,12 @@ use graph::{
         block_stream::{
             BlockStream, BlockStreamEvent, BlockWithTriggers, ScanTriggersError, TriggersAdapter,
         },
-        Block, BlockHash, Blockchain, DataSource, IngestorAdapter as IngestorAdapterTrait,
-        Manifest, TriggerFilter,
+        Block, BlockHash, Blockchain, DataSource, EthereumAdapterError,
+        IngestorAdapter as IngestorAdapterTrait, Manifest, TriggerFilter,
     },
     prelude::{
         async_trait, error, serde_yaml, web3::types::H256, BlockNumber, BlockPtr, ChainStore,
-        DeploymentHash, EthereumAdapter, EthereumAdapterError, Future01CompatExt, LinkResolver,
-        Logger,
+        DeploymentHash, EthereumAdapter, Future01CompatExt, LinkResolver, Logger,
     },
     runtime::{AscType, DeterministicHostError},
     tokio_stream::Stream,

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -9,6 +9,7 @@ use graph::{
         Block, BlockHash, Blockchain, DataSource, IngestorAdapter as IngestorAdapterTrait,
         IngestorError, Manifest, TriggerFilter,
     },
+    cheap_clone::CheapClone,
     prelude::{
         async_trait, error, serde_yaml, web3::types::H256, BlockNumber, BlockPtr, ChainStore,
         DeploymentHash, EthereumAdapter, Future01CompatExt, LinkResolver, Logger,
@@ -243,7 +244,7 @@ impl IngestorAdapterTrait<Chain> for IngestorAdapter {
         self.chain_store.upsert_block(block).await?;
 
         self.chain_store
-            .clone()
+            .cheap_clone()
             .attempt_chain_head_update(self.ancestor_count)
             .await
             .map(|missing| missing.map(|h256| h256.into()))

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -8,19 +8,22 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use ethabi::ParamType;
-use graph::prelude::{
-    anyhow, async_trait, debug, error, ethabi,
-    futures03::{self, compat::Future01CompatExt, FutureExt, StreamExt, TryStreamExt},
-    hex, retry, stream, tiny_keccak, trace, warn,
-    web3::{
-        self,
-        types::{
-            Address, Block, BlockId, BlockNumber as Web3BlockNumber, Bytes, CallRequest,
-            FilterBuilder, Log, H256,
+use graph::{
+    blockchain::EthereumAdapterError,
+    prelude::{
+        anyhow, async_trait, debug, error, ethabi,
+        futures03::{self, compat::Future01CompatExt, FutureExt, StreamExt, TryStreamExt},
+        hex, retry, stream, tiny_keccak, trace, warn,
+        web3::{
+            self,
+            types::{
+                Address, Block, BlockId, BlockNumber as Web3BlockNumber, Bytes, CallRequest,
+                FilterBuilder, Log, H256,
+            },
         },
+        BlockNumber, ChainStore, CheapClone, DynTryFuture, Error, EthereumCallCache, Logger,
+        TimeoutError,
     },
-    BlockNumber, ChainStore, CheapClone, DynTryFuture, Error, EthereumCallCache, Logger,
-    TimeoutError,
 };
 use graph::{
     components::ethereum::{EthereumAdapter as EthereumAdapterTrait, *},

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -12,3 +12,5 @@ pub use self::block_ingestor::{BlockIngestor, CLEANUP_BLOCKS};
 pub use self::block_stream::{BlockStream, BlockStreamBuilder};
 pub use self::ethereum_adapter::EthereumAdapter;
 pub use self::transport::{EventLoopHandle, Transport};
+
+mod chain;

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -14,3 +14,5 @@ pub use self::ethereum_adapter::EthereumAdapter;
 pub use self::transport::{EventLoopHandle, Transport};
 
 mod chain;
+
+pub use chain::Chain;

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -1,14 +1,9 @@
-#[macro_use]
-extern crate lazy_static;
-
-mod block_ingestor;
 mod block_stream;
 mod config;
 mod ethereum_adapter;
 pub mod network_indexer;
 mod transport;
 
-pub use self::block_ingestor::{BlockIngestor, CLEANUP_BLOCKS};
 pub use self::block_stream::{BlockStream, BlockStreamBuilder};
 pub use self::ethereum_adapter::EthereumAdapter;
 pub use self::transport::{EventLoopHandle, Transport};

--- a/graph/src/blockchain/block_ingestor.rs
+++ b/graph/src/blockchain/block_ingestor.rs
@@ -2,10 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use crate::{
     blockchain::{Blockchain, IngestorAdapter, IngestorError},
-    prelude::{
-        info, lazy_static, o, tokio, trace, warn, BlockNumber, ComponentLoggerConfig,
-        ElasticComponentLoggerConfig, Error, LogCode, Logger, LoggerFactory,
-    },
+    prelude::{info, lazy_static, tokio, trace, warn, BlockNumber, Error, LogCode, Logger},
 };
 
 lazy_static! {
@@ -32,23 +29,11 @@ where
     C: Blockchain,
 {
     pub fn new(
+        logger: Logger,
         adapter: Arc<C::IngestorAdapter>,
-        provider: String,
         ancestor_count: BlockNumber,
-        logger_factory: &LoggerFactory,
         polling_interval: Duration,
     ) -> Result<BlockIngestor<C>, Error> {
-        let logger = logger_factory.component_logger(
-            "BlockIngestor",
-            Some(ComponentLoggerConfig {
-                elastic: Some(ElasticComponentLoggerConfig {
-                    index: String::from("block-ingestor-logs"),
-                }),
-            }),
-        );
-
-        let logger = logger.new(o!("provider" => provider));
-
         Ok(BlockIngestor {
             adapter,
             ancestor_count,

--- a/graph/src/blockchain/block_ingestor.rs
+++ b/graph/src/blockchain/block_ingestor.rs
@@ -1,10 +1,9 @@
-use lazy_static;
 use std::{sync::Arc, time::Duration};
 
-use graph::{
+use crate::{
     blockchain::{Blockchain, IngestorAdapter, IngestorError},
     prelude::{
-        info, o, tokio, trace, warn, BlockNumber, ComponentLoggerConfig,
+        info, lazy_static, o, tokio, trace, warn, BlockNumber, ComponentLoggerConfig,
         ElasticComponentLoggerConfig, Error, LogCode, Logger, LoggerFactory,
     },
 };

--- a/graph/src/blockchain/block_ingestor.rs
+++ b/graph/src/blockchain/block_ingestor.rs
@@ -23,7 +23,6 @@ where
 {
     adapter: Arc<C::IngestorAdapter>,
     ancestor_count: BlockNumber,
-    _network_name: String,
     logger: Logger,
     polling_interval: Duration,
 }
@@ -36,7 +35,6 @@ where
         adapter: Arc<C::IngestorAdapter>,
         provider: String,
         ancestor_count: BlockNumber,
-        network_name: String,
         logger_factory: &LoggerFactory,
         polling_interval: Duration,
     ) -> Result<BlockIngestor<C>, Error> {
@@ -54,7 +52,6 @@ where
         Ok(BlockIngestor {
             adapter,
             ancestor_count,
-            _network_name: network_name,
             logger,
             polling_interval,
         })

--- a/graph/src/blockchain/block_ingestor.rs
+++ b/graph/src/blockchain/block_ingestor.rs
@@ -33,7 +33,7 @@ where
     C: Blockchain,
 {
     pub fn new(
-        chain: &C,
+        adapter: Arc<C::IngestorAdapter>,
         provider: String,
         ancestor_count: BlockNumber,
         network_name: String,
@@ -50,8 +50,6 @@ where
         );
 
         let logger = logger.new(o!("provider" => provider));
-
-        let adapter = chain.ingestor_adapter();
 
         Ok(BlockIngestor {
             adapter,

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -1,0 +1,45 @@
+use super::{BlockPtr, Blockchain};
+use anyhow::Error;
+use async_trait::async_trait;
+use futures03::Stream;
+
+pub struct BlockWithTriggers<C: Blockchain> {
+    pub block: Box<C::Block>,
+    pub trigger_data: Vec<C::TriggerData>,
+}
+
+pub enum ScanTriggersError {
+    // The chain base could not be found. It should be reverted.
+    ChainBaseNotFound,
+    Unknown(Error),
+}
+
+#[async_trait]
+pub trait TriggersAdapter<C: Blockchain> {
+    // Returns a sequence of blocks in increasing order of block number.
+    // Each block will include all of its triggers that match the given `filter`.
+    // The sequence may omit blocks that contain no triggers,
+    // but all returned blocks must part of a same chain starting at `chain_base`.
+    // At least one block will be returned, even if it contains no triggers.
+    // `step_size` is the suggested number blocks to be scanned.
+    async fn scan_triggers(
+        &self,
+        chain_base: BlockPtr,
+        step_size: u32,
+        filter: C::TriggerFilter,
+    ) -> Result<Vec<BlockWithTriggers<C>>, ScanTriggersError>;
+
+    // Used for reprocessing blocks when creating a data source.
+    async fn triggers_in_block(
+        &self,
+        block: C::Block,
+        filter: C::TriggerFilter,
+    ) -> Result<BlockWithTriggers<C>, Error>;
+}
+
+pub enum BlockStreamEvent<C: Blockchain> {
+    RevertTo(BlockPtr),
+    ProcessBlock(BlockWithTriggers<C>),
+}
+
+pub trait BlockStream<C: Blockchain>: Stream<Item = Result<BlockStreamEvent<C>, Error>> {}

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -102,34 +102,31 @@ pub trait Blockchain: Sized + Send + Sync + 'static {
 }
 
 #[derive(Error, Debug)]
-pub enum EthereumAdapterError {
+pub enum IngestorError {
     /// The Ethereum node does not know about this block for some reason, probably because it
     /// disappeared in a chain reorg.
     #[error("Block data unavailable, block was likely uncled (block hash = {0:?})")]
     BlockUnavailable(H256),
 
     /// An unexpected error occurred.
-    #[error("Ethereum adapter error: {0}")]
+    #[error("Ingestor error: {0}")]
     Unknown(Error),
 }
 
-impl From<Error> for EthereumAdapterError {
+impl From<Error> for IngestorError {
     fn from(e: Error) -> Self {
-        EthereumAdapterError::Unknown(e)
+        IngestorError::Unknown(e)
     }
 }
 
 #[async_trait]
 pub trait IngestorAdapter<C: Blockchain> {
     /// Get the latest block from the chain
-    async fn latest_block(&self) -> Result<BlockPtr, EthereumAdapterError>;
+    async fn latest_block(&self) -> Result<BlockPtr, IngestorError>;
 
     /// Retrieve all necessary data for the block  `hash` from the chain and
     /// store it in the database
-    async fn ingest_block(
-        &self,
-        hash: &BlockHash,
-    ) -> Result<Option<BlockHash>, EthereumAdapterError>;
+    async fn ingest_block(&self, hash: &BlockHash) -> Result<Option<BlockHash>, IngestorError>;
 
     /// Return the chain head that is stored locally, and therefore visible
     /// to the block streams of subgraphs

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -1,0 +1,127 @@
+//! The `blockchain` module exports the necessary traits and data structures to integrate a
+//! blockchain into Graph Node. A blockchain is represented by an implementation of the `Blockchain`
+//! trait which is the centerpiece of this module.
+
+pub mod block_stream;
+
+// Try to reexport most of the necessary types
+use crate::prelude::{BlockPtr, CheapClone, DeploymentHash, LinkResolver};
+use crate::runtime::AscType;
+use anyhow::Error;
+use async_trait::async_trait;
+use slog;
+use slog::Logger;
+use std::fmt;
+use std::sync::Arc;
+use web3::types::H256;
+
+use block_stream::{BlockStream, TriggersAdapter};
+
+/// A simple marker for byte arrays that are really block hashes
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct BlockHash(pub Box<[u8]>);
+
+impl fmt::Display for BlockHash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "0x{}", hex::encode(&self.0))
+    }
+}
+
+impl CheapClone for BlockHash {}
+
+impl From<H256> for BlockHash {
+    fn from(hash: H256) -> Self {
+        BlockHash(hash.as_bytes().into())
+    }
+}
+
+impl From<Vec<u8>> for BlockHash {
+    fn from(bytes: Vec<u8>) -> Self {
+        BlockHash(bytes.as_slice().into())
+    }
+}
+
+pub trait Block {
+    fn ptr(&self) -> BlockPtr;
+    fn parent_ptr(&self) -> Option<BlockPtr>;
+
+    fn number(&self) -> i32 {
+        self.ptr().number
+    }
+
+    fn hash(&self) -> BlockHash {
+        self.ptr().hash.clone()
+    }
+}
+
+pub trait Blockchain: Sized + Send + Sync + 'static {
+    type Block: Block;
+    type DataSource: DataSource<Self>;
+    type DataSourceTemplate;
+    type Manifest: Manifest<Self>;
+
+    type TriggersAdapter: TriggersAdapter<Self>;
+    type BlockStream: BlockStream<Self>;
+
+    /// Trigger data as parsed from the triggers adapter.
+    type TriggerData;
+
+    /// Decoded trigger ready to be processed by the mapping.
+    type MappingTrigger: AscType;
+
+    /// Trigger filter used as input to the triggers adapter.
+    type TriggerFilter: TriggerFilter<Self>;
+
+    type NodeCapabilities;
+
+    // type IngestorAdapter: IngestorAdapter<Self>;
+    // type RuntimeAdapter: RuntimeAdapter;
+    // ...WIP
+
+    fn reorg_threshold() -> u32;
+    fn triggers_adapter(
+        &self,
+        network: &str,
+        capabilities: Self::NodeCapabilities,
+    ) -> Arc<Self::TriggersAdapter>;
+
+    fn new_block_stream(
+        &self,
+        current_head: BlockPtr,
+        filter: Self::TriggerFilter,
+    ) -> Result<Self::BlockStream, Error>;
+}
+
+pub trait TriggerFilter<C: Blockchain>: Default {
+    fn from_data_sources<'a>(data_sources: impl Iterator<Item = &'a C::DataSource>) -> Self {
+        let mut this = Self::default();
+        this.extend(data_sources);
+        this
+    }
+
+    fn extend<'a>(&mut self, data_sources: impl Iterator<Item = &'a C::DataSource>);
+}
+
+pub trait DataSource<C: Blockchain>: 'static {
+    /// Checks if `trigger` matches this data source, and if so decodes it into a `MappingTrigger`.
+    /// A return of `Ok(None)` mean the trigger does not match.
+    fn match_and_decode(
+        &self,
+        trigger: &C::TriggerData,
+        block: &C::Block,
+        logger: &Logger,
+    ) -> Result<Option<C::MappingTrigger>, Error>;
+}
+
+#[async_trait]
+pub trait Manifest<C: Blockchain>: Sized {
+    async fn resolve_from_raw(
+        id: DeploymentHash,
+        raw: serde_yaml::Mapping,
+        resolver: &impl LinkResolver,
+        logger: &Logger,
+    ) -> Result<Self, Error>;
+
+    fn data_sources(&self) -> &[C::DataSource];
+    fn templates(&self) -> &[C::DataSourceTemplate];
+}

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -74,7 +74,8 @@ pub trait Blockchain: Sized + Send + Sync + 'static {
 
     type NodeCapabilities;
 
-    // type IngestorAdapter: IngestorAdapter<Self>;
+    type IngestorAdapter: IngestorAdapter<Self>;
+
     // type RuntimeAdapter: RuntimeAdapter;
     // ...WIP
 
@@ -90,6 +91,15 @@ pub trait Blockchain: Sized + Send + Sync + 'static {
         current_head: BlockPtr,
         filter: Self::TriggerFilter,
     ) -> Result<Self::BlockStream, Error>;
+}
+
+pub trait IngestorAdapter<C: Blockchain> {
+    /// Get the latest block from the chain
+    fn head_block(&self) -> C::Block;
+
+    /// Retrieve all necessary data for `block` from the chain and store it
+    /// in the `ChainStore`
+    fn ingest_block(&self, block: &C::Block) -> Result<(), Error>;
 }
 
 pub trait TriggerFilter<C: Blockchain>: Default {

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -2,6 +2,7 @@
 //! blockchain into Graph Node. A blockchain is represented by an implementation of the `Blockchain`
 //! trait which is the centerpiece of this module.
 
+pub mod block_ingestor;
 pub mod block_stream;
 
 // Try to reexport most of the necessary types

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -109,12 +109,25 @@ pub trait IngestorAdapter<C: Blockchain> {
     /// Get the latest block from the chain
     async fn latest_block(&self) -> Result<BlockPtr, EthereumAdapterError>;
 
-    /// Retrieve all necessary data for `block` from the chain and store it
-    /// in the `ChainStore`
+    /// Retrieve all necessary data for the block  `hash` from the chain and
+    /// store it in the database
     async fn ingest_block(
         &self,
         hash: &BlockHash,
     ) -> Result<Option<BlockHash>, EthereumAdapterError>;
+
+    /// Return the chain head that is stored locally, and therefore visible
+    /// to the block streams of subgraphs
+    fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error>;
+
+    /// Remove old blocks from the database cache and return a pair
+    /// containing the number of the oldest block retained and the number of
+    /// blocks deleted if anything was removed. This is generally only used
+    /// in small test installations, and can remain a noop without
+    /// influencing correctness.
+    fn cleanup_cached_blocks(&self) -> Result<Option<(i32, usize)>, Error> {
+        Ok(None)
+    }
 }
 
 pub trait TriggerFilter<C: Blockchain>: Default {

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -16,7 +16,7 @@ use web3::types::{Address, Block, Log, H2048, H256};
 use super::types::*;
 use crate::prelude::*;
 use crate::{
-    blockchain::EthereumAdapterError,
+    blockchain::IngestorError,
     components::metrics::{labels, CounterVec, GaugeVec, HistogramVec},
 };
 
@@ -595,13 +595,13 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     fn latest_block(
         &self,
         logger: &Logger,
-    ) -> Box<dyn Future<Item = LightEthereumBlock, Error = EthereumAdapterError> + Send + Unpin>;
+    ) -> Box<dyn Future<Item = LightEthereumBlock, Error = IngestorError> + Send + Unpin>;
 
     /// Get the latest block, with only the header and transaction hashes.
     fn latest_block_header(
         &self,
         logger: &Logger,
-    ) -> Box<dyn Future<Item = web3::types::Block<H256>, Error = EthereumAdapterError> + Send>;
+    ) -> Box<dyn Future<Item = web3::types::Block<H256>, Error = IngestorError> + Send>;
 
     fn load_block(
         &self,
@@ -644,7 +644,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         &self,
         logger: &Logger,
         block: LightEthereumBlock,
-    ) -> Box<dyn Future<Item = EthereumBlock, Error = EthereumAdapterError> + Send>;
+    ) -> Box<dyn Future<Item = EthereumBlock, Error = IngestorError> + Send>;
 
     /// Load block pointer for the specified `block number`.
     fn block_pointer_from_number(
@@ -652,7 +652,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         logger: &Logger,
         chain_store: Arc<dyn ChainStore>,
         block_number: BlockNumber,
-    ) -> Box<dyn Future<Item = BlockPtr, Error = EthereumAdapterError> + Send>;
+    ) -> Box<dyn Future<Item = BlockPtr, Error = IngestorError> + Send>;
 
     /// Find a block by its number. The `block_is_final` flag indicates whether
     /// it is ok to remove blocks in the block cache with that number but with

--- a/graph/src/components/ethereum/adapter.rs
+++ b/graph/src/components/ethereum/adapter.rs
@@ -14,8 +14,11 @@ use tiny_keccak::keccak256;
 use web3::types::{Address, Block, Log, H2048, H256};
 
 use super::types::*;
-use crate::components::metrics::{labels, CounterVec, GaugeVec, HistogramVec};
 use crate::prelude::*;
+use crate::{
+    blockchain::EthereumAdapterError,
+    components::metrics::{labels, CounterVec, GaugeVec, HistogramVec},
+};
 
 pub type EventSignature = H256;
 
@@ -72,24 +75,6 @@ pub enum EthereumContractCallError {
 impl From<ABIError> for EthereumContractCallError {
     fn from(e: ABIError) -> Self {
         EthereumContractCallError::ABIError(e)
-    }
-}
-
-#[derive(Error, Debug)]
-pub enum EthereumAdapterError {
-    /// The Ethereum node does not know about this block for some reason, probably because it
-    /// disappeared in a chain reorg.
-    #[error("Block data unavailable, block was likely uncled (block hash = {0:?})")]
-    BlockUnavailable(H256),
-
-    /// An unexpected error occurred.
-    #[error("Ethereum adapter error: {0}")]
-    Unknown(Error),
-}
-
-impl From<Error> for EthereumAdapterError {
-    fn from(e: Error) -> Self {
-        EthereumAdapterError::Unknown(e)
     }
 }
 

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -15,7 +15,7 @@ pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpda
 pub use self::network::{EthereumNetworkAdapters, EthereumNetworks, NodeCapabilities};
 pub use self::stream::{BlockStream, BlockStreamBuilder, BlockStreamEvent};
 pub use self::types::{
-    BlockFinality, BlockHash, BlockPtr, EthereumBlock, EthereumBlockData, EthereumBlockTriggerType,
+    BlockFinality, BlockPtr, EthereumBlock, EthereumBlockData, EthereumBlockTriggerType,
     EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall, EthereumCallData,
     EthereumEventData, EthereumTransactionData, EthereumTrigger, LightEthereumBlock,
     LightEthereumBlockExt, MappingTrigger,

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -6,10 +6,10 @@ mod types;
 
 pub use self::adapter::{
     blocks_with_triggers, triggers_in_block, BlockStreamMetrics, EthGetLogsFilter, EthereumAdapter,
-    EthereumAdapterError, EthereumBlockFilter, EthereumCallFilter, EthereumContractCall,
-    EthereumContractCallError, EthereumContractState, EthereumContractStateError,
-    EthereumContractStateRequest, EthereumLogFilter, EthereumNetworkIdentifier,
-    MockEthereumAdapter, ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
+    EthereumBlockFilter, EthereumCallFilter, EthereumContractCall, EthereumContractCallError,
+    EthereumContractState, EthereumContractStateError, EthereumContractStateRequest,
+    EthereumLogFilter, EthereumNetworkIdentifier, MockEthereumAdapter, ProviderEthRpcMetrics,
+    SubgraphEthRpcMetrics,
 };
 pub use self::listener::{ChainHeadUpdate, ChainHeadUpdateListener, ChainHeadUpdateStream};
 pub use self::network::{EthereumNetworkAdapters, EthereumNetworks, NodeCapabilities};

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -6,19 +6,19 @@ use stable_hash::prelude::*;
 use stable_hash::utils::AsBytes;
 use std::{cmp::Ordering, convert::TryFrom};
 use std::{fmt, str::FromStr};
-use std::{
-    fmt::{Display, Write},
-    sync::Arc,
-};
+use std::{fmt::Write, sync::Arc};
 use strum_macros::AsStaticStr;
 use web3::types::{
     Action, Address, Block, Bytes, Log, Res, Trace, Transaction, TransactionReceipt, H160, H256,
     U128, U256, U64,
 };
 
-use crate::prelude::{
-    BlockNumber, CheapClone, DeploymentHash, EntityKey, MappingBlockHandler, MappingCallHandler,
-    MappingEventHandler, ToEntityKey,
+use crate::{
+    blockchain::BlockHash,
+    prelude::{
+        BlockNumber, CheapClone, DeploymentHash, EntityKey, MappingBlockHandler,
+        MappingCallHandler, MappingEventHandler, ToEntityKey,
+    },
 };
 
 pub type LightEthereumBlock = Block<Transaction>;
@@ -458,34 +458,6 @@ impl Clone for EthereumCallData {
                 })
                 .collect(),
         }
-    }
-}
-
-/// A simple marker for byte arrays that are really block hashes
-#[derive(Clone, Default, PartialEq, Eq, Hash)]
-pub struct BlockHash(pub Box<[u8]>);
-
-impl From<H256> for BlockHash {
-    fn from(hash: H256) -> Self {
-        BlockHash(hash.as_bytes().into())
-    }
-}
-
-impl Display for BlockHash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "0x{}", hex::encode(&self.0))
-    }
-}
-
-impl fmt::Debug for BlockHash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "0x{}", hex::encode(&self.0))
-    }
-}
-
-impl From<Vec<u8>> for BlockHash {
-    fn from(bytes: Vec<u8>) -> Self {
-        BlockHash(bytes.as_slice().into())
     }
 }
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1254,8 +1254,10 @@ pub trait ChainStore: Send + Sync + 'static {
     ///
     /// If the candidate new head block had one or more missing ancestors, returns
     /// `Ok(missing_blocks)`, where `missing_blocks` is a nonexhaustive list of missing blocks.
-    fn attempt_chain_head_update(&self, ancestor_count: BlockNumber)
-        -> Result<Option<H256>, Error>;
+    async fn attempt_chain_head_update(
+        self: Arc<Self>,
+        ancestor_count: BlockNumber,
+    ) -> Result<Option<H256>, Error>;
 
     /// Get the current head block pointer for this chain.
     /// Any changes to the head block pointer will be to a block with a larger block number, never

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1288,7 +1288,7 @@ pub trait ChainStore: Send + Sync + 'static {
     fn cleanup_cached_blocks(
         &self,
         ancestor_count: BlockNumber,
-    ) -> Result<(BlockNumber, usize), Error>;
+    ) -> Result<Option<(BlockNumber, usize)>, Error>;
 
     /// Return the hashes of all blocks with the given number
     fn block_hashes_by_block_number(&self, number: BlockNumber) -> Result<Vec<H256>, Error>;

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1234,7 +1234,7 @@ pub trait ChainStore: Send + Sync + 'static {
     fn genesis_block_ptr(&self) -> Result<BlockPtr, Error>;
 
     /// Insert a block into the store (or update if they are already present).
-    fn upsert_block(&self, block: EthereumBlock) -> Result<(), Error>;
+    async fn upsert_block(&self, block: EthereumBlock) -> Result<(), Error>;
 
     fn upsert_light_blocks(&self, blocks: Vec<LightEthereumBlock>) -> Result<(), Error>;
 

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 
 pub use num_bigint::Sign as BigIntSign;
 
-use crate::components::ethereum::BlockHash;
+use crate::blockchain::BlockHash;
 
 /// All operations on `BigDecimal` return a normalized value.
 // Caveat: The exponent is currently an i64 and may overflow. See

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -70,6 +70,7 @@ pub mod prelude {
     pub use reqwest;
     pub use serde_derive::{Deserialize, Serialize};
     pub use serde_json;
+    pub use serde_yaml;
     pub use slog::{self, crit, debug, error, info, o, trace, warn, Logger};
     pub use std::convert::TryFrom;
     pub use std::fmt::Debug;

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -88,13 +88,12 @@ pub mod prelude {
 
     pub use crate::components::ethereum::{
         BlockFinality, BlockPtr, BlockStream, BlockStreamBuilder, BlockStreamEvent,
-        BlockStreamMetrics, ChainHeadUpdate, ChainHeadUpdateStream, EthereumAdapter,
-        EthereumAdapterError, EthereumBlock, EthereumBlockData, EthereumBlockFilter,
-        EthereumBlockTriggerType, EthereumBlockWithCalls, EthereumBlockWithTriggers, EthereumCall,
-        EthereumCallData, EthereumCallFilter, EthereumContractCall, EthereumContractCallError,
-        EthereumEventData, EthereumLogFilter, EthereumNetworkIdentifier, EthereumTransactionData,
-        EthereumTrigger, LightEthereumBlock, LightEthereumBlockExt, MappingTrigger,
-        ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
+        BlockStreamMetrics, ChainHeadUpdate, ChainHeadUpdateStream, EthereumAdapter, EthereumBlock,
+        EthereumBlockData, EthereumBlockFilter, EthereumBlockTriggerType, EthereumBlockWithCalls,
+        EthereumBlockWithTriggers, EthereumCall, EthereumCallData, EthereumCallFilter,
+        EthereumContractCall, EthereumContractCallError, EthereumEventData, EthereumLogFilter,
+        EthereumNetworkIdentifier, EthereumTransactionData, EthereumTrigger, LightEthereumBlock,
+        LightEthereumBlockExt, MappingTrigger, ProviderEthRpcMetrics, SubgraphEthRpcMetrics,
     };
     pub use crate::components::graphql::{
         GraphQlRunner, QueryLoadManager, SubscriptionResultFuture,

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -18,6 +18,8 @@ pub mod cheap_clone;
 
 pub mod ipfs_client;
 
+pub mod blockchain;
+
 pub mod runtime;
 
 /// Module with mocks for different parts of the system.

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -19,7 +19,7 @@ mock! {
     trait ChainStore: Send + Sync + 'static {
         fn genesis_block_ptr(&self) -> Result<BlockPtr, Error>;
 
-        fn upsert_block(&self, block: EthereumBlock) -> Result<(), Error>;
+        async fn upsert_block(&self, block: EthereumBlock) -> Result<(), Error>;
 
         fn upsert_light_blocks(&self, blocks: Vec<LightEthereumBlock>) -> Result<(), Error>;
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -19,15 +19,11 @@ mock! {
     trait ChainStore: Send + Sync + 'static {
         fn genesis_block_ptr(&self) -> Result<BlockPtr, Error>;
 
-        fn upsert_blocks<B, E>(&self, blocks: B) -> Box<dyn Future<Item = (), Error = E> + Send + 'static>
-        where
-            B: Stream<Item = EthereumBlock, Error = E> + Send + 'static,
-            E: From<Error> + Send + 'static,
-            Self: Sized;
+        fn upsert_block(&self, block: EthereumBlock) -> Result<(), Error>;
 
         fn upsert_light_blocks(&self, blocks: Vec<LightEthereumBlock>) -> Result<(), Error>;
 
-        fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Vec<H256>, Error>;
+        fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Option<H256>, Error>;
 
         fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error>;
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -23,7 +23,7 @@ mock! {
 
         fn upsert_light_blocks(&self, blocks: Vec<LightEthereumBlock>) -> Result<(), Error>;
 
-        fn attempt_chain_head_update(&self, ancestor_count: BlockNumber) -> Result<Option<H256>, Error>;
+        async fn attempt_chain_head_update(self: Arc<Self>, ancestor_count: BlockNumber) -> Result<Option<H256>, Error>;
 
         fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error>;
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -35,7 +35,7 @@ mock! {
             offset: BlockNumber,
         ) -> Result<Option<EthereumBlock>, Error>;
 
-        fn cleanup_cached_blocks(&self, ancestor_count: BlockNumber) -> Result<(BlockNumber, usize), Error>;
+        fn cleanup_cached_blocks(&self, ancestor_count: BlockNumber) -> Result<Option<(BlockNumber, usize)>, Error>;
 
         fn block_hashes_by_block_number(&self, number: BlockNumber) -> Result<Vec<H256>, Error>;
 

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1,11 +1,11 @@
 use graph::{
+    blockchain::block_ingestor::CLEANUP_BLOCKS,
     components::ethereum::NodeCapabilities,
     prelude::{
         anyhow::{anyhow, bail, Context, Result},
         info, serde_json, Logger, NodeId,
     },
 };
-use graph_chain_ethereum::CLEANUP_BLOCKS;
 use graph_store_postgres::{DeploymentPlacer, Shard as ShardName, PRIMARY_SHARD};
 
 use regex::Regex;

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -736,7 +736,6 @@ fn start_block_ingestor(
                 chain.ingestor_adapter(),
                 eth_adapter.provider().to_string(),
                 *ANCESTOR_COUNT,
-                network_name.to_string(),
                 logger_factory,
                 block_polling_interval,
             )

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -10,6 +10,7 @@ use std::{collections::HashMap, env};
 use structopt::StructOpt;
 use tokio::sync::mpsc;
 
+use graph::blockchain::block_ingestor::BlockIngestor;
 use graph::components::{
     ethereum::{EthereumNetworks, NodeCapabilities},
     store::BlockStore,
@@ -19,9 +20,7 @@ use graph::log::logger;
 use graph::prelude::{IndexNodeServer as _, JsonRpcServer as _, *};
 use graph::util::security::SafeDisplay;
 use graph_chain_arweave::adapter::ArweaveAdapter;
-use graph_chain_ethereum::{
-    self as ethereum, network_indexer, BlockIngestor, BlockStreamBuilder, Transport,
-};
+use graph_chain_ethereum::{self as ethereum, network_indexer, BlockStreamBuilder, Transport};
 use graph_core::{
     three_box::ThreeBoxAdapter, LinkResolver, MetricsRegistry,
     SubgraphAssignmentProvider as IpfsSubgraphAssignmentProvider, SubgraphInstanceManager,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -11,6 +11,7 @@ use structopt::StructOpt;
 use tokio::sync::mpsc;
 
 use graph::blockchain::block_ingestor::BlockIngestor;
+use graph::blockchain::Blockchain as _;
 use graph::components::{
     ethereum::{EthereumNetworks, NodeCapabilities},
     store::BlockStore,
@@ -731,8 +732,8 @@ fn start_block_ingestor(
 
             let chain = ethereum::Chain::new(chain_logger, chain_store, eth_adapter.clone(), *ANCESTOR_COUNT);
 
-            let block_ingestor = BlockIngestor::new(
-                &chain,
+            let block_ingestor = BlockIngestor::<ethereum::Chain>::new(
+                chain.ingestor_adapter(),
                 eth_adapter.provider().to_string(),
                 *ANCESTOR_COUNT,
                 network_name.to_string(),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -728,15 +728,15 @@ fn start_block_ingestor(
                         index: String::from("block-ingestor-logs"),
                     }),
                 }),
-            );
+            )
+            .new(o!("provider" => eth_adapter.provider().to_string()));
 
-            let chain = ethereum::Chain::new(chain_logger, chain_store, eth_adapter.clone(), *ANCESTOR_COUNT);
+            let chain = ethereum::Chain::new(chain_logger.clone(), chain_store, eth_adapter.clone(), *ANCESTOR_COUNT);
 
             let block_ingestor = BlockIngestor::<ethereum::Chain>::new(
+                chain_logger,
                 chain.ingestor_adapter(),
-                eth_adapter.provider().to_string(),
                 *ANCESTOR_COUNT,
-                logger_factory,
                 block_polling_interval,
             )
             .expect("failed to create Ethereum block ingestor");

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -730,11 +730,10 @@ fn start_block_ingestor(
                 }),
             );
 
-            let chain = ethereum::Chain::new(chain_logger, chain_store.clone(), eth_adapter.clone(), *ANCESTOR_COUNT);
+            let chain = ethereum::Chain::new(chain_logger, chain_store, eth_adapter.clone(), *ANCESTOR_COUNT);
 
             let block_ingestor = BlockIngestor::new(
                 &chain,
-                chain_store,
                 eth_adapter.provider().to_string(),
                 *ANCESTOR_COUNT,
                 network_name.to_string(),

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -600,10 +600,8 @@ mod data {
 
         /// Find the first block that is missing from the database needed to
         /// complete the chain from block `hash` to the block with number
-        /// `first_block`. We return the hash of the missing block as an
-        /// array because the remaining code expects that, but the array will only
-        /// ever have at most one element.
-        pub(super) fn missing_parents(
+        /// `first_block`.
+        pub(super) fn missing_parent(
             &self,
             conn: &PgConnection,
             chain: &str,
@@ -1212,7 +1210,7 @@ impl ChainStoreTrait for ChainStore {
 
                     match chain_store
                         .storage
-                        .missing_parents(
+                        .missing_parent(
                             &conn,
                             &chain_store.chain,
                             first_block as i64,

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -1295,7 +1295,7 @@ impl ChainStoreTrait for ChainStore {
     fn cleanup_cached_blocks(
         &self,
         ancestor_count: BlockNumber,
-    ) -> Result<(BlockNumber, usize), Error> {
+    ) -> Result<Option<(BlockNumber, usize)>, Error> {
         use diesel::sql_types::Integer;
 
         #[derive(QueryableByName)]
@@ -1351,12 +1351,12 @@ impl ChainStoreTrait for ChainStore {
                 if *block > 0 {
                     self.storage
                         .delete_blocks_before(&conn, &self.chain, *block as i64)
-                        .map(|rows| (*block, rows))
+                        .map(|rows| Some((*block, rows)))
                 } else {
-                    Ok((0, 0))
+                    Ok(None)
                 }
             })
-            .unwrap_or(Ok((0, 0)))
+            .unwrap_or(Ok(None))
             .map_err(|e| e.into())
     }
 

--- a/store/postgres/tests/chain_head.rs
+++ b/store/postgres/tests/chain_head.rs
@@ -73,9 +73,11 @@ fn check_chain_head_update(
     head_exp: Option<&'static FakeBlock>,
     missing: Option<&'static str>,
 ) {
-    run_test(chain, move |store, _| {
+    run_test_async(chain, move |store, _| async move {
         let missing_act: Vec<_> = store
+            .clone()
             .attempt_chain_head_update(ANCESTOR_COUNT)
+            .await
             .expect("attempt_chain_head_update failed")
             .iter()
             .map(|h| format!("{:x}", h))
@@ -89,7 +91,6 @@ fn check_chain_head_update(
             .expect("chain_head_ptr failed")
             .map(|ebp| ebp.hash_hex());
         assert_eq!(head_hash_exp, head_hash_act);
-        Ok(())
     })
 }
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1861,7 +1861,7 @@ fn cleanup_cached_blocks() {
         let cleaned = chain_store
             .cleanup_cached_blocks(10)
             .expect("cleanup succeeds");
-        assert_eq!((2, 1), cleaned);
+        assert_eq!(Some((2, 1)), cleaned);
     })
 }
 


### PR DESCRIPTION
This PR started out as a simple refactor of some ingestion logic, but now has the code to make block ingestion independent of Ethereum by introducing an `IngestorAdapter`.

This is what I had to say on the initial PR:

The code looked like we could try to find multiple missing ancestors for a  chain head candidate. But the logic of a chain dictates that we can only    ever find one block that we are missing when checking whether we have a    long enough chain in our database. Therefore, the vecs of missing parents    that we were passing around could only ever contain 0 or 1 element.
    
The code now clearly spells out that we will only ever know about one    missing parent at a time.