### PR TITLE
Serialize entity fields in defined order

### DIFF
--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -23,7 +23,7 @@ fn insert_and_query(
             key: EntityKey {
                 subgraph_id: subgraph_id.clone(),
                 entity_type: EntityType::new(entity_type.to_owned()),
-                entity_id: data["id"].clone().as_string().unwrap(),
+                entity_id: data.get("id").unwrap().clone().as_string().unwrap(),
             },
             data,
         });

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -11,7 +11,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
 use std::fmt;
 use std::iter::FromIterator;
-use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use strum::AsStaticRef as _;
 use strum_macros::AsStaticStr;
@@ -503,6 +502,29 @@ impl Entity {
         Default::default()
     }
 
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.0.get(key)
+    }
+
+    pub fn insert(&mut self, key: String, value: Value) -> Option<Value> {
+        self.0.insert(key, value)
+    }
+
+    pub fn remove(&mut self, key: &str) -> Option<Value> {
+        self.0.remove(key)
+    }
+
+    pub fn contains_key(&mut self, key: &str) -> bool {
+        self.0.contains_key(key)
+    }
+
+    // This collects the entity into an ordered vector so that it can be iterated deterministically.
+    pub fn sorted(self) -> Vec<(String, Value)> {
+        let mut v: Vec<_> = self.0.into_iter().collect();
+        v.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+        v
+    }
+
     /// Try to get this entity's ID
     pub fn id(&self) -> Result<String, Error> {
         match self.get("id") {
@@ -514,7 +536,7 @@ impl Entity {
 
     /// Convenience method to save having to `.into()` the arguments.
     pub fn set(&mut self, name: impl Into<Attribute>, value: impl Into<Value>) -> Option<Value> {
-        self.insert(name.into(), value.into())
+        self.0.insert(name.into(), value.into())
     }
 
     /// Merges an entity update `update` into this entity.
@@ -540,20 +562,6 @@ impl Entity {
                 _ => self.insert(key, value),
             };
         }
-    }
-}
-
-impl Deref for Entity {
-    type Target = HashMap<Attribute, Value>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Entity {
-    fn deref_mut(&mut self) -> &mut HashMap<Attribute, Value> {
-        &mut self.0
     }
 }
 

--- a/graph/src/runtime/asc_heap.rs
+++ b/graph/src/runtime/asc_heap.rs
@@ -55,6 +55,12 @@ impl ToAscObj<bool> for bool {
     }
 }
 
+impl<C: AscType, T: ToAscObj<C>> ToAscObj<C> for &T {
+    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<C, DeterministicHostError> {
+        (*self).to_asc_obj(heap)
+    }
+}
+
 /// Type that can be converted from an Asc object of class `C`.
 pub trait FromAscObj<C: AscType> {
     fn from_asc_obj<H: AscHeap>(obj: C, heap: &H) -> Result<Self, DeterministicHostError>

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -217,8 +217,8 @@ fn insert_test_entities(
         let insert_ops = entities.into_iter().map(|data| EntityOperation::Set {
             key: EntityKey::data(
                 deployment.hash.clone(),
-                data["__typename"].clone().as_string().unwrap(),
-                data["id"].clone().as_string().unwrap(),
+                data.get("__typename").unwrap().clone().as_string().unwrap(),
+                data.get("id").unwrap().clone().as_string().unwrap(),
             ),
             data,
         });

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -807,7 +807,7 @@ impl WasmInstanceContext {
                     .host_metrics
                     .stopwatch
                     .start_section("store_get_asc_new");
-                self.asc_new(&entity)?
+                self.asc_new(&entity.sorted())?
             }
             None => AscPtr::null(),
         };
@@ -1350,7 +1350,7 @@ impl WasmInstanceContext {
 
     /// function dataSource.context(): DataSourceContext
     fn data_source_context(&mut self) -> Result<AscPtr<AscEntity>, DeterministicHostError> {
-        self.asc_new(&self.ctx.host_exports.data_source_context())
+        self.asc_new(&self.ctx.host_exports.data_source_context().sorted())
     }
 
     fn ens_name_by_hash(

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -1,5 +1,4 @@
 use ethabi;
-use std::collections::HashMap;
 
 use graph::{
     components::ethereum::{
@@ -295,18 +294,11 @@ impl ToAscObj<AscJson> for serde_json::Map<String, serde_json::Value> {
     }
 }
 
-impl ToAscObj<AscEntity> for HashMap<String, store::Value> {
+// Used for serializing entities.
+impl ToAscObj<AscEntity> for Vec<(String, store::Value)> {
     fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscEntity, DeterministicHostError> {
         Ok(AscTypedMap {
-            entries: heap.asc_new(&*self.iter().collect::<Vec<_>>())?,
-        })
-    }
-}
-
-impl ToAscObj<AscEntity> for store::Entity {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscEntity, DeterministicHostError> {
-        Ok(AscTypedMap {
-            entries: heap.asc_new(&*self.iter().collect::<Vec<_>>())?,
+            entries: heap.asc_new(self.as_slice())?,
         })
     }
 }

--- a/runtime/wasm/src/to_from/mod.rs
+++ b/runtime/wasm/src/to_from/mod.rs
@@ -166,16 +166,16 @@ impl<K: AscType, V: AscType, T: TryFromAscObj<K>, U: TryFromAscObj<V>>
     }
 }
 
-impl<'a, 'b, K: AscType, V: AscType, T: ToAscObj<K>, U: ToAscObj<V>>
-    ToAscObj<AscTypedMapEntry<K, V>> for (&'a T, &'b U)
+impl<K: AscType, V: AscType, T: ToAscObj<K>, U: ToAscObj<V>> ToAscObj<AscTypedMapEntry<K, V>>
+    for (T, U)
 {
     fn to_asc_obj<H: AscHeap>(
         &self,
         heap: &mut H,
     ) -> Result<AscTypedMapEntry<K, V>, DeterministicHostError> {
         Ok(AscTypedMapEntry {
-            key: heap.asc_new(self.0)?,
-            value: heap.asc_new(self.1)?,
+            key: heap.asc_new(&self.0)?,
+            value: heap.asc_new(&self.1)?,
         })
     }
 }

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -422,14 +422,14 @@ macro_rules! assert_entity_eq {
         let (left, right) = (&($left), &($right));
         let mut pass = true;
 
-        for (key, left_value) in left.iter() {
-            match right.get(key) {
+        for (key, left_value) in left.clone().sorted() {
+            match right.get(&key) {
                 None => {
                     pass = false;
                     println!("key '{}' missing from right", key);
                 }
                 Some(right_value) => {
-                    if left_value != right_value {
+                    if left_value != *right_value {
                         pass = false;
                         println!(
                             "values for '{}' differ:\n     left: {:?}\n    right: {:?}",
@@ -439,8 +439,8 @@ macro_rules! assert_entity_eq {
                 }
             }
         }
-        for key in right.keys() {
-            if left.get(key).is_none() {
+        for (key, _) in right.clone().sorted() {
+            if left.get(&key).is_none() {
                 pass = false;
                 println!("key '{}' missing from left", key);
             }
@@ -673,7 +673,7 @@ fn serialize_bigdecimal() {
                 .find(conn, &*SCALAR, "one", BLOCK_NUMBER_MAX)
                 .expect("Failed to read Scalar[one]")
                 .unwrap();
-            assert_entity_eq!(&entity, actual);
+            assert_entity_eq!(entity, actual);
         }
     });
 }

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -137,14 +137,14 @@ macro_rules! assert_entity_eq {
         let (left, right) = (&($left), &($right));
         let mut pass = true;
 
-        for (key, left_value) in left.iter() {
-            match right.get(key) {
+        for (key, left_value) in left.clone().sorted() {
+            match right.get(&key) {
                 None => {
                     pass = false;
                     println!("key '{}' missing from right", key);
                 }
                 Some(right_value) => {
-                    if left_value != right_value {
+                    if left_value != *right_value {
                         pass = false;
                         println!(
                             "values for '{}' differ:\n     left: {:?}\n    right: {:?}",
@@ -154,8 +154,8 @@ macro_rules! assert_entity_eq {
                 }
             }
         }
-        for key in right.keys() {
-            if left.get(key).is_none() {
+        for (key, _) in right.clone().sorted() {
+            if left.get(&key).is_none() {
                 pass = false;
                 println!("key '{}' missing from left", key);
             }

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -300,7 +300,7 @@ pub fn insert_entities(
             key: EntityKey {
                 subgraph_id: deployment.hash.clone(),
                 entity_type: entity_type.to_owned(),
-                entity_id: data["id"].clone().as_string().unwrap(),
+                entity_id: data.get("id").unwrap().clone().as_string().unwrap(),
             },
             data,
         });


### PR DESCRIPTION
Currently they are passed in the random order given by the hash map. Remove `Deref` and `DerefMut` from `Entity` to prevent bugs like this.
