### PR TITLE
docs: Fix config.md links

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 ## 0.22.0
 
 ### Feature: Block store sharding
-This release makes it possible to [shard the block and call cache](./docs/sharding.md) for chain
+This release makes it possible to [shard the block and call cache](./docs/config.md) for chain
 data across multiple independent Postgres databases. **This feature is considered experimental. We
 encourage users to try this out in a test environment, but do not recommend it yet for production
 use.** In particular, the details of how sharding is configured may change in backwards-incompatible
@@ -46,7 +46,7 @@ Various related bug fixes have been made #2121 #2136 #2149 #2160.
 ### Feature: Database sharding
 
 This release makes it possible to [shard subgraph
-storage](./docs/sharding.md) and spread subgraph deployments, and the load
+storage](./docs/config.md) and spread subgraph deployments, and the load
 coming from indexing and querying them across multiple independent Postgres
 databases.
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The command line arguments generally are all that is needed to run a
 can further be configured through [environment
 variables](https://github.com/graphprotocol/graph-node/blob/master/docs/environment-variables.md). Very
 large `graph-node` instances can also split the work of querying and
-indexing across [multiple databases](./docs/sharding.md).
+indexing across [multiple databases](./docs/config.md).
 
 ## Project Layout
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,19 +14,19 @@ ARG TAG_NAME=unknown
 ADD . /graph-node
 
 RUN cd /graph-node \
- && RUSTFLAGS="-g" cargo install --locked --path node \
- && cargo clean \
- && objcopy --only-keep-debug /usr/local/cargo/bin/graph-node /usr/local/cargo/bin/graph-node.debug \
- && strip -g /usr/local/cargo/bin/graph-node \
- && strip -g /usr/local/cargo/bin/graphman \
- && cd /usr/local/cargo/bin \
- && objcopy --add-gnu-debuglink=graph-node.debug graph-node \
- && echo "REPO_NAME='$REPO_NAME'" > /etc/image-info \
- && echo "TAG_NAME='$TAG_NAME'" >> /etc/image-info \
- && echo "BRANCH_NAME='$BRANCH_NAME'" >> /etc/image-info \
- && echo "COMMIT_SHA='$COMMIT_SHA'" >> /etc/image-info \
- && echo "CARGO_VERSION='$(cargo --version)'" >> /etc/image-info \
- && echo "RUST_VERSION='$(rustc --version)'" >> /etc/image-info
+    && RUSTFLAGS="-g" cargo install --locked --path node \
+    && cargo clean \
+    && objcopy --only-keep-debug /usr/local/cargo/bin/graph-node /usr/local/cargo/bin/graph-node.debug \
+    && strip -g /usr/local/cargo/bin/graph-node \
+    && strip -g /usr/local/cargo/bin/graphman \
+    && cd /usr/local/cargo/bin \
+    && objcopy --add-gnu-debuglink=graph-node.debug graph-node \
+    && echo "REPO_NAME='$REPO_NAME'" > /etc/image-info \
+    && echo "TAG_NAME='$TAG_NAME'" >> /etc/image-info \
+    && echo "BRANCH_NAME='$BRANCH_NAME'" >> /etc/image-info \
+    && echo "COMMIT_SHA='$COMMIT_SHA'" >> /etc/image-info \
+    && echo "CARGO_VERSION='$(cargo --version)'" >> /etc/image-info \
+    && echo "RUST_VERSION='$(rustc --version)'" >> /etc/image-info
 
 # The graph-node runtime image with only the executable
 FROM debian:buster-slim as graph-node
@@ -54,7 +54,7 @@ ENV node_id "default"
 ENV ethereum_polling_interval ""
 
 # The location of an optional configuration file for graph-node, as
-# described in ../docs/sharding.md
+# described in ../docs/config.md
 # Using a configuration file is experimental, and the file format may
 # change in backwards-incompatible ways
 ENV GRAPH_NODE_CONFIG ""
@@ -73,7 +73,7 @@ EXPOSE 8020
 EXPOSE 8030
 
 RUN apt-get update \
- && apt-get install -y libpq-dev ca-certificates netcat
+    && apt-get install -y libpq-dev ca-certificates netcat
 
 ADD docker/wait_for docker/start /usr/local/bin/
 COPY --from=graph-node-build /usr/local/cargo/bin/graph-node /usr/local/cargo/bin/graphman /usr/local/bin/
@@ -84,7 +84,7 @@ CMD start
 # Debug image to access core dumps
 FROM graph-node-build as graph-node-debug
 RUN apt-get update \
- && apt-get install -y curl gdb postgresql-client
+    && apt-get install -y curl gdb postgresql-client
 
 COPY docker/Dockerfile /Dockerfile
 COPY docker/bin/* /usr/local/bin/

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -130,7 +130,7 @@ pub mod unused {
 /// database, in which case they are all backed by one connection pool, or
 /// separate databases in the same Postgres cluster, or entirely separate
 /// clusters. Details of how to configure shards can be found in [this
-/// document](https://github.com/graphprotocol/graph-node/blob/master/docs/sharding.md)
+/// document](https://github.com/graphprotocol/graph-node/blob/master/docs/config.md)
 ///
 /// The primary uses the following database tables:
 /// - `public.deployment_schemas`: immutable data about deployments,


### PR DESCRIPTION
They got broken in https://github.com/graphprotocol/graph-node/pull/2576 when sharding.md was renamed to config.md. Also formats the Dockerfile. Resolves #2582.