### PR TITLE
ethereum: Downgrade spammy log to trace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Logs
+- The log `"Skipping handler because the event parameters do not match the event signature."` was downgraded from info to trace level.
+
 ### Metrics
 - `query_semaphore_wait_ms` is now by shard, and has the `pool` and `shard` labels.
 

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Error};
 use anyhow::{ensure, Context};
 use ethabi::{Address, Event, Function, LogParam, ParamType, RawLog};
 use graph::components::store::StoredDynamicDataSource;
+use graph::slog::trace;
 use std::str::FromStr;
 use std::{convert::TryFrom, sync::Arc};
 use tiny_keccak::keccak256;
@@ -415,7 +416,7 @@ impl DataSource {
                             })
                             .map(|log| log.params)
                             .map_err(|e| {
-                                info!(
+                                trace!(
                                     logger,
                                     "Skipping handler because the event parameters do not \
                                     match the event signature. This is typically the case \


### PR DESCRIPTION
This is a nicely written log, but for some subgraphs it logs too often during normal execution. In the hosted service, this logs thousands of times per second!