### PR TITLE
Making structs, functions and fields public to be used in testing framework

### DIFF
--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -2,7 +2,7 @@ mod adapter;
 mod data_source;
 mod ethereum_adapter;
 pub mod network_indexer;
-mod runtime;
+pub mod runtime;
 mod transport;
 
 pub use self::ethereum_adapter::EthereumAdapter;

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -7,7 +7,6 @@ mod transport;
 
 pub use self::ethereum_adapter::EthereumAdapter;
 pub use self::runtime::RuntimeAdapter;
-pub use self::runtime::abi;
 pub use self::transport::{EventLoopHandle, Transport};
 
 // ETHDEP: These concrete types should probably not be exposed.

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -7,6 +7,7 @@ mod transport;
 
 pub use self::ethereum_adapter::EthereumAdapter;
 pub use self::runtime::RuntimeAdapter;
+pub use self::runtime::abi;
 pub use self::transport::{EventLoopHandle, Transport};
 
 // ETHDEP: These concrete types should probably not be exposed.

--- a/chain/ethereum/src/runtime/abi.rs
+++ b/chain/ethereum/src/runtime/abi.rs
@@ -17,7 +17,7 @@ type AscLogParamArray = Array<AscPtr<AscLogParam>>;
 
 #[repr(C)]
 #[derive(AscType)]
-pub(crate) struct AscUnresolvedContractCall_0_0_4 {
+pub struct AscUnresolvedContractCall_0_0_4 {
     pub contract_name: AscPtr<AscString>,
     pub contract_address: AscPtr<AscAddress>,
     pub function_name: AscPtr<AscString>,
@@ -42,7 +42,7 @@ impl FromAscObj<AscUnresolvedContractCall_0_0_4> for UnresolvedContractCall {
 
 #[repr(C)]
 #[derive(AscType)]
-pub(crate) struct AscUnresolvedContractCall {
+pub struct AscUnresolvedContractCall {
     pub contract_name: AscPtr<AscString>,
     pub contract_address: AscPtr<AscAddress>,
     pub function_name: AscPtr<AscString>,

--- a/chain/ethereum/src/runtime/mod.rs
+++ b/chain/ethereum/src/runtime/mod.rs
@@ -1,4 +1,4 @@
 pub use runtime_adapter::RuntimeAdapter;
 
-pub(crate) mod abi;
+pub mod abi;
 mod runtime_adapter;

--- a/runtime/wasm/src/asc_abi/class.rs
+++ b/runtime/wasm/src/asc_abi/class.rs
@@ -498,7 +498,7 @@ pub(crate) type AscJson = AscTypedMap<AscString, AscEnum<JsonValueKind>>;
 
 #[repr(u32)]
 #[derive(AscType, Copy, Clone)]
-pub(crate) enum JsonValueKind {
+pub enum JsonValueKind {
     Null,
     Bool,
     Number,
@@ -562,14 +562,14 @@ impl From<LogLevel> for slog::Level {
 
 #[repr(C)]
 #[derive(AscType)]
-pub(crate) struct AscResult<V: AscValue, E: AscValue> {
+pub struct AscResult<V: AscValue, E: AscValue> {
     pub value: AscPtr<AscWrapped<V>>,
     pub error: AscPtr<AscWrapped<E>>,
 }
 
 #[repr(C)]
 #[derive(AscType)]
-pub(crate) struct AscWrapped<V: AscValue> {
+pub struct AscWrapped<V: AscValue> {
     pub inner: V,
 }
 

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -9,7 +9,7 @@ use graph::components::{arweave::ArweaveAdapter, store::EntityType};
 use graph::data::store;
 use graph::prelude::serde_json;
 use graph::prelude::{slog::b, slog::record_static, *};
-use graph::runtime::{DeterministicHostError, HostExportError};
+pub use graph::runtime::{DeterministicHostError, HostExportError};
 use graph::{blockchain::DataSource, bytes::Bytes};
 use never::Never;
 use semver::Version;

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -1,20 +1,20 @@
 pub mod asc_abi;
 
 mod host;
-mod to_from;
+pub mod to_from;
 
 /// Public interface of the crate, receives triggers to be processed.
 
 /// Pre-processes modules and manages their threads. Serves as an interface from `host` to `module`.
-mod mapping;
+pub mod mapping;
 
 /// WASM module instance.
 pub mod module;
 
 /// Runtime-agnostic implementation of exports to WASM.
-mod host_exports;
+pub mod host_exports;
 
-mod error;
+pub mod error;
 
 pub use host::RuntimeHostBuilder;
 pub use host_exports::HostExports;

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -9,7 +9,7 @@ mod to_from;
 mod mapping;
 
 /// WASM module instance.
-mod module;
+pub mod module;
 
 /// Runtime-agnostic implementation of exports to WASM.
 mod host_exports;

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -116,7 +116,7 @@ impl<C: Blockchain> MappingContext<C> {
 
 /// A pre-processed and valid WASM module, ready to be started as a WasmModule.
 pub struct ValidModule {
-    pub(super) module: wasmtime::Module,
+    pub module: wasmtime::Module,
 
     // A wasm import consists of a `module` and a `name`. AS will generate imports such that they
     // have `module` set to the name of the file it is imported from and `name` set to the imported
@@ -126,7 +126,7 @@ pub struct ValidModule {
     //
     // AS now has an `@external("module", "name")` decorator which would make things cleaner, but
     // the ship has sailed.
-    pub(super) import_name_to_modules: BTreeMap<String, Vec<String>>,
+    pub import_name_to_modules: BTreeMap<String, Vec<String>>,
 }
 
 impl ValidModule {

--- a/runtime/wasm/src/module/into_wasm_ret.rs
+++ b/runtime/wasm/src/module/into_wasm_ret.rs
@@ -3,7 +3,7 @@ use never::Never;
 use wasmtime::Trap;
 
 /// Helper trait for the `link!` macro.
-pub(crate) trait IntoWasmRet {
+pub trait IntoWasmRet {
     type Ret: wasmtime::WasmRet;
 
     fn into_wasm_ret(self) -> Self::Ret;

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -30,7 +30,7 @@ mod into_wasm_ret;
 mod stopwatch;
 
 use into_wasm_ret::IntoWasmRet;
-use stopwatch::TimeoutStopwatch;
+pub use stopwatch::TimeoutStopwatch;
 
 pub const TRAP_TIMEOUT: &str = "trap: interrupt";
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -236,7 +236,7 @@ pub struct WasmInstanceContext<C: Blockchain> {
     arena_free_size: i32,
 
     // A trap ocurred due to a possible reorg detection.
-    possible_reorg: bool,
+    pub possible_reorg: bool,
 
     // A host export trap ocurred for a deterministic reason.
     pub deterministic_host_trap: bool,

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -938,19 +938,28 @@ impl<C: Blockchain> WasmInstanceContext<C> {
 
     /// Expects a decimal string.
     /// function json.toI64(json: String): i64
-    pub fn json_to_i64(&mut self, json_ptr: AscPtr<AscString>) -> Result<i64, DeterministicHostError> {
+    pub fn json_to_i64(
+        &mut self,
+        json_ptr: AscPtr<AscString>,
+    ) -> Result<i64, DeterministicHostError> {
         self.ctx.host_exports.json_to_i64(asc_get(self, json_ptr)?)
     }
 
     /// Expects a decimal string.
     /// function json.toU64(json: String): u64
-    pub fn json_to_u64(&mut self, json_ptr: AscPtr<AscString>) -> Result<u64, DeterministicHostError> {
+    pub fn json_to_u64(
+        &mut self,
+        json_ptr: AscPtr<AscString>,
+    ) -> Result<u64, DeterministicHostError> {
         self.ctx.host_exports.json_to_u64(asc_get(self, json_ptr)?)
     }
 
     /// Expects a decimal string.
     /// function json.toF64(json: String): f64
-    pub fn json_to_f64(&mut self, json_ptr: AscPtr<AscString>) -> Result<f64, DeterministicHostError> {
+    pub fn json_to_f64(
+        &mut self,
+        json_ptr: AscPtr<AscString>,
+    ) -> Result<f64, DeterministicHostError> {
         self.ctx.host_exports.json_to_f64(asc_get(self, json_ptr)?)
     }
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -27,7 +27,7 @@ use crate::host_exports::HostExports;
 use crate::mapping::ValidModule;
 
 mod into_wasm_ret;
-mod stopwatch;
+pub mod stopwatch;
 
 use into_wasm_ret::IntoWasmRet;
 pub use stopwatch::TimeoutStopwatch;

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -23,7 +23,7 @@ use graph::{
 };
 
 use crate::asc_abi::class::*;
-use crate::host_exports::HostExports;
+pub use crate::host_exports::HostExports;
 use crate::mapping::ValidModule;
 
 mod into_wasm_ret;

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -11,7 +11,7 @@ use semver::Version;
 use wasmtime::{Memory, Trap};
 
 use crate::error::DeterminismLevel;
-use crate::host_exports;
+pub use crate::host_exports;
 use crate::mapping::MappingContext;
 use anyhow::Error;
 use graph::prelude::*;
@@ -23,13 +23,13 @@ use graph::{
 };
 
 use crate::asc_abi::class::*;
-pub use crate::host_exports::HostExports;
+use crate::host_exports::HostExports;
 use crate::mapping::ValidModule;
 
 mod into_wasm_ret;
 pub mod stopwatch;
 
-use into_wasm_ret::IntoWasmRet;
+pub use into_wasm_ret::IntoWasmRet;
 pub use stopwatch::TimeoutStopwatch;
 
 pub const TRAP_TIMEOUT: &str = "trap: interrupt";
@@ -222,8 +222,8 @@ pub struct WasmInstanceContext<C: Blockchain> {
     memory_allocate: wasmtime::TypedFunc<i32, i32>,
 
     pub ctx: MappingContext<C>,
-    pub(crate) valid_module: Arc<ValidModule>,
-    pub(crate) host_metrics: Arc<HostMetrics>,
+    pub valid_module: Arc<ValidModule>,
+    pub host_metrics: Arc<HostMetrics>,
     pub(crate) timeout: Option<Duration>,
 
     // Used by ipfs.map.
@@ -239,7 +239,7 @@ pub struct WasmInstanceContext<C: Blockchain> {
     possible_reorg: bool,
 
     // A host export trap ocurred for a deterministic reason.
-    deterministic_host_trap: bool,
+    pub deterministic_host_trap: bool,
 
     pub(crate) experimental_features: ExperimentalFeatures,
 }
@@ -651,7 +651,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
 impl<C: Blockchain> WasmInstanceContext<C> {
     /// function abort(message?: string | null, fileName?: string | null, lineNumber?: u32, columnNumber?: u32): void
     /// Always returns a trap.
-    fn abort(
+    pub fn abort(
         &mut self,
         message_ptr: AscPtr<AscString>,
         file_name_ptr: AscPtr<AscString>,
@@ -681,7 +681,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function store.set(entity: string, id: string, data: Entity): void
-    fn store_set(
+    pub fn store_set(
         &mut self,
         entity_ptr: AscPtr<AscString>,
         id_ptr: AscPtr<AscString>,
@@ -707,7 +707,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function store.remove(entity: string, id: string): void
-    fn store_remove(
+    pub fn store_remove(
         &mut self,
         entity_ptr: AscPtr<AscString>,
         id_ptr: AscPtr<AscString>,
@@ -724,7 +724,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function store.get(entity: string, id: string): Entity | null
-    fn store_get(
+    pub fn store_get(
         &mut self,
         entity_ptr: AscPtr<AscString>,
         id_ptr: AscPtr<AscString>,
@@ -755,7 +755,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function typeConversion.bytesToString(bytes: Bytes): string
-    fn bytes_to_string(
+    pub fn bytes_to_string(
         &mut self,
         bytes_ptr: AscPtr<Uint8Array>,
     ) -> Result<AscPtr<AscString>, DeterministicHostError> {
@@ -768,7 +768,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     /// References:
     /// https://godoc.org/github.com/ethereum/go-ethereum/common/hexutil#hdr-Encoding_Rules
     /// https://github.com/ethereum/web3.js/blob/f98fe1462625a6c865125fecc9cb6b414f0a5e83/packages/web3-utils/src/utils.js#L283
-    fn bytes_to_hex(
+    pub fn bytes_to_hex(
         &mut self,
         bytes_ptr: AscPtr<Uint8Array>,
     ) -> Result<AscPtr<AscString>, DeterministicHostError> {
@@ -780,7 +780,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function typeConversion.bigIntToString(n: Uint8Array): string
-    fn big_int_to_string(
+    pub fn big_int_to_string(
         &mut self,
         big_int_ptr: AscPtr<AscBigInt>,
     ) -> Result<AscPtr<AscString>, DeterministicHostError> {
@@ -789,7 +789,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigInt.fromString(x: string): BigInt
-    fn big_int_from_string(
+    pub fn big_int_from_string(
         &mut self,
         string_ptr: AscPtr<AscString>,
     ) -> Result<AscPtr<AscBigInt>, DeterministicHostError> {
@@ -801,7 +801,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function typeConversion.bigIntToHex(n: Uint8Array): string
-    fn big_int_to_hex(
+    pub fn big_int_to_hex(
         &mut self,
         big_int_ptr: AscPtr<AscBigInt>,
     ) -> Result<AscPtr<AscString>, DeterministicHostError> {
@@ -811,7 +811,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function typeConversion.stringToH160(s: String): H160
-    fn string_to_h160(
+    pub fn string_to_h160(
         &mut self,
         str_ptr: AscPtr<AscString>,
     ) -> Result<AscPtr<AscH160>, DeterministicHostError> {
@@ -821,7 +821,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function json.fromBytes(bytes: Bytes): JSONValue
-    fn json_from_bytes(
+    pub fn json_from_bytes(
         &mut self,
         bytes_ptr: AscPtr<Uint8Array>,
     ) -> Result<AscPtr<AscEnum<JsonValueKind>>, DeterministicHostError> {
@@ -839,7 +839,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function json.try_fromBytes(bytes: Bytes): Result<JSONValue, boolean>
-    fn json_try_from_bytes(
+    pub fn json_try_from_bytes(
         &mut self,
         bytes_ptr: AscPtr<Uint8Array>,
     ) -> Result<AscPtr<AscResult<AscPtr<AscEnum<JsonValueKind>>, bool>>, DeterministicHostError>
@@ -861,7 +861,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function ipfs.cat(link: String): Bytes
-    fn ipfs_cat(
+    pub fn ipfs_cat(
         &mut self,
         link_ptr: AscPtr<AscString>,
     ) -> Result<AscPtr<Uint8Array>, HostExportError> {
@@ -887,7 +887,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function ipfs.map(link: String, callback: String, flags: String[]): void
-    fn ipfs_map(
+    pub fn ipfs_map(
         &mut self,
         link_ptr: AscPtr<AscString>,
         callback: AscPtr<AscString>,
@@ -938,25 +938,25 @@ impl<C: Blockchain> WasmInstanceContext<C> {
 
     /// Expects a decimal string.
     /// function json.toI64(json: String): i64
-    fn json_to_i64(&mut self, json_ptr: AscPtr<AscString>) -> Result<i64, DeterministicHostError> {
+    pub fn json_to_i64(&mut self, json_ptr: AscPtr<AscString>) -> Result<i64, DeterministicHostError> {
         self.ctx.host_exports.json_to_i64(asc_get(self, json_ptr)?)
     }
 
     /// Expects a decimal string.
     /// function json.toU64(json: String): u64
-    fn json_to_u64(&mut self, json_ptr: AscPtr<AscString>) -> Result<u64, DeterministicHostError> {
+    pub fn json_to_u64(&mut self, json_ptr: AscPtr<AscString>) -> Result<u64, DeterministicHostError> {
         self.ctx.host_exports.json_to_u64(asc_get(self, json_ptr)?)
     }
 
     /// Expects a decimal string.
     /// function json.toF64(json: String): f64
-    fn json_to_f64(&mut self, json_ptr: AscPtr<AscString>) -> Result<f64, DeterministicHostError> {
+    pub fn json_to_f64(&mut self, json_ptr: AscPtr<AscString>) -> Result<f64, DeterministicHostError> {
         self.ctx.host_exports.json_to_f64(asc_get(self, json_ptr)?)
     }
 
     /// Expects a decimal string.
     /// function json.toBigInt(json: String): BigInt
-    fn json_to_big_int(
+    pub fn json_to_big_int(
         &mut self,
         json_ptr: AscPtr<AscString>,
     ) -> Result<AscPtr<AscBigInt>, DeterministicHostError> {
@@ -968,7 +968,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function crypto.keccak256(input: Bytes): Bytes
-    fn crypto_keccak_256(
+    pub fn crypto_keccak_256(
         &mut self,
         input_ptr: AscPtr<Uint8Array>,
     ) -> Result<AscPtr<Uint8Array>, DeterministicHostError> {
@@ -980,7 +980,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigInt.plus(x: BigInt, y: BigInt): BigInt
-    fn big_int_plus(
+    pub fn big_int_plus(
         &mut self,
         x_ptr: AscPtr<AscBigInt>,
         y_ptr: AscPtr<AscBigInt>,
@@ -993,7 +993,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigInt.minus(x: BigInt, y: BigInt): BigInt
-    fn big_int_minus(
+    pub fn big_int_minus(
         &mut self,
         x_ptr: AscPtr<AscBigInt>,
         y_ptr: AscPtr<AscBigInt>,
@@ -1006,7 +1006,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigInt.times(x: BigInt, y: BigInt): BigInt
-    fn big_int_times(
+    pub fn big_int_times(
         &mut self,
         x_ptr: AscPtr<AscBigInt>,
         y_ptr: AscPtr<AscBigInt>,
@@ -1032,7 +1032,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigInt.dividedByDecimal(x: BigInt, y: BigDecimal): BigDecimal
-    fn big_int_divided_by_decimal(
+    pub fn big_int_divided_by_decimal(
         &mut self,
         x_ptr: AscPtr<AscBigInt>,
         y_ptr: AscPtr<AscBigDecimal>,
@@ -1046,7 +1046,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigInt.mod(x: BigInt, y: BigInt): BigInt
-    fn big_int_mod(
+    pub fn big_int_mod(
         &mut self,
         x_ptr: AscPtr<AscBigInt>,
         y_ptr: AscPtr<AscBigInt>,
@@ -1059,7 +1059,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigInt.pow(x: BigInt, exp: u8): BigInt
-    fn big_int_pow(
+    pub fn big_int_pow(
         &mut self,
         x_ptr: AscPtr<AscBigInt>,
         exp: u32,
@@ -1073,7 +1073,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigInt.bitOr(x: BigInt, y: BigInt): BigInt
-    fn big_int_bit_or(
+    pub fn big_int_bit_or(
         &mut self,
         x_ptr: AscPtr<AscBigInt>,
         y_ptr: AscPtr<AscBigInt>,
@@ -1086,7 +1086,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigInt.bitAnd(x: BigInt, y: BigInt): BigInt
-    fn big_int_bit_and(
+    pub fn big_int_bit_and(
         &mut self,
         x_ptr: AscPtr<AscBigInt>,
         y_ptr: AscPtr<AscBigInt>,
@@ -1099,7 +1099,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigInt.leftShift(x: BigInt, bits: u8): BigInt
-    fn big_int_left_shift(
+    pub fn big_int_left_shift(
         &mut self,
         x_ptr: AscPtr<AscBigInt>,
         bits: u32,
@@ -1113,7 +1113,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigInt.rightShift(x: BigInt, bits: u8): BigInt
-    fn big_int_right_shift(
+    pub fn big_int_right_shift(
         &mut self,
         x_ptr: AscPtr<AscBigInt>,
         bits: u32,
@@ -1127,7 +1127,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function typeConversion.bytesToBase58(bytes: Bytes): string
-    fn bytes_to_base58(
+    pub fn bytes_to_base58(
         &mut self,
         bytes_ptr: AscPtr<Uint8Array>,
     ) -> Result<AscPtr<AscString>, DeterministicHostError> {
@@ -1139,7 +1139,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigDecimal.toString(x: BigDecimal): string
-    fn big_decimal_to_string(
+    pub fn big_decimal_to_string(
         &mut self,
         big_decimal_ptr: AscPtr<AscBigDecimal>,
     ) -> Result<AscPtr<AscString>, DeterministicHostError> {
@@ -1151,7 +1151,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigDecimal.fromString(x: string): BigDecimal
-    fn big_decimal_from_string(
+    pub fn big_decimal_from_string(
         &mut self,
         string_ptr: AscPtr<AscString>,
     ) -> Result<AscPtr<AscBigDecimal>, DeterministicHostError> {
@@ -1163,7 +1163,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigDecimal.plus(x: BigDecimal, y: BigDecimal): BigDecimal
-    fn big_decimal_plus(
+    pub fn big_decimal_plus(
         &mut self,
         x_ptr: AscPtr<AscBigDecimal>,
         y_ptr: AscPtr<AscBigDecimal>,
@@ -1176,7 +1176,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigDecimal.minus(x: BigDecimal, y: BigDecimal): BigDecimal
-    fn big_decimal_minus(
+    pub fn big_decimal_minus(
         &mut self,
         x_ptr: AscPtr<AscBigDecimal>,
         y_ptr: AscPtr<AscBigDecimal>,
@@ -1189,7 +1189,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigDecimal.times(x: BigDecimal, y: BigDecimal): BigDecimal
-    fn big_decimal_times(
+    pub fn big_decimal_times(
         &mut self,
         x_ptr: AscPtr<AscBigDecimal>,
         y_ptr: AscPtr<AscBigDecimal>,
@@ -1202,7 +1202,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigDecimal.dividedBy(x: BigDecimal, y: BigDecimal): BigDecimal
-    fn big_decimal_divided_by(
+    pub fn big_decimal_divided_by(
         &mut self,
         x_ptr: AscPtr<AscBigDecimal>,
         y_ptr: AscPtr<AscBigDecimal>,
@@ -1215,7 +1215,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigDecimal.equals(x: BigDecimal, y: BigDecimal): bool
-    fn big_decimal_equals(
+    pub fn big_decimal_equals(
         &mut self,
         x_ptr: AscPtr<AscBigDecimal>,
         y_ptr: AscPtr<AscBigDecimal>,
@@ -1226,7 +1226,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function dataSource.create(name: string, params: Array<string>): void
-    fn data_source_create(
+    pub fn data_source_create(
         &mut self,
         name_ptr: AscPtr<AscString>,
         params_ptr: AscPtr<Array<AscPtr<AscString>>>,
@@ -1244,7 +1244,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function createWithContext(name: string, params: Array<string>, context: DataSourceContext): void
-    fn data_source_create_with_context(
+    pub fn data_source_create_with_context(
         &mut self,
         name_ptr: AscPtr<AscString>,
         params_ptr: AscPtr<Array<AscPtr<AscString>>>,
@@ -1264,21 +1264,21 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function dataSource.address(): Bytes
-    fn data_source_address(&mut self) -> Result<AscPtr<Uint8Array>, DeterministicHostError> {
+    pub fn data_source_address(&mut self) -> Result<AscPtr<Uint8Array>, DeterministicHostError> {
         asc_new(self, &self.ctx.host_exports.data_source_address())
     }
 
     /// function dataSource.network(): String
-    fn data_source_network(&mut self) -> Result<AscPtr<AscString>, DeterministicHostError> {
+    pub fn data_source_network(&mut self) -> Result<AscPtr<AscString>, DeterministicHostError> {
         asc_new(self, &self.ctx.host_exports.data_source_network())
     }
 
     /// function dataSource.context(): DataSourceContext
-    fn data_source_context(&mut self) -> Result<AscPtr<AscEntity>, DeterministicHostError> {
+    pub fn data_source_context(&mut self) -> Result<AscPtr<AscEntity>, DeterministicHostError> {
         asc_new(self, &self.ctx.host_exports.data_source_context().sorted())
     }
 
-    fn ens_name_by_hash(
+    pub fn ens_name_by_hash(
         &mut self,
         hash_ptr: AscPtr<AscString>,
     ) -> Result<AscPtr<AscString>, HostExportError> {
@@ -1289,7 +1289,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
             .unwrap_or(Ok(AscPtr::null()))
     }
 
-    fn log_log(
+    pub fn log_log(
         &mut self,
         level: u32,
         msg: AscPtr<AscString>,
@@ -1300,7 +1300,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function encode(token: ethereum.Value): Bytes | null
-    fn ethereum_encode(
+    pub fn ethereum_encode(
         &mut self,
         token_ptr: AscPtr<AscEnum<EthereumValueKind>>,
     ) -> Result<AscPtr<Uint8Array>, DeterministicHostError> {
@@ -1311,7 +1311,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function decode(types: String, data: Bytes): ethereum.Value | null
-    fn ethereum_decode(
+    pub fn ethereum_decode(
         &mut self,
         types_ptr: AscPtr<AscString>,
         data_ptr: AscPtr<Uint8Array>,
@@ -1325,7 +1325,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function arweave.transactionData(txId: string): Bytes | null
-    fn arweave_transaction_data(
+    pub fn arweave_transaction_data(
         &mut self,
         tx_id: AscPtr<AscString>,
     ) -> Result<AscPtr<Uint8Array>, HostExportError> {
@@ -1341,7 +1341,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function box.profile(address: string): JSONValue | null
-    fn box_profile(
+    pub fn box_profile(
         &mut self,
         address: AscPtr<AscString>,
     ) -> Result<AscPtr<AscJson>, HostExportError> {

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -573,7 +573,7 @@ impl<C: Blockchain> AscHeap for WasmInstanceContext<C> {
 }
 
 impl<C: Blockchain> WasmInstanceContext<C> {
-    fn from_instance(
+    pub fn from_instance(
         instance: &wasmtime::Instance,
         ctx: MappingContext<C>,
         valid_module: Arc<ValidModule>,
@@ -609,7 +609,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
         })
     }
 
-    fn from_caller(
+    pub fn from_caller(
         caller: wasmtime::Caller,
         ctx: MappingContext<C>,
         valid_module: Arc<ValidModule>,
@@ -1019,7 +1019,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
     }
 
     /// function bigInt.dividedBy(x: BigInt, y: BigInt): BigInt
-    fn big_int_divided_by(
+    pub fn big_int_divided_by(
         &mut self,
         x_ptr: AscPtr<AscBigInt>,
         y_ptr: AscPtr<AscBigInt>,

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -23,7 +23,7 @@ use graph::{
 };
 
 use crate::asc_abi::class::*;
-pub use crate::host_exports::HostExports;
+use crate::host_exports::HostExports;
 use crate::mapping::ValidModule;
 
 mod into_wasm_ret;

--- a/runtime/wasm/src/module/stopwatch.rs
+++ b/runtime/wasm/src/module/stopwatch.rs
@@ -9,7 +9,7 @@ pub struct TimeoutStopwatch {
     /// The time the stopwatch was started last, if ever.
     start_time: Option<Instant>,
     /// The time elapsed while the stopwatch was running (between start() and stop()).
-    elapsed: Duration,
+    pub elapsed: Duration,
 }
 
 impl Default for TimeoutStopwatch {


### PR DESCRIPTION
As per work being done for the development of a subgraph unit testing framework, we need to be able to access fields form graph-node, which are currently private/package private. This PR aims to make those public.

PS I know it's a lot of commits (sorry, needed to commit in order to test), whoever merges it - be sure to squash and merge.