### PR TITLE
Fix trigger ordering

### DIFF
--- a/chain/ethereum/tests/triggers.rs
+++ b/chain/ethereum/tests/triggers.rs
@@ -1,0 +1,93 @@
+use std::sync::Arc;
+
+use graph::{
+    blockchain::{block_stream::BlockWithTriggers, BlockPtr},
+    prelude::{BlockFinality, EthereumBlockTriggerType, EthereumCall, EthereumTrigger},
+};
+use graph_chain_ethereum::WrappedBlockFinality;
+use web3::types::*;
+
+#[test]
+fn test_trigger_ordering() {
+    let block1 = EthereumTrigger::Block(
+        BlockPtr::from((H256::random(), 1u64)),
+        EthereumBlockTriggerType::Every,
+    );
+
+    let block2 = EthereumTrigger::Block(
+        BlockPtr::from((H256::random(), 0u64)),
+        EthereumBlockTriggerType::WithCallTo(Address::random()),
+    );
+
+    let mut call1 = EthereumCall::default();
+    call1.transaction_index = 1;
+    let call1 = EthereumTrigger::Call(Arc::new(call1));
+
+    let mut call2 = EthereumCall::default();
+    call2.transaction_index = 2;
+    let call2 = EthereumTrigger::Call(Arc::new(call2));
+
+    let mut call3 = EthereumCall::default();
+    call3.transaction_index = 3;
+    let call3 = EthereumTrigger::Call(Arc::new(call3));
+
+    // Call with the same tx index as call2
+    let mut call4 = EthereumCall::default();
+    call4.transaction_index = 2;
+    let call4 = EthereumTrigger::Call(Arc::new(call4));
+
+    fn create_log(tx_index: u64, log_index: u64) -> Arc<Log> {
+        Arc::new(Log {
+            address: H160::default(),
+            topics: vec![],
+            data: Bytes::default(),
+            block_hash: Some(H256::zero()),
+            block_number: Some(U64::zero()),
+            transaction_hash: Some(H256::zero()),
+            transaction_index: Some(tx_index.into()),
+            log_index: Some(log_index.into()),
+            transaction_log_index: Some(log_index.into()),
+            log_type: Some("".into()),
+            removed: Some(false),
+        })
+    }
+
+    // Event with transaction_index 1 and log_index 0;
+    // should be the first element after sorting
+    let log1 = EthereumTrigger::Log(create_log(1, 0));
+
+    // Event with transaction_index 1 and log_index 1;
+    // should be the second element after sorting
+    let log2 = EthereumTrigger::Log(create_log(1, 1));
+
+    // Event with transaction_index 2 and log_index 5;
+    // should come after call1 and before call2 after sorting
+    let log3 = EthereumTrigger::Log(create_log(2, 5));
+
+    let triggers = vec![
+        // Call triggers; these should be in the order 1, 2, 4, 3 after sorting
+        call3.clone(),
+        call1.clone(),
+        call2.clone(),
+        call4.clone(),
+        // Block triggers; these should appear at the end after sorting
+        // but with their order unchanged
+        block2.clone(),
+        block1.clone(),
+        // Event triggers
+        log3.clone(),
+        log2.clone(),
+        log1.clone(),
+    ];
+
+    // Test that `BlockWithTriggers` sorts the triggers.
+    let block_with_triggers = BlockWithTriggers::<graph_chain_ethereum::Chain>::new(
+        WrappedBlockFinality(BlockFinality::Final(Default::default())),
+        triggers,
+    );
+
+    assert_eq!(
+        block_with_triggers.trigger_data,
+        vec![log1, log2, call1, log3, call2, call4, call3, block2, block1]
+    );
+}

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -21,7 +21,9 @@ pub struct BlockWithTriggers<C: Blockchain> {
 }
 
 impl<C: Blockchain> BlockWithTriggers<C> {
-    pub fn new(block: C::Block, trigger_data: Vec<C::TriggerData>) -> Self {
+    pub fn new(block: C::Block, mut trigger_data: Vec<C::TriggerData>) -> Self {
+        // This is where triggers get sorted.
+        trigger_data.sort();
         Self {
             block,
             trigger_data,

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -59,7 +59,7 @@ pub trait Blockchain: Sized + Send + Sync + 'static {
     type TriggersAdapter: TriggersAdapter<Self>;
 
     /// Trigger data as parsed from the triggers adapter.
-    type TriggerData;
+    type TriggerData: Ord;
 
     /// Decoded trigger ready to be processed by the mapping.
     type MappingTrigger: AscType;

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -135,7 +135,7 @@ pub struct EthereumCall {
     pub block_number: BlockNumber,
     pub block_hash: H256,
     pub transaction_hash: Option<H256>,
-    transaction_index: u64,
+    pub transaction_index: u64,
 }
 
 impl EthereumCall {
@@ -548,93 +548,5 @@ impl<'a> From<&'a BlockFinality> for BlockPtr {
 impl ToEntityKey for BlockPtr {
     fn to_entity_key(&self, subgraph: DeploymentHash) -> EntityKey {
         EntityKey::data(subgraph, "Block".into(), self.hash_hex())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use std::sync::Arc;
-
-    use super::{BlockPtr, EthereumBlockTriggerType, EthereumCall, EthereumTrigger};
-    use web3::types::*;
-
-    #[test]
-    fn test_trigger_ordering() {
-        let block1 = EthereumTrigger::Block(
-            BlockPtr::from((H256::random(), 1u64)),
-            EthereumBlockTriggerType::Every,
-        );
-
-        let block2 = EthereumTrigger::Block(
-            BlockPtr::from((H256::random(), 0u64)),
-            EthereumBlockTriggerType::WithCallTo(Address::random()),
-        );
-
-        let mut call1 = EthereumCall::default();
-        call1.transaction_index = 1;
-        let call1 = EthereumTrigger::Call(Arc::new(call1));
-
-        let mut call2 = EthereumCall::default();
-        call2.transaction_index = 2;
-        let call2 = EthereumTrigger::Call(Arc::new(call2));
-
-        let mut call3 = EthereumCall::default();
-        call3.transaction_index = 3;
-        let call3 = EthereumTrigger::Call(Arc::new(call3));
-
-        // Call with the same tx index as call2
-        let mut call4 = EthereumCall::default();
-        call4.transaction_index = 2;
-        let call4 = EthereumTrigger::Call(Arc::new(call4));
-
-        fn create_log(tx_index: u64, log_index: u64) -> Arc<Log> {
-            Arc::new(Log {
-                address: H160::default(),
-                topics: vec![],
-                data: Bytes::default(),
-                block_hash: Some(H256::zero()),
-                block_number: Some(U64::zero()),
-                transaction_hash: Some(H256::zero()),
-                transaction_index: Some(tx_index.into()),
-                log_index: Some(log_index.into()),
-                transaction_log_index: Some(log_index.into()),
-                log_type: Some("".into()),
-                removed: Some(false),
-            })
-        }
-
-        // Event with transaction_index 1 and log_index 0;
-        // should be the first element after sorting
-        let log1 = EthereumTrigger::Log(create_log(1, 0));
-
-        // Event with transaction_index 1 and log_index 1;
-        // should be the second element after sorting
-        let log2 = EthereumTrigger::Log(create_log(1, 1));
-
-        // Event with transaction_index 2 and log_index 5;
-        // should come after call1 and before call2 after sorting
-        let log3 = EthereumTrigger::Log(create_log(2, 5));
-
-        let mut triggers = vec![
-            // Call triggers; these should be in the order 1, 2, 4, 3 after sorting
-            call3.clone(),
-            call1.clone(),
-            call2.clone(),
-            call4.clone(),
-            // Block triggers; these should appear at the end after sorting
-            // but with their order unchanged
-            block2.clone(),
-            block1.clone(),
-            // Event triggers
-            log3.clone(),
-            log2.clone(),
-            log1.clone(),
-        ];
-        triggers.sort();
-
-        assert_eq!(
-            triggers,
-            vec![log1, log2, call1, log3, call2, call4, call3, block2, block1]
-        );
     }
 }


### PR DESCRIPTION
The call to `sort()` was lost when refactoring from `EthereumBlockWithTriggers` to `BlockWithTriggers`.