### PR TITLE
Integration-tests: Update yarn.lock to rebased branches

### DIFF
--- a/tests/integration-tests/yarn.lock
+++ b/tests/integration-tests/yarn.lock
@@ -781,7 +781,7 @@
   optionalDependencies:
     keytar "^7.4.0"
 
-"@graphprotocol/graph-cli@https://github.com/graphprotocol/graph-cli#otavio/update-assembly-script":
+"@graphprotocol/graph-cli@https://github.com/graphprotocol/graph-cli#otavio/update-assembly-script2":
   version "0.21.1"
   resolved "https://github.com/graphprotocol/graph-cli#96adba9ef58963a82cfdd49e1359a013b7bef708"
   dependencies:
@@ -814,7 +814,7 @@
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
 
-"@graphprotocol/graph-ts@https://github.com/graphprotocol/graph-ts#otavio/update-assembly-script":
+"@graphprotocol/graph-ts@https://github.com/graphprotocol/graph-ts#otavio/update-assembly-script2":
   version "0.21.0"
   resolved "https://github.com/graphprotocol/graph-ts#d49f8747eea835d9cf7c3438ccd827d1f91c71e4"
   dependencies:

--- a/tests/integration-tests/yarn.lock
+++ b/tests/integration-tests/yarn.lock
@@ -782,8 +782,8 @@
     keytar "^7.4.0"
 
 "@graphprotocol/graph-cli@https://github.com/graphprotocol/graph-cli#otavio/update-assembly-script":
-  version "0.20.1"
-  resolved "https://github.com/graphprotocol/graph-cli#8ff5148bb7c5f73a7cc73f77acbb68716696c45a"
+  version "0.21.1"
+  resolved "https://github.com/graphprotocol/graph-cli#96adba9ef58963a82cfdd49e1359a013b7bef708"
   dependencies:
     assemblyscript "0.19.2"
     chalk "^3.0.0"
@@ -816,7 +816,7 @@
 
 "@graphprotocol/graph-ts@https://github.com/graphprotocol/graph-ts#otavio/update-assembly-script":
   version "0.21.0"
-  resolved "https://github.com/graphprotocol/graph-ts#da9d30f105695aa86df90ed559fc984768e0a9f1"
+  resolved "https://github.com/graphprotocol/graph-ts#d49f8747eea835d9cf7c3438ccd827d1f91c71e4"
   dependencies:
     assemblyscript "0.19.2"
 


### PR DESCRIPTION
Graph-cli and graph-ts had new commits in master but the `otavio/update-assembly-script` branch was not up to date.

This PR fixed this by pointing to the new commits on a branch with the `2` suffix, this was necessary because if the commits were overwritten in the original branch, the integration tests would start to fail, because they would point to an unexisting commit of a branch.