### PR TITLE
Added tracing logs when a giving deployment is assigned/not assigned

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -171,12 +171,14 @@ where
                                     if let Some(assigned) = assigned {
                                         if assigned == node_id {
                                             // Start subgraph on this node
+                                            debug!(logger, "Deployment assignee is this node, broadcasting add event"; "assigned_to" => assigned, "node_id" => &node_id);
                                             Box::new(stream::once(Ok(AssignmentEvent::Add {
                                                 deployment,
                                                 node_id: node_id.clone(),
                                             })))
                                         } else {
                                             // Ensure it is removed from this node
+                                            debug!(logger, "Deployment assignee is not this node, broadcasting remove event"; "assigned_to" => assigned, "node_id" => &node_id);
                                             Box::new(stream::once(Ok(AssignmentEvent::Remove {
                                                 deployment,
                                                 node_id: node_id.clone(),
@@ -184,7 +186,7 @@ where
                                         }
                                     } else {
                                         // Was added/updated, but is now gone.
-                                        // We will get a separate Removed event later.
+                                        debug!(logger, "Deployment has not assignee, we will get a separate remove event later"; "node_id" => &node_id);
                                         Box::new(stream::empty())
                                     }
                                 })

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -79,6 +79,17 @@ impl fmt::Display for NodeId {
     }
 }
 
+impl slog::Value for NodeId {
+    fn serialize(
+        &self,
+        record: &slog::Record,
+        key: slog::Key,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        serializer.emit_str(key, self.0.as_str())
+    }
+}
+
 impl<'de> de::Deserialize<'de> for NodeId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -82,7 +82,7 @@ impl fmt::Display for NodeId {
 impl slog::Value for NodeId {
     fn serialize(
         &self,
-        record: &slog::Record,
+        _record: &slog::Record,
         key: slog::Key,
         serializer: &mut dyn slog::Serializer,
     ) -> slog::Result {


### PR DESCRIPTION
While doing some development, I had a misconfiguration where my `node_id` was not in sync with my configuration file.

This led to a deployment to be immediately removed on the receiving node leading to the deployment not starting.

To alleviate that problem a bit, I added some log lines that should make it clearer about what is happening and more especially why it's happening.

I choose to go with `debug` level but willing to switch to a `trace` level if you think it would be more appropriate.

