### PR TITLE
Move the `DataSource` type from `graph` to `ethereum`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,6 +1583,7 @@ dependencies = [
  "fail",
  "futures 0.1.31",
  "futures 0.3.13",
+ "graph-chain-ethereum",
  "graphql-parser",
  "hex",
  "http 0.2.3",
@@ -1640,10 +1641,12 @@ dependencies = [
  "config",
  "diesel",
  "dirs-next",
+ "ethabi 12.0.0-graph",
  "futures 0.1.31",
  "graph",
  "graph-core",
  "graph-store-postgres",
+ "hex",
  "http 0.1.21",
  "jsonrpc-core",
  "lazy_static",
@@ -1652,6 +1655,8 @@ dependencies = [
  "serde",
  "state_machine_future",
  "test-store",
+ "tiny-keccak 1.5.0",
+ "web3",
 ]
 
 [[package]]
@@ -1691,6 +1696,7 @@ dependencies = [
  "defer",
  "futures 0.1.31",
  "graph",
+ "graph-chain-ethereum",
  "graphql-parser",
  "indexmap",
  "lazy_static",
@@ -4454,6 +4460,7 @@ version = "0.22.0"
 dependencies = [
  "diesel",
  "graph",
+ "graph-chain-ethereum",
  "graph-graphql",
  "graph-mock",
  "graph-node",

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -16,6 +16,18 @@ serde = "1.0"
 config = { version = "0.11", features = ["toml"], default-features = false }
 dirs-next = "2.0"
 anyhow = "1.0"
+tiny-keccak = "1.5.0"
+hex = "0.4.3"
+
+# master contains changes such as
+# https://github.com/paritytech/ethabi/pull/140, which upstream does not want
+# and we should try to implement on top of ethabi instead of inside it, and
+# tuple support which isn't upstreamed yet. For now, we shall deviate from
+# ethabi, but long term we want to find a way to drop our fork.
+ethabi = { git = "https://github.com/graphprotocol/ethabi.git", branch = "master" }
+
+# We have a couple custom patches to web3.
+web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "master" }
 
 [dev-dependencies]
 diesel = { version = "1.4.6", features = ["postgres", "serde_json", "numeric", "r2d2"] }

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -21,7 +21,7 @@ use graph::{
 };
 use graph::{components::ethereum::EthereumNetworkIdentifier, prelude::*};
 
-use crate::Chain;
+use crate::{data_source::DataSource, Chain};
 
 pub type EventSignature = H256;
 

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -17,9 +17,9 @@ use graph::{
     log::factory::{ComponentLoggerConfig, ElasticComponentLoggerConfig},
     prelude::{
         async_trait, error, lazy_static, o, serde_yaml, web3::types::H256, BlockFinality,
-        BlockNumber, ChainStore, DataSource, DeploymentHash, EthereumBlockWithCalls,
-        EthereumTrigger, Future01CompatExt, LinkResolver, Logger, LoggerFactory, MetricsRegistry,
-        NodeId, SubgraphStore,
+        BlockNumber, ChainStore, DeploymentHash, EthereumBlockWithCalls, EthereumTrigger,
+        Future01CompatExt, LinkResolver, Logger, LoggerFactory, MetricsRegistry, NodeId,
+        SubgraphStore,
     },
     runtime::{AscType, DeterministicHostError},
     tokio_stream::Stream,
@@ -27,6 +27,7 @@ use graph::{
 
 use crate::{
     adapter::EthereumAdapter as _,
+    data_source::DataSource,
     ethereum_adapter::{
         blocks_with_triggers, get_calls, parse_block_triggers, parse_call_triggers,
         parse_log_triggers,
@@ -96,7 +97,7 @@ impl Chain {
 impl Blockchain for Chain {
     type Block = WrappedBlockFinality;
 
-    type DataSource = graph::data::subgraph::DataSource;
+    type DataSource = DataSource;
 
     type DataSourceTemplate = DummyDataSourceTemplate;
 

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -1,11 +1,15 @@
 mod adapter;
 mod config;
+mod data_source;
 mod ethereum_adapter;
 pub mod network_indexer;
 mod transport;
 
 pub use self::ethereum_adapter::EthereumAdapter;
 pub use self::transport::{EventLoopHandle, Transport};
+
+// ETHDEP: This concrete type should probably not be exposed.
+pub use data_source::DataSource;
 
 pub mod chain;
 mod network;

--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -1,3 +1,5 @@
+use crate::data_source::DataSource;
+
 use super::*;
 use futures::future::FutureResult;
 use std::collections::BTreeSet;
@@ -17,7 +19,7 @@ fn create_subgraph(
     network_name: String,
 ) -> FutureResult<(), Error> {
     // Create a fake manifest
-    let manifest = SubgraphManifest {
+    let manifest = SubgraphManifest::<DataSource> {
         id: subgraph_id.clone(),
         spec_version: String::from("0.0.2"),
         features: BTreeSet::new(),

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -203,7 +203,7 @@ where
         NodeCapabilities = NodeCapabilities,
         Block = WrappedBlockFinality,
         TriggerData = EthereumTrigger,
-        DataSource = DataSource,
+        DataSource = graph_chain_ethereum::DataSource,
     >,
     M: MetricsRegistry,
     H: RuntimeHostBuilder<C>,
@@ -267,7 +267,7 @@ where
         NodeCapabilities = NodeCapabilities,
         Block = WrappedBlockFinality,
         TriggerData = EthereumTrigger,
-        DataSource = DataSource,
+        DataSource = graph_chain_ethereum::DataSource,
     >,
     M: MetricsRegistry,
     H: RuntimeHostBuilder<C>,
@@ -483,7 +483,7 @@ where
     C: Blockchain<
         Block = WrappedBlockFinality,
         TriggerData = EthereumTrigger,
-        DataSource = DataSource,
+        DataSource = graph_chain_ethereum::DataSource,
     >,
 {
     // Clone a few things for different parts of the async processing
@@ -708,7 +708,7 @@ where
     C: Blockchain<
         Block = WrappedBlockFinality,
         TriggerData = EthereumTrigger,
-        DataSource = DataSource,
+        DataSource = graph_chain_ethereum::DataSource,
     >,
 {
     let triggers = block.trigger_data;
@@ -1078,16 +1078,16 @@ fn create_dynamic_data_sources<T: RuntimeHostBuilder<C>, C>(
     ctx: &mut IndexingContext<T, C>,
     host_metrics: Arc<HostMetrics>,
     created_data_sources: Vec<DataSourceTemplateInfo>,
-) -> Result<(Vec<DataSource>, Vec<Arc<T::Host>>), Error>
+) -> Result<(Vec<graph_chain_ethereum::DataSource>, Vec<Arc<T::Host>>), Error>
 where
-    C: Blockchain,
+    C: Blockchain<DataSource = graph_chain_ethereum::DataSource>,
 {
     let mut data_sources = vec![];
     let mut runtime_hosts = vec![];
 
     for info in created_data_sources {
         // Try to instantiate a data source from the template
-        let data_source = DataSource::try_from(info)?;
+        let data_source = graph_chain_ethereum::DataSource::try_from(info)?;
 
         // Try to create a runtime host for the data source
         let host = ctx.state.instance.add_dynamic_data_source(
@@ -1125,9 +1125,9 @@ fn persist_dynamic_data_sources<T: RuntimeHostBuilder<C>, C>(
     logger: Logger,
     ctx: &mut IndexingContext<T, C>,
     entity_cache: &mut EntityCache,
-    data_sources: Vec<DataSource>,
+    data_sources: Vec<graph_chain_ethereum::DataSource>,
 ) where
-    C: Blockchain<DataSource = DataSource>,
+    C: Blockchain<DataSource = graph_chain_ethereum::DataSource>,
 {
     if !data_sources.is_empty() {
         debug!(

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -10,7 +10,7 @@ pub async fn load_dynamic_data_sources(
     deployment_id: &DeploymentHash,
     logger: Logger,
     templates: Vec<DataSourceTemplate>,
-) -> Result<Vec<DataSource>, Error> {
+) -> Result<Vec<graph_chain_ethereum::DataSource>, Error> {
     let start_time = Instant::now();
 
     let template_map: HashMap<&str, &DataSourceTemplate> = HashMap::from_iter(
@@ -18,7 +18,7 @@ pub async fn load_dynamic_data_sources(
             .iter()
             .map(|template| (template.name.as_str(), template)),
     );
-    let mut data_sources: Vec<DataSource> = vec![];
+    let mut data_sources: Vec<graph_chain_ethereum::DataSource> = vec![];
 
     for stored in store.load_dynamic_data_sources().await? {
         let StoredDynamicDataSource {
@@ -41,7 +41,7 @@ pub async fn load_dynamic_data_sources(
 
         let contract_abi = template.mapping.find_abi(&template.source.abi)?;
 
-        let ds = DataSource {
+        let ds = graph_chain_ethereum::DataSource {
             kind: template.kind.clone(),
             network: template.network.clone(),
             name,

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -65,3 +65,4 @@ web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "master" }
 test-store = { path = "../store/test-store" }
 maplit = "1.0.2"
 structopt = { version = "0.3" }
+graph-chain-ethereum = { path = "../chain/ethereum" }

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -163,7 +163,7 @@ pub trait TriggerFilter<C: Blockchain>: Default + Clone + Send + Sync {
 }
 
 // ETHDEP: `Source` and `Mapping`, at least, are Ethereum-specific.
-pub trait DataSource: 'static + Sized + Send + Sync + Debug {
+pub trait DataSource: 'static + Sized + Send + Sync {
     type C: Blockchain;
 
     fn mapping(&self) -> &Mapping;

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -42,7 +42,7 @@ impl MappingError {
 
 /// Common trait for runtime host implementations.
 #[async_trait]
-pub trait RuntimeHost<C: Blockchain>: Send + Sync + Debug + 'static {
+pub trait RuntimeHost<C: Blockchain>: Send + Sync + 'static {
     fn match_and_decode(
         &self,
         trigger: &EthereumTrigger,
@@ -156,7 +156,7 @@ pub trait RuntimeHostBuilder<C: Blockchain>: Clone + Send + Sync + 'static {
         &self,
         network_name: String,
         subgraph_id: DeploymentHash,
-        data_source: DataSource,
+        data_source: C::DataSource,
         top_level_templates: Arc<Vec<DataSourceTemplate>>,
         mapping_request_sender: mpsc::Sender<Self::Req>,
         metrics: Arc<HostMetrics>,

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -11,10 +11,10 @@ use std::{fmt, fmt::Display};
 
 use super::DeploymentHash;
 use crate::components::store::EntityType;
-use crate::data::graphql::TryFromValue;
 use crate::data::store::Value;
 use crate::data::subgraph::SubgraphManifest;
 use crate::prelude::*;
+use crate::{blockchain::DataSource, data::graphql::TryFromValue};
 
 pub const POI_TABLE: &str = "poi2$";
 lazy_static! {
@@ -113,7 +113,7 @@ pub struct SubgraphDeploymentEntity {
 
 impl SubgraphDeploymentEntity {
     pub fn new(
-        source_manifest: &SubgraphManifest,
+        source_manifest: &SubgraphManifest<impl DataSource>,
         synced: bool,
         earliest_block: Option<BlockPtr>,
     ) -> Self {
@@ -155,8 +155,8 @@ pub struct SubgraphManifestEntity {
     pub schema: String,
 }
 
-impl<'a> From<&'a super::SubgraphManifest> for SubgraphManifestEntity {
-    fn from(manifest: &'a super::SubgraphManifest) -> Self {
+impl<'a, DS: DataSource> From<&'a super::SubgraphManifest<DS>> for SubgraphManifestEntity {
+    fn from(manifest: &'a super::SubgraphManifest<DS>) -> Self {
         Self {
             spec_version: manifest.spec_version.clone(),
             description: manifest.description.clone(),

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -142,9 +142,9 @@ pub mod prelude {
     };
     pub use crate::data::subgraph::schema::SubgraphDeploymentEntity;
     pub use crate::data::subgraph::{
-        BlockHandlerFilter, CreateSubgraphResult, DataSource, DataSourceContext,
-        DataSourceTemplate, DeploymentHash, DeploymentState, Link, MappingABI, MappingBlockHandler,
-        MappingCallHandler, MappingEventHandler, SubgraphAssignmentProviderError, SubgraphManifest,
+        BlockHandlerFilter, CreateSubgraphResult, DataSourceContext, DataSourceTemplate,
+        DeploymentHash, DeploymentState, Link, MappingABI, MappingBlockHandler, MappingCallHandler,
+        MappingEventHandler, SubgraphAssignmentProviderError, SubgraphManifest,
         SubgraphManifestResolveError, SubgraphManifestValidationError, SubgraphName,
         SubgraphRegistrarError, UnvalidatedSubgraphManifest,
     };

--- a/graph/tests/manifest.rs
+++ b/graph/tests/manifest.rs
@@ -58,7 +58,7 @@ const ABI: &str = "[{\"type\":\"function\", \"inputs\": [{\"name\": \"i\",\"type
 
 const MAPPING: &str = "export function handleGet(call: getCall): void {}";
 
-async fn resolve_manifest(text: &str) -> SubgraphManifest {
+async fn resolve_manifest(text: &str) -> SubgraphManifest<graph_chain_ethereum::DataSource> {
     let mut resolver = TextResolver::default();
     let id = DeploymentHash::new("Qmmanifest").unwrap();
 
@@ -72,7 +72,9 @@ async fn resolve_manifest(text: &str) -> SubgraphManifest {
         .expect("Parsing simple manifest works")
 }
 
-async fn resolve_unvalidated(text: &str) -> UnvalidatedSubgraphManifest {
+async fn resolve_unvalidated(
+    text: &str,
+) -> UnvalidatedSubgraphManifest<graph_chain_ethereum::DataSource> {
     let mut resolver = TextResolver::default();
     let id = DeploymentHash::new("Qmmanifest").unwrap();
 

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -20,3 +20,4 @@ anyhow = "1.0"
 [dev-dependencies]
 pretty_assertions = "0.7.2"
 test-store = { path = "../store/test-store" }
+graph-chain-ethereum = { path = "../chain/ethereum" }

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -48,7 +48,7 @@ fn setup_with_features(id: &str, features: BTreeSet<SubgraphFeature>) -> Deploym
     test_store::remove_subgraphs();
 
     let schema = test_schema(id.clone());
-    let manifest = SubgraphManifest {
+    let manifest = SubgraphManifest::<graph_chain_ethereum::DataSource> {
         id: id.clone(),
         spec_version: "1".to_owned(),
         features,
@@ -101,7 +101,7 @@ fn test_schema(id: DeploymentHash) -> Schema {
 
 fn insert_test_entities(
     store: &impl SubgraphStore,
-    manifest: SubgraphManifest,
+    manifest: SubgraphManifest<graph_chain_ethereum::DataSource>,
 ) -> DeploymentLocator {
     let deployment = SubgraphDeploymentEntity::new(&manifest, false, None);
     let name = SubgraphName::new("test/query").unwrap();

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -98,7 +98,7 @@ impl std::fmt::Debug for HostExports {
 impl HostExports {
     pub(crate) fn new(
         subgraph_id: DeploymentHash,
-        data_source: &DataSource,
+        data_source: &graph_chain_ethereum::DataSource,
         data_source_network: String,
         templates: Arc<Vec<DataSourceTemplate>>,
         ethereum_adapter: Arc<dyn EthereumAdapterTrait>,

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -8,7 +8,7 @@ use graph::data::store::scalar;
 use graph::data::subgraph::*;
 use graph::{components::store::*, ipfs_client::IpfsClient};
 use graph_chain_arweave::adapter::ArweaveAdapter;
-use graph_chain_ethereum::MockEthereumAdapter;
+use graph_chain_ethereum::{DataSource, MockEthereumAdapter};
 use graph_core;
 use graph_core::three_box::ThreeBoxAdapter;
 use graph_mock::MockMetricsRegistry;

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -117,7 +117,7 @@ where
 /// Inserts data in test blocks 1, 2, and 3, leaving test blocks 3A, 4, and 4A for the tests to
 /// use.
 fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator {
-    let manifest = SubgraphManifest {
+    let manifest = SubgraphManifest::<graph_chain_ethereum::DataSource> {
         id: TEST_SUBGRAPH_ID.clone(),
         spec_version: "1".to_owned(),
         features: Default::default(),

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use std::{collections::HashSet, sync::Mutex};
 use test_store::*;
 
-use graph::components::store::{DeploymentLocator, WritableStore};
+use graph::components::store::{DeploymentLocator, StoredDynamicDataSource, WritableStore};
 use graph::data::subgraph::*;
 use graph::prelude::*;
 use graph::{
@@ -150,7 +150,7 @@ where
 /// Inserts data in test blocks `GENESIS_PTR`, `TEST_BLOCK_1_PTR`, and
 /// `TEST_BLOCK_2_PTR`
 fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator {
-    let manifest = SubgraphManifest {
+    let manifest = SubgraphManifest::<graph_chain_ethereum::DataSource> {
         id: TEST_SUBGRAPH_ID.clone(),
         spec_version: "1".to_owned(),
         features: Default::default(),
@@ -1132,8 +1132,8 @@ fn revert_block_with_partial_update() {
     })
 }
 
-fn mock_data_source() -> DataSource {
-    DataSource {
+fn mock_data_source() -> graph_chain_ethereum::DataSource {
+    graph_chain_ethereum::DataSource {
         kind: String::from("ethereum/contract"),
         name: String::from("example data source"),
         network: Some(String::from("mainnet")),
@@ -1215,7 +1215,7 @@ fn revert_block_with_dynamic_data_source_operations() {
             &subgraph_store,
             deployment.clone(),
             TEST_BLOCK_3_PTR.clone(),
-            vec![&data_source],
+            vec![StoredDynamicDataSource::from(&data_source)],
             ops,
         )
         .unwrap();
@@ -1273,7 +1273,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
         let subgraph_id = DeploymentHash::new("EntityChangeTestSubgraph").unwrap();
         let schema =
             Schema::parse(USER_GQL, subgraph_id.clone()).expect("Failed to parse user schema");
-        let manifest = SubgraphManifest {
+        let manifest = SubgraphManifest::<graph_chain_ethereum::DataSource> {
             id: subgraph_id.clone(),
             spec_version: "1".to_owned(),
             features: Default::default(),

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -112,7 +112,7 @@ fn create_subgraph() {
         let id = DeploymentHash::new(id.to_string()).unwrap();
         let schema = Schema::parse(SUBGRAPH_GQL, id.clone()).unwrap();
 
-        let manifest = SubgraphManifest {
+        let manifest = SubgraphManifest::<graph_chain_ethereum::DataSource> {
             id: id.clone(),
             spec_version: "1".to_owned(),
             features: Default::default(),

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -15,3 +15,4 @@ graph-store-postgres = { path = "../postgres" }
 lazy_static = "1.1"
 hex-literal = "0.3"
 diesel = { version = "1.4.6", features = ["postgres", "serde_json", "numeric", "r2d2"] }
+graph-chain-ethereum = { path = "../../chain/ethereum" }

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -152,7 +152,7 @@ pub fn create_subgraph(
 ) -> Result<DeploymentLocator, StoreError> {
     let schema = Schema::parse(schema, subgraph_id.clone()).unwrap();
 
-    let manifest = SubgraphManifest {
+    let manifest = SubgraphManifest::<graph_chain_ethereum::DataSource> {
         id: subgraph_id.clone(),
         spec_version: "1".to_owned(),
         features: BTreeSet::new(),
@@ -238,7 +238,7 @@ pub fn transact_entities_and_dynamic_data_sources(
     store: &Arc<DieselSubgraphStore>,
     deployment: DeploymentLocator,
     block_ptr_to: BlockPtr,
-    data_sources: Vec<&DataSource>,
+    data_sources: Vec<StoredDynamicDataSource>,
     ops: Vec<EntityOperation>,
 ) -> Result<(), StoreError> {
     let store = store.writable(&deployment)?;
@@ -254,10 +254,6 @@ pub fn transact_entities_and_dynamic_data_sources(
         deployment.hash.clone(),
         metrics_registry.clone(),
     );
-    let data_sources = data_sources
-        .into_iter()
-        .map(StoredDynamicDataSource::from)
-        .collect();
     store.transact_block_operations(
         block_ptr_to,
         mods,


### PR DESCRIPTION
This does the minimal necessary to move the module `graph/src/data/subgraph/data_source.rs` to `chain/ethereum/src/data_source.rs`, which unblocks other refactorings. There are still a lot of Ethereum dependencies in the manifest data structures.