### PR TITLE
Add `fn api_version` to `AscHeap`

### DIFF
--- a/graph/src/runtime/asc_heap.rs
+++ b/graph/src/runtime/asc_heap.rs
@@ -1,3 +1,5 @@
+use semver::Version;
+
 use super::{AscPtr, AscType, DeterministicHostError};
 /// A type that can read and write to the Asc heap. Call `asc_new` and `asc_get`
 /// for reading and writing Rust structs from and to Asc.
@@ -42,6 +44,8 @@ pub trait AscHeap: Sized {
     {
         T::try_from_asc_obj(asc_ptr.read_ptr(self)?, self)
     }
+
+    fn api_version(&self) -> Version;
 }
 
 /// Type that can be converted to an Asc object of class `C`.

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -71,6 +71,10 @@ impl AscHeap for WasmInstance {
     fn get(&self, offset: u32, size: u32) -> Result<Vec<u8>, DeterministicHostError> {
         self.instance_ctx().get(offset, size)
     }
+
+    fn api_version(&self) -> Version {
+        self.instance_ctx().api_version()
+    }
 }
 
 impl WasmInstance {
@@ -630,6 +634,10 @@ impl AscHeap for WasmInstanceContext {
         })?;
 
         Ok(data)
+    }
+
+    fn api_version(&self) -> Version {
+        self.ctx.host_exports.api_version.clone()
     }
 }
 


### PR DESCRIPTION
Since `api_version` defines the AS serialization format, having this in AscHeap will be convenient.