### PR TITLE
blockchain: Remove `DataSource::source`

### DIFF
--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -42,6 +42,14 @@ pub struct DataSource {
 }
 
 impl blockchain::DataSource<Chain> for DataSource {
+    fn address(&self) -> Option<&[u8]> {
+        self.source.address.as_ref().map(|x| x.as_bytes())
+    }
+
+    fn start_block(&self) -> BlockNumber {
+        self.source.start_block
+    }
+
     fn match_and_decode(
         &self,
         trigger: &<Chain as Blockchain>::TriggerData,
@@ -54,10 +62,6 @@ impl blockchain::DataSource<Chain> for DataSource {
 
     fn mapping(&self) -> &Mapping {
         &self.mapping
-    }
-
-    fn source(&self) -> &Source {
-        &self.source
     }
 
     fn from_manifest(

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Error};
 use blockchain::HostFn;
 use ethabi::{Address, Token};
 use graph::{
-    blockchain::{self, BlockPtr, DataSource as _, HostFnCtx},
+    blockchain::{self, BlockPtr, HostFnCtx},
     cheap_clone::CheapClone,
     components::ethereum::NodeCapabilities,
     prelude::{EthereumCallCache, Future01CompatExt, MappingABI},
@@ -27,12 +27,12 @@ pub struct RuntimeAdapter {
 
 impl blockchain::RuntimeAdapter<Chain> for RuntimeAdapter {
     fn host_fns(&self, ds: &DataSource) -> Result<Vec<HostFn>, Error> {
-        let abis = ds.mapping().abis.clone();
+        let abis = ds.mapping.abis.clone();
         let call_cache = self.call_cache.cheap_clone();
         let eth_adapter = self
             .eth_adapters
             .cheapest_with(&NodeCapabilities {
-                archive: ds.mapping().requires_archive(),
+                archive: ds.mapping.requires_archive(),
                 traces: false,
             })?
             .cheap_clone();

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -1046,8 +1046,8 @@ fn create_dynamic_data_sources<T: RuntimeHostBuilder<C>, C: Blockchain>(
                     "no runtime hosted created, there is already a runtime host instantiated for \
                      this data source";
                     "name" => &data_source.name(),
-                    "address" => &data_source.source().address
-                        .map(|address| address.to_string())
+                    "address" => &data_source.address()
+                        .map(|address| hex::encode(address))
                         .unwrap_or("none".to_string()),
                 )
             }
@@ -1078,7 +1078,7 @@ fn persist_dynamic_data_sources<T: RuntimeHostBuilder<C>, C: Blockchain>(
             logger,
             "Persisting data_source";
             "name" => &data_source.name(),
-            "address" => &data_source.source().address.map(|address| address.to_string()).unwrap_or("none".to_string()),
+            "address" => &data_source.address().map(|address| hex::encode(address)).unwrap_or("none".to_string()),
         );
         entity_cache.add_data_source(data_source);
     }

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -184,12 +184,14 @@ pub trait TriggerFilter<C: Blockchain>: Default + Clone + Send + Sync {
     fn node_capabilities(&self) -> C::NodeCapabilities;
 }
 
-// ETHDEP: `Source` and `Mapping`, at least, are Ethereum-specific.
 pub trait DataSource<C: Blockchain>:
     'static + Sized + Send + Sync + Clone + TryFrom<DataSourceTemplateInfo<C>, Error = anyhow::Error>
 {
+    // ETHDEP: `Mapping` is Ethereum-specific.
     fn mapping(&self) -> &Mapping;
-    fn source(&self) -> &Source;
+
+    fn address(&self) -> Option<&[u8]>;
+    fn start_block(&self) -> BlockNumber;
 
     fn from_manifest(
         kind: String,

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -809,7 +809,7 @@ impl<C: Blockchain> UnvalidatedSubgraphManifest<C> {
         // Validate that the manifest has a `source` address in each data source
         // which has call or block handlers
         if self.0.data_sources.iter().any(|data_source| {
-            let no_source_address = data_source.source().address.is_none();
+            let no_source_address = data_source.address().is_none();
             let has_call_handlers = !data_source.mapping().call_handlers.is_empty();
             let has_block_handlers = !data_source.mapping().block_handlers.is_empty();
 
@@ -958,7 +958,7 @@ impl<C: Blockchain> SubgraphManifest<C> {
     pub fn start_blocks(&self) -> Vec<BlockNumber> {
         self.data_sources
             .iter()
-            .map(|data_source| data_source.source().start_block)
+            .map(|data_source| data_source.start_block())
             .collect()
     }
 

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -1,6 +1,6 @@
 use crate::{error::DeterminismLevel, module::IntoTrap};
 use ethabi::param_type::Reader;
-use ethabi::{decode, encode, Address, Token};
+use ethabi::{decode, encode, Token};
 use graph::blockchain::{Blockchain, DataSourceTemplate as _};
 use graph::components::store::EntityKey;
 use graph::components::subgraph::{ProofOfIndexingEvent, SharedProofOfIndexing};
@@ -46,7 +46,7 @@ pub struct HostExports<C: Blockchain> {
     pub(crate) subgraph_id: DeploymentHash,
     pub(crate) api_version: Version,
     data_source_name: String,
-    data_source_address: Option<Address>,
+    data_source_address: Vec<u8>,
     data_source_network: String,
     data_source_context: Arc<Option<DataSourceContext>>,
     /// Some data sources have indeterminism or different notions of time. These
@@ -78,7 +78,7 @@ impl<C: Blockchain> HostExports<C> {
             subgraph_id,
             api_version: data_source.mapping().api_version.clone(),
             data_source_name: data_source.name().to_owned(),
-            data_source_address: data_source.source().address.clone(),
+            data_source_address: data_source.address().unwrap_or_default().to_owned(),
             data_source_network,
             data_source_context: data_source.context().cheap_clone(),
             causality_region,
@@ -595,8 +595,8 @@ impl<C: Blockchain> HostExports<C> {
         Ok(())
     }
 
-    pub(crate) fn data_source_address(&self) -> H160 {
-        self.data_source_address.clone().unwrap_or_default()
+    pub(crate) fn data_source_address(&self) -> Vec<u8> {
+        self.data_source_address.clone()
     }
 
     pub(crate) fn data_source_network(&self) -> String {

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -1274,7 +1274,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
 
     /// function dataSource.address(): Bytes
     pub fn data_source_address(&mut self) -> Result<AscPtr<Uint8Array>, DeterministicHostError> {
-        asc_new(self, &self.ctx.host_exports.data_source_address())
+        asc_new(self, self.ctx.host_exports.data_source_address().as_slice())
     }
 
     /// function dataSource.network(): String


### PR DESCRIPTION
`Source` is an Ethereum-specific type. It's still used in more places than we'd like, but this is a start.

