### PR TITLE
Control which tables are 'account like' without query node restarts

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -154,6 +154,8 @@ pub enum Command {
     },
     /// Get information about chains and manipulate them
     Chain(ChainCommand),
+    /// Manipulate internal subgraph statistics
+    Stats(StatsCommand),
 }
 
 impl Command {
@@ -292,6 +294,16 @@ pub enum ChainCommand {
     /// There must be no deployments using that chain. If there are, the
     /// subgraphs and/or deployments using the chain must first be removed
     Remove { name: String },
+}
+
+#[derive(Clone, Debug, StructOpt)]
+pub enum StatsCommand {
+    /// List all chains that are in the database
+    AccountLike {
+        #[structopt(long, help = "do not set but clear the account-like flag\n")]
+        clear: bool,
+        table: String,
+    },
 }
 
 impl From<Opt> for config::Opt {
@@ -555,6 +567,14 @@ async fn main() {
                 Remove { name } => {
                     let (block_store, primary) = ctx.block_store_and_primary_pool();
                     commands::chain::remove(primary, block_store, name)
+                }
+            }
+        }
+        Stats(cmd) => {
+            use StatsCommand::*;
+            match cmd {
+                AccountLike { clear, table } => {
+                    commands::stats::account_like(ctx.pools(), clear, table)
                 }
             }
         }

--- a/node/src/manager/commands/mod.rs
+++ b/node/src/manager/commands/mod.rs
@@ -8,5 +8,6 @@ pub mod listen;
 pub mod query;
 pub mod remove;
 pub mod rewind;
+pub mod stats;
 pub mod txn_speed;
 pub mod unused_deployments;

--- a/node/src/manager/commands/stats.rs
+++ b/node/src/manager/commands/stats.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+
+use graph::prelude::anyhow;
+use graph_store_postgres::command_support::{catalog as store_catalog, SqlName};
+use graph_store_postgres::connection_pool::ConnectionPool;
+use graph_store_postgres::Shard;
+use graph_store_postgres::PRIMARY_SHARD;
+
+fn parse_table_name(table: &str) -> Result<(&str, SqlName), anyhow::Error> {
+    let mut parts = table.split('.');
+    let nsp = parts
+        .next()
+        .ok_or_else(|| anyhow!("the table must be in the form 'sgdNNN.table'"))?;
+    let table = parts
+        .next()
+        .ok_or_else(|| anyhow!("the table must be in the form 'sgdNNN.table'"))?;
+    let table = SqlName::from(table);
+
+    if !parts.next().is_none() {
+        return Err(anyhow!("the table must be in the form 'sgdNNN.table'"));
+    }
+    Ok((nsp, table))
+}
+
+pub fn account_like(
+    pools: HashMap<Shard, ConnectionPool>,
+    clear: bool,
+    table: String,
+) -> Result<(), anyhow::Error> {
+    let (nsp, table_name) = parse_table_name(&table)?;
+
+    let conn = pools.get(&*PRIMARY_SHARD).unwrap().get()?;
+    let conn = store_catalog::Connection::new(conn);
+
+    let site = conn
+        .find_site_by_name(nsp)?
+        .ok_or_else(|| anyhow!("deployment `{}` does not exist", table_name))?;
+
+    let conn = pools.get(&site.shard).unwrap().get()?;
+    store_catalog::set_account_like(&conn, &site, &table_name, !clear)?;
+    let clear_text = if clear { "cleared" } else { "set" };
+    println!("{}: account-like flag {}", table, clear_text);
+
+    Ok(())
+}

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -145,13 +145,13 @@ pub fn main() {
         Namespace::new(namespace.to_string()),
         "Invalid database schema",
     );
+    let site = Arc::new(make_dummy_site(subgraph, namespace, "anet".to_string()));
     let catalog = ensure(
-        Catalog::make_empty(namespace.clone()),
+        Catalog::make_empty(site.clone()),
         "Failed to construct catalog",
     );
-    let site = make_dummy_site(subgraph, namespace, "anet".to_string());
     let layout = ensure(
-        Layout::new(Arc::new(site), &schema, catalog, false),
+        Layout::new(site, &schema, catalog, false),
         "Failed to construct Mapping",
     );
     match kind {

--- a/store/postgres/migrations/2021-06-01-222649_create_stats/down.sql
+++ b/store/postgres/migrations/2021-06-01-222649_create_stats/down.sql
@@ -1,0 +1,1 @@
+drop table subgraphs.table_stats;

--- a/store/postgres/migrations/2021-06-01-222649_create_stats/up.sql
+++ b/store/postgres/migrations/2021-06-01-222649_create_stats/up.sql
@@ -1,0 +1,9 @@
+create table subgraphs.table_stats(
+  id              serial primary key,
+  deployment      int not null
+                  references subgraphs.subgraph_deployment
+                  on delete cascade,
+  table_name      text not null,
+  is_account_like bool,
+  unique(deployment, table_name)
+);

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -185,8 +185,8 @@ impl DeploymentStore {
                         return Err(StoreError::Unknown(anyhow!(
                             "The subgraph `{}` cannot be used as the graft base \
                                                     for `{}` because the schemas are incompatible:\n    - {}",
-                            &base.catalog.namespace,
-                            &layout.catalog.namespace,
+                            &base.catalog.site.namespace,
+                            &layout.catalog.site.namespace,
                             errors.join("\n    - ")
                         )));
                     }
@@ -504,7 +504,7 @@ impl DeploymentStore {
 
         let subgraph_schema = deployment::schema(conn, site.as_ref())?;
         let has_poi = crate::catalog::supports_proof_of_indexing(conn, &site.namespace)?;
-        let catalog = Catalog::new(conn, site.namespace.clone())?;
+        let catalog = Catalog::new(conn, site.clone())?;
         let layout = Arc::new(Layout::new(
             site.clone(),
             &subgraph_schema,
@@ -1091,8 +1091,8 @@ impl DeploymentStore {
             info!(
                 logger,
                 "Initializing graft by copying data from {} to {}",
-                src.catalog.namespace,
-                dst.catalog.namespace
+                src.catalog.site.namespace,
+                dst.catalog.site.namespace
             );
 
             // Copy subgraph data

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -52,6 +52,7 @@ mod subgraph_store;
 pub mod layout_for_tests {
     pub use crate::block_range::*;
     pub use crate::block_store::FAKE_NETWORK_SHARED;
+    pub use crate::catalog::set_account_like;
     pub use crate::chain_store::test_support as chain_support;
     pub use crate::primary::{
         make_dummy_site, Connection, Namespace, EVENT_TAP, EVENT_TAP_ENABLED,

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -74,6 +74,7 @@ pub use self::subgraph_store::{unused, DeploymentPlacer, Shard, SubgraphStore, P
 pub mod command_support {
     pub mod catalog {
         pub use crate::block_store::primary as block_store;
+        pub use crate::catalog::set_account_like;
         pub use crate::copy::{copy_state, copy_table_state};
         pub use crate::primary::Connection;
         pub use crate::primary::{
@@ -82,5 +83,5 @@ pub mod command_support {
         };
     }
     pub use crate::primary::Namespace;
-    pub use crate::relational::{Catalog, Column, ColumnType, Layout};
+    pub use crate::relational::{Catalog, Column, ColumnType, Layout, SqlName};
 }

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -912,6 +912,14 @@ impl<'a> Connection<'a> {
         schema.map(|schema| schema.try_into()).transpose()
     }
 
+    pub fn find_site_by_name(&self, name: &str) -> Result<Option<Site>, StoreError> {
+        let schema = deployment_schemas::table
+            .filter(deployment_schemas::name.eq(name))
+            .first::<Schema>(self.0.as_ref())
+            .optional()?;
+        schema.map(|schema| schema.try_into()).transpose()
+    }
+
     pub fn find_sites_for_network(&self, network: &str) -> Result<Vec<Site>, StoreError> {
         use deployment_schemas as ds;
 

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -8,7 +8,9 @@
 //! information about mapping a GraphQL schema to database tables
 use diesel::{connection::SimpleConnection, Connection};
 use diesel::{debug_query, OptionalExtension, PgConnection, RunQueryDsl};
+use graph::cheap_clone::CheapClone;
 use graph::prelude::{q, s, StopwatchMetrics};
+use graph::slog::warn;
 use inflector::Inflector;
 use lazy_static::lazy_static;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -16,7 +18,7 @@ use std::convert::{From, TryFrom};
 use std::env;
 use std::fmt::{self, Write};
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::{
@@ -38,9 +40,9 @@ use graph::prelude::{
 };
 
 use crate::block_range::BLOCK_RANGE_COLUMN;
-use crate::catalog;
 pub use crate::catalog::Catalog;
 use crate::connection_pool::ForeignServer;
+use crate::{catalog, deployment};
 
 const POSTGRES_MAX_PARAMETERS: usize = u16::MAX as usize; // 65535
 const DELETE_OPERATION_CHUNK_SIZE: usize = 1_000;
@@ -54,21 +56,6 @@ const DELETE_OPERATION_CHUNK_SIZE: usize = 1_000;
 pub const STRING_PREFIX_SIZE: usize = 256;
 
 lazy_static! {
-    /// Experimental: a list of fully qualified table names that contain
-    /// entities that are like accounts in that they have a relatively small
-    /// number of entities, with a large number of change for each entity. It
-    /// is useful to treat such tables special in queries by changing the
-    /// clause that selects for a specific block range in a way that makes
-    /// the BRIN index on block_range usable
-    ///
-    /// Example: GRAPH_ACCOUNT_TABLES=sgd21902.pair,sgd1708.things
-    static ref ACCOUNT_TABLES: HashSet<String> = {
-        env::var("GRAPH_ACCOUNT_TABLES")
-            .ok()
-            .map(|v| v.split(",").map(|s| s.to_owned()).collect())
-            .unwrap_or(HashSet::new())
-    };
-
     /// `GRAPH_SQL_STATEMENT_TIMEOUT` is the timeout for queries in seconds.
     /// If it is not set, no statement timeout will be enforced. The statement
     /// timeout is local, i.e., can only be used within a transaction and
@@ -792,6 +779,28 @@ impl Layout {
         // safe to cache a Layout
         true
     }
+
+    /// Update the layout with the latest information from the database; for
+    /// now, an update only changes the `is_account_like` flag for tables.
+    /// If no update is needed, just return `self`.
+    pub fn refresh(self: Arc<Self>, conn: &PgConnection) -> Result<Arc<Self>, StoreError> {
+        let account_like = crate::catalog::account_like(conn, &self.site)?;
+        let changed_tables: Vec<_> = self
+            .tables
+            .values()
+            .filter(|table| table.is_account_like != account_like.contains(table.name.as_str()))
+            .collect();
+        if changed_tables.is_empty() {
+            return Ok(self);
+        }
+        let mut layout = (*self).clone();
+        for table in changed_tables.into_iter() {
+            let mut table = (*table.as_ref()).clone();
+            table.is_account_like = account_like.contains(table.name.as_str());
+            layout.tables.insert(table.object.clone(), Arc::new(table));
+        }
+        Ok(Arc::new(layout))
+    }
 }
 
 /// A user-defined enum
@@ -1085,7 +1094,7 @@ pub(crate) const PRIMARY_KEY_COLUMN: &str = "id";
 /// synthetic primary key. This is the name of the column we use.
 pub(crate) const VID_COLUMN: &str = "vid";
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub struct Table {
     /// The name of the GraphQL object type ('Thing')
     pub object: EntityType,
@@ -1129,13 +1138,11 @@ impl Table {
             .map(|field| Column::new(&table_name, field, catalog, enums, id_types))
             .chain(fulltexts.iter().map(|def| Column::new_fulltext(def)))
             .collect::<Result<Vec<Column>, StoreError>>()?;
-        let is_account_like =
-            ACCOUNT_TABLES.contains(&format!("{}.{}", catalog.site.namespace, table_name));
         let table = Table {
             object: EntityType::from(defn),
             name: table_name.clone(),
             qualified_name: SqlName::qualified_name(&catalog.site.namespace, &table_name),
-            is_account_like,
+            is_account_like: false,
             columns,
             position,
         };
@@ -1329,6 +1336,130 @@ fn is_object_type(field_type: &q::Type, enums: &EnumMap) -> bool {
     let name = named_type(field_type);
 
     !enums.contains_key(&*name) && !ValueType::is_scalar(name)
+}
+
+#[derive(Clone)]
+struct CacheEntry {
+    value: Arc<Layout>,
+    expires: Instant,
+}
+
+/// Cache layouts for some time and refresh them when they expire.
+/// Refreshing happens one at a time, and the cache makes sure we minimize
+/// blocking while a refresh happens, favoring using an expired layout over
+/// a refreshed one.
+pub struct LayoutCache {
+    entries: Mutex<HashMap<DeploymentHash, CacheEntry>>,
+    ttl: Duration,
+    /// Use this so that we only refresh one layout at any given time to
+    /// avoid refreshing the same layout multiple times
+    refresh: Mutex<()>,
+}
+
+impl LayoutCache {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+            ttl,
+            refresh: Mutex::new(()),
+        }
+    }
+
+    fn load(conn: &PgConnection, site: Arc<Site>) -> Result<Arc<Layout>, StoreError> {
+        let subgraph_schema = deployment::schema(conn, site.as_ref())?;
+        let has_poi = crate::catalog::supports_proof_of_indexing(conn, &site.namespace)?;
+        let catalog = Catalog::new(conn, site.clone())?;
+        let layout = Arc::new(Layout::new(
+            site.clone(),
+            &subgraph_schema,
+            catalog,
+            has_poi,
+        )?);
+        Ok(layout)
+    }
+
+    fn cache(&self, layout: Arc<Layout>) {
+        if layout.is_cacheable() {
+            let deployment = layout.site.deployment.clone();
+            let entry = CacheEntry {
+                expires: Instant::now() + self.ttl,
+                value: layout,
+            };
+            &self.entries.lock().unwrap().insert(deployment, entry);
+        }
+    }
+
+    /// Return the corresponding layout if we have one in cache already, and
+    /// ignore expiration information
+    pub(crate) fn find(&self, site: &Site) -> Option<Arc<Layout>> {
+        self.entries
+            .lock()
+            .unwrap()
+            .get(&site.deployment)
+            .map(|CacheEntry { value, expires: _ }| value.clone())
+    }
+
+    /// Get the layout for `site`. If it's not in cache, load it. If it is
+    /// expired, try to refresh it if there isn't another refresh happening
+    /// already
+    pub fn get(
+        &self,
+        logger: &Logger,
+        conn: &PgConnection,
+        site: Arc<Site>,
+    ) -> Result<Arc<Layout>, StoreError> {
+        let now = Instant::now();
+        let entry = {
+            let lock = self.entries.lock().unwrap();
+            lock.get(&site.deployment).cloned()
+        };
+        match entry {
+            Some(CacheEntry { value, expires }) => {
+                if now <= expires {
+                    // Entry is not expired; use it
+                    return Ok(value);
+                } else {
+                    // Only do a cache refresh once; we don't want to have
+                    // multiple threads refreshing the same layout
+                    // simultaneously. It's easiest to refresh at most one
+                    // layout globally
+                    let refresh = self.refresh.try_lock();
+                    if let Err(_) = refresh {
+                        return Ok(value.clone());
+                    }
+                    match value.cheap_clone().refresh(conn) {
+                        Err(e) => {
+                            warn!(
+                                logger,
+                                "failed to refresh statistics. Continuing with old statistics";
+                                "deployment" => &value.site.deployment,
+                                "error" => e.to_string()
+                            );
+                            // Update the timestamp so we don't retry
+                            // refreshing too often
+                            self.cache(value.cheap_clone());
+                            return Ok(value);
+                        }
+                        Ok(layout) => {
+                            self.cache(layout.cheap_clone());
+                            return Ok(layout);
+                        }
+                    }
+                }
+            }
+            None => {
+                let layout = Self::load(conn, site)?;
+                self.cache(layout.cheap_clone());
+                return Ok(layout);
+            }
+        }
+    }
+
+    // Only needed for tests
+    #[cfg(debug_assertions)]
+    pub(crate) fn clear(&self) {
+        self.entries.lock().unwrap().clear()
+    }
 }
 
 #[cfg(test)]

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -289,7 +289,7 @@ impl SubgraphStoreInner {
     #[cfg(debug_assertions)]
     pub(crate) fn clear_caches(&self) {
         for store in self.stores.values() {
-            store.layout_cache.lock().unwrap().clear();
+            store.layout_cache.clear();
         }
         self.sites.clear();
     }


### PR DESCRIPTION
With these changes, which tables are 'account like' is set through a database table, and the corresponding information is refreshed every 5 minutes, making it possible to change query behavior without restarting query nodes.

A future enhancement would be to gather information about which tables are 'account like', i.e., with a high ratio of entity versions to entities automatically, and base the decision on that data. Gathering this data isn't entirely trivial, and is therefore left out of this PR.