### PR TITLE
Revamp query semaphore to be by shard

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # NEWS
 
+## Unreleased
+
+### Metrics
+- `query_semaphore_wait_ms` is now by shard, and has the `pool` and `shard` labels.
+
 ## 0.23.1
 
 - Fix ipfs timeout detection [#2584](https://github.com/graphprotocol/graph-node/pull/2584).

--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -47,7 +47,5 @@ pub trait GraphQlRunner: Send + Sync + 'static {
 
 #[async_trait]
 pub trait QueryLoadManager: Send + Sync {
-    async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit;
-
     fn record_work(&self, shape_hash: u64, duration: Duration, cache_status: CacheStatus);
 }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1345,11 +1345,18 @@ pub trait QueryStore: Send + Sync {
     fn api_schema(&self) -> Result<Arc<ApiSchema>, QueryExecutionError>;
 
     fn network_name(&self) -> &str;
+
+    /// A permit should be acquired before starting query execution.
+    async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit;
 }
 
 /// A view of the store that can provide information about the indexing status
 /// of any subgraph and any deployment
+#[async_trait]
 pub trait StatusStore: Send + Sync + 'static {
+    /// A permit should be acquired before starting query execution.
+    async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit;
+
     fn status(&self, filter: status::Filter) -> Result<Vec<status::Info>, StoreError>;
 
     /// Support for the explorer-specific API

--- a/graph/src/util/stats.rs
+++ b/graph/src/util/stats.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use std::time::{Duration, Instant};
 
 use lazy_static::lazy_static;
+use prometheus::Gauge;
 
 lazy_static! {
     pub static ref WINDOW_SIZE: Duration = {
@@ -178,6 +179,16 @@ impl MovingStats {
 
     pub fn duration(&self) -> Duration {
         self.total.duration
+    }
+
+    /// Adds `duration` to the stats, and register the average ms to `avg_gauge`.
+    pub fn add_and_register(&mut self, duration: Duration, avg_gauge: &Gauge) {
+        let wait_avg = {
+            self.add(duration);
+            self.average()
+        };
+        let wait_avg = wait_avg.map(|wait_avg| wait_avg.as_millis()).unwrap_or(0);
+        avg_gauge.set(wait_avg as f64);
     }
 }
 

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::execution::ExecutionContext;
-use graph::prelude::{async_trait, q, s, Error, QueryExecutionError, StoreEventStreamBox};
+use graph::prelude::{async_trait, q, s, tokio, Error, QueryExecutionError, StoreEventStreamBox};
 use graph::{
     data::graphql::{ext::DocumentExt, ObjectOrInterface},
     prelude::QueryResult,
@@ -11,6 +11,8 @@ use graph::{
 #[async_trait]
 pub trait Resolver: Sized + Send + Sync + 'static {
     const CACHEABLE: bool;
+
+    async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit;
 
     /// Prepare for executing a query by prefetching as much data as possible
     fn prefetch(

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -346,10 +346,15 @@ impl IntrospectionResolver {
 }
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
+#[async_trait]
 impl Resolver for IntrospectionResolver {
     // `IntrospectionResolver` is not used as a "top level" resolver,
     // see `fn as_introspection_context`, so this value is irrelevant.
     const CACHEABLE: bool = false;
+
+    async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit {
+        unreachable!()
+    }
 
     fn prefetch(
         &self,

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -49,7 +49,6 @@ where
         max_first: options.max_first,
         max_skip: options.max_skip,
         cache_status: Default::default(),
-        load_manager: options.load_manager.cheap_clone(),
     });
 
     if !query.is_query() {

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -288,7 +288,6 @@ where
                 max_depth: *GRAPHQL_MAX_DEPTH,
                 max_first: *GRAPHQL_MAX_FIRST,
                 max_skip: *GRAPHQL_MAX_SKIP,
-                load_manager: self.load_manager.cheap_clone(),
             },
         )
         .await

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -212,6 +212,10 @@ impl StoreResolver {
 impl Resolver for StoreResolver {
     const CACHEABLE: bool = true;
 
+    async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit {
+        self.store.query_permit().await
+    }
+
     fn prefetch(
         &self,
         ctx: &ExecutionContext<Self>,

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -35,8 +35,6 @@ pub struct SubscriptionExecutionOptions {
 
     /// Maximum value for the `skip` argument.
     pub max_skip: u32,
-
-    pub load_manager: Arc<dyn QueryLoadManager>,
 }
 
 pub async fn execute_subscription(
@@ -94,7 +92,6 @@ async fn create_source_event_stream(
         max_first: options.max_first,
         max_skip: options.max_skip,
         cache_status: Default::default(),
-        load_manager: options.load_manager.cheap_clone(),
     };
 
     let subscription_type = ctx
@@ -161,7 +158,6 @@ fn map_source_to_response_stream(
         max_depth: _,
         max_first,
         max_skip,
-        load_manager,
     } = options;
 
     Box::new(
@@ -181,7 +177,6 @@ fn map_source_to_response_stream(
                     timeout,
                     max_first,
                     max_skip,
-                    load_manager.cheap_clone(),
                 )
                 .boxed(),
             }),
@@ -197,7 +192,6 @@ async fn execute_subscription_event(
     timeout: Option<Duration>,
     max_first: u32,
     max_skip: u32,
-    load_manager: Arc<dyn QueryLoadManager>,
 ) -> Arc<QueryResult> {
     debug!(logger, "Execute subscription event"; "event" => format!("{:?}", event));
 
@@ -226,7 +220,6 @@ async fn execute_subscription_event(
         max_first,
         max_skip,
         cache_status: Default::default(),
-        load_manager,
     });
 
     let subscription_type = match ctx.query.schema.subscription_type.as_ref() {

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -425,7 +425,7 @@ impl Context {
         let store = self.store();
 
         let subscription_manager = Arc::new(PanicSubscriptionManager);
-        let load_manager = Arc::new(LoadManager::new(&logger, vec![], registry, 128));
+        let load_manager = Arc::new(LoadManager::new(&logger, vec![], registry));
 
         Arc::new(GraphQlRunner::new(
             &logger,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -148,9 +148,6 @@ async fn main() {
     // Obtain metrics server port
     let metrics_port = opt.metrics_port;
 
-    // Obtain STORE_CONNECTION_POOL_SIZE setting
-    let store_conn_pool_size: u32 = opt.store_connection_pool_size;
-
     let arweave_adapter = Arc::new(ArweaveAdapter::new(opt.arweave_api.clone()));
 
     let three_box_adapter = Arc::new(ThreeBoxAdapter::new(opt.three_box_api.clone()));
@@ -226,7 +223,6 @@ async fn main() {
             &logger,
             expensive_queries,
             metrics_registry.clone(),
-            store_conn_pool_size as usize,
         ));
         let graphql_runner = Arc::new(GraphQlRunner::new(
             &logger,

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -163,11 +163,16 @@ where
     }
 }
 
+#[async_trait]
 impl<S> Resolver for IndexNodeResolver<S>
 where
     S: StatusStore,
 {
     const CACHEABLE: bool = false;
+
+    async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit {
+        self.store.query_permit().await
+    }
 
     fn prefetch(
         &self,

--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use graph::prelude::StoreError;
+use graph::prelude::{tokio, StoreError};
 use graph::{
     components::store::BlockStore as BlockStoreTrait,
     prelude::{error, warn, BlockNumber, BlockPtr, EthereumNetworkIdentifier, Logger},
@@ -321,6 +321,10 @@ impl BlockStore {
             block_store.add_chain_store(&chain, ChainStatus::ReadOnly, false)?;
         }
         Ok(block_store)
+    }
+
+    pub(crate) async fn query_permit_primary(&self) -> tokio::sync::OwnedSemaphorePermit {
+        self.primary.query_permit().await
     }
 
     fn add_chain_store(

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -110,4 +110,8 @@ impl QueryStoreTrait for QueryStore {
     fn network_name(&self) -> &str {
         &self.site.network
     }
+
+    async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit {
+        self.store.query_permit(self.replica_id).await
+    }
 }

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -51,7 +51,6 @@ lazy_static! {
         &*LOGGER,
         Vec::new(),
         Arc::new(MockMetricsRegistry::new()),
-        CONN_POOL_SIZE as usize
     ));
     static ref STORE_POOL_CONFIG: (Arc<Store>, ConnectionPool, Config, Arc<SubscriptionManager>) =
         build_store();


### PR DESCRIPTION
This moves the query semaphore implementation from the `LoadManager` to the per-shard (or replica) `ConnectionPool`s, with a capacity equal to the shard's (or replica's) connection pool size. It is accessed through the resolver. The indexing status queries are now also guarded by the primary shard semaphore.