### PR TITLE
runtime: Fix string truncation

### DIFF
--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -802,7 +802,7 @@ pub(crate) fn bytes_to_string(logger: &Logger, bytes: Vec<u8>) -> String {
             "Bytes contain invalid UTF8. This may be caused by attempting \
             to convert a value such as an address that cannot be parsed to a unicode string. \
             You may want to use 'toHexString()' instead. String (truncated to 1024 chars): '{}'",
-            &s[..s.len().min(1024)],
+            &s.chars().take(1024).collect::<String>(),
         )
     }
 


### PR DESCRIPTION
Truncating utf-8 is tricky! But this is a panic-free way to do it.