### PR TITLE
stopwatch: Add send_store_event section

### DIFF
--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -39,6 +39,8 @@ pub struct StopwatchMetrics {
     inner: Arc<Mutex<StopwatchInner>>,
 }
 
+impl CheapClone for StopwatchMetrics {}
+
 impl StopwatchMetrics {
     pub fn new(
         logger: Logger,

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1090,10 +1090,12 @@ impl WritableStoreTrait for WritableStore {
             self.site.clone(),
             block_ptr_to,
             mods,
-            stopwatch,
+            stopwatch.cheap_clone(),
             data_sources,
             deterministic_errors,
         )?;
+
+        let _section = stopwatch.start_section("send_store_event");
         self.store.send_store_event(&event)
     }
 


### PR DESCRIPTION
We've seen subgraphs take a lot of time in the `transact_block` section, this will break it down further.