### PR TITLE
runtime: Make `to_asc_bytes` take `self` instead of `&self`

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -404,7 +404,7 @@ impl Stream for DummyBlockStream {
 pub struct DummyMappingTrigger;
 
 impl AscType for DummyMappingTrigger {
-    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
         todo!()
     }
 

--- a/graph/src/runtime/asc_heap.rs
+++ b/graph/src/runtime/asc_heap.rs
@@ -20,7 +20,7 @@ pub trait AscHeap: Sized {
         T: ToAscObj<C>,
     {
         let obj = rust_obj.to_asc_obj(self)?;
-        AscPtr::alloc_obj(&obj, self)
+        AscPtr::alloc_obj(obj, self)
     }
 
     ///  Read the rust representation of an Asc object of class `C`.

--- a/graph/src/runtime/asc_ptr.rs
+++ b/graph/src/runtime/asc_ptr.rs
@@ -55,7 +55,7 @@ impl<C: AscType> AscPtr<C> {
 
     /// Allocate `asc_obj` as an Asc object of class `C`.
     pub fn alloc_obj<H: AscHeap>(
-        asc_obj: &C,
+        asc_obj: C,
         heap: &mut H,
     ) -> Result<AscPtr<C>, DeterministicHostError> {
         let heap_ptr = heap.raw_new(&asc_obj.to_asc_bytes()?)?;
@@ -94,7 +94,7 @@ impl<C> From<u32> for AscPtr<C> {
 }
 
 impl<T> AscType for AscPtr<T> {
-    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
         self.0.to_asc_bytes()
     }
 

--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -25,7 +25,7 @@ use std::mem::size_of;
 pub trait AscType: Sized {
     /// Transform the Rust representation of this instance into an sequence of
     /// bytes that is precisely the memory layout of a corresponding Asc instance.
-    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError>;
+    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError>;
 
     /// The Rust representation of an Asc object as layed out in Asc memory.
     fn from_asc_bytes(asc_obj: &[u8]) -> Result<Self, DeterministicHostError>;
@@ -42,8 +42,8 @@ pub trait AscType: Sized {
 pub trait AscValue: AscType + Copy + Default {}
 
 impl AscType for bool {
-    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
-        Ok(vec![*self as u8])
+    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
+        Ok(vec![self as u8])
     }
 
     fn from_asc_bytes(asc_obj: &[u8]) -> Result<Self, DeterministicHostError> {
@@ -65,7 +65,7 @@ macro_rules! impl_asc_type {
     ($($T:ty),*) => {
         $(
             impl AscType for $T {
-                fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+                fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
                     Ok(self.to_le_bytes().to_vec())
                 }
 

--- a/runtime/derive/src/lib.rs
+++ b/runtime/derive/src/lib.rs
@@ -26,7 +26,7 @@ pub fn asc_type_derive(input: TokenStream) -> TokenStream {
 //
 // Example output:
 // impl<K, V> AscType for AscTypedMapEntry<K, V> {
-//     fn to_asc_bytes(&self) -> Vec<u8> {
+//     fn to_asc_bytes(self) -> Vec<u8> {
 //         let mut bytes = Vec::new();
 //         bytes.extend_from_slice(&self.key.to_asc_bytes());
 //         bytes.extend_from_slice(&self.value.to_asc_bytes());
@@ -67,7 +67,7 @@ fn asc_type_derive_struct(item_struct: ItemStruct) -> TokenStream {
 
     TokenStream::from(quote! {
         impl#impl_generics AscType for #struct_name#ty_generics #where_clause {
-            fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+            fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
                let mut bytes = Vec::new();
                 #(bytes.extend_from_slice(&self.#field_names.to_asc_bytes()?);)*
 
@@ -114,7 +114,7 @@ fn asc_type_derive_struct(item_struct: ItemStruct) -> TokenStream {
 //
 // Example output:
 // impl AscType for JsonValueKind {
-//     fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+//     fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
 //         let discriminant: u32 = match *self {
 //             JsonValueKind::Null => 0u32,
 //             JsonValueKind::Bool => 1u32,
@@ -163,8 +163,8 @@ fn asc_type_derive_enum(item_enum: ItemEnum) -> TokenStream {
 
     TokenStream::from(quote! {
         impl#impl_generics AscType for #enum_name#ty_generics #where_clause {
-            fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
-                let discriminant: u32 = match *self {
+            fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
+                let discriminant: u32 = match self {
                     #(#enum_name_iter::#variant_paths => #variant_discriminant,)*
                 };
                 discriminant.to_asc_bytes()

--- a/runtime/wasm/src/asc_abi/class.rs
+++ b/runtime/wasm/src/asc_abi/class.rs
@@ -81,7 +81,7 @@ impl<T: AscValue> ArrayBuffer<T> {
 }
 
 impl<T> AscType for ArrayBuffer<T> {
-    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
         let mut asc_layout: Vec<u8> = Vec::new();
 
         let byte_length: [u8; 4] = self.byte_length.to_le_bytes();
@@ -146,9 +146,9 @@ impl<T: AscValue> TypedArray<T> {
     ) -> Result<Self, DeterministicHostError> {
         let buffer = ArrayBuffer::new(content)?;
         Ok(TypedArray {
-            buffer: AscPtr::alloc_obj(&buffer, heap)?,
-            byte_offset: 0,
             byte_length: buffer.byte_length,
+            buffer: AscPtr::alloc_obj(buffer, heap)?,
+            byte_offset: 0,
         })
     }
 
@@ -187,7 +187,7 @@ impl AscString {
 }
 
 impl AscType for AscString {
-    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
         let mut asc_layout: Vec<u8> = Vec::new();
 
         let length: [u8; 4] = self.length.to_le_bytes();
@@ -276,7 +276,7 @@ pub(crate) struct Array<T> {
 impl<T: AscValue> Array<T> {
     pub fn new<H: AscHeap>(content: &[T], heap: &mut H) -> Result<Self, DeterministicHostError> {
         Ok(Array {
-            buffer: AscPtr::alloc_obj(&ArrayBuffer::new(content)?, heap)?,
+            buffer: AscPtr::alloc_obj(ArrayBuffer::new(content)?, heap)?,
             // If this cast would overflow, the above line has already panicked.
             length: content.len() as u32,
         })
@@ -293,7 +293,7 @@ impl<T: AscValue> Array<T> {
 pub(crate) struct EnumPayload(pub u64);
 
 impl AscType for EnumPayload {
-    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
         self.0.to_asc_bytes()
     }
 


### PR DESCRIPTION
This will work better for multiblockchain.