### PR TITLE
store, migration: Use a different functon that works in PSQL 9.6

### DIFF
--- a/store/postgres/migrations/2021-06-14-201635_add_ethereum_hex_to_bytea_function/up.sql
+++ b/store/postgres/migrations/2021-06-14-201635_add_ethereum_hex_to_bytea_function/up.sql
@@ -33,7 +33,7 @@ create or replace function ethereum_hex_to_bytea (eth_hex text)
     select
         case when $1 is null then
             null
-        when not substring(eth_hex, from 1 for 2) = '0x' then
+        when not substring(eth_hex from 1 for  2) = '0x' then
             raise_exception_bytea('Input must start with ''0x''.')
         when length(eth_hex) = 2 then
             raise_exception_bytea('Can''t decode an empty hexadecimal string.')

--- a/store/postgres/migrations/2021-06-14-201635_add_ethereum_hex_to_bytea_function/up.sql
+++ b/store/postgres/migrations/2021-06-14-201635_add_ethereum_hex_to_bytea_function/up.sql
@@ -33,7 +33,7 @@ create or replace function ethereum_hex_to_bytea (eth_hex text)
     select
         case when $1 is null then
             null
-        when not starts_with (eth_hex, '0x') then
+        when not substring(eth_hex, from 1 for 2) = '0x' then
             raise_exception_bytea('Input must start with ''0x''.')
         when length(eth_hex) = 2 then
             raise_exception_bytea('Can''t decode an empty hexadecimal string.')


### PR DESCRIPTION
The previous function, `starts_with` didn't exist in Postgres 9.6 version.
This fix uses the `substring` function for the same effect.