### PR TITLE
Fix ipfs timeout detection

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -261,8 +261,6 @@ where
         let logger = logger_factory.component_logger("SubgraphInstanceManager", None);
         let logger_factory = logger_factory.with_parent(logger.clone());
 
-        let link_resolver = Arc::new(link_resolver.as_ref().clone().with_retries());
-
         SubgraphInstanceManager {
             logger_factory,
             subgraph_store,
@@ -316,7 +314,8 @@ where
             let mut manifest = SubgraphManifest::resolve_from_raw(
                 deployment.hash.cheap_clone(),
                 manifest,
-                &*link_resolver,
+                // Allow for infinite retries for subgraph definition files.
+                &link_resolver.as_ref().clone().with_retries(),
                 &logger,
             )
             .await

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -28,7 +28,6 @@ use graph::{components::ethereum::NodeCapabilities, data::store::scalar::Bytes};
 
 use super::loader::load_dynamic_data_sources;
 use super::SubgraphInstance;
-use crate::subgraph::registrar::IPFS_SUBGRAPH_LOADING_TIMEOUT;
 
 lazy_static! {
     /// Size limit of the entity LFU cache, in bytes.
@@ -262,13 +261,7 @@ where
         let logger = logger_factory.component_logger("SubgraphInstanceManager", None);
         let logger_factory = logger_factory.with_parent(logger.clone());
 
-        let link_resolver = Arc::new(
-            link_resolver
-                .as_ref()
-                .clone()
-                .with_timeout(*IPFS_SUBGRAPH_LOADING_TIMEOUT)
-                .with_retries(),
-        );
+        let link_resolver = Arc::new(link_resolver.as_ref().clone().with_retries());
 
         SubgraphInstanceManager {
             logger_factory,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -1,28 +1,15 @@
 use std::collections::HashSet;
-use std::env;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use async_trait::async_trait;
-use graph::blockchain::BlockchainMap;
-use lazy_static::lazy_static;
-
 use graph::blockchain::Blockchain;
+use graph::blockchain::BlockchainMap;
 use graph::components::store::{DeploymentId, DeploymentLocator, SubscriptionManager};
 use graph::data::subgraph::schema::SubgraphDeploymentEntity;
 use graph::prelude::{
     CreateSubgraphResult, SubgraphAssignmentProvider as SubgraphAssignmentProviderTrait,
     SubgraphRegistrar as SubgraphRegistrarTrait, *,
 };
-
-lazy_static! {
-    // The timeout for IPFS requests in seconds
-    pub static ref IPFS_SUBGRAPH_LOADING_TIMEOUT: Duration = Duration::from_secs(
-        env::var("GRAPH_IPFS_SUBGRAPH_LOADING_TIMEOUT")
-            .unwrap_or("60".into())
-            .parse::<u64>()
-            .expect("invalid IPFS subgraph loading timeout")
-    );
-}
 
 pub struct SubgraphRegistrar<C, L, P, S, SM> {
     logger: Logger,
@@ -61,13 +48,7 @@ where
         SubgraphRegistrar {
             logger,
             logger_factory,
-            resolver: Arc::new(
-                resolver
-                    .as_ref()
-                    .clone()
-                    .with_timeout(*IPFS_SUBGRAPH_LOADING_TIMEOUT)
-                    .with_retries(),
-            ),
+            resolver: Arc::new(resolver.as_ref().clone().with_retries()),
             provider,
             store,
             subscription_manager,

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -48,10 +48,8 @@ those.
 
 - `GRAPH_MAPPING_HANDLER_TIMEOUT`: amount of time a mapping handler is allowed to
   take (in seconds, default is unlimited)
-- `GRAPH_IPFS_SUBGRAPH_LOADING_TIMEOUT`: timeout for IPFS requests made to load
-  subgraph files from IPFS (in seconds, default is 60).
-- `GRAPH_IPFS_TIMEOUT`: timeout for IPFS requests from mappings using `ipfs.cat`
-  or `ipfs.map` (in seconds, default is 30).
+- `GRAPH_IPFS_TIMEOUT`: timeout for IPFS, which includes requests for manifest files
+  and from mappings using `ipfs.cat` or `ipfs.map` (in seconds, default is 30).
 - `GRAPH_MAX_IPFS_FILE_BYTES`: maximum size for a file that can be retrieved
   with `ipfs.cat` (in bytes, default is unlimited)
 - `GRAPH_MAX_IPFS_MAP_FILE_SIZE`: maximum size of files that can be processed


### PR DESCRIPTION
#2556 didn't get it right, because in `instance_manager.rs` we were still requesting infinite retries for ipfs.cat. Also we had two different env vars for the IPFS timeout which confused me, I think we can do with just one.