### PR TITLE
chain, graph: Move manifest tests to chain crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,6 @@ dependencies = [
  "fail",
  "futures 0.1.31",
  "futures 0.3.13",
- "graph-chain-ethereum",
  "graphql-parser",
  "hex",
  "http 0.2.3",

--- a/chain/ethereum/tests/manifest.rs
+++ b/chain/ethereum/tests/manifest.rs
@@ -1,5 +1,3 @@
-use async_trait::async_trait;
-use slog::Logger;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -9,10 +7,11 @@ use graph::components::{
     store::EntityType,
 };
 use graph::prelude::{
-    anyhow, DeploymentHash, Entity, Link, SubgraphManifest, SubgraphManifestValidationError,
-    UnvalidatedSubgraphManifest,
+    anyhow, async_trait, tokio, DeploymentHash, Entity, Link, Logger, SubgraphManifest,
+    SubgraphManifestValidationError, UnvalidatedSubgraphManifest,
 };
 
+use graph_chain_ethereum::Chain;
 use test_store::LOGGER;
 
 #[derive(Default)]
@@ -72,9 +71,7 @@ async fn resolve_manifest(text: &str) -> SubgraphManifest<graph_chain_ethereum::
         .expect("Parsing simple manifest works")
 }
 
-async fn resolve_unvalidated(
-    text: &str,
-) -> UnvalidatedSubgraphManifest<graph_chain_ethereum::Chain> {
+async fn resolve_unvalidated(text: &str) -> UnvalidatedSubgraphManifest<Chain> {
     let mut resolver = TextResolver::default();
     let id = DeploymentHash::new("Qmmanifest").unwrap();
 
@@ -85,6 +82,9 @@ async fn resolve_unvalidated(
         .await
         .expect("Parsing simple manifest works")
 }
+
+// Some of these manifest tests should be made chain-independent, but for
+// now we just run them for the ethereum `Chain`
 
 #[tokio::test]
 async fn simple_manifest() {
@@ -185,7 +185,6 @@ specVersion: 0.0.2
     })
 }
 
-// ETHDEP: This test needs to be moved to the chain::ethereum crate
 #[tokio::test]
 async fn parse_call_handlers() {
     const YAML: &str = "

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -65,4 +65,3 @@ web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "master" }
 test-store = { path = "../store/test-store" }
 maplit = "1.0.2"
 structopt = { version = "0.3" }
-graph-chain-ethereum = { path = "../chain/ethereum" }


### PR DESCRIPTION
Having it in the graph crate requires that to depend on chain, which it
shouldn't and causes a lot of headaches.

