### PR TITLE
graphql: remove duplication of `get_named_type`

### DIFF
--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -633,7 +633,7 @@ fn coerce_variable(
 ) -> Result<q::Value, Vec<QueryExecutionError>> {
     use crate::values::coercion::coerce_value;
 
-    let resolver = |name: &str| sast::get_named_type(schema.document(), name);
+    let resolver = |name: &str| schema.document().get_named_type(name);
 
     coerce_value(value, &variable_def.var_type, &resolver, &HashMap::new()).map_err(|value| {
         vec![QueryExecutionError::InvalidArgumentError(


### PR DESCRIPTION
Fixes #2652

There's currently a redundant implementation for `get_named_type`:

https://github.com/graphprotocol/graph-node/blob/42bd19e47a94d9900b4fdb18619f69482003543a/graph/src/data/graphql/ext.rs#L169-L184

https://github.com/graphprotocol/graph-node/blob/42bd19e47a94d9900b4fdb18619f69482003543a/graphql/src/schema/ast.rs#L169-L185

There's also a third `get_named_type` in `graphql/src/execution/execution.rs`: 

https://github.com/graphprotocol/graph-node/blob/42bd19e47a94d9900b4fdb18619f69482003543a/graphql/src/execution/execution.rs#L236-L242

This one _has been kept_, as well as references to it, as to still allow for look-ups into the introspection document.

Usages of the removed `get_named_type` function were replaced