### PR TITLE
multichain: Abstract NodeCapabilities

### DIFF
--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -13,14 +13,12 @@ use web3::types::{Address, Block, Log, H256};
 
 use graph::{
     blockchain as bc,
-    components::{
-        ethereum::NodeCapabilities,
-        metrics::{CounterVec, GaugeVec, HistogramVec},
-    },
+    components::metrics::{CounterVec, GaugeVec, HistogramVec},
     petgraph::{self, graphmap::GraphMap},
 };
 use graph::{components::ethereum::EthereumNetworkIdentifier, prelude::*};
 
+use crate::capabilities::NodeCapabilities;
 use crate::{data_source::DataSource, Chain};
 
 pub type EventSignature = H256;

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -12,15 +12,15 @@ use graph::{
             TriggersAdapter as TriggersAdapterTrait,
         },
         Block, BlockHash, BlockPtr, Blockchain, ChainHeadUpdateListener,
-        IngestorAdapter as IngestorAdapterTrait, IngestorError, Manifest, TriggerFilter as _,
+        IngestorAdapter as IngestorAdapterTrait, IngestorError, TriggerFilter as _,
     },
     cheap_clone::CheapClone,
     components::store::DeploymentLocator,
     log::factory::{ComponentLoggerConfig, ElasticComponentLoggerConfig},
     prelude::{
-        async_trait, error, lazy_static, o, serde_yaml, web3::types::H256, BlockNumber, ChainStore,
-        DeploymentHash, EthereumBlockWithCalls, Future01CompatExt, LinkResolver, Logger,
-        LoggerFactory, MetricsRegistry, NodeId, SubgraphStore,
+        async_trait, error, lazy_static, o, web3::types::H256, BlockNumber, ChainStore,
+        EthereumBlockWithCalls, Future01CompatExt, Logger, LoggerFactory, MetricsRegistry, NodeId,
+        SubgraphStore,
     },
 };
 
@@ -116,8 +116,6 @@ impl Blockchain for Chain {
     type DataSourceTemplate = DataSourceTemplate;
 
     type UnresolvedDataSourceTemplate = UnresolvedDataSourceTemplate;
-
-    type Manifest = DummyManifest;
 
     type TriggersAdapter = TriggersAdapter;
 
@@ -304,28 +302,6 @@ impl Block for BlockFinality {
 }
 
 pub struct DummyDataSourceTemplate;
-
-pub struct DummyManifest;
-
-#[async_trait]
-impl Manifest<Chain> for DummyManifest {
-    async fn resolve_from_raw(
-        _id: DeploymentHash,
-        _raw: serde_yaml::Mapping,
-        _resolver: &impl LinkResolver,
-        _logger: &Logger,
-    ) -> Result<Self, Error> {
-        todo!()
-    }
-
-    fn data_sources(&self) -> &[DataSource] {
-        todo!()
-    }
-
-    fn templates(&self) -> &[DataSourceTemplate] {
-        todo!()
-    }
-}
 
 pub struct TriggersAdapter {
     logger: Logger,

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -15,7 +15,7 @@ use graph::{
         IngestorAdapter as IngestorAdapterTrait, IngestorError, Manifest, TriggerFilter as _,
     },
     cheap_clone::CheapClone,
-    components::{ethereum::NodeCapabilities, store::DeploymentLocator},
+    components::store::DeploymentLocator,
     log::factory::{ComponentLoggerConfig, ElasticComponentLoggerConfig},
     prelude::{
         async_trait, error, lazy_static, o, serde_yaml, web3::types::H256, BlockNumber, ChainStore,
@@ -127,7 +127,7 @@ impl Blockchain for Chain {
 
     type TriggerFilter = crate::adapter::TriggerFilter;
 
-    type NodeCapabilities = NodeCapabilities;
+    type NodeCapabilities = crate::capabilities::NodeCapabilities;
 
     type IngestorAdapter = IngestorAdapter;
 

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -1,10 +1,12 @@
 mod adapter;
+mod capabilities;
 mod data_source;
 mod ethereum_adapter;
 pub mod network_indexer;
 pub mod runtime;
 mod transport;
 
+pub use self::capabilities::NodeCapabilities;
 pub use self::ethereum_adapter::EthereumAdapter;
 pub use self::runtime::RuntimeAdapter;
 pub use self::transport::{EventLoopHandle, Transport};

--- a/chain/ethereum/src/network.rs
+++ b/chain/ethereum/src/network.rs
@@ -1,8 +1,5 @@
 use anyhow::anyhow;
-use graph::{
-    components::ethereum::NodeCapabilities,
-    prelude::rand::{self, seq::IteratorRandom},
-};
+use graph::prelude::rand::{self, seq::IteratorRandom};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -10,6 +7,7 @@ pub use graph::impl_slog_value;
 use graph::prelude::Error;
 
 use crate::adapter::EthereumAdapter as _;
+use crate::capabilities::NodeCapabilities;
 use crate::EthereumAdapter;
 
 #[derive(Clone)]

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -1,16 +1,15 @@
 use std::{sync::Arc, time::Instant};
 
 use crate::{
-    network::EthereumNetworkAdapters, Chain, DataSource, EthereumAdapter, EthereumAdapterTrait,
-    EthereumContractCall, EthereumContractCallError,
+    capabilities::NodeCapabilities, network::EthereumNetworkAdapters, Chain, DataSource,
+    EthereumAdapter, EthereumAdapterTrait, EthereumContractCall, EthereumContractCallError,
 };
 use anyhow::{Context, Error};
 use blockchain::HostFn;
 use ethabi::{Address, Token};
 use graph::{
-    blockchain::{self, BlockPtr, DataSource as _, HostFnCtx},
+    blockchain::{self, BlockPtr, HostFnCtx},
     cheap_clone::CheapClone,
-    components::ethereum::NodeCapabilities,
     prelude::{EthereumCallCache, Future01CompatExt, MappingABI},
     runtime::{asc_get, asc_new, AscPtr, HostExportError},
     semver::Version,
@@ -27,12 +26,12 @@ pub struct RuntimeAdapter {
 
 impl blockchain::RuntimeAdapter<Chain> for RuntimeAdapter {
     fn host_fns(&self, ds: &DataSource) -> Result<Vec<HostFn>, Error> {
-        let abis = ds.mapping().abis.clone();
+        let abis = ds.mapping.abis.clone();
         let call_cache = self.call_cache.cheap_clone();
         let eth_adapter = self
             .eth_adapters
             .cheapest_with(&NodeCapabilities {
-                archive: ds.mapping().requires_archive(),
+                archive: ds.mapping.requires_archive(),
                 traces: false,
             })?
             .cheap_clone();

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -5,12 +5,14 @@ use fail::fail_point;
 use graph::blockchain::DataSource;
 use graph::components::arweave::ArweaveAdapter;
 use graph::components::three_box::ThreeBoxAdapter;
+use graph::data::store::scalar::Bytes;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::prelude::{SubgraphInstanceManager as SubgraphInstanceManagerTrait, *};
 use graph::util::lfu_cache::LfuCache;
 use graph::{blockchain::block_stream::BlockStreamMetrics, components::store::WritableStore};
 use graph::{blockchain::block_stream::BlockWithTriggers, data::subgraph::SubgraphFeature};
 use graph::{
+    blockchain::NodeCapabilities,
     blockchain::TriggersAdapter,
     data::subgraph::schema::{SubgraphError, POI_OBJECT},
 };
@@ -22,7 +24,6 @@ use graph::{
     blockchain::{Block, BlockchainMap},
     components::store::{DeploymentId, DeploymentLocator, ModificationsAndCache},
 };
-use graph::{components::ethereum::NodeCapabilities, data::store::scalar::Bytes};
 use lazy_static::lazy_static;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, RwLock};
@@ -177,9 +178,7 @@ impl SubgraphInstanceMetrics {
 impl<C, S, M, L> SubgraphInstanceManagerTrait for SubgraphInstanceManager<C, S, M, L>
 where
     S: SubgraphStore,
-
-    // ETHDEP: Associated types should be unconstrained
-    C: Blockchain<NodeCapabilities = NodeCapabilities>,
+    C: Blockchain,
     M: MetricsRegistry,
     L: LinkResolver + Clone,
 {
@@ -236,9 +235,7 @@ where
 impl<C, S, M, L> SubgraphInstanceManager<C, S, M, L>
 where
     S: SubgraphStore,
-
-    // ETHDEP: Associated types should be unconstrained
-    C: Blockchain<NodeCapabilities = NodeCapabilities>,
+    C: Blockchain,
     M: MetricsRegistry,
     L: LinkResolver + Clone,
 {
@@ -336,7 +333,7 @@ where
             manifest
         };
 
-        let required_capabilities = manifest.required_ethereum_capabilities();
+        let required_capabilities = C::NodeCapabilities::from_data_sources(&manifest.data_sources);
         let network = manifest.network_name();
 
         let chain = chains

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         store::{BlockNumber, ChainStore},
         subgraph::DataSourceTemplateInfo,
     },
-    prelude::{thiserror::Error, DeploymentHash, LinkResolver},
+    prelude::{thiserror::Error, LinkResolver},
 };
 use anyhow::Error;
 use async_trait::async_trait;
@@ -66,8 +66,6 @@ pub trait Blockchain: Debug + Sized + Send + Sync + 'static {
 
     type DataSourceTemplate: DataSourceTemplate<Self>;
     type UnresolvedDataSourceTemplate: UnresolvedDataSourceTemplate<Self>;
-
-    type Manifest: Manifest<Self>;
 
     type TriggersAdapter: TriggersAdapter<Self>;
 
@@ -250,19 +248,6 @@ pub trait UnresolvedDataSource<C: Blockchain>:
         resolver: &impl LinkResolver,
         logger: &Logger,
     ) -> Result<C::DataSource, anyhow::Error>;
-}
-
-#[async_trait]
-pub trait Manifest<C: Blockchain>: Sized {
-    async fn resolve_from_raw(
-        id: DeploymentHash,
-        raw: serde_yaml::Mapping,
-        resolver: &impl LinkResolver,
-        logger: &Logger,
-    ) -> Result<Self, Error>;
-
-    fn data_sources(&self) -> &[C::DataSource];
-    fn templates(&self) -> &[C::DataSourceTemplate];
 }
 
 pub trait TriggerData {

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -80,7 +80,7 @@ pub trait Blockchain: Debug + Sized + Send + Sync + 'static {
     /// Trigger filter used as input to the triggers adapter.
     type TriggerFilter: TriggerFilter<Self>;
 
-    type NodeCapabilities: std::fmt::Display;
+    type NodeCapabilities: NodeCapabilities<Self> + std::fmt::Display;
 
     type IngestorAdapter: IngestorAdapter<Self>;
 
@@ -309,4 +309,8 @@ impl CheapClone for HostFn {
 
 pub trait RuntimeAdapter<C: Blockchain>: Send + Sync {
     fn host_fns(&self, ds: &C::DataSource) -> Result<Vec<HostFn>, Error>;
+}
+
+pub trait NodeCapabilities<C: Blockchain> {
+    fn from_data_sources(data_sources: &[C::DataSource]) -> Self;
 }

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -1,9 +1,7 @@
-mod network;
 mod types;
 
 use web3::types::H256;
 
-pub use self::network::NodeCapabilities;
 pub use self::types::{
     EthereumBlock, EthereumBlockWithCalls, EthereumCall, LightEthereumBlock, LightEthereumBlockExt,
 };

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -26,7 +26,6 @@ use crate::{blockchain::DataSourceTemplate as _, data::query::QueryExecutionErro
 use crate::{
     blockchain::{Blockchain, UnresolvedDataSource as _, UnresolvedDataSourceTemplate as _},
     components::{
-        ethereum::NodeCapabilities,
         link_resolver::LinkResolver,
         store::{DeploymentLocator, StoreError, SubgraphStore},
     },
@@ -268,8 +267,6 @@ pub enum SubgraphRegistrarError {
     NameNotFound(String),
     #[error("Ethereum network not supported by registrar: {0}")]
     NetworkNotSupported(String),
-    #[error("Ethereum nodes for network {0} are missing the following capabilities: {1}")]
-    SubgraphNetworkRequirementsNotSupported(String, NodeCapabilities),
     #[error("deployment not found: {0}")]
     DeploymentNotFound(String),
     #[error("deployment assignment unchanged: {0}")]
@@ -564,11 +561,11 @@ impl Mapping {
         false
     }
 
-    fn has_call_handler(&self) -> bool {
+    pub fn has_call_handler(&self) -> bool {
         !self.call_handlers.is_empty()
     }
 
-    fn has_block_handler_with_call_filter(&self) -> bool {
+    pub fn has_block_handler_with_call_filter(&self) -> bool {
         self.block_handlers
             .iter()
             .any(|handler| matches!(handler.filter, Some(BlockHandlerFilter::Call)))
@@ -980,16 +977,6 @@ impl<C: Blockchain> SubgraphManifest<C> {
         self.mappings().iter().any(|mapping| {
             mapping.has_call_handler() || mapping.has_block_handler_with_call_filter()
         })
-    }
-
-    pub fn required_ethereum_capabilities(&self) -> NodeCapabilities {
-        let mappings = self.mappings();
-        NodeCapabilities {
-            archive: mappings.iter().any(|mapping| mapping.requires_archive()),
-            traces: mappings.iter().any(|mapping| {
-                mapping.has_call_handler() || mapping.has_block_handler_with_call_filter()
-            }),
-        }
     }
 
     pub fn unified_mapping_api_version(

--- a/graph/src/log/mod.rs
+++ b/graph/src/log/mod.rs
@@ -4,13 +4,13 @@ macro_rules! impl_slog_value {
         impl_slog_value!($T, "{}");
     };
     ($T:ty, $fmt:expr) => {
-        impl ::slog::Value for $T {
+        impl $crate::slog::Value for $T {
             fn serialize(
                 &self,
-                record: &::slog::Record,
-                key: ::slog::Key,
-                serializer: &mut dyn ::slog::Serializer,
-            ) -> ::slog::Result {
+                record: &$crate::slog::Record,
+                key: $crate::slog::Key,
+                serializer: &mut dyn $crate::slog::Serializer,
+            ) -> $crate::slog::Result {
                 format!($fmt, self).serialize(record, key, serializer)
             }
         }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1,11 +1,11 @@
 use graph::{
     blockchain::block_ingestor::CLEANUP_BLOCKS,
-    components::ethereum::NodeCapabilities,
     prelude::{
         anyhow::{anyhow, bail, Context, Result},
         info, serde_json, Logger, NodeId,
     },
 };
+use graph_chain_ethereum::NodeCapabilities;
 use graph_store_postgres::{DeploymentPlacer, Shard as ShardName, PRIMARY_SHARD};
 
 use http::HeaderMap;

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,4 +1,4 @@
-use ethereum::{EthereumNetworks, ProviderEthRpcMetrics};
+use ethereum::{EthereumNetworks, NodeCapabilities, ProviderEthRpcMetrics};
 use futures::future::join_all;
 use git_testament::{git_testament, render_testament};
 use graph::{ipfs_client::IpfsClient, prometheus::Registry};
@@ -13,7 +13,7 @@ use tokio::sync::mpsc;
 
 use graph::blockchain::block_ingestor::BlockIngestor;
 use graph::blockchain::Blockchain as _;
-use graph::components::{ethereum::NodeCapabilities, store::BlockStore};
+use graph::components::store::BlockStore;
 use graph::data::graphql::effort::LoadManager;
 use graph::log::logger;
 use graph::prelude::{IndexNodeServer as _, JsonRpcServer as _, *};

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -745,10 +745,10 @@ fn start_block_ingestor(
 mod test {
     use super::create_ethereum_networks;
     use crate::config::{Config, Opt};
-    use graph::components::ethereum::NodeCapabilities;
     use graph::log::logger;
     use graph::prelude::tokio;
     use graph::prometheus::Registry;
+    use graph_chain_ethereum::NodeCapabilities;
     use graph_core::MetricsRegistry;
     use std::sync::Arc;
 


### PR DESCRIPTION
This removes the last case in which the instance manager was constraining an associated type of `Blockchain` to something ethereum specific. Also removes `Blockchain::Manifest` since I think we'll keep the manifest as a shared structure.