### PR TITLE
Sort network adapters

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -506,6 +506,7 @@ async fn create_ethereum_networks(
             );
         }
     }
+    parsed_networks.sort();
     Ok(parsed_networks)
 }
 


### PR DESCRIPTION
We weren't sorting them at all, so `cheapest` was selecting the first adapter, not the cheapest adapter. See also #2466 which I've found out about.