### PR TITLE
Add timestamps for deployment_schemas and unused_deployments tables

### DIFF
--- a/store/postgres/migrations/2021-05-21-165219_add_created_at_columns_for_deployment_schemas/down.sql
+++ b/store/postgres/migrations/2021-05-21-165219_add_created_at_columns_for_deployment_schemas/down.sql
@@ -1,0 +1,5 @@
+alter table public.deployment_schemas
+    drop column created_at;
+
+alter table public.unused_deployments
+    drop column deployment_created_at;

--- a/store/postgres/migrations/2021-05-21-165219_add_created_at_columns_for_deployment_schemas/down.sql
+++ b/store/postgres/migrations/2021-05-21-165219_add_created_at_columns_for_deployment_schemas/down.sql
@@ -2,4 +2,4 @@ alter table public.deployment_schemas
     drop column created_at;
 
 alter table public.unused_deployments
-    drop column deployment_created_at;
+    drop column created_at;

--- a/store/postgres/migrations/2021-05-21-165219_add_created_at_columns_for_deployment_schemas/up.sql
+++ b/store/postgres/migrations/2021-05-21-165219_add_created_at_columns_for_deployment_schemas/up.sql
@@ -2,4 +2,13 @@ alter table public.deployment_schemas
     add column created_at timestamptz not null default now();
 
 alter table public.unused_deployments
-    add column created_at timestamptz not null;
+    add column created_at timestamptz;
+
+-- use a predefined default date that doesn't have a meaning.
+update
+    public.unused_deployments
+set
+    created_at = '2000-01-01';
+
+alter table public.unused_deployments
+    alter column created_at set not null;

--- a/store/postgres/migrations/2021-05-21-165219_add_created_at_columns_for_deployment_schemas/up.sql
+++ b/store/postgres/migrations/2021-05-21-165219_add_created_at_columns_for_deployment_schemas/up.sql
@@ -1,0 +1,5 @@
+alter table public.deployment_schemas
+    add column created_at timestamptz not null default now();
+
+alter table public.unused_deployments
+    add column deployment_created_at timestamptz not null;

--- a/store/postgres/migrations/2021-05-21-165219_add_created_at_columns_for_deployment_schemas/up.sql
+++ b/store/postgres/migrations/2021-05-21-165219_add_created_at_columns_for_deployment_schemas/up.sql
@@ -2,4 +2,4 @@ alter table public.deployment_schemas
     add column created_at timestamptz not null default now();
 
 alter table public.unused_deployments
-    add column deployment_created_at timestamptz not null;
+    add column created_at timestamptz not null;

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -144,7 +144,7 @@ table! {
         id -> Integer,
         // The IPFS hash of the deployment
         deployment -> Text,
-        // When we first detected that the deployment was unsued
+        // When we first detected that the deployment was unused
         unused_at -> Timestamptz,
         // When we actually deleted the deployment
         removed_at -> Nullable<Timestamptz>,
@@ -1210,7 +1210,7 @@ impl<'a> Connection<'a> {
             .collect()
     }
 
-    /// Add details from the deployment shard to unuseddeployments
+    /// Add details from the deployment shard to unused deployments
     pub fn update_unused_deployments(
         &self,
         details: &Vec<DeploymentDetail>,


### PR DESCRIPTION
Resolves  #2224

- [x] add timestamp to `deployment_schemas` table
- [x] copy that column data  to `unused_deployments` when a deployment is recorded as unused  
- [x] fix compilation errors