### PR TITLE
Remove Blockchain::reorg_threshold

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -135,10 +135,6 @@ impl Blockchain for Chain {
 
     type RuntimeAdapter = RuntimeAdapter;
 
-    fn reorg_threshold() -> u32 {
-        todo!()
-    }
-
     fn triggers_adapter(
         &self,
         loc: &DeploymentLocator,

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -87,8 +87,6 @@ pub trait Blockchain: Debug + Sized + Send + Sync + 'static {
 
     type RuntimeAdapter: RuntimeAdapter<Self>;
 
-    fn reorg_threshold() -> u32;
-
     fn triggers_adapter(
         &self,
         loc: &DeploymentLocator,


### PR DESCRIPTION
This is not currently being used and I don't anticipate that it will be needed. Anyways it can always be re-added if necessary.