### PR TITLE
Upgraded from future 0.1 to future 0.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+
 # Contributing to graph-node
 
 Welcome to the Graph Protocol! Thanks a ton for your interest in contributing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "thiserror",
- "tokio 1.4.0",
+ "tokio 1.8.1",
  "tokio-util 0.6.3",
  "url 2.2.1",
  "winapi 0.3.9",
@@ -1612,6 +1612,7 @@ dependencies = [
  "thiserror",
  "tiny-keccak 1.5.0",
  "tokio 0.2.25",
+ "tokio 1.8.1",
  "tokio-retry",
  "tokio-stream",
  "url 2.2.1",
@@ -1914,7 +1915,7 @@ dependencies = [
  "futures 0.3.13",
  "lazy_static",
  "port_check",
- "tokio 1.4.0",
+ "tokio 1.8.1",
  "tokio-stream",
 ]
 
@@ -1979,7 +1980,7 @@ dependencies = [
  "http 0.2.3",
  "indexmap",
  "slab 0.4.2",
- "tokio 1.4.0",
+ "tokio 1.8.1",
  "tokio-util 0.6.3",
  "tracing",
 ]
@@ -2202,7 +2203,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.5",
  "socket2 0.4.0",
- "tokio 1.4.0",
+ "tokio 1.8.1",
  "tower-service",
  "tracing",
  "want 0.3.0",
@@ -2244,7 +2245,7 @@ dependencies = [
  "hex",
  "hyper 0.14.5",
  "pin-project 1.0.5",
- "tokio 1.4.0",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -3181,7 +3182,7 @@ dependencies = [
  "fallible-iterator 0.2.0",
  "futures 0.3.13",
  "log 0.4.11",
- "tokio 1.4.0",
+ "tokio 1.8.1",
  "tokio-postgres",
 ]
 
@@ -3417,19 +3418,6 @@ name = "radium"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "rand"
@@ -4594,9 +4582,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.4.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
@@ -4605,6 +4593,7 @@ dependencies = [
  "mio 0.7.9",
  "num_cpus",
  "once_cell",
+ "parking_lot 0.11.1",
  "pin-project-lite 0.2.6",
  "signal-hook-registry",
  "tokio-macros 1.1.0",
@@ -4735,7 +4724,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "socket2 0.4.0",
- "tokio 1.4.0",
+ "tokio 1.8.1",
  "tokio-util 0.6.3",
 ]
 
@@ -4760,13 +4749,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-retry"
-version = "0.2.0"
-source = "git+https://github.com/graphprotocol/rust-tokio-retry?branch=update-to-tokio-02#fc0e868bdc7ff79ac84cf502d4cec20c5ce5adaf"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
- "futures 0.1.31",
- "futures 0.3.13",
- "rand 0.4.6",
- "tokio 0.2.25",
+ "pin-project 1.0.5",
+ "rand 0.8.3",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -4777,7 +4766,7 @@ checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.6",
- "tokio 1.4.0",
+ "tokio 1.8.1",
  "tokio-util 0.6.3",
 ]
 
@@ -4953,7 +4942,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project-lite 0.2.6",
- "tokio 1.4.0",
+ "tokio 1.8.1",
 ]
 
 [[package]]

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -5,9 +5,9 @@ use graph::prelude::{
 };
 use graph::{
     blockchain::{
+        block_stream::BlockStream,
         block_stream::{
-            BlockStream, BlockStreamMetrics, BlockWithTriggers,
-            TriggersAdapter as TriggersAdapterTrait,
+            BlockStreamMetrics, BlockWithTriggers, TriggersAdapter as TriggersAdapterTrait,
         },
         Block, BlockHash, BlockPtr, Blockchain, ChainHeadUpdateListener,
         IngestorAdapter as IngestorAdapterTrait, IngestorError, TriggerFilter as _,
@@ -165,7 +165,7 @@ impl Blockchain for Chain {
         &self,
         deployment: DeploymentLocator,
         start_blocks: Vec<BlockNumber>,
-        filter: TriggerFilter,
+        filter: Arc<TriggerFilter>,
         metrics: Arc<BlockStreamMetrics>,
         unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<BlockStream<Self>, Error> {

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -160,14 +160,14 @@ impl EthereumAdapter {
         }
     }
 
-    fn traces(
-        &self,
-        logger: &Logger,
+    async fn traces(
+        self,
+        logger: Logger,
         subgraph_metrics: Arc<SubgraphEthRpcMetrics>,
         from: BlockNumber,
         to: BlockNumber,
         addresses: Vec<H160>,
-    ) -> impl Future<Item = Vec<Trace>, Error = Error> {
+    ) -> Result<Vec<Trace>, Error> {
         let eth = self.clone();
         let logger = logger.to_owned();
 
@@ -234,6 +234,7 @@ impl EthereumAdapter {
                         }
                         result
                     })
+                    .compat()
             })
             .map_err(move |e| {
                 e.into_inner().unwrap_or_else(move || {
@@ -245,17 +246,18 @@ impl EthereumAdapter {
                     )
                 })
             })
+            .await
     }
 
-    fn logs_with_sigs(
+    async fn logs_with_sigs(
         &self,
-        logger: &Logger,
+        logger: Logger,
         subgraph_metrics: Arc<SubgraphEthRpcMetrics>,
         from: BlockNumber,
         to: BlockNumber,
         filter: Arc<EthGetLogsFilter>,
         too_many_logs_fingerprints: &'static [&'static str],
-    ) -> impl Future<Item = Vec<Log>, Error = TimeoutError<web3::error::Error>> {
+    ) -> Result<Vec<Log>, TimeoutError<web3::error::Error>> {
         let eth_adapter = self.clone();
 
         retry("eth_getLogs RPC call", &logger)
@@ -281,17 +283,23 @@ impl EthereumAdapter {
                     .build();
 
                 // Request logs from client
-                eth_adapter.web3.eth().logs(log_filter).then(move |result| {
-                    let elapsed = start.elapsed().as_secs_f64();
-                    provider_metrics.observe_request(elapsed, "eth_getLogs");
-                    subgraph_metrics.observe_request(elapsed, "eth_getLogs");
-                    if result.is_err() {
-                        provider_metrics.add_error("eth_getLogs");
-                        subgraph_metrics.add_error("eth_getLogs");
-                    }
-                    result
-                })
+                eth_adapter
+                    .web3
+                    .eth()
+                    .logs(log_filter)
+                    .then(move |result| {
+                        let elapsed = start.elapsed().as_secs_f64();
+                        provider_metrics.observe_request(elapsed, "eth_getLogs");
+                        subgraph_metrics.observe_request(elapsed, "eth_getLogs");
+                        if result.is_err() {
+                            provider_metrics.add_error("eth_getLogs");
+                            subgraph_metrics.add_error("eth_getLogs");
+                        }
+                        result
+                    })
+                    .compat()
             })
+            .await
     }
 
     fn trace_stream(
@@ -325,13 +333,16 @@ impl EthereumAdapter {
                 debug!(logger, "Requesting traces for blocks [{}, {}]", start, end);
             }
             Some(futures::future::ok((
-                eth.traces(
-                    &logger,
-                    subgraph_metrics.clone(),
-                    start,
-                    end,
-                    addresses.clone(),
-                ),
+                eth.clone()
+                    .traces(
+                        logger.cheap_clone(),
+                        subgraph_metrics.clone(),
+                        start,
+                        end,
+                        addresses.clone(),
+                    )
+                    .boxed()
+                    .compat(),
                 new_start,
             )))
         })
@@ -394,14 +405,13 @@ impl EthereumAdapter {
                 );
                 let res = eth
                     .logs_with_sigs(
-                        &logger,
+                        logger.cheap_clone(),
                         subgraph_metrics.cheap_clone(),
                         start,
                         end,
                         filter.cheap_clone(),
                         TOO_MANY_LOGS_FINGERPRINTS,
                     )
-                    .compat()
                     .await;
 
                 match res {
@@ -467,113 +477,121 @@ impl EthereumAdapter {
                     value: None,
                     data: Some(call_data.clone()),
                 };
-                web3.eth().call(req, Some(block_id)).then(|result| {
-                    // Try to check if the call was reverted. The JSON-RPC response for reverts is
-                    // not standardized, so we have ad-hoc checks for each of Geth, Parity and
-                    // Ganache.
+                web3.eth()
+                    .call(req, Some(block_id))
+                    .then(|result| {
+                        // Try to check if the call was reverted. The JSON-RPC response for reverts is
+                        // not standardized, so we have ad-hoc checks for each of Geth, Parity and
+                        // Ganache.
 
-                    // 0xfe is the "designated bad instruction" of the EVM, and Solidity uses it for
-                    // asserts.
-                    const PARITY_BAD_INSTRUCTION_FE: &str = "Bad instruction fe";
+                        // 0xfe is the "designated bad instruction" of the EVM, and Solidity uses it for
+                        // asserts.
+                        const PARITY_BAD_INSTRUCTION_FE: &str = "Bad instruction fe";
 
-                    // 0xfd is REVERT, but on some contracts, and only on older blocks,
-                    // this happens. Makes sense to consider it a revert as well.
-                    const PARITY_BAD_INSTRUCTION_FD: &str = "Bad instruction fd";
+                        // 0xfd is REVERT, but on some contracts, and only on older blocks,
+                        // this happens. Makes sense to consider it a revert as well.
+                        const PARITY_BAD_INSTRUCTION_FD: &str = "Bad instruction fd";
 
-                    const PARITY_BAD_JUMP_PREFIX: &str = "Bad jump";
-                    const PARITY_STACK_LIMIT_PREFIX: &str = "Out of stack";
+                        const PARITY_BAD_JUMP_PREFIX: &str = "Bad jump";
+                        const PARITY_STACK_LIMIT_PREFIX: &str = "Out of stack";
 
-                    const GANACHE_VM_EXECUTION_ERROR: i64 = -32000;
-                    const GANACHE_REVERT_MESSAGE: &str =
-                        "VM Exception while processing transaction: revert";
-                    const PARITY_VM_EXECUTION_ERROR: i64 = -32015;
-                    const PARITY_REVERT_PREFIX: &str = "Reverted 0x";
+                        const GANACHE_VM_EXECUTION_ERROR: i64 = -32000;
+                        const GANACHE_REVERT_MESSAGE: &str =
+                            "VM Exception while processing transaction: revert";
+                        const PARITY_VM_EXECUTION_ERROR: i64 = -32015;
+                        const PARITY_REVERT_PREFIX: &str = "Reverted 0x";
 
-                    // Deterministic Geth execution errors. We might need to expand this as
-                    // subgraphs come across other errors. See
-                    // https://github.com/ethereum/go-ethereum/blob/cd57d5cd38ef692de8fbedaa56598b4e9fbfbabc/core/vm/errors.go
-                    const GETH_EXECUTION_ERRORS: &[&str] = &[
-                        "execution reverted",
-                        "invalid jump destination",
-                        "invalid opcode",
-                        // Ethereum says 1024 is the stack sizes limit, so this is deterministic.
-                        "stack limit reached 1024",
-                        // See f0af4ab0-6b7c-4b68-9141-5b79346a5f61 for why the gas limit is considered deterministic.
-                        "out of gas",
-                    ];
+                        // Deterministic Geth execution errors. We might need to expand this as
+                        // subgraphs come across other errors. See
+                        // https://github.com/ethereum/go-ethereum/blob/cd57d5cd38ef692de8fbedaa56598b4e9fbfbabc/core/vm/errors.go
+                        const GETH_EXECUTION_ERRORS: &[&str] = &[
+                            "execution reverted",
+                            "invalid jump destination",
+                            "invalid opcode",
+                            // Ethereum says 1024 is the stack sizes limit, so this is deterministic.
+                            "stack limit reached 1024",
+                            // See f0af4ab0-6b7c-4b68-9141-5b79346a5f61 for why the gas limit is considered deterministic.
+                            "out of gas",
+                        ];
 
-                    let as_solidity_revert_with_reason = |bytes: &[u8]| {
-                        let solidity_revert_function_selector =
-                            &tiny_keccak::keccak256(b"Error(string)")[..4];
+                        let as_solidity_revert_with_reason = |bytes: &[u8]| {
+                            let solidity_revert_function_selector =
+                                &tiny_keccak::keccak256(b"Error(string)")[..4];
 
-                        match bytes.len() >= 4 && &bytes[..4] == solidity_revert_function_selector {
-                            false => None,
-                            true => ethabi::decode(&[ParamType::String], &bytes[4..])
-                                .ok()
-                                .and_then(|tokens| tokens[0].clone().to_string()),
-                        }
-                    };
-
-                    match result {
-                        // A successful response.
-                        Ok(bytes) => Ok(bytes),
-
-                        // Check for Geth revert.
-                        Err(web3::Error::Rpc(rpc_error))
-                            if GETH_EXECUTION_ERRORS
-                                .iter()
-                                .any(|e| rpc_error.message.contains(e)) =>
-                        {
-                            Err(EthereumContractCallError::Revert(rpc_error.message))
-                        }
-
-                        // Check for Parity revert.
-                        Err(web3::Error::Rpc(ref rpc_error))
-                            if rpc_error.code.code() == PARITY_VM_EXECUTION_ERROR =>
-                        {
-                            match rpc_error.data.as_ref().and_then(|d| d.as_str()) {
-                                Some(data)
-                                    if data.starts_with(PARITY_REVERT_PREFIX)
-                                        || data.starts_with(PARITY_BAD_JUMP_PREFIX)
-                                        || data.starts_with(PARITY_STACK_LIMIT_PREFIX)
-                                        || data == PARITY_BAD_INSTRUCTION_FE
-                                        || data == PARITY_BAD_INSTRUCTION_FD =>
-                                {
-                                    let reason = if data == PARITY_BAD_INSTRUCTION_FE {
-                                        PARITY_BAD_INSTRUCTION_FE.to_owned()
-                                    } else {
-                                        let payload = data.trim_start_matches(PARITY_REVERT_PREFIX);
-                                        hex::decode(payload)
-                                            .ok()
-                                            .and_then(|payload| {
-                                                as_solidity_revert_with_reason(&payload)
-                                            })
-                                            .unwrap_or("no reason".to_owned())
-                                    };
-                                    Err(EthereumContractCallError::Revert(reason))
-                                }
-
-                                // The VM execution error was not identified as a revert.
-                                _ => Err(EthereumContractCallError::Web3Error(web3::Error::Rpc(
-                                    rpc_error.clone(),
-                                ))),
+                            match bytes.len() >= 4
+                                && &bytes[..4] == solidity_revert_function_selector
+                            {
+                                false => None,
+                                true => ethabi::decode(&[ParamType::String], &bytes[4..])
+                                    .ok()
+                                    .and_then(|tokens| tokens[0].clone().to_string()),
                             }
-                        }
+                        };
 
-                        // Check for Ganache revert.
-                        Err(web3::Error::Rpc(ref rpc_error))
-                            if rpc_error.code.code() == GANACHE_VM_EXECUTION_ERROR
-                                && rpc_error.message.starts_with(GANACHE_REVERT_MESSAGE) =>
-                        {
-                            Err(EthereumContractCallError::Revert(rpc_error.message.clone()))
-                        }
+                        match result {
+                            // A successful response.
+                            Ok(bytes) => Ok(bytes),
 
-                        // The error was not identified as a revert.
-                        Err(err) => Err(EthereumContractCallError::Web3Error(err)),
-                    }
-                })
+                            // Check for Geth revert.
+                            Err(web3::Error::Rpc(rpc_error))
+                                if GETH_EXECUTION_ERRORS
+                                    .iter()
+                                    .any(|e| rpc_error.message.contains(e)) =>
+                            {
+                                Err(EthereumContractCallError::Revert(rpc_error.message))
+                            }
+
+                            // Check for Parity revert.
+                            Err(web3::Error::Rpc(ref rpc_error))
+                                if rpc_error.code.code() == PARITY_VM_EXECUTION_ERROR =>
+                            {
+                                match rpc_error.data.as_ref().and_then(|d| d.as_str()) {
+                                    Some(data)
+                                        if data.starts_with(PARITY_REVERT_PREFIX)
+                                            || data.starts_with(PARITY_BAD_JUMP_PREFIX)
+                                            || data.starts_with(PARITY_STACK_LIMIT_PREFIX)
+                                            || data == PARITY_BAD_INSTRUCTION_FE
+                                            || data == PARITY_BAD_INSTRUCTION_FD =>
+                                    {
+                                        let reason = if data == PARITY_BAD_INSTRUCTION_FE {
+                                            PARITY_BAD_INSTRUCTION_FE.to_owned()
+                                        } else {
+                                            let payload =
+                                                data.trim_start_matches(PARITY_REVERT_PREFIX);
+                                            hex::decode(payload)
+                                                .ok()
+                                                .and_then(|payload| {
+                                                    as_solidity_revert_with_reason(&payload)
+                                                })
+                                                .unwrap_or("no reason".to_owned())
+                                        };
+                                        Err(EthereumContractCallError::Revert(reason))
+                                    }
+
+                                    // The VM execution error was not identified as a revert.
+                                    _ => Err(EthereumContractCallError::Web3Error(
+                                        web3::Error::Rpc(rpc_error.clone()),
+                                    )),
+                                }
+                            }
+
+                            // Check for Ganache revert.
+                            Err(web3::Error::Rpc(ref rpc_error))
+                                if rpc_error.code.code() == GANACHE_VM_EXECUTION_ERROR
+                                    && rpc_error.message.starts_with(GANACHE_REVERT_MESSAGE) =>
+                            {
+                                Err(EthereumContractCallError::Revert(rpc_error.message.clone()))
+                            }
+
+                            // The error was not identified as a revert.
+                            Err(err) => Err(EthereumContractCallError::Web3Error(err)),
+                        }
+                    })
+                    .compat()
             })
             .map_err(|e| e.into_inner().unwrap_or(EthereumContractCallError::Timeout))
+            .boxed()
+            .compat()
     }
 
     /// Request blocks by hash through JSON-RPC.
@@ -598,7 +616,10 @@ impl EthereumAdapter {
                                 anyhow::anyhow!("Ethereum node did not find block {:?}", hash)
                             })
                         })
+                        .compat()
                 })
+                .boxed()
+                .compat()
                 .from_err()
         }))
         .buffered(*BLOCK_BATCH_SIZE)
@@ -628,7 +649,10 @@ impl EthereumAdapter {
                                 anyhow!("Ethereum node did not find block {:?}", block_num)
                             })
                         })
+                        .compat()
                 })
+                .boxed()
+                .compat()
                 .from_err()
         }))
         .buffered(*BLOCK_BATCH_SIZE)
@@ -809,7 +833,9 @@ impl EthereumAdapterTrait for EthereumAdapter {
         let net_version_future = retry("net_version RPC call", &logger)
             .no_limit()
             .timeout_secs(20)
-            .run(move || web3.net().version().from_err());
+            .run(move || web3.net().version().from_err().compat())
+            .boxed()
+            .compat();
 
         let web3 = self.web3.clone();
         let gen_block_hash_future = retry("eth_getBlockByNumber(0, false) RPC call", &logger)
@@ -828,7 +854,10 @@ impl EthereumAdapterTrait for EthereumAdapter {
                                 }),
                         )
                     })
-            });
+                    .compat()
+            })
+            .boxed()
+            .compat();
 
         net_version_future
             .join(gen_block_hash_future)
@@ -867,12 +896,15 @@ impl EthereumAdapterTrait for EthereumAdapter {
                                 anyhow!("no latest block returned from Ethereum").into()
                             })
                         })
+                        .compat()
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
                         anyhow!("Ethereum node took too long to return latest block").into()
                     })
-                }),
+                })
+                .boxed()
+                .compat(),
         )
     }
 
@@ -896,12 +928,15 @@ impl EthereumAdapterTrait for EthereumAdapter {
                                 anyhow!("no latest block returned from Ethereum").into()
                             })
                         })
+                        .compat()
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
                         anyhow!("Ethereum node took too long to return latest block").into()
                     })
-                }),
+                })
+                .boxed()
+                .compat(),
         )
     }
 
@@ -939,12 +974,15 @@ impl EthereumAdapterTrait for EthereumAdapter {
                     web3.eth()
                         .block_with_txs(BlockId::Hash(block_hash))
                         .from_err()
+                        .compat()
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
                         anyhow!("Ethereum node took too long to return block {}", block_hash)
                     })
-                }),
+                })
+                .boxed()
+                .compat(),
         )
     }
 
@@ -964,6 +1002,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
                     web3.eth()
                         .block_with_txs(BlockId::Number(block_number.into()))
                         .from_err()
+                        .compat()
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
@@ -972,7 +1011,9 @@ impl EthereumAdapterTrait for EthereumAdapter {
                             block_number
                         )
                     })
-                }),
+                })
+                .boxed()
+                .compat(),
         )
     }
 
@@ -1083,6 +1124,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
                                 },
                             )
                         })
+                        .compat()
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
@@ -1092,7 +1134,9 @@ impl EthereumAdapterTrait for EthereumAdapter {
                         )
                         .into()
                     })
-                }),
+                })
+                .boxed()
+                .compat(),
         )
     }
 
@@ -1176,7 +1220,10 @@ impl EthereumAdapterTrait for EthereumAdapter {
                             .block(BlockId::Number(block_number.into()))
                             .from_err()
                             .map(|block_opt| block_opt.map(|block| block.hash).flatten())
+                            .compat()
                     })
+                    .boxed()
+                    .compat()
                     .inspect(confirm_block_hash)
                     .map_err(move |e| {
                         e.into_inner().unwrap_or_else(move || {
@@ -1228,12 +1275,15 @@ impl EthereumAdapterTrait for EthereumAdapter {
                                     e
                                 )
                             })
+                            .compat()
                     })
                     .map_err(move |e| {
                         e.into_inner().unwrap_or_else(move || {
                             anyhow!("Ethereum node took too long to return uncle")
                         })
                     })
+                    .boxed()
+                    .compat()
             }))
             .collect(),
         )

--- a/chain/ethereum/tests/network_indexer.rs
+++ b/chain/ethereum/tests/network_indexer.rs
@@ -81,6 +81,7 @@ fn run_network_indexer(
             .expect("failed to take stream from indexer")
             .forward(event_sink.sink_map_err(|_| ()))
             .map(|_| ())
+            .compat()
             .timeout(timeout),
     );
 

--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -224,7 +224,7 @@ impl LinkResolverTrait for LinkResolver {
         let timeout = self.timeout.clone();
         let logger = logger.clone();
         let data = retry_policy(self.retry, "ipfs.cat", &logger)
-            .run( move || {
+            .run(move || {
                 let path = path.clone();
                 let client = client.clone();
                 let this = this.clone();
@@ -246,10 +246,7 @@ impl LinkResolverTrait for LinkResolver {
                     }
                     Result::<Vec<u8>, reqwest::Error>::Ok(data)
                 }
-                // .boxed()
-                // .compat()
             })
-            // .compat()
             .await?;
 
         Ok(data)

--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -100,15 +100,11 @@ async fn select_fastest_client_with_stat(
         .map(|(i, c)| {
             let c = c.cheap_clone();
             let path = path.clone();
-            retry_policy(do_retry, "object.stat", &logger)
-                .run(move || {
-                    let path = path.clone();
-                    let c = c.cheap_clone();
-                    async move { c.object_stat(path, timeout).map_ok(move |s| (s, i)).await }
-                        .boxed()
-                        .compat()
-                })
-                .compat()
+            retry_policy(do_retry, "object.stat", &logger).run(move || {
+                let path = path.clone();
+                let c = c.cheap_clone();
+                async move { c.object_stat(path, timeout).map_ok(move |s| (s, i)).await }
+            })
         })
         .collect();
 
@@ -228,7 +224,7 @@ impl LinkResolverTrait for LinkResolver {
         let timeout = self.timeout.clone();
         let logger = logger.clone();
         let data = retry_policy(self.retry, "ipfs.cat", &logger)
-            .run(move || {
+            .run( move || {
                 let path = path.clone();
                 let client = client.clone();
                 let this = this.clone();
@@ -250,10 +246,10 @@ impl LinkResolverTrait for LinkResolver {
                     }
                     Result::<Vec<u8>, reqwest::Error>::Ok(data)
                 }
-                .boxed()
-                .compat()
+                // .boxed()
+                // .compat()
             })
-            .compat()
+            // .compat()
             .await?;
 
         Ok(data)

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -470,13 +470,12 @@ where
             .new_block_stream(
                 ctx.inputs.deployment.clone(),
                 ctx.inputs.start_blocks.clone(),
-                ctx.state.filter.clone(),
+                Arc::new(ctx.state.filter.clone()),
                 ctx.block_stream_metrics.clone(),
                 ctx.inputs.unified_api_version.clone(),
             )?
             .map_err(CancelableError::Error)
-            .cancelable(&block_stream_canceler, || CancelableError::Cancel)
-            .compat();
+            .cancelable(&block_stream_canceler, || Err(CancelableError::Cancel));
 
         // Keep the stream's cancel guard around to be able to shut it down
         // when the subgraph deployment is unassigned

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -98,11 +98,13 @@ where
             // Blocking due to store interactions. Won't be blocking after #905.
             graph::spawn_blocking(
                 assignment_event_stream
+                    .compat()
                     .map_err(SubgraphAssignmentProviderError::Unknown)
                     .map_err(CancelableError::Error)
                     .cancelable(&assignment_event_stream_cancel_handle, || {
-                        CancelableError::Cancel
+                        Err(CancelableError::Cancel)
                     })
+                    .compat()
                     .for_each(move |assignment_event| {
                         assert_eq!(assignment_event.node_id(), &node_id);
                         handle_assignment_event(

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -47,9 +47,10 @@ slog-envlogger = "2.1.0"
 slog-term = "2.7.0"
 petgraph = "0.5.1"
 tiny-keccak = "1.5.0"
+tokio18 = { version = "1.8.1", package = "tokio", features = ["full"] }
 tokio = { version = "0.2.25", features = ["stream", "rt-threaded", "rt-util", "blocking", "time", "sync", "macros", "test-util", "net"] }
 tokio-stream = { version = "0.1.6", features = ["sync"] }
-tokio-retry = { git = "https://github.com/graphprotocol/rust-tokio-retry", branch = "update-to-tokio-02" }
+tokio-retry = { version = "0.3.0" }
 url = "2.2.1"
 prometheus = "0.12.0"
 priority-queue = "0.7.0"

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -1,9 +1,10 @@
 use anyhow::Error;
-use async_trait::async_trait;
-use futures::Stream;
+use futures03::{stream::Stream, Future, FutureExt};
 use std::cmp;
 use std::collections::VecDeque;
-use std::mem;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use crate::components::store::BlockNumber;
@@ -141,19 +142,19 @@ where
     /// The BlockStream is reconciling the subgraph store state with the chain store state.
     ///
     /// Valid next states: YieldingBlocks, Idle, BeginReconciliation (in case of revert)
-    Reconciliation(Box<dyn Future<Item = NextBlocks<C>, Error = Error> + Send>),
+    Reconciliation(Pin<Box<dyn Future<Output = Result<NextBlocks<C>, Error>> + Send>>),
 
     /// The BlockStream is emitting blocks that must be processed in order to bring the subgraph
     /// store up to date with the chain store.
     ///
     /// Valid next states: BeginReconciliation
-    YieldingBlocks(VecDeque<BlockWithTriggers<C>>),
+    YieldingBlocks(Box<VecDeque<BlockWithTriggers<C>>>),
 
     /// The BlockStream experienced an error and is pausing before attempting to produce
     /// blocks again.
     ///
     /// Valid next states: BeginReconciliation
-    RetryAfterDelay(Box<dyn Future<Item = (), Error = Error> + Send>),
+    RetryAfterDelay(Box<dyn Future<Output = Result<(), Error>> + Send + Unpin>),
 
     /// The BlockStream has reconciled the subgraph store and chain store states.
     /// No more work is needed until a chain head update.
@@ -199,7 +200,7 @@ where
     // This is not really a block number, but the (unsigned) difference
     // between two block numbers
     reorg_threshold: BlockNumber,
-    filter: C::TriggerFilter,
+    filter: Arc<C::TriggerFilter>,
     start_blocks: Vec<BlockNumber>,
     logger: Logger,
     metrics: Arc<BlockStreamMetrics>,
@@ -238,7 +239,7 @@ impl<C: Blockchain> Clone for BlockStreamContext<C> {
 /// an update on this stream whenever the head of the underlying chain
 /// changes. The updates have no payload, receivers should call
 /// `Store::chain_head_ptr` to check what the latest block is.
-pub type ChainHeadUpdateStream = Box<dyn Stream<Item = (), Error = ()> + Send>;
+pub type ChainHeadUpdateStream = Box<dyn Stream<Item = ()> + Send + Unpin>;
 
 pub trait ChainHeadUpdateListener: Send + Sync + 'static {
     /// Subscribe to chain head updates for the given network.
@@ -277,7 +278,7 @@ where
         adapter: Arc<C::TriggersAdapter>,
         node_id: NodeId,
         subgraph_id: DeploymentHash,
-        filter: C::TriggerFilter,
+        filter: Arc<C::TriggerFilter>,
         start_blocks: Vec<BlockNumber>,
         reorg_threshold: BlockNumber,
         logger: Logger,
@@ -610,27 +611,22 @@ where
 }
 
 impl<C: Blockchain> Stream for BlockStream<C> {
-    type Item = BlockStreamEvent<C>;
-    type Error = Error;
+    type Item = Result<BlockStreamEvent<C>, Error>;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        let mut state = BlockStreamState::Transition;
-        mem::swap(&mut self.state, &mut state);
-
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let result = loop {
-            match state {
+            match &mut self.state {
                 BlockStreamState::BeginReconciliation => {
                     // Start the reconciliation process by asking for blocks
                     let ctx = self.ctx.clone();
                     let fut = async move { ctx.next_blocks().await };
-                    state = BlockStreamState::Reconciliation(Box::new(fut.boxed().compat()));
+                    self.state = BlockStreamState::Reconciliation(fut.boxed());
                 }
 
                 // Waiting for the reconciliation to complete or yield blocks
-                BlockStreamState::Reconciliation(mut next_blocks_future) => {
-                    match next_blocks_future.poll() {
-                        // Reconciliation found blocks to process
-                        Ok(Async::Ready(NextBlocks::Blocks(next_blocks, block_range_size))) => {
+                BlockStreamState::Reconciliation(next_blocks_future) => {
+                    match next_blocks_future.poll_unpin(cx) {
+                        Poll::Ready(Ok(NextBlocks::Blocks(next_blocks, block_range_size))) => {
                             // We had only one error, so we infer that reducing the range size is
                             // what fixed it. Reduce the max range size to prevent future errors.
                             // See: 018c6df4-132f-4acc-8697-a2d64e83a9f0
@@ -651,36 +647,33 @@ impl<C: Blockchain> Stream for BlockStream<C> {
                             }
 
                             // Switch to yielding state until next_blocks is depleted
-                            state = BlockStreamState::YieldingBlocks(next_blocks);
+                            self.state = BlockStreamState::YieldingBlocks(Box::new(next_blocks));
 
                             // Yield the first block in next_blocks
                             continue;
                         }
-
                         // Reconciliation completed. We're caught up to chain head.
-                        Ok(Async::Ready(NextBlocks::Done)) => {
+                        Poll::Ready(Ok(NextBlocks::Done)) => {
                             // Reset error count
                             self.consecutive_err_count = 0;
 
                             // Switch to idle
-                            state = BlockStreamState::Idle;
+                            self.state = BlockStreamState::Idle;
 
                             // Poll for chain head update
                             continue;
                         }
-
-                        Ok(Async::Ready(NextBlocks::Revert(block))) => {
-                            state = BlockStreamState::BeginReconciliation;
-                            break Ok(Async::Ready(Some(BlockStreamEvent::Revert(block))));
+                        Poll::Ready(Ok(NextBlocks::Revert(block))) => {
+                            self.state = BlockStreamState::BeginReconciliation;
+                            break Poll::Ready(Some(Ok(BlockStreamEvent::Revert(block))));
                         }
-
-                        Ok(Async::NotReady) => {
+                        Poll::Pending => {
                             // Nothing to change or yield yet.
-                            state = BlockStreamState::Reconciliation(next_blocks_future);
-                            break Ok(Async::NotReady);
+                            // self.state =
+                            //     BlockStreamState::Reconciliation(next_blocks_future);
+                            break Poll::Pending; //todo: is this ok
                         }
-
-                        Err(e) => {
+                        Poll::Ready(Err(e)) => {
                             // Reset the block range size in an attempt to recover from the error.
                             // See also: 018c6df4-132f-4acc-8697-a2d64e83a9f0
                             self.ctx.previous_block_range_size = 1;
@@ -688,73 +681,69 @@ impl<C: Blockchain> Stream for BlockStream<C> {
 
                             // Pause before trying again
                             let secs = (5 * self.consecutive_err_count).max(120) as u64;
-                            state = BlockStreamState::RetryAfterDelay(Box::new(
-                                tokio::time::delay_for(Duration::from_secs(secs))
-                                    .map(Ok)
-                                    .boxed()
-                                    .compat(),
+                            // (Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>),
+
+                            self.state = BlockStreamState::RetryAfterDelay(Box::new(
+                                tokio::time::delay_for(Duration::from_secs(secs)).map(Ok),
                             ));
-                            break Err(e);
+
+                            break Poll::Ready(Some(Err(e)));
                         }
                     }
                 }
 
                 // Yielding blocks from reconciliation process
-                BlockStreamState::YieldingBlocks(mut next_blocks) => {
+                BlockStreamState::YieldingBlocks(ref mut next_blocks) => {
                     match next_blocks.pop_front() {
                         // Yield one block
                         Some(next_block) => {
-                            state = BlockStreamState::YieldingBlocks(next_blocks);
-                            break Ok(Async::Ready(Some(BlockStreamEvent::ProcessBlock(
+                            // self.state = BlockStreamState::YieldingBlocks(next_blocks);
+                            break Poll::Ready(Some(Ok(BlockStreamEvent::ProcessBlock(
                                 next_block,
                             ))));
                         }
 
                         // Done yielding blocks
                         None => {
-                            state = BlockStreamState::BeginReconciliation;
+                            self.state = BlockStreamState::BeginReconciliation;
                         }
                     }
                 }
 
                 // Pausing after an error, before looking for more blocks
-                BlockStreamState::RetryAfterDelay(mut delay) => match delay.poll() {
-                    Ok(Async::Ready(())) | Err(_) => {
-                        state = BlockStreamState::BeginReconciliation;
-                    }
+                BlockStreamState::RetryAfterDelay(ref mut delay) => {
+                    match Pin::new(delay.as_mut()).poll(cx) {
+                        Poll::Ready(Ok(..)) | Poll::Ready(Err(_)) => {
+                            self.state = BlockStreamState::BeginReconciliation;
+                        }
 
-                    Ok(Async::NotReady) => {
-                        state = BlockStreamState::RetryAfterDelay(delay);
-                        break Ok(Async::NotReady);
+                        Poll::Pending => {
+                            // self.state = BlockStreamState::RetryAfterDelay(delay);
+                            break Poll::Pending;
+                        }
                     }
-                },
+                }
 
                 // Waiting for a chain head update
                 BlockStreamState::Idle => {
-                    match self.chain_head_update_stream.poll() {
+                    match Pin::new(self.chain_head_update_stream.as_mut()).poll_next(cx) {
                         // Chain head was updated
-                        Ok(Async::Ready(Some(()))) => {
-                            state = BlockStreamState::BeginReconciliation;
+                        Poll::Ready(Some(())) => {
+                            self.state = BlockStreamState::BeginReconciliation;
                         }
 
                         // Chain head update stream ended
-                        Ok(Async::Ready(None)) => {
+                        Poll::Ready(None) => {
                             // Should not happen
-                            return Err(anyhow::anyhow!(
+                            return Poll::Ready(Some(Err(anyhow::anyhow!(
                                 "chain head update stream ended unexpectedly"
-                            ));
+                            ))));
                         }
 
-                        Ok(Async::NotReady) => {
+                        Poll::Pending => {
                             // Stay idle
-                            state = BlockStreamState::Idle;
-                            break Ok(Async::NotReady);
-                        }
-
-                        // mpsc channel failed
-                        Err(()) => {
-                            // Should not happen
-                            return Err(anyhow::anyhow!("chain head update Receiver failed"));
+                            self.state = BlockStreamState::Idle;
+                            break Poll::Pending;
                         }
                     }
                 }
@@ -764,8 +753,6 @@ impl<C: Blockchain> Stream for BlockStream<C> {
                 BlockStreamState::Transition => unreachable!(),
             }
         };
-
-        self.state = state;
 
         result
     }

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -161,9 +161,6 @@ where
     ///
     /// Valid next states: BeginReconciliation
     Idle,
-
-    /// Not a real state, only used when going from one state to another.
-    Transition,
 }
 
 /// A single next step to take in reconciling the state of the subgraph store with the state of the
@@ -668,7 +665,7 @@ impl<C: Blockchain> Stream for BlockStream<C> {
                             break Poll::Ready(Some(Ok(BlockStreamEvent::Revert(block))));
                         }
                         Poll::Pending => {
-                            break Poll::Pending; //todo: is this ok
+                            break Poll::Pending;
                         }
                         Poll::Ready(Err(e)) => {
                             // Reset the block range size in an attempt to recover from the error.
@@ -742,10 +739,6 @@ impl<C: Blockchain> Stream for BlockStream<C> {
                         }
                     }
                 }
-
-                // This will only happen if this poll function fails to complete normally then is
-                // called again.
-                BlockStreamState::Transition => unreachable!(),
             }
         };
 

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -668,9 +668,6 @@ impl<C: Blockchain> Stream for BlockStream<C> {
                             break Poll::Ready(Some(Ok(BlockStreamEvent::Revert(block))));
                         }
                         Poll::Pending => {
-                            // Nothing to change or yield yet.
-                            // self.state =
-                            //     BlockStreamState::Reconciliation(next_blocks_future);
                             break Poll::Pending; //todo: is this ok
                         }
                         Poll::Ready(Err(e)) => {
@@ -681,7 +678,6 @@ impl<C: Blockchain> Stream for BlockStream<C> {
 
                             // Pause before trying again
                             let secs = (5 * self.consecutive_err_count).max(120) as u64;
-                            // (Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>),
 
                             self.state = BlockStreamState::RetryAfterDelay(Box::new(
                                 tokio::time::delay_for(Duration::from_secs(secs)).map(Ok),
@@ -697,7 +693,6 @@ impl<C: Blockchain> Stream for BlockStream<C> {
                     match next_blocks.pop_front() {
                         // Yield one block
                         Some(next_block) => {
-                            // self.state = BlockStreamState::YieldingBlocks(next_blocks);
                             break Poll::Ready(Some(Ok(BlockStreamEvent::ProcessBlock(
                                 next_block,
                             ))));

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -35,11 +35,11 @@ use std::{collections::HashMap, convert::TryFrom};
 use web3::types::H256;
 
 pub use block_stream::{
-    BlockStream, ChainHeadUpdateListener, ChainHeadUpdateStream, TriggersAdapter,
+    BlockStream, BlockStreamMetrics, ChainHeadUpdateListener, ChainHeadUpdateStream,
+    TriggersAdapter,
 };
-pub use types::{BlockHash, BlockPtr};
 
-use self::block_stream::BlockStreamMetrics;
+pub use types::{BlockHash, BlockPtr};
 
 pub trait Block: Send + Sync {
     fn ptr(&self) -> BlockPtr;
@@ -60,7 +60,7 @@ pub trait Block: Send + Sync {
 
 #[async_trait]
 // This is only `Debug` because some tests require that
-pub trait Blockchain: Debug + Sized + Send + Sync + 'static {
+pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
     // The `Clone` bound is used when reprocessing a block, because `triggers_in_block` requires an
     // owned `Block`. It would be good to come up with a way to remove this bound.
     type Block: Block + Clone;
@@ -101,7 +101,7 @@ pub trait Blockchain: Debug + Sized + Send + Sync + 'static {
         &self,
         deployment: DeploymentLocator,
         start_blocks: Vec<BlockNumber>,
-        filter: Self::TriggerFilter,
+        filter: Arc<Self::TriggerFilter>,
         metrics: Arc<BlockStreamMetrics>,
         unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<BlockStream<Self>, Error>;

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -1,10 +1,17 @@
-use crate::prelude::StoreError;
-use futures::future::Fuse;
-use futures::prelude::{Future, Poll, Stream};
-use futures::sync::oneshot;
-use futures03::compat::{Compat01As03, Future01CompatExt};
+use crate::prelude::{Pin, StoreError};
+
+use futures03::channel::oneshot;
+use futures03::{future::Fuse, Future, FutureExt, Stream};
+
+// use futures::future::Fuse;
+// use futures::prelude::{Future, Poll, Stream};
+// use futures::sync::oneshot;
+// use futures03::compat::{Compat01As03, Future01CompatExt};
+
+use crate::prelude::tokio::macros::support::Poll;
 use std::fmt::{Debug, Display};
 use std::sync::{Arc, Mutex, Weak};
+use std::task::Context;
 use std::time::Duration;
 
 /// A cancelable stream or future.
@@ -16,36 +23,32 @@ pub struct Cancelable<T, C> {
     cancel_receiver: Fuse<oneshot::Receiver<()>>,
     on_cancel: C,
 }
-
+// CancelableError::Cancel
 /// It's not viable to use `select` directly, so we do a custom implementation.
-impl<S: Stream, C: Fn() -> S::Error> Stream for Cancelable<S, C> {
+impl<S: Stream + Unpin, C: Fn() -> S::Item + Unpin> Stream for Cancelable<S, C> {
     type Item = S::Item;
-    type Error = S::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // Error if the stream was canceled by dropping the sender.
         // `cancel_receiver` is fused so we may ignore `Ok`s.
-        if self.cancel_receiver.poll().is_err() {
-            Err((self.on_cancel)())
-        // Otherwise poll it.
-        } else {
-            self.inner.poll()
+        match self.cancel_receiver.poll_unpin(cx) {
+            Poll::Ready(Ok(_)) => unreachable!(),
+            Poll::Ready(Err(_)) => Poll::Ready(Some((self.on_cancel)())),
+            Poll::Pending => Pin::new(&mut self.inner).poll_next(cx),
         }
     }
 }
 
-impl<F: Future, C: Fn() -> F::Error> Future for Cancelable<F, C> {
-    type Item = F::Item;
-    type Error = F::Error;
+impl<F: Future + Unpin, C: Fn() -> F::Output + Unpin> Future for Cancelable<F, C> {
+    type Output = F::Output;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // Error if the future was canceled by dropping the sender.
-        // `cancel_receiver` is fused so we may ignore `Ok`s.
-        if self.cancel_receiver.poll().is_err() {
-            Err((self.on_cancel)())
-        // Otherwise poll it.
-        } else {
-            self.inner.poll()
+        // `canceled` is fused so we may ignore `Ok`s.
+        match self.cancel_receiver.poll_unpin(cx) {
+            Poll::Ready(Ok(_)) => unreachable!(),
+            Poll::Ready(Err(_)) => Poll::Ready((self.on_cancel)()),
+            Poll::Pending => Pin::new(&mut self.inner).poll(cx),
         }
     }
 }
@@ -199,8 +202,7 @@ pub trait StreamExtension: Stream + Sized {
     /// When `cancel` is called on a `CancelGuard` or it is dropped,
     /// `Cancelable` receives an error.
     ///
-    /// `on_cancel` is called to make an error value upon cancelation.
-    fn cancelable<C: Fn() -> Self::Error>(
+    fn cancelable<C: Fn() -> Self::Item>(
         self,
         guard: &impl Canceler,
         on_cancel: C,
@@ -208,7 +210,7 @@ pub trait StreamExtension: Stream + Sized {
 }
 
 impl<S: Stream> StreamExtension for S {
-    fn cancelable<C: Fn() -> S::Error>(
+    fn cancelable<C: Fn() -> S::Item>(
         self,
         guard: &impl Canceler,
         on_cancel: C,
@@ -228,17 +230,17 @@ pub trait FutureExtension: Future + Sized {
     /// `Cancelable` receives an error.
     ///
     /// `on_cancel` is called to make an error value upon cancelation.
-    fn cancelable<C: Fn() -> Self::Error>(
+    fn cancelable<C: Fn() -> Self::Output>(
         self,
         guard: &impl Canceler,
         on_cancel: C,
     ) -> Cancelable<Self, C>;
 
-    fn timeout(self, dur: Duration) -> tokio::time::Timeout<Compat01As03<Self>>;
+    fn timeout(self, dur: Duration) -> tokio::time::Timeout<Self>;
 }
 
 impl<F: Future> FutureExtension for F {
-    fn cancelable<C: Fn() -> F::Error>(
+    fn cancelable<C: Fn() -> F::Output>(
         self,
         guard: &impl Canceler,
         on_cancel: C,
@@ -252,9 +254,14 @@ impl<F: Future> FutureExtension for F {
         }
     }
 
-    fn timeout(self, dur: Duration) -> tokio::time::Timeout<Compat01As03<Self>> {
-        tokio::time::timeout(dur, self.compat())
+    fn timeout(self, dur: Duration) -> tokio::time::Timeout<Self> {
+        tokio::time::timeout(dur, self)
     }
+}
+
+pub enum CancelableItem<T> {
+    Item(T),
+    Cancel,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -16,7 +16,7 @@ pub struct Cancelable<T, C> {
     cancel_receiver: Fuse<oneshot::Receiver<()>>,
     on_cancel: C,
 }
-// CancelableError::Cancel
+
 /// It's not viable to use `select` directly, so we do a custom implementation.
 impl<S: Stream + Unpin, C: Fn() -> S::Item + Unpin> Stream for Cancelable<S, C> {
     type Item = S::Item;

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -1,14 +1,7 @@
+use crate::prelude::tokio::macros::support::Poll;
 use crate::prelude::{Pin, StoreError};
-
 use futures03::channel::oneshot;
 use futures03::{future::Fuse, Future, FutureExt, Stream};
-
-// use futures::future::Fuse;
-// use futures::prelude::{Future, Poll, Stream};
-// use futures::sync::oneshot;
-// use futures03::compat::{Compat01As03, Future01CompatExt};
-
-use crate::prelude::tokio::macros::support::Poll;
 use std::fmt::{Debug, Display};
 use std::sync::{Arc, Mutex, Weak};
 use std::task::Context;
@@ -30,7 +23,6 @@ impl<S: Stream + Unpin, C: Fn() -> S::Item + Unpin> Stream for Cancelable<S, C> 
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // Error if the stream was canceled by dropping the sender.
-        // `cancel_receiver` is fused so we may ignore `Ok`s.
         match self.cancel_receiver.poll_unpin(cx) {
             Poll::Ready(Ok(_)) => unreachable!(),
             Poll::Ready(Err(_)) => Poll::Ready(Some((self.on_cancel)())),
@@ -257,11 +249,6 @@ impl<F: Future> FutureExtension for F {
     fn timeout(self, dur: Duration) -> tokio::time::Timeout<Self> {
         tokio::time::timeout(dur, self)
     }
-}
-
-pub enum CancelableItem<T> {
-    Item(T),
-    Cancel,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
-// use std::future::Future;
 
 /// Generic helper function for retrying async operations with built-in logging.
 ///

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -1,6 +1,5 @@
 use crate::ext::futures::FutureExtension;
-use futures::prelude::*;
-use futures03::{FutureExt, TryFutureExt};
+use futures03::{Future, FutureExt, TryFutureExt};
 use slog::{debug, trace, warn, Logger};
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -9,6 +8,7 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
+// use std::future::Future;
 
 /// Generic helper function for retrying async operations with built-in logging.
 ///
@@ -29,14 +29,16 @@ use tokio_retry::Retry;
 /// # extern crate graph;
 /// # use graph::prelude::*;
 /// # use tokio::time::timeout;
+/// use std::future::Future;
+/// use graph::prelude::{Logger, TimeoutError};
 /// #
 /// # type Memes = (); // the memes are a lie :(
 /// #
-/// # fn download_the_memes() -> impl Future<Item=(), Error=()> {
-/// #     future::ok(())
+/// # async fn  download_the_memes() -> Result<Memes, ()> {
+/// #     Ok(())
 /// # }
 ///
-/// fn async_function(logger: Logger) -> impl Future<Item=Memes, Error=TimeoutError<()>> {
+/// fn async_function(logger: Logger) -> impl Future<Output=Result<Memes, TimeoutError<()>>> {
 ///     // Retry on error
 ///     retry("download memes", &logger)
 ///         .no_limit() // Retry forever
@@ -155,10 +157,10 @@ where
     E: Debug + Send + Send + Sync + 'static,
 {
     /// Rerun the provided function as many times as needed.
-    pub fn run<F, R>(self, mut try_it: F) -> impl Future<Item = I, Error = TimeoutError<E>>
+    pub fn run<F, R>(self, mut try_it: F) -> impl Future<Output = Result<I, TimeoutError<E>>>
     where
         F: FnMut() -> R + Send + 'static,
-        R: Future<Item = I, Error = E> + Send + 'static,
+        R: Future<Output = Result<I, E>> + Send + 'static,
     {
         let operation_name = self.inner.operation_name;
         let logger = self.inner.logger.clone();
@@ -181,9 +183,8 @@ where
                 try_it()
                     .timeout(timeout)
                     .map_err(|_| TimeoutError::Elapsed)
-                    .and_then(|res| futures03::future::ready(res.map_err(TimeoutError::Inner)))
+                    .and_then(|res| std::future::ready(res.map_err(TimeoutError::Inner)))
                     .boxed()
-                    .compat()
             },
         )
     }
@@ -195,12 +196,12 @@ pub struct RetryConfigNoTimeout<I, E> {
 
 impl<I, E> RetryConfigNoTimeout<I, E> {
     /// Rerun the provided function as many times as needed.
-    pub fn run<F, R>(self, try_it: F) -> impl Future<Item = I, Error = E>
+    pub fn run<F, R>(self, try_it: F) -> impl Future<Output = Result<I, E>>
     where
         I: Debug + Send + 'static,
         E: Debug + Send + Sync + 'static,
         F: Fn() -> R + Send + 'static,
-        R: Future<Item = I, Error = E> + Send,
+        R: Future<Output = Result<I, E>> + Send,
     {
         let operation_name = self.inner.operation_name;
         let logger = self.inner.logger.clone();
@@ -252,24 +253,25 @@ impl<T: Debug + Send + Sync + 'static> TimeoutError<T> {
     }
 }
 
-fn run_retry<I, E, F, R>(
+fn run_retry<O, E, F, R>(
     operation_name: String,
     logger: Logger,
-    condition: RetryIf<I, E>,
+    condition: RetryIf<O, E>,
     log_after: u64,
     warn_after: u64,
     limit_opt: Option<usize>,
     mut try_it_with_timeout: F,
-) -> impl Future<Item = I, Error = TimeoutError<E>> + Send
+) -> impl Future<Output = Result<O, TimeoutError<E>>> + Send
 where
-    I: Debug + Send + 'static,
+    O: Debug + Send + 'static,
     E: Debug + Send + Sync + 'static,
     F: FnMut() -> R + Send + 'static,
-    R: Future<Item = I, Error = TimeoutError<E>> + Send,
+    R: Future<Output = Result<O, TimeoutError<E>>> + Send,
 {
     let condition = Arc::new(condition);
 
     let mut attempt_count = 0;
+
     Retry::spawn(retry_strategy(limit_opt), move || {
         let operation_name = operation_name.clone();
         let logger = logger.clone();
@@ -295,7 +297,7 @@ where
                 }
 
                 // Wrap in Err to force retry
-                Err(result_with_timeout)
+                std::future::ready(Err(result_with_timeout))
             } else {
                 // Any error must now be an inner error.
                 // Unwrap the inner error so that the predicate doesn't need to think
@@ -327,15 +329,15 @@ where
                     }
 
                     // Wrap in Err to force retry
-                    Err(result.map_err(TimeoutError::Inner))
+                    std::future::ready(Err(result.map_err(TimeoutError::Inner)))
                 } else {
                     // Wrap in Ok to prevent retry
-                    Ok(result.map_err(TimeoutError::Inner))
+                    std::future::ready(Ok(result.map_err(TimeoutError::Inner)))
                 }
             }
         })
     })
-    .then(|retry_result| {
+    .then(|retry_result| async {
         // Unwrap the inner result.
         // The outer Ok/Err is only used for retry control flow.
         match retry_result {
@@ -429,126 +431,118 @@ mod tests {
     use futures03::compat::Future01CompatExt;
     use slog::o;
     use std::sync::Mutex;
-
+    use tokio18;
     #[test]
     fn test() {
         let logger = Logger::root(::slog::Discard, o!());
-        let mut runtime = tokio::runtime::Builder::new()
-            .basic_scheduler()
+
+        let runtime = tokio18::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
+        let result = runtime.block_on(async {
+            let c = Mutex::new(0);
+            retry("test", &logger)
+                .no_logging()
+                .no_limit()
+                .no_timeout()
+                .run(move || {
+                    let mut c_guard = c.lock().unwrap();
+                    *c_guard += 1;
 
-        let result = runtime.block_on(
-            future::lazy(move || {
-                let c = Mutex::new(0);
-                retry("test", &logger)
-                    .no_logging()
-                    .no_limit()
-                    .no_timeout()
-                    .run(move || {
-                        let mut c_guard = c.lock().unwrap();
-                        *c_guard += 1;
-
-                        if *c_guard >= 10 {
-                            future::ok(*c_guard)
-                        } else {
-                            future::err(())
-                        }
-                    })
-            })
-            .compat(),
-        );
+                    if *c_guard >= 10 {
+                        future::ok(*c_guard).compat()
+                    } else {
+                        future::err(()).compat()
+                    }
+                })
+                .await
+        });
         assert_eq!(result, Ok(10));
     }
 
     #[test]
     fn limit_reached() {
         let logger = Logger::root(::slog::Discard, o!());
-        let mut runtime = tokio::runtime::Builder::new()
-            .basic_scheduler()
+        let runtime = tokio18::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
 
-        let result = runtime.block_on(
-            future::lazy(move || {
-                let c = Mutex::new(0);
-                retry("test", &logger)
-                    .no_logging()
-                    .limit(5)
-                    .no_timeout()
-                    .run(move || {
-                        let mut c_guard = c.lock().unwrap();
-                        *c_guard += 1;
+        let result = runtime.block_on({
+            let c = Mutex::new(0);
+            retry("test", &logger)
+                .no_logging()
+                .limit(5)
+                .no_timeout()
+                .run(move || {
+                    let mut c_guard = c.lock().unwrap();
+                    *c_guard += 1;
 
-                        if *c_guard >= 10 {
-                            future::ok(*c_guard)
-                        } else {
-                            future::err(*c_guard)
-                        }
-                    })
-            })
-            .compat(),
-        );
+                    if *c_guard >= 10 {
+                        future::ok(*c_guard).compat()
+                    } else {
+                        future::err(*c_guard).compat()
+                    }
+                })
+        });
         assert_eq!(result, Err(5));
     }
 
     #[test]
     fn limit_not_reached() {
         let logger = Logger::root(::slog::Discard, o!());
-        let mut runtime = tokio::runtime::Builder::new()
-            .basic_scheduler()
+        let runtime = tokio18::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
 
-        let result = runtime.block_on(
-            future::lazy(move || {
-                let c = Mutex::new(0);
-                retry("test", &logger)
-                    .no_logging()
-                    .limit(20)
-                    .no_timeout()
-                    .run(move || {
-                        let mut c_guard = c.lock().unwrap();
-                        *c_guard += 1;
+        let result = runtime.block_on({
+            let c = Mutex::new(0);
+            retry("test", &logger)
+                .no_logging()
+                .limit(20)
+                .no_timeout()
+                .run(move || {
+                    let mut c_guard = c.lock().unwrap();
+                    *c_guard += 1;
 
-                        if *c_guard >= 10 {
-                            future::ok(*c_guard)
-                        } else {
-                            future::err(*c_guard)
-                        }
-                    })
-            })
-            .compat(),
-        );
+                    if *c_guard >= 10 {
+                        future::ok(*c_guard).compat()
+                    } else {
+                        future::err(*c_guard).compat()
+                    }
+                })
+        });
         assert_eq!(result, Ok(10));
     }
 
-    #[tokio::test]
-    async fn custom_when() {
+    #[test]
+    fn custom_when() {
         let logger = Logger::root(::slog::Discard, o!());
         let c = Mutex::new(0);
 
-        let result = retry("test", &logger)
-            .when(|result| result.unwrap() < 10)
-            .no_logging()
-            .limit(20)
-            .no_timeout()
-            .run(move || {
-                let mut c_guard = c.lock().unwrap();
-                *c_guard += 1;
-                if *c_guard > 30 {
-                    future::err(())
-                } else {
-                    future::ok(*c_guard)
-                }
-            })
-            .compat()
-            .await
+        let runtime = tokio18::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
             .unwrap();
+        let result = runtime.block_on({
+            retry("test", &logger)
+                .when(|result| result.unwrap() < 10)
+                .no_logging()
+                .limit(20)
+                .no_timeout()
+                .run(move || {
+                    let mut c_guard = c.lock().unwrap();
+                    *c_guard += 1;
+                    if *c_guard > 30 {
+                        future::err(()).compat()
+                    } else {
+                        future::ok(*c_guard).compat()
+                    }
+                })
+        });
 
-        assert_eq!(result, 10);
+        assert_eq!(result, Ok(10));
     }
 }

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -19,7 +19,7 @@ use graph::{
         subgraph::SubgraphFeature,
     },
     prelude::{
-        futures03::stream::StreamExt, futures03::FutureExt, futures03::TryFutureExt, o, q,
+        futures03::stream::StreamExt, o, q,
         serde_json, slog, BlockPtr, DeploymentHash, Entity, EntityKey, EntityOperation,
         FutureExtension, GraphQlRunner as _, Logger, NodeId, Query, QueryError,
         QueryExecutionError, QueryResult, QueryStoreManager, QueryVariables, Schema,
@@ -1320,11 +1320,10 @@ fn subscription_gets_result_even_without_events() {
         let results: Vec<_> = stream
             .take(1)
             .collect()
-            .map(Result::<_, ()>::Ok)
-            .compat()
+            // .map(Result::<_, ()>::Ok)
             .timeout(Duration::from_secs(3))
             .await
-            .unwrap()
+            // .unwrap()
             .unwrap();
 
         assert_eq!(results.len(), 1);

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -366,14 +366,16 @@ where
                     let logger = logger.clone();
                     let cancel_id = id.clone();
                     let connection_id = connection_id.clone();
-                    let run_subscription = run_subscription.cancelable(&guard, move || {
-                        debug!(logger, "Stopped operation";
+                    let run_subscription =
+                        run_subscription.compat().cancelable(&guard, move || {
+                            debug!(logger, "Stopped operation";
                                        "connection" => &connection_id,
-                                       "id" => &cancel_id)
-                    });
+                                       "id" => &cancel_id);
+                            Ok(())
+                        });
                     operations.insert(id, guard);
 
-                    graph::spawn_allow_panic(run_subscription.compat());
+                    graph::spawn_allow_panic(run_subscription);
                     Ok(())
                 }
             }?

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -13,7 +13,6 @@ use crate::{
     notification_listener::{JsonNotification, NotificationListener, SafeChannelName},
 };
 use graph::blockchain::ChainHeadUpdateListener as ChainHeadUpdateListenerTrait;
-use graph::prelude::futures03::prelude::stream::{StreamExt, TryStreamExt};
 use graph::prelude::serde::{Deserialize, Serialize};
 use graph::prelude::serde_json::{self, json};
 use graph::prelude::tokio::sync::{mpsc::Receiver, watch};
@@ -164,7 +163,7 @@ impl ChainHeadUpdateListenerTrait for ChainHeadUpdateListener {
             .receiver
             .clone();
 
-        Box::new(update_receiver.map(Result::<_, ()>::Ok).boxed().compat())
+        Box::new(update_receiver)
     }
 }
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -952,6 +952,7 @@ async fn check_events(
             future::ok(!expected.is_empty())
         })
         .collect()
+        .compat()
         .timeout(Duration::from_secs(3))
         .await
         .expect(&format!(
@@ -1467,6 +1468,7 @@ fn throttle_subscription_throttles() {
         let res = subscription
             .take(1)
             .collect()
+            .compat()
             .timeout(Duration::from_millis(500))
             .await;
         assert!(res.is_err());


### PR DESCRIPTION
- Modified blockstream implementation to support future 0.3
- Modified cancellable to support future 0.3
- Modified `retry` lib to support future 0.3. Now retry func expects a future 0.3 function
- Sprinkled some `boxed` & `compat` where needed
- Fixed examples

