### PR TITLE
ethereum: Don't use cached block on `is_on_main_chain`

### DIFF
--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -613,16 +613,10 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     fn block_pointer_from_number(
         &self,
         logger: &Logger,
-        chain_store: Arc<dyn ChainStore>,
         block_number: BlockNumber,
     ) -> Box<dyn Future<Item = BlockPtr, Error = bc::IngestorError> + Send>;
 
-    /// Find a block by its number. The `block_is_final` flag indicates whether
-    /// it is ok to remove blocks in the block cache with that number but with
-    /// a different hash which were left over from reorgs we saw before we
-    /// settled on a final block. Since our overall logic depends on being
-    /// able to access uncled blocks back to the main chain when we revert
-    /// blocks, we need to make sure we keep those in the block cache
+    /// Find a block by its number, according to the Ethereum node.
     ///
     /// Careful: don't use this function without considering race conditions.
     /// Chain reorgs could happen at any time, and could affect the answer received.
@@ -634,9 +628,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     fn block_hash_by_block_number(
         &self,
         logger: &Logger,
-        chain_store: Arc<dyn ChainStore>,
         block_number: BlockNumber,
-        block_is_final: bool,
     ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send>;
 
     /// Obtain all uncle blocks for a given block hash.

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -250,7 +250,7 @@ impl Blockchain for Chain {
             .with_context(|| format!("no adapter for chain {}", self.name))?
             .clone();
         eth_adapter
-            .block_pointer_from_number(logger, self.chain_store.cheap_clone(), number)
+            .block_pointer_from_number(logger, number)
             .compat()
             .await
     }
@@ -390,7 +390,7 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
 
     async fn is_on_main_chain(&self, ptr: BlockPtr) -> Result<bool, Error> {
         self.eth_adapter
-            .is_on_main_chain(&self.logger, self.chain_store.clone(), ptr.clone())
+            .is_on_main_chain(&self.logger, ptr.clone())
             .await
     }
 

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -96,7 +96,7 @@ mod test {
                 let node_id = NodeId::new("test").unwrap();
                 let mut server = HyperGraphQLServer::new(&logger_factory, metrics_registry, query_runner, node_id);
                 let http_server = server
-                    .serve(8001, 8002)
+                    .serve(8007, 8008)
                     .expect("Failed to start GraphQL server");
 
                 // Launch the server to handle a single request
@@ -107,7 +107,7 @@ mod test {
                         // Send an empty JSON POST request
                         let client = Client::new();
                         let request =
-                            Request::post(format!("http://localhost:8001/subgraphs/id/{}", id))
+                            Request::post(format!("http://localhost:8007/subgraphs/id/{}", id))
                                 .body(Body::from("{}"))
                                 .unwrap();
 


### PR DESCRIPTION
As it turns out, the optimization in https://github.com/graphprotocol/graph-node/pull/1477 was incorrect wrt reverts.

The block stream relies on this function to check with the Ethereum node if a block is on the main chain, but it is assuming that the block being checked is final if it is past the reorg threshold. If the current subgraph head is in the cache when passed into `is_on_main_chain`, as long as it is present in the block cache it will be assumed to be final, which can lead to it not being reverted when it should be.

The most likely way for this bug to affect a subgraph is if a large reorg happens, such that by the time the last blocks are having the reorg processed by graph node they have fallen out of the threshold and are passed into `is_on_main_chain` and considered final. Since mainnet does not see large reorgs relative to the threshold this should not affect subgraphs currently on the network. In the hosted service, I have seen a Ropsten subgraph affected during a 200 block reorg, which was how I became aware of this bug.

The fix is to basically revert https://github.com/graphprotocol/graph-node/pull/1477.
