### PR TITLE
node: Refactor config to accept Firehose provider 

### DIFF
--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -8,11 +8,14 @@ use graph::{
 use graph_chain_ethereum::NodeCapabilities;
 use graph_store_postgres::{DeploymentPlacer, Shard as ShardName, PRIMARY_SHARD};
 
-use http::HeaderMap;
+use http::{HeaderMap, Uri};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
 use std::fs::read_to_string;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
 use url::Url;
 
 const ANY_NAME: &str = ".*";
@@ -434,10 +437,12 @@ impl ChainSection {
                 let features = features.into_iter().map(|s| s.to_string()).collect();
                 let provider = Provider {
                     label: format!("{}-{}-{}", name, transport, nr),
-                    transport,
-                    url: url.to_string(),
-                    features,
-                    headers: Default::default(),
+                    details: ProviderDetails::Web3(Web3Provider {
+                        transport,
+                        url: url.to_string(),
+                        features,
+                        headers: Default::default(),
+                    }),
                 };
                 let entry = chains.entry(name.to_string()).or_insert_with(|| Chain {
                     shard: PRIMARY_SHARD.to_string(),
@@ -473,6 +478,10 @@ where
     D: serde::Deserializer<'de>,
 {
     let kvs: BTreeMap<String, String> = Deserialize::deserialize(deserializer)?;
+    Ok(btree_map_to_http_headers(kvs))
+}
+
+fn btree_map_to_http_headers(kvs: BTreeMap<String, String>) -> HeaderMap {
     let mut headers = HeaderMap::new();
     for (k, v) in kvs.into_iter() {
         headers.insert(
@@ -482,12 +491,29 @@ where
                 .expect(&format!("invalid HTTP header value: {}: {}", k, v)),
         );
     }
-    Ok(headers)
+    headers
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct Provider {
     pub label: String,
+    pub details: ProviderDetails,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ProviderDetails {
+    Firehose(FirehoseProvider),
+    Web3(Web3Provider),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct FirehoseProvider {
+    pub url: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct Web3Provider {
     #[serde(default)]
     pub transport: Transport,
     pub url: String,
@@ -502,37 +528,7 @@ pub struct Provider {
     pub headers: HeaderMap,
 }
 
-const PROVIDER_FEATURES: [&str; 3] = ["traces", "archive", "no_eip1898"];
-const DEFAULT_PROVIDER_FEATURES: [&str; 2] = ["traces", "archive"];
-
-impl Provider {
-    fn validate(&mut self) -> Result<()> {
-        validate_name(&self.label).context("illegal provider name")?;
-
-        for feature in &self.features {
-            if !PROVIDER_FEATURES.contains(&feature.as_str()) {
-                return Err(anyhow!(
-                    "illegal feature `{}` for provider {}. Features must be one of {}",
-                    feature,
-                    self.label,
-                    PROVIDER_FEATURES.join(", ")
-                ));
-            }
-        }
-
-        self.url = shellexpand::env(&self.url)?.into_owned();
-
-        Url::parse(&self.url).map_err(|e| {
-            anyhow!(
-                "the url `{}` for provider {} is not a legal URL: {}",
-                self.url,
-                self.label,
-                e
-            )
-        })?;
-        Ok(())
-    }
-
+impl Web3Provider {
     pub fn node_capabilities(&self) -> NodeCapabilities {
         NodeCapabilities {
             archive: self.features.contains("archive"),
@@ -541,7 +537,179 @@ impl Provider {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+const PROVIDER_FEATURES: [&str; 3] = ["traces", "archive", "no_eip1898"];
+const DEFAULT_PROVIDER_FEATURES: [&str; 2] = ["traces", "archive"];
+
+impl Provider {
+    fn validate(&mut self) -> Result<()> {
+        validate_name(&self.label).context("illegal provider name")?;
+
+        match self.details {
+            ProviderDetails::Firehose(ref firehose) => {
+                // A Firehose url must be a valid Uri since gRPC library we use (Tonic)
+                // works with Uri.
+                firehose.url.parse::<Uri>().map_err(|e| {
+                    anyhow!(
+                        "the url `{}` for firehose provider {} is not a legal URI: {}",
+                        firehose.url,
+                        self.label,
+                        e
+                    )
+                })?;
+            }
+
+            ProviderDetails::Web3(ref mut web3) => {
+                for feature in &web3.features {
+                    if !PROVIDER_FEATURES.contains(&feature.as_str()) {
+                        return Err(anyhow!(
+                            "illegal feature `{}` for provider {}. Features must be one of {}",
+                            feature,
+                            self.label,
+                            PROVIDER_FEATURES.join(", ")
+                        ));
+                    }
+                }
+
+                web3.url = shellexpand::env(&web3.url)?.into_owned();
+
+                let label = &self.label;
+                Url::parse(&web3.url).map_err(|e| {
+                    anyhow!(
+                        "the url `{}` for provider {} is not a legal URL: {}",
+                        web3.url,
+                        label,
+                        e
+                    )
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for Provider {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ProviderVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for ProviderVisitor {
+            type Value = Provider;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Provider")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Provider, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut label = None;
+                let mut details = None;
+
+                let mut url = None;
+                let mut transport = None;
+                let mut features = None;
+                let mut headers = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        ProviderField::Label => {
+                            if label.is_some() {
+                                return Err(serde::de::Error::duplicate_field("label"));
+                            }
+                            label = Some(map.next_value()?);
+                        }
+                        ProviderField::Details => {
+                            if details.is_some() {
+                                return Err(serde::de::Error::duplicate_field("details"));
+                            }
+                            details = Some(map.next_value()?);
+                        }
+                        ProviderField::Url => {
+                            if url.is_some() {
+                                return Err(serde::de::Error::duplicate_field("url"));
+                            }
+                            url = Some(map.next_value()?);
+                        }
+                        ProviderField::Transport => {
+                            if transport.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transport"));
+                            }
+                            transport = Some(map.next_value()?);
+                        }
+                        ProviderField::Features => {
+                            if features.is_some() {
+                                return Err(serde::de::Error::duplicate_field("features"));
+                            }
+                            features = Some(map.next_value()?);
+                        }
+                        ProviderField::Headers => {
+                            if headers.is_some() {
+                                return Err(serde::de::Error::duplicate_field("headers"));
+                            }
+
+                            let raw_headers: BTreeMap<String, String> = map.next_value()?;
+                            headers = Some(btree_map_to_http_headers(raw_headers));
+                        }
+                    }
+                }
+
+                let label = label.ok_or_else(|| serde::de::Error::missing_field("label"))?;
+                let details = match details {
+                    Some(v) => {
+                        if url.is_some()
+                            || transport.is_some()
+                            || features.is_some()
+                            || headers.is_some()
+                        {
+                            return Err(serde::de::Error::custom("when `details` field is provided, deprecated `url`, `transport`, `features` and `headers` cannot be specified"));
+                        }
+
+                        v
+                    }
+                    None => ProviderDetails::Web3(Web3Provider {
+                        url: url.ok_or_else(|| serde::de::Error::missing_field("url"))?,
+                        transport: transport
+                            .ok_or_else(|| serde::de::Error::missing_field("transport"))?,
+                        features: features
+                            .ok_or_else(|| serde::de::Error::missing_field("features"))?,
+                        headers: headers.unwrap_or_else(|| HeaderMap::new()),
+                    }),
+                };
+
+                Ok(Provider { label, details })
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &[
+            "label",
+            "details",
+            "transport",
+            "url",
+            "features",
+            "headers",
+        ];
+        deserializer.deserialize_struct("Provider", FIELDS, ProviderVisitor)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(field_identifier, rename_all = "lowercase")]
+enum ProviderField {
+    Label,
+    Details,
+
+    // Deprecated fields
+    Url,
+    Transport,
+    Features,
+    Headers,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub enum Transport {
     #[serde(rename = "rpc")]
     Rpc,
@@ -751,4 +919,137 @@ fn primary_store() -> String {
 
 fn one() -> usize {
     1
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::{FirehoseProvider, Provider, ProviderDetails, Transport, Web3Provider};
+    use http::{HeaderMap, HeaderValue};
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn it_works_on_deprecated_provider_from_toml() {
+        let actual = toml::from_str(
+            r#"
+            transport = "rpc"
+            label = "peering"
+            url = "http://localhost:8545"
+            features = []
+        "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            Provider {
+                label: "peering".to_owned(),
+                details: ProviderDetails::Web3(Web3Provider {
+                    transport: Transport::Rpc,
+                    url: "http://localhost:8545".to_owned(),
+                    features: BTreeSet::new(),
+                    headers: HeaderMap::new(),
+                }),
+            },
+            actual
+        );
+    }
+
+    #[test]
+    fn it_errors_on_deprecated_provider_missing_url_from_toml() {
+        let actual = toml::from_str::<Provider>(
+            r#"
+            transport = "rpc"
+            label = "peering"
+            features = []
+        "#,
+        );
+
+        assert_eq!(true, actual.is_err());
+        assert_eq!(
+            actual.unwrap_err().to_string(),
+            "missing field `url` at line 1 column 1"
+        );
+    }
+
+    #[test]
+    fn it_errors_on_deprecated_provider_missing_features_from_toml() {
+        let actual = toml::from_str::<Provider>(
+            r#"
+            transport = "rpc"
+            url = "http://localhost:8545"
+            label = "peering"
+        "#,
+        );
+
+        assert_eq!(true, actual.is_err());
+        assert_eq!(
+            actual.unwrap_err().to_string(),
+            "missing field `features` at line 1 column 1"
+        );
+    }
+
+    #[test]
+    fn it_works_on_new_web3_provider_from_toml() {
+        let actual = toml::from_str(
+            r#"
+            label = "peering"
+            details = { type = "web3", transport = "ipc", url = "http://localhost:8545", features = ["archive"], headers = { x-test = "value" } }
+        "#,
+        )
+        .unwrap();
+
+        let mut features = BTreeSet::new();
+        features.insert("archive".to_string());
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-test", HeaderValue::from_static("value"));
+
+        assert_eq!(
+            Provider {
+                label: "peering".to_owned(),
+                details: ProviderDetails::Web3(Web3Provider {
+                    transport: Transport::Ipc,
+                    url: "http://localhost:8545".to_owned(),
+                    features,
+                    headers,
+                }),
+            },
+            actual
+        );
+    }
+
+    #[test]
+    fn it_errors_on_new_provider_with_deprecated_fields_from_toml() {
+        let actual = toml::from_str::<Provider>(
+            r#"
+            label = "peering"
+            url = "http://localhost:8545"
+            details = { type = "web3", url = "http://localhost:8545", features = [] }
+        "#,
+        );
+
+        assert_eq!(true, actual.is_err());
+        assert_eq!(actual.unwrap_err().to_string(), "when `details` field is provided, deprecated `url`, `transport`, `features` and `headers` cannot be specified at line 1 column 1");
+    }
+
+    #[test]
+    fn it_works_on_new_firehose_provider_from_toml() {
+        let actual = toml::from_str(
+            r#"
+                label = "firehose"
+                details = { type = "firehose", url = "http://localhost:9000" }
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            Provider {
+                label: "firehose".to_owned(),
+                details: ProviderDetails::Firehose(FirehoseProvider {
+                    url: "http://localhost:9000".to_owned(),
+                }),
+            },
+            actual
+        );
+    }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -40,6 +40,8 @@ mod store_builder;
 use config::Config;
 use store_builder::StoreBuilder;
 
+use crate::config::ProviderDetails;
+
 lazy_static! {
     // Default to an Ethereum reorg threshold to 50 blocks
     static ref REORG_THRESHOLD: BlockNumber = env::var("ETHEREUM_REORG_THRESHOLD")
@@ -451,45 +453,47 @@ async fn create_ethereum_networks(
     let mut parsed_networks = EthereumNetworks::new();
     for (name, chain) in config.chains.chains {
         for provider in chain.providers {
-            let capabilities = provider.node_capabilities();
+            if let ProviderDetails::Web3(web3) = provider.details {
+                let capabilities = web3.node_capabilities();
 
-            let logger = logger.new(o!("provider" => provider.label.clone()));
-            info!(
-                logger,
-                "Creating transport";
-                "url" => &provider.url,
-                "capabilities" => capabilities
-            );
+                let logger = logger.new(o!("provider" => provider.label.clone()));
+                info!(
+                    logger,
+                    "Creating transport";
+                    "url" => &web3.url,
+                    "capabilities" => capabilities
+                );
 
-            use crate::config::Transport::*;
+                use crate::config::Transport::*;
 
-            let (transport_event_loop, transport) = match provider.transport {
-                Rpc => Transport::new_rpc(&provider.url, provider.headers),
-                Ipc => Transport::new_ipc(&provider.url),
-                Ws => Transport::new_ws(&provider.url),
-            };
+                let (transport_event_loop, transport) = match web3.transport {
+                    Rpc => Transport::new_rpc(&web3.url, web3.headers),
+                    Ipc => Transport::new_ipc(&web3.url),
+                    Ws => Transport::new_ws(&web3.url),
+                };
 
-            // If we drop the event loop the transport will stop working.
-            // For now it's fine to just leak it.
-            std::mem::forget(transport_event_loop);
+                // If we drop the event loop the transport will stop working.
+                // For now it's fine to just leak it.
+                std::mem::forget(transport_event_loop);
 
-            let supports_eip_1898 = !provider.features.contains("no_eip1898");
+                let supports_eip_1898 = !web3.features.contains("no_eip1898");
 
-            parsed_networks.insert(
-                name.to_string(),
-                capabilities,
-                Arc::new(
-                    graph_chain_ethereum::EthereumAdapter::new(
-                        logger,
-                        provider.label,
-                        &provider.url,
-                        transport,
-                        eth_rpc_metrics.clone(),
-                        supports_eip_1898,
-                    )
-                    .await,
-                ),
-            );
+                parsed_networks.insert(
+                    name.to_string(),
+                    capabilities,
+                    Arc::new(
+                        graph_chain_ethereum::EthereumAdapter::new(
+                            logger,
+                            provider.label,
+                            &web3.url,
+                            transport,
+                            eth_rpc_metrics.clone(),
+                            supports_eip_1898,
+                        )
+                        .await,
+                    ),
+                );
+            }
         }
     }
     parsed_networks.sort();
@@ -712,7 +716,16 @@ fn start_block_ingestor(
     // database.
     assert!(*ANCESTOR_COUNT >= *REORG_THRESHOLD);
 
-    info!(logger, "Starting block ingestors");
+    info!(
+        logger,
+        "Starting block ingestors with {} chains [{}]",
+        chains.len(),
+        chains
+            .keys()
+            .map(|v| v.clone())
+            .collect::<Vec<String>>()
+            .join(", ")
+    );
 
     // Create Ethereum block ingestors and spawn a thread to run each
     chains


### PR DESCRIPTION
(and made Provide a little bit more extensible along the way)

There is a backward compatible handling of config that at some point should be converted to the new syntax form. The new syntax form is

```toml
[chains]
[chains.ropsten]
provider = [
  { label = "firehose", details = { type = "web3", transport = "rpc", url = "https://ropsten.sf.io/rpc", features = [] } },
]
```

While a Firehose provider now looks like:

```toml
[chains]
[chains.ropsten]
provider = [
  { label = "firehose", details = { type = "firehose", url = "https://ropsten.streamingfast.io" } },
]
```

This is for now undocumented and is first step towards Firehose integration in the codebase directly.

