### PR TITLE
ipfs: Lower default timeout

### DIFF
--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -38,7 +38,7 @@ lazy_static! {
 
     /// The timeout for IPFS requests in seconds
     static ref IPFS_TIMEOUT: Duration = Duration::from_secs(
-        read_u64_from_env("GRAPH_IPFS_TIMEOUT").unwrap_or(60)
+        read_u64_from_env("GRAPH_IPFS_TIMEOUT").unwrap_or(30)
     );
 }
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -51,7 +51,7 @@ those.
 - `GRAPH_IPFS_SUBGRAPH_LOADING_TIMEOUT`: timeout for IPFS requests made to load
   subgraph files from IPFS (in seconds, default is 60).
 - `GRAPH_IPFS_TIMEOUT`: timeout for IPFS requests from mappings using `ipfs.cat`
-  or `ipfs.map` (in seconds, default is 60).
+  or `ipfs.map` (in seconds, default is 30).
 - `GRAPH_MAX_IPFS_FILE_BYTES`: maximum size for a file that can be retrieved
   with `ipfs.cat` (in bytes, default is unlimited)
 - `GRAPH_MAX_IPFS_MAP_FILE_SIZE`: maximum size of files that can be processed


### PR DESCRIPTION
To avoid hitting external timeouts from gateways, since we rely on timing out on our side to detect a missing file.