### PR TITLE
ethereum: Fix accessing call handler transaction input

### DIFF
--- a/chain/ethereum/src/runtime/abi.rs
+++ b/chain/ethereum/src/runtime/abi.rs
@@ -85,7 +85,7 @@ pub(crate) struct AscEthereumBlock {
 
 #[repr(C)]
 #[derive(AscType)]
-pub(crate) struct AscEthereumTransaction {
+pub(crate) struct AscEthereumTransaction_0_0_1 {
     pub hash: AscPtr<AscH256>,
     pub index: AscPtr<AscBigInt>,
     pub from: AscPtr<AscH160>,
@@ -135,7 +135,7 @@ pub(crate) struct AscLogParam {
 pub(crate) struct AscEthereumCall {
     pub address: AscPtr<AscAddress>,
     pub block: AscPtr<AscEthereumBlock>,
-    pub transaction: AscPtr<AscEthereumTransaction>,
+    pub transaction: AscPtr<AscEthereumTransaction_0_0_1>,
     pub inputs: AscPtr<AscLogParamArray>,
     pub outputs: AscPtr<AscLogParamArray>,
 }
@@ -146,7 +146,7 @@ pub(crate) struct AscEthereumCall_0_0_3 {
     pub to: AscPtr<AscAddress>,
     pub from: AscPtr<AscAddress>,
     pub block: AscPtr<AscEthereumBlock>,
-    pub transaction: AscPtr<AscEthereumTransaction>,
+    pub transaction: AscPtr<AscEthereumTransaction_0_0_2>,
     pub inputs: AscPtr<AscLogParamArray>,
     pub outputs: AscPtr<AscLogParamArray>,
 }
@@ -178,12 +178,12 @@ impl ToAscObj<AscEthereumBlock> for EthereumBlockData {
     }
 }
 
-impl ToAscObj<AscEthereumTransaction> for EthereumTransactionData {
+impl ToAscObj<AscEthereumTransaction_0_0_1> for EthereumTransactionData {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
-    ) -> Result<AscEthereumTransaction, DeterministicHostError> {
-        Ok(AscEthereumTransaction {
+    ) -> Result<AscEthereumTransaction_0_0_1, DeterministicHostError> {
+        Ok(AscEthereumTransaction_0_0_1 {
             hash: asc_new(heap, &self.hash)?,
             index: asc_new(heap, &BigInt::from(self.index))?,
             from: asc_new(heap, &self.from)?,

--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -25,7 +25,7 @@ use web3::types::{Address, Block, Log, Transaction, H256};
 use crate::runtime::abi::AscEthereumCall;
 use crate::runtime::abi::AscEthereumCall_0_0_3;
 use crate::runtime::abi::AscEthereumEvent;
-use crate::runtime::abi::AscEthereumTransaction;
+use crate::runtime::abi::AscEthereumTransaction_0_0_1;
 use crate::runtime::abi::AscEthereumTransaction_0_0_2;
 
 // ETHDEP: This should be defined in only one place.
@@ -159,7 +159,7 @@ impl blockchain::MappingTrigger for MappingTrigger {
                     )?
                     .erase()
                 } else {
-                    asc_new::<AscEthereumEvent<AscEthereumTransaction>, _, _>(
+                    asc_new::<AscEthereumEvent<AscEthereumTransaction_0_0_1>, _, _>(
                         heap,
                         &EthereumEventData {
                             block: EthereumBlockData::from(block.as_ref()),


### PR DESCRIPTION
For clarity this renames `AscEthereumTransaction` to `AscEthereumTransaction_0_0_1`. The actual fix is to switch `AscEthereumCall_0_0_3` to use `AscEthereumTransaction_0_0_2`.