### PR TITLE
graph: Bump default max api version

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -60,7 +60,7 @@ lazy_static! {
     static ref MAX_API_VERSION: Version = std::env::var("GRAPH_MAX_API_VERSION")
         .ok()
         .and_then(|api_version_str| Version::parse(&api_version_str).ok())
-        .unwrap_or(Version::new(0, 0, 4));
+        .unwrap_or(Version::new(0, 0, 5));
 }
 
 /// Rust representation of the GraphQL schema for a `SubgraphManifest`.

--- a/tests/tests/parallel_tests.rs
+++ b/tests/tests/parallel_tests.rs
@@ -387,8 +387,6 @@ async fn run_graph_node(test_setup: &IntegrationTestSetup) -> anyhow::Result<Chi
         );
     }
 
-    command.env("GRAPH_MAX_API_VERSION", "0.0.5");
-
     command
         .spawn()
         .context("failed to start graph-node command.")


### PR DESCRIPTION
This should be merged after both:

- https://github.com/graphprotocol/graph-cli/pull/690
- https://github.com/graphprotocol/graph-ts/pull/185