### PR TITLE
Remove generic type parameter from ArrayBuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "graphql-parser"
 version = "0.3.0"
-source = "git+https://github.com/graphql-rust/graphql-parser#45167b53e9533c331298683577ba8df7e43480ac"
+source = "git+https://github.com/graphql-rust/graphql-parser?rev=45167b53e9533c331298683577ba8df7e43480ac#45167b53e9533c331298683577ba8df7e43480ac"
 dependencies = [
  "combine",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,8 +1758,8 @@ dependencies = [
 name = "graph-runtime-derive"
 version = "0.22.0"
 dependencies = [
- "quote 0.6.13",
- "syn 0.15.44",
+ "quote 1.0.7",
+ "syn 1.0.62",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ members = [
 
 [patch.crates-io]
 # Include protection against stack overflow when parsing from this PR: https://github.com/graphql-rust/graphql-parser/commit/45167b53e9533c331298683577ba8df7e43480ac
-graphql-parser = {git="https://github.com/graphql-rust/graphql-parser", commit="45167b53e9533c331298683577ba8df7e43480ac"}
+graphql-parser = {git="https://github.com/graphql-rust/graphql-parser", rev="45167b53e9533c331298683577ba8df7e43480ac"}

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -385,7 +385,7 @@ impl Stream for DummyBlockStream {
 pub struct DummyMappingTrigger;
 
 impl AscType for DummyMappingTrigger {
-    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
+    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
         todo!()
     }
 

--- a/graph/src/runtime/asc_ptr.rs
+++ b/graph/src/runtime/asc_ptr.rs
@@ -94,7 +94,7 @@ impl<C> From<u32> for AscPtr<C> {
 }
 
 impl<T> AscType for AscPtr<T> {
-    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
+    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
         self.0.to_asc_bytes()
     }
 

--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -25,7 +25,7 @@ use std::mem::size_of;
 pub trait AscType: Sized {
     /// Transform the Rust representation of this instance into an sequence of
     /// bytes that is precisely the memory layout of a corresponding Asc instance.
-    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError>;
+    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError>;
 
     /// The Rust representation of an Asc object as layed out in Asc memory.
     fn from_asc_bytes(asc_obj: &[u8]) -> Result<Self, DeterministicHostError>;
@@ -42,8 +42,8 @@ pub trait AscType: Sized {
 pub trait AscValue: AscType + Copy + Default {}
 
 impl AscType for bool {
-    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
-        Ok(vec![self as u8])
+    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+        Ok(vec![*self as u8])
     }
 
     fn from_asc_bytes(asc_obj: &[u8]) -> Result<Self, DeterministicHostError> {
@@ -65,7 +65,7 @@ macro_rules! impl_asc_type {
     ($($T:ty),*) => {
         $(
             impl AscType for $T {
-                fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
+                fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
                     Ok(self.to_le_bytes().to_vec())
                 }
 

--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -36,6 +36,20 @@ pub trait AscType: Sized {
     }
 }
 
+// Only implemented because of structs that derive AscType and
+// contain fields that are PhantomData.
+impl<T> AscType for std::marker::PhantomData<T> {
+    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+        Ok(vec![])
+    }
+
+    fn from_asc_bytes(asc_obj: &[u8]) -> Result<Self, DeterministicHostError> {
+        assert!(asc_obj.len() == 0);
+
+        Ok(Self)
+    }
+}
+
 /// An Asc primitive or an `AscPtr` into the Asc heap. A type marked as
 /// `AscValue` must have the same byte representation in Rust and Asc, including
 /// same size, and size must be equal to alignment.

--- a/runtime/derive/Cargo.toml
+++ b/runtime/derive/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = { version = "0.15", features = ["full"] }
-quote = "0.6"
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"

--- a/runtime/derive/src/lib.rs
+++ b/runtime/derive/src/lib.rs
@@ -26,7 +26,7 @@ pub fn asc_type_derive(input: TokenStream) -> TokenStream {
 //
 // Example output:
 // impl<K, V> AscType for AscTypedMapEntry<K, V> {
-//     fn to_asc_bytes(self) -> Vec<u8> {
+//     fn to_asc_bytes(&self) -> Vec<u8> {
 //         let mut bytes = Vec::new();
 //         bytes.extend_from_slice(&self.key.to_asc_bytes());
 //         bytes.extend_from_slice(&self.value.to_asc_bytes());
@@ -67,7 +67,7 @@ fn asc_type_derive_struct(item_struct: ItemStruct) -> TokenStream {
 
     TokenStream::from(quote! {
         impl#impl_generics AscType for #struct_name#ty_generics #where_clause {
-            fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
+            fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
                let mut bytes = Vec::new();
                 #(bytes.extend_from_slice(&self.#field_names.to_asc_bytes()?);)*
 
@@ -114,7 +114,7 @@ fn asc_type_derive_struct(item_struct: ItemStruct) -> TokenStream {
 //
 // Example output:
 // impl AscType for JsonValueKind {
-//     fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
+//     fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
 //         let discriminant: u32 = match *self {
 //             JsonValueKind::Null => 0u32,
 //             JsonValueKind::Bool => 1u32,
@@ -163,7 +163,7 @@ fn asc_type_derive_enum(item_enum: ItemEnum) -> TokenStream {
 
     TokenStream::from(quote! {
         impl#impl_generics AscType for #enum_name#ty_generics #where_clause {
-            fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
+            fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
                 let discriminant: u32 = match self {
                     #(#enum_name_iter::#variant_paths => #variant_discriminant,)*
                 };

--- a/runtime/wasm/src/asc_abi/class.rs
+++ b/runtime/wasm/src/asc_abi/class.rs
@@ -81,7 +81,7 @@ impl<T: AscValue> ArrayBuffer<T> {
 }
 
 impl<T> AscType for ArrayBuffer<T> {
-    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
+    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
         let mut asc_layout: Vec<u8> = Vec::new();
 
         let byte_length: [u8; 4] = self.byte_length.to_le_bytes();
@@ -187,7 +187,7 @@ impl AscString {
 }
 
 impl AscType for AscString {
-    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
+    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
         let mut asc_layout: Vec<u8> = Vec::new();
 
         let length: [u8; 4] = self.length.to_le_bytes();
@@ -293,7 +293,7 @@ impl<T: AscValue> Array<T> {
 pub(crate) struct EnumPayload(pub u64);
 
 impl AscType for EnumPayload {
-    fn to_asc_bytes(self) -> Result<Vec<u8>, DeterministicHostError> {
+    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
         self.0.to_asc_bytes()
     }
 

--- a/runtime/wasm/src/asc_abi/class.rs
+++ b/runtime/wasm/src/asc_abi/class.rs
@@ -16,7 +16,7 @@ use std::mem::{size_of, size_of_val};
 
 /// Asc std ArrayBuffer: "a generic, fixed-length raw binary data buffer".
 /// See https://github.com/AssemblyScript/assemblyscript/wiki/Memory-Layout-&-Management#arrays
-pub(crate) struct ArrayBuffer<T> {
+pub(crate) struct ArrayBuffer {
     byte_length: u32,
     // Asc allocators always align at 8 bytes, we already have 4 bytes from
     // `byte_length_size` so with 4 more bytes we align the contents at 8
@@ -25,11 +25,10 @@ pub(crate) struct ArrayBuffer<T> {
     padding: [u8; 4],
     // In Asc this slice is layed out inline with the ArrayBuffer.
     content: Box<[u8]>,
-    ty: PhantomData<T>,
 }
 
-impl<T: AscValue> ArrayBuffer<T> {
-    fn new(values: &[T]) -> Result<Self, DeterministicHostError> {
+impl ArrayBuffer {
+    fn new<T: AscType>(values: &[T]) -> Result<Self, DeterministicHostError> {
         let mut content = Vec::new();
         for value in values {
             let asc_bytes = value.to_asc_bytes()?;
@@ -46,14 +45,17 @@ impl<T: AscValue> ArrayBuffer<T> {
             byte_length: content.len() as u32,
             padding: [0; 4],
             content: content.into(),
-            ty: PhantomData,
         })
     }
 
     /// Read `length` elements of type `T` starting at `byte_offset`.
     ///
     /// Panics if that tries to read beyond the length of `self.content`.
-    fn get(&self, byte_offset: u32, length: u32) -> Result<Vec<T>, DeterministicHostError> {
+    fn get<T: AscType>(
+        &self,
+        byte_offset: u32,
+        length: u32,
+    ) -> Result<Vec<T>, DeterministicHostError> {
         let length = length as usize;
         let byte_offset = byte_offset as usize;
 
@@ -80,7 +82,7 @@ impl<T: AscValue> ArrayBuffer<T> {
     }
 }
 
-impl<T> AscType for ArrayBuffer<T> {
+impl AscType for ArrayBuffer {
     fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
         let mut asc_layout: Vec<u8> = Vec::new();
 
@@ -114,7 +116,6 @@ impl<T> AscType for ArrayBuffer<T> {
             byte_length: u32::from_asc_bytes(&byte_length)?,
             padding: [0; 4],
             content: content.to_vec().into(),
-            ty: PhantomData,
         })
     }
 
@@ -133,10 +134,11 @@ impl<T> AscType for ArrayBuffer<T> {
 #[repr(C)]
 #[derive(AscType)]
 pub(crate) struct TypedArray<T> {
-    pub buffer: AscPtr<ArrayBuffer<T>>,
+    pub buffer: AscPtr<ArrayBuffer>,
     /// Byte position in `buffer` of the array start.
     byte_offset: u32,
     byte_length: u32,
+    ty: PhantomData<T>,
 }
 
 impl<T: AscValue> TypedArray<T> {
@@ -149,6 +151,7 @@ impl<T: AscValue> TypedArray<T> {
             byte_length: buffer.byte_length,
             buffer: AscPtr::alloc_obj(buffer, heap)?,
             byte_offset: 0,
+            ty: PhantomData,
         })
     }
 
@@ -269,8 +272,9 @@ impl AscType for AscString {
 #[repr(C)]
 #[derive(AscType)]
 pub(crate) struct Array<T> {
-    buffer: AscPtr<ArrayBuffer<T>>,
+    buffer: AscPtr<ArrayBuffer>,
     length: u32,
+    ty: PhantomData<T>,
 }
 
 impl<T: AscValue> Array<T> {
@@ -279,6 +283,7 @@ impl<T: AscValue> Array<T> {
             buffer: AscPtr::alloc_obj(ArrayBuffer::new(content)?, heap)?,
             // If this cast would overflow, the above line has already panicked.
             length: content.len() as u32,
+            ty: PhantomData,
         })
     }
 

--- a/runtime/wasm/src/module/test/abi.rs
+++ b/runtime/wasm/src/module/test/abi.rs
@@ -103,7 +103,7 @@ async fn abi_ethabi_token_identity() {
     let token_address = Token::Address(address);
 
     let token_address_ptr = module.asc_new(&token_address).unwrap();
-    let new_address_obj: AscPtr<ArrayBuffer<u8>> =
+    let new_address_obj: AscPtr<ArrayBuffer> =
         module.invoke_export("token_to_address", token_address_ptr);
 
     let new_token_ptr = module.invoke_export("token_from_address", new_address_obj);
@@ -115,7 +115,7 @@ async fn abi_ethabi_token_identity() {
     let token_bytes = Token::Bytes(vec![42, 45, 7, 245, 45]);
 
     let token_bytes_ptr = module.asc_new(&token_bytes).unwrap();
-    let new_bytes_obj: AscPtr<ArrayBuffer<u8>> =
+    let new_bytes_obj: AscPtr<ArrayBuffer> =
         module.invoke_export("token_to_bytes", token_bytes_ptr);
 
     let new_token_ptr = module.invoke_export("token_from_bytes", new_bytes_obj);
@@ -127,7 +127,7 @@ async fn abi_ethabi_token_identity() {
     let int_token = Token::Int(U256([256, 453452345, 0, 42]));
 
     let int_token_ptr = module.asc_new(&int_token).unwrap();
-    let new_int_obj: AscPtr<ArrayBuffer<u8>> = module.invoke_export("token_to_int", int_token_ptr);
+    let new_int_obj: AscPtr<ArrayBuffer> = module.invoke_export("token_to_int", int_token_ptr);
 
     let new_token_ptr = module.invoke_export("token_from_int", new_int_obj);
     let new_token = module.asc_get(new_token_ptr).unwrap();
@@ -138,8 +138,7 @@ async fn abi_ethabi_token_identity() {
     let uint_token = Token::Uint(U256([256, 453452345, 0, 42]));
 
     let uint_token_ptr = module.asc_new(&uint_token).unwrap();
-    let new_uint_obj: AscPtr<ArrayBuffer<u8>> =
-        module.invoke_export("token_to_uint", uint_token_ptr);
+    let new_uint_obj: AscPtr<ArrayBuffer> = module.invoke_export("token_to_uint", uint_token_ptr);
 
     let new_token_ptr = module.invoke_export("token_from_uint", new_uint_obj);
     let new_token = module.asc_get(new_token_ptr).unwrap();


### PR DESCRIPTION
I've done some simple fixes as well as removing the generic type parameter.

One of them is to rollback this PR: https://github.com/graphprotocol/graph-node/pull/2457

This is being done so that its a bit easier to do the AssemblyScript update (that I'm working on).