### PR TITLE
Asyncify is_deployment_synced

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -660,7 +660,7 @@ where
     /// on the returned stream as a single `StoreEvent`; the events are
     /// combined by using the maximum of all sources and the concatenation
     /// of the changes of the `StoreEvents` received during the interval.
-    pub fn throttle_while_syncing(
+    pub async fn throttle_while_syncing(
         self,
         logger: &Logger,
         store: Arc<dyn QueryStore>,
@@ -669,7 +669,7 @@ where
         // Check whether a deployment is marked as synced in the store. Note that in the moment a
         // subgraph becomes synced any existing subscriptions will continue to be throttled since
         // this is not re-checked.
-        let synced = store.is_deployment_synced().unwrap_or(false);
+        let synced = store.is_deployment_synced().await.unwrap_or(false);
 
         let mut pending_event: Option<StoreEvent> = None;
         let mut source = self.source.fuse();
@@ -1039,7 +1039,7 @@ pub trait WritableStore: Send + Sync + 'static {
 
     /// Return true if the deployment with the given id is fully synced,
     /// and return false otherwise. Errors from the store are passed back up
-    fn is_deployment_synced(&self) -> Result<bool, Error>;
+    async fn is_deployment_synced(&self) -> Result<bool, Error>;
 
     fn unassign_subgraph(&self) -> Result<(), StoreError>;
 
@@ -1202,7 +1202,7 @@ impl WritableStore for MockStore {
         self.get_many_mock(ids_for_type)
     }
 
-    fn is_deployment_synced(&self) -> Result<bool, Error> {
+    async fn is_deployment_synced(&self) -> Result<bool, Error> {
         unimplemented!()
     }
 
@@ -1327,7 +1327,7 @@ pub trait QueryStore: Send + Sync {
         query: EntityQuery,
     ) -> Result<Vec<BTreeMap<String, q::Value>>, QueryExecutionError>;
 
-    fn is_deployment_synced(&self) -> Result<bool, Error>;
+    async fn is_deployment_synced(&self) -> Result<bool, Error>;
 
     fn block_ptr(&self) -> Result<Option<BlockPtr>, Error>;
 

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 
 use crate::execution::ExecutionContext;
-use graph::prelude::{q, s, Error, QueryExecutionError, StoreEventStreamBox};
+use graph::prelude::{async_trait, q, s, Error, QueryExecutionError, StoreEventStreamBox};
 use graph::{
     data::graphql::{ext::DocumentExt, ObjectOrInterface},
     prelude::QueryResult,
 };
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
+#[async_trait]
 pub trait Resolver: Sized + Send + Sync + 'static {
     const CACHEABLE: bool;
 
@@ -106,11 +107,11 @@ pub trait Resolver: Sized + Send + Sync + 'static {
     }
 
     // Resolves a change stream for a given field.
-    fn resolve_field_stream<'a, 'b>(
+    async fn resolve_field_stream(
         &self,
-        _schema: &'a s::Document,
-        _object_type: &'a s::ObjectType,
-        _field: &'b q::Field,
+        _schema: &s::Document,
+        _object_type: &s::ObjectType,
+        _field: &q::Field,
     ) -> Result<StoreEventStreamBox, QueryExecutionError> {
         Err(QueryExecutionError::NotSupported(String::from(
             "Resolving field streams is not supported by this resolver",

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -301,6 +301,7 @@ where
                 load_manager: self.load_manager.cheap_clone(),
             },
         )
+        .await
     }
 
     fn load_manager(&self) -> Arc<LoadManager> {

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -208,6 +208,7 @@ impl StoreResolver {
     }
 }
 
+#[async_trait]
 impl Resolver for StoreResolver {
     const CACHEABLE: bool = true;
 
@@ -276,11 +277,11 @@ impl Resolver for StoreResolver {
         }
     }
 
-    fn resolve_field_stream<'a, 'b>(
+    async fn resolve_field_stream(
         &self,
-        schema: &'a s::Document,
-        object_type: &'a s::ObjectType,
-        field: &'b q::Field,
+        schema: &s::Document,
+        object_type: &s::ObjectType,
+        field: &q::Field,
     ) -> result::Result<StoreEventStreamBox, QueryExecutionError> {
         // Collect all entities involved in the query field
         let entities = collect_entities_from_query_field(schema, object_type, field);
@@ -293,7 +294,8 @@ impl Resolver for StoreResolver {
                 &self.logger,
                 self.store.clone(),
                 *SUBSCRIPTION_THROTTLE_INTERVAL,
-            ))
+            )
+            .await)
     }
 
     fn post_process(&self, result: &mut QueryResult) -> Result<(), anyhow::Error> {

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -910,8 +910,9 @@ fn query_complexity_subscriptions() {
 
         // This query is exactly at the maximum complexity.
         // FIXME: Not collecting the stream because that will hang the test.
-        let _ignore_stream =
-            execute_subscription(Subscription { query }, schema.clone(), options).unwrap();
+        let _ignore_stream = execute_subscription(Subscription { query }, schema.clone(), options)
+            .await
+            .unwrap();
 
         let query = Query::new(
             graphql_parser::parse_query(
@@ -956,7 +957,7 @@ fn query_complexity_subscriptions() {
         };
 
         // The extra introspection causes the complexity to go over.
-        let result = execute_subscription(Subscription { query }, schema, options);
+        let result = execute_subscription(Subscription { query }, schema, options).await;
         match result {
             Err(SubscriptionError::GraphQLError(e)) => match e[0] {
                 QueryExecutionError::TooComplex(1_010_200, _) => (), // Expected
@@ -1335,7 +1336,9 @@ fn subscription_gets_result_even_without_events() {
         };
         // Execute the subscription and expect at least one result to be
         // available in the result stream
-        let stream = execute_subscription(Subscription { query }, schema, options).unwrap();
+        let stream = execute_subscription(Subscription { query }, schema, options)
+            .await
+            .unwrap();
         let results: Vec<_> = stream
             .take(1)
             .collect()

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1057,9 +1057,12 @@ impl DeploymentStore {
         .await
     }
 
-    pub(crate) fn exists_and_synced(&self, id: &DeploymentHash) -> Result<bool, StoreError> {
-        let conn = self.get_conn()?;
-        conn.transaction(|| deployment::exists_and_synced(&conn, id))
+    pub(crate) async fn exists_and_synced(&self, id: DeploymentHash) -> Result<bool, StoreError> {
+        self.with_conn(move |conn, _| {
+            conn.transaction(|| deployment::exists_and_synced(&conn, &id))
+                .map_err(Into::into)
+        })
+        .await
     }
 
     pub(crate) fn graft_pending(

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -47,8 +47,11 @@ impl QueryStoreTrait for QueryStore {
 
     /// Return true if the deployment with the given id is fully synced,
     /// and return false otherwise. Errors from the store are passed back up
-    fn is_deployment_synced(&self) -> Result<bool, Error> {
-        Ok(self.store.exists_and_synced(&self.site.deployment)?)
+    async fn is_deployment_synced(&self) -> Result<bool, Error> {
+        Ok(self
+            .store
+            .exists_and_synced(self.site.deployment.cheap_clone())
+            .await?)
     }
 
     fn block_ptr(&self) -> Result<Option<BlockPtr>, Error> {

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -9,6 +9,7 @@ use std::{fmt, io::Write};
 use std::{iter::FromIterator, time::Duration};
 
 use graph::{
+    cheap_clone::CheapClone,
     components::{
         server::index_node::VersionInfo,
         store::{self, DeploymentLocator, EntityType, WritableStore as WritableStoreTrait},
@@ -1099,8 +1100,11 @@ impl WritableStoreTrait for WritableStore {
         self.writable.get_many(self.site.clone(), ids_for_type)
     }
 
-    fn is_deployment_synced(&self) -> Result<bool, Error> {
-        Ok(self.writable.exists_and_synced(&self.site.deployment)?)
+    async fn is_deployment_synced(&self) -> Result<bool, Error> {
+        Ok(self
+            .writable
+            .exists_and_synced(self.site.deployment.cheap_clone())
+            .await?)
     }
 
     fn unassign_subgraph(&self) -> Result<(), StoreError> {

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1391,15 +1391,17 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
 #[test]
 fn throttle_subscription_delivers() {
     run_test(|store, _, deployment| async move {
-        let subscription = subscribe(&deployment.hash, USER).throttle_while_syncing(
-            &*LOGGER,
-            store
-                .clone()
-                .query_store(deployment.hash.clone().into(), true)
-                .await
-                .unwrap(),
-            Duration::from_millis(500),
-        );
+        let subscription = subscribe(&deployment.hash, USER)
+            .throttle_while_syncing(
+                &*LOGGER,
+                store
+                    .clone()
+                    .query_store(deployment.hash.clone().into(), true)
+                    .await
+                    .unwrap(),
+                Duration::from_millis(500),
+            )
+            .await;
 
         let user4 = create_test_entity(
             "4",
@@ -1430,15 +1432,17 @@ fn throttle_subscription_delivers() {
 fn throttle_subscription_throttles() {
     run_test(|store, _, deployment| async move {
         // Throttle for a very long time (30s)
-        let subscription = subscribe(&deployment.hash, USER).throttle_while_syncing(
-            &*LOGGER,
-            store
-                .clone()
-                .query_store(deployment.hash.clone().into(), true)
-                .await
-                .unwrap(),
-            Duration::from_secs(30),
-        );
+        let subscription = subscribe(&deployment.hash, USER)
+            .throttle_while_syncing(
+                &*LOGGER,
+                store
+                    .clone()
+                    .query_store(deployment.hash.clone().into(), true)
+                    .await
+                    .unwrap(),
+                Duration::from_secs(30),
+            )
+            .await;
 
         let user4 = create_test_entity(
             "4",


### PR DESCRIPTION
We noticed that if one DB shard is overloaded, that causes contention in the query nodes' non-blocking tokio threadpool. This is likely caused by a blocking DB operation being done in an async context in the query execution path. The only case I could find of this was in `throttle_while_syncing` for subscriptions, the solution was to asyncify the `is_deployment_synced` store operation.

To facilitate this change, the first commit checks the synced status for subscription throttling only when the subscription is first created. Hopefully this is ok.