### PR TITLE
Prevent handling triggers for failed transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,6 +1644,7 @@ dependencies = [
  "graph-store-postgres",
  "hex",
  "http 0.1.21",
+ "itertools",
  "jsonrpc-core",
  "lazy_static",
  "mockall 0.9.1",

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -28,6 +28,7 @@ ethabi = { git = "https://github.com/graphprotocol/ethabi.git", branch = "master
 
 # We have a couple custom patches to web3.
 web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "master" }
+itertools = "0.10.0"
 
 graph-runtime-wasm = { path = "../../runtime/wasm" }
 graph-runtime-derive = { path = "../../runtime/derive" }

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -24,6 +24,7 @@ use graph::{components::ethereum::EthereumNetworkIdentifier, prelude::*};
 use crate::{data_source::DataSource, Chain};
 
 pub type EventSignature = H256;
+pub type FunctionSelector = [u8; 4];
 
 #[derive(Clone, Debug)]
 pub struct EthereumContractCall {
@@ -270,7 +271,8 @@ impl EthereumLogFilter {
 pub(crate) struct EthereumCallFilter {
     // Each call filter has a map of filters keyed by address, each containing a tuple with
     // start_block and the set of function signatures
-    pub contract_addresses_function_signatures: HashMap<Address, (BlockNumber, HashSet<[u8; 4]>)>,
+    pub contract_addresses_function_signatures:
+        HashMap<Address, (BlockNumber, HashSet<FunctionSelector>)>,
 }
 
 impl EthereumCallFilter {
@@ -355,12 +357,12 @@ impl EthereumCallFilter {
     }
 }
 
-impl FromIterator<(BlockNumber, Address, [u8; 4])> for EthereumCallFilter {
+impl FromIterator<(BlockNumber, Address, FunctionSelector)> for EthereumCallFilter {
     fn from_iter<I>(iter: I) -> Self
     where
-        I: IntoIterator<Item = (BlockNumber, Address, [u8; 4])>,
+        I: IntoIterator<Item = (BlockNumber, Address, FunctionSelector)>,
     {
-        let mut lookup: HashMap<Address, (BlockNumber, HashSet<[u8; 4]>)> = HashMap::new();
+        let mut lookup: HashMap<Address, (BlockNumber, HashSet<FunctionSelector>)> = HashMap::new();
         iter.into_iter()
             .for_each(|(start_block, address, function_signature)| {
                 if !lookup.contains_key(&address) {
@@ -387,7 +389,7 @@ impl From<EthereumBlockFilter> for EthereumCallFilter {
                 .contract_addresses
                 .into_iter()
                 .map(|(start_block_opt, address)| (address, (start_block_opt, HashSet::default())))
-                .collect::<HashMap<Address, (BlockNumber, HashSet<[u8; 4]>)>>(),
+                .collect::<HashMap<Address, (BlockNumber, HashSet<FunctionSelector>)>>(),
         }
     }
 }

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -1,10 +1,8 @@
-use std::collections::HashSet;
-use std::iter::FromIterator;
-use std::sync::Arc;
-
 use anyhow::{Context, Error};
 use graph::data::subgraph::UnifiedMappingApiVersion;
-use graph::prelude::{EthereumCallCache, LightEthereumBlock, LightEthereumBlockExt};
+use graph::prelude::{
+    EthereumCallCache, LightEthereumBlock, LightEthereumBlockExt, StopwatchMetrics,
+};
 use graph::{
     blockchain::{
         block_stream::{
@@ -23,6 +21,9 @@ use graph::{
         LoggerFactory, MetricsRegistry, NodeId, SubgraphStore,
     },
 };
+use std::collections::HashSet;
+use std::iter::FromIterator;
+use std::sync::Arc;
 
 use crate::data_source::DataSourceTemplate;
 use crate::data_source::UnresolvedDataSourceTemplate;
@@ -142,6 +143,7 @@ impl Blockchain for Chain {
         loc: &DeploymentLocator,
         capabilities: &Self::NodeCapabilities,
         unified_api_version: UnifiedMappingApiVersion,
+        stopwatch_metrics: StopwatchMetrics,
     ) -> Result<Arc<Self::TriggersAdapter>, Error> {
         let eth_adapter = self.eth_adapters.cheapest_with(capabilities)?.clone();
         let logger = self
@@ -154,8 +156,9 @@ impl Blockchain for Chain {
             logger,
             ethrpc_metrics,
             eth_adapter,
+            stopwatch_metrics,
             chain_store: self.chain_store.cheap_clone(),
-            _unified_api_version: unified_api_version,
+            unified_api_version,
         };
         Ok(Arc::new(adapter))
     }
@@ -182,7 +185,12 @@ impl Blockchain for Chain {
         let requirements = filter.node_capabilities();
 
         let triggers_adapter = self
-            .triggers_adapter(&deployment, &requirements, unified_api_version.clone())
+            .triggers_adapter(
+                &deployment,
+                &requirements,
+                unified_api_version.clone(),
+                metrics.stopwatch.clone(),
+            )
             .expect(&format!(
                 "no adapter for network {} with capabilities {}",
                 self.name, requirements
@@ -330,9 +338,10 @@ impl Manifest<Chain> for DummyManifest {
 pub struct TriggersAdapter {
     logger: Logger,
     ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
+    stopwatch_metrics: StopwatchMetrics,
     chain_store: Arc<dyn ChainStore>,
     eth_adapter: Arc<EthereumAdapter>,
-    _unified_api_version: UnifiedMappingApiVersion,
+    unified_api_version: UnifiedMappingApiVersion,
 }
 
 #[async_trait]
@@ -348,9 +357,11 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             self.logger.clone(),
             self.chain_store.clone(),
             self.ethrpc_metrics.clone(),
+            self.stopwatch_metrics.clone(),
             from,
             to,
             filter,
+            self.unified_api_version.clone(),
         )
         .await
     }
@@ -378,9 +389,11 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
                     logger.clone(),
                     self.chain_store.clone(),
                     self.ethrpc_metrics.clone(),
+                    self.stopwatch_metrics.clone(),
                     block_number,
                     block_number,
                     filter,
+                    self.unified_api_version.clone(),
                 )
                 .await?;
                 assert!(blocks.len() == 1);
@@ -392,7 +405,7 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
                     &filter.log,
                     &full_block.ethereum_block,
                 ));
-                triggers.append(&mut parse_call_triggers(&filter.call, &full_block));
+                triggers.append(&mut parse_call_triggers(&filter.call, &full_block)?);
                 triggers.append(&mut parse_block_triggers(filter.block.clone(), &full_block));
                 Ok(BlockWithTriggers::new(block, triggers))
             }

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -344,13 +344,6 @@ where
             .with_context(|| format!("no chain configured for network {}", network))?
             .clone();
 
-        let unified_mapping_api_version = manifest.unified_mapping_api_version()?;
-        let triggers_adapter = chain.triggers_adapter(&deployment, &required_capabilities, unified_mapping_api_version).map_err(|e|
-                anyhow!(
-                "expected triggers adapter that matches deployment {} with required capabilities: {}: {}",
-                &deployment,
-                &required_capabilities, e))?.clone();
-
         // Obtain filters from the manifest
         let filter = C::TriggerFilter::from_data_sources(manifest.data_sources.iter());
         let start_blocks = manifest.start_blocks();
@@ -361,6 +354,14 @@ where
         // ownership of the manifest and host builder into the new instance
         let stopwatch_metrics =
             StopwatchMetrics::new(logger.clone(), deployment.hash.clone(), registry.clone());
+
+        let unified_mapping_api_version = manifest.unified_mapping_api_version()?;
+        let triggers_adapter = chain.triggers_adapter(&deployment, &required_capabilities, unified_mapping_api_version ,stopwatch_metrics.clone()).map_err(|e|
+                anyhow!(
+                "expected triggers adapter that matches deployment {} with required capabilities: {}: {}",
+                &deployment,
+                &required_capabilities, e))?.clone();
+
         let subgraph_metrics = Arc::new(SubgraphInstanceMetrics::new(
             registry.clone(),
             deployment.hash.as_str(),
@@ -377,6 +378,7 @@ where
             manifest.network_name(),
             stopwatch_metrics,
         ));
+
         // Initialize deployment_head with current deployment head. Any sort of trouble in
         // getting the deployment head ptr leads to initializing with 0
         let deployment_head = store

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -9,7 +9,10 @@ mod types;
 // Try to reexport most of the necessary types
 use crate::{
     cheap_clone::CheapClone,
-    components::store::{DeploymentLocator, StoredDynamicDataSource},
+    components::{
+        metrics::stopwatch::StopwatchMetrics,
+        store::{DeploymentLocator, StoredDynamicDataSource},
+    },
     data::subgraph::{Mapping, Source, UnifiedMappingApiVersion},
     prelude::DataSourceContext,
     runtime::{AscHeap, AscPtr, DeterministicHostError, HostExportError},
@@ -93,6 +96,7 @@ pub trait Blockchain: Debug + Sized + Send + Sync + 'static {
         loc: &DeploymentLocator,
         capabilities: &Self::NodeCapabilities,
         unified_api_version: UnifiedMappingApiVersion,
+        stopwatch_metrics: StopwatchMetrics,
     ) -> Result<Arc<Self::TriggersAdapter>, Error>;
 
     fn new_block_stream(

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -5,7 +5,8 @@ use web3::types::H256;
 
 pub use self::network::NodeCapabilities;
 pub use self::types::{
-    EthereumBlock, EthereumBlockWithCalls, EthereumCall, LightEthereumBlock, LightEthereumBlockExt,
+    evaluate_transaction_status, EthereumBlock, EthereumBlockWithCalls, EthereumCall,
+    LightEthereumBlock, LightEthereumBlockExt,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/graph/src/components/mod.rs
+++ b/graph/src/components/mod.rs
@@ -76,3 +76,5 @@ pub trait EventProducer<E> {
     /// Avoid calling directly, prefer helpers such as `forward`.
     fn take_event_stream(&mut self) -> Option<Box<dyn Stream<Item = E, Error = ()> + Send>>;
 }
+
+pub mod transaction_receipt;

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -19,6 +19,8 @@ use thiserror::Error;
 use web3::types::{Address, H256};
 
 use crate::blockchain::Blockchain;
+use crate::components::server::index_node::VersionInfo;
+use crate::components::transaction_receipt;
 use crate::data::subgraph::status;
 use crate::data::{store::*, subgraph::Source};
 use crate::prelude::*;
@@ -27,8 +29,6 @@ use crate::{
     blockchain::DataSource,
     data::{query::QueryTarget, subgraph::schema::*},
 };
-
-use crate::components::server::index_node::VersionInfo;
 
 lazy_static! {
     pub static ref SUBSCRIPTION_THROTTLE_INTERVAL: Duration =
@@ -1298,6 +1298,12 @@ pub trait ChainStore: Send + Sync + 'static {
 
     /// Find the block with `block_hash` and return the network name and number
     fn block_number(&self, block_hash: H256) -> Result<Option<(String, BlockNumber)>, StoreError>;
+
+    /// Tries to retrieve all transactions receipts for a given block.
+    async fn transaction_receipts_in_block(
+        &self,
+        block_ptr: &H256,
+    ) -> Result<Vec<transaction_receipt::LightTransactionReceipt>, StoreError>;
 }
 
 pub trait EthereumCallCache: Send + Sync + 'static {

--- a/graph/src/components/transaction_receipt.rs
+++ b/graph/src/components/transaction_receipt.rs
@@ -1,0 +1,206 @@
+//! Code for retrieving transaction receipts from the database.
+//!
+//! This module exposes:
+//! 1. the [`find_transaction_receipts_in_block`] function, that queries the database and returns
+//!    transaction receipts present in a given block.
+//! 2. the [`LightTransactionReceipt`] type, which holds basic information about the retrieved
+//!    transaction receipts.
+
+use diesel::{
+    pg::{Pg, PgConnection},
+    prelude::*,
+    query_builder::{Query, QueryFragment},
+    sql_types::{Binary, Nullable},
+};
+use diesel_derives::{Queryable, QueryableByName};
+use itertools::Itertools;
+use std::convert::TryFrom;
+use web3::types::*;
+
+/// Parameters for querying for all transaction receipts of a given block.
+struct TransactionReceiptQuery<'a> {
+    block_hash: &'a [u8],
+    schema_name: &'a str,
+}
+
+impl<'a> diesel::query_builder::QueryId for TransactionReceiptQuery<'a> {
+    type QueryId = ();
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a> QueryFragment<Pg> for TransactionReceiptQuery<'a> {
+    /// Writes the following SQL:
+    ///
+    /// ```sql
+    /// select
+    ///     ethereum_hex_to_bytea(receipt ->> 'transactionHash') as transaction_hash,
+    ///     ethereum_hex_to_bytea(receipt ->> 'transactionIndex') as transaction_index,
+    ///     ethereum_hex_to_bytea(receipt ->> 'blockHash') as block_hash,
+    ///     ethereum_hex_to_bytea(receipt ->> 'blockNumber') as block_number,
+    ///     ethereum_hex_to_bytea(receipt ->> 'gasUsed') as gas_used,
+    ///     ethereum_hex_to_bytea(receipt ->> 'status') as status
+    /// from (
+    ///     select
+    ///         jsonb_array_elements(data -> 'transaction_receipts') as receipt
+    ///     from
+    ///         $CHAIN_SCHEMA.blocks
+    ///     where hash = $BLOCK_HASH) as temp;
+    ///```
+    fn walk_ast(&self, mut out: diesel::query_builder::AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql(
+            r#"
+select
+    ethereum_hex_to_bytea(receipt ->> 'transactionHash') as transaction_hash,
+    ethereum_hex_to_bytea(receipt ->> 'transactionIndex') as transaction_index,
+    ethereum_hex_to_bytea(receipt ->> 'blockHash') as block_hash,
+    ethereum_hex_to_bytea(receipt ->> 'blockNumber') as block_number,
+    ethereum_hex_to_bytea(receipt ->> 'gasUsed') as gas_used,
+    ethereum_hex_to_bytea(receipt ->> 'status') as status
+from (
+    select jsonb_array_elements(data -> 'transaction_receipts') as receipt
+    from"#,
+        );
+        out.push_identifier(&self.schema_name)?;
+        out.push_sql(".");
+        out.push_identifier("blocks")?;
+        out.push_sql(" where hash = ");
+        out.push_bind_param::<Binary, _>(&self.block_hash)?;
+        out.push_sql(") as temp;");
+        Ok(())
+    }
+}
+
+impl<'a> Query for TransactionReceiptQuery<'a> {
+    type SqlType = (
+        Binary,
+        Binary,
+        Nullable<Binary>,
+        Nullable<Binary>,
+        Nullable<Binary>,
+        Nullable<Binary>,
+    );
+}
+
+impl<'a> RunQueryDsl<PgConnection> for TransactionReceiptQuery<'a> {}
+
+/// Type that comes straight out of a SQL query
+#[derive(QueryableByName, Queryable)]
+struct RawTransactionReceipt {
+    #[sql_type = "Binary"]
+    transaction_hash: Vec<u8>,
+    #[sql_type = "Binary"]
+    transaction_index: Vec<u8>,
+    #[sql_type = "Nullable<Binary>"]
+    block_hash: Option<Vec<u8>>,
+    #[sql_type = "Nullable<Binary>"]
+    block_number: Option<Vec<u8>>,
+    #[sql_type = "Nullable<Binary>"]
+    gas_used: Option<Vec<u8>>,
+    #[sql_type = "Nullable<Binary>"]
+    status: Option<Vec<u8>>,
+}
+
+/// Like web3::types::Receipt, but with fewer fields.
+pub struct LightTransactionReceipt {
+    pub transaction_hash: H256,
+    pub transaction_index: U64,
+    pub block_hash: Option<H256>,
+    pub block_number: Option<U64>,
+    pub gas_used: Option<U256>,
+    pub status: Option<U64>,
+}
+
+/// Converts Vec<u8> to [u8; N], where N is the vector's expected lenght.
+/// Fails if input size is larger than output size.
+pub(crate) fn drain_vector<const N: usize>(input: Vec<u8>) -> Result<[u8; N], anyhow::Error> {
+    anyhow::ensure!(input.len() <= N, "source is larger than output");
+    let mut output = [0u8; N];
+    let start = output.len() - input.len();
+    output[start..].iter_mut().set_from(input);
+    Ok(output)
+}
+
+#[test]
+fn test_drain_vector() {
+    let input = vec![191, 153, 17];
+    let expected_output = [0, 0, 0, 0, 0, 191, 153, 17];
+    let result = drain_vector(input).expect("failed to drain vector into array");
+    assert_eq!(result, expected_output);
+}
+
+impl TryFrom<RawTransactionReceipt> for LightTransactionReceipt {
+    type Error = anyhow::Error;
+
+    fn try_from(value: RawTransactionReceipt) -> Result<Self, Self::Error> {
+        let RawTransactionReceipt {
+            transaction_hash,
+            transaction_index,
+            block_hash,
+            block_number,
+            gas_used,
+            status,
+        } = value;
+
+        let transaction_hash = drain_vector(transaction_hash)?;
+        let transaction_index = drain_vector(transaction_index)?;
+        let block_hash = block_hash.map(drain_vector).transpose()?;
+        let block_number = block_number.map(drain_vector).transpose()?;
+        let gas_used = gas_used.map(drain_vector).transpose()?;
+        let status = status.map(drain_vector).transpose()?;
+
+        Ok(LightTransactionReceipt {
+            transaction_hash: transaction_hash.into(),
+            transaction_index: transaction_index.into(),
+            block_hash: block_hash.map(Into::into),
+            block_number: block_number.map(Into::into),
+            gas_used: gas_used.map(Into::into),
+            status: status.map(Into::into),
+        })
+    }
+}
+
+/// Queries the database for all the transaction receipts in a given block range.
+pub fn find_transaction_receipts_in_block(
+    conn: &PgConnection,
+    schema_name: &str,
+    block_hash: &H256,
+) -> anyhow::Result<Vec<LightTransactionReceipt>> {
+    let query = TransactionReceiptQuery {
+        schema_name,
+        block_hash: block_hash.as_bytes(),
+    };
+
+    query
+        .get_results::<RawTransactionReceipt>(conn)
+        .or_else(|error| {
+            Err(anyhow::anyhow!(
+                "Error fetching transaction receipt from database: {}",
+                error
+            ))
+        })?
+        .into_iter()
+        .map(LightTransactionReceipt::try_from)
+        .collect()
+}
+
+impl From<TransactionReceipt> for LightTransactionReceipt {
+    fn from(receipt: TransactionReceipt) -> Self {
+        let TransactionReceipt {
+            transaction_hash,
+            transaction_index,
+            block_hash,
+            block_number,
+            gas_used,
+            status,
+            ..
+        } = receipt;
+        LightTransactionReceipt {
+            transaction_hash,
+            transaction_index,
+            block_hash,
+            block_number,
+            gas_used,
+            status,
+        }
+    }
+}

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -656,7 +656,7 @@ impl UnresolvedMapping {
 pub struct UnifiedMappingApiVersion(Option<Version>);
 
 impl UnifiedMappingApiVersion {
-    pub fn equal_or_greater_than(&self, other_version: &'static Version) -> bool {
+    pub fn equal_or_greater_than(&self, other_version: &Version) -> bool {
         assert!(
             other_version >= &API_VERSION_0_0_5,
             "api versions before 0.0.5 should not be used for comparison"

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -123,7 +123,7 @@ pub mod prelude {
         SubgraphAssignmentProvider, SubgraphInstanceManager, SubgraphRegistrar,
         SubgraphVersionSwitchingMode,
     };
-    pub use crate::components::{EventConsumer, EventProducer};
+    pub use crate::components::{transaction_receipt, EventConsumer, EventProducer};
 
     pub use crate::cheap_clone::CheapClone;
     pub use crate::data::graphql::{

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -42,6 +42,9 @@ mock! {
         fn confirm_block_hash(&self, number: BlockNumber, hash: &H256) -> Result<usize, Error>;
 
         fn block_number(&self, block_hash: H256) -> Result<Option<(String, BlockNumber)>, StoreError>;
+
+        async fn transaction_receipts_in_block(&self, block_hash: &H256) -> Result<Vec<transaction_receipt::LightTransactionReceipt>, StoreError>;
+
     }
 }
 

--- a/store/postgres/migrations/2021-06-14-201635_add_ethereum_hex_to_bytea_function/down.sql
+++ b/store/postgres/migrations/2021-06-14-201635_add_ethereum_hex_to_bytea_function/down.sql
@@ -1,0 +1,2 @@
+drop function if exists ethereum_hex_to_bytea (text);
+drop function if exists raise_exception_bytea (text);

--- a/store/postgres/migrations/2021-06-14-201635_add_ethereum_hex_to_bytea_function/up.sql
+++ b/store/postgres/migrations/2021-06-14-201635_add_ethereum_hex_to_bytea_function/up.sql
@@ -1,0 +1,47 @@
+/*
+Since we deal with a lot of hex data encoded in a very specific string pattern [see link #1], we
+need a function to convert that data into byte arrays (the "bytea" PostgreSQL type). Using byte
+arrays is also useful because the former occupies double the space of the latter.
+
+The idea is to have a deliberately generic database function to send bytes over so we can re-encode
+them into concrete types, such as U64 and H256 and booleans.
+
+Examples:
+1. ethereum_hex_to_bytea(null)         -> null
+2. ethereum_hex_to_bytea("0x1")        -> \x01
+3. ethereum_hex_to_bytea("0x0")        -> \x00
+4. ethereum_hex_to_bytea("0xdeadbeef") -> \xdeadbeef
+5. ethereum_hex_to_bytea("0x")         -> ERROR: Can't decode an empty hexadecimal string.
+6. ethereum_hex_to_bytea("")           -> ERROR: Input must start with '0x'.
+
+
+[1: https://openethereum.github.io/JSONRPC#types-in-the-jsonrpc]
+ */
+create or replace function raise_exception_bytea (text)
+    returns bytea
+    as $$
+begin
+    raise exception '%', $1;
+end;
+$$
+language plpgsql
+volatile;
+
+create or replace function ethereum_hex_to_bytea (eth_hex text)
+    returns bytea
+    as $$
+    select
+        case when $1 is null then
+            null
+        when not starts_with (eth_hex, '0x') then
+            raise_exception_bytea('Input must start with ''0x''.')
+        when length(eth_hex) = 2 then
+            raise_exception_bytea('Can''t decode an empty hexadecimal string.')
+        when length($1) % 2 = 0 then
+            decode(right ($1, -2), 'hex')
+        else
+            decode(replace(eth_hex, 'x', ''), 'hex')
+        end as return
+$$
+language sql
+immutable strict;


### PR DESCRIPTION
Resolves #2409

- [x] Handle Non-Final blocks
- [x] Handle Final blocks
  - [x] Fetch existing transaction receipts from database
  - [x] Fetch existing transaction receipts from ethereum client
- [x] Add stopwatch metrics
- [x] Add manifest version switch

This PR adds a verification step to call-handler execution that filters off traces with failed transactions.

For **non-final blocks**, we determine failure by inspecting each transaction receipt and gas usage, which are already present in program memory, so it should be fast. 

For **final blocks**, we search the database once for each block. If that data is absent, we call an external API once for each transaction receipt.

