### PR TITLE
ethereum: Support Celo block reward events

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -790,6 +790,10 @@ impl EthereumAdapter {
                 .collect(),
         )
     }
+
+    pub async fn chain_id(&self) -> Result<u64, Error> {
+        Ok(u64::try_from(self.web3.eth().chain_id().compat().await?).unwrap())
+    }
 }
 
 #[async_trait]

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -459,7 +459,8 @@ where
                 ctx.state.filter.clone(),
                 ctx.block_stream_metrics.clone(),
                 ctx.inputs.unified_api_version.clone(),
-            )?
+            )
+            .await?
             .map_err(CancelableError::Error)
             .cancelable(&block_stream_canceler, || CancelableError::Cancel)
             .compat();

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -97,7 +97,7 @@ pub trait Blockchain: Debug + Sized + Send + Sync + 'static {
         stopwatch_metrics: StopwatchMetrics,
     ) -> Result<Arc<Self::TriggersAdapter>, Error>;
 
-    fn new_block_stream(
+    async fn new_block_stream(
         &self,
         deployment: DeploymentLocator,
         start_blocks: Vec<BlockNumber>,


### PR DESCRIPTION
Celo has special events that have the transaction hash == block hash and are returned from eth_getLogs but not included as transaction receipts. See code comments for details.

Closes #2648. Closes #2353.