### PR TITLE
graph, graphql, store, server: Replace &String by &str

### DIFF
--- a/graph/src/data/graphql/ext.rs
+++ b/graph/src/data/graphql/ext.rs
@@ -16,12 +16,12 @@ lazy_static! {
 }
 
 pub trait ObjectTypeExt {
-    fn field(&self, name: &String) -> Option<&Field>;
+    fn field(&self, name: &str) -> Option<&Field>;
     fn is_meta(&self) -> bool;
 }
 
 impl ObjectTypeExt for ObjectType {
-    fn field(&self, name: &String) -> Option<&Field> {
+    fn field(&self, name: &str) -> Option<&Field> {
         self.fields.iter().find(|field| &field.name == name)
     }
 
@@ -31,7 +31,7 @@ impl ObjectTypeExt for ObjectType {
 }
 
 impl ObjectTypeExt for InterfaceType {
-    fn field(&self, name: &String) -> Option<&Field> {
+    fn field(&self, name: &str) -> Option<&Field> {
         self.fields.iter().find(|field| &field.name == name)
     }
 
@@ -45,7 +45,7 @@ pub trait DocumentExt {
 
     fn get_object_type_definition(&self, name: &str) -> Option<&ObjectType>;
 
-    fn get_object_and_interface_type_fields(&self) -> HashMap<&String, &Vec<Field>>;
+    fn get_object_and_interface_type_fields(&self) -> HashMap<&str, &Vec<Field>>;
 
     fn get_enum_definitions(&self) -> Vec<&EnumType>;
 
@@ -79,11 +79,13 @@ impl DocumentExt for Document {
             .find(|object_type| object_type.name.eq(name))
     }
 
-    fn get_object_and_interface_type_fields(&self) -> HashMap<&String, &Vec<Field>> {
+    fn get_object_and_interface_type_fields(&self) -> HashMap<&str, &Vec<Field>> {
         self.definitions
             .iter()
             .filter_map(|d| match d {
-                Definition::TypeDefinition(TypeDefinition::Object(t)) => Some((&t.name, &t.fields)),
+                Definition::TypeDefinition(TypeDefinition::Object(t)) => {
+                    Some((t.name.as_str(), &t.fields))
+                }
                 Definition::TypeDefinition(TypeDefinition::Interface(t)) => {
                     Some((&t.name, &t.fields))
                 }
@@ -183,11 +185,11 @@ impl DocumentExt for Document {
 }
 
 pub trait TypeExt {
-    fn get_base_type(&self) -> &String;
+    fn get_base_type(&self) -> &str;
 }
 
 impl TypeExt for Type {
-    fn get_base_type(&self) -> &String {
+    fn get_base_type(&self) -> &str {
         match self {
             Type::NamedType(name) => name,
             Type::NonNullType(inner) => Self::get_base_type(&inner),
@@ -212,8 +214,8 @@ impl DirectiveExt for Directive {
 pub trait ValueExt {
     fn as_object(&self) -> Option<&BTreeMap<String, Value>>;
     fn as_list(&self) -> Option<&Vec<Value>>;
-    fn as_string(&self) -> Option<&String>;
-    fn as_enum(&self) -> Option<&String>;
+    fn as_str(&self) -> Option<&str>;
+    fn as_enum(&self) -> Option<&str>;
 }
 
 impl ValueExt for Value {
@@ -231,14 +233,14 @@ impl ValueExt for Value {
         }
     }
 
-    fn as_string(&self) -> Option<&String> {
+    fn as_str(&self) -> Option<&str> {
         match self {
             Value::String(string) => Some(string),
             _ => None,
         }
     }
 
-    fn as_enum(&self) -> Option<&String> {
+    fn as_enum(&self) -> Option<&str> {
         match self {
             Value::Enum(e) => Some(e),
             _ => None,

--- a/graph/src/data/graphql/values.rs
+++ b/graph/src/data/graphql/values.rs
@@ -167,12 +167,12 @@ impl ValueMap for &BTreeMap<String, q::Value> {
     }
 }
 
-impl ValueMap for &HashMap<&String, q::Value> {
+impl ValueMap for &HashMap<&str, q::Value> {
     fn get_required<T>(&self, key: &str) -> Result<T, Error>
     where
         T: TryFromValue,
     {
-        self.get(&String::from(key))
+        self.get(key)
             .ok_or_else(|| anyhow!("Required field `{}` not set", key))
             .and_then(|value| T::try_from_value(value).map_err(|e| e.into()))
     }
@@ -181,11 +181,10 @@ impl ValueMap for &HashMap<&String, q::Value> {
     where
         T: TryFromValue,
     {
-        self.get(&String::from(key))
-            .map_or(Ok(None), |value| match value {
-                q::Value::Null => Ok(None),
-                _ => T::try_from_value(value).map(Some).map_err(Into::into),
-            })
+        self.get(key).map_or(Ok(None), |value| match value {
+            q::Value::Null => Ok(None),
+            _ => T::try_from_value(value).map(Some).map_err(Into::into),
+        })
     }
 }
 

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -123,9 +123,9 @@ pub enum FulltextLanguage {
     Turkish,
 }
 
-impl TryFrom<&String> for FulltextLanguage {
+impl TryFrom<&str> for FulltextLanguage {
     type Error = String;
-    fn try_from(language: &String) -> Result<Self, Self::Error> {
+    fn try_from(language: &str) -> Result<Self, Self::Error> {
         match &language[..] {
             "simple" => Ok(FulltextLanguage::Simple),
             "da" => Ok(FulltextLanguage::Danish),
@@ -180,9 +180,9 @@ pub enum FulltextAlgorithm {
     ProximityRank,
 }
 
-impl TryFrom<&String> for FulltextAlgorithm {
+impl TryFrom<&str> for FulltextAlgorithm {
     type Error = String;
-    fn try_from(algorithm: &String) -> Result<Self, Self::Error> {
+    fn try_from(algorithm: &str) -> Result<Self, Self::Error> {
         match &algorithm[..] {
             "rank" => Ok(FulltextAlgorithm::Rank),
             "proximityRank" => Ok(FulltextAlgorithm::ProximityRank),
@@ -213,7 +213,7 @@ impl From<&s::Directive> for FulltextDefinition {
         let name = directive
             .argument("name")
             .unwrap()
-            .as_string()
+            .as_str()
             .unwrap()
             .clone();
 
@@ -238,9 +238,9 @@ impl From<&s::Directive> for FulltextDefinition {
                     .unwrap()
                     .get("name")
                     .unwrap()
-                    .as_string()
+                    .as_str()
                     .unwrap()
-                    .clone()
+                    .into()
             })
             .collect();
 
@@ -250,7 +250,7 @@ impl From<&s::Directive> for FulltextDefinition {
                 algorithm,
             },
             included_fields,
-            name,
+            name: name.into(),
         }
     }
 }
@@ -872,7 +872,7 @@ impl Schema {
             Some(Value::Enum(language)) => language,
             _ => return vec![SchemaValidationError::FulltextLanguageUndefined],
         };
-        match FulltextLanguage::try_from(language) {
+        match FulltextLanguage::try_from(language.as_str()) {
             Ok(_) => vec![],
             Err(_) => vec![SchemaValidationError::FulltextLanguageInvalid(
                 language.to_string(),
@@ -888,7 +888,7 @@ impl Schema {
             Some(Value::Enum(algorithm)) => algorithm,
             _ => return vec![SchemaValidationError::FulltextAlgorithmUndefined],
         };
-        match FulltextAlgorithm::try_from(algorithm) {
+        match FulltextAlgorithm::try_from(algorithm.as_str()) {
             Ok(_) => vec![],
             Err(_) => vec![SchemaValidationError::FulltextAlgorithmInvalid(
                 algorithm.to_string(),
@@ -1191,7 +1191,7 @@ impl Schema {
                     .iter()
                     .any(|iface| target_field_type.eq(iface.clone()))
             {
-                fn type_signatures(name: &String) -> Vec<String> {
+                fn type_signatures(name: &str) -> Vec<String> {
                     vec![
                         format!("{}", name),
                         format!("{}!", name),

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -239,7 +239,7 @@ where
 }
 
 // Helpers to look for types and fields on both the introspection and regular schemas.
-pub(crate) fn get_named_type(schema: &s::Document, name: &String) -> Option<s::TypeDefinition> {
+pub(crate) fn get_named_type(schema: &s::Document, name: &str) -> Option<s::TypeDefinition> {
     if name.starts_with("__") {
         sast::get_named_type(&INTROSPECTION_DOCUMENT, name).cloned()
     } else {
@@ -249,7 +249,7 @@ pub(crate) fn get_named_type(schema: &s::Document, name: &String) -> Option<s::T
 
 pub(crate) fn get_field<'a>(
     object_type: impl Into<ObjectOrInterface<'a>>,
-    name: &String,
+    name: &str,
 ) -> Option<s::Field> {
     if name == "__schema" || name == "__type" {
         let object_type = *INTROSPECTION_QUERY_TYPE;
@@ -261,7 +261,7 @@ pub(crate) fn get_field<'a>(
 
 pub(crate) fn object_or_interface<'a>(
     schema: &'a s::Document,
-    name: &String,
+    name: &str,
 ) -> Option<ObjectOrInterface<'a>> {
     if name.starts_with("__") {
         INTROSPECTION_DOCUMENT.object_or_interface(name)
@@ -606,7 +606,7 @@ pub fn collect_fields<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
     selection_sets: impl Iterator<Item = &'a q::SelectionSet>,
-) -> IndexMap<&'a String, Vec<&'a q::Field>> {
+) -> IndexMap<&'a str, Vec<&'a q::Field>> {
     let mut grouped_fields = IndexMap::new();
     collect_fields_inner(
         ctx,
@@ -622,8 +622,8 @@ pub fn collect_fields_inner<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
     selection_sets: impl Iterator<Item = &'a q::SelectionSet>,
-    visited_fragments: &mut HashSet<&'a String>,
-    output: &mut IndexMap<&'a String, Vec<&'a q::Field>>,
+    visited_fragments: &mut HashSet<&'a str>,
+    output: &mut IndexMap<&'a str, Vec<&'a q::Field>>,
 ) {
     for selection_set in selection_sets {
         // Only consider selections that are not skipped and should be included
@@ -747,7 +747,7 @@ fn resolve_field_value(
     field: &q::Field,
     field_definition: &s::Field,
     field_type: &s::Type,
-    argument_values: &HashMap<&String, q::Value>,
+    argument_values: &HashMap<&str, q::Value>,
 ) -> Result<q::Value, Vec<QueryExecutionError>> {
     match field_type {
         s::Type::NonNullType(inner_type) => resolve_field_value(
@@ -789,8 +789,8 @@ fn resolve_field_value_for_named_type(
     field_value: Option<q::Value>,
     field: &q::Field,
     field_definition: &s::Field,
-    type_name: &String,
-    argument_values: &HashMap<&String, q::Value>,
+    type_name: &str,
+    argument_values: &HashMap<&str, q::Value>,
 ) -> Result<q::Value, Vec<QueryExecutionError>> {
     // Try to resolve the type name into the actual type
     let named_type = sast::get_named_type(ctx.query.schema.document(), type_name)
@@ -839,7 +839,7 @@ fn resolve_field_value_for_list_type(
     field: &q::Field,
     field_definition: &s::Field,
     inner_type: &s::Type,
-    argument_values: &HashMap<&String, q::Value>,
+    argument_values: &HashMap<&str, q::Value>,
 ) -> Result<q::Value, Vec<QueryExecutionError>> {
     match inner_type {
         s::Type::NonNullType(inner_type) => resolve_field_value_for_list_type(
@@ -1063,11 +1063,11 @@ pub fn coerce_argument_values<'a>(
     query: &crate::execution::Query,
     ty: impl Into<ObjectOrInterface<'a>>,
     field: &q::Field,
-) -> Result<HashMap<&'a String, q::Value>, Vec<QueryExecutionError>> {
+) -> Result<HashMap<&'a str, q::Value>, Vec<QueryExecutionError>> {
     let mut coerced_values = HashMap::new();
     let mut errors = vec![];
 
-    let resolver = |name: &String| sast::get_named_type(&query.schema.document(), name);
+    let resolver = |name: &str| sast::get_named_type(&query.schema.document(), name);
 
     for argument_def in sast::get_argument_definitions(ty, &field.name)
         .into_iter()
@@ -1078,7 +1078,7 @@ pub fn coerce_argument_values<'a>(
             Ok(Some(value)) => {
                 if argument_def.name == "text".to_string() {
                     coerced_values.insert(
-                        &argument_def.name,
+                        argument_def.name.as_str(),
                         q::Value::Object(BTreeMap::from_iter(vec![(field.name.clone(), value)])),
                     );
                 } else {

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -207,7 +207,7 @@ impl Query {
                 }
             };
 
-            let bc = match args.get(&"block".to_string()) {
+            let bc = match args.get("block") {
                 Some(bc) => BlockConstraint::try_from_value(bc).map_err(|_| {
                     vec![QueryExecutionError::InvalidArgumentError(
                         Pos::default(),
@@ -218,7 +218,7 @@ impl Query {
                 None => BlockConstraint::Latest,
             };
 
-            let field_error_policy = match args.get(&"subgraphError".to_string()) {
+            let field_error_policy = match args.get("subgraphError") {
                 Some(value) => ErrorPolicy::try_from(value).map_err(|_| {
                     vec![QueryExecutionError::InvalidArgumentError(
                         Pos::default(),
@@ -273,7 +273,7 @@ impl Query {
 
     /// Should only be called for fragments that exist in the query, and therefore have been
     /// validated to exist. Panics otherwise.
-    pub fn get_fragment(&self, name: &String) -> &q::FragmentDefinition {
+    pub fn get_fragment(&self, name: &str) -> &q::FragmentDefinition {
         self.fragments.get(name).unwrap()
     }
 
@@ -379,7 +379,7 @@ impl Query {
     // Checks for invalid selections.
     fn validate_fields_inner(
         &self,
-        type_name: &String,
+        type_name: &str,
         ty: ObjectOrInterface<'_>,
         selection_set: &q::SelectionSet,
     ) -> Vec<QueryExecutionError> {
@@ -394,7 +394,7 @@ impl Query {
                         Some(s_field) => {
                             let base_type = s_field.field_type.get_base_type();
                             if get_named_type(schema, base_type).is_none() {
-                                errors.push(QueryExecutionError::NamedTypeError(base_type.clone()));
+                                errors.push(QueryExecutionError::NamedTypeError(base_type.into()));
                             } else if let Some(ty) = object_or_interface(schema, base_type) {
                                 errors.extend(self.validate_fields_inner(
                                     base_type,
@@ -405,7 +405,7 @@ impl Query {
                         }
                         None => errors.push(QueryExecutionError::UnknownField(
                             field.position,
-                            type_name.clone(),
+                            type_name.into(),
                             field.name.clone(),
                         )),
                     },
@@ -601,7 +601,7 @@ fn coerce_variable(
 ) -> Result<q::Value, Vec<QueryExecutionError>> {
     use crate::values::coercion::coerce_value;
 
-    let resolver = |name: &String| sast::get_named_type(schema.document(), name);
+    let resolver = |name: &str| sast::get_named_type(schema.document(), name);
 
     coerce_value(value, &variable_def.var_type, &resolver, &HashMap::new()).map_err(|value| {
         vec![QueryExecutionError::InvalidArgumentError(

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -25,7 +25,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&String, q::Value>,
+        arguments: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an object, `prefetched_object` is `Some` if the parent already calculated the value.
@@ -35,7 +35,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&String, q::Value>,
+        arguments: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError>;
 
     /// Resolves an enum value for a given enum type.
@@ -55,7 +55,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         _field: &q::Field,
         _scalar_type: &s::ScalarType,
         value: Option<q::Value>,
-        _argument_values: &HashMap<&String, q::Value>,
+        _argument_values: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         // This code is duplicated.
         // See also c2112309-44fd-4a84-92a0-5a651e6ed548

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -365,7 +365,7 @@ impl Resolver for IntrospectionResolver {
         field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&String, q::Value>,
+        _arguments: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         match field.name.as_str() {
             "possibleTypes" => {
@@ -400,12 +400,12 @@ impl Resolver for IntrospectionResolver {
         field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&String, q::Value>,
+        arguments: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         let object = match field.name.as_str() {
             "__schema" => self.schema_object(),
             "__type" => {
-                let name = arguments.get(&String::from("name")).ok_or_else(|| {
+                let name = arguments.get("name").ok_or_else(|| {
                     QueryExecutionError::MissingArgumentError(
                         Pos::default(),
                         "missing argument `name` in `__type(name: String!)`".to_owned(),

--- a/graphql/src/query/ast.rs
+++ b/graphql/src/query/ast.rs
@@ -1,5 +1,6 @@
 use graph::prelude::q::*;
 use std::collections::HashMap;
+use std::ops::Deref;
 
 use graph::prelude::QueryExecutionError;
 
@@ -37,12 +38,12 @@ pub fn get_operations(document: &Document) -> Vec<&OperationDefinition> {
 }
 
 /// Returns the name of the given operation (if it has one).
-pub fn get_operation_name(operation: &OperationDefinition) -> Option<&String> {
+pub fn get_operation_name(operation: &OperationDefinition) -> Option<&str> {
     match operation {
-        OperationDefinition::Mutation(m) => m.name.as_ref(),
-        OperationDefinition::Query(q) => q.name.as_ref(),
+        OperationDefinition::Mutation(m) => m.name.as_ref().map(Deref::deref),
+        OperationDefinition::Query(q) => q.name.as_ref().map(Deref::deref),
         OperationDefinition::SelectionSet(_) => None,
-        OperationDefinition::Subscription(s) => s.name.as_ref(),
+        OperationDefinition::Subscription(s) => s.name.as_ref().map(Deref::deref),
     }
 }
 
@@ -107,8 +108,12 @@ pub fn include_selection(selection: &Selection, variables: &HashMap<String, Valu
 }
 
 /// Returns the response key of a field, which is either its name or its alias (if there is one).
-pub fn get_response_key(field: &Field) -> &String {
-    field.alias.as_ref().unwrap_or(&field.name)
+pub fn get_response_key(field: &Field) -> &str {
+    field
+        .alias
+        .as_ref()
+        .map(Deref::deref)
+        .unwrap_or(field.name.as_str())
 }
 
 /// Returns up the fragment with the given name, if it exists.

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -28,7 +28,7 @@ pub(crate) enum FilterOp {
 }
 
 /// Split a "name_eq" style name into an attribute ("name") and a filter op (`Equal`).
-pub(crate) fn parse_field_as_filter(key: &String) -> (String, FilterOp) {
+pub(crate) fn parse_field_as_filter(key: &str) -> (String, FilterOp) {
     let (suffix, op) = match key {
         k if k.ends_with("_not") => ("_not", FilterOp::Not),
         k if k.ends_with("_gt") => ("_gt", FilterOp::GreaterThan),
@@ -85,10 +85,7 @@ pub fn get_object_type_definitions(schema: &Document) -> Vec<&ObjectType> {
 }
 
 /// Returns the object type with the given name.
-pub fn get_object_type_mut<'a>(
-    schema: &'a mut Document,
-    name: &String,
-) -> Option<&'a mut ObjectType> {
+pub fn get_object_type_mut<'a>(schema: &'a mut Document, name: &str) -> Option<&'a mut ObjectType> {
     use graphql_parser::schema::TypeDefinition::*;
 
     get_named_type_definition_mut(schema, name).and_then(|type_def| match type_def {
@@ -112,7 +109,7 @@ pub fn get_interface_type_definitions(schema: &Document) -> Vec<&InterfaceType> 
 /// Returns the interface type with the given name.
 pub fn get_interface_type_mut<'a>(
     schema: &'a mut Document,
-    name: &String,
+    name: &str,
 ) -> Option<&'a mut InterfaceType> {
     use graphql_parser::schema::TypeDefinition::*;
 
@@ -125,7 +122,7 @@ pub fn get_interface_type_mut<'a>(
 /// Returns the type of a field of an object type.
 pub fn get_field<'a>(
     object_type: impl Into<ObjectOrInterface<'a>>,
-    name: &String,
+    name: &str,
 ) -> Option<&'a Field> {
     lazy_static! {
         pub static ref TYPENAME_FIELD: Field = Field {
@@ -189,7 +186,7 @@ pub fn get_named_type<'a>(schema: &'a Document, name: &str) -> Option<&'a TypeDe
 /// Returns a mutable version of the type with the given name.
 pub fn get_named_type_definition_mut<'a>(
     schema: &'a mut Document,
-    name: &String,
+    name: &str,
 ) -> Option<&'a mut TypeDefinition> {
     schema
         .definitions
@@ -209,7 +206,7 @@ pub fn get_named_type_definition_mut<'a>(
 }
 
 /// Returns the name of a type.
-pub fn get_type_name(t: &TypeDefinition) -> &String {
+pub fn get_type_name(t: &TypeDefinition) -> &str {
     match t {
         TypeDefinition::Enum(t) => &t.name,
         TypeDefinition::InputObject(t) => &t.name,
@@ -235,7 +232,7 @@ pub fn get_type_description(t: &TypeDefinition) -> &Option<String> {
 /// Returns the argument definitions for a field of an object type.
 pub fn get_argument_definitions<'a>(
     object_type: impl Into<ObjectOrInterface<'a>>,
-    name: &String,
+    name: &str,
 ) -> Option<&'a Vec<InputValue>> {
     lazy_static! {
         pub static ref NAME_ARGUMENT: Vec<InputValue> = vec![InputValue {

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -203,7 +203,7 @@ impl<'a> JoinCond<'a> {
     fn new(
         parent_type: &'a s::ObjectType,
         child_type: &'a s::ObjectType,
-        field_name: &String,
+        field_name: &str,
     ) -> Self {
         let field = parent_type
             .field(field_name)
@@ -302,7 +302,7 @@ impl<'a> Join<'a> {
         schema: &'a ApiSchema,
         parent_type: ObjectOrInterface<'a>,
         child_type: ObjectOrInterface<'a>,
-        field_name: &String,
+        field_name: &str,
     ) -> Self {
         let parent_types = parent_type
             .object_types(schema.schema())
@@ -455,7 +455,7 @@ fn execute_selection_set<'a>(
     resolver: &StoreResolver,
     ctx: &'a ExecutionContext<impl Resolver>,
     mut parents: Vec<Node>,
-    grouped_field_set: IndexMap<&'a String, CollectedResponseKey<'a>>,
+    grouped_field_set: IndexMap<&'a str, CollectedResponseKey<'a>>,
 ) -> Result<Vec<Node>, Vec<QueryExecutionError>> {
     let schema = &ctx.query.schema;
     let mut errors: Vec<QueryExecutionError> = Vec::new();
@@ -589,7 +589,7 @@ fn collect_fields<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     parent_ty: ObjectOrInterface<'a>,
     selection_sets: impl Iterator<Item = &'a q::SelectionSet>,
-) -> IndexMap<&'a String, CollectedResponseKey<'a>> {
+) -> IndexMap<&'a str, CollectedResponseKey<'a>> {
     let mut grouped_fields = IndexMap::new();
 
     for selection_set in selection_sets {
@@ -624,8 +624,8 @@ fn collect_fields_inner<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     type_condition: ObjectOrInterface<'a>,
     selection_set: &'a q::SelectionSet,
-    visited_fragments: &mut HashSet<&'a String>,
-    output: &mut IndexMap<&'a String, CollectedResponseKey<'a>>,
+    visited_fragments: &mut HashSet<&'a str>,
+    output: &mut IndexMap<&'a str, CollectedResponseKey<'a>>,
 ) {
     fn is_reference_field(
         schema: &s::Document,
@@ -648,8 +648,8 @@ fn collect_fields_inner<'a>(
         outer_type_condition: ObjectOrInterface<'a>,
         frag_ty_condition: Option<&'a q::TypeCondition>,
         frag_selection_set: &'a q::SelectionSet,
-        visited_fragments: &mut HashSet<&'a String>,
-        output: &mut IndexMap<&'a String, CollectedResponseKey<'a>>,
+        visited_fragments: &mut HashSet<&'a str>,
+        output: &mut IndexMap<&'a str, CollectedResponseKey<'a>>,
     ) {
         let schema = &ctx.query.schema.document();
         let fragment_ty = match frag_ty_condition {
@@ -790,7 +790,7 @@ fn fetch(
     store: &(impl QueryStore + ?Sized),
     parents: &Vec<&mut Node>,
     join: &Join<'_>,
-    arguments: HashMap<&String, q::Value>,
+    arguments: HashMap<&str, q::Value>,
     multiplicity: ChildMultiplicity,
     types_for_interface: &BTreeMap<EntityType, Vec<s::ObjectType>>,
     block: BlockNumber,
@@ -815,7 +815,7 @@ fn fetch(
     }
 
     query.logger = Some(logger);
-    if let Some(q::Value::String(id)) = arguments.get(&*ARG_ID) {
+    if let Some(q::Value::String(id)) = arguments.get(ARG_ID.as_str()) {
         query.filter = Some(
             EntityFilter::Equal(ARG_ID.to_owned(), StoreValue::from(id.to_owned()))
                 .and_maybe(query.filter),

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -18,7 +18,7 @@ enum OrderDirection {
 pub fn build_query<'a>(
     entity: impl Into<ObjectOrInterface<'a>>,
     block: BlockNumber,
-    arguments: &HashMap<&String, q::Value>,
+    arguments: &HashMap<&str, q::Value>,
     types_for_interface: &BTreeMap<EntityType, Vec<s::ObjectType>>,
     max_first: u32,
     max_skip: u32,
@@ -55,11 +55,11 @@ pub fn build_query<'a>(
 
 /// Parses GraphQL arguments into a EntityRange, if present.
 fn build_range(
-    arguments: &HashMap<&String, q::Value>,
+    arguments: &HashMap<&str, q::Value>,
     max_first: u32,
     max_skip: u32,
 ) -> Result<EntityRange, QueryExecutionError> {
-    let first = match arguments.get(&"first".to_string()) {
+    let first = match arguments.get("first") {
         Some(q::Value::Int(n)) => {
             let n = n.as_i64().expect("first is Int");
             if n > 0 && n <= (max_first as i64) {
@@ -74,7 +74,7 @@ fn build_range(
         _ => unreachable!("first is an Int with a default value"),
     };
 
-    let skip = match arguments.get(&"skip".to_string()) {
+    let skip = match arguments.get("skip") {
         Some(q::Value::Int(n)) => {
             let n = n.as_i64().expect("skip is Int");
             if n >= 0 && n <= (max_skip as i64) {
@@ -98,12 +98,12 @@ fn build_range(
 /// Parses GraphQL arguments into an EntityFilter, if present.
 fn build_filter(
     entity: ObjectOrInterface,
-    arguments: &HashMap<&String, q::Value>,
+    arguments: &HashMap<&str, q::Value>,
 ) -> Result<Option<EntityFilter>, QueryExecutionError> {
-    match arguments.get(&"where".to_string()) {
+    match arguments.get("where") {
         Some(q::Value::Object(object)) => build_filter_from_object(entity, object),
         Some(q::Value::Null) => Ok(None),
-        None => match arguments.get(&"text".to_string()) {
+        None => match arguments.get("text") {
             Some(q::Value::Object(filter)) => build_fulltext_filter_from_object(filter),
             None => Ok(None),
             _ => Err(QueryExecutionError::InvalidFilterError),
@@ -205,9 +205,9 @@ fn list_values(value: Value, filter_type: &str) -> Result<Vec<Value>, QueryExecu
 /// Parses GraphQL arguments into an field name to order by, if present.
 fn build_order_by(
     entity: ObjectOrInterface,
-    arguments: &HashMap<&String, q::Value>,
+    arguments: &HashMap<&str, q::Value>,
 ) -> Result<Option<(String, ValueType)>, QueryExecutionError> {
-    match arguments.get(&"orderBy".to_string()) {
+    match arguments.get("orderBy") {
         Some(q::Value::Enum(name)) => {
             let field = sast::get_field(entity, &name).ok_or_else(|| {
                 QueryExecutionError::EntityFieldError(entity.name().to_owned(), name.clone())
@@ -221,7 +221,7 @@ fn build_order_by(
                     )
                 })
         }
-        _ => match arguments.get(&"text".to_string()) {
+        _ => match arguments.get("text") {
             Some(q::Value::Object(filter)) => build_fulltext_order_by_from_object(filter),
             None => Ok(None),
             _ => Err(QueryExecutionError::InvalidFilterError),
@@ -246,10 +246,10 @@ fn build_fulltext_order_by_from_object(
 
 /// Parses GraphQL arguments into a EntityOrder, if present.
 fn build_order_direction(
-    arguments: &HashMap<&String, q::Value>,
+    arguments: &HashMap<&str, q::Value>,
 ) -> Result<OrderDirection, QueryExecutionError> {
     Ok(arguments
-        .get(&"orderDirection".to_string())
+        .get("orderDirection")
         .map(|value| match value {
             q::Value::Enum(name) if name == "asc" => OrderDirection::Ascending,
             q::Value::Enum(name) if name == "desc" => OrderDirection::Descending,
@@ -410,10 +410,10 @@ mod tests {
         }
     }
 
-    fn default_arguments<'a>() -> HashMap<&'a String, q::Value> {
+    fn default_arguments<'a>() -> HashMap<&'a str, q::Value> {
         let mut map = HashMap::new();
-        let first: &String = Box::leak(Box::new("first".to_owned()));
-        let skip: &String = Box::leak(Box::new("skip".to_owned()));
+        let first = "first";
+        let skip = "skip";
         map.insert(first, q::Value::Int(100.into()));
         map.insert(skip, q::Value::Int(0.into()));
         map

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -225,7 +225,7 @@ impl Resolver for StoreResolver {
         field: &q::Field,
         _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&String, q::Value>,
+        _arguments: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         if let Some(child) = prefetched_objects {
             Ok(child)
@@ -245,7 +245,7 @@ impl Resolver for StoreResolver {
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&String, q::Value>,
+        _arguments: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         let (prefetched_object, meta) = self.handle_meta(prefetched_object, &object_type)?;
         if let Some(meta) = meta {

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -130,7 +130,7 @@ fn resolve_field_stream(
     ctx: &ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
     field: &q::Field,
-    _argument_values: HashMap<&String, q::Value>,
+    _argument_values: HashMap<&str, q::Value>,
 ) -> Result<StoreEventStreamBox, SubscriptionError> {
     ctx.resolver
         .resolve_field_stream(&ctx.query.schema.document(), object_type, field)

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -36,7 +36,7 @@ impl Resolver for MockResolver {
         _field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&String, q::Value>,
+        _arguments: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }
@@ -47,7 +47,7 @@ impl Resolver for MockResolver {
         _field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&String, q::Value>,
+        _arguments: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         Ok(q::Value::Null)
     }

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -33,10 +33,10 @@ where
 
     fn resolve_indexing_statuses(
         &self,
-        arguments: &HashMap<&String, q::Value>,
+        arguments: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         let deployments = arguments
-            .get(&String::from("subgraphs"))
+            .get("subgraphs")
             .map(|value| match value {
                 q::Value::List(ids) => ids
                     .into_iter()
@@ -57,7 +57,7 @@ where
 
     fn resolve_indexing_statuses_for_subgraph_name(
         &self,
-        arguments: &HashMap<&String, q::Value>,
+        arguments: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         // Get the subgraph name from the arguments; we can safely use `expect` here
         // because the argument will already have been validated prior to the resolver
@@ -81,7 +81,7 @@ where
 
     fn resolve_proof_of_indexing(
         &self,
-        argument_values: &HashMap<&String, q::Value>,
+        argument_values: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         let deployment_id = argument_values
             .get_required::<DeploymentHash>("subgraph")
@@ -129,7 +129,7 @@ where
 
     fn resolve_indexing_status_for_version(
         &self,
-        arguments: &HashMap<&String, q::Value>,
+        arguments: &HashMap<&str, q::Value>,
 
         // If `true` return the current version, if `false` return the pending version.
         current_version: bool,
@@ -193,7 +193,7 @@ where
         field: &q::Field,
         scalar_type: &s::ScalarType,
         value: Option<q::Value>,
-        argument_values: &HashMap<&String, q::Value>,
+        argument_values: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         // Check if we are resolving the proofOfIndexing bytes
         if &parent_object_type.name == "Query"
@@ -216,7 +216,7 @@ where
         field: &q::Field,
         _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&String, q::Value>,
+        arguments: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         match (prefetched_objects, object_type.name(), field.name.as_str()) {
             // The top-level `indexingStatuses` field
@@ -240,7 +240,7 @@ where
         field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&String, q::Value>,
+        arguments: &HashMap<&str, q::Value>,
     ) -> Result<q::Value, QueryExecutionError> {
         match (prefetched_object, field.name.as_str()) {
             // The top-level `indexingStatusForCurrentVersion` field

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -581,7 +581,7 @@ impl Layout {
     pub fn conflicting_entity(
         &self,
         conn: &PgConnection,
-        entity_id: &String,
+        entity_id: &str,
         entities: Vec<EntityType>,
     ) -> Result<Option<String>, StoreError> {
         Ok(ConflictingEntityQuery::new(self, entities, entity_id)?

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1374,13 +1374,13 @@ impl<'a, Conn> RunQueryDsl<Conn> for InsertQuery<'a> {}
 pub struct ConflictingEntityQuery<'a> {
     layout: &'a Layout,
     tables: Vec<&'a Table>,
-    entity_id: &'a String,
+    entity_id: &'a str,
 }
 impl<'a> ConflictingEntityQuery<'a> {
     pub fn new(
         layout: &'a Layout,
         entities: Vec<EntityType>,
-        entity_id: &'a String,
+        entity_id: &'a str,
     ) -> Result<Self, StoreError> {
         let tables = entities
             .iter()
@@ -1413,7 +1413,7 @@ impl<'a> QueryFragment<Pg> for ConflictingEntityQuery<'a> {
             out.push_sql(" as entity from ");
             out.push_sql(table.qualified_name.as_str());
             out.push_sql(" where id = ");
-            out.push_bind_param::<Text, _>(self.entity_id)?;
+            out.push_bind_param::<Text, _>(&self.entity_id)?;
         }
         Ok(())
     }
@@ -2134,7 +2134,7 @@ impl<'a> SortKey<'a> {
                 out.push_identifier(name)?;
                 out.push_sql(", to_tsquery(");
 
-                out.push_bind_param::<Text, _>(&String::from(value.unwrap()))?;
+                out.push_bind_param::<Text, _>(&value.unwrap())?;
                 out.push_sql("))");
             }
             _ => {


### PR DESCRIPTION
This PR replaces graph-node's usage of `&String` with `&str`

`&str` is preferable since it allows for more generic code, removing the need of the argument to be allocated on the heap (e.g., can remove the several instances of `&"some-term".to_string()` from the code, probably increasing performance).

This new change also removes a layer of indirection since you no longer need to deref `&String` to get a `String` and then deref that to get a `&str`

[Related Clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg)

P.S.: this is the same as #2426 but with a cleaner git history