### PR TITLE
Wrap 'LightEthereumBlock' in an Arc

### DIFF
--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -38,7 +38,6 @@ pub struct DataSource {
     pub contract_abi: Arc<MappingABI>,
 }
 
-// ETHDEP: The whole DataSource struct needs to move to chain::ethereum
 impl blockchain::DataSource<Chain> for DataSource {
     fn match_and_decode(
         &self,
@@ -46,7 +45,7 @@ impl blockchain::DataSource<Chain> for DataSource {
         block: Arc<<Chain as Blockchain>::Block>,
         logger: &Logger,
     ) -> Result<Option<<Chain as Blockchain>::MappingTrigger>, Error> {
-        let block = Arc::new(block.0.light_block());
+        let block = block.0.light_block();
         self.match_and_decode(trigger, block, logger)
     }
 

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -985,7 +985,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
         if block.transactions.is_empty() {
             trace!(logger, "Block {} contains no transactions", block_hash);
             return Box::new(future::ok(EthereumBlock {
-                block,
+                block: Arc::new(block),
                 transaction_receipts: Vec::new(),
             }));
         }
@@ -1074,7 +1074,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
                         .and_then(move |_| {
                             stream::futures_ordered(receipt_futures).collect().map(
                                 move |transaction_receipts| EthereumBlock {
-                                    block,
+                                    block: Arc::new(block),
                                     transaction_receipts,
                                 },
                             )
@@ -1490,7 +1490,7 @@ pub(crate) async fn blocks_with_triggers(
         .and_then(
             move |block| match triggers_by_block.remove(&(block.number() as BlockNumber)) {
                 Some(triggers) => Ok(BlockWithTriggers::new(
-                    WrappedBlockFinality(BlockFinality::Final(block)),
+                    WrappedBlockFinality(BlockFinality::Final(Arc::new(block))),
                     triggers,
                 )),
                 None => Err(anyhow!(


### PR DESCRIPTION
In #2482 performance regressed due to [this](https://github.com/graphprotocol/graph-node/blob/2abd2f3626ea570d8b213cd4cc9ebebdbae13256/chain/ethereum/src/data_source.rs#L49), the `light_block()` call would actually clone the entire block, and we went from doing that once per block per subgraph, to once trigger per subgraph.

In this PR the block is wrapped in an Arc so no deep cloning is necessary at all, making for a performance gain relative to pre-#2482. 