### PR TITLE
Make `AscHeap` dyn-safe

### DIFF
--- a/graph/src/runtime/asc_heap.rs
+++ b/graph/src/runtime/asc_heap.rs
@@ -5,73 +5,88 @@ use super::{AscPtr, AscType, DeterministicHostError};
 /// for reading and writing Rust structs from and to Asc.
 ///
 /// The implementor must provide the direct Asc interface with `raw_new` and `get`.
-pub trait AscHeap: Sized {
+pub trait AscHeap {
     /// Allocate new space and write `bytes`, return the allocated address.
     fn raw_new(&mut self, bytes: &[u8]) -> Result<u32, DeterministicHostError>;
 
     fn get(&self, offset: u32, size: u32) -> Result<Vec<u8>, DeterministicHostError>;
 
-    /// Instantiate `rust_obj` as an Asc object of class `C`.
-    /// Returns a pointer to the Asc heap.
-    ///
-    /// This operation is expensive as it requires a call to `raw_new` for every
-    /// nested object.
-    fn asc_new<C, T: ?Sized>(&mut self, rust_obj: &T) -> Result<AscPtr<C>, DeterministicHostError>
-    where
-        C: AscType,
-        T: ToAscObj<C>,
-    {
-        let obj = rust_obj.to_asc_obj(self)?;
-        AscPtr::alloc_obj(obj, self)
-    }
-
-    ///  Read the rust representation of an Asc object of class `C`.
-    ///
-    ///  This operation is expensive as it requires a call to `get` for every
-    ///  nested object.
-    fn asc_get<T, C>(&self, asc_ptr: AscPtr<C>) -> Result<T, DeterministicHostError>
-    where
-        C: AscType,
-        T: FromAscObj<C>,
-    {
-        T::from_asc_obj(asc_ptr.read_ptr(self)?, self)
-    }
-
-    fn try_asc_get<T, C>(&self, asc_ptr: AscPtr<C>) -> Result<T, DeterministicHostError>
-    where
-        C: AscType,
-        T: TryFromAscObj<C>,
-    {
-        T::try_from_asc_obj(asc_ptr.read_ptr(self)?, self)
-    }
-
     fn api_version(&self) -> Version;
+}
+
+/// Instantiate `rust_obj` as an Asc object of class `C`.
+/// Returns a pointer to the Asc heap.
+///
+/// This operation is expensive as it requires a call to `raw_new` for every
+/// nested object.
+pub fn asc_new<C, T: ?Sized, H: AscHeap + ?Sized>(
+    heap: &mut H,
+    rust_obj: &T,
+) -> Result<AscPtr<C>, DeterministicHostError>
+where
+    C: AscType,
+    T: ToAscObj<C>,
+{
+    let obj = rust_obj.to_asc_obj(heap)?;
+    AscPtr::alloc_obj(obj, heap)
+}
+
+///  Read the rust representation of an Asc object of class `C`.
+///
+///  This operation is expensive as it requires a call to `get` for every
+///  nested object.
+pub fn asc_get<T, C, H: AscHeap + ?Sized>(
+    heap: &H,
+    asc_ptr: AscPtr<C>,
+) -> Result<T, DeterministicHostError>
+where
+    C: AscType,
+    T: FromAscObj<C>,
+{
+    T::from_asc_obj(asc_ptr.read_ptr(heap)?, heap)
+}
+
+pub fn try_asc_get<T, C, H: AscHeap + ?Sized>(
+    heap: &H,
+    asc_ptr: AscPtr<C>,
+) -> Result<T, DeterministicHostError>
+where
+    C: AscType,
+    T: TryFromAscObj<C>,
+{
+    T::try_from_asc_obj(asc_ptr.read_ptr(heap)?, heap)
 }
 
 /// Type that can be converted to an Asc object of class `C`.
 pub trait ToAscObj<C: AscType> {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<C, DeterministicHostError>;
+    fn to_asc_obj<H: AscHeap + ?Sized>(&self, heap: &mut H) -> Result<C, DeterministicHostError>;
 }
 
 impl ToAscObj<bool> for bool {
-    fn to_asc_obj<H: AscHeap>(&self, _heap: &mut H) -> Result<bool, DeterministicHostError> {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        _heap: &mut H,
+    ) -> Result<bool, DeterministicHostError> {
         Ok(*self)
     }
 }
 
 impl<C: AscType, T: ToAscObj<C>> ToAscObj<C> for &T {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<C, DeterministicHostError> {
+    fn to_asc_obj<H: AscHeap + ?Sized>(&self, heap: &mut H) -> Result<C, DeterministicHostError> {
         (*self).to_asc_obj(heap)
     }
 }
 
 /// Type that can be converted from an Asc object of class `C`.
 pub trait FromAscObj<C: AscType> {
-    fn from_asc_obj<H: AscHeap>(obj: C, heap: &H) -> Result<Self, DeterministicHostError>
+    fn from_asc_obj<H: AscHeap + ?Sized>(obj: C, heap: &H) -> Result<Self, DeterministicHostError>
     where
         Self: Sized;
 }
 
 pub trait TryFromAscObj<C: AscType>: Sized {
-    fn try_from_asc_obj<H: AscHeap>(obj: C, heap: &H) -> Result<Self, DeterministicHostError>;
+    fn try_from_asc_obj<H: AscHeap + ?Sized>(
+        obj: C,
+        heap: &H,
+    ) -> Result<Self, DeterministicHostError>;
 }

--- a/graph/src/runtime/asc_ptr.rs
+++ b/graph/src/runtime/asc_ptr.rs
@@ -48,13 +48,13 @@ impl<C: AscType> AscPtr<C> {
     }
 
     /// Read from `self` into the Rust struct `C`.
-    pub fn read_ptr<H: AscHeap>(self, heap: &H) -> Result<C, DeterministicHostError> {
+    pub fn read_ptr<H: AscHeap + ?Sized>(self, heap: &H) -> Result<C, DeterministicHostError> {
         let bytes = heap.get(self.0, C::asc_size(self, heap)?)?;
         C::from_asc_bytes(&bytes)
     }
 
     /// Allocate `asc_obj` as an Asc object of class `C`.
-    pub fn alloc_obj<H: AscHeap>(
+    pub fn alloc_obj<H: AscHeap + ?Sized>(
         asc_obj: C,
         heap: &mut H,
     ) -> Result<AscPtr<C>, DeterministicHostError> {
@@ -63,7 +63,7 @@ impl<C: AscType> AscPtr<C> {
     }
 
     /// Helper used by arrays and strings to read their length.
-    pub fn read_u32<H: AscHeap>(&self, heap: &H) -> Result<u32, DeterministicHostError> {
+    pub fn read_u32<H: AscHeap + ?Sized>(&self, heap: &H) -> Result<u32, DeterministicHostError> {
         // Read the bytes pointed to by `self` as the bytes of a `u32`.
         let raw_bytes = heap.get(self.0, size_of::<u32>() as u32)?;
         let mut u32_bytes: [u8; size_of::<u32>()] = [0; size_of::<u32>()];

--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -6,7 +6,7 @@
 mod asc_heap;
 mod asc_ptr;
 
-pub use asc_heap::{AscHeap, FromAscObj, ToAscObj, TryFromAscObj};
+pub use asc_heap::{asc_get, asc_new, try_asc_get, AscHeap, FromAscObj, ToAscObj, TryFromAscObj};
 pub use asc_ptr::AscPtr;
 
 use anyhow::Error;
@@ -31,7 +31,10 @@ pub trait AscType: Sized {
     fn from_asc_bytes(asc_obj: &[u8]) -> Result<Self, DeterministicHostError>;
 
     /// Size of the corresponding Asc instance in bytes.
-    fn asc_size<H: AscHeap>(_ptr: AscPtr<Self>, _heap: &H) -> Result<u32, DeterministicHostError> {
+    fn asc_size<H: AscHeap + ?Sized>(
+        _ptr: AscPtr<Self>,
+        _heap: &H,
+    ) -> Result<u32, DeterministicHostError> {
         Ok(std::mem::size_of::<Self>() as u32)
     }
 }

--- a/runtime/wasm/src/asc_abi/class.rs
+++ b/runtime/wasm/src/asc_abi/class.rs
@@ -119,7 +119,10 @@ impl AscType for ArrayBuffer {
         })
     }
 
-    fn asc_size<H: AscHeap>(ptr: AscPtr<Self>, heap: &H) -> Result<u32, DeterministicHostError> {
+    fn asc_size<H: AscHeap + ?Sized>(
+        ptr: AscPtr<Self>,
+        heap: &H,
+    ) -> Result<u32, DeterministicHostError> {
         let byte_length = ptr.read_u32(heap)?;
         let byte_length_size = size_of::<u32>() as u32;
         let padding_size = size_of::<u32>() as u32;
@@ -142,7 +145,7 @@ pub(crate) struct TypedArray<T> {
 }
 
 impl<T: AscValue> TypedArray<T> {
-    pub(crate) fn new<H: AscHeap>(
+    pub(crate) fn new<H: AscHeap + ?Sized>(
         content: &[T],
         heap: &mut H,
     ) -> Result<Self, DeterministicHostError> {
@@ -155,7 +158,10 @@ impl<T: AscValue> TypedArray<T> {
         })
     }
 
-    pub(crate) fn to_vec<H: AscHeap>(&self, heap: &H) -> Result<Vec<T>, DeterministicHostError> {
+    pub(crate) fn to_vec<H: AscHeap + ?Sized>(
+        &self,
+        heap: &H,
+    ) -> Result<Vec<T>, DeterministicHostError> {
         self.buffer
             .read_ptr(heap)?
             .get(self.byte_offset, self.byte_length / size_of::<T>() as u32)
@@ -255,7 +261,10 @@ impl AscType for AscString {
         AscString::new(&content)
     }
 
-    fn asc_size<H: AscHeap>(ptr: AscPtr<Self>, heap: &H) -> Result<u32, DeterministicHostError> {
+    fn asc_size<H: AscHeap + ?Sized>(
+        ptr: AscPtr<Self>,
+        heap: &H,
+    ) -> Result<u32, DeterministicHostError> {
         let length = ptr.read_u32(heap)?;
         let length_size = size_of::<u32>() as u32;
         let code_point_size = size_of::<u16>() as u32;
@@ -278,7 +287,10 @@ pub(crate) struct Array<T> {
 }
 
 impl<T: AscValue> Array<T> {
-    pub fn new<H: AscHeap>(content: &[T], heap: &mut H) -> Result<Self, DeterministicHostError> {
+    pub fn new<H: AscHeap + ?Sized>(
+        content: &[T],
+        heap: &mut H,
+    ) -> Result<Self, DeterministicHostError> {
         Ok(Array {
             buffer: AscPtr::alloc_obj(ArrayBuffer::new(content)?, heap)?,
             // If this cast would overflow, the above line has already panicked.
@@ -287,7 +299,10 @@ impl<T: AscValue> Array<T> {
         })
     }
 
-    pub(crate) fn to_vec<H: AscHeap>(&self, heap: &H) -> Result<Vec<T>, DeterministicHostError> {
+    pub(crate) fn to_vec<H: AscHeap + ?Sized>(
+        &self,
+        heap: &H,
+    ) -> Result<Vec<T>, DeterministicHostError> {
         self.buffer.read_ptr(heap)?.get(0, self.length)
     }
 }

--- a/runtime/wasm/src/module/test.rs
+++ b/runtime/wasm/src/module/test.rs
@@ -266,27 +266,27 @@ async fn json_conversions() {
 
     // test u64 conversion
     let number = 9223372036850770800;
-    let number_ptr = module.asc_new(&number.to_string()).unwrap();
+    let number_ptr = asc_new(&mut module, &number.to_string()).unwrap();
     let converted: i64 = module.takes_ptr_returns_val("testToU64", number_ptr);
     assert_eq!(number, u64::from_le_bytes(converted.to_le_bytes()));
 
     // test i64 conversion
     let number = -9223372036850770800;
-    let number_ptr = module.asc_new(&number.to_string()).unwrap();
+    let number_ptr = asc_new(&mut module, &number.to_string()).unwrap();
     let converted: i64 = module.takes_ptr_returns_val("testToI64", number_ptr);
     assert_eq!(number, converted);
 
     // test f64 conversion
     let number = -9223372036850770.92345034;
-    let number_ptr = module.asc_new(&number.to_string()).unwrap();
+    let number_ptr = asc_new(&mut module, &number.to_string()).unwrap();
     let converted: f64 = module.takes_ptr_returns_val("testToF64", number_ptr);
     assert_eq!(number, converted);
 
     // test BigInt conversion
     let number = "-922337203685077092345034";
-    let number_ptr = module.asc_new(number).unwrap();
+    let number_ptr = asc_new(&mut module, number).unwrap();
     let big_int_obj: AscPtr<AscBigInt> = module.invoke_export("testToBigInt", number_ptr);
-    let bytes: Vec<u8> = module.asc_get(big_int_obj).unwrap();
+    let bytes: Vec<u8> = asc_get(&module, big_int_obj).unwrap();
     assert_eq!(
         scalar::BigInt::from_str(number).unwrap(),
         scalar::BigInt::from_signed_bytes_le(&bytes)
@@ -303,17 +303,17 @@ async fn json_parsing() {
     // Parse invalid JSON and handle the error gracefully
     let s = "foo"; // Invalid because there are no quotes around `foo`
     let bytes: &[u8] = s.as_ref();
-    let bytes_ptr = module.asc_new(bytes).unwrap();
+    let bytes_ptr = asc_new(&mut module, bytes).unwrap();
     let return_value: AscPtr<AscString> = module.invoke_export("handleJsonError", bytes_ptr);
-    let output: String = module.asc_get(return_value).unwrap();
+    let output: String = asc_get(&module, return_value).unwrap();
     assert_eq!(output, "ERROR: true");
 
     // Parse valid JSON and get it back
     let s = "\"foo\""; // Valid because there are quotes around `foo`
     let bytes: &[u8] = s.as_ref();
-    let bytes_ptr = module.asc_new(bytes).unwrap();
+    let bytes_ptr = asc_new(&mut module, bytes).unwrap();
     let return_value: AscPtr<AscString> = module.invoke_export("handleJsonError", bytes_ptr);
-    let output: String = module.asc_get(return_value).unwrap();
+    let output: String = asc_get(&module, return_value).unwrap();
     assert_eq!(output, "OK: foo");
 }
 
@@ -328,9 +328,9 @@ async fn ipfs_cat() {
     std::thread::spawn(move || {
         runtime.enter(|| {
             let mut module = test_module("ipfsCat", mock_data_source("wasm_test/ipfs_cat.wasm"));
-            let arg = module.asc_new(&hash).unwrap();
+            let arg = asc_new(&mut module, &hash).unwrap();
             let converted: AscPtr<AscString> = module.invoke_export("ipfsCatString", arg);
-            let data: String = module.instance_ctx().asc_get(converted).unwrap();
+            let data: String = asc_get(&module, converted).unwrap();
             assert_eq!(data, "42");
         })
     })
@@ -384,8 +384,8 @@ async fn ipfs_map() {
                     subgraph_id,
                     mock_data_source("wasm_test/ipfs_map.wasm"),
                 );
-                let value = module.asc_new(&hash).unwrap();
-                let user_data = module.asc_new(USER_DATA).unwrap();
+                let value = asc_new(&mut module, &hash).unwrap();
+                let user_data = asc_new(&mut module, USER_DATA).unwrap();
 
                 // Invoke the callback
                 let func = module.get_func("ipfsMap").typed().unwrap().clone();
@@ -476,7 +476,7 @@ async fn ipfs_fail() {
         runtime.enter(|| {
             let mut module = test_module("ipfsFail", mock_data_source("wasm_test/ipfs_cat.wasm"));
 
-            let hash = module.asc_new("invalid hash").unwrap();
+            let hash = asc_new(&mut module, "invalid hash").unwrap();
             assert!(module
                 .invoke_export::<_, AscString>("ipfsCat", hash,)
                 .is_null());
@@ -490,10 +490,10 @@ async fn ipfs_fail() {
 async fn crypto_keccak256() {
     let mut module = test_module("cryptoKeccak256", mock_data_source("wasm_test/crypto.wasm"));
     let input: &[u8] = "eth".as_ref();
-    let input: AscPtr<Uint8Array> = module.asc_new(input).unwrap();
+    let input: AscPtr<Uint8Array> = asc_new(&mut module, input).unwrap();
 
     let hash: AscPtr<Uint8Array> = module.invoke_export("hash", input);
-    let hash: Vec<u8> = module.asc_get(hash).unwrap();
+    let hash: Vec<u8> = asc_get(&module, hash).unwrap();
     assert_eq!(
         hex::encode(hash),
         "4f5b812789fc606be1b3b16908db13fc7a9adf7ca72641f84d75b47069d3d7f0"
@@ -509,23 +509,23 @@ async fn big_int_to_hex() {
 
     // Convert zero to hex
     let zero = BigInt::from_unsigned_u256(&U256::zero());
-    let zero: AscPtr<AscBigInt> = module.asc_new(&zero).unwrap();
+    let zero: AscPtr<AscBigInt> = asc_new(&mut module, &zero).unwrap();
     let zero_hex_ptr: AscPtr<AscString> = module.invoke_export("big_int_to_hex", zero);
-    let zero_hex_str: String = module.asc_get(zero_hex_ptr).unwrap();
+    let zero_hex_str: String = asc_get(&module, zero_hex_ptr).unwrap();
     assert_eq!(zero_hex_str, "0x0");
 
     // Convert 1 to hex
     let one = BigInt::from_unsigned_u256(&U256::one());
-    let one: AscPtr<AscBigInt> = module.asc_new(&one).unwrap();
+    let one: AscPtr<AscBigInt> = asc_new(&mut module, &one).unwrap();
     let one_hex_ptr: AscPtr<AscString> = module.invoke_export("big_int_to_hex", one);
-    let one_hex_str: String = module.asc_get(one_hex_ptr).unwrap();
+    let one_hex_str: String = asc_get(&module, one_hex_ptr).unwrap();
     assert_eq!(one_hex_str, "0x1");
 
     // Convert U256::max_value() to hex
     let u256_max = BigInt::from_unsigned_u256(&U256::max_value());
-    let u256_max: AscPtr<AscBigInt> = module.asc_new(&u256_max).unwrap();
+    let u256_max: AscPtr<AscBigInt> = asc_new(&mut module, &u256_max).unwrap();
     let u256_max_hex_ptr: AscPtr<AscString> = module.invoke_export("big_int_to_hex", u256_max);
-    let u256_max_hex_str: String = module.asc_get(u256_max_hex_ptr).unwrap();
+    let u256_max_hex_str: String = asc_get(&module, u256_max_hex_ptr).unwrap();
     assert_eq!(
         u256_max_hex_str,
         "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
@@ -541,56 +541,56 @@ async fn big_int_arithmetic() {
 
     // 0 + 1 = 1
     let zero = BigInt::from(0);
-    let zero: AscPtr<AscBigInt> = module.asc_new(&zero).unwrap();
+    let zero: AscPtr<AscBigInt> = asc_new(&mut module, &zero).unwrap();
     let one = BigInt::from(1);
-    let one: AscPtr<AscBigInt> = module.asc_new(&one).unwrap();
+    let one: AscPtr<AscBigInt> = asc_new(&mut module, &one).unwrap();
     let result_ptr: AscPtr<AscBigInt> = module.invoke_export2("plus", zero, one);
-    let result: BigInt = module.asc_get(result_ptr).unwrap();
+    let result: BigInt = asc_get(&module, result_ptr).unwrap();
     assert_eq!(result, BigInt::from(1));
 
     // 127 + 1 = 128
     let zero = BigInt::from(127);
-    let zero: AscPtr<AscBigInt> = module.asc_new(&zero).unwrap();
+    let zero: AscPtr<AscBigInt> = asc_new(&mut module, &zero).unwrap();
     let one = BigInt::from(1);
-    let one: AscPtr<AscBigInt> = module.asc_new(&one).unwrap();
+    let one: AscPtr<AscBigInt> = asc_new(&mut module, &one).unwrap();
     let result_ptr: AscPtr<AscBigInt> = module.invoke_export2("plus", zero, one);
-    let result: BigInt = module.asc_get(result_ptr).unwrap();
+    let result: BigInt = asc_get(&module, result_ptr).unwrap();
     assert_eq!(result, BigInt::from(128));
 
     // 5 - 10 = -5
     let five = BigInt::from(5);
-    let five: AscPtr<AscBigInt> = module.asc_new(&five).unwrap();
+    let five: AscPtr<AscBigInt> = asc_new(&mut module, &five).unwrap();
     let ten = BigInt::from(10);
-    let ten: AscPtr<AscBigInt> = module.asc_new(&ten).unwrap();
+    let ten: AscPtr<AscBigInt> = asc_new(&mut module, &ten).unwrap();
     let result_ptr: AscPtr<AscBigInt> = module.invoke_export2("minus", five, ten);
-    let result: BigInt = module.asc_get(result_ptr).unwrap();
+    let result: BigInt = asc_get(&module, result_ptr).unwrap();
     assert_eq!(result, BigInt::from(-5));
 
     // -20 * 5 = -100
     let minus_twenty = BigInt::from(-20);
-    let minus_twenty: AscPtr<AscBigInt> = module.asc_new(&minus_twenty).unwrap();
+    let minus_twenty: AscPtr<AscBigInt> = asc_new(&mut module, &minus_twenty).unwrap();
     let five = BigInt::from(5);
-    let five: AscPtr<AscBigInt> = module.asc_new(&five).unwrap();
+    let five: AscPtr<AscBigInt> = asc_new(&mut module, &five).unwrap();
     let result_ptr: AscPtr<AscBigInt> = module.invoke_export2("times", minus_twenty, five);
-    let result: BigInt = module.asc_get(result_ptr).unwrap();
+    let result: BigInt = asc_get(&module, result_ptr).unwrap();
     assert_eq!(result, BigInt::from(-100));
 
     // 5 / 2 = 2
     let five = BigInt::from(5);
-    let five: AscPtr<AscBigInt> = module.asc_new(&five).unwrap();
+    let five: AscPtr<AscBigInt> = asc_new(&mut module, &five).unwrap();
     let two = BigInt::from(2);
-    let two: AscPtr<AscBigInt> = module.asc_new(&two).unwrap();
+    let two: AscPtr<AscBigInt> = asc_new(&mut module, &two).unwrap();
     let result_ptr: AscPtr<AscBigInt> = module.invoke_export2("dividedBy", five, two);
-    let result: BigInt = module.asc_get(result_ptr).unwrap();
+    let result: BigInt = asc_get(&module, result_ptr).unwrap();
     assert_eq!(result, BigInt::from(2));
 
     // 5 % 2 = 1
     let five = BigInt::from(5);
-    let five: AscPtr<AscBigInt> = module.asc_new(&five).unwrap();
+    let five: AscPtr<AscBigInt> = asc_new(&mut module, &five).unwrap();
     let two = BigInt::from(2);
-    let two: AscPtr<AscBigInt> = module.asc_new(&two).unwrap();
+    let two: AscPtr<AscBigInt> = asc_new(&mut module, &two).unwrap();
     let result_ptr: AscPtr<AscBigInt> = module.invoke_export2("mod", five, two);
-    let result: BigInt = module.asc_get(result_ptr).unwrap();
+    let result: BigInt = asc_get(&module, result_ptr).unwrap();
     assert_eq!(result, BigInt::from(1));
 }
 
@@ -612,9 +612,9 @@ async fn bytes_to_base58() {
     );
     let bytes = hex::decode("12207D5A99F603F231D53A4F39D1521F98D2E8BB279CF29BEBFD0687DC98458E7F89")
         .unwrap();
-    let bytes_ptr = module.asc_new(bytes.as_slice()).unwrap();
+    let bytes_ptr = asc_new(&mut module, bytes.as_slice()).unwrap();
     let result_ptr: AscPtr<AscString> = module.invoke_export("bytes_to_base58", bytes_ptr);
-    let base58: String = module.asc_get(result_ptr).unwrap();
+    let base58: String = asc_get(&module, result_ptr).unwrap();
     assert_eq!(base58, "QmWmyoMoctfbAaiEs2G46gpeUmhqFRDW6KWo64y5r581Vz");
 }
 
@@ -629,8 +629,8 @@ async fn data_source_create() {
                 mock_data_source("wasm_test/data_source_create.wasm"),
             );
 
-            let name = module.asc_new(&name).unwrap();
-            let params = module.asc_new(&*params).unwrap();
+            let name = asc_new(&mut module, &name).unwrap();
+            let params = asc_new(&mut module, &*params).unwrap();
             module.instance_ctx_mut().ctx.state.enter_handler();
             module.invoke_export2_void("dataSourceCreate", name, params)?;
             module.instance_ctx_mut().ctx.state.exit_handler();
@@ -668,12 +668,12 @@ async fn ens_name_by_hash() {
     let hash = "0x7f0c1b04d1a4926f9c635a030eeb611d4c26e5e73291b32a1c7a4ac56935b5b3";
     let name = "dealdrafts";
     test_store::insert_ens_name(hash, name);
-    let val = module.asc_new(hash).unwrap();
+    let val = asc_new(&mut module, hash).unwrap();
     let converted: AscPtr<AscString> = module.invoke_export("nameByHash", val);
-    let data: String = module.asc_get(converted).unwrap();
+    let data: String = asc_get(&module, converted).unwrap();
     assert_eq!(data, name);
 
-    let hash = module.asc_new("impossible keccak hash").unwrap();
+    let hash = asc_new(&mut module, "impossible keccak hash").unwrap();
     assert!(module
         .invoke_export::<_, AscString>("nameByHash", hash)
         .is_null());
@@ -698,22 +698,20 @@ async fn entity_store() {
     .unwrap();
 
     let get_user = move |module: &mut WasmInstance<Chain>, id: &str| -> Option<Entity> {
-        let id = module.asc_new(id).unwrap();
+        let id = asc_new(module, id).unwrap();
         let entity_ptr: AscPtr<AscEntity> = module.invoke_export("getUser", id);
         if entity_ptr.is_null() {
             None
         } else {
             Some(Entity::from(
-                module
-                    .try_asc_get::<HashMap<String, Value>, _>(entity_ptr)
-                    .unwrap(),
+                try_asc_get::<HashMap<String, Value>, _, _>(module, entity_ptr).unwrap(),
             ))
         }
     };
 
     let load_and_set_user_name = |module: &mut WasmInstance<Chain>, id: &str, name: &str| {
-        let id_ptr = module.asc_new(id).unwrap();
-        let name_ptr = module.asc_new(name).unwrap();
+        let id_ptr = asc_new(module, id).unwrap();
+        let name_ptr = asc_new(module, name).unwrap();
         module
             .invoke_export2_void("loadAndSetUserName", id_ptr, name_ptr)
             .unwrap();

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -4,7 +4,7 @@ use graph::{
     components::ethereum::{
         EthereumBlockData, EthereumCallData, EthereumEventData, EthereumTransactionData,
     },
-    runtime::{AscPtr, AscType, ToAscObj},
+    runtime::{asc_get, asc_new, try_asc_get, AscPtr, AscType, ToAscObj},
 };
 use graph::{data::store, runtime::DeterministicHostError};
 use graph::{prelude::serde_json, runtime::FromAscObj};
@@ -19,13 +19,16 @@ use crate::asc_abi::class::*;
 use crate::UnresolvedContractCall;
 
 impl ToAscObj<Uint8Array> for web3::H160 {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<Uint8Array, DeterministicHostError> {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+    ) -> Result<Uint8Array, DeterministicHostError> {
         self.0.to_asc_obj(heap)
     }
 }
 
 impl FromAscObj<Uint8Array> for web3::H160 {
-    fn from_asc_obj<H: AscHeap>(
+    fn from_asc_obj<H: AscHeap + ?Sized>(
         typed_array: Uint8Array,
         heap: &H,
     ) -> Result<Self, DeterministicHostError> {
@@ -35,7 +38,7 @@ impl FromAscObj<Uint8Array> for web3::H160 {
 }
 
 impl FromAscObj<Uint8Array> for web3::H256 {
-    fn from_asc_obj<H: AscHeap>(
+    fn from_asc_obj<H: AscHeap + ?Sized>(
         typed_array: Uint8Array,
         heap: &H,
     ) -> Result<Self, DeterministicHostError> {
@@ -45,13 +48,19 @@ impl FromAscObj<Uint8Array> for web3::H256 {
 }
 
 impl ToAscObj<Uint8Array> for web3::H256 {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<Uint8Array, DeterministicHostError> {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+    ) -> Result<Uint8Array, DeterministicHostError> {
         self.0.to_asc_obj(heap)
     }
 }
 
 impl ToAscObj<AscBigInt> for web3::U128 {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscBigInt, DeterministicHostError> {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscBigInt, DeterministicHostError> {
         let mut bytes: [u8; 16] = [0; 16];
         self.to_little_endian(&mut bytes);
         bytes.to_asc_obj(heap)
@@ -59,14 +68,17 @@ impl ToAscObj<AscBigInt> for web3::U128 {
 }
 
 impl ToAscObj<AscBigInt> for BigInt {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscBigInt, DeterministicHostError> {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscBigInt, DeterministicHostError> {
         let bytes = self.to_signed_bytes_le();
         bytes.to_asc_obj(heap)
     }
 }
 
 impl FromAscObj<AscBigInt> for BigInt {
-    fn from_asc_obj<H: AscHeap>(
+    fn from_asc_obj<H: AscHeap + ?Sized>(
         array_buffer: AscBigInt,
         heap: &H,
     ) -> Result<Self, DeterministicHostError> {
@@ -76,7 +88,7 @@ impl FromAscObj<AscBigInt> for BigInt {
 }
 
 impl ToAscObj<AscBigDecimal> for BigDecimal {
-    fn to_asc_obj<H: AscHeap>(
+    fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
     ) -> Result<AscBigDecimal, DeterministicHostError> {
@@ -84,19 +96,19 @@ impl ToAscObj<AscBigDecimal> for BigDecimal {
         // so "exponent" is the opposite of what you'd expect.
         let (digits, negative_exp) = self.as_bigint_and_exponent();
         Ok(AscBigDecimal {
-            exp: heap.asc_new(&BigInt::from(-negative_exp))?,
-            digits: heap.asc_new(&BigInt::from(digits))?,
+            exp: asc_new(heap, &BigInt::from(-negative_exp))?,
+            digits: asc_new(heap, &BigInt::from(digits))?,
         })
     }
 }
 
 impl TryFromAscObj<AscBigDecimal> for BigDecimal {
-    fn try_from_asc_obj<H: AscHeap>(
+    fn try_from_asc_obj<H: AscHeap + ?Sized>(
         big_decimal: AscBigDecimal,
         heap: &H,
     ) -> Result<Self, DeterministicHostError> {
-        let digits: BigInt = heap.asc_get(big_decimal.digits)?;
-        let exp: BigInt = heap.asc_get(big_decimal.exp)?;
+        let digits: BigInt = asc_get(heap, big_decimal.digits)?;
+        let exp: BigInt = asc_get(heap, big_decimal.exp)?;
 
         let bytes = exp.to_signed_bytes_le();
         let mut byte_array = if exp >= 0.into() { [0; 8] } else { [255; 8] };
@@ -121,7 +133,7 @@ impl TryFromAscObj<AscBigDecimal> for BigDecimal {
 }
 
 impl ToAscObj<AscEnum<EthereumValueKind>> for ethabi::Token {
-    fn to_asc_obj<H: AscHeap>(
+    fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
     ) -> Result<AscEnum<EthereumValueKind>, DeterministicHostError> {
@@ -129,22 +141,22 @@ impl ToAscObj<AscEnum<EthereumValueKind>> for ethabi::Token {
 
         let kind = EthereumValueKind::get_kind(self);
         let payload = match self {
-            Address(address) => heap.asc_new::<AscAddress, _>(address)?.to_payload(),
+            Address(address) => asc_new::<AscAddress, _, _>(heap, address)?.to_payload(),
             FixedBytes(bytes) | Bytes(bytes) => {
-                heap.asc_new::<Uint8Array, _>(&**bytes)?.to_payload()
+                asc_new::<Uint8Array, _, _>(heap, &**bytes)?.to_payload()
             }
             Int(uint) => {
                 let n = BigInt::from_signed_u256(&uint);
-                heap.asc_new(&n)?.to_payload()
+                asc_new(heap, &n)?.to_payload()
             }
             Uint(uint) => {
                 let n = BigInt::from_unsigned_u256(&uint);
-                heap.asc_new(&n)?.to_payload()
+                asc_new(heap, &n)?.to_payload()
             }
             Bool(b) => *b as u64,
-            String(string) => heap.asc_new(&**string)?.to_payload(),
-            FixedArray(tokens) | Array(tokens) => heap.asc_new(&**tokens)?.to_payload(),
-            Tuple(tokens) => heap.asc_new(&**tokens)?.to_payload(),
+            String(string) => asc_new(heap, &**string)?.to_payload(),
+            FixedArray(tokens) | Array(tokens) => asc_new(heap, &**tokens)?.to_payload(),
+            Tuple(tokens) => asc_new(heap, &**tokens)?.to_payload(),
         };
 
         Ok(AscEnum {
@@ -156,7 +168,7 @@ impl ToAscObj<AscEnum<EthereumValueKind>> for ethabi::Token {
 }
 
 impl FromAscObj<AscEnum<EthereumValueKind>> for ethabi::Token {
-    fn from_asc_obj<H: AscHeap>(
+    fn from_asc_obj<H: AscHeap + ?Sized>(
         asc_enum: AscEnum<EthereumValueKind>,
         heap: &H,
     ) -> Result<Self, DeterministicHostError> {
@@ -167,48 +179,48 @@ impl FromAscObj<AscEnum<EthereumValueKind>> for ethabi::Token {
             EthereumValueKind::Bool => Token::Bool(bool::from(payload)),
             EthereumValueKind::Address => {
                 let ptr: AscPtr<AscAddress> = AscPtr::from(payload);
-                Token::Address(heap.asc_get(ptr)?)
+                Token::Address(asc_get(heap, ptr)?)
             }
             EthereumValueKind::FixedBytes => {
                 let ptr: AscPtr<Uint8Array> = AscPtr::from(payload);
-                Token::FixedBytes(heap.asc_get(ptr)?)
+                Token::FixedBytes(asc_get(heap, ptr)?)
             }
             EthereumValueKind::Bytes => {
                 let ptr: AscPtr<Uint8Array> = AscPtr::from(payload);
-                Token::Bytes(heap.asc_get(ptr)?)
+                Token::Bytes(asc_get(heap, ptr)?)
             }
             EthereumValueKind::Int => {
                 let ptr: AscPtr<AscBigInt> = AscPtr::from(payload);
-                let n: BigInt = heap.asc_get(ptr)?;
+                let n: BigInt = asc_get(heap, ptr)?;
                 Token::Int(n.to_signed_u256())
             }
             EthereumValueKind::Uint => {
                 let ptr: AscPtr<AscBigInt> = AscPtr::from(payload);
-                let n: BigInt = heap.asc_get(ptr)?;
+                let n: BigInt = asc_get(heap, ptr)?;
                 Token::Uint(n.to_unsigned_u256())
             }
             EthereumValueKind::String => {
                 let ptr: AscPtr<AscString> = AscPtr::from(payload);
-                Token::String(heap.asc_get(ptr)?)
+                Token::String(asc_get(heap, ptr)?)
             }
             EthereumValueKind::FixedArray => {
                 let ptr: AscEnumArray<EthereumValueKind> = AscPtr::from(payload);
-                Token::FixedArray(heap.asc_get(ptr)?)
+                Token::FixedArray(asc_get(heap, ptr)?)
             }
             EthereumValueKind::Array => {
                 let ptr: AscEnumArray<EthereumValueKind> = AscPtr::from(payload);
-                Token::Array(heap.asc_get(ptr)?)
+                Token::Array(asc_get(heap, ptr)?)
             }
             EthereumValueKind::Tuple => {
                 let ptr: AscEnumArray<EthereumValueKind> = AscPtr::from(payload);
-                Token::Tuple(heap.asc_get(ptr)?)
+                Token::Tuple(asc_get(heap, ptr)?)
             }
         })
     }
 }
 
 impl TryFromAscObj<AscEnum<StoreValueKind>> for store::Value {
-    fn try_from_asc_obj<H: AscHeap>(
+    fn try_from_asc_obj<H: AscHeap + ?Sized>(
         asc_enum: AscEnum<StoreValueKind>,
         heap: &H,
     ) -> Result<Self, DeterministicHostError> {
@@ -218,27 +230,27 @@ impl TryFromAscObj<AscEnum<StoreValueKind>> for store::Value {
         Ok(match asc_enum.kind {
             StoreValueKind::String => {
                 let ptr: AscPtr<AscString> = AscPtr::from(payload);
-                Value::String(heap.asc_get(ptr)?)
+                Value::String(asc_get(heap, ptr)?)
             }
             StoreValueKind::Int => Value::Int(i32::from(payload)),
             StoreValueKind::BigDecimal => {
                 let ptr: AscPtr<AscBigDecimal> = AscPtr::from(payload);
-                Value::BigDecimal(heap.try_asc_get(ptr)?)
+                Value::BigDecimal(try_asc_get(heap, ptr)?)
             }
             StoreValueKind::Bool => Value::Bool(bool::from(payload)),
             StoreValueKind::Array => {
                 let ptr: AscEnumArray<StoreValueKind> = AscPtr::from(payload);
-                Value::List(heap.try_asc_get(ptr)?)
+                Value::List(try_asc_get(heap, ptr)?)
             }
             StoreValueKind::Null => Value::Null,
             StoreValueKind::Bytes => {
                 let ptr: AscPtr<Bytes> = AscPtr::from(payload);
-                let array: Vec<u8> = heap.asc_get(ptr)?;
+                let array: Vec<u8> = asc_get(heap, ptr)?;
                 Value::Bytes(array.as_slice().into())
             }
             StoreValueKind::BigInt => {
                 let ptr: AscPtr<AscBigInt> = AscPtr::from(payload);
-                let array: Vec<u8> = heap.asc_get(ptr)?;
+                let array: Vec<u8> = asc_get(heap, ptr)?;
                 Value::BigInt(store::scalar::BigInt::from_signed_bytes_le(&array))
             }
         })
@@ -246,25 +258,25 @@ impl TryFromAscObj<AscEnum<StoreValueKind>> for store::Value {
 }
 
 impl ToAscObj<AscEnum<StoreValueKind>> for store::Value {
-    fn to_asc_obj<H: AscHeap>(
+    fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
     ) -> Result<AscEnum<StoreValueKind>, DeterministicHostError> {
         use self::store::Value;
 
         let payload = match self {
-            Value::String(string) => heap.asc_new(string.as_str())?.into(),
+            Value::String(string) => asc_new(heap, string.as_str())?.into(),
             Value::Int(n) => EnumPayload::from(*n),
-            Value::BigDecimal(n) => heap.asc_new(n)?.into(),
+            Value::BigDecimal(n) => asc_new(heap, n)?.into(),
             Value::Bool(b) => EnumPayload::from(*b),
-            Value::List(array) => heap.asc_new(array.as_slice())?.into(),
+            Value::List(array) => asc_new(heap, array.as_slice())?.into(),
             Value::Null => EnumPayload(0),
             Value::Bytes(bytes) => {
-                let bytes_obj: AscPtr<Uint8Array> = heap.asc_new(bytes.as_slice())?;
+                let bytes_obj: AscPtr<Uint8Array> = asc_new(heap, bytes.as_slice())?;
                 bytes_obj.into()
             }
             Value::BigInt(big_int) => {
-                let bytes_obj: AscPtr<Uint8Array> = heap.asc_new(&*big_int.to_signed_bytes_le())?;
+                let bytes_obj: AscPtr<Uint8Array> = asc_new(heap, &*big_int.to_signed_bytes_le())?;
                 bytes_obj.into()
             }
         };
@@ -278,33 +290,42 @@ impl ToAscObj<AscEnum<StoreValueKind>> for store::Value {
 }
 
 impl ToAscObj<AscLogParam> for ethabi::LogParam {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscLogParam, DeterministicHostError> {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscLogParam, DeterministicHostError> {
         Ok(AscLogParam {
-            name: heap.asc_new(self.name.as_str())?,
-            value: heap.asc_new(&self.value)?,
+            name: asc_new(heap, self.name.as_str())?,
+            value: asc_new(heap, &self.value)?,
         })
     }
 }
 
 impl ToAscObj<AscJson> for serde_json::Map<String, serde_json::Value> {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscJson, DeterministicHostError> {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscJson, DeterministicHostError> {
         Ok(AscTypedMap {
-            entries: heap.asc_new(&*self.iter().collect::<Vec<_>>())?,
+            entries: asc_new(heap, &*self.iter().collect::<Vec<_>>())?,
         })
     }
 }
 
 // Used for serializing entities.
 impl ToAscObj<AscEntity> for Vec<(String, store::Value)> {
-    fn to_asc_obj<H: AscHeap>(&self, heap: &mut H) -> Result<AscEntity, DeterministicHostError> {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+    ) -> Result<AscEntity, DeterministicHostError> {
         Ok(AscTypedMap {
-            entries: heap.asc_new(self.as_slice())?,
+            entries: asc_new(heap, self.as_slice())?,
         })
     }
 }
 
 impl ToAscObj<AscEnum<JsonValueKind>> for serde_json::Value {
-    fn to_asc_obj<H: AscHeap>(
+    fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
     ) -> Result<AscEnum<JsonValueKind>, DeterministicHostError> {
@@ -313,10 +334,10 @@ impl ToAscObj<AscEnum<JsonValueKind>> for serde_json::Value {
         let payload = match self {
             Value::Null => EnumPayload(0),
             Value::Bool(b) => EnumPayload::from(*b),
-            Value::Number(number) => heap.asc_new(&*number.to_string())?.into(),
-            Value::String(string) => heap.asc_new(string.as_str())?.into(),
-            Value::Array(array) => heap.asc_new(array.as_slice())?.into(),
-            Value::Object(object) => heap.asc_new(object)?.into(),
+            Value::Number(number) => asc_new(heap, &*number.to_string())?.into(),
+            Value::String(string) => asc_new(heap, string.as_str())?.into(),
+            Value::Array(array) => asc_new(heap, array.as_slice())?.into(),
+            Value::Object(object) => asc_new(heap, object)?.into(),
         };
 
         Ok(AscEnum {
@@ -328,69 +349,69 @@ impl ToAscObj<AscEnum<JsonValueKind>> for serde_json::Value {
 }
 
 impl ToAscObj<AscEthereumBlock> for EthereumBlockData {
-    fn to_asc_obj<H: AscHeap>(
+    fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
     ) -> Result<AscEthereumBlock, DeterministicHostError> {
         Ok(AscEthereumBlock {
-            hash: heap.asc_new(&self.hash)?,
-            parent_hash: heap.asc_new(&self.parent_hash)?,
-            uncles_hash: heap.asc_new(&self.uncles_hash)?,
-            author: heap.asc_new(&self.author)?,
-            state_root: heap.asc_new(&self.state_root)?,
-            transactions_root: heap.asc_new(&self.transactions_root)?,
-            receipts_root: heap.asc_new(&self.receipts_root)?,
-            number: heap.asc_new(&BigInt::from(self.number))?,
-            gas_used: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_used))?,
-            gas_limit: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_limit))?,
-            timestamp: heap.asc_new(&BigInt::from_unsigned_u256(&self.timestamp))?,
-            difficulty: heap.asc_new(&BigInt::from_unsigned_u256(&self.difficulty))?,
-            total_difficulty: heap.asc_new(&BigInt::from_unsigned_u256(&self.total_difficulty))?,
+            hash: asc_new(heap, &self.hash)?,
+            parent_hash: asc_new(heap, &self.parent_hash)?,
+            uncles_hash: asc_new(heap, &self.uncles_hash)?,
+            author: asc_new(heap, &self.author)?,
+            state_root: asc_new(heap, &self.state_root)?,
+            transactions_root: asc_new(heap, &self.transactions_root)?,
+            receipts_root: asc_new(heap, &self.receipts_root)?,
+            number: asc_new(heap, &BigInt::from(self.number))?,
+            gas_used: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_used))?,
+            gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_limit))?,
+            timestamp: asc_new(heap, &BigInt::from_unsigned_u256(&self.timestamp))?,
+            difficulty: asc_new(heap, &BigInt::from_unsigned_u256(&self.difficulty))?,
+            total_difficulty: asc_new(heap, &BigInt::from_unsigned_u256(&self.total_difficulty))?,
             size: self
                 .size
-                .map(|size| heap.asc_new(&BigInt::from_unsigned_u256(&size)))
+                .map(|size| asc_new(heap, &BigInt::from_unsigned_u256(&size)))
                 .unwrap_or(Ok(AscPtr::null()))?,
         })
     }
 }
 
 impl ToAscObj<AscEthereumTransaction> for EthereumTransactionData {
-    fn to_asc_obj<H: AscHeap>(
+    fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
     ) -> Result<AscEthereumTransaction, DeterministicHostError> {
         Ok(AscEthereumTransaction {
-            hash: heap.asc_new(&self.hash)?,
-            index: heap.asc_new(&BigInt::from(self.index))?,
-            from: heap.asc_new(&self.from)?,
+            hash: asc_new(heap, &self.hash)?,
+            index: asc_new(heap, &BigInt::from(self.index))?,
+            from: asc_new(heap, &self.from)?,
             to: self
                 .to
-                .map(|to| heap.asc_new(&to))
+                .map(|to| asc_new(heap, &to))
                 .unwrap_or(Ok(AscPtr::null()))?,
-            value: heap.asc_new(&BigInt::from_unsigned_u256(&self.value))?,
-            gas_used: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_used))?,
-            gas_price: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_price))?,
+            value: asc_new(heap, &BigInt::from_unsigned_u256(&self.value))?,
+            gas_used: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_used))?,
+            gas_price: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_price))?,
         })
     }
 }
 
 impl ToAscObj<AscEthereumTransaction_0_0_2> for EthereumTransactionData {
-    fn to_asc_obj<H: AscHeap>(
+    fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
     ) -> Result<AscEthereumTransaction_0_0_2, DeterministicHostError> {
         Ok(AscEthereumTransaction_0_0_2 {
-            hash: heap.asc_new(&self.hash)?,
-            index: heap.asc_new(&BigInt::from(self.index))?,
-            from: heap.asc_new(&self.from)?,
+            hash: asc_new(heap, &self.hash)?,
+            index: asc_new(heap, &BigInt::from(self.index))?,
+            from: asc_new(heap, &self.from)?,
             to: self
                 .to
-                .map(|to| heap.asc_new(&to))
+                .map(|to| asc_new(heap, &to))
                 .unwrap_or(Ok(AscPtr::null()))?,
-            value: heap.asc_new(&BigInt::from_unsigned_u256(&self.value))?,
-            gas_used: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_used))?,
-            gas_price: heap.asc_new(&BigInt::from_unsigned_u256(&self.gas_price))?,
-            input: heap.asc_new(&*self.input.0)?,
+            value: asc_new(heap, &BigInt::from_unsigned_u256(&self.value))?,
+            gas_used: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_used))?,
+            gas_price: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_price))?,
+            input: asc_new(heap, &*self.input.0)?,
         })
     }
 }
@@ -399,84 +420,86 @@ impl<T: AscType> ToAscObj<AscEthereumEvent<T>> for EthereumEventData
 where
     EthereumTransactionData: ToAscObj<T>,
 {
-    fn to_asc_obj<H: AscHeap>(
+    fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
     ) -> Result<AscEthereumEvent<T>, DeterministicHostError> {
         Ok(AscEthereumEvent {
-            address: heap.asc_new(&self.address)?,
-            log_index: heap.asc_new(&BigInt::from_unsigned_u256(&self.log_index))?,
-            transaction_log_index: heap
-                .asc_new(&BigInt::from_unsigned_u256(&self.transaction_log_index))?,
+            address: asc_new(heap, &self.address)?,
+            log_index: asc_new(heap, &BigInt::from_unsigned_u256(&self.log_index))?,
+            transaction_log_index: asc_new(
+                heap,
+                &BigInt::from_unsigned_u256(&self.transaction_log_index),
+            )?,
             log_type: self
                 .log_type
                 .clone()
-                .map(|log_type| heap.asc_new(&log_type))
+                .map(|log_type| asc_new(heap, &log_type))
                 .unwrap_or(Ok(AscPtr::null()))?,
-            block: heap.asc_new(&self.block)?,
-            transaction: heap.asc_new::<T, EthereumTransactionData>(&self.transaction)?,
-            params: heap.asc_new(self.params.as_slice())?,
+            block: asc_new(heap, &self.block)?,
+            transaction: asc_new::<T, EthereumTransactionData, _>(heap, &self.transaction)?,
+            params: asc_new(heap, self.params.as_slice())?,
         })
     }
 }
 
 impl ToAscObj<AscEthereumCall> for EthereumCallData {
-    fn to_asc_obj<H: AscHeap>(
+    fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
     ) -> Result<AscEthereumCall, DeterministicHostError> {
         Ok(AscEthereumCall {
-            address: heap.asc_new(&self.to)?,
-            block: heap.asc_new(&self.block)?,
-            transaction: heap.asc_new(&self.transaction)?,
-            inputs: heap.asc_new(self.inputs.as_slice())?,
-            outputs: heap.asc_new(self.outputs.as_slice())?,
+            address: asc_new(heap, &self.to)?,
+            block: asc_new(heap, &self.block)?,
+            transaction: asc_new(heap, &self.transaction)?,
+            inputs: asc_new(heap, self.inputs.as_slice())?,
+            outputs: asc_new(heap, self.outputs.as_slice())?,
         })
     }
 }
 
 impl ToAscObj<AscEthereumCall_0_0_3> for EthereumCallData {
-    fn to_asc_obj<H: AscHeap>(
+    fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
     ) -> Result<AscEthereumCall_0_0_3, DeterministicHostError> {
         Ok(AscEthereumCall_0_0_3 {
-            to: heap.asc_new(&self.to)?,
-            from: heap.asc_new(&self.from)?,
-            block: heap.asc_new(&self.block)?,
-            transaction: heap.asc_new(&self.transaction)?,
-            inputs: heap.asc_new(self.inputs.as_slice())?,
-            outputs: heap.asc_new(self.outputs.as_slice())?,
+            to: asc_new(heap, &self.to)?,
+            from: asc_new(heap, &self.from)?,
+            block: asc_new(heap, &self.block)?,
+            transaction: asc_new(heap, &self.transaction)?,
+            inputs: asc_new(heap, self.inputs.as_slice())?,
+            outputs: asc_new(heap, self.outputs.as_slice())?,
         })
     }
 }
 
 impl FromAscObj<AscUnresolvedContractCall> for UnresolvedContractCall {
-    fn from_asc_obj<H: AscHeap>(
+    fn from_asc_obj<H: AscHeap + ?Sized>(
         asc_call: AscUnresolvedContractCall,
         heap: &H,
     ) -> Result<Self, DeterministicHostError> {
         Ok(UnresolvedContractCall {
-            contract_name: heap.asc_get(asc_call.contract_name)?,
-            contract_address: heap.asc_get(asc_call.contract_address)?,
-            function_name: heap.asc_get(asc_call.function_name)?,
+            contract_name: asc_get(heap, asc_call.contract_name)?,
+            contract_address: asc_get(heap, asc_call.contract_address)?,
+            function_name: asc_get(heap, asc_call.function_name)?,
             function_signature: None,
-            function_args: heap.asc_get(asc_call.function_args)?,
+            function_args: asc_get(heap, asc_call.function_args)?,
         })
     }
 }
 
 impl FromAscObj<AscUnresolvedContractCall_0_0_4> for UnresolvedContractCall {
-    fn from_asc_obj<H: AscHeap>(
+    fn from_asc_obj<H: AscHeap + ?Sized>(
         asc_call: AscUnresolvedContractCall_0_0_4,
         heap: &H,
     ) -> Result<Self, DeterministicHostError> {
         Ok(UnresolvedContractCall {
-            contract_name: heap.asc_get(asc_call.contract_name)?,
-            contract_address: heap.asc_get(asc_call.contract_address)?,
-            function_name: heap.asc_get(asc_call.function_name)?,
-            function_signature: Some(heap.asc_get(asc_call.function_signature)?),
-            function_args: heap.asc_get(asc_call.function_args)?,
+            contract_name: asc_get(heap, asc_call.contract_name)?,
+            contract_address: asc_get(heap, asc_call.contract_address)?,
+            function_name: asc_get(heap, asc_call.function_name)?,
+            function_signature: Some(asc_get(heap, asc_call.function_signature)?),
+            function_args: asc_get(heap, asc_call.function_args)?,
         })
     }
 }
@@ -495,7 +518,7 @@ impl From<u32> for LogLevel {
 }
 
 impl<T: AscType> ToAscObj<AscWrapped<T>> for AscWrapped<T> {
-    fn to_asc_obj<H: AscHeap>(
+    fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         _heap: &mut H,
     ) -> Result<AscWrapped<T>, DeterministicHostError> {
@@ -510,25 +533,25 @@ where
     VAsc: AscType,
     EAsc: AscType,
 {
-    fn to_asc_obj<H: AscHeap>(
+    fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
     ) -> Result<AscResult<VAsc, EAsc>, DeterministicHostError> {
         Ok(match self {
             Ok(value) => AscResult {
                 value: {
-                    let inner = heap.asc_new(value)?;
+                    let inner = asc_new(heap, value)?;
                     let wrapped = AscWrapped { inner };
-                    heap.asc_new(&wrapped)?
+                    asc_new(heap, &wrapped)?
                 },
                 error: AscPtr::null(),
             },
             Err(e) => AscResult {
                 value: AscPtr::null(),
                 error: {
-                    let inner = heap.asc_new(e)?;
+                    let inner = asc_new(heap, e)?;
                     let wrapped = AscWrapped { inner };
-                    heap.asc_new(&wrapped)?
+                    asc_new(heap, &wrapped)?
                 },
             },
         })


### PR DESCRIPTION
By moving `try_asc_get`, `asc_get` and `asc_new` out of the trait.

The only real change is in `graph/src/runtime/asc_heap.rs`, the rest is just mechanical refactoring from the fallout.