### PR TITLE
 graph: check usage of reserved types on `Schema::validate`

### DIFF
--- a/graph/src/data/graphql/ext.rs
+++ b/graph/src/data/graphql/ext.rs
@@ -43,6 +43,8 @@ impl ObjectTypeExt for InterfaceType {
 pub trait DocumentExt {
     fn get_object_type_definitions(&self) -> Vec<&ObjectType>;
 
+    fn get_interface_type_definitions(&self) -> Vec<&InterfaceType>;
+
     fn get_object_type_definition(&self, name: &str) -> Option<&ObjectType>;
 
     fn get_object_and_interface_type_fields(&self) -> HashMap<&str, &Vec<Field>>;
@@ -63,11 +65,23 @@ pub trait DocumentExt {
 }
 
 impl DocumentExt for Document {
+    /// Returns all object type definitions in the schema.
     fn get_object_type_definitions(&self) -> Vec<&ObjectType> {
         self.definitions
             .iter()
             .filter_map(|d| match d {
                 Definition::TypeDefinition(TypeDefinition::Object(t)) => Some(t),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Returns all interface definitions in the schema.
+    fn get_interface_type_definitions(&self) -> Vec<&InterfaceType> {
+        self.definitions
+            .iter()
+            .filter_map(|d| match d {
+                Definition::TypeDefinition(TypeDefinition::Interface(t)) => Some(t),
                 _ => None,
             })
             .collect()

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -53,7 +53,7 @@ pub enum SchemaValidationError {
     InterfaceFieldsMissing(String, String, Strings), // (type, interface, missing_fields)
     #[error("Field `{1}` in type `{0}` has invalid @derivedFrom: {2}")]
     InvalidDerivedFrom(String, String, String), // (type, field, reason)
-    #[error("The following types are reserved: `{0}`")]
+    #[error("The following type names are reserved: `{0}`")]
     UsageOfReservedTypes(Strings),
     #[error("_Schema_ type is only for @imports and must not have any fields")]
     SchemaTypeWithFields,

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -1,7 +1,7 @@
 use graphql_parser::Pos;
 use std::collections::{BTreeMap, HashMap};
 
-use graph::data::graphql::{DocumentExt, ObjectOrInterface, object};
+use graph::data::graphql::{object, DocumentExt, ObjectOrInterface};
 use graph::prelude::*;
 
 use crate::prelude::*;

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -1,7 +1,7 @@
 use graphql_parser::Pos;
 use std::collections::{BTreeMap, HashMap};
 
-use graph::data::graphql::{object, ObjectOrInterface};
+use graph::data::graphql::{DocumentExt, ObjectOrInterface, object};
 use graph::prelude::*;
 
 use crate::prelude::*;
@@ -213,7 +213,7 @@ fn union_type_object(schema: &Schema, union_type: &s::UnionType) -> q::Value {
         kind: q::Value::Enum(String::from("UNION")),
         description: union_type.description.clone(),
         possibleTypes:
-            sast::get_object_type_definitions(&schema.document)
+            schema.document.get_object_type_definitions()
                 .iter()
                 .filter(|object_type| {
                     object_type

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -70,8 +70,8 @@ pub fn api_schema(
     features: &BTreeSet<SubgraphFeature>,
 ) -> Result<Document, APISchemaError> {
     // Refactor: Take `input_schema` by value.
-    let object_types = ast::get_object_type_definitions(input_schema);
-    let interface_types = ast::get_interface_type_definitions(input_schema);
+    let object_types = input_schema.get_object_type_definitions();
+    let interface_types = input_schema.get_interface_type_definitions();
 
     // Refactor: Don't clone the schema.
     let mut schema = input_schema.clone();
@@ -780,7 +780,7 @@ fn add_field_arguments(
     // Refactor: Remove the `input_schema` argument and do a mutable iteration
     // over the definitions in `schema`. Also the duplication between this and
     // the loop for interfaces below.
-    for input_object_type in ast::get_object_type_definitions(input_schema) {
+    for input_object_type in input_schema.get_object_type_definitions() {
         for input_field in &input_object_type.fields {
             if let Some(input_reference_type) =
                 ast::get_referenced_entity_type(input_schema, &input_field)
@@ -811,7 +811,7 @@ fn add_field_arguments(
         }
     }
 
-    for input_interface_type in ast::get_interface_type_definitions(input_schema) {
+    for input_interface_type in input_schema.get_interface_type_definitions() {
         for input_field in &input_interface_type.fields {
             if let Some(input_reference_type) =
                 ast::get_referenced_entity_type(input_schema, &input_field)

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -421,7 +421,7 @@ pub fn validate_entity(
     key: &EntityKey,
     entity: &Entity,
 ) -> Result<(), anyhow::Error> {
-    let object_type_definitions = get_object_type_definitions(schema);
+    let object_type_definitions = schema.get_object_type_definitions();
     let object_type = object_type_definitions
         .iter()
         .find(|object_type| key.entity_type.as_str() == &object_type.name)

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use crate::query::ast as qast;
-use graph::data::graphql::ObjectOrInterface;
+use graph::data::graphql::{DocumentExt, ObjectOrInterface};
 use graph::data::store;
 use graph::prelude::s::{Value, *};
 use graph::prelude::*;
@@ -73,18 +73,6 @@ pub fn get_type_definitions(schema: &Document) -> Vec<&TypeDefinition> {
         .collect()
 }
 
-/// Returns all object type definitions in the schema.
-pub fn get_object_type_definitions(schema: &Document) -> Vec<&ObjectType> {
-    schema
-        .definitions
-        .iter()
-        .filter_map(|d| match d {
-            Definition::TypeDefinition(TypeDefinition::Object(t)) => Some(t),
-            _ => None,
-        })
-        .collect()
-}
-
 /// Returns the object type with the given name.
 pub fn get_object_type_mut<'a>(schema: &'a mut Document, name: &str) -> Option<&'a mut ObjectType> {
     use graphql_parser::schema::TypeDefinition::*;
@@ -93,18 +81,6 @@ pub fn get_object_type_mut<'a>(schema: &'a mut Document, name: &str) -> Option<&
         Object(object_type) => Some(object_type),
         _ => None,
     })
-}
-
-/// Returns all interface definitions in the schema.
-pub fn get_interface_type_definitions(schema: &Document) -> Vec<&InterfaceType> {
-    schema
-        .definitions
-        .iter()
-        .filter_map(|d| match d {
-            Definition::TypeDefinition(TypeDefinition::Interface(t)) => Some(t),
-            _ => None,
-        })
-        .collect()
 }
 
 /// Returns the interface type with the given name.


### PR DESCRIPTION
Closes #2498

Validates usage of reserved types in `Schema::validate`, aiming to provide clearer error messages when an input schema uses said types. Adds a new variant to `SchemaValidationError`.

There's also been changes to `DocumentExt` and `ast.rs`:
* `get_object_type_definitions` in `ast.rs` was duplicated and removed in favour of `Document`'s implementation of `get_object_type_definitions`
* `get_interface_type_definitions` was added to `DocumentExt` and removed from `ast.rs`