### PR TITLE
graph: Replace unwrap_or by lazily evaluated counterparts

### DIFF
--- a/graph/src/log/mod.rs
+++ b/graph/src/log/mod.rs
@@ -377,7 +377,7 @@ impl ser::Serializer for KeyValueSerializer {
 
 fn log_query_timing(kind: &str) -> bool {
     env::var("GRAPH_LOG_QUERY_TIMING")
-        .unwrap_or("".into())
+        .unwrap_or_default()
         .split(",")
         .any(|v| v == kind)
 }

--- a/graph/src/util/timed_rw_lock.rs
+++ b/graph/src/util/timed_rw_lock.rs
@@ -8,7 +8,7 @@ lazy_static::lazy_static! {
     static ref LOCK_CONTENTION_LOG_THRESHOLD: Duration = {
         Duration::from_millis(
             std::env::var("GRAPH_LOCK_CONTENTION_LOG_THRESHOLD_MS")
-                .unwrap_or("100".to_string())
+                .unwrap_or_else(|_| "100".to_string())
                 .parse::<u64>()
                 .expect("Invalid value for LOCK_CONTENTION_LOG_THRESHOLD_MS environment variable")
        )


### PR DESCRIPTION
These `unwrap_or`s will allocate a String even when they're not needed. They were replaced by methods that only allocate the strings if necessary 