### PR TITLE
Prohibit subgraphs from using different api_versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,6 +1582,7 @@ dependencies = [
  "hex",
  "http 0.2.3",
  "isatty",
+ "itertools",
  "lazy_static",
  "maplit",
  "mockall 0.8.3",

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -155,7 +155,7 @@ impl Blockchain for Chain {
             ethrpc_metrics,
             eth_adapter,
             chain_store: self.chain_store.cheap_clone(),
-            unified_api_version,
+            _unified_api_version: unified_api_version,
         };
         Ok(Arc::new(adapter))
     }
@@ -332,7 +332,7 @@ pub struct TriggersAdapter {
     ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
     chain_store: Arc<dyn ChainStore>,
     eth_adapter: Arc<EthereumAdapter>,
-    unified_api_version: UnifiedMappingApiVersion,
+    _unified_api_version: UnifiedMappingApiVersion,
 }
 
 #[async_trait]

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -141,6 +141,7 @@ impl Blockchain for Chain {
         &self,
         loc: &DeploymentLocator,
         capabilities: &Self::NodeCapabilities,
+        unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Arc<Self::TriggersAdapter>, Error> {
         let eth_adapter = self.eth_adapters.cheapest_with(capabilities)?.clone();
         let logger = self
@@ -154,6 +155,7 @@ impl Blockchain for Chain {
             ethrpc_metrics,
             eth_adapter,
             chain_store: self.chain_store.cheap_clone(),
+            unified_api_version,
         };
         Ok(Arc::new(adapter))
     }
@@ -180,7 +182,7 @@ impl Blockchain for Chain {
         let requirements = filter.node_capabilities();
 
         let triggers_adapter = self
-            .triggers_adapter(&deployment, &requirements)
+            .triggers_adapter(&deployment, &requirements, unified_api_version.clone())
             .expect(&format!(
                 "no adapter for network {} with capabilities {}",
                 self.name, requirements
@@ -330,6 +332,7 @@ pub struct TriggersAdapter {
     ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
     chain_store: Arc<dyn ChainStore>,
     eth_adapter: Arc<EthereumAdapter>,
+    unified_api_version: UnifiedMappingApiVersion,
 }
 
 #[async_trait]

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -3,6 +3,7 @@ use std::iter::FromIterator;
 use std::sync::Arc;
 
 use anyhow::{Context, Error};
+use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::prelude::{EthereumCallCache, LightEthereumBlock, LightEthereumBlockExt};
 use graph::{
     blockchain::{
@@ -163,6 +164,7 @@ impl Blockchain for Chain {
         start_blocks: Vec<BlockNumber>,
         filter: TriggerFilter,
         metrics: Arc<BlockStreamMetrics>,
+        unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<BlockStream<Self>, Error> {
         let logger = self
             .logger_factory
@@ -198,6 +200,7 @@ impl Blockchain for Chain {
             metrics,
             *MAX_BLOCK_RANGE_SIZE,
             *TARGET_TRIGGERS_PER_BLOCK_RANGE,
+            unified_api_version,
         ))
     }
 

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -1,8 +1,5 @@
 use super::loader::load_dynamic_data_sources;
-use super::loader::load_dynamic_data_sources;
 use super::SubgraphInstance;
-use super::SubgraphInstance;
-use crate::subgraph::registrar::IPFS_SUBGRAPH_LOADING_TIMEOUT;
 use atomic_refcell::AtomicRefCell;
 use fail::fail_point;
 use graph::components::arweave::ArweaveAdapter;
@@ -25,7 +22,6 @@ use graph::{
     components::store::{DeploymentId, DeploymentLocator, ModificationsAndCache},
 };
 use graph::{components::ethereum::NodeCapabilities, data::store::scalar::Bytes};
-use graph_chain_ethereum::{SubgraphEthRpcMetrics, WrappedBlockFinality};
 use lazy_static::lazy_static;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, RwLock};

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -310,7 +310,7 @@ where
             .and_then(|x| x)?;
         }
 
-        let manifest = {
+        let manifest: SubgraphManifest<C> = {
             info!(logger, "Resolve subgraph files using IPFS");
 
             let mut manifest = SubgraphManifest::resolve_from_raw(
@@ -354,7 +354,7 @@ where
             .with_context(|| format!("no chain configured for network {}", network))?
             .clone();
 
-        let triggers_adapter = chain.triggers_adapter(&deployment, &required_capabilities).map_err(|e|
+        let triggers_adapter = chain.triggers_adapter(&deployment, &required_capabilities, manifest.unified_mapping_api_version()).map_err(|e|
                 anyhow!(
                 "expected triggers adapter that matches deployment {} with required capabilities: {}: {}",
                 &deployment,

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -4,8 +4,7 @@ use graph::components::arweave::ArweaveAdapter;
 use graph::components::three_box::ThreeBoxAdapter;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use lazy_static::lazy_static;
-use semver::Version;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 use tokio::task;
@@ -486,6 +485,7 @@ where
                 ctx.inputs.start_blocks.clone(),
                 ctx.state.filter.clone(),
                 ctx.block_stream_metrics.clone(),
+                ctx.inputs.unified_api_version.clone(),
             )?
             .map_err(CancelableError::Error)
             .cancelable(&block_stream_canceler, || CancelableError::Cancel)

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -2,6 +2,7 @@ use atomic_refcell::AtomicRefCell;
 use fail::fail_point;
 use graph::components::arweave::ArweaveAdapter;
 use graph::components::three_box::ThreeBoxAdapter;
+use graph::data::subgraph::UnifiedMappingApiVersion;
 use lazy_static::lazy_static;
 use semver::Version;
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -55,6 +56,7 @@ struct IndexingInputs<C: Blockchain> {
     triggers_adapter: Arc<C::TriggersAdapter>,
     chain: Arc<C>,
     templates: Arc<Vec<C::DataSourceTemplate>>,
+    unified_api_version: UnifiedMappingApiVersion,
 }
 
 struct IndexingState<T: RuntimeHostBuilder<C>, C: Blockchain> {
@@ -403,6 +405,7 @@ where
         );
 
         let features = manifest.features.clone();
+        let unified_api_version = manifest.unified_mapping_api_version();
         let instance =
             SubgraphInstance::from_manifest(&logger, manifest, host_builder, host_metrics.clone())?;
 
@@ -416,6 +419,7 @@ where
                 triggers_adapter,
                 chain,
                 templates,
+                unified_api_version,
             },
             state: IndexingState {
                 logger: logger.cheap_clone(),

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -57,35 +57,6 @@ struct IndexingInputs<C: Blockchain> {
     templates: Arc<Vec<C::DataSourceTemplate>>,
 }
 
-pub struct UnifiedMappingApiVersion(Option<Version>);
-
-impl UnifiedMappingApiVersion {
-    pub fn equal_or_greater_than(&self, other_version: &Version) -> bool {
-        match &self.0 {
-            Some(version) => version >= other_version,
-            None => false,
-        }
-    }
-}
-
-impl<C: Blockchain> IndexingInputs<C> {
-    pub fn unified_mapping_api_version(&self) -> UnifiedMappingApiVersion {
-        use graph::blockchain::DataSourceTemplate;
-        let api_versions: HashSet<Version> = self
-            .templates
-            .iter()
-            .map(|ds| ds.mapping().api_version.to_owned())
-            .collect();
-
-        if api_versions.len() != 1 {
-            UnifiedMappingApiVersion(None)
-        } else {
-            let version = api_versions.into_iter().nth(0).unwrap();
-            UnifiedMappingApiVersion(Some(version))
-        }
-    }
-}
-
 struct IndexingState<T: RuntimeHostBuilder<C>, C: Blockchain> {
     logger: Logger,
     instance: SubgraphInstance<C, T>,

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -57,6 +57,7 @@ futures03 = { version = "0.3.1", package = "futures", features = ["compat"] }
 wasmparser = "0.78.2"
 thiserror = "1.0.25"
 parking_lot = "0.11.1"
+itertools = "0.10.1"
 
 # Our fork contains a small but hacky patch.
 web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "master" }

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use crate::components::store::BlockNumber;
 use crate::components::store::WritableStore;
+use crate::data::subgraph::UnifiedMappingApiVersion;
 use crate::{prelude::*, prometheus::labels};
 
 use super::{Block, BlockPtr, Blockchain};
@@ -208,6 +209,7 @@ where
     // Not a BlockNumber, but the difference between two block numbers
     max_block_range_size: BlockNumber,
     target_triggers_per_block_range: u64,
+    unified_api_version: UnifiedMappingApiVersion,
 }
 
 impl<C: Blockchain> Clone for BlockStreamContext<C> {
@@ -227,6 +229,7 @@ impl<C: Blockchain> Clone for BlockStreamContext<C> {
             previous_block_range_size: self.previous_block_range_size,
             max_block_range_size: self.max_block_range_size,
             target_triggers_per_block_range: self.target_triggers_per_block_range,
+            unified_api_version: self.unified_api_version.clone(),
         }
     }
 }
@@ -281,6 +284,7 @@ where
         metrics: Arc<BlockStreamMetrics>,
         max_block_range_size: BlockNumber,
         target_triggers_per_block_range: u64,
+        unified_api_version: UnifiedMappingApiVersion,
     ) -> Self {
         BlockStream {
             state: BlockStreamState::BeginReconciliation,
@@ -303,6 +307,7 @@ where
                 previous_block_range_size: 1,
                 max_block_range_size,
                 target_triggers_per_block_range,
+                unified_api_version,
             },
         }
     }

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -10,7 +10,7 @@ mod types;
 use crate::{
     cheap_clone::CheapClone,
     components::store::{DeploymentLocator, StoredDynamicDataSource},
-    data::subgraph::{Mapping, Source, TemplateSource},
+    data::subgraph::{Mapping, Source, TemplateSource, UnifiedMappingApiVersion},
     prelude::DataSourceContext,
     runtime::{AscHeap, AscPtr, DeterministicHostError, HostExportError},
 };
@@ -100,6 +100,7 @@ pub trait Blockchain: Debug + Sized + Send + Sync + 'static {
         start_blocks: Vec<BlockNumber>,
         filter: Self::TriggerFilter,
         metrics: Arc<BlockStreamMetrics>,
+        unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<BlockStream<Self>, Error>;
 
     fn ingestor_adapter(&self) -> Arc<Self::IngestorAdapter>;

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -92,6 +92,7 @@ pub trait Blockchain: Debug + Sized + Send + Sync + 'static {
         &self,
         loc: &DeploymentLocator,
         capabilities: &Self::NodeCapabilities,
+        unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Arc<Self::TriggersAdapter>, Error>;
 
     fn new_block_stream(

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -676,6 +676,7 @@ impl UnresolvedMapping {
     }
 }
 
+#[derive(Clone)]
 pub struct UnifiedMappingApiVersion(Option<Version>);
 
 impl UnifiedMappingApiVersion {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -819,8 +819,8 @@ impl<C: Blockchain> UnvalidatedSubgraphManifest<C> {
             errors.push(SubgraphManifestValidationError::DataSourceBlockHandlerLimitExceeded)
         }
 
-        // For API versions newer than 0.5, validate that all mappings uses the same api_version
-        let referential_api_version = Version::new(0, 5, 0);
+        // For API versions newer than 0.0.5, validate that all mappings uses the same api_version
+        let referential_api_version = Version::new(0, 0, 5);
         let unique_api_versions: HashSet<&Version> = self
             .0
             .data_sources

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -845,11 +845,7 @@ impl<C: Blockchain> UnvalidatedSubgraphManifest<C> {
         }
 
         // For API versions newer than 0.0.5, validate that all mappings uses the same api_version
-        let mappings = self.0.mappings();
-        let versions_iterator = mappings.iter().map(|mapping| &mapping.api_version);
-        if let Err(different_api_versions) =
-            UnifiedMappingApiVersion::try_from_versions(versions_iterator)
-        {
+        if let Err(different_api_versions) = self.0.unified_mapping_api_version() {
             errors.push(different_api_versions.into());
         };
 

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -251,36 +251,6 @@ impl<'de> de::Deserialize<'de> for SubgraphName {
     }
 }
 
-#[test]
-fn test_subgraph_name_validation() {
-    assert!(SubgraphName::new("a").is_ok());
-    assert!(SubgraphName::new("a/a").is_ok());
-    assert!(SubgraphName::new("a-lOng-name_with_0ne-component").is_ok());
-    assert!(SubgraphName::new("a-long-name_with_one-3omponent").is_ok());
-    assert!(SubgraphName::new("a/b_c").is_ok());
-    assert!(SubgraphName::new("A/Z-Z").is_ok());
-    assert!(SubgraphName::new("a1/A-A").is_ok());
-    assert!(SubgraphName::new("aaa/a1").is_ok());
-    assert!(SubgraphName::new("1a/aaaa").is_ok());
-    assert!(SubgraphName::new("aaaa/1a").is_ok());
-    assert!(SubgraphName::new("2nena4test/lala").is_ok());
-
-    assert!(SubgraphName::new("").is_err());
-    assert!(SubgraphName::new("/a").is_err());
-    assert!(SubgraphName::new("a/").is_err());
-    assert!(SubgraphName::new("a//a").is_err());
-    assert!(SubgraphName::new("a/0").is_err());
-    assert!(SubgraphName::new("a/_").is_err());
-    assert!(SubgraphName::new("a/a_").is_err());
-    assert!(SubgraphName::new("a/_a").is_err());
-    assert!(SubgraphName::new("aaaa aaaaa").is_err());
-    assert!(SubgraphName::new("aaaa!aaaaa").is_err());
-    assert!(SubgraphName::new("aaaa+aaaaa").is_err());
-    assert!(SubgraphName::new("a/graphql").is_err());
-    assert!(SubgraphName::new("graphql/a").is_err());
-    assert!(SubgraphName::new("this-component-is-longer-than-the-length-limit").is_err());
-}
-
 /// Result of a creating a subgraph in the registar.
 #[derive(Serialize)]
 pub struct CreateSubgraphResult {
@@ -703,42 +673,6 @@ impl UnifiedMappingApiVersion {
         };
 
         Ok(UnifiedMappingApiVersion(unified_version))
-    }
-}
-
-#[test]
-fn unified_mapping_api_version_from_iterator() {
-    let input = [
-        vec![Version::new(0, 0, 5), Version::new(0, 0, 5)], // Ok(Some(0.0.5))
-        vec![Version::new(0, 0, 6), Version::new(0, 0, 6)], // Ok(Some(0.0.6))
-        vec![Version::new(0, 0, 3), Version::new(0, 0, 4)], // Ok(None)
-        vec![Version::new(0, 0, 4), Version::new(0, 0, 4)], // Ok(None)
-        vec![Version::new(0, 0, 3), Version::new(0, 0, 5)], // Err({0.0.3, 0.0.5})
-        vec![Version::new(0, 0, 6), Version::new(0, 0, 5)], // Err({0.0.5, 0.0.6})
-    ];
-    let output: [Result<UnifiedMappingApiVersion, DifferentMappingApiVersions>; 6] = [
-        Ok(UnifiedMappingApiVersion(Some(Version::new(0, 0, 5)))),
-        Ok(UnifiedMappingApiVersion(Some(Version::new(0, 0, 6)))),
-        Ok(UnifiedMappingApiVersion(None)),
-        Ok(UnifiedMappingApiVersion(None)),
-        Err(input[4]
-            .iter()
-            .cloned()
-            .collect::<BTreeSet<Version>>()
-            .into()),
-        Err(input[5]
-            .iter()
-            .cloned()
-            .collect::<BTreeSet<Version>>()
-            .into()),
-    ];
-    for (version_vec, expected_unified_version) in input.iter().zip(output.iter()) {
-        let unified = UnifiedMappingApiVersion::try_from_versions(version_vec.iter());
-        match (unified, expected_unified_version) {
-            (Ok(a), Ok(b)) => assert_eq!(a, *b),
-            (Err(a), Err(b)) => assert_eq!(a, *b),
-            _ => panic!(),
-        }
     }
 }
 
@@ -1193,6 +1127,72 @@ fn display_vector(input: &Vec<impl std::fmt::Display>) -> impl std::fmt::Display
         .collect::<Vec<String>>()
         .join("; ");
     format!("[{}]", formatted_errors)
+}
+
+#[test]
+fn test_subgraph_name_validation() {
+    assert!(SubgraphName::new("a").is_ok());
+    assert!(SubgraphName::new("a/a").is_ok());
+    assert!(SubgraphName::new("a-lOng-name_with_0ne-component").is_ok());
+    assert!(SubgraphName::new("a-long-name_with_one-3omponent").is_ok());
+    assert!(SubgraphName::new("a/b_c").is_ok());
+    assert!(SubgraphName::new("A/Z-Z").is_ok());
+    assert!(SubgraphName::new("a1/A-A").is_ok());
+    assert!(SubgraphName::new("aaa/a1").is_ok());
+    assert!(SubgraphName::new("1a/aaaa").is_ok());
+    assert!(SubgraphName::new("aaaa/1a").is_ok());
+    assert!(SubgraphName::new("2nena4test/lala").is_ok());
+
+    assert!(SubgraphName::new("").is_err());
+    assert!(SubgraphName::new("/a").is_err());
+    assert!(SubgraphName::new("a/").is_err());
+    assert!(SubgraphName::new("a//a").is_err());
+    assert!(SubgraphName::new("a/0").is_err());
+    assert!(SubgraphName::new("a/_").is_err());
+    assert!(SubgraphName::new("a/a_").is_err());
+    assert!(SubgraphName::new("a/_a").is_err());
+    assert!(SubgraphName::new("aaaa aaaaa").is_err());
+    assert!(SubgraphName::new("aaaa!aaaaa").is_err());
+    assert!(SubgraphName::new("aaaa+aaaaa").is_err());
+    assert!(SubgraphName::new("a/graphql").is_err());
+    assert!(SubgraphName::new("graphql/a").is_err());
+    assert!(SubgraphName::new("this-component-is-longer-than-the-length-limit").is_err());
+}
+
+#[test]
+fn unified_mapping_api_version_from_iterator() {
+    let input = [
+        vec![Version::new(0, 0, 5), Version::new(0, 0, 5)], // Ok(Some(0.0.5))
+        vec![Version::new(0, 0, 6), Version::new(0, 0, 6)], // Ok(Some(0.0.6))
+        vec![Version::new(0, 0, 3), Version::new(0, 0, 4)], // Ok(None)
+        vec![Version::new(0, 0, 4), Version::new(0, 0, 4)], // Ok(None)
+        vec![Version::new(0, 0, 3), Version::new(0, 0, 5)], // Err({0.0.3, 0.0.5})
+        vec![Version::new(0, 0, 6), Version::new(0, 0, 5)], // Err({0.0.5, 0.0.6})
+    ];
+    let output: [Result<UnifiedMappingApiVersion, DifferentMappingApiVersions>; 6] = [
+        Ok(UnifiedMappingApiVersion(Some(Version::new(0, 0, 5)))),
+        Ok(UnifiedMappingApiVersion(Some(Version::new(0, 0, 6)))),
+        Ok(UnifiedMappingApiVersion(None)),
+        Ok(UnifiedMappingApiVersion(None)),
+        Err(input[4]
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<Version>>()
+            .into()),
+        Err(input[5]
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<Version>>()
+            .into()),
+    ];
+    for (version_vec, expected_unified_version) in input.iter().zip(output.iter()) {
+        let unified = UnifiedMappingApiVersion::try_from_versions(version_vec.iter());
+        match (unified, expected_unified_version) {
+            (Ok(a), Ok(b)) => assert_eq!(a, *b),
+            (Err(a), Err(b)) => assert_eq!(a, *b),
+            _ => panic!(),
+        }
+    }
 }
 
 #[test]

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -743,7 +743,7 @@ fn unified_mapping_api_version_from_iterator() {
 }
 
 #[derive(Error, Debug, PartialEq)]
-#[error("Expected a single apiVersion for mapings. Found: {}.", format_versions(.0))]
+#[error("Expected a single apiVersion for mappings. Found: {}.", format_versions(.0))]
 pub struct DifferentMappingApiVersions(BTreeSet<Version>);
 
 fn format_versions(versions: &BTreeSet<Version>) -> String {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -693,14 +693,13 @@ impl UnifiedMappingApiVersion {
     }
 }
 
-impl<'a> FromIterator<&'a Mapping> for UnifiedMappingApiVersion {
+impl<'a> FromIterator<&'a Version> for UnifiedMappingApiVersion {
     /// Will return a `UnifiedMappingApiVersion(Some(_))` if mappings' api versions are identical
     /// and equal to or higher than 0.0.5. Returns `UnifiedMappingApiVersion(None)` otherwise.
-    fn from_iter<T: IntoIterator<Item = &'a Mapping>>(iter: T) -> Self {
+    fn from_iter<T: IntoIterator<Item = &'a Version>>(iter: T) -> Self {
         let mut unified_version: Option<Version> = None;
         for api_version in iter
             .into_iter()
-            .map(|mapping| &mapping.api_version)
             .filter(|api_version| *api_version >= &API_VERSION_0_0_5)
         {
             match unified_version.as_ref() {
@@ -1030,7 +1029,7 @@ impl<C: Blockchain> SubgraphManifest<C> {
     }
 
     pub fn unified_mapping_api_version(&self) -> UnifiedMappingApiVersion {
-        self.mappings().iter().collect()
+        self.mappings().iter().map(|m| &m.api_version).collect()
     }
 }
 

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -397,7 +397,6 @@ pub enum SubgraphManifestValidationError {
     #[error("the graft base is invalid: {0}")]
     GraftBaseInvalid(String),
     #[error("subgraph must use a single apiVersion across its data sources. Found: {0:?}")]
-    // #[error("subgraph uses different api versions between its data sources")]
     DifferentApiVersions(String),
 }
 
@@ -862,11 +861,10 @@ impl<C: Blockchain> UnvalidatedSubgraphManifest<C> {
 
         // For API versions newer than 0.0.5, validate that all mappings uses the same api_version
         let referential_api_version = Version::new(0, 0, 5);
-        let unique_api_versions: HashSet<&Version> = self
-            .0
-            .data_sources
+        let mappings = self.0.mappings();
+        let unique_api_versions: HashSet<&Version> = mappings
             .iter()
-            .map(|ds| &ds.mapping().api_version)
+            .map(|mapping| &mapping.api_version)
             .collect();
         if unique_api_versions.len() > 1
             && unique_api_versions


### PR DESCRIPTION
This PR adds the following:
- [X] Manifest validation logic to prohibit subgraphs from using different `apiVersions` across mappings
- [X] Passes the unified mapping API version value to `BlockStream` and `TriggerAdapter` instances.