### PR TITLE
Put the block for triggers in the trigger itself

### DIFF
--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -158,7 +158,7 @@ where
             state = host
                 .process_mapping_trigger(
                     logger,
-                    &block,
+                    block.block_ptr(),
                     mapping_trigger,
                     state,
                     proof_of_indexing.cheap_clone(),

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -146,13 +146,14 @@ where
     ) -> Result<BlockState, MappingError> {
         let block = Arc::new(block.light_block());
         for host in hosts {
-            let mapping_trigger = match host.match_and_decode(&trigger, &block, logger)? {
-                // Trigger matches and was decoded as a mapping trigger.
-                Some(mapping_trigger) => mapping_trigger,
+            let mapping_trigger =
+                match host.match_and_decode(&trigger, block.cheap_clone(), logger)? {
+                    // Trigger matches and was decoded as a mapping trigger.
+                    Some(mapping_trigger) => mapping_trigger,
 
-                // Trigger does not match, do not process it.
-                None => continue,
-            };
+                    // Trigger does not match, do not process it.
+                    None => continue,
+                };
 
             state = host
                 .process_mapping_trigger(

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -180,7 +180,7 @@ pub trait DataSource<C: Blockchain>: 'static {
     fn match_and_decode(
         &self,
         trigger: &C::TriggerData,
-        block: &C::Block,
+        block: Arc<C::Block>,
         logger: &Logger,
     ) -> Result<Option<C::MappingTrigger>, Error>;
 }

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -293,12 +293,14 @@ impl PartialOrd for EthereumTrigger {
 #[derive(Debug, AsStaticStr)]
 pub enum MappingTrigger {
     Log {
+        block: Arc<LightEthereumBlock>,
         transaction: Arc<Transaction>,
         log: Arc<Log>,
         params: Vec<LogParam>,
         handler: MappingEventHandler,
     },
     Call {
+        block: Arc<LightEthereumBlock>,
         transaction: Arc<Transaction>,
         call: Arc<EthereumCall>,
         inputs: Vec<LogParam>,
@@ -306,6 +308,7 @@ pub enum MappingTrigger {
         handler: MappingCallHandler,
     },
     Block {
+        block: Arc<LightEthereumBlock>,
         handler: MappingBlockHandler,
     },
 }

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -46,7 +46,7 @@ pub trait RuntimeHost<C: Blockchain>: Send + Sync + Debug + 'static {
     fn match_and_decode(
         &self,
         trigger: &EthereumTrigger,
-        block: &LightEthereumBlock,
+        block: Arc<LightEthereumBlock>,
         logger: &Logger,
     ) -> Result<Option<MappingTrigger>, Error>;
 

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -53,7 +53,7 @@ pub trait RuntimeHost<C: Blockchain>: Send + Sync + Debug + 'static {
     async fn process_mapping_trigger(
         &self,
         logger: &Logger,
-        block: &Arc<LightEthereumBlock>,
+        block_ptr: BlockPtr,
         trigger: MappingTrigger,
         state: BlockState,
         proof_of_indexing: SharedProofOfIndexing,

--- a/graph/src/data/subgraph/data_source.rs
+++ b/graph/src/data/subgraph/data_source.rs
@@ -43,7 +43,7 @@ where
     fn match_and_decode(
         &self,
         _trigger: &C::TriggerData,
-        _block: &C::Block,
+        _block: Arc<C::Block>,
         _logger: &Logger,
     ) -> Result<Option<C::MappingTrigger>, Error> {
         todo!()
@@ -319,7 +319,7 @@ impl super::DataSource {
     pub fn match_and_decode(
         &self,
         trigger: &EthereumTrigger,
-        block: &LightEthereumBlock,
+        block: Arc<LightEthereumBlock>,
         logger: &Logger,
     ) -> Result<Option<MappingTrigger>, Error> {
         if !self.matches_trigger_address(&trigger) {
@@ -336,7 +336,7 @@ impl super::DataSource {
                     Some(handler) => handler,
                     None => return Ok(None),
                 };
-                Ok(Some(MappingTrigger::Block { handler }))
+                Ok(Some(MappingTrigger::Block { block, handler }))
             }
             EthereumTrigger::Log(log) => {
                 let potential_handlers = self.handlers_for_log(log)?;
@@ -415,6 +415,7 @@ impl super::DataSource {
                 );
 
                 Ok(Some(MappingTrigger::Log {
+                    block,
                     transaction,
                     log: log.cheap_clone(),
                     params,
@@ -508,6 +509,7 @@ impl super::DataSource {
                 );
 
                 Ok(Some(MappingTrigger::Call {
+                    block,
                     transaction,
                     call: call.cheap_clone(),
                     inputs,

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -270,7 +270,7 @@ impl<C: Blockchain> RuntimeHostTrait<C> for RuntimeHost {
     fn match_and_decode(
         &self,
         trigger: &EthereumTrigger,
-        block: &LightEthereumBlock,
+        block: Arc<LightEthereumBlock>,
         logger: &Logger,
     ) -> Result<Option<MappingTrigger>, Error> {
         self.data_source.match_and_decode(trigger, block, logger)

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -209,7 +209,7 @@ impl RuntimeHost {
         logger: &Logger,
         state: BlockState,
         trigger: MappingTrigger,
-        block: &Arc<LightEthereumBlock>,
+        block_ptr: BlockPtr,
         proof_of_indexing: SharedProofOfIndexing,
     ) -> Result<BlockState, MappingError> {
         let trigger_type = trigger.as_static();
@@ -235,7 +235,7 @@ impl RuntimeHost {
                     logger: logger.cheap_clone(),
                     state,
                     host_exports: self.host_exports.cheap_clone(),
-                    block: block.cheap_clone(),
+                    block_ptr,
                     proof_of_indexing,
                 },
                 trigger,
@@ -279,12 +279,12 @@ impl<C: Blockchain> RuntimeHostTrait<C> for RuntimeHost {
     async fn process_mapping_trigger(
         &self,
         logger: &Logger,
-        block: &Arc<LightEthereumBlock>,
+        block_ptr: BlockPtr,
         trigger: MappingTrigger,
         state: BlockState,
         proof_of_indexing: SharedProofOfIndexing,
     ) -> Result<BlockState, MappingError> {
-        self.send_mapping_request(logger, state, trigger, block, proof_of_indexing)
+        self.send_mapping_request(logger, state, trigger, block_ptr, proof_of_indexing)
             .await
     }
 

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -2,7 +2,6 @@ use crate::{error::DeterminismLevel, module::IntoTrap, UnresolvedContractCall};
 use ethabi::param_type::Reader;
 use ethabi::{decode, encode, Address, Token};
 use graph::bytes::Bytes;
-use graph::components::ethereum::*;
 use graph::components::store::EntityKey;
 use graph::components::subgraph::{ProofOfIndexingEvent, SharedProofOfIndexing};
 use graph::components::three_box::ThreeBoxAdapter;
@@ -274,7 +273,7 @@ impl HostExports {
     pub(crate) fn ethereum_call(
         &self,
         logger: &Logger,
-        block: &LightEthereumBlock,
+        block_ptr: &BlockPtr,
         unresolved_call: UnresolvedContractCall,
     ) -> Result<Option<Vec<Token>>, EthereumCallError> {
         let start_time = Instant::now();
@@ -333,7 +332,7 @@ impl HostExports {
 
         let call = EthereumContractCall {
             address: unresolved_call.contract_address.clone(),
-            block_ptr: block.into(),
+            block_ptr: block_ptr.cheap_clone(),
             function: function.clone(),
             args: unresolved_call.function_args.clone(),
         };

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -129,7 +129,7 @@ pub struct MappingRequest {
 pub(crate) struct MappingContext {
     pub(crate) logger: Logger,
     pub(crate) host_exports: Arc<crate::host_exports::HostExports>,
-    pub(crate) block: Arc<LightEthereumBlock>,
+    pub(crate) block_ptr: BlockPtr,
     pub(crate) state: BlockState,
     pub(crate) proof_of_indexing: SharedProofOfIndexing,
 }
@@ -137,9 +137,9 @@ pub(crate) struct MappingContext {
 impl MappingContext {
     pub fn derive_with_empty_block_state(&self) -> Self {
         MappingContext {
-            logger: self.logger.clone(),
-            host_exports: self.host_exports.clone(),
-            block: self.block.clone(),
+            logger: self.logger.cheap_clone(),
+            host_exports: self.host_exports.cheap_clone(),
+            block_ptr: self.block_ptr.cheap_clone(),
             state: BlockState::new(self.state.entity_cache.store.clone(), Default::default()),
             proof_of_indexing: self.proof_of_indexing.cheap_clone(),
         }

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -67,31 +67,35 @@ pub fn spawn_module(
                     }
                     let result = match trigger {
                         MappingTrigger::Log {
+                            block,
                             transaction,
                             log,
                             params,
                             handler,
                         } => module.handle_ethereum_log(
+                            block,
                             handler.handler.as_str(),
                             transaction,
                             log,
                             params,
                         ),
                         MappingTrigger::Call {
+                            block,
                             transaction,
                             call,
                             inputs,
                             outputs,
                             handler,
                         } => module.handle_ethereum_call(
+                            block,
                             handler.handler.as_str(),
                             transaction,
                             call,
                             inputs,
                             outputs,
                         ),
-                        MappingTrigger::Block { handler } => {
-                            module.handle_ethereum_block(handler.handler.as_str())
+                        MappingTrigger::Block { block, handler } => {
+                            module.handle_ethereum_block(block, handler.handler.as_str())
                         }
                     };
                     section.end();

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -259,7 +259,7 @@ impl WasmInstance {
             let subgraph_error = SubgraphError {
                 subgraph_id: self.instance_ctx().ctx.host_exports.subgraph_id.clone(),
                 message,
-                block_ptr: Some(self.instance_ctx().ctx.block.block_ptr()),
+                block_ptr: Some(self.instance_ctx().ctx.block_ptr.cheap_clone()),
                 handler: Some(handler.to_string()),
                 deterministic: true,
             };
@@ -829,10 +829,10 @@ impl WasmInstanceContext {
         &mut self,
         call: UnresolvedContractCall,
     ) -> Result<AscEnumArray<EthereumValueKind>, HostExportError> {
-        let result = self
-            .ctx
-            .host_exports
-            .ethereum_call(&self.ctx.logger, &self.ctx.block, call);
+        let result =
+            self.ctx
+                .host_exports
+                .ethereum_call(&self.ctx.logger, &self.ctx.block_ptr, call);
         match result {
             Ok(Some(tokens)) => Ok(self.asc_new(tokens.as_slice())?),
             Ok(None) => Ok(AscPtr::null()),
@@ -1328,7 +1328,7 @@ impl WasmInstanceContext {
             name,
             params,
             None,
-            self.ctx.block.block_ptr().number,
+            self.ctx.block_ptr.number,
         )
     }
 
@@ -1348,7 +1348,7 @@ impl WasmInstanceContext {
             name,
             params,
             Some(context.into()),
-            self.ctx.block.block_ptr().number,
+            self.ctx.block_ptr.number,
         )
     }
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -104,13 +104,12 @@ impl WasmInstance {
 
     pub(crate) fn handle_ethereum_log(
         mut self,
+        block: Arc<LightEthereumBlock>,
         handler_name: &str,
         transaction: Arc<Transaction>,
         log: Arc<Log>,
         params: Vec<LogParam>,
     ) -> Result<BlockState, MappingError> {
-        let block = self.instance_ctx().ctx.block.clone();
-
         // Prepare an EthereumEvent for the WASM runtime
         // Decide on the destination type using the mapping
         // api version provided in the subgraph manifest
@@ -143,6 +142,7 @@ impl WasmInstance {
 
     pub(crate) fn handle_ethereum_call(
         mut self,
+        block: Arc<LightEthereumBlock>,
         handler_name: &str,
         transaction: Arc<Transaction>,
         call: Arc<EthereumCall>,
@@ -152,7 +152,7 @@ impl WasmInstance {
         let call = EthereumCallData {
             to: call.to,
             from: call.from,
-            block: EthereumBlockData::from(self.instance_ctx().ctx.block.as_ref()),
+            block: EthereumBlockData::from(block.as_ref()),
             transaction: EthereumTransactionData::from(transaction.deref()),
             inputs,
             outputs,
@@ -168,9 +168,10 @@ impl WasmInstance {
 
     pub(crate) fn handle_ethereum_block(
         mut self,
+        block: Arc<LightEthereumBlock>,
         handler_name: &str,
     ) -> Result<BlockState, MappingError> {
-        let block = EthereumBlockData::from(self.instance_ctx().ctx.block.as_ref());
+        let block = EthereumBlockData::from(block.as_ref());
 
         // Prepare an EthereumBlock for the WASM runtime
         let arg = self.asc_new(&block)?;

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -197,12 +197,12 @@ fn mock_context(
     store: Arc<impl SubgraphStore>,
     call_cache: Arc<impl EthereumCallCache>,
 ) -> MappingContext {
-    let mut block = LightEthereumBlock::default();
-    block.hash = Some(Default::default());
-    block.number = Some(0.into());
     MappingContext {
         logger: test_store::LOGGER.clone(),
-        block: Arc::new(block),
+        block_ptr: BlockPtr {
+            hash: Default::default(),
+            number: 0,
+        },
         host_exports: Arc::new(mock_host_exports(
             deployment.hash.clone(),
             data_source,


### PR DESCRIPTION
This allows replacing the full block in `MappingContext` with just a `BlockPtr` which is a nice simplification.