### PR TITLE
Reduce max delay

### DIFF
--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -347,7 +347,7 @@ where
 
 fn retry_strategy(limit_opt: Option<usize>) -> Box<dyn Iterator<Item = Duration> + Send> {
     // Exponential backoff, but with a maximum
-    let max_delay_ms = 30_000;
+    let max_delay_ms = 5_000;
     let backoff = ExponentialBackoff::from_millis(2)
         .max_delay(Duration::from_millis(max_delay_ms))
         .map(jitter);


### PR DESCRIPTION
30 seconds can be a long time to be stuck in a retry loop that might just be failing repeatedly and waiting for the retries to run out. This reduces the max delay between retries to 5 seconds.