### PR TITLE
store: Avoid unnecessary updates in call_meta

### DIFF
--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -987,6 +987,9 @@ mod data {
                         .on_conflict(meta::contract_address)
                         .do_update()
                         .set(accessed_at)
+                        // TODO: Add a where clause similar to the Private
+                        // branch to avoid unnecessary updates (not entirely
+                        // trivial with diesel)
                         .execute(conn)
                 }
                 Storage::Private(Schema {
@@ -1009,7 +1012,9 @@ mod data {
                     let query = format!(
                         "insert into {}(contract_address, accessed_at) \
                          values ($1, CURRENT_DATE) \
-                         on conflict(contract_address) do update set accessed_at = CURRENT_DATE",
+                         on conflict(contract_address)
+                         do update set accessed_at = CURRENT_DATE \
+                                 where excluded.accessed_at < CURRENT_DATE",
                         call_meta.qname
                     );
                     sql_query(query)


### PR DESCRIPTION
Profiling data suggests that for busy chains with lots of subgraphs indexing the same contracts, inserting new calls can take 300-400ms because all the conflicting inserts need to wait for locks to do the update. With this change, updates are performed at most once a day which should reduce the amount of time indexing has to wait for these cache operations.

This only changes things for per-chain call caches, not for a shared call cache. If this proves to be effective, we'll figure out the diesel gyrations to make that work in that case, too.

