### PR TITLE
Consider providers that timeout as broken

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -539,7 +539,6 @@ async fn connect_networks(
             network: String,
             provider: String,
         },
-        NoVersion,
         Version {
             network: String,
             ident: EthereumNetworkIdentifier,
@@ -549,54 +548,45 @@ async fn connect_networks(
     // This has one entry for each provider, and therefore multiple entries
     // for each network
     let statuses = join_all(
-            eth_networks
-                .flatten()
-                .into_iter()
-                .map(|(network_name, capabilities, eth_adapter)| {
-                    (network_name, capabilities, eth_adapter, logger.clone())
-                })
-                .map(
-                    |(network, capabilities, eth_adapter, logger)| async move {
-                        let logger = logger.new(
-                            o!("provider" => eth_adapter.provider().to_string()),
-                        );
+        eth_networks
+            .flatten()
+            .into_iter()
+            .map(|(network_name, capabilities, eth_adapter)| {
+                (network_name, capabilities, eth_adapter, logger.clone())
+            })
+            .map(|(network, capabilities, eth_adapter, logger)| async move {
+                let logger = logger.new(o!("provider" => eth_adapter.provider().to_string()));
+                info!(
+                    logger, "Connecting to Ethereum to get network identifier";
+                    "capabilities" => &capabilities
+                );
+                match tokio::time::timeout(ETH_NET_VERSION_WAIT_TIME, eth_adapter.net_identifiers())
+                    .await
+                    .map_err(Error::from)
+                {
+                    // An `Err` means a timeout, an `Ok(Err)` means some other error (maybe a typo
+                    // on the URL)
+                    Ok(Err(e)) | Err(e) => {
+                        error!(logger, "Connection to provider failed. Not using this provider";
+                                       "error" =>  e.to_string());
+                        Status::Broken {
+                            network,
+                            provider: eth_adapter.provider().to_string(),
+                        }
+                    }
+                    Ok(Ok(ident)) => {
                         info!(
-                            logger, "Connecting to Ethereum to get network identifier";
+                            logger,
+                            "Connected to Ethereum";
+                            "network_version" => &ident.net_version,
                             "capabilities" => &capabilities
                         );
-                        match tokio::time::timeout(
-                            ETH_NET_VERSION_WAIT_TIME,
-                            eth_adapter.net_identifiers(),
-                        )
-                        .await
-                        {
-                            // the client didn't respond fast enough. Try to
-                            // continue without knowing the net version
-                            Err(_) => {
-                                warn!(logger, "Provider did not respond fast enough. Continuing without checking for change in net version");
-                                Status::NoVersion
-                            },
-                            // we got some other error (maybe a typo on the URL)
-                            // still continue with startup
-                            Ok(Err(e)) => {
-                                error!(logger, "Connection to provider failed. Not using this provider";
-                                       "error" =>  e.to_string());
-                                Status::Broken { network, provider: eth_adapter.provider().to_string() }
-                            }
-                            Ok(Ok(ident)) => {
-                                info!(
-                                    logger,
-                                    "Connected to Ethereum";
-                                    "network_version" => &ident.net_version,
-                                    "capabilities" => &capabilities
-                                );
-                                Status::Version { network, ident }
-                            }
-                        }
-                    },
-                ),
-        )
-        .await;
+                        Status::Version { network, ident }
+                    }
+                }
+            }),
+    )
+    .await;
 
     // Group identifiers by network name
     let idents: HashMap<String, Vec<EthereumNetworkIdentifier>> =
@@ -610,7 +600,6 @@ async fn connect_networks(
                     Status::Version { network, ident } => {
                         networks.entry(network.to_string()).or_default().push(ident)
                     }
-                    Status::NoVersion => { /* ignore */ }
                 }
                 networks
             });


### PR DESCRIPTION
The thing is that `net_identifiers` will retry forever. So even if it tries 15 times and returns an error every time, it will continue retrying until the outer timeout is hit, so we will try to use the provider even if it is evidently defective. @lutter interested to know if you have a better solution for this.

Read with whitespace diff disabled.