### PR TITLE
graph: Replace .len() comparisons with zero with .is_empty()

### DIFF
--- a/graph/src/data/graphql/ext.rs
+++ b/graph/src/data/graphql/ext.rs
@@ -120,7 +120,7 @@ impl DocumentExt for Document {
                     .collect()
             },
         );
-        if !*ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH && directives.len() != 0 {
+        if !*ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH && !directives.is_empty() {
             Err(anyhow::anyhow!("Fulltext search is not yet deterministic"))
         } else {
             Ok(directives)

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -914,7 +914,7 @@ impl Schema {
 
         // Validate that each entity in fulltext.include exists
         let includes = match fulltext.argument("include") {
-            Some(Value::List(includes)) if includes.len() > 0 => includes,
+            Some(Value::List(includes)) if !includes.is_empty() => includes,
             _ => return vec![SchemaValidationError::FulltextIncludeUndefined],
         };
 
@@ -1275,7 +1275,7 @@ impl Schema {
             .get_fulltext_directives()?
             .into_iter()
             .filter(|directive| match directive.argument("include") {
-                Some(Value::List(includes)) if includes.len() > 0 => includes
+                Some(Value::List(includes)) if !includes.is_empty() => includes
                     .iter()
                     .find(|include| match include {
                         Value::Object(include) => match include.get("entity") {

--- a/graph/src/log/mod.rs
+++ b/graph/src/log/mod.rs
@@ -147,7 +147,7 @@ where
             }
 
             // Then log the component hierarchy
-            if components.len() > 0 {
+            if !components.is_empty() {
                 decorator.start_comma()?;
                 write!(decorator, ", ")?;
                 decorator.start_key()?;

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -48,7 +48,7 @@ impl<T: CacheWeight, U: CacheWeight> CacheWeight for std::collections::BTreeMap<
         // key/value entries in its root node, except for the empty tree, which
         // takes no space. If there is more than a root node, at worst,
         // each page is half full
-        let kv_slots = if self.len() == 0 {
+        let kv_slots = if self.is_empty() {
             0
         } else if self.len() < NODE_CAPACITY {
             NODE_CAPACITY


### PR DESCRIPTION
I guess this is a personal preference but I feel like using `is_empty()` is 'clearer' than comparing `.len()` to zero