### PR TITLE
Quick fix: Unintend line break in error message

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -1020,8 +1020,7 @@ impl<C: Blockchain> UnresolvedSubgraphManifest<C> {
             Ok(ver) if (*MIN_SPEC_VERSION <= ver && ver <= *MAX_SPEC_VERSION) => {}
             _ => {
                 return Err(anyhow!(
-                    "This Graph Node only supports manifest spec versions between {} and {},
-                    but subgraph `{}` uses `{}`",
+                    "This Graph Node only supports manifest spec versions between {} and {}, but subgraph `{}` uses `{}`",
                     *MIN_SPEC_VERSION,
                     *MAX_SPEC_VERSION,
                     id,


### PR DESCRIPTION
This error message is currently being displayed with a line break:

```
Failed to deploy to Graph node http://127.0.0.1:8020/: subgraph resolve error: resolve error: This Graph Node only supports manifest spec versions between 0.0.2 and 0.0.3,
                    but subgraph `QmNj41SDq75ryMGvjpCSTARvXNNGRPEoWg9RwWiZiawxc9` uses `0.0.4`
^^^^^^^^^^^^^^^^^^^^
 ```
 
 This PR fixes it.