### PR TITLE
Create public common module in test crate

### DIFF
--- a/chain/ethereum/src/runtime/mod.rs
+++ b/chain/ethereum/src/runtime/mod.rs
@@ -1,4 +1,4 @@
 pub use runtime_adapter::RuntimeAdapter;
 
 pub mod abi;
-mod runtime_adapter;
+pub mod runtime_adapter;

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -197,7 +197,7 @@ fn eth_call(
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct UnresolvedContractCall {
+pub struct UnresolvedContractCall {
     pub contract_name: String,
     pub contract_address: Address,
     pub function_name: String,

--- a/runtime/test/Cargo.toml
+++ b/runtime/test/Cargo.toml
@@ -3,7 +3,7 @@ name = "graph-runtime-test"
 version = "0.23.1"
 edition = "2018"
 
-[dev-dependencies]
+[dependencies]
 semver = "1.0"
 wasmtime = "0.27.0"
 graph = { path = "../../graph" }

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -1,13 +1,13 @@
 use ethabi::Contract;
+use graph::components::store::DeploymentLocator;
 use graph::data::subgraph::*;
+use graph::ipfs_client::IpfsClient;
 use graph::prelude::*;
-use graph_chain_ethereum::{DataSource, Chain, DataSourceTemplate};
+use graph_chain_ethereum::{Chain, DataSource, DataSourceTemplate};
+use graph_runtime_wasm::{HostExports, MappingContext};
 use semver::Version;
 use std::str::FromStr;
 use web3::types::Address;
-use graph::components::store::DeploymentLocator;
-use graph_runtime_wasm::{MappingContext, HostExports};
-use graph::ipfs_client::IpfsClient;
 
 fn mock_host_exports(
     subgraph_id: DeploymentHash,
@@ -64,9 +64,9 @@ pub fn mock_abi() -> MappingABI {
                 "type": "constructor"
             }
         ]"#
-                .as_bytes(),
+            .as_bytes(),
         )
-            .unwrap(),
+        .unwrap(),
     }
 }
 

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -1,0 +1,62 @@
+use ethabi::Contract;
+use graph::data::subgraph::*;
+use graph::prelude::*;
+use graph_chain_ethereum::DataSource;
+use semver::Version;
+use std::str::FromStr;
+use web3::types::Address;
+
+#[allow(unused)]
+pub fn mock_abi() -> MappingABI {
+    MappingABI {
+        name: "mock_abi".to_string(),
+        contract: Contract::load(
+            r#"[
+            {
+                "inputs": [
+                    {
+                        "name": "a",
+                        "type": "address"
+                    }
+                ],
+                "type": "constructor"
+            }
+        ]"#
+            .as_bytes(),
+        )
+        .unwrap(),
+    }
+}
+
+#[allow(unused)]
+pub fn mock_data_source(path: &str, api_version: Version) -> DataSource {
+    let runtime = std::fs::read(path).unwrap();
+
+    DataSource {
+        kind: String::from("ethereum/contract"),
+        name: String::from("example data source"),
+        network: Some(String::from("mainnet")),
+        source: Source {
+            address: Some(Address::from_str("0123123123012312312301231231230123123123").unwrap()),
+            abi: String::from("123123"),
+            start_block: 0,
+        },
+        mapping: Mapping {
+            kind: String::from("ethereum/events"),
+            api_version,
+            language: String::from("wasm/assemblyscript"),
+            entities: vec![],
+            abis: vec![],
+            event_handlers: vec![],
+            call_handlers: vec![],
+            block_handlers: vec![],
+            link: Link {
+                link: "link".to_owned(),
+            },
+            runtime: Arc::new(runtime.clone()),
+        },
+        context: Default::default(),
+        creation_block: None,
+        contract_abi: Arc::new(mock_abi()),
+    }
+}

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -49,7 +49,7 @@ fn mock_host_exports(
     )
 }
 
-pub fn mock_abi() -> MappingABI {
+fn mock_abi() -> MappingABI {
     MappingABI {
         name: "mock_abi".to_string(),
         contract: Contract::load(
@@ -70,7 +70,6 @@ pub fn mock_abi() -> MappingABI {
     }
 }
 
-#[allow(unused)]
 pub fn mock_context(
     deployment: DeploymentLocator,
     data_source: DataSource,
@@ -95,7 +94,6 @@ pub fn mock_context(
     }
 }
 
-#[allow(unused)]
 pub fn mock_data_source(path: &str, api_version: Version) -> DataSource {
     let runtime = std::fs::read(path).unwrap();
 

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -1,4 +1,3 @@
-//! This crate is for tests only.
-
+mod common;
 #[cfg(test)]
 mod test;

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -1,4 +1,3 @@
-#[cfg(debug_assertions)]
 pub mod common;
 #[cfg(test)]
 mod test;

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -1,3 +1,3 @@
-mod common;
+pub mod common;
 #[cfg(test)]
 mod test;

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(debug_assertions)]
 pub mod common;
 #[cfg(test)]
 mod test;

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 use test_store::STORE;
 use web3::types::H160;
 
-use crate::common::{mock_data_source, mock_abi};
+use crate::common::{mock_abi, mock_data_source};
 
 mod abi;
 

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -1,11 +1,3 @@
-use std::collections::{BTreeMap, HashMap};
-use std::str::FromStr;
-
-use ethabi::Contract;
-use hex;
-use semver::Version;
-use web3::types::{Address, H160};
-
 use graph::data::store::scalar;
 use graph::data::subgraph::*;
 use graph::prelude::web3::types::U256;
@@ -20,9 +12,14 @@ use graph_runtime_wasm::asc_abi::class::{Array, AscBigInt, AscEntity, AscString,
 use graph_runtime_wasm::{
     ExperimentalFeatures, HostExports, MappingContext, ValidModule, WasmInstance,
 };
+use hex;
+use semver::Version;
+use std::collections::{BTreeMap, HashMap};
+use std::str::FromStr;
 use test_store::STORE;
+use web3::types::H160;
 
-use crate::common::{mock_abi, mock_data_source};
+use crate::common::mock_data_source;
 
 mod abi;
 

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 use test_store::STORE;
 use web3::types::H160;
 
-use crate::common::mock_data_source;
+use crate::common::{mock_data_source, mock_abi};
 
 mod abi;
 
@@ -119,70 +119,6 @@ fn test_module(
     api_version: Version,
 ) -> WasmInstance<Chain> {
     test_valid_module_and_store(subgraph_id, data_source, api_version).0
-}
-
-fn mock_host_exports(
-    subgraph_id: DeploymentHash,
-    data_source: DataSource,
-    store: Arc<impl SubgraphStore>,
-    api_version: Version,
-) -> HostExports<Chain> {
-    let templates = vec![DataSourceTemplate {
-        kind: String::from("ethereum/contract"),
-        name: String::from("example template"),
-        network: Some(String::from("mainnet")),
-        source: TemplateSource {
-            abi: String::from("foo"),
-        },
-        mapping: Mapping {
-            kind: String::from("ethereum/events"),
-            api_version,
-            language: String::from("wasm/assemblyscript"),
-            entities: vec![],
-            abis: vec![],
-            event_handlers: vec![],
-            call_handlers: vec![],
-            block_handlers: vec![],
-            link: Link {
-                link: "link".to_owned(),
-            },
-            runtime: Arc::new(vec![]),
-        },
-    }];
-
-    let network = data_source.network.clone().unwrap();
-    HostExports::new(
-        subgraph_id,
-        &data_source,
-        network,
-        Arc::new(templates),
-        Arc::new(graph_core::LinkResolver::from(IpfsClient::localhost())),
-        store,
-    )
-}
-
-fn mock_context(
-    deployment: DeploymentLocator,
-    data_source: DataSource,
-    store: Arc<impl SubgraphStore>,
-    api_version: Version,
-) -> MappingContext<Chain> {
-    MappingContext {
-        logger: test_store::LOGGER.clone(),
-        block_ptr: BlockPtr {
-            hash: Default::default(),
-            number: 0,
-        },
-        host_exports: Arc::new(mock_host_exports(
-            deployment.hash.clone(),
-            data_source,
-            store.clone(),
-            api_version,
-        )),
-        state: BlockState::new(store.writable(&deployment).unwrap(), Default::default()),
-        proof_of_indexing: None,
-        host_fns: Arc::new(Vec::new()),
-    }
 }
 
 trait WasmInstanceExt {

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -294,7 +294,10 @@ async fn json_conversions_v0_0_5() {
 fn test_json_parsing(api_version: Version) {
     let mut module = test_module(
         "jsonParsing",
-        mock_data_source(&wasm_file_path("json_parsing.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("json_parsing.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 
@@ -336,7 +339,10 @@ async fn test_ipfs_cat(api_version: Version) {
         runtime.enter(|| {
             let mut module = test_module(
                 "ipfsCat",
-                mock_data_source(&wasm_file_path("ipfs_cat.wasm", api_version.clone()), api_version.clone()),
+                mock_data_source(
+                    &wasm_file_path("ipfs_cat.wasm", api_version.clone()),
+                    api_version.clone(),
+                ),
                 api_version,
             );
             let arg = asc_new(&mut module, &hash).unwrap();
@@ -406,7 +412,10 @@ async fn run_ipfs_map(
         runtime.enter(|| {
             let (mut module, _, _) = test_valid_module_and_store(
                 &subgraph_id,
-                mock_data_source(&wasm_file_path("ipfs_map.wasm", api_version.clone()), api_version.clone()),
+                mock_data_source(
+                    &wasm_file_path("ipfs_map.wasm", api_version.clone()),
+                    api_version.clone(),
+                ),
                 api_version,
             );
             let value = asc_new(&mut module, &hash).unwrap();
@@ -540,7 +549,10 @@ async fn test_ipfs_fail(api_version: Version) {
         runtime.enter(|| {
             let mut module = test_module(
                 "ipfsFail",
-                mock_data_source(&wasm_file_path("ipfs_cat.wasm", api_version.clone()), api_version.clone()),
+                mock_data_source(
+                    &wasm_file_path("ipfs_cat.wasm", api_version.clone()),
+                    api_version.clone(),
+                ),
                 api_version,
             );
 
@@ -567,7 +579,10 @@ async fn ipfs_fail_v0_0_5() {
 fn test_crypto_keccak256(api_version: Version) {
     let mut module = test_module(
         "cryptoKeccak256",
-        mock_data_source(&wasm_file_path("crypto.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("crypto.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
     let input: &[u8] = "eth".as_ref();
@@ -594,7 +609,10 @@ async fn crypto_keccak256_v0_0_5() {
 fn test_big_int_to_hex(api_version: Version) {
     let mut module = test_module(
         "BigIntToHex",
-        mock_data_source(&wasm_file_path("big_int_to_hex.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("big_int_to_hex.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 
@@ -636,7 +654,10 @@ async fn big_int_to_hex_v0_0_5() {
 fn test_big_int_arithmetic(api_version: Version) {
     let mut module = test_module(
         "BigIntArithmetic",
-        mock_data_source(&wasm_file_path("big_int_arithmetic.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("big_int_arithmetic.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 
@@ -708,7 +729,10 @@ async fn big_int_arithmetic_v0_0_5() {
 fn test_abort(api_version: Version, error_msg: &str) {
     let module = test_module(
         "abort",
-        mock_data_source(&wasm_file_path("abort.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("abort.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
     let res: Result<(), _> = module.get_func("abort").typed().unwrap().call(());
@@ -734,7 +758,10 @@ async fn abort_v0_0_5() {
 fn test_bytes_to_base58(api_version: Version) {
     let mut module = test_module(
         "bytesToBase58",
-        mock_data_source(&wasm_file_path("bytes_to_base58.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("bytes_to_base58.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
     let bytes = hex::decode("12207D5A99F603F231D53A4F39D1521F98D2E8BB279CF29BEBFD0687DC98458E7F89")
@@ -762,7 +789,10 @@ fn test_data_source_create(api_version: Version) {
               -> Result<Vec<DataSourceTemplateInfo<Chain>>, wasmtime::Trap> {
             let mut module = test_module(
                 "DataSourceCreate",
-                mock_data_source(&wasm_file_path("data_source_create.wasm", api_version.clone()), api_version.clone()),
+                mock_data_source(
+                    &wasm_file_path("data_source_create.wasm", api_version.clone()),
+                    api_version.clone(),
+                ),
                 api_version.clone(),
             );
 
@@ -808,7 +838,10 @@ async fn data_source_create_v0_0_5() {
 fn test_ens_name_by_hash(api_version: Version) {
     let mut module = test_module(
         "EnsNameByHash",
-        mock_data_source(&wasm_file_path("ens_name_by_hash.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("ens_name_by_hash.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 
@@ -839,7 +872,10 @@ async fn ens_name_by_hash_v0_0_5() {
 fn test_entity_store(api_version: Version) {
     let (mut module, store, deployment) = test_valid_module_and_store(
         "entityStore",
-        mock_data_source(&wasm_file_path("store.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("store.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 
@@ -936,10 +972,16 @@ async fn entity_store_v0_0_5() {
 }
 
 fn test_detect_contract_calls(api_version: Version) {
-    let data_source_without_calls = mock_data_source(&wasm_file_path("abi_store_value.wasm", api_version.clone()), api_version.clone());
+    let data_source_without_calls = mock_data_source(
+        &wasm_file_path("abi_store_value.wasm", api_version.clone()),
+        api_version.clone(),
+    );
     assert_eq!(data_source_without_calls.mapping.requires_archive(), false);
 
-    let data_source_with_calls = mock_data_source(&wasm_file_path("contract_calls.wasm", api_version.clone()), api_version);
+    let data_source_with_calls = mock_data_source(
+        &wasm_file_path("contract_calls.wasm", api_version.clone()),
+        api_version,
+    );
     assert_eq!(data_source_with_calls.mapping.requires_archive(), true);
 }
 
@@ -956,7 +998,10 @@ async fn detect_contract_calls_v0_0_5() {
 fn test_allocate_global(api_version: Version) {
     let module = test_module(
         "AllocateGlobal",
-        mock_data_source(&wasm_file_path("allocate_global.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("allocate_global.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -5,12 +5,11 @@ use graph::prelude::*;
 use graph::runtime::AscPtr;
 use graph::runtime::{asc_get, asc_new, try_asc_get};
 use graph::{components::store::*, ipfs_client::IpfsClient};
-use graph_chain_ethereum::{Chain, DataSource, DataSourceTemplate};
-use graph_core;
+use graph_chain_ethereum::{Chain, DataSource};
 use graph_mock::MockMetricsRegistry;
 use graph_runtime_wasm::asc_abi::class::{Array, AscBigInt, AscEntity, AscString, Uint8Array};
 use graph_runtime_wasm::{
-    ExperimentalFeatures, HostExports, MappingContext, ValidModule, WasmInstance,
+    ExperimentalFeatures, ValidModule, WasmInstance,
 };
 use hex;
 use semver::Version;
@@ -19,7 +18,7 @@ use std::str::FromStr;
 use test_store::STORE;
 use web3::types::H160;
 
-use crate::common::{mock_abi, mock_data_source};
+use crate::common::{mock_data_source, mock_context};
 
 mod abi;
 

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -8,9 +8,7 @@ use graph::{components::store::*, ipfs_client::IpfsClient};
 use graph_chain_ethereum::{Chain, DataSource};
 use graph_mock::MockMetricsRegistry;
 use graph_runtime_wasm::asc_abi::class::{Array, AscBigInt, AscEntity, AscString, Uint8Array};
-use graph_runtime_wasm::{
-    ExperimentalFeatures, ValidModule, WasmInstance,
-};
+use graph_runtime_wasm::{ExperimentalFeatures, ValidModule, WasmInstance};
 use hex;
 use semver::Version;
 use std::collections::{BTreeMap, HashMap};
@@ -18,7 +16,7 @@ use std::str::FromStr;
 use test_store::STORE;
 use web3::types::H160;
 
-use crate::common::{mock_data_source, mock_context};
+use crate::common::{mock_context, mock_data_source};
 
 mod abi;
 

--- a/runtime/test/src/test/abi.rs
+++ b/runtime/test/src/test/abi.rs
@@ -13,7 +13,7 @@ fn test_unbounded_loop(api_version: Version) {
     // Set handler timeout to 3 seconds.
     let module = test_valid_module_and_store_with_timeout(
         "unboundedLoop",
-        mock_data_source("non_terminating.wasm", api_version.clone()),
+        mock_data_source(&wasm_file_path("non_terminating.wasm", api_version.clone()), api_version.clone()),
         api_version,
         Some(Duration::from_secs(3)),
     )
@@ -35,7 +35,7 @@ async fn unbounded_loop_v0_0_5() {
 fn test_unbounded_recursion(api_version: Version) {
     let module = test_module(
         "unboundedRecursion",
-        mock_data_source("non_terminating.wasm", api_version.clone()),
+        mock_data_source(&wasm_file_path("non_terminating.wasm", api_version.clone()), api_version.clone()),
         api_version,
     );
     let res: Result<(), _> = module.get_func("rabbit_hole").typed().unwrap().call(());
@@ -56,7 +56,7 @@ async fn unbounded_recursion_v0_0_5() {
 fn test_abi_array(api_version: Version) {
     let mut module = test_module(
         "abiArray",
-        mock_data_source("abi_classes.wasm", api_version.clone()),
+        mock_data_source(&wasm_file_path("abi_classes.wasm", api_version.clone()), api_version.clone()),
         api_version,
     );
 
@@ -96,7 +96,7 @@ async fn abi_array_v0_0_5() {
 fn test_abi_subarray(api_version: Version) {
     let mut module = test_module(
         "abiSubarray",
-        mock_data_source("abi_classes.wasm", api_version.clone()),
+        mock_data_source(&wasm_file_path("abi_classes.wasm", api_version.clone()), api_version.clone()),
         api_version,
     );
 
@@ -123,7 +123,7 @@ async fn abi_subarray_v0_0_5() {
 fn test_abi_bytes_and_fixed_bytes(api_version: Version) {
     let mut module = test_module(
         "abiBytesAndFixedBytes",
-        mock_data_source("abi_classes.wasm", api_version.clone()),
+        mock_data_source(&wasm_file_path("abi_classes.wasm", api_version.clone()), api_version.clone()),
         api_version,
     );
     let bytes1: Vec<u8> = vec![42, 45, 7, 245, 45];
@@ -154,7 +154,7 @@ async fn abi_bytes_and_fixed_bytes_v0_0_5() {
 fn test_abi_ethabi_token_identity(api_version: Version) {
     let mut module = test_module(
         "abiEthabiTokenIdentity",
-        mock_data_source("abi_token.wasm", api_version.clone()),
+        mock_data_source(&wasm_file_path("abi_token.wasm", api_version.clone()), api_version.clone()),
         api_version,
     );
 
@@ -261,7 +261,7 @@ async fn abi_ethabi_token_identity_v0_0_5() {
 fn test_abi_store_value(api_version: Version) {
     let mut module = test_module(
         "abiStoreValue",
-        mock_data_source("abi_store_value.wasm", api_version.clone()),
+        mock_data_source(&wasm_file_path("abi_store_value.wasm", api_version.clone()), api_version.clone()),
         api_version,
     );
 
@@ -367,7 +367,7 @@ async fn abi_store_value_v0_0_5() {
 fn test_abi_h160(api_version: Version) {
     let mut module = test_module(
         "abiH160",
-        mock_data_source("abi_classes.wasm", api_version.clone()),
+        mock_data_source(&wasm_file_path("abi_classes.wasm", api_version.clone()), api_version.clone()),
         api_version,
     );
     let address = H160::zero();
@@ -398,7 +398,7 @@ async fn abi_h160_v0_0_5() {
 fn test_string(api_version: Version) {
     let mut module = test_module(
         "string",
-        mock_data_source("abi_classes.wasm", api_version.clone()),
+        mock_data_source(&wasm_file_path("abi_classes.wasm", api_version.clone()), api_version.clone()),
         api_version,
     );
     let string = "    漢字Double_Me🇧🇷  ";
@@ -422,7 +422,7 @@ async fn string_v0_0_5() {
 fn test_abi_big_int(api_version: Version) {
     let mut module = test_module(
         "abiBigInt",
-        mock_data_source("abi_classes.wasm", api_version.clone()),
+        mock_data_source(&wasm_file_path("abi_classes.wasm", api_version.clone()), api_version.clone()),
         api_version,
     );
 
@@ -459,7 +459,7 @@ async fn abi_big_int_v0_0_5() {
 fn test_big_int_to_string(api_version: Version) {
     let mut module = test_module(
         "bigIntToString",
-        mock_data_source("big_int_to_string.wasm", api_version.clone()),
+        mock_data_source(&wasm_file_path("big_int_to_string.wasm", api_version.clone()), api_version.clone()),
         api_version,
     );
 
@@ -484,7 +484,7 @@ async fn big_int_to_string_v0_0_5() {
 fn test_invalid_discriminant(api_version: Version) {
     let module = test_module(
         "invalidDiscriminant",
-        mock_data_source("abi_store_value.wasm", api_version.clone()),
+        mock_data_source(&wasm_file_path("abi_store_value.wasm", api_version.clone()), api_version.clone()),
         api_version,
     );
 

--- a/runtime/test/src/test/abi.rs
+++ b/runtime/test/src/test/abi.rs
@@ -13,7 +13,10 @@ fn test_unbounded_loop(api_version: Version) {
     // Set handler timeout to 3 seconds.
     let module = test_valid_module_and_store_with_timeout(
         "unboundedLoop",
-        mock_data_source(&wasm_file_path("non_terminating.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("non_terminating.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
         Some(Duration::from_secs(3)),
     )
@@ -35,7 +38,10 @@ async fn unbounded_loop_v0_0_5() {
 fn test_unbounded_recursion(api_version: Version) {
     let module = test_module(
         "unboundedRecursion",
-        mock_data_source(&wasm_file_path("non_terminating.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("non_terminating.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
     let res: Result<(), _> = module.get_func("rabbit_hole").typed().unwrap().call(());
@@ -56,7 +62,10 @@ async fn unbounded_recursion_v0_0_5() {
 fn test_abi_array(api_version: Version) {
     let mut module = test_module(
         "abiArray",
-        mock_data_source(&wasm_file_path("abi_classes.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("abi_classes.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 
@@ -96,7 +105,10 @@ async fn abi_array_v0_0_5() {
 fn test_abi_subarray(api_version: Version) {
     let mut module = test_module(
         "abiSubarray",
-        mock_data_source(&wasm_file_path("abi_classes.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("abi_classes.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 
@@ -123,7 +135,10 @@ async fn abi_subarray_v0_0_5() {
 fn test_abi_bytes_and_fixed_bytes(api_version: Version) {
     let mut module = test_module(
         "abiBytesAndFixedBytes",
-        mock_data_source(&wasm_file_path("abi_classes.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("abi_classes.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
     let bytes1: Vec<u8> = vec![42, 45, 7, 245, 45];
@@ -154,7 +169,10 @@ async fn abi_bytes_and_fixed_bytes_v0_0_5() {
 fn test_abi_ethabi_token_identity(api_version: Version) {
     let mut module = test_module(
         "abiEthabiTokenIdentity",
-        mock_data_source(&wasm_file_path("abi_token.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("abi_token.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 
@@ -261,7 +279,10 @@ async fn abi_ethabi_token_identity_v0_0_5() {
 fn test_abi_store_value(api_version: Version) {
     let mut module = test_module(
         "abiStoreValue",
-        mock_data_source(&wasm_file_path("abi_store_value.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("abi_store_value.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 
@@ -367,7 +388,10 @@ async fn abi_store_value_v0_0_5() {
 fn test_abi_h160(api_version: Version) {
     let mut module = test_module(
         "abiH160",
-        mock_data_source(&wasm_file_path("abi_classes.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("abi_classes.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
     let address = H160::zero();
@@ -398,7 +422,10 @@ async fn abi_h160_v0_0_5() {
 fn test_string(api_version: Version) {
     let mut module = test_module(
         "string",
-        mock_data_source(&wasm_file_path("abi_classes.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("abi_classes.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
     let string = "    漢字Double_Me🇧🇷  ";
@@ -422,7 +449,10 @@ async fn string_v0_0_5() {
 fn test_abi_big_int(api_version: Version) {
     let mut module = test_module(
         "abiBigInt",
-        mock_data_source(&wasm_file_path("abi_classes.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("abi_classes.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 
@@ -459,7 +489,10 @@ async fn abi_big_int_v0_0_5() {
 fn test_big_int_to_string(api_version: Version) {
     let mut module = test_module(
         "bigIntToString",
-        mock_data_source(&wasm_file_path("big_int_to_string.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("big_int_to_string.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 
@@ -484,7 +517,10 @@ async fn big_int_to_string_v0_0_5() {
 fn test_invalid_discriminant(api_version: Version) {
     let module = test_module(
         "invalidDiscriminant",
-        mock_data_source(&wasm_file_path("abi_store_value.wasm", api_version.clone()), api_version.clone()),
+        mock_data_source(
+            &wasm_file_path("abi_store_value.wasm", api_version.clone()),
+            api_version.clone(),
+        ),
         api_version,
     );
 

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -43,7 +43,7 @@ impl IntoTrap for HostExportError {
 
 pub struct HostExports<C: Blockchain> {
     pub(crate) subgraph_id: DeploymentHash,
-    pub(crate) api_version: Version,
+    pub api_version: Version,
     data_source_name: String,
     data_source_address: Vec<u8>,
     data_source_network: String,

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -49,7 +49,7 @@ pub struct WasmInstance<C: Blockchain> {
     //
     // Also this is the only strong reference, so the instance will be dropped once this is dropped.
     // The weak references are circulary held by instance itself through host exports.
-    instance_ctx: Rc<RefCell<Option<WasmInstanceContext<C>>>>,
+    pub instance_ctx: Rc<RefCell<Option<WasmInstanceContext<C>>>>,
 }
 
 impl<C: Blockchain> Drop for WasmInstance<C> {

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -42,7 +42,7 @@ pub trait IntoTrap {
 
 /// Handle to a WASM instance, which is terminated if and only if this is dropped.
 pub struct WasmInstance<C: Blockchain> {
-    instance: wasmtime::Instance,
+    pub instance: wasmtime::Instance,
 
     // This is the only reference to `WasmInstanceContext` that's not within the instance itself, so
     // we can always borrow the `RefCell` with no concern for race conditions.


### PR DESCRIPTION
We need these fields, functions and the whole test crate to be public in order to reuse as much as possible in the [unit testing framework](https://github.com/LimeChain/matchstick).

PS I know there's lots of commits 😢  If you guys can do "Squash and merge" upon merging that'll be awesome.