### PR TITLE
Sf/block stream future03

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+
 # Contributing to graph-node
 
 Welcome to the Graph Protocol! Thanks a ton for your interest in contributing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,27 +14,27 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.14.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
-dependencies = [
- "gimli 0.23.0",
-]
-
-[[package]]
-name = "addr2line"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03345e98af8f3d786b6d9f656ccfa6ac316d954e92bc4841f0bba20789d5fb5a"
+checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
 dependencies = [
  "gimli 0.24.0",
 ]
 
 [[package]]
-name = "adler"
-version = "0.2.3"
+name = "addr2line"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+dependencies = [
+ "gimli 0.25.0",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
@@ -65,15 +65,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
 
 [[package]]
 name = "arrayref"
@@ -109,13 +109,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -149,15 +149,16 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.57"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ed203b9ba68b242c62b3fb7480f589dd49829be1edb3fe8fc8b4ffda2dcb8d"
+checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
 dependencies = [
- "addr2line 0.14.1",
+ "addr2line 0.16.0",
+ "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.23.0",
+ "object 0.26.0",
  "rustc-demangle",
 ]
 
@@ -170,12 +171,6 @@ dependencies = [
  "byteorder",
  "safemem",
 ]
-
-[[package]]
-name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
@@ -203,11 +198,10 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "byteorder",
  "serde",
 ]
 
@@ -234,17 +228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
 name = "blake3"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,19 +239,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "constant_time_eq",
  "crypto-mac 0.8.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
+ "digest",
 ]
 
 [[package]]
@@ -277,16 +248,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "generic-array",
 ]
 
 [[package]]
@@ -304,19 +266,19 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 0.2.3",
- "hyper 0.14.5",
+ "http 0.2.4",
+ "hyper 0.14.11",
  "hyper-unix-connector",
- "log 0.4.11",
- "pin-project 1.0.5",
+ "log 0.4.14",
+ "pin-project",
  "serde",
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
  "thiserror",
- "tokio 1.8.1",
- "tokio-util 0.6.3",
- "url 2.2.1",
+ "tokio 1.9.0",
+ "tokio-util",
+ "url 2.2.2",
  "winapi 0.3.9",
 ]
 
@@ -339,18 +301,18 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.4.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byte-slice-cast"
@@ -359,16 +321,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-
-[[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -395,9 +351,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.62"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 dependencies = [
  "jobserver",
 ]
@@ -449,15 +405,6 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.2.1",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags 1.2.1",
 ]
@@ -522,19 +469,21 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44919ecaf6f99e8e737bc239408931c9a01e9a6c74814fee8242dd2506b65390"
+checksum = "8ea47428dc9d2237f3c6bc134472edfd63ebba0af932e783506dcfd66f10d18a"
 dependencies = [
  "cfg-if 1.0.0",
- "glob",
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.2"
+name = "cpufeatures"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cranelift-bforest"
@@ -556,7 +505,7 @@ dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
  "gimli 0.24.0",
- "log 0.4.11",
+ "log 0.4.14",
  "regalloc",
  "serde",
  "smallvec 1.6.1",
@@ -598,7 +547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b783b351f966fce33e3c03498cb116d16d97a8f9978164a60920bd0d3a99c"
 dependencies = [
  "cranelift-codegen",
- "log 0.4.11",
+ "log 0.4.14",
  "smallvec 1.6.1",
  "target-lexicon",
 ]
@@ -623,7 +572,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "itertools",
- "log 0.4.11",
+ "log 0.4.14",
  "serde",
  "smallvec 1.6.1",
  "thiserror",
@@ -646,21 +595,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-channel 0.5.1",
- "crossbeam-deque 0.8.0",
+ "crossbeam-channel",
+ "crossbeam-deque 0.8.1",
  "crossbeam-epoch 0.9.5",
  "crossbeam-queue 0.3.2",
  "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
 ]
 
 [[package]]
@@ -675,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
 dependencies = [
  "crossbeam-epoch 0.8.2",
  "crossbeam-utils 0.7.2",
@@ -686,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch 0.9.5",
@@ -719,7 +658,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.5",
  "lazy_static",
- "memoffset 0.6.3",
+ "memoffset 0.6.4",
  "scopeguard",
 ]
 
@@ -777,17 +716,17 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
  "subtle",
 ]
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
  "subtle",
 ]
 
@@ -802,12 +741,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.16"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -822,12 +761,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06d4a9551359071d1890820e3571252b91229e0712e7c36b08940e603c5a8fc"
+checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
 dependencies = [
- "darling_core 0.12.2",
- "darling_macro 0.12.2",
+ "darling_core 0.13.0",
+ "darling_macro 0.13.0",
 ]
 
 [[package]]
@@ -845,16 +784,16 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b443e5fb0ddd56e0c9bfa47dc060c5306ee500cb731f2b91432dd65589a77684"
+checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
  "strsim 0.10.0",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -870,13 +809,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0220073ce504f12a70efc4e7cdaea9e9b1b324872e7ad96a208056d7a638b81"
+checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
- "darling_core 0.12.2",
+ "darling_core 0.13.0",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -887,14 +826,15 @@ checksum = "647605a6345d5e89c3950a36a638c56478af9b414c55c6f2477c73b115f9acde"
 
 [[package]]
 name = "derive_more"
-version = "0.99.14"
+version = "0.99.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc7b9cef1e351660e5443924e4f43ab25fbbed3e9a5f052df3677deb4d6b320"
+checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "rustc_version 0.3.3",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -937,9 +877,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70806b70be328e646f243680a3fc93b3cfdd6db373faa5110660a5dd5af243bc"
 dependencies = [
  "heck",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -956,9 +896,9 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -985,20 +925,11 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -1012,16 +943,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
-dependencies = [
- "cfg-if 0.1.10",
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,21 +953,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
-dependencies = [
- "libc",
- "redox_users",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "dirs-sys-next"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
@@ -1061,9 +971,9 @@ checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "dtoa"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
@@ -1073,23 +983,11 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.26"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
-dependencies = [
- "heck",
- "proc-macro2 1.0.24",
- "quote 1.0.9",
- "syn 1.0.67",
 ]
 
 [[package]]
@@ -1100,7 +998,7 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
  "humantime 1.3.0",
- "log 0.4.11",
+ "log 0.4.14",
  "regex",
  "termcolor",
 ]
@@ -1112,8 +1010,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
- "humantime 2.0.1",
- "log 0.4.11",
+ "humantime 2.1.0",
+ "log 0.4.14",
  "regex",
  "termcolor",
 ]
@@ -1206,7 +1104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
 dependencies = [
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.14",
  "rand 0.7.3",
 ]
 
@@ -1226,17 +1124,11 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
  "synstructure",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fallible-iterator"
@@ -1251,7 +1143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fdbe0d94371f9ce939b555dd342d0686cc4c0cadbcd4b61d70af5ff97eb4126"
 dependencies = [
  "env_logger 0.7.1",
- "log 0.4.11",
+ "log 0.4.14",
 ]
 
 [[package]]
@@ -1316,9 +1208,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding 2.1.0",
@@ -1360,9 +1252,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1375,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1385,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "futures-cpupool"
@@ -1401,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1412,40 +1304,42 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
+ "autocfg 1.0.1",
  "proc-macro-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
+ "autocfg 1.0.1",
  "futures 0.1.31",
  "futures-channel",
  "futures-core",
@@ -1454,11 +1348,11 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
- "slab 0.4.2",
+ "slab 0.4.3",
 ]
 
 [[package]]
@@ -1469,50 +1363,35 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check 0.9.2",
+ "version_check 0.9.3",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "gimli"
@@ -1524,6 +1403,12 @@ dependencies = [
  "indexmap",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "git-testament"
@@ -1542,28 +1427,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45ceded7b01141664c3fc4a50199c408a6ed247e6c8415dc005e895f1d233374"
 dependencies = [
  "chrono",
- "log 0.4.11",
- "proc-macro2 1.0.24",
+ "log 0.4.14",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
 name = "globset"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
 dependencies = [
  "aho-corasick",
  "bstr",
  "fnv",
- "log 0.4.11",
+ "log 0.4.14",
  "regex",
 ]
 
@@ -1576,17 +1455,17 @@ dependencies = [
  "async-trait",
  "atomic_refcell",
  "bigdecimal",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "chrono",
  "diesel",
  "diesel_derives",
  "ethabi 12.0.0-graph",
  "fail",
  "futures 0.1.31",
- "futures 0.3.13",
+ "futures 0.3.16",
  "graphql-parser",
  "hex",
- "http 0.2.3",
+ "http 0.2.4",
  "isatty",
  "itertools",
  "lazy_static",
@@ -1601,7 +1480,7 @@ dependencies = [
  "prometheus",
  "rand 0.6.5",
  "reqwest",
- "semver 1.0.3",
+ "semver 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1617,10 +1496,10 @@ dependencies = [
  "test-store",
  "thiserror",
  "tiny-keccak 1.5.0",
- "tokio 0.2.25",
+ "tokio 1.9.0",
  "tokio-retry",
  "tokio-stream",
- "url 2.2.1",
+ "url 2.2.2",
  "wasmparser",
  "web3",
 ]
@@ -1647,7 +1526,7 @@ dependencies = [
  "lazy_static",
  "mockall 0.9.1",
  "pretty_assertions",
- "semver 1.0.3",
+ "semver 1.0.4",
  "serde",
  "state_machine_future",
  "test-store",
@@ -1665,7 +1544,7 @@ dependencies = [
  "bytes 0.5.6",
  "fail",
  "futures 0.1.31",
- "futures 0.3.13",
+ "futures 0.3.16",
  "graph",
  "graph-chain-ethereum",
  "graph-mock",
@@ -1675,7 +1554,7 @@ dependencies = [
  "lazy_static",
  "lru_time_cache",
  "pretty_assertions",
- "semver 1.0.3",
+ "semver 1.0.4",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1722,11 +1601,11 @@ version = "0.23.1"
 dependencies = [
  "assert_cli",
  "clap",
- "crossbeam-channel 0.5.1",
+ "crossbeam-channel",
  "diesel",
  "env_logger 0.9.0",
  "fail",
- "futures 0.3.13",
+ "futures 0.3.16",
  "git-testament",
  "graph",
  "graph-chain-ethereum",
@@ -1748,7 +1627,7 @@ dependencies = [
  "shellexpand",
  "structopt",
  "toml",
- "url 2.2.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -1757,7 +1636,7 @@ version = "0.23.1"
 dependencies = [
  "anyhow",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -1769,7 +1648,7 @@ dependencies = [
  "graph-core",
  "graph-mock",
  "graph-runtime-wasm",
- "semver 1.0.3",
+ "semver 1.0.4",
  "test-store",
  "wasmtime",
 ]
@@ -1782,6 +1661,7 @@ dependencies = [
  "async-trait",
  "atomic_refcell",
  "bs58",
+ "bytes 1.0.1",
  "defer",
  "ethabi 12.0.0-graph",
  "futures 0.1.31",
@@ -1791,10 +1671,10 @@ dependencies = [
  "hex",
  "lazy_static",
  "never",
- "semver 1.0.3",
+ "semver 1.0.4",
  "strum",
  "strum_macros",
- "uuid 0.8.1",
+ "uuid 0.8.2",
  "wasmtime",
 ]
 
@@ -1807,8 +1687,8 @@ dependencies = [
  "graph-graphql",
  "graph-mock",
  "graphql-parser",
- "http 0.2.3",
- "hyper 0.13.10",
+ "http 0.2.4",
+ "hyper 0.14.11",
  "serde",
 ]
 
@@ -1816,12 +1696,12 @@ dependencies = [
 name = "graph-server-index-node"
 version = "0.23.1"
 dependencies = [
- "futures 0.3.13",
+ "futures 0.3.16",
  "graph",
  "graph-graphql",
  "graphql-parser",
- "http 0.2.3",
- "hyper 0.13.10",
+ "http 0.2.4",
+ "hyper 0.14.11",
  "serde",
 ]
 
@@ -1841,8 +1721,8 @@ version = "0.23.1"
 dependencies = [
  "futures 0.1.31",
  "graph",
- "http 0.2.3",
- "hyper 0.13.10",
+ "http 0.2.4",
+ "hyper 0.14.11",
  "lazy_static",
  "serde",
 ]
@@ -1855,7 +1735,7 @@ dependencies = [
  "futures 0.1.31",
  "graph",
  "graphql-parser",
- "http 0.2.3",
+ "http 0.2.4",
  "lazy_static",
  "serde",
  "serde_derive",
@@ -1898,7 +1778,7 @@ dependencies = [
  "serde",
  "stable-hash",
  "test-store",
- "uuid 0.8.1",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1907,10 +1787,10 @@ version = "0.23.1"
 dependencies = [
  "anyhow",
  "bollard",
- "futures 0.3.13",
+ "futures 0.3.16",
  "lazy_static",
  "port_check",
- "tokio 1.8.1",
+ "tokio 1.9.0",
  "tokio-stream",
 ]
 
@@ -1935,48 +1815,28 @@ dependencies = [
  "futures 0.1.31",
  "http 0.1.21",
  "indexmap",
- "log 0.4.11",
- "slab 0.4.2",
+ "log 0.4.14",
+ "slab 0.4.3",
  "string",
  "tokio-io",
 ]
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.3",
- "indexmap",
- "slab 0.4.2",
- "tokio 0.2.25",
- "tokio-util 0.3.1",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.3",
+ "http 0.2.4",
  "indexmap",
- "slab 0.4.2",
- "tokio 1.8.1",
- "tokio-util 0.6.3",
+ "slab 0.4.3",
+ "tokio 1.9.0",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1988,18 +1848,18 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -2022,19 +1882,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac 0.10.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi 0.3.9",
+ "crypto-mac 0.10.1",
+ "digest",
 ]
 
 [[package]]
@@ -2050,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -2073,35 +1922,26 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
-dependencies = [
- "bytes 0.5.6",
- "http 0.2.3",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes 1.0.1",
- "http 0.2.3",
+ "http 0.2.4",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.4"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "humantime"
@@ -2114,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -2152,9 +1992,9 @@ dependencies = [
  "httparse",
  "iovec",
  "itoa",
- "log 0.4.11",
+ "log 0.4.14",
  "net2",
- "rustc_version",
+ "rustc_version 0.2.3",
  "time",
  "tokio 0.1.22",
  "tokio-buf",
@@ -2169,47 +2009,23 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.10"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
-dependencies = [
- "bytes 0.5.6",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.2.7",
- "http 0.2.3",
- "http-body 0.3.1",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project 1.0.5",
- "socket2 0.3.16",
- "tokio 0.2.25",
- "tower-service",
- "tracing",
- "want 0.3.0",
-]
-
-[[package]]
-name = "hyper"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.1",
- "http 0.2.3",
- "http-body 0.4.0",
+ "h2 0.3.3",
+ "http 0.2.4",
+ "http-body 0.4.2",
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
- "socket2 0.4.0",
- "tokio 1.8.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio 1.9.0",
  "tower-service",
  "tracing",
  "want 0.3.0",
@@ -2230,15 +2046,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 0.5.6",
- "hyper 0.13.10",
+ "bytes 1.0.1",
+ "hyper 0.14.11",
  "native-tls",
- "tokio 0.2.25",
- "tokio-tls 0.3.1",
+ "tokio 1.9.0",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -2249,20 +2065,21 @@ checksum = "24ef1fd95d34b4ff007d3f0590727b5cf33572cace09b42032fc817dc8b16557"
 dependencies = [
  "anyhow",
  "hex",
- "hyper 0.14.5",
- "pin-project 1.0.5",
- "tokio 1.8.1",
+ "hyper 0.14.11",
+ "pin-project",
+ "tokio 1.9.0",
 ]
 
 [[package]]
 name = "ibig"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42ebaad57c538d4ae7331331511bb4abaadcb7286d8ebf13cb4371fdea90e3b"
+checksum = "61c5022ee7f7a2feb0bd2fdc4b8ec882cd14903cebf33e7c1847e3f3a282f8b7"
 dependencies = [
+ "cfg-if 1.0.0",
  "const_fn_assert",
  "num-traits",
- "rand 0.8.3",
+ "rand 0.8.4",
  "static_assertions",
 ]
 
@@ -2285,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -2334,18 +2151,18 @@ dependencies = [
 
 [[package]]
 name = "input_buffer"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
+checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
 ]
 
 [[package]]
 name = "instant"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -2360,22 +2177,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipconfig"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
-dependencies = [
- "socket2 0.3.16",
- "widestring",
- "winapi 0.3.9",
- "winreg 0.6.2",
-]
-
-[[package]]
 name = "ipnet"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "isatty"
@@ -2385,7 +2190,7 @@ checksum = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "winapi 0.3.9",
 ]
 
@@ -2400,24 +2205,24 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jobserver"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2429,7 +2234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
 dependencies = [
  "futures 0.1.31",
- "log 0.4.11",
+ "log 0.4.14",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2444,7 +2249,7 @@ dependencies = [
  "hyper 0.12.36",
  "jsonrpc-core",
  "jsonrpc-server-utils",
- "log 0.4.11",
+ "log 0.4.14",
  "net2",
  "parking_lot 0.10.2",
  "unicase 2.6.0",
@@ -2460,7 +2265,7 @@ dependencies = [
  "globset",
  "jsonrpc-core",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.14",
  "tokio 0.1.22",
  "tokio-codec",
  "unicase 2.6.0",
@@ -2496,15 +2301,15 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -2517,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -2530,32 +2335,23 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.14",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "lru_time_cache"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991058cf0e7f161b37a4a610ddbada9d2f051d0db76369b973de9f3466f1cba3"
+checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
 name = "mach"
@@ -2571,12 +2367,6 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
@@ -2602,9 +2392,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "block-buffer",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -2624,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -2647,9 +2437,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
 dependencies = [
  "migrations_internals",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -2679,9 +2469,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg 1.0.1",
@@ -2699,22 +2489,22 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.11",
+ "log 0.4.14",
  "miow 0.2.2",
  "net2",
- "slab 0.4.2",
+ "slab 0.4.3",
  "winapi 0.2.8",
 ]
 
 [[package]]
 name = "mio"
-version = "0.7.9"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
- "log 0.4.11",
- "miow 0.3.6",
+ "log 0.4.14",
+ "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
 ]
@@ -2744,11 +2534,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2 0.3.16",
  "winapi 0.3.9",
 ]
 
@@ -2789,9 +2578,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c461918bf7f59eefb1459252756bf2351a995d6bd510d0b2061bd86bcdabfa6"
 dependencies = [
  "cfg-if 0.1.10",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -2801,9 +2590,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd4234635bca06fc96c7368d038061e0aae1b00a764dc817e900dc974e3deea"
 dependencies = [
  "cfg-if 1.0.0",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -2820,7 +2609,7 @@ checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.11",
+ "log 0.4.14",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -2911,18 +2700,21 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
-
-[[package]]
-name = "object"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
 dependencies = [
  "crc32fast",
  "indexmap",
+]
+
+[[package]]
+name = "object"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2933,41 +2725,35 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
 dependencies = [
  "bitflags 1.2.1",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.58"
+version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -2993,9 +2779,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.5"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
+checksum = "a4b26b16c7687c3075982af47719e481815df30bc544f7a6690763a25ca16e9d"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -3011,7 +2797,7 @@ checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
  "lock_api 0.3.4",
  "parking_lot_core 0.6.2",
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -3031,8 +2817,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
- "lock_api 0.4.1",
- "parking_lot_core 0.8.0",
+ "lock_api 0.4.4",
+ "parking_lot_core 0.8.3",
 ]
 
 [[package]]
@@ -3042,11 +2828,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if 0.1.10",
- "cloudabi 0.0.3",
+ "cloudabi",
  "libc",
- "redox_syscall",
- "rustc_version",
- "smallvec 0.6.13",
+ "redox_syscall 0.1.57",
+ "rustc_version 0.2.3",
+ "smallvec 0.6.14",
  "winapi 0.3.9",
 ]
 
@@ -3057,24 +2843,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if 0.1.10",
- "cloudabi 0.0.3",
+ "cloudabi",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi 0.1.0",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.9",
  "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
@@ -3096,6 +2881,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "petgraph"
@@ -3137,55 +2931,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.28"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
 dependencies = [
- "pin-project-internal 0.4.28",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
-dependencies = [
- "pin-project-internal 1.0.5",
+ "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.28"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -3213,9 +2981,9 @@ checksum = "c7871ee579860d8183f542e387b176a25f2656b9fb5211e045397f745a68d1c2"
 dependencies = [
  "bytes 1.0.1",
  "fallible-iterator",
- "futures 0.3.13",
- "log 0.4.11",
- "tokio 1.8.1",
+ "futures 0.3.16",
+ "log 0.4.14",
+ "tokio 1.9.0",
  "tokio-postgres",
 ]
 
@@ -3232,7 +3000,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.8.3",
+ "rand 0.8.4",
  "sha2",
  "stringprep",
 ]
@@ -3265,9 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
+checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
 dependencies = [
  "difference",
  "float-cmp",
@@ -3278,15 +3046,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+checksum = "15f553275e5721409451eb85e15fd9a860a6e5ab4496eb215987502b5f5391f2"
 dependencies = [
  "predicates-core",
  "treeline",
@@ -3334,10 +3102,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
- "version_check 0.9.2",
+ "syn 1.0.74",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -3346,9 +3114,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "version_check 0.9.2",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -3359,9 +3127,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -3374,11 +3142,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
- "unicode-xid 0.2.1",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -3398,15 +3166,15 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.18.0"
+version = "2.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d147edb77bcccbfc81fabffdc7bd50c13e103b15ca1e27515fe40de69a5776b"
+checksum = "db50e77ae196458ccd3dc58a31ea1a90b0698ab1b7928d89f644c25d72070267"
 
 [[package]]
 name = "psm"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e0536f6528466dbbbbe6b986c34175a8d0ff25b794c4bacda22e068cd2f2c5"
+checksum = "14ce37fa8c0428a37307d163292add09b3aedc003472e6b3622486878404191d"
 dependencies = [
  "cc",
 ]
@@ -3432,7 +3200,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
 ]
 
 [[package]]
@@ -3441,7 +3209,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.14",
  "parking_lot 0.11.1",
  "scheduled-thread-pool",
 ]
@@ -3454,24 +3222,11 @@ checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 dependencies = [
- "cloudabi 0.0.3",
+ "cloudabi",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.3.1",
@@ -3503,7 +3258,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -3512,14 +3267,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.2",
- "rand_hc 0.3.0",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -3544,12 +3299,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3573,16 +3328,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -3605,11 +3360,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3638,7 +3393,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "cloudabi 0.0.3",
+ "cloudabi",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.4.2",
@@ -3667,24 +3422,24 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg 1.0.1",
- "crossbeam-deque 0.8.0",
+ "crossbeam-deque 0.8.1",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
- "crossbeam-channel 0.5.1",
- "crossbeam-deque 0.8.0",
+ "crossbeam-channel",
+ "crossbeam-deque 0.8.1",
  "crossbeam-utils 0.8.5",
  "lazy_static",
  "num_cpus",
@@ -3706,14 +3461,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
-name = "redox_users"
-version = "0.3.5"
+name = "redox_syscall"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
- "getrandom 0.1.15",
- "redox_syscall",
- "rust-argon2",
+ "bitflags 1.2.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.3",
+ "redox_syscall 0.2.9",
 ]
 
 [[package]]
@@ -3722,7 +3485,7 @@ version = "0.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.14",
  "rustc-hash",
  "serde",
  "smallvec 1.6.1",
@@ -3774,49 +3537,38 @@ checksum = "05a51ad2b1c5c710fa89e6b1631068dab84ed687bc6a5fe061ad65da3d0c25b2"
 
 [[package]]
 name = "reqwest"
-version = "0.10.10"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "base64 0.13.0",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http 0.2.3",
- "http-body 0.3.1",
- "hyper 0.13.10",
- "hyper-tls 0.4.3",
+ "http 0.2.4",
+ "http-body 0.4.2",
+ "hyper 0.14.11",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.14",
  "mime 0.3.16",
  "mime_guess",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.25",
- "tokio-tls 0.3.1",
- "trust-dns-resolver",
- "url 2.2.1",
+ "tokio 1.9.0",
+ "tokio-native-tls",
+ "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.7.0",
-]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
-dependencies = [
- "hostname",
- "quick-error",
+ "winreg",
 ]
 
 [[package]]
@@ -3844,22 +3596,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-argon2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
-dependencies = [
- "base64 0.12.3",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils 0.7.2",
-]
-
-[[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
 name = "rustc-hash"
@@ -3881,6 +3621,21 @@ checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
 ]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
@@ -3945,20 +3700,20 @@ dependencies = [
 
 [[package]]
 name = "scroll_derive"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12bd20b94c7cdfda8c7ba9b92ad0d9a56e3fa018c25fca83b51aa664c9b4c0d"
+checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
@@ -3982,9 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.0.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",
@@ -3995,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
+checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4009,14 +3764,23 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "semver-parser"
@@ -4025,30 +3789,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "serde"
-version = "1.0.126"
+name = "semver-parser"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -4079,24 +3852,25 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.6.4"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44be9227e214a0420707c9ca74c2d4991d9955bae9415a8f93f05cebf561be5"
+checksum = "1ad9fdbb69badc8916db738c25efd04f0a65297d26c2f8de4b62e57b8c12bc72"
 dependencies = [
+ "rustversion",
  "serde",
  "serde_with_macros",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48b35457e9d855d3dc05ef32a73e0df1e2c0fd72c38796a4ee909160c8eeec2"
+checksum = "e1569374bd54623ec8bd592cf22ba6e03c0f177ff55fbc8c29a49e296e7adecf"
 dependencies = [
- "darling 0.12.2",
- "proc-macro2 1.0.24",
+ "darling 0.13.0",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -4113,14 +3887,15 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.8.2"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+checksum = "1a0c8611594e2ab4ebbf06ec7cbbf0a99450b8570e96cbf5188b5d5f6ef18d81"
 dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4131,15 +3906,15 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
- "cpuid-bool",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4153,18 +3928,18 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "siphasher"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
+checksum = "729a25c17d72b06c68cb47955d44fda88ad2d3e7d77e025663fdd69b93dd71a1"
 
 [[package]]
 name = "slab"
@@ -4174,9 +3949,9 @@ checksum = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "slog"
@@ -4186,11 +3961,11 @@ checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 
 [[package]]
 name = "slog-async"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b3336ce47ce2f96673499fc07eb85e3472727b9a7a2959964b002c2ce8fbbb"
+checksum = "766c59b252e62a34651412870ff55d8c4e6d04df19b43eecb2703e417b097ffe"
 dependencies = [
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "slog",
  "take_mut",
  "thread_local",
@@ -4202,7 +3977,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "906a1a0bc43fed692df4b82a5e2fbfc3733db8dad8bb514ab27a4f23ad04f5c0"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.14",
  "regex",
  "slog",
  "slog-async",
@@ -4213,9 +3988,9 @@ dependencies = [
 
 [[package]]
 name = "slog-scope"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c44c89dd8b0ae4537d1ae318353eaf7840b4869c536e31c41e963d1ea523ee6"
+checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
 dependencies = [
  "arc-swap",
  "lazy_static",
@@ -4228,16 +4003,16 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8228ab7302adbf4fcb37e66f3cda78003feb521e7fd9e3847ec117a7784d0f5a"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.14",
  "slog",
  "slog-scope",
 ]
 
 [[package]]
 name = "slog-term"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76d88c965d3c60da712ef89ba2bca3fd118ed6dead726a9b7153eaddd7a56b1"
+checksum = "95c1e7e5aab61ced6006149ea772770b84a0d16ce0f7885def313e4829946d76"
 dependencies = [
  "atty",
  "chrono",
@@ -4248,9 +4023,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
 dependencies = [
  "maybe-uninit",
 ]
@@ -4263,21 +4038,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.3.16"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "redox_syscall",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -4375,9 +4138,9 @@ checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -4393,16 +4156,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
 dependencies = [
  "heck",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -4417,25 +4180,25 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.67"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "unicode-xid 0.2.1",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
 name = "synstructure"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
- "unicode-xid 0.2.1",
+ "syn 1.0.74",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -4446,31 +4209,32 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
+checksum = "b0652da4c4121005e9ed22b79f6c5f2d9e2752906b53a33e9490489ba421a6fb"
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
- "redox_syscall",
+ "rand 0.8.4",
+ "redox_syscall 0.2.9",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "term"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
- "dirs",
+ "dirs-next",
+ "rustversion",
  "winapi 0.3.9",
 ]
 
@@ -4486,9 +4250,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
@@ -4521,31 +4285,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -4579,9 +4343,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.0.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4618,41 +4382,20 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.25"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "libc",
- "memchr",
- "mio 0.6.23",
- "mio-uds",
- "num_cpus",
- "pin-project-lite 0.1.11",
- "slab 0.4.2",
- "tokio-macros 0.2.6",
-]
-
-[[package]]
-name = "tokio"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
  "libc",
  "memchr",
- "mio 0.7.9",
+ "mio 0.7.13",
  "num_cpus",
  "once_cell",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "signal-hook-registry",
- "tokio-macros 1.1.0",
+ "tokio-macros",
  "winapi 0.3.9",
 ]
 
@@ -4680,14 +4423,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
+checksum = "87b1395334443abca552f63d4f61d0486f12377c2ba8b368e523f89e828cffd4"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
  "iovec",
- "log 0.4.11",
+ "log 0.4.14",
  "mio 0.6.23",
  "scoped-tls",
  "tokio 0.1.22",
@@ -4736,52 +4479,51 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "log 0.4.11",
+ "log 0.4.14",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.6"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
 ]
 
 [[package]]
-name = "tokio-macros"
-version = "1.1.0"
+name = "tokio-native-tls"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.9",
- "syn 1.0.67",
+ "native-tls",
+ "tokio 1.9.0",
 ]
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98779a950cb6ef76f8ad71c411176115c5c1200a83eeeca4dd9f61e3fc4836c8"
+checksum = "2d2b1383c7e4fb9a09e292c7c6afb7da54418d53b045f1c1fac7a911411a2b8b"
 dependencies = [
  "async-trait",
  "byteorder",
  "bytes 1.0.1",
  "fallible-iterator",
- "futures 0.3.13",
- "log 0.4.11",
+ "futures 0.3.16",
+ "log 0.4.14",
  "parking_lot 0.11.1",
  "percent-encoding 2.1.0",
  "phf",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2 0.4.0",
- "tokio 1.8.1",
- "tokio-util 0.6.3",
+ "socket2",
+ "tokio 1.9.0",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4793,11 +4535,11 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.14",
  "mio 0.6.23",
  "num_cpus",
  "parking_lot 0.9.0",
- "slab 0.4.2",
+ "slab 0.4.3",
  "tokio-executor",
  "tokio-io",
  "tokio-sync",
@@ -4805,13 +4547,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-retry"
-version = "0.2.0"
-source = "git+https://github.com/graphprotocol/rust-tokio-retry?branch=update-to-tokio-02#fc0e868bdc7ff79ac84cf502d4cec20c5ce5adaf"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
- "futures 0.1.31",
- "futures 0.3.13",
- "rand 0.4.6",
- "tokio 0.2.25",
+ "pin-project",
+ "rand 0.8.4",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -4821,9 +4563,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.6",
- "tokio 1.8.1",
- "tokio-util 0.6.3",
+ "pin-project-lite",
+ "tokio 1.9.0",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4856,14 +4598,14 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 dependencies = [
- "crossbeam-deque 0.7.3",
+ "crossbeam-deque 0.7.4",
  "crossbeam-queue 0.2.3",
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
  "lazy_static",
- "log 0.4.11",
+ "log 0.4.14",
  "num_cpus",
- "slab 0.4.2",
+ "slab 0.4.3",
  "tokio-executor",
 ]
 
@@ -4885,7 +4627,7 @@ checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.31",
- "slab 0.4.2",
+ "slab 0.4.3",
  "tokio-executor",
 ]
 
@@ -4901,25 +4643,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio 0.2.25",
-]
-
-[[package]]
 name = "tokio-tungstenite"
-version = "0.10.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
+checksum = "1e96bb520beab540ab664bd5a9cfeaa1fcd846fa68c830b42e2c8963071251d2"
 dependencies = [
- "futures 0.3.13",
- "log 0.4.11",
- "pin-project 0.4.28",
- "tokio 0.2.25",
+ "futures-util",
+ "log 0.4.14",
+ "pin-project",
+ "tokio 1.9.0",
  "tungstenite",
 ]
 
@@ -4931,7 +4663,7 @@ checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "log 0.4.11",
+ "log 0.4.14",
  "mio 0.6.23",
  "tokio-codec",
  "tokio-io",
@@ -4965,7 +4697,7 @@ dependencies = [
  "futures 0.1.31",
  "iovec",
  "libc",
- "log 0.4.11",
+ "log 0.4.14",
  "mio 0.6.23",
  "mio-uds",
  "tokio-codec",
@@ -4975,76 +4707,51 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.3.1"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "futures-sink",
- "log 0.4.11",
- "pin-project-lite 0.1.11",
- "tokio 0.2.25",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
  "bytes 1.0.1",
  "futures-core",
  "futures-sink",
- "log 0.4.11",
- "pin-project-lite 0.2.6",
- "tokio 1.8.1",
+ "log 0.4.14",
+ "pin-project-lite",
+ "tokio 1.9.0",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tower-service"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
- "cfg-if 0.1.10",
- "log 0.4.11",
- "pin-project-lite 0.1.11",
+ "cfg-if 1.0.0",
+ "pin-project-lite",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project 1.0.5",
- "tracing",
 ]
 
 [[package]]
@@ -5060,46 +4767,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.19.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cad71a0c0d68ab9941d2fb6e82f8fb2e86d9945b94e1661dd0aaea2b88215a9"
-dependencies = [
- "async-trait",
- "backtrace",
- "cfg-if 1.0.0",
- "enum-as-inner",
- "futures 0.3.13",
- "idna 0.2.0",
- "lazy_static",
- "log 0.4.11",
- "rand 0.7.3",
- "smallvec 1.6.1",
- "thiserror",
- "tokio 0.2.25",
- "url 2.2.1",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.19.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710f593b371175db53a26d0b38ed2978fafb9e9e8d3868b1acd753ea18df0ceb"
-dependencies = [
- "cfg-if 0.1.10",
- "futures 0.3.13",
- "ipconfig",
- "lazy_static",
- "log 0.4.11",
- "lru-cache",
- "resolv-conf",
- "smallvec 1.6.1",
- "thiserror",
- "tokio 0.2.25",
- "trust-dns-proto",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5107,20 +4774,21 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.10.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
+checksum = "5fe8dada8c1a3aeca77d6b51a4f1314e0f4b8e438b7b1b71e3ddaca8080e4093"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.13.0",
  "byteorder",
- "bytes 0.5.6",
- "http 0.2.3",
+ "bytes 1.0.1",
+ "http 0.2.4",
  "httparse",
  "input_buffer",
- "log 0.4.11",
- "rand 0.7.3",
+ "log 0.4.14",
+ "rand 0.8.4",
  "sha-1",
- "url 2.2.1",
+ "thiserror",
+ "url 2.2.2",
  "utf-8",
 ]
 
@@ -5132,9 +4800,15 @@ checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"
@@ -5163,32 +4837,32 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.2",
+ "version_check 0.9.3",
 ]
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.14"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -5204,9 +4878,9 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "unreachable"
@@ -5236,21 +4910,21 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.0",
+ "idna 0.2.3",
  "matches",
  "percent-encoding 2.1.0",
 ]
 
 [[package]]
 name = "utf-8"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
@@ -5263,18 +4937,18 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "rand 0.7.3",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -5290,9 +4964,9 @@ checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "void"
@@ -5318,7 +4992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
  "futures 0.1.31",
- "log 0.4.11",
+ "log 0.4.14",
  "try-lock",
 ]
 
@@ -5328,7 +5002,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.14",
  "try-lock",
 ]
 
@@ -5346,11 +5020,11 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -5358,26 +5032,26 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.11",
- "proc-macro2 1.0.24",
+ "log 0.4.14",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.18"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -5385,9 +5059,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote 1.0.9",
  "wasm-bindgen-macro-support",
@@ -5395,22 +5069,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.28",
  "quote 1.0.9",
- "syn 1.0.67",
+ "syn 1.0.74",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "wasmparser"
@@ -5432,7 +5106,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "libc",
- "log 0.4.11",
+ "log 0.4.14",
  "paste",
  "psm",
  "region",
@@ -5464,7 +5138,7 @@ dependencies = [
  "errno",
  "file-per-thread-logger",
  "libc",
- "log 0.4.11",
+ "log 0.4.14",
  "serde",
  "sha2",
  "toml",
@@ -5515,7 +5189,7 @@ dependencies = [
  "cranelift-wasm",
  "gimli 0.24.0",
  "indexmap",
- "log 0.4.11",
+ "log 0.4.14",
  "more-asserts",
  "serde",
  "thiserror",
@@ -5539,7 +5213,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d4539ea734422b7c868107e2187d7746d8affbcaa71916d72639f53757ad707"
 dependencies = [
- "addr2line 0.15.1",
+ "addr2line 0.15.2",
  "anyhow",
  "cfg-if 1.0.0",
  "cranelift-codegen",
@@ -5548,7 +5222,7 @@ dependencies = [
  "cranelift-native",
  "cranelift-wasm",
  "gimli 0.24.0",
- "log 0.4.11",
+ "log 0.4.14",
  "more-asserts",
  "object 0.24.0",
  "rayon",
@@ -5612,11 +5286,11 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "libc",
- "log 0.4.11",
+ "log 0.4.14",
  "mach",
- "memoffset 0.6.3",
+ "memoffset 0.6.4",
  "more-asserts",
- "rand 0.8.3",
+ "rand 0.8.4",
  "region",
  "thiserror",
  "wasmtime-environ",
@@ -5626,27 +5300,27 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "35.0.1"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5800e9f86a1eae935e38bea11e60fd253f6d514d153fb39b3e5535a7b37b56"
+checksum = "8b5d7ba374a364571da1cb0a379a3dc302582a2d9937a183bfe35b68ad5bb9c4"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec280a739b69173e0ffd12c1658507996836ba4e992ed9bc1e5385a0bd72a02"
+checksum = "16383df7f0e3901484c2dda6294ed6895caa3627ce4f6584141dcf30a33a23e6"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5666,7 +5340,7 @@ dependencies = [
  "hyper 0.12.36",
  "hyper-tls 0.3.2",
  "jsonrpc-core",
- "log 0.4.11",
+ "log 0.4.14",
  "native-tls",
  "parking_lot 0.10.2",
  "rlp",
@@ -5679,7 +5353,7 @@ dependencies = [
  "tokio-io",
  "tokio-timer 0.1.2",
  "tokio-uds 0.1.7",
- "url 2.2.1",
+ "url 2.2.2",
  "websocket",
  "zeroize",
 ]
@@ -5701,16 +5375,10 @@ dependencies = [
  "sha1",
  "tokio-core",
  "tokio-io",
- "tokio-tls 0.2.1",
+ "tokio-tls",
  "unicase 1.4.2",
  "url 1.7.2",
 ]
-
-[[package]]
-name = "widestring"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"
@@ -5757,15 +5425,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winreg"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
@@ -5794,9 +5453,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.1.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
 
 [[package]]
 name = "zstd"

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -5,9 +5,9 @@ use graph::prelude::{
 };
 use graph::{
     blockchain::{
+        block_stream::BlockStream,
         block_stream::{
-            BlockStream, BlockStreamMetrics, BlockWithTriggers,
-            TriggersAdapter as TriggersAdapterTrait,
+            BlockStreamMetrics, BlockWithTriggers, TriggersAdapter as TriggersAdapterTrait,
         },
         Block, BlockHash, BlockPtr, Blockchain, ChainHeadUpdateListener,
         IngestorAdapter as IngestorAdapterTrait, IngestorError, TriggerFilter as _,
@@ -168,7 +168,7 @@ impl Blockchain for Chain {
         &self,
         deployment: DeploymentLocator,
         start_blocks: Vec<BlockNumber>,
-        filter: TriggerFilter,
+        filter: Arc<TriggerFilter>,
         metrics: Arc<BlockStreamMetrics>,
         unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<BlockStream<Self>, Error> {

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -160,14 +160,14 @@ impl EthereumAdapter {
         }
     }
 
-    fn traces(
-        &self,
-        logger: &Logger,
+    async fn traces(
+        self,
+        logger: Logger,
         subgraph_metrics: Arc<SubgraphEthRpcMetrics>,
         from: BlockNumber,
         to: BlockNumber,
         addresses: Vec<H160>,
-    ) -> impl Future<Item = Vec<Trace>, Error = Error> {
+    ) -> Result<Vec<Trace>, Error> {
         let eth = self.clone();
         let logger = logger.to_owned();
 
@@ -234,6 +234,7 @@ impl EthereumAdapter {
                         }
                         result
                     })
+                    .compat()
             })
             .map_err(move |e| {
                 e.into_inner().unwrap_or_else(move || {
@@ -245,17 +246,18 @@ impl EthereumAdapter {
                     )
                 })
             })
+            .await
     }
 
-    fn logs_with_sigs(
+    async fn logs_with_sigs(
         &self,
-        logger: &Logger,
+        logger: Logger,
         subgraph_metrics: Arc<SubgraphEthRpcMetrics>,
         from: BlockNumber,
         to: BlockNumber,
         filter: Arc<EthGetLogsFilter>,
         too_many_logs_fingerprints: &'static [&'static str],
-    ) -> impl Future<Item = Vec<Log>, Error = TimeoutError<web3::error::Error>> {
+    ) -> Result<Vec<Log>, TimeoutError<web3::error::Error>> {
         let eth_adapter = self.clone();
 
         retry("eth_getLogs RPC call", &logger)
@@ -281,17 +283,23 @@ impl EthereumAdapter {
                     .build();
 
                 // Request logs from client
-                eth_adapter.web3.eth().logs(log_filter).then(move |result| {
-                    let elapsed = start.elapsed().as_secs_f64();
-                    provider_metrics.observe_request(elapsed, "eth_getLogs");
-                    subgraph_metrics.observe_request(elapsed, "eth_getLogs");
-                    if result.is_err() {
-                        provider_metrics.add_error("eth_getLogs");
-                        subgraph_metrics.add_error("eth_getLogs");
-                    }
-                    result
-                })
+                eth_adapter
+                    .web3
+                    .eth()
+                    .logs(log_filter)
+                    .then(move |result| {
+                        let elapsed = start.elapsed().as_secs_f64();
+                        provider_metrics.observe_request(elapsed, "eth_getLogs");
+                        subgraph_metrics.observe_request(elapsed, "eth_getLogs");
+                        if result.is_err() {
+                            provider_metrics.add_error("eth_getLogs");
+                            subgraph_metrics.add_error("eth_getLogs");
+                        }
+                        result
+                    })
+                    .compat()
             })
+            .await
     }
 
     fn trace_stream(
@@ -325,13 +333,16 @@ impl EthereumAdapter {
                 debug!(logger, "Requesting traces for blocks [{}, {}]", start, end);
             }
             Some(futures::future::ok((
-                eth.traces(
-                    &logger,
-                    subgraph_metrics.clone(),
-                    start,
-                    end,
-                    addresses.clone(),
-                ),
+                eth.clone()
+                    .traces(
+                        logger.cheap_clone(),
+                        subgraph_metrics.clone(),
+                        start,
+                        end,
+                        addresses.clone(),
+                    )
+                    .boxed()
+                    .compat(),
                 new_start,
             )))
         })
@@ -394,14 +405,13 @@ impl EthereumAdapter {
                 );
                 let res = eth
                     .logs_with_sigs(
-                        &logger,
+                        logger.cheap_clone(),
                         subgraph_metrics.cheap_clone(),
                         start,
                         end,
                         filter.cheap_clone(),
                         TOO_MANY_LOGS_FINGERPRINTS,
                     )
-                    .compat()
                     .await;
 
                 match res {
@@ -467,113 +477,121 @@ impl EthereumAdapter {
                     value: None,
                     data: Some(call_data.clone()),
                 };
-                web3.eth().call(req, Some(block_id)).then(|result| {
-                    // Try to check if the call was reverted. The JSON-RPC response for reverts is
-                    // not standardized, so we have ad-hoc checks for each of Geth, Parity and
-                    // Ganache.
+                web3.eth()
+                    .call(req, Some(block_id))
+                    .then(|result| {
+                        // Try to check if the call was reverted. The JSON-RPC response for reverts is
+                        // not standardized, so we have ad-hoc checks for each of Geth, Parity and
+                        // Ganache.
 
-                    // 0xfe is the "designated bad instruction" of the EVM, and Solidity uses it for
-                    // asserts.
-                    const PARITY_BAD_INSTRUCTION_FE: &str = "Bad instruction fe";
+                        // 0xfe is the "designated bad instruction" of the EVM, and Solidity uses it for
+                        // asserts.
+                        const PARITY_BAD_INSTRUCTION_FE: &str = "Bad instruction fe";
 
-                    // 0xfd is REVERT, but on some contracts, and only on older blocks,
-                    // this happens. Makes sense to consider it a revert as well.
-                    const PARITY_BAD_INSTRUCTION_FD: &str = "Bad instruction fd";
+                        // 0xfd is REVERT, but on some contracts, and only on older blocks,
+                        // this happens. Makes sense to consider it a revert as well.
+                        const PARITY_BAD_INSTRUCTION_FD: &str = "Bad instruction fd";
 
-                    const PARITY_BAD_JUMP_PREFIX: &str = "Bad jump";
-                    const PARITY_STACK_LIMIT_PREFIX: &str = "Out of stack";
+                        const PARITY_BAD_JUMP_PREFIX: &str = "Bad jump";
+                        const PARITY_STACK_LIMIT_PREFIX: &str = "Out of stack";
 
-                    const GANACHE_VM_EXECUTION_ERROR: i64 = -32000;
-                    const GANACHE_REVERT_MESSAGE: &str =
-                        "VM Exception while processing transaction: revert";
-                    const PARITY_VM_EXECUTION_ERROR: i64 = -32015;
-                    const PARITY_REVERT_PREFIX: &str = "Reverted 0x";
+                        const GANACHE_VM_EXECUTION_ERROR: i64 = -32000;
+                        const GANACHE_REVERT_MESSAGE: &str =
+                            "VM Exception while processing transaction: revert";
+                        const PARITY_VM_EXECUTION_ERROR: i64 = -32015;
+                        const PARITY_REVERT_PREFIX: &str = "Reverted 0x";
 
-                    // Deterministic Geth execution errors. We might need to expand this as
-                    // subgraphs come across other errors. See
-                    // https://github.com/ethereum/go-ethereum/blob/cd57d5cd38ef692de8fbedaa56598b4e9fbfbabc/core/vm/errors.go
-                    const GETH_EXECUTION_ERRORS: &[&str] = &[
-                        "execution reverted",
-                        "invalid jump destination",
-                        "invalid opcode",
-                        // Ethereum says 1024 is the stack sizes limit, so this is deterministic.
-                        "stack limit reached 1024",
-                        // See f0af4ab0-6b7c-4b68-9141-5b79346a5f61 for why the gas limit is considered deterministic.
-                        "out of gas",
-                    ];
+                        // Deterministic Geth execution errors. We might need to expand this as
+                        // subgraphs come across other errors. See
+                        // https://github.com/ethereum/go-ethereum/blob/cd57d5cd38ef692de8fbedaa56598b4e9fbfbabc/core/vm/errors.go
+                        const GETH_EXECUTION_ERRORS: &[&str] = &[
+                            "execution reverted",
+                            "invalid jump destination",
+                            "invalid opcode",
+                            // Ethereum says 1024 is the stack sizes limit, so this is deterministic.
+                            "stack limit reached 1024",
+                            // See f0af4ab0-6b7c-4b68-9141-5b79346a5f61 for why the gas limit is considered deterministic.
+                            "out of gas",
+                        ];
 
-                    let as_solidity_revert_with_reason = |bytes: &[u8]| {
-                        let solidity_revert_function_selector =
-                            &tiny_keccak::keccak256(b"Error(string)")[..4];
+                        let as_solidity_revert_with_reason = |bytes: &[u8]| {
+                            let solidity_revert_function_selector =
+                                &tiny_keccak::keccak256(b"Error(string)")[..4];
 
-                        match bytes.len() >= 4 && &bytes[..4] == solidity_revert_function_selector {
-                            false => None,
-                            true => ethabi::decode(&[ParamType::String], &bytes[4..])
-                                .ok()
-                                .and_then(|tokens| tokens[0].clone().to_string()),
-                        }
-                    };
-
-                    match result {
-                        // A successful response.
-                        Ok(bytes) => Ok(bytes),
-
-                        // Check for Geth revert.
-                        Err(web3::Error::Rpc(rpc_error))
-                            if GETH_EXECUTION_ERRORS
-                                .iter()
-                                .any(|e| rpc_error.message.contains(e)) =>
-                        {
-                            Err(EthereumContractCallError::Revert(rpc_error.message))
-                        }
-
-                        // Check for Parity revert.
-                        Err(web3::Error::Rpc(ref rpc_error))
-                            if rpc_error.code.code() == PARITY_VM_EXECUTION_ERROR =>
-                        {
-                            match rpc_error.data.as_ref().and_then(|d| d.as_str()) {
-                                Some(data)
-                                    if data.starts_with(PARITY_REVERT_PREFIX)
-                                        || data.starts_with(PARITY_BAD_JUMP_PREFIX)
-                                        || data.starts_with(PARITY_STACK_LIMIT_PREFIX)
-                                        || data == PARITY_BAD_INSTRUCTION_FE
-                                        || data == PARITY_BAD_INSTRUCTION_FD =>
-                                {
-                                    let reason = if data == PARITY_BAD_INSTRUCTION_FE {
-                                        PARITY_BAD_INSTRUCTION_FE.to_owned()
-                                    } else {
-                                        let payload = data.trim_start_matches(PARITY_REVERT_PREFIX);
-                                        hex::decode(payload)
-                                            .ok()
-                                            .and_then(|payload| {
-                                                as_solidity_revert_with_reason(&payload)
-                                            })
-                                            .unwrap_or("no reason".to_owned())
-                                    };
-                                    Err(EthereumContractCallError::Revert(reason))
-                                }
-
-                                // The VM execution error was not identified as a revert.
-                                _ => Err(EthereumContractCallError::Web3Error(web3::Error::Rpc(
-                                    rpc_error.clone(),
-                                ))),
+                            match bytes.len() >= 4
+                                && &bytes[..4] == solidity_revert_function_selector
+                            {
+                                false => None,
+                                true => ethabi::decode(&[ParamType::String], &bytes[4..])
+                                    .ok()
+                                    .and_then(|tokens| tokens[0].clone().to_string()),
                             }
-                        }
+                        };
 
-                        // Check for Ganache revert.
-                        Err(web3::Error::Rpc(ref rpc_error))
-                            if rpc_error.code.code() == GANACHE_VM_EXECUTION_ERROR
-                                && rpc_error.message.starts_with(GANACHE_REVERT_MESSAGE) =>
-                        {
-                            Err(EthereumContractCallError::Revert(rpc_error.message.clone()))
-                        }
+                        match result {
+                            // A successful response.
+                            Ok(bytes) => Ok(bytes),
 
-                        // The error was not identified as a revert.
-                        Err(err) => Err(EthereumContractCallError::Web3Error(err)),
-                    }
-                })
+                            // Check for Geth revert.
+                            Err(web3::Error::Rpc(rpc_error))
+                                if GETH_EXECUTION_ERRORS
+                                    .iter()
+                                    .any(|e| rpc_error.message.contains(e)) =>
+                            {
+                                Err(EthereumContractCallError::Revert(rpc_error.message))
+                            }
+
+                            // Check for Parity revert.
+                            Err(web3::Error::Rpc(ref rpc_error))
+                                if rpc_error.code.code() == PARITY_VM_EXECUTION_ERROR =>
+                            {
+                                match rpc_error.data.as_ref().and_then(|d| d.as_str()) {
+                                    Some(data)
+                                        if data.starts_with(PARITY_REVERT_PREFIX)
+                                            || data.starts_with(PARITY_BAD_JUMP_PREFIX)
+                                            || data.starts_with(PARITY_STACK_LIMIT_PREFIX)
+                                            || data == PARITY_BAD_INSTRUCTION_FE
+                                            || data == PARITY_BAD_INSTRUCTION_FD =>
+                                    {
+                                        let reason = if data == PARITY_BAD_INSTRUCTION_FE {
+                                            PARITY_BAD_INSTRUCTION_FE.to_owned()
+                                        } else {
+                                            let payload =
+                                                data.trim_start_matches(PARITY_REVERT_PREFIX);
+                                            hex::decode(payload)
+                                                .ok()
+                                                .and_then(|payload| {
+                                                    as_solidity_revert_with_reason(&payload)
+                                                })
+                                                .unwrap_or("no reason".to_owned())
+                                        };
+                                        Err(EthereumContractCallError::Revert(reason))
+                                    }
+
+                                    // The VM execution error was not identified as a revert.
+                                    _ => Err(EthereumContractCallError::Web3Error(
+                                        web3::Error::Rpc(rpc_error.clone()),
+                                    )),
+                                }
+                            }
+
+                            // Check for Ganache revert.
+                            Err(web3::Error::Rpc(ref rpc_error))
+                                if rpc_error.code.code() == GANACHE_VM_EXECUTION_ERROR
+                                    && rpc_error.message.starts_with(GANACHE_REVERT_MESSAGE) =>
+                            {
+                                Err(EthereumContractCallError::Revert(rpc_error.message.clone()))
+                            }
+
+                            // The error was not identified as a revert.
+                            Err(err) => Err(EthereumContractCallError::Web3Error(err)),
+                        }
+                    })
+                    .compat()
             })
             .map_err(|e| e.into_inner().unwrap_or(EthereumContractCallError::Timeout))
+            .boxed()
+            .compat()
     }
 
     /// Request blocks by hash through JSON-RPC.
@@ -598,7 +616,10 @@ impl EthereumAdapter {
                                 anyhow::anyhow!("Ethereum node did not find block {:?}", hash)
                             })
                         })
+                        .compat()
                 })
+                .boxed()
+                .compat()
                 .from_err()
         }))
         .buffered(*BLOCK_BATCH_SIZE)
@@ -628,7 +649,10 @@ impl EthereumAdapter {
                                 anyhow!("Ethereum node did not find block {:?}", block_num)
                             })
                         })
+                        .compat()
                 })
+                .boxed()
+                .compat()
                 .from_err()
         }))
         .buffered(*BLOCK_BATCH_SIZE)
@@ -812,7 +836,9 @@ impl EthereumAdapterTrait for EthereumAdapter {
         let net_version_future = retry("net_version RPC call", &logger)
             .no_limit()
             .timeout_secs(20)
-            .run(move || web3.net().version().from_err());
+            .run(move || web3.net().version().from_err().compat())
+            .boxed()
+            .compat();
 
         let web3 = self.web3.clone();
         let gen_block_hash_future = retry("eth_getBlockByNumber(0, false) RPC call", &logger)
@@ -831,7 +857,10 @@ impl EthereumAdapterTrait for EthereumAdapter {
                                 }),
                         )
                     })
-            });
+                    .compat()
+            })
+            .boxed()
+            .compat();
 
         net_version_future
             .join(gen_block_hash_future)
@@ -870,12 +899,15 @@ impl EthereumAdapterTrait for EthereumAdapter {
                                 anyhow!("no latest block returned from Ethereum").into()
                             })
                         })
+                        .compat()
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
                         anyhow!("Ethereum node took too long to return latest block").into()
                     })
-                }),
+                })
+                .boxed()
+                .compat(),
         )
     }
 
@@ -899,12 +931,15 @@ impl EthereumAdapterTrait for EthereumAdapter {
                                 anyhow!("no latest block returned from Ethereum").into()
                             })
                         })
+                        .compat()
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
                         anyhow!("Ethereum node took too long to return latest block").into()
                     })
-                }),
+                })
+                .boxed()
+                .compat(),
         )
     }
 
@@ -942,12 +977,15 @@ impl EthereumAdapterTrait for EthereumAdapter {
                     web3.eth()
                         .block_with_txs(BlockId::Hash(block_hash))
                         .from_err()
+                        .compat()
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
                         anyhow!("Ethereum node took too long to return block {}", block_hash)
                     })
-                }),
+                })
+                .boxed()
+                .compat(),
         )
     }
 
@@ -967,6 +1005,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
                     web3.eth()
                         .block_with_txs(BlockId::Number(block_number.into()))
                         .from_err()
+                        .compat()
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
@@ -975,7 +1014,9 @@ impl EthereumAdapterTrait for EthereumAdapter {
                             block_number
                         )
                     })
-                }),
+                })
+                .boxed()
+                .compat(),
         )
     }
 
@@ -1086,6 +1127,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
                                 },
                             )
                         })
+                        .compat()
                 })
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
@@ -1095,7 +1137,9 @@ impl EthereumAdapterTrait for EthereumAdapter {
                         )
                         .into()
                     })
-                }),
+                })
+                .boxed()
+                .compat(),
         )
     }
 
@@ -1135,7 +1179,10 @@ impl EthereumAdapterTrait for EthereumAdapter {
                         .block(BlockId::Number(block_number.into()))
                         .from_err()
                         .map(|block_opt| block_opt.map(|block| block.hash).flatten())
+                        .compat()
                 })
+                .boxed()
+                .compat()
                 .map_err(move |e| {
                     e.into_inner().unwrap_or_else(move || {
                         anyhow!(
@@ -1185,12 +1232,15 @@ impl EthereumAdapterTrait for EthereumAdapter {
                                     e
                                 )
                             })
+                            .compat()
                     })
                     .map_err(move |e| {
                         e.into_inner().unwrap_or_else(move || {
                             anyhow!("Ethereum node took too long to return uncle")
                         })
                     })
+                    .boxed()
+                    .compat()
             }))
             .collect(),
         )

--- a/chain/ethereum/tests/network_indexer.rs
+++ b/chain/ethereum/tests/network_indexer.rs
@@ -81,6 +81,7 @@ fn run_network_indexer(
             .expect("failed to take stream from indexer")
             .forward(event_sink.sink_map_err(|_| ()))
             .map(|_| ())
+            .compat()
             .timeout(timeout),
     );
 

--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -246,10 +246,7 @@ impl LinkResolverTrait for LinkResolver {
                     }
                     Result::<Vec<u8>, reqwest::Error>::Ok(data)
                 }
-                // .boxed()
-                // .compat()
             })
-            // .compat()
             .await?;
 
         Ok(data)

--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -100,15 +100,11 @@ async fn select_fastest_client_with_stat(
         .map(|(i, c)| {
             let c = c.cheap_clone();
             let path = path.clone();
-            retry_policy(do_retry, "object.stat", &logger)
-                .run(move || {
-                    let path = path.clone();
-                    let c = c.cheap_clone();
-                    async move { c.object_stat(path, timeout).map_ok(move |s| (s, i)).await }
-                        .boxed()
-                        .compat()
-                })
-                .compat()
+            retry_policy(do_retry, "object.stat", &logger).run(move || {
+                let path = path.clone();
+                let c = c.cheap_clone();
+                async move { c.object_stat(path, timeout).map_ok(move |s| (s, i)).await }
+            })
         })
         .collect();
 
@@ -250,10 +246,10 @@ impl LinkResolverTrait for LinkResolver {
                     }
                     Result::<Vec<u8>, reqwest::Error>::Ok(data)
                 }
-                .boxed()
-                .compat()
+                // .boxed()
+                // .compat()
             })
-            .compat()
+            // .compat()
             .await?;
 
         Ok(data)

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -459,14 +459,13 @@ where
             .new_block_stream(
                 ctx.inputs.deployment.clone(),
                 ctx.inputs.start_blocks.clone(),
-                ctx.state.filter.clone(),
+                Arc::new(ctx.state.filter.clone()),
                 ctx.block_stream_metrics.clone(),
                 ctx.inputs.unified_api_version.clone(),
             )
             .await?
             .map_err(CancelableError::Error)
-            .cancelable(&block_stream_canceler, || CancelableError::Cancel)
-            .compat();
+            .cancelable(&block_stream_canceler, || Err(CancelableError::Cancel));
 
         // Keep the stream's cancel guard around to be able to shut it down
         // when the subgraph deployment is unassigned

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -415,11 +415,14 @@ where
         // forward; this is easier than updating the existing block stream.
         //
         // This is a long-running and unfortunately a blocking future (see #905), so it is run in
-        // its own thread. When upgrading to tokio 1.0 it would be logical to run this with
-        // `task::unconstrained`, since it has a dedicated OS thread so the OS will handle the
-        // preemption.
+        // its own thread. It is also run with `task::unconstrained` because we have seen deadlocks
+        // occur without it, possibly caused by our use of legacy futures and tokio versions in the
+        // codebase and dependencies, which may not play well with the tokio 1.0 cooperative
+        // scheduling. It is also logical in terms of performance to run this with `unconstrained`,
+        // it has a dedicated OS thread so the OS will handle the preemption. See
+        // https://github.com/tokio-rs/tokio/issues/3493.
         graph::spawn_thread(deployment.to_string(), move || {
-            if let Err(e) = graph::block_on(run_subgraph(ctx)) {
+            if let Err(e) = graph::block_on(task::unconstrained(run_subgraph(ctx))) {
                 error!(
                     &logger,
                     "Subgraph instance failed to run: {}",

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -98,11 +98,13 @@ where
             // Blocking due to store interactions. Won't be blocking after #905.
             graph::spawn_blocking(
                 assignment_event_stream
+                    .compat()
                     .map_err(SubgraphAssignmentProviderError::Unknown)
                     .map_err(CancelableError::Error)
                     .cancelable(&assignment_event_stream_cancel_handle, || {
-                        CancelableError::Cancel
+                        Err(CancelableError::Cancel)
                     })
+                    .compat()
                     .for_each(move |assignment_event| {
                         assert_eq!(assignment_event.node_id(), &node_id);
                         handle_assignment_event(

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -48,7 +48,7 @@ slog-term = "2.7.0"
 petgraph = "0.6.0"
 tiny-keccak = "1.5.0"
 tokio = { version = "1.9.0", features = ["time", "sync", "macros", "test-util", "rt-multi-thread"] }
-tokio-stream = { version = "0.1.5", features = ["sync"] }
+tokio-stream = { version = "0.1.6", features = ["sync"] }
 tokio-retry = "0.3.0"
 url = "2.2.1"
 prometheus = "0.12.0"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -8,13 +8,13 @@ anyhow = "1.0"
 async-trait = "0.1.50"
 atomic_refcell = "0.1.7"
 bigdecimal = { version = "0.1.0", features = ["serde"] }
-bytes = "0.5"
+bytes = "1.0.1"
 diesel = { version = "1.4.7", features = ["postgres", "serde_json", "numeric", "r2d2", "chrono"] }
 diesel_derives = "1.4"
 chrono = "0.4.19"
 Inflector = "0.11.3"
 isatty = "0.1.9"
-reqwest = { version = "0.10", features = ["json", "stream", "trust-dns-resolver"] }
+reqwest = { version = "0.11.2", features = ["json", "stream", "multipart"] }
 
 # master contains changes such as
 # https://github.com/paritytech/ethabi/pull/140, which upstream does not want
@@ -47,9 +47,9 @@ slog-envlogger = "2.1.0"
 slog-term = "2.7.0"
 petgraph = "0.6.0"
 tiny-keccak = "1.5.0"
-tokio = { version = "0.2.25", features = ["stream", "rt-threaded", "rt-util", "blocking", "time", "sync", "macros", "test-util", "net"] }
-tokio-stream = { version = "0.1.7", features = ["sync"] }
-tokio-retry = { git = "https://github.com/graphprotocol/rust-tokio-retry", branch = "update-to-tokio-02" }
+tokio = { version = "1.4.0", features = ["time", "sync", "macros", "test-util", "rt-multi-thread"] }
+tokio-stream = { version = "0.1.5", features = ["sync"] }
+tokio-retry = "0.3.0"
 url = "2.2.1"
 prometheus = "0.12.0"
 priority-queue = "0.7.0"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -47,7 +47,7 @@ slog-envlogger = "2.1.0"
 slog-term = "2.7.0"
 petgraph = "0.6.0"
 tiny-keccak = "1.5.0"
-tokio = { version = "1.4.0", features = ["time", "sync", "macros", "test-util", "rt-multi-thread"] }
+tokio = { version = "1.9.0", features = ["time", "sync", "macros", "test-util", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.5", features = ["sync"] }
 tokio-retry = "0.3.0"
 url = "2.2.1"

--- a/graph/src/blockchain/block_ingestor.rs
+++ b/graph/src/blockchain/block_ingestor.rs
@@ -62,7 +62,7 @@ where
                 self.cleanup_cached_blocks()
             }
 
-            tokio::time::delay_for(self.polling_interval).await;
+            tokio::time::sleep(self.polling_interval).await;
         }
     }
 

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -665,9 +665,6 @@ impl<C: Blockchain> Stream for BlockStream<C> {
                             break Poll::Ready(Some(Ok(BlockStreamEvent::Revert(block))));
                         }
                         Poll::Pending => {
-                            // Nothing to change or yield yet.
-                            // self.state =
-                            //     BlockStreamState::Reconciliation(next_blocks_future);
                             break Poll::Pending; //todo: is this ok
                         }
                         Poll::Ready(Err(e)) => {
@@ -678,7 +675,6 @@ impl<C: Blockchain> Stream for BlockStream<C> {
 
                             // Pause before trying again
                             let secs = (5 * self.consecutive_err_count).max(120) as u64;
-                            // (Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>),
 
                             self.state = BlockStreamState::RetryAfterDelay(Box::pin(
                                 tokio::time::sleep(Duration::from_secs(secs)).map(Ok),
@@ -694,7 +690,6 @@ impl<C: Blockchain> Stream for BlockStream<C> {
                     match next_blocks.pop_front() {
                         // Yield one block
                         Some(next_block) => {
-                            // self.state = BlockStreamState::YieldingBlocks(next_blocks);
                             break Poll::Ready(Some(Ok(BlockStreamEvent::ProcessBlock(
                                 next_block,
                             ))));

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -1,9 +1,10 @@
 use anyhow::Error;
-use async_trait::async_trait;
-use futures::Stream;
+use futures03::{stream::Stream, Future, FutureExt};
 use std::cmp;
 use std::collections::VecDeque;
-use std::mem;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use crate::components::store::BlockNumber;
@@ -141,28 +142,25 @@ where
     /// The BlockStream is reconciling the subgraph store state with the chain store state.
     ///
     /// Valid next states: YieldingBlocks, Idle, BeginReconciliation (in case of revert)
-    Reconciliation(Box<dyn Future<Item = NextBlocks<C>, Error = Error> + Send>),
+    Reconciliation(Pin<Box<dyn Future<Output = Result<NextBlocks<C>, Error>> + Send>>),
 
     /// The BlockStream is emitting blocks that must be processed in order to bring the subgraph
     /// store up to date with the chain store.
     ///
     /// Valid next states: BeginReconciliation
-    YieldingBlocks(VecDeque<BlockWithTriggers<C>>),
+    YieldingBlocks(Box<VecDeque<BlockWithTriggers<C>>>),
 
     /// The BlockStream experienced an error and is pausing before attempting to produce
     /// blocks again.
     ///
     /// Valid next states: BeginReconciliation
-    RetryAfterDelay(Box<dyn Future<Item = (), Error = Error> + Send>),
+    RetryAfterDelay(Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>),
 
     /// The BlockStream has reconciled the subgraph store and chain store states.
     /// No more work is needed until a chain head update.
     ///
     /// Valid next states: BeginReconciliation
     Idle,
-
-    /// Not a real state, only used when going from one state to another.
-    Transition,
 }
 
 /// A single next step to take in reconciling the state of the subgraph store with the state of the
@@ -199,7 +197,7 @@ where
     // This is not really a block number, but the (unsigned) difference
     // between two block numbers
     reorg_threshold: BlockNumber,
-    filter: C::TriggerFilter,
+    filter: Arc<C::TriggerFilter>,
     start_blocks: Vec<BlockNumber>,
     logger: Logger,
     metrics: Arc<BlockStreamMetrics>,
@@ -238,7 +236,7 @@ impl<C: Blockchain> Clone for BlockStreamContext<C> {
 /// an update on this stream whenever the head of the underlying chain
 /// changes. The updates have no payload, receivers should call
 /// `Store::chain_head_ptr` to check what the latest block is.
-pub type ChainHeadUpdateStream = Box<dyn Stream<Item = (), Error = ()> + Send>;
+pub type ChainHeadUpdateStream = Box<dyn Stream<Item = ()> + Send + Unpin>;
 
 pub trait ChainHeadUpdateListener: Send + Sync + 'static {
     /// Subscribe to chain head updates for the given network.
@@ -277,7 +275,7 @@ where
         adapter: Arc<C::TriggersAdapter>,
         node_id: NodeId,
         subgraph_id: DeploymentHash,
-        filter: C::TriggerFilter,
+        filter: Arc<C::TriggerFilter>,
         start_blocks: Vec<BlockNumber>,
         reorg_threshold: BlockNumber,
         logger: Logger,
@@ -610,27 +608,22 @@ where
 }
 
 impl<C: Blockchain> Stream for BlockStream<C> {
-    type Item = BlockStreamEvent<C>;
-    type Error = Error;
+    type Item = Result<BlockStreamEvent<C>, Error>;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        let mut state = BlockStreamState::Transition;
-        mem::swap(&mut self.state, &mut state);
-
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let result = loop {
-            match state {
+            match &mut self.state {
                 BlockStreamState::BeginReconciliation => {
                     // Start the reconciliation process by asking for blocks
                     let ctx = self.ctx.clone();
                     let fut = async move { ctx.next_blocks().await };
-                    state = BlockStreamState::Reconciliation(Box::new(fut.boxed().compat()));
+                    self.state = BlockStreamState::Reconciliation(fut.boxed());
                 }
 
                 // Waiting for the reconciliation to complete or yield blocks
-                BlockStreamState::Reconciliation(mut next_blocks_future) => {
-                    match next_blocks_future.poll() {
-                        // Reconciliation found blocks to process
-                        Ok(Async::Ready(NextBlocks::Blocks(next_blocks, block_range_size))) => {
+                BlockStreamState::Reconciliation(next_blocks_future) => {
+                    match next_blocks_future.poll_unpin(cx) {
+                        Poll::Ready(Ok(NextBlocks::Blocks(next_blocks, block_range_size))) => {
                             // We had only one error, so we infer that reducing the range size is
                             // what fixed it. Reduce the max range size to prevent future errors.
                             // See: 018c6df4-132f-4acc-8697-a2d64e83a9f0
@@ -651,36 +644,33 @@ impl<C: Blockchain> Stream for BlockStream<C> {
                             }
 
                             // Switch to yielding state until next_blocks is depleted
-                            state = BlockStreamState::YieldingBlocks(next_blocks);
+                            self.state = BlockStreamState::YieldingBlocks(Box::new(next_blocks));
 
                             // Yield the first block in next_blocks
                             continue;
                         }
-
                         // Reconciliation completed. We're caught up to chain head.
-                        Ok(Async::Ready(NextBlocks::Done)) => {
+                        Poll::Ready(Ok(NextBlocks::Done)) => {
                             // Reset error count
                             self.consecutive_err_count = 0;
 
                             // Switch to idle
-                            state = BlockStreamState::Idle;
+                            self.state = BlockStreamState::Idle;
 
                             // Poll for chain head update
                             continue;
                         }
-
-                        Ok(Async::Ready(NextBlocks::Revert(block))) => {
-                            state = BlockStreamState::BeginReconciliation;
-                            break Ok(Async::Ready(Some(BlockStreamEvent::Revert(block))));
+                        Poll::Ready(Ok(NextBlocks::Revert(block))) => {
+                            self.state = BlockStreamState::BeginReconciliation;
+                            break Poll::Ready(Some(Ok(BlockStreamEvent::Revert(block))));
                         }
-
-                        Ok(Async::NotReady) => {
+                        Poll::Pending => {
                             // Nothing to change or yield yet.
-                            state = BlockStreamState::Reconciliation(next_blocks_future);
-                            break Ok(Async::NotReady);
+                            // self.state =
+                            //     BlockStreamState::Reconciliation(next_blocks_future);
+                            break Poll::Pending; //todo: is this ok
                         }
-
-                        Err(e) => {
+                        Poll::Ready(Err(e)) => {
                             // Reset the block range size in an attempt to recover from the error.
                             // See also: 018c6df4-132f-4acc-8697-a2d64e83a9f0
                             self.ctx.previous_block_range_size = 1;
@@ -688,84 +678,74 @@ impl<C: Blockchain> Stream for BlockStream<C> {
 
                             // Pause before trying again
                             let secs = (5 * self.consecutive_err_count).max(120) as u64;
-                            state = BlockStreamState::RetryAfterDelay(Box::new(
-                                tokio::time::sleep(Duration::from_secs(secs))
-                                    .map(Ok)
-                                    .boxed()
-                                    .compat(),
+                            // (Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>),
+
+                            self.state = BlockStreamState::RetryAfterDelay(Box::pin(
+                                tokio::time::sleep(Duration::from_secs(secs)).map(Ok),
                             ));
-                            break Err(e);
+
+                            break Poll::Ready(Some(Err(e)));
                         }
                     }
                 }
 
                 // Yielding blocks from reconciliation process
-                BlockStreamState::YieldingBlocks(mut next_blocks) => {
+                BlockStreamState::YieldingBlocks(ref mut next_blocks) => {
                     match next_blocks.pop_front() {
                         // Yield one block
                         Some(next_block) => {
-                            state = BlockStreamState::YieldingBlocks(next_blocks);
-                            break Ok(Async::Ready(Some(BlockStreamEvent::ProcessBlock(
+                            // self.state = BlockStreamState::YieldingBlocks(next_blocks);
+                            break Poll::Ready(Some(Ok(BlockStreamEvent::ProcessBlock(
                                 next_block,
                             ))));
                         }
 
                         // Done yielding blocks
                         None => {
-                            state = BlockStreamState::BeginReconciliation;
+                            self.state = BlockStreamState::BeginReconciliation;
                         }
                     }
                 }
 
                 // Pausing after an error, before looking for more blocks
-                BlockStreamState::RetryAfterDelay(mut delay) => match delay.poll() {
-                    Ok(Async::Ready(())) | Err(_) => {
-                        state = BlockStreamState::BeginReconciliation;
-                    }
-
-                    Ok(Async::NotReady) => {
-                        state = BlockStreamState::RetryAfterDelay(delay);
-                        break Ok(Async::NotReady);
-                    }
-                },
-
-                // Waiting for a chain head update
-                BlockStreamState::Idle => {
-                    match self.chain_head_update_stream.poll() {
-                        // Chain head was updated
-                        Ok(Async::Ready(Some(()))) => {
-                            state = BlockStreamState::BeginReconciliation;
+                BlockStreamState::RetryAfterDelay(ref mut delay) => {
+                    match delay.as_mut().poll(cx) {
+                        Poll::Ready(Ok(..)) | Poll::Ready(Err(_)) => {
+                            self.state = BlockStreamState::BeginReconciliation;
                         }
 
-                        // Chain head update stream ended
-                        Ok(Async::Ready(None)) => {
-                            // Should not happen
-                            return Err(anyhow::anyhow!(
-                                "chain head update stream ended unexpectedly"
-                            ));
-                        }
-
-                        Ok(Async::NotReady) => {
-                            // Stay idle
-                            state = BlockStreamState::Idle;
-                            break Ok(Async::NotReady);
-                        }
-
-                        // mpsc channel failed
-                        Err(()) => {
-                            // Should not happen
-                            return Err(anyhow::anyhow!("chain head update Receiver failed"));
+                        Poll::Pending => {
+                            // self.state = BlockStreamState::RetryAfterDelay(delay);
+                            break Poll::Pending;
                         }
                     }
                 }
 
-                // This will only happen if this poll function fails to complete normally then is
-                // called again.
-                BlockStreamState::Transition => unreachable!(),
+                // Waiting for a chain head update
+                BlockStreamState::Idle => {
+                    match Pin::new(self.chain_head_update_stream.as_mut()).poll_next(cx) {
+                        // Chain head was updated
+                        Poll::Ready(Some(())) => {
+                            self.state = BlockStreamState::BeginReconciliation;
+                        }
+
+                        // Chain head update stream ended
+                        Poll::Ready(None) => {
+                            // Should not happen
+                            return Poll::Ready(Some(Err(anyhow::anyhow!(
+                                "chain head update stream ended unexpectedly"
+                            ))));
+                        }
+
+                        Poll::Pending => {
+                            // Stay idle
+                            self.state = BlockStreamState::Idle;
+                            break Poll::Pending;
+                        }
+                    }
+                }
             }
         };
-
-        self.state = state;
 
         result
     }

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -665,7 +665,7 @@ impl<C: Blockchain> Stream for BlockStream<C> {
                             break Poll::Ready(Some(Ok(BlockStreamEvent::Revert(block))));
                         }
                         Poll::Pending => {
-                            break Poll::Pending; //todo: is this ok
+                            break Poll::Pending;
                         }
                         Poll::Ready(Err(e)) => {
                             // Reset the block range size in an attempt to recover from the error.

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -689,7 +689,7 @@ impl<C: Blockchain> Stream for BlockStream<C> {
                             // Pause before trying again
                             let secs = (5 * self.consecutive_err_count).max(120) as u64;
                             state = BlockStreamState::RetryAfterDelay(Box::new(
-                                tokio::time::delay_for(Duration::from_secs(secs))
+                                tokio::time::sleep(Duration::from_secs(secs))
                                     .map(Ok)
                                     .boxed()
                                     .compat(),

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -35,11 +35,11 @@ use std::{collections::HashMap, convert::TryFrom};
 use web3::types::H256;
 
 pub use block_stream::{
-    BlockStream, ChainHeadUpdateListener, ChainHeadUpdateStream, TriggersAdapter,
+    BlockStream, BlockStreamMetrics, ChainHeadUpdateListener, ChainHeadUpdateStream,
+    TriggersAdapter,
 };
-pub use types::{BlockHash, BlockPtr};
 
-use self::block_stream::BlockStreamMetrics;
+pub use types::{BlockHash, BlockPtr};
 
 pub trait Block: Send + Sync {
     fn ptr(&self) -> BlockPtr;
@@ -60,7 +60,7 @@ pub trait Block: Send + Sync {
 
 #[async_trait]
 // This is only `Debug` because some tests require that
-pub trait Blockchain: Debug + Sized + Send + Sync + 'static {
+pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
     // The `Clone` bound is used when reprocessing a block, because `triggers_in_block` requires an
     // owned `Block`. It would be good to come up with a way to remove this bound.
     type Block: Block + Clone;
@@ -101,7 +101,7 @@ pub trait Blockchain: Debug + Sized + Send + Sync + 'static {
         &self,
         deployment: DeploymentLocator,
         start_blocks: Vec<BlockNumber>,
-        filter: Self::TriggerFilter,
+        filter: Arc<Self::TriggerFilter>,
         metrics: Arc<BlockStreamMetrics>,
         unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<BlockStream<Self>, Error>;

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -674,10 +674,7 @@ where
         let mut pending_event: Option<StoreEvent> = None;
         let mut source = self.source.fuse();
         let mut had_err = false;
-        let mut delay = tokio::time::delay_for(interval)
-            .unit_error()
-            .boxed()
-            .compat();
+        let mut delay = tokio::time::sleep(interval).unit_error().boxed().compat();
         let logger = logger.clone();
 
         let source = Box::new(poll_fn(move || -> Poll<Option<Arc<StoreEvent>>, ()> {
@@ -699,10 +696,7 @@ where
                 // Timer errors are harmless. Treat them as if the timer had
                 // become ready.
                 Ok(Async::Ready(())) | Err(_) => {
-                    delay = tokio::time::delay_for(interval)
-                        .unit_error()
-                        .boxed()
-                        .compat();
+                    delay = tokio::time::sleep(interval).unit_error().boxed().compat();
                     true
                 }
             };

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -1,10 +1,17 @@
-use crate::prelude::StoreError;
-use futures::future::Fuse;
-use futures::prelude::{Future, Poll, Stream};
-use futures::sync::oneshot;
-use futures03::compat::{Compat01As03, Future01CompatExt};
+use crate::prelude::{Pin, StoreError};
+
+use futures03::channel::oneshot;
+use futures03::{future::Fuse, Future, FutureExt, Stream};
+
+// use futures::future::Fuse;
+// use futures::prelude::{Future, Poll, Stream};
+// use futures::sync::oneshot;
+// use futures03::compat::{Compat01As03, Future01CompatExt};
+
+use crate::prelude::tokio::macros::support::Poll;
 use std::fmt::{Debug, Display};
 use std::sync::{Arc, Mutex, Weak};
+use std::task::Context;
 use std::time::Duration;
 
 /// A cancelable stream or future.
@@ -16,36 +23,32 @@ pub struct Cancelable<T, C> {
     cancel_receiver: Fuse<oneshot::Receiver<()>>,
     on_cancel: C,
 }
-
+// CancelableError::Cancel
 /// It's not viable to use `select` directly, so we do a custom implementation.
-impl<S: Stream, C: Fn() -> S::Error> Stream for Cancelable<S, C> {
+impl<S: Stream + Unpin, C: Fn() -> S::Item + Unpin> Stream for Cancelable<S, C> {
     type Item = S::Item;
-    type Error = S::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // Error if the stream was canceled by dropping the sender.
         // `cancel_receiver` is fused so we may ignore `Ok`s.
-        if self.cancel_receiver.poll().is_err() {
-            Err((self.on_cancel)())
-        // Otherwise poll it.
-        } else {
-            self.inner.poll()
+        match self.cancel_receiver.poll_unpin(cx) {
+            Poll::Ready(Ok(_)) => unreachable!(),
+            Poll::Ready(Err(_)) => Poll::Ready(Some((self.on_cancel)())),
+            Poll::Pending => Pin::new(&mut self.inner).poll_next(cx),
         }
     }
 }
 
-impl<F: Future, C: Fn() -> F::Error> Future for Cancelable<F, C> {
-    type Item = F::Item;
-    type Error = F::Error;
+impl<F: Future + Unpin, C: Fn() -> F::Output + Unpin> Future for Cancelable<F, C> {
+    type Output = F::Output;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // Error if the future was canceled by dropping the sender.
-        // `cancel_receiver` is fused so we may ignore `Ok`s.
-        if self.cancel_receiver.poll().is_err() {
-            Err((self.on_cancel)())
-        // Otherwise poll it.
-        } else {
-            self.inner.poll()
+        // `canceled` is fused so we may ignore `Ok`s.
+        match self.cancel_receiver.poll_unpin(cx) {
+            Poll::Ready(Ok(_)) => unreachable!(),
+            Poll::Ready(Err(_)) => Poll::Ready((self.on_cancel)()),
+            Poll::Pending => Pin::new(&mut self.inner).poll(cx),
         }
     }
 }
@@ -199,8 +202,7 @@ pub trait StreamExtension: Stream + Sized {
     /// When `cancel` is called on a `CancelGuard` or it is dropped,
     /// `Cancelable` receives an error.
     ///
-    /// `on_cancel` is called to make an error value upon cancelation.
-    fn cancelable<C: Fn() -> Self::Error>(
+    fn cancelable<C: Fn() -> Self::Item>(
         self,
         guard: &impl Canceler,
         on_cancel: C,
@@ -208,7 +210,7 @@ pub trait StreamExtension: Stream + Sized {
 }
 
 impl<S: Stream> StreamExtension for S {
-    fn cancelable<C: Fn() -> S::Error>(
+    fn cancelable<C: Fn() -> S::Item>(
         self,
         guard: &impl Canceler,
         on_cancel: C,
@@ -228,17 +230,17 @@ pub trait FutureExtension: Future + Sized {
     /// `Cancelable` receives an error.
     ///
     /// `on_cancel` is called to make an error value upon cancelation.
-    fn cancelable<C: Fn() -> Self::Error>(
+    fn cancelable<C: Fn() -> Self::Output>(
         self,
         guard: &impl Canceler,
         on_cancel: C,
     ) -> Cancelable<Self, C>;
 
-    fn timeout(self, dur: Duration) -> tokio::time::Timeout<Compat01As03<Self>>;
+    fn timeout(self, dur: Duration) -> tokio::time::Timeout<Self>;
 }
 
 impl<F: Future> FutureExtension for F {
-    fn cancelable<C: Fn() -> F::Error>(
+    fn cancelable<C: Fn() -> F::Output>(
         self,
         guard: &impl Canceler,
         on_cancel: C,
@@ -252,9 +254,14 @@ impl<F: Future> FutureExtension for F {
         }
     }
 
-    fn timeout(self, dur: Duration) -> tokio::time::Timeout<Compat01As03<Self>> {
-        tokio::time::timeout(dur, self.compat())
+    fn timeout(self, dur: Duration) -> tokio::time::Timeout<Self> {
+        tokio::time::timeout(dur, self)
     }
+}
+
+pub enum CancelableItem<T> {
+    Item(T),
+    Cancel,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -16,7 +16,7 @@ pub struct Cancelable<T, C> {
     cancel_receiver: Fuse<oneshot::Receiver<()>>,
     on_cancel: C,
 }
-// CancelableError::Cancel
+
 /// It's not viable to use `select` directly, so we do a custom implementation.
 impl<S: Stream + Unpin, C: Fn() -> S::Item + Unpin> Stream for Cancelable<S, C> {
     type Item = S::Item;

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -1,14 +1,7 @@
+use crate::prelude::tokio::macros::support::Poll;
 use crate::prelude::{Pin, StoreError};
-
 use futures03::channel::oneshot;
 use futures03::{future::Fuse, Future, FutureExt, Stream};
-
-// use futures::future::Fuse;
-// use futures::prelude::{Future, Poll, Stream};
-// use futures::sync::oneshot;
-// use futures03::compat::{Compat01As03, Future01CompatExt};
-
-use crate::prelude::tokio::macros::support::Poll;
 use std::fmt::{Debug, Display};
 use std::sync::{Arc, Mutex, Weak};
 use std::task::Context;
@@ -30,7 +23,6 @@ impl<S: Stream + Unpin, C: Fn() -> S::Item + Unpin> Stream for Cancelable<S, C> 
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // Error if the stream was canceled by dropping the sender.
-        // `cancel_receiver` is fused so we may ignore `Ok`s.
         match self.cancel_receiver.poll_unpin(cx) {
             Poll::Ready(Ok(_)) => unreachable!(),
             Poll::Ready(Err(_)) => Poll::Ready(Some((self.on_cancel)())),
@@ -257,11 +249,6 @@ impl<F: Future> FutureExtension for F {
     fn timeout(self, dur: Duration) -> tokio::time::Timeout<Self> {
         tokio::time::timeout(dur, self)
     }
-}
-
-pub enum CancelableItem<T> {
-    Item(T),
-    Cancel,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/graph/src/task_spawn.rs
+++ b/graph/src/task_spawn.rs
@@ -59,5 +59,9 @@ pub fn block_on<T>(f: impl Future03<Output = T>) -> T {
 pub fn spawn_thread(name: String, f: impl 'static + FnOnce() + Send) {
     let conf = std::thread::Builder::new().name(name);
     let runtime = tokio::runtime::Handle::current();
-    conf.spawn(move || runtime.enter(f)).unwrap();
+    conf.spawn(move || {
+        let _runtime_guard = runtime.enter();
+        f()
+    })
+    .unwrap();
 }

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -1,7 +1,5 @@
 use crate::ext::futures::FutureExtension;
-use futures::prelude::*;
-use futures03::compat::Future01CompatExt;
-use futures03::{FutureExt, TryFutureExt};
+use futures03::{Future, FutureExt, TryFutureExt};
 use slog::{debug, trace, warn, Logger};
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -10,6 +8,7 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
+// use std::future::Future;
 
 /// Generic helper function for retrying async operations with built-in logging.
 ///
@@ -30,14 +29,16 @@ use tokio_retry::Retry;
 /// # extern crate graph;
 /// # use graph::prelude::*;
 /// # use tokio::time::timeout;
+/// use std::future::Future;
+/// use graph::prelude::{Logger, TimeoutError};
 /// #
 /// # type Memes = (); // the memes are a lie :(
 /// #
-/// # fn download_the_memes() -> impl Future<Item=(), Error=()> {
-/// #     future::ok(())
+/// # async fn  download_the_memes() -> Result<Memes, ()> {
+/// #     Ok(())
 /// # }
 ///
-/// fn async_function(logger: Logger) -> impl Future<Item=Memes, Error=TimeoutError<()>> {
+/// fn async_function(logger: Logger) -> impl Future<Output=Result<Memes, TimeoutError<()>>> {
 ///     // Retry on error
 ///     retry("download memes", &logger)
 ///         .no_limit() // Retry forever
@@ -156,10 +157,10 @@ where
     E: Debug + Send + Send + Sync + 'static,
 {
     /// Rerun the provided function as many times as needed.
-    pub fn run<F, R>(self, mut try_it: F) -> impl Future<Item = I, Error = TimeoutError<E>>
+    pub fn run<F, R>(self, mut try_it: F) -> impl Future<Output = Result<I, TimeoutError<E>>>
     where
         F: FnMut() -> R + Send + 'static,
-        R: Future<Item = I, Error = E> + Send + 'static,
+        R: Future<Output = Result<I, E>> + Send + 'static,
     {
         let operation_name = self.inner.operation_name;
         let logger = self.inner.logger.clone();
@@ -182,9 +183,8 @@ where
                 try_it()
                     .timeout(timeout)
                     .map_err(|_| TimeoutError::Elapsed)
-                    .and_then(|res| futures03::future::ready(res.map_err(TimeoutError::Inner)))
+                    .and_then(|res| std::future::ready(res.map_err(TimeoutError::Inner)))
                     .boxed()
-                    .compat()
             },
         )
     }
@@ -196,12 +196,12 @@ pub struct RetryConfigNoTimeout<I, E> {
 
 impl<I, E> RetryConfigNoTimeout<I, E> {
     /// Rerun the provided function as many times as needed.
-    pub fn run<F, R>(self, try_it: F) -> impl Future<Item = I, Error = E>
+    pub fn run<F, R>(self, try_it: F) -> impl Future<Output = Result<I, E>>
     where
         I: Debug + Send + 'static,
         E: Debug + Send + Sync + 'static,
         F: Fn() -> R + Send + 'static,
-        R: Future<Item = I, Error = E> + Send,
+        R: Future<Output = Result<I, E>> + Send,
     {
         let operation_name = self.inner.operation_name;
         let logger = self.inner.logger.clone();
@@ -253,24 +253,25 @@ impl<T: Debug + Send + Sync + 'static> TimeoutError<T> {
     }
 }
 
-fn run_retry<I, E, F, R>(
+fn run_retry<O, E, F, R>(
     operation_name: String,
     logger: Logger,
-    condition: RetryIf<I, E>,
+    condition: RetryIf<O, E>,
     log_after: u64,
     warn_after: u64,
     limit_opt: Option<usize>,
     mut try_it_with_timeout: F,
-) -> impl Future<Item = I, Error = TimeoutError<E>> + Send
+) -> impl Future<Output = Result<O, TimeoutError<E>>> + Send
 where
-    I: Debug + Send + 'static,
+    O: Debug + Send + 'static,
     E: Debug + Send + Sync + 'static,
     F: FnMut() -> R + Send + 'static,
-    R: Future<Item = I, Error = TimeoutError<E>> + Send,
+    R: Future<Output = Result<O, TimeoutError<E>>> + Send,
 {
     let condition = Arc::new(condition);
 
     let mut attempt_count = 0;
+
     Retry::spawn(retry_strategy(limit_opt), move || {
         let operation_name = operation_name.clone();
         let logger = logger.clone();
@@ -278,69 +279,66 @@ where
 
         attempt_count += 1;
 
-        try_it_with_timeout()
-            .then(move |result_with_timeout| {
-                let is_elapsed = result_with_timeout
-                    .as_ref()
-                    .err()
-                    .map(TimeoutError::is_elapsed)
-                    .unwrap_or(false);
+        try_it_with_timeout().then(move |result_with_timeout| {
+            let is_elapsed = result_with_timeout
+                .as_ref()
+                .err()
+                .map(TimeoutError::is_elapsed)
+                .unwrap_or(false);
 
-                if is_elapsed {
-                    if attempt_count >= log_after {
-                        debug!(
+            if is_elapsed {
+                if attempt_count >= log_after {
+                    debug!(
+                        logger,
+                        "Trying again after {} timed out (attempt #{})",
+                        &operation_name,
+                        attempt_count,
+                    );
+                }
+
+                // Wrap in Err to force retry
+                std::future::ready(Err(result_with_timeout))
+            } else {
+                // Any error must now be an inner error.
+                // Unwrap the inner error so that the predicate doesn't need to think
+                // about timeout::Error.
+                let result = result_with_timeout.map_err(|e| e.into_inner().unwrap());
+
+                // If needs retry
+                if condition.check(&result) {
+                    if attempt_count >= warn_after {
+                        // This looks like it would be nice to de-duplicate, but if we try
+                        // to use log! slog complains about requiring a const for the log level
+                        // See also b05e1594-e408-4047-aefb-71fc60d70e8f
+                        warn!(
                             logger,
-                            "Trying again after {} timed out (attempt #{})",
+                            "Trying again after {} failed (attempt #{}) with result {:?}",
                             &operation_name,
                             attempt_count,
+                            result
+                        );
+                    } else if attempt_count >= log_after {
+                        // See also b05e1594-e408-4047-aefb-71fc60d70e8f
+                        debug!(
+                            logger,
+                            "Trying again after {} failed (attempt #{}) with result {:?}",
+                            &operation_name,
+                            attempt_count,
+                            result
                         );
                     }
 
                     // Wrap in Err to force retry
-                    Err(result_with_timeout)
+                    std::future::ready(Err(result.map_err(TimeoutError::Inner)))
                 } else {
-                    // Any error must now be an inner error.
-                    // Unwrap the inner error so that the predicate doesn't need to think
-                    // about timeout::Error.
-                    let result = result_with_timeout.map_err(|e| e.into_inner().unwrap());
-
-                    // If needs retry
-                    if condition.check(&result) {
-                        if attempt_count >= warn_after {
-                            // This looks like it would be nice to de-duplicate, but if we try
-                            // to use log! slog complains about requiring a const for the log level
-                            // See also b05e1594-e408-4047-aefb-71fc60d70e8f
-                            warn!(
-                                logger,
-                                "Trying again after {} failed (attempt #{}) with result {:?}",
-                                &operation_name,
-                                attempt_count,
-                                result
-                            );
-                        } else if attempt_count >= log_after {
-                            // See also b05e1594-e408-4047-aefb-71fc60d70e8f
-                            debug!(
-                                logger,
-                                "Trying again after {} failed (attempt #{}) with result {:?}",
-                                &operation_name,
-                                attempt_count,
-                                result
-                            );
-                        }
-
-                        // Wrap in Err to force retry
-                        Err(result.map_err(TimeoutError::Inner))
-                    } else {
-                        // Wrap in Ok to prevent retry
-                        Ok(result.map_err(TimeoutError::Inner))
-                    }
+                    // Wrap in Ok to prevent retry
+                    std::future::ready(Ok(result.map_err(TimeoutError::Inner)))
                 }
-            })
-            .compat()
+            }
+        })
     })
     .boxed()
-    .compat()
-    .then(|retry_result| {
+    .then(|retry_result| async {
         // Unwrap the inner result.
         // The outer Ok/Err is only used for retry control flow.
         match retry_result {
@@ -434,123 +432,118 @@ mod tests {
     use futures03::compat::Future01CompatExt;
     use slog::o;
     use std::sync::Mutex;
-
+    use tokio18;
     #[test]
     fn test() {
         let logger = Logger::root(::slog::Discard, o!());
-        let runtime = tokio::runtime::Builder::new_current_thread()
+
+        let runtime = tokio18::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
+        let result = runtime.block_on(async {
+            let c = Mutex::new(0);
+            retry("test", &logger)
+                .no_logging()
+                .no_limit()
+                .no_timeout()
+                .run(move || {
+                    let mut c_guard = c.lock().unwrap();
+                    *c_guard += 1;
 
-        let result = runtime.block_on(
-            future::lazy(move || {
-                let c = Mutex::new(0);
-                retry("test", &logger)
-                    .no_logging()
-                    .no_limit()
-                    .no_timeout()
-                    .run(move || {
-                        let mut c_guard = c.lock().unwrap();
-                        *c_guard += 1;
-
-                        if *c_guard >= 10 {
-                            future::ok(*c_guard)
-                        } else {
-                            future::err(())
-                        }
-                    })
-            })
-            .compat(),
-        );
+                    if *c_guard >= 10 {
+                        future::ok(*c_guard).compat()
+                    } else {
+                        future::err(()).compat()
+                    }
+                })
+                .await
+        });
         assert_eq!(result, Ok(10));
     }
 
     #[test]
     fn limit_reached() {
         let logger = Logger::root(::slog::Discard, o!());
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let runtime = tokio18::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
 
-        let result = runtime.block_on(
-            future::lazy(move || {
-                let c = Mutex::new(0);
-                retry("test", &logger)
-                    .no_logging()
-                    .limit(5)
-                    .no_timeout()
-                    .run(move || {
-                        let mut c_guard = c.lock().unwrap();
-                        *c_guard += 1;
+        let result = runtime.block_on({
+            let c = Mutex::new(0);
+            retry("test", &logger)
+                .no_logging()
+                .limit(5)
+                .no_timeout()
+                .run(move || {
+                    let mut c_guard = c.lock().unwrap();
+                    *c_guard += 1;
 
-                        if *c_guard >= 10 {
-                            future::ok(*c_guard)
-                        } else {
-                            future::err(*c_guard)
-                        }
-                    })
-            })
-            .compat(),
-        );
+                    if *c_guard >= 10 {
+                        future::ok(*c_guard).compat()
+                    } else {
+                        future::err(*c_guard).compat()
+                    }
+                })
+        });
         assert_eq!(result, Err(5));
     }
 
     #[test]
     fn limit_not_reached() {
         let logger = Logger::root(::slog::Discard, o!());
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let runtime = tokio18::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
 
-        let result = runtime.block_on(
-            future::lazy(move || {
-                let c = Mutex::new(0);
-                retry("test", &logger)
-                    .no_logging()
-                    .limit(20)
-                    .no_timeout()
-                    .run(move || {
-                        let mut c_guard = c.lock().unwrap();
-                        *c_guard += 1;
+        let result = runtime.block_on({
+            let c = Mutex::new(0);
+            retry("test", &logger)
+                .no_logging()
+                .limit(20)
+                .no_timeout()
+                .run(move || {
+                    let mut c_guard = c.lock().unwrap();
+                    *c_guard += 1;
 
-                        if *c_guard >= 10 {
-                            future::ok(*c_guard)
-                        } else {
-                            future::err(*c_guard)
-                        }
-                    })
-            })
-            .compat(),
-        );
+                    if *c_guard >= 10 {
+                        future::ok(*c_guard).compat()
+                    } else {
+                        future::err(*c_guard).compat()
+                    }
+                })
+        });
         assert_eq!(result, Ok(10));
     }
 
-    #[tokio::test]
-    async fn custom_when() {
+    #[test]
+    fn custom_when() {
         let logger = Logger::root(::slog::Discard, o!());
         let c = Mutex::new(0);
 
-        let result = retry("test", &logger)
-            .when(|result| result.unwrap() < 10)
-            .no_logging()
-            .limit(20)
-            .no_timeout()
-            .run(move || {
-                let mut c_guard = c.lock().unwrap();
-                *c_guard += 1;
-                if *c_guard > 30 {
-                    future::err(())
-                } else {
-                    future::ok(*c_guard)
-                }
-            })
-            .compat()
-            .await
+        let runtime = tokio18::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
             .unwrap();
+        let result = runtime.block_on({
+            retry("test", &logger)
+                .when(|result| result.unwrap() < 10)
+                .no_logging()
+                .limit(20)
+                .no_timeout()
+                .run(move || {
+                    let mut c_guard = c.lock().unwrap();
+                    *c_guard += 1;
+                    if *c_guard > 30 {
+                        future::err(()).compat()
+                    } else {
+                        future::ok(*c_guard).compat()
+                    }
+                })
+        });
 
-        assert_eq!(result, 10);
+        assert_eq!(result, Ok(10));
     }
 }

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -431,12 +431,12 @@ mod tests {
     use futures03::compat::Future01CompatExt;
     use slog::o;
     use std::sync::Mutex;
-    use tokio18;
+
     #[test]
     fn test() {
         let logger = Logger::root(::slog::Discard, o!());
 
-        let runtime = tokio18::runtime::Builder::new_current_thread()
+        let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
@@ -464,7 +464,7 @@ mod tests {
     #[test]
     fn limit_reached() {
         let logger = Logger::root(::slog::Discard, o!());
-        let runtime = tokio18::runtime::Builder::new_current_thread()
+        let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn limit_not_reached() {
         let logger = Logger::root(::slog::Discard, o!());
-        let runtime = tokio18::runtime::Builder::new_current_thread()
+        let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
@@ -522,7 +522,7 @@ mod tests {
         let logger = Logger::root(::slog::Discard, o!());
         let c = Mutex::new(0);
 
-        let runtime = tokio18::runtime::Builder::new_current_thread()
+        let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
-// use std::future::Future;
 
 /// Generic helper function for retrying async operations with built-in logging.
 ///

--- a/graph/src/util/jobs.rs
+++ b/graph/src/util/jobs.rs
@@ -85,7 +85,7 @@ impl Runner {
                 next = next.min(task.next_run);
             }
             let wait = next.saturating_duration_since(Instant::now());
-            tokio::time::delay_for(wait).await;
+            tokio::time::sleep(wait).await;
         }
         self.stop.store(false, Ordering::SeqCst);
         warn!(self.logger, "Received request to stop. Stopping runner");
@@ -116,7 +116,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn jobs_run() {
         let count = Arc::new(Mutex::new(0));
         let job = CounterJob {
@@ -142,7 +142,7 @@ mod tests {
         stop.store(true, Ordering::SeqCst);
         // Wait for the runner to shut down
         while stop.load(Ordering::SeqCst) {
-            tokio::time::delay_for(Duration::from_millis(10)).await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }
 }

--- a/graph/src/util/security.rs
+++ b/graph/src/util/security.rs
@@ -13,7 +13,7 @@ fn display_url(url: &str) -> String {
             .expect("failed to redact password");
     }
 
-    url.into_string()
+    String::from(url)
 }
 
 pub struct SafeDisplay<T>(pub T);

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -57,6 +57,7 @@ impl Resolver for MockResolver {
         Arc::new(tokio::sync::Semaphore::new(1))
             .acquire_owned()
             .await
+            .unwrap()
     }
 }
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -19,10 +19,9 @@ use graph::{
         subgraph::SubgraphFeature,
     },
     prelude::{
-        futures03::stream::StreamExt, futures03::FutureExt, futures03::TryFutureExt, o, q,
-        serde_json, slog, BlockPtr, DeploymentHash, Entity, EntityKey, EntityOperation,
-        FutureExtension, GraphQlRunner as _, Logger, NodeId, Query, QueryError,
-        QueryExecutionError, QueryResult, QueryStoreManager, QueryVariables, Schema,
+        futures03::stream::StreamExt, o, q, serde_json, slog, BlockPtr, DeploymentHash, Entity,
+        EntityKey, EntityOperation, FutureExtension, GraphQlRunner as _, Logger, NodeId, Query,
+        QueryError, QueryExecutionError, QueryResult, QueryStoreManager, QueryVariables, Schema,
         SubgraphDeploymentEntity, SubgraphManifest, SubgraphName, SubgraphStore,
         SubgraphVersionSwitchingMode, Subscription, SubscriptionError, Value,
     },
@@ -1320,11 +1319,10 @@ fn subscription_gets_result_even_without_events() {
         let results: Vec<_> = stream
             .take(1)
             .collect()
-            .map(Result::<_, ()>::Ok)
-            .compat()
+            // .map(Result::<_, ()>::Ok)
             .timeout(Duration::from_secs(3))
             .await
-            .unwrap()
+            // .unwrap()
             .unwrap();
 
         assert_eq!(results.len(), 1);

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -733,7 +733,7 @@ fn replace_host(url: &str, host: &str) -> String {
     if let Err(e) = url.set_host(Some(host)) {
         panic!("Invalid Postgres url {}: {}", url, e.to_string());
     }
-    url.into_string()
+    String::from(url)
 }
 
 // Various default functions for deserialization

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -376,28 +376,28 @@ async fn test_ipfs_cat(api_version: Version) {
     // so we replicate what we do `spawn_module`.
     let runtime = tokio::runtime::Handle::current();
     std::thread::spawn(move || {
-        runtime.enter(|| {
-            let mut module = test_module(
-                "ipfsCat",
-                mock_data_source("ipfs_cat.wasm", api_version.clone()),
-                api_version,
-            );
-            let arg = asc_new(&mut module, &hash).unwrap();
-            let converted: AscPtr<AscString> = module.invoke_export("ipfsCatString", arg);
-            let data: String = asc_get(&module, converted).unwrap();
-            assert_eq!(data, "42");
-        })
+        let _runtime_guard = runtime.enter();
+
+        let mut module = test_module(
+            "ipfsCat",
+            mock_data_source("ipfs_cat.wasm", api_version.clone()),
+            api_version,
+        );
+        let arg = asc_new(&mut module, &hash).unwrap();
+        let converted: AscPtr<AscString> = module.invoke_export("ipfsCatString", arg);
+        let data: String = asc_get(&module, converted).unwrap();
+        assert_eq!(data, "42");
     })
     .join()
     .unwrap();
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn ipfs_cat_v0_0_4() {
     test_ipfs_cat(API_VERSION_0_0_4).await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn ipfs_cat_v0_0_5() {
     test_ipfs_cat(API_VERSION_0_0_5).await;
 }
@@ -564,12 +564,12 @@ async fn test_ipfs_map(api_version: Version, json_error_msg: &str) {
     assert!(errmsg.contains("500 Internal Server Error"));
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn ipfs_map_v0_0_4() {
     test_ipfs_map(API_VERSION_0_0_4, "JSON value is not a string.").await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn ipfs_map_v0_0_5() {
     test_ipfs_map(API_VERSION_0_0_5, "'id' should not be null").await;
 }
@@ -597,12 +597,12 @@ async fn test_ipfs_fail(api_version: Version) {
     .unwrap();
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn ipfs_fail_v0_0_4() {
     test_ipfs_fail(API_VERSION_0_0_4).await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn ipfs_fail_v0_0_5() {
     test_ipfs_fail(API_VERSION_0_0_5).await;
 }

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -446,35 +446,35 @@ async fn run_ipfs_map(
     // so we replicate what we do `spawn_module`.
     let runtime = tokio::runtime::Handle::current();
     std::thread::spawn(move || {
-        runtime.enter(|| {
-            let (mut module, _, _) = test_valid_module_and_store(
-                &subgraph_id,
-                mock_data_source("ipfs_map.wasm", api_version.clone()),
-                api_version,
-            );
-            let value = asc_new(&mut module, &hash).unwrap();
-            let user_data = asc_new(&mut module, USER_DATA).unwrap();
+        let _runtime_guard = runtime.enter();
 
-            // Invoke the callback
-            let func = module.get_func("ipfsMap").typed().unwrap().clone();
-            let _: () = func.call((value.wasm_ptr(), user_data.wasm_ptr()))?;
-            let mut mods = module
-                .take_ctx()
-                .ctx
-                .state
-                .entity_cache
-                .as_modifications()?
-                .modifications;
+        let (mut module, _, _) = test_valid_module_and_store(
+            &subgraph_id,
+            mock_data_source("ipfs_map.wasm", api_version.clone()),
+            api_version,
+        );
+        let value = asc_new(&mut module, &hash).unwrap();
+        let user_data = asc_new(&mut module, USER_DATA).unwrap();
 
-            // Bring the modifications into a predictable order (by entity_id)
-            mods.sort_by(|a, b| {
-                a.entity_key()
-                    .entity_id
-                    .partial_cmp(&b.entity_key().entity_id)
-                    .unwrap()
-            });
-            Ok(mods)
-        })
+        // Invoke the callback
+        let func = module.get_func("ipfsMap").typed().unwrap().clone();
+        let _: () = func.call((value.wasm_ptr(), user_data.wasm_ptr()))?;
+        let mut mods = module
+            .take_ctx()
+            .ctx
+            .state
+            .entity_cache
+            .as_modifications()?
+            .modifications;
+
+        // Bring the modifications into a predictable order (by entity_id)
+        mods.sort_by(|a, b| {
+            a.entity_key()
+                .entity_id
+                .partial_cmp(&b.entity_key().entity_id)
+                .unwrap()
+        });
+        Ok(mods)
     })
     .join()
     .unwrap()
@@ -580,18 +580,17 @@ async fn test_ipfs_fail(api_version: Version) {
     // Ipfs host functions use `block_on` which must be called from a sync context,
     // so we replicate what we do `spawn_module`.
     std::thread::spawn(move || {
-        runtime.enter(|| {
-            let mut module = test_module(
-                "ipfsFail",
-                mock_data_source("ipfs_cat.wasm", api_version.clone()),
-                api_version,
-            );
+        let _runtime_guard = runtime.enter();
+        let mut module = test_module(
+            "ipfsFail",
+            mock_data_source("ipfs_cat.wasm", api_version.clone()),
+            api_version,
+        );
 
-            let hash = asc_new(&mut module, "invalid hash").unwrap();
-            assert!(module
-                .invoke_export::<_, AscString>("ipfsCat", hash,)
-                .is_null());
-        })
+        let hash = asc_new(&mut module, "invalid hash").unwrap();
+        assert!(module
+            .invoke_export::<_, AscString>("ipfsCat", hash,)
+            .is_null());
     })
     .join()
     .unwrap();

--- a/runtime/test/src/test/abi.rs
+++ b/runtime/test/src/test/abi.rs
@@ -22,12 +22,12 @@ fn test_unbounded_loop(api_version: Version) {
     assert!(res.unwrap_err().to_string().contains(TRAP_TIMEOUT));
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn unbounded_loop_v0_0_4() {
     test_unbounded_loop(API_VERSION_0_0_4);
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn unbounded_loop_v0_0_5() {
     test_unbounded_loop(API_VERSION_0_0_5);
 }

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -18,6 +18,7 @@ lazy_static = "1.4"
 uuid = { version = "0.8.1", features = ["v4"] }
 strum = "0.21.0"
 strum_macros = "0.21.1"
+bytes = "1.0"
 anyhow = "1.0"
 wasmtime = "0.27.0"
 defer = "0.1"

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -37,48 +37,48 @@ pub fn spawn_module<C: Blockchain>(
     let conf =
         thread::Builder::new().name(format!("mapping-{}-{}", &subgraph_id, uuid::Uuid::new_v4()));
     conf.spawn(move || {
-        runtime.enter(|| {
-            // Pass incoming triggers to the WASM module and return entity changes;
-            // Stop when canceled because all RuntimeHosts and their senders were dropped.
-            match mapping_request_receiver
-                .map_err(|()| unreachable!())
-                .for_each(move |request| {
-                    let MappingRequest {
-                        ctx,
-                        trigger,
-                        result_sender,
-                    } = request;
-                    let logger = ctx.logger.cheap_clone();
+        let _runtime_guard = runtime.enter();
 
-                    // Start the WASM module runtime.
-                    let section = host_metrics.stopwatch.start_section("module_init");
-                    let module = WasmInstance::from_valid_module_with_ctx(
-                        valid_module.cheap_clone(),
-                        ctx,
-                        host_metrics.cheap_clone(),
-                        timeout,
-                        experimental_features.clone(),
-                    )?;
-                    section.end();
+        // Pass incoming triggers to the WASM module and return entity changes;
+        // Stop when canceled because all RuntimeHosts and their senders were dropped.
+        match mapping_request_receiver
+            .map_err(|()| unreachable!())
+            .for_each(move |request| {
+                let MappingRequest {
+                    ctx,
+                    trigger,
+                    result_sender,
+                } = request;
+                let logger = ctx.logger.cheap_clone();
 
-                    let section = host_metrics.stopwatch.start_section("run_handler");
-                    if *LOG_TRIGGER_DATA {
-                        debug!(logger, "trigger data: {:?}", trigger);
-                    }
-                    let result = module.handle_trigger(trigger);
-                    section.end();
+                // Start the WASM module runtime.
+                let section = host_metrics.stopwatch.start_section("module_init");
+                let module = WasmInstance::from_valid_module_with_ctx(
+                    valid_module.cheap_clone(),
+                    ctx,
+                    host_metrics.cheap_clone(),
+                    timeout,
+                    experimental_features.clone(),
+                )?;
+                section.end();
 
-                    result_sender
-                        .send(result)
-                        .map_err(|_| anyhow::anyhow!("WASM module result receiver dropped."))
-                })
-                .wait()
-            {
-                Ok(()) => debug!(logger, "Subgraph stopped, WASM runtime thread terminated"),
-                Err(e) => debug!(logger, "WASM runtime thread terminated abnormally";
+                let section = host_metrics.stopwatch.start_section("run_handler");
+                if *LOG_TRIGGER_DATA {
+                    debug!(logger, "trigger data: {:?}", trigger);
+                }
+                let result = module.handle_trigger(trigger);
+                section.end();
+
+                result_sender
+                    .send(result)
+                    .map_err(|_| anyhow::anyhow!("WASM module result receiver dropped."))
+            })
+            .wait()
+        {
+            Ok(()) => debug!(logger, "Subgraph stopped, WASM runtime thread terminated"),
+            Err(e) => debug!(logger, "WASM runtime thread terminated abnormally";
                                     "error" => e.to_string()),
-            }
-        })
+        }
     })
     .map(|_| ())
     .context("Spawning WASM runtime thread failed")?;

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -291,7 +291,7 @@ impl<C: Blockchain> WasmInstance<C> {
                         None => break interrupt_handle.interrupt(), // Timed out.
 
                         Some(time) if time < minimum_wait => break interrupt_handle.interrupt(),
-                        Some(time) => tokio::time::delay_for(time).await,
+                        Some(time) => tokio::time::sleep(time).await,
                     }
                 }
             });

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 futures = "0.1.21"
 graphql-parser = "0.3"
 http = "0.2"
-hyper = "0.13"
+hyper = "0.14"
 serde = "1.0"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -480,7 +480,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn posting_valid_queries_yields_result_response() {
         let logger = Logger::root(slog::Discard, o!());
         let metrics_registry = Arc::new(MockMetricsRegistry::new());

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -12,7 +12,7 @@ use graph::prelude::*;
 use graph_server_http::test_utils;
 use graph_server_http::GraphQLServer as HyperGraphQLServer;
 
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 /// A simple stupid query runner for testing.
 pub struct TestGraphQlRunner;
@@ -85,7 +85,7 @@ mod test {
 
     #[test]
     fn rejects_empty_json() {
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime
             .block_on(async {
                 let logger = Logger::root(slog::Discard, o!());
@@ -102,7 +102,7 @@ mod test {
                 // Launch the server to handle a single request
                 tokio::spawn(http_server.fuse().compat());
                 // Give some time for the server to start.
-                delay_for(Duration::from_secs(2))
+                sleep(Duration::from_secs(2))
                     .then(move |()| {
                         // Send an empty JSON POST request
                         let client = Client::new();
@@ -128,7 +128,7 @@ mod test {
 
     #[test]
     fn rejects_invalid_queries() {
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
             let logger_factory = LoggerFactory::new(logger, None);
@@ -145,7 +145,7 @@ mod test {
             // Launch the server to handle a single request
             tokio::spawn(http_server.fuse().compat());
             // Give some time for the server to start.
-            delay_for(Duration::from_secs(2))
+            sleep(Duration::from_secs(2))
                 .then(move |()| {
                     // Send an broken query request
                     let client = Client::new();
@@ -210,7 +210,7 @@ mod test {
 
     #[test]
     fn accepts_valid_queries() {
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
             let logger_factory = LoggerFactory::new(logger, None);
@@ -227,7 +227,7 @@ mod test {
             // Launch the server to handle a single request
             tokio::spawn(http_server.fuse().compat());
             // Give some time for the server to start.
-            delay_for(Duration::from_secs(2))
+            sleep(Duration::from_secs(2))
                 .then(move |()| {
                     // Send a valid example query
                     let client = Client::new();
@@ -257,7 +257,7 @@ mod test {
 
     #[test]
     fn accepts_valid_queries_with_variables() {
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
         let _ = runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
             let logger_factory = LoggerFactory::new(logger, None);
@@ -274,7 +274,7 @@ mod test {
             // Launch the server to handle a single request
             tokio::spawn(http_server.fuse().compat());
             // Give some time for the server to start.
-            delay_for(Duration::from_secs(2))
+            sleep(Duration::from_secs(2))
                 .then(move |()| {
                     // Send a valid example query
                     let client = Client::new();

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -9,5 +9,5 @@ graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
 graphql-parser = "0.3"
 http = "0.2"
-hyper = "0.13"
+hyper = "0.14"
 serde = "1.0"

--- a/server/metrics/Cargo.toml
+++ b/server/metrics/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 futures = "0.1.21"
 graph = { path = "../../graph" }
 http = "0.2"
-hyper = "0.13"
+hyper = { version = "0.14", features = ["server"] }
 lazy_static = "1.2.0"
 serde = "1.0"

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -11,6 +11,6 @@ http = "0.2"
 lazy_static = "1.2.0"
 serde = "1.0"
 serde_derive = "1.0"
-tokio-tungstenite = "0.10"
+tokio-tungstenite = "0.14"
 uuid = { version = "0.7.2", features = ["v4"] }
 anyhow = "1.0"

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -45,9 +45,9 @@ impl IncomingMessage {
     pub fn from_ws_message(msg: WsMessage) -> Result<Self, WsError> {
         let text = msg.into_text()?;
         serde_json::from_str(text.as_str()).map_err(|e| {
-            WsError::Protocol(
+            WsError::Http(http::Response::new(Some(
                 format!("Invalid GraphQL over WebSocket message: {}: {}", text, e).into(),
-            )
+            )))
         })
     }
 }
@@ -94,8 +94,11 @@ fn send_message(
     sink: &mpsc::UnboundedSender<WsMessage>,
     msg: OutgoingMessage,
 ) -> Result<(), WsError> {
-    sink.unbounded_send(msg.into())
-        .map_err(|_| WsError::Http(StatusCode::INTERNAL_SERVER_ERROR))
+    sink.unbounded_send(msg.into()).map_err(|_| {
+        let mut response = http::Response::new(None);
+        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+        WsError::Http(response)
+    })
 }
 
 /// Helper function to send error messages.
@@ -105,7 +108,11 @@ fn send_error_string(
     error: String,
 ) -> Result<(), WsError> {
     sink.unbounded_send(OutgoingMessage::from_error_string(operation_id, error).into())
-        .map_err(|_| WsError::Http(StatusCode::INTERNAL_SERVER_ERROR))
+        .map_err(|_| {
+            let mut response = http::Response::new(None);
+            *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            WsError::Http(response)
+        })
 }
 
 /// Responsible for recording operation ids and stopping them.

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -373,14 +373,16 @@ where
                     let logger = logger.clone();
                     let cancel_id = id.clone();
                     let connection_id = connection_id.clone();
-                    let run_subscription = run_subscription.cancelable(&guard, move || {
-                        debug!(logger, "Stopped operation";
+                    let run_subscription =
+                        run_subscription.compat().cancelable(&guard, move || {
+                            debug!(logger, "Stopped operation";
                                        "connection" => &connection_id,
-                                       "id" => &cancel_id)
-                    });
+                                       "id" => &cancel_id);
+                            Ok(())
+                        });
                     operations.insert(id, guard);
 
-                    graph::spawn_allow_panic(run_subscription.compat());
+                    graph::spawn_allow_panic(run_subscription);
                     Ok(())
                 }
             }?

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -102,7 +102,7 @@ where
         );
 
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
-        let mut socket = TcpListener::bind(&addr)
+        let socket = TcpListener::bind(&addr)
             .await
             .expect("Failed to bind WebSocket port");
 

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -18,6 +18,7 @@ use graph::prelude::serde::{Deserialize, Serialize};
 use graph::prelude::serde_json::{self, json};
 use graph::prelude::tokio::sync::{mpsc::Receiver, watch};
 use graph::prelude::{crit, o, CheapClone, Logger, MetricsRegistry};
+use graph::tokio_stream::wrappers::WatchStream;
 
 lazy_static! {
     pub static ref CHANNEL_NAME: SafeChannelName =
@@ -37,7 +38,7 @@ impl Watcher {
 
     fn send(&self) {
         // Unwrap: `self` holds a receiver.
-        self.sender.broadcast(()).unwrap()
+        self.sender.send(()).unwrap()
     }
 }
 
@@ -164,7 +165,12 @@ impl ChainHeadUpdateListenerTrait for ChainHeadUpdateListener {
             .receiver
             .clone();
 
-        Box::new(update_receiver.map(Result::<_, ()>::Ok).boxed().compat())
+        Box::new(
+            WatchStream::new(update_receiver)
+                .map(Result::<_, ()>::Ok)
+                .boxed()
+                .compat(),
+        )
     }
 }
 

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -13,7 +13,6 @@ use crate::{
     notification_listener::{JsonNotification, NotificationListener, SafeChannelName},
 };
 use graph::blockchain::ChainHeadUpdateListener as ChainHeadUpdateListenerTrait;
-use graph::prelude::futures03::prelude::stream::{StreamExt, TryStreamExt};
 use graph::prelude::serde::{Deserialize, Serialize};
 use graph::prelude::serde_json::{self, json};
 use graph::prelude::tokio::sync::{mpsc::Receiver, watch};
@@ -165,12 +164,7 @@ impl ChainHeadUpdateListenerTrait for ChainHeadUpdateListener {
             .receiver
             .clone();
 
-        Box::new(
-            WatchStream::new(update_receiver)
-                .map(Result::<_, ()>::Ok)
-                .boxed()
-                .compat(),
-        )
+        Box::new(WatchStream::new(update_receiver))
     }
 }
 

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -603,7 +603,7 @@ impl ConnectionPool {
             .write()
             .unwrap()
             .add_and_register(start.elapsed(), &self.semaphore_wait_gauge);
-        permit
+        permit.unwrap()
     }
 
     fn configure_fdw(&self, servers: &Vec<ForeignServer>) -> Result<(), StoreError> {

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -193,11 +193,7 @@ impl NotificationListener {
                                 // We'll assume here that if sending fails, this means that the
                                 // listener has already been dropped, the receiving
                                 // end is gone and we should terminate the listener loop
-                                if Box::pin(sender.clone().send(json_notification))
-                                    .compat()
-                                    .wait()
-                                    .is_err()
-                                {
+                                if sender.clone().blocking_send(json_notification).is_err() {
                                     break;
                                 }
                             }

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -1,5 +1,6 @@
 use futures::sync::mpsc::{channel, Sender};
 use futures03::TryStreamExt;
+use graph::tokio_stream::wrappers::ReceiverStream;
 use std::sync::{atomic::Ordering, Arc, RwLock};
 use std::{collections::HashMap, sync::atomic::AtomicUsize};
 use uuid::Uuid;
@@ -24,38 +25,41 @@ impl StoreEventListener {
             SafeChannelName::i_promise_this_is_safe("store_events"),
         );
 
-        let event_stream = Box::new(receiver.map(Result::<_, ()>::Ok).compat().filter_map(
-            move |notification| {
-                // When graph-node is starting up, it is possible that
-                // Postgres still has old messages queued up that we
-                // can't decode anymore. It is safe to skip them; once
-                // We've seen 10 valid messages, we can assume that
-                // whatever old messages Postgres had queued have been
-                // cleared. Seeing an invalid message after that
-                // definitely indicates trouble.
-                let num_valid = AtomicUsize::new(0);
-                serde_json::from_value(notification.payload.clone()).map_or_else(
-                    |_err| {
-                        error!(
-                            &logger,
-                            "invalid store event received from database: {:?}",
-                            notification.payload
-                        );
-                        if num_valid.load(Ordering::SeqCst) > 10 {
-                            panic!(
+        let event_stream = Box::new(
+            ReceiverStream::new(receiver)
+                .map(Result::<_, ()>::Ok)
+                .compat()
+                .filter_map(move |notification| {
+                    // When graph-node is starting up, it is possible that
+                    // Postgres still has old messages queued up that we
+                    // can't decode anymore. It is safe to skip them; once
+                    // We've seen 10 valid messages, we can assume that
+                    // whatever old messages Postgres had queued have been
+                    // cleared. Seeing an invalid message after that
+                    // definitely indicates trouble.
+                    let num_valid = AtomicUsize::new(0);
+                    serde_json::from_value(notification.payload.clone()).map_or_else(
+                        |_err| {
+                            error!(
+                                &logger,
                                 "invalid store event received from database: {:?}",
                                 notification.payload
                             );
-                        }
-                        None
-                    },
-                    |change| {
-                        num_valid.fetch_add(1, Ordering::SeqCst);
-                        Some(change)
-                    },
-                )
-            },
-        ));
+                            if num_valid.load(Ordering::SeqCst) > 10 {
+                                panic!(
+                                    "invalid store event received from database: {:?}",
+                                    notification.payload
+                                );
+                            }
+                            None
+                        },
+                        |change| {
+                            num_valid.fetch_add(1, Ordering::SeqCst);
+                            Some(change)
+                        },
+                    )
+                }),
+        );
 
         (
             StoreEventListener {

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -952,6 +952,7 @@ async fn check_events(
             future::ok(!expected.is_empty())
         })
         .collect()
+        .compat()
         .timeout(Duration::from_secs(3))
         .await
         .expect(&format!(
@@ -1467,6 +1468,7 @@ fn throttle_subscription_throttles() {
         let res = subscription
             .take(1)
             .collect()
+            .compat()
             .timeout(Duration::from_millis(500))
             .await;
         assert!(res.is_err());

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -42,11 +42,8 @@ lazy_static! {
         None => Logger::root(slog::Discard, o!()),
     };
     static ref SEQ_LOCK: Mutex<()> = Mutex::new(());
-    static ref STORE_RUNTIME: Runtime = Builder::new()
-        .threaded_scheduler()
-        .enable_all()
-        .build()
-        .unwrap();
+    pub static ref STORE_RUNTIME: Runtime =
+        Builder::new_current_thread().enable_all().build().unwrap();
     pub static ref LOAD_MANAGER: Arc<LoadManager> = Arc::new(LoadManager::new(
         &*LOGGER,
         Vec::new(),
@@ -367,8 +364,7 @@ fn execute_subgraph_query_internal(
     max_complexity: Option<u64>,
     deadline: Option<Instant>,
 ) -> QueryResults {
-    let mut rt = tokio::runtime::Builder::new()
-        .basic_scheduler()
+    let rt = tokio::runtime::Builder::new_current_thread()
         .enable_io()
         .enable_time()
         .build()

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -43,7 +43,7 @@ lazy_static! {
     };
     static ref SEQ_LOCK: Mutex<()> = Mutex::new(());
     pub static ref STORE_RUNTIME: Runtime =
-        Builder::new_current_thread().enable_all().build().unwrap();
+        Builder::new_multi_thread().enable_all().build().unwrap();
     pub static ref LOAD_MANAGER: Arc<LoadManager> = Arc::new(LoadManager::new(
         &*LOGGER,
         Vec::new(),

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dev-dependencies]
 bollard = "0.10"
-tokio = {version = "1.2.0", features = ["rt", "macros", "process"]}
+tokio = {version = "1.9.0", features = ["rt", "macros", "process"]}
 tokio-stream = "0.1"
 futures = "0.3.13"
 port_check = "0.1.5"


### PR DESCRIPTION
Rebased atop tokio 1.9 upgrader

- Modified blockstream implementation to support future 0.3
- Modified cancellable to support future 0.3
- Modified retry lib to support future 0.3. Now retry func expects a future 0.3 function
- Sprinkled some boxed & compat where needed
- Fixed examples