### PR TITLE
Unconditionally log eth_call details

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -92,9 +92,6 @@ lazy_static! {
             .parse::<usize>()
             .expect("invalid GRAPH_ETHEREUM_REQUEST_RETRIES env var");
 
-    /// Log eth_call data and target address at trace level. Turn on for debugging.
-    static ref ETH_CALL_FULL_LOG: bool = std::env::var("GRAPH_ETH_CALL_FULL_LOG").is_ok();
-
     /// Gas limit for `eth_call`. The value of 25_000_000 is a protocol-wide parameter so this
     /// should be changed only for debugging purposes and never on an indexer in the network. The
     /// value of 25_000_000 was chosen because it is the Geth default
@@ -1261,12 +1258,10 @@ impl EthereumAdapterTrait for EthereumAdapter {
             Err(e) => return Box::new(future::err(EthereumContractCallError::EncodingError(e))),
         };
 
-        if *ETH_CALL_FULL_LOG {
-            trace!(logger, "eth_call";
-                "address" => hex::encode(&call.address),
-                "data" => hex::encode(&call_data)
-            );
-        }
+        trace!(logger, "eth_call";
+            "address" => hex::encode(&call.address),
+            "data" => hex::encode(&call_data)
+        );
 
         // Check if we have it cached, if not do the call and cache.
         Box::new(


### PR DESCRIPTION
This is an useful log and it's already at `trace` level, no need for an additional env var.