### PR TITLE
block stream: Less trigger filter cloning

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -262,7 +262,7 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
         &self,
         from: BlockNumber,
         to: BlockNumber,
-        filter: TriggerFilter,
+        filter: &TriggerFilter,
     ) -> Result<Vec<BlockWithTriggers<Chain>>, Error> {
         blocks_with_triggers(
             self.eth_adapter.clone(),
@@ -271,7 +271,7 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             self.ethrpc_metrics.clone(),
             from,
             to,
-            filter.clone(),
+            filter,
         )
         .await
         .map(|blocks| {
@@ -291,7 +291,7 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
         &self,
         logger: &Logger,
         block: WrappedBlockFinality,
-        filter: TriggerFilter,
+        filter: &TriggerFilter,
     ) -> Result<BlockWithTriggers<Chain>, Error> {
         let block = get_calls(
             self.eth_adapter.as_ref(),
@@ -330,11 +330,11 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             BlockFinality::NonFinal(full_block) => {
                 let mut triggers = Vec::new();
                 triggers.append(&mut parse_log_triggers(
-                    filter.log,
+                    &filter.log,
                     &full_block.ethereum_block,
                 ));
-                triggers.append(&mut parse_call_triggers(filter.call, &full_block));
-                triggers.append(&mut parse_block_triggers(filter.block, &full_block));
+                triggers.append(&mut parse_call_triggers(&filter.call, &full_block));
+                triggers.append(&mut parse_block_triggers(filter.block.clone(), &full_block));
                 Ok(BlockWithTriggers::new(
                     WrappedBlockFinality(block),
                     triggers,

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -804,7 +804,7 @@ where
             .triggers_in_block(
                 &logger,
                 WrappedBlockFinality(block.as_ref().clone()),
-                filter,
+                &filter,
             )
             .await?;
 


### PR DESCRIPTION
Trigger filters grow with the number of dynamic data sources, so they can become large data structures. Some clones are hard to avoid, but this PR handles some easy cases. Ultimately these filters need to be written to a network request so there will always be at least that allocation, so I wouldn't be too concerned about the remaining clones unless we can measure the impact.