### PR TITLE
node: Refactor config to accept Firehose providers 

### DIFF
--- a/node/resources/tests/full_config.toml
+++ b/node/resources/tests/full_config.toml
@@ -1,0 +1,68 @@
+[general]
+query = "query_node_.*"
+
+[store]
+[store.primary]
+connection = "postgresql://postgres:1.1.1.1@test/primary"
+pool_size = [
+  { node = "index_node_1_.*", size = 2 },
+  { node = "index_node_2_.*", size = 10 },
+  { node = "index_node_3_.*", size = 10 },
+  { node = "index_node_4_.*", size = 2 },
+  { node = "query_node_.*", size = 10 }
+]
+
+[store.shard_a]
+connection = "postgresql://postgres:1.1.1.1@test/shard-a"
+pool_size = [
+  { node = "index_node_1_.*", size = 2 },
+  { node = "index_node_2_.*", size = 10 },
+  { node = "index_node_3_.*", size = 10 },
+  { node = "index_node_4_.*", size = 2 },
+  { node = "query_node_.*", size = 10 }
+]
+
+[deployment]
+# Studio subgraphs
+[[deployment.rule]]
+match = { name = "^prefix/" }
+shard = "shard_a"
+indexers = [ "index_prefix_0",
+             "index_prefix_1" ]
+
+[[deployment.rule]]
+match = { name = "^custom/.*" }
+indexers = [ "index_custom_0" ]
+
+[[deployment.rule]]
+shard = "shard_a"
+indexers = [ "index_node_1_a",
+             "index_node_2_a",
+             "index_node_3_a" ]
+
+[chains]
+ingestor = "index_0"
+
+[chains.mainnet]
+shard = "primary"
+provider = [
+  { label = "mainnet-0", url = "http://rpc.mainnet.io", features = ["archive", "traces"] }
+]
+
+[chains.ropsten]
+shard = "primary"
+provider = [
+  { label = "ropsten-0", url = "http://rpc.ropsten.io", transport = "rpc", features = ["archive", "traces"] }
+]
+
+[chains.goerli]
+shard = "primary"
+provider = [
+  { label = "goerli-0", url = "http://rpc.goerli.io", transport = "ipc", features = ["archive"] }
+]
+
+[chains.kovan]
+shard = "primary"
+provider = [
+  { label = "kovan-0", url = "http://rpc.kovan.io", transport = "ws", features = [] }
+]

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -8,11 +8,14 @@ use graph::{
 use graph_chain_ethereum::NodeCapabilities;
 use graph_store_postgres::{DeploymentPlacer, Shard as ShardName, PRIMARY_SHARD};
 
-use http::HeaderMap;
+use http::{HeaderMap, Uri};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
 use std::fs::read_to_string;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
 use url::Url;
 
 const ANY_NAME: &str = ".*";
@@ -434,10 +437,12 @@ impl ChainSection {
                 let features = features.into_iter().map(|s| s.to_string()).collect();
                 let provider = Provider {
                     label: format!("{}-{}-{}", name, transport, nr),
-                    transport,
-                    url: url.to_string(),
-                    features,
-                    headers: Default::default(),
+                    details: ProviderDetails::Web3(Web3Provider {
+                        transport,
+                        url: url.to_string(),
+                        features,
+                        headers: Default::default(),
+                    }),
                 };
                 let entry = chains.entry(name.to_string()).or_insert_with(|| Chain {
                     shard: PRIMARY_SHARD.to_string(),
@@ -473,6 +478,10 @@ where
     D: serde::Deserializer<'de>,
 {
     let kvs: BTreeMap<String, String> = Deserialize::deserialize(deserializer)?;
+    Ok(btree_map_to_http_headers(kvs))
+}
+
+fn btree_map_to_http_headers(kvs: BTreeMap<String, String>) -> HeaderMap {
     let mut headers = HeaderMap::new();
     for (k, v) in kvs.into_iter() {
         headers.insert(
@@ -482,12 +491,29 @@ where
                 .expect(&format!("invalid HTTP header value: {}: {}", k, v)),
         );
     }
-    Ok(headers)
+    headers
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct Provider {
     pub label: String,
+    pub details: ProviderDetails,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ProviderDetails {
+    Firehose(FirehoseProvider),
+    Web3(Web3Provider),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct FirehoseProvider {
+    pub url: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct Web3Provider {
     #[serde(default)]
     pub transport: Transport,
     pub url: String,
@@ -502,37 +528,7 @@ pub struct Provider {
     pub headers: HeaderMap,
 }
 
-const PROVIDER_FEATURES: [&str; 3] = ["traces", "archive", "no_eip1898"];
-const DEFAULT_PROVIDER_FEATURES: [&str; 2] = ["traces", "archive"];
-
-impl Provider {
-    fn validate(&mut self) -> Result<()> {
-        validate_name(&self.label).context("illegal provider name")?;
-
-        for feature in &self.features {
-            if !PROVIDER_FEATURES.contains(&feature.as_str()) {
-                return Err(anyhow!(
-                    "illegal feature `{}` for provider {}. Features must be one of {}",
-                    feature,
-                    self.label,
-                    PROVIDER_FEATURES.join(", ")
-                ));
-            }
-        }
-
-        self.url = shellexpand::env(&self.url)?.into_owned();
-
-        Url::parse(&self.url).map_err(|e| {
-            anyhow!(
-                "the url `{}` for provider {} is not a legal URL: {}",
-                self.url,
-                self.label,
-                e
-            )
-        })?;
-        Ok(())
-    }
-
+impl Web3Provider {
     pub fn node_capabilities(&self) -> NodeCapabilities {
         NodeCapabilities {
             archive: self.features.contains("archive"),
@@ -541,7 +537,178 @@ impl Provider {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+const PROVIDER_FEATURES: [&str; 3] = ["traces", "archive", "no_eip1898"];
+const DEFAULT_PROVIDER_FEATURES: [&str; 2] = ["traces", "archive"];
+
+impl Provider {
+    fn validate(&mut self) -> Result<()> {
+        validate_name(&self.label).context("illegal provider name")?;
+
+        match self.details {
+            ProviderDetails::Firehose(ref firehose) => {
+                // A Firehose url must be a valid Uri since gRPC library we use (Tonic)
+                // works with Uri.
+                firehose.url.parse::<Uri>().map_err(|e| {
+                    anyhow!(
+                        "the url `{}` for firehose provider {} is not a legal URI: {}",
+                        firehose.url,
+                        self.label,
+                        e
+                    )
+                })?;
+            }
+
+            ProviderDetails::Web3(ref mut web3) => {
+                for feature in &web3.features {
+                    if !PROVIDER_FEATURES.contains(&feature.as_str()) {
+                        return Err(anyhow!(
+                            "illegal feature `{}` for provider {}. Features must be one of {}",
+                            feature,
+                            self.label,
+                            PROVIDER_FEATURES.join(", ")
+                        ));
+                    }
+                }
+
+                web3.url = shellexpand::env(&web3.url)?.into_owned();
+
+                let label = &self.label;
+                Url::parse(&web3.url).map_err(|e| {
+                    anyhow!(
+                        "the url `{}` for provider {} is not a legal URL: {}",
+                        web3.url,
+                        label,
+                        e
+                    )
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for Provider {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ProviderVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for ProviderVisitor {
+            type Value = Provider;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Provider")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Provider, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut label = None;
+                let mut details = None;
+
+                let mut url = None;
+                let mut transport = None;
+                let mut features = None;
+                let mut headers = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        ProviderField::Label => {
+                            if label.is_some() {
+                                return Err(serde::de::Error::duplicate_field("label"));
+                            }
+                            label = Some(map.next_value()?);
+                        }
+                        ProviderField::Details => {
+                            if details.is_some() {
+                                return Err(serde::de::Error::duplicate_field("details"));
+                            }
+                            details = Some(map.next_value()?);
+                        }
+                        ProviderField::Url => {
+                            if url.is_some() {
+                                return Err(serde::de::Error::duplicate_field("url"));
+                            }
+                            url = Some(map.next_value()?);
+                        }
+                        ProviderField::Transport => {
+                            if transport.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transport"));
+                            }
+                            transport = Some(map.next_value()?);
+                        }
+                        ProviderField::Features => {
+                            if features.is_some() {
+                                return Err(serde::de::Error::duplicate_field("features"));
+                            }
+                            features = Some(map.next_value()?);
+                        }
+                        ProviderField::Headers => {
+                            if headers.is_some() {
+                                return Err(serde::de::Error::duplicate_field("headers"));
+                            }
+
+                            let raw_headers: BTreeMap<String, String> = map.next_value()?;
+                            headers = Some(btree_map_to_http_headers(raw_headers));
+                        }
+                    }
+                }
+
+                let label = label.ok_or_else(|| serde::de::Error::missing_field("label"))?;
+                let details = match details {
+                    Some(v) => {
+                        if url.is_some()
+                            || transport.is_some()
+                            || features.is_some()
+                            || headers.is_some()
+                        {
+                            return Err(serde::de::Error::custom("when `details` field is provided, deprecated `url`, `transport`, `features` and `headers` cannot be specified"));
+                        }
+
+                        v
+                    }
+                    None => ProviderDetails::Web3(Web3Provider {
+                        url: url.ok_or_else(|| serde::de::Error::missing_field("url"))?,
+                        transport: transport.unwrap_or(Transport::Rpc),
+                        features: features
+                            .ok_or_else(|| serde::de::Error::missing_field("features"))?,
+                        headers: headers.unwrap_or_else(|| HeaderMap::new()),
+                    }),
+                };
+
+                Ok(Provider { label, details })
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &[
+            "label",
+            "details",
+            "transport",
+            "url",
+            "features",
+            "headers",
+        ];
+        deserializer.deserialize_struct("Provider", FIELDS, ProviderVisitor)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(field_identifier, rename_all = "lowercase")]
+enum ProviderField {
+    Label,
+    Details,
+
+    // Deprecated fields
+    Url,
+    Transport,
+    Features,
+    Headers,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub enum Transport {
     #[serde(rename = "rpc")]
     Rpc,
@@ -751,4 +918,212 @@ fn primary_store() -> String {
 
 fn one() -> usize {
     1
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::{Config, FirehoseProvider, Provider, ProviderDetails, Transport, Web3Provider};
+    use http::{HeaderMap, HeaderValue};
+    use std::collections::BTreeSet;
+    use std::fs::read_to_string;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn it_works_on_standard_config() {
+        let content = read_resource_as_string("full_config.toml");
+        let actual: Config = toml::from_str(&content).unwrap();
+
+        // We do basic checks because writing the full equality method is really too long
+
+        assert_eq!(
+            "query_node_.*".to_string(),
+            actual.general.unwrap().query.to_string()
+        );
+        assert_eq!(4, actual.chains.chains.len());
+        assert_eq!(2, actual.stores.len());
+        assert_eq!(3, actual.deployment.rules.len());
+    }
+
+    #[test]
+    fn it_works_on_deprecated_provider_from_toml() {
+        let actual = toml::from_str(
+            r#"
+            transport = "rpc"
+            label = "peering"
+            url = "http://localhost:8545"
+            features = []
+        "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            Provider {
+                label: "peering".to_owned(),
+                details: ProviderDetails::Web3(Web3Provider {
+                    transport: Transport::Rpc,
+                    url: "http://localhost:8545".to_owned(),
+                    features: BTreeSet::new(),
+                    headers: HeaderMap::new(),
+                }),
+            },
+            actual
+        );
+    }
+
+    #[test]
+    fn it_works_on_deprecated_provider_without_transport_from_toml() {
+        let actual = toml::from_str(
+            r#"
+            label = "peering"
+            url = "http://localhost:8545"
+            features = []
+        "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            Provider {
+                label: "peering".to_owned(),
+                details: ProviderDetails::Web3(Web3Provider {
+                    transport: Transport::Rpc,
+                    url: "http://localhost:8545".to_owned(),
+                    features: BTreeSet::new(),
+                    headers: HeaderMap::new(),
+                }),
+            },
+            actual
+        );
+    }
+
+    #[test]
+    fn it_errors_on_deprecated_provider_missing_url_from_toml() {
+        let actual = toml::from_str::<Provider>(
+            r#"
+            transport = "rpc"
+            label = "peering"
+            features = []
+        "#,
+        );
+
+        assert_eq!(true, actual.is_err());
+        assert_eq!(
+            actual.unwrap_err().to_string(),
+            "missing field `url` at line 1 column 1"
+        );
+    }
+
+    #[test]
+    fn it_errors_on_deprecated_provider_missing_features_from_toml() {
+        let actual = toml::from_str::<Provider>(
+            r#"
+            transport = "rpc"
+            url = "http://localhost:8545"
+            label = "peering"
+        "#,
+        );
+
+        assert_eq!(true, actual.is_err());
+        assert_eq!(
+            actual.unwrap_err().to_string(),
+            "missing field `features` at line 1 column 1"
+        );
+    }
+
+    #[test]
+    fn it_works_on_new_web3_provider_from_toml() {
+        let actual = toml::from_str(
+            r#"
+            label = "peering"
+            details = { type = "web3", transport = "ipc", url = "http://localhost:8545", features = ["archive"], headers = { x-test = "value" } }
+        "#,
+        )
+        .unwrap();
+
+        let mut features = BTreeSet::new();
+        features.insert("archive".to_string());
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-test", HeaderValue::from_static("value"));
+
+        assert_eq!(
+            Provider {
+                label: "peering".to_owned(),
+                details: ProviderDetails::Web3(Web3Provider {
+                    transport: Transport::Ipc,
+                    url: "http://localhost:8545".to_owned(),
+                    features,
+                    headers,
+                }),
+            },
+            actual
+        );
+    }
+
+    #[test]
+    fn it_works_on_new_web3_provider_without_transport_from_toml() {
+        let actual = toml::from_str(
+            r#"
+            label = "peering"
+            details = { type = "web3", url = "http://localhost:8545", features = [] }
+        "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            Provider {
+                label: "peering".to_owned(),
+                details: ProviderDetails::Web3(Web3Provider {
+                    transport: Transport::Rpc,
+                    url: "http://localhost:8545".to_owned(),
+                    features: BTreeSet::new(),
+                    headers: HeaderMap::new(),
+                }),
+            },
+            actual
+        );
+    }
+
+    #[test]
+    fn it_errors_on_new_provider_with_deprecated_fields_from_toml() {
+        let actual = toml::from_str::<Provider>(
+            r#"
+            label = "peering"
+            url = "http://localhost:8545"
+            details = { type = "web3", url = "http://localhost:8545", features = [] }
+        "#,
+        );
+
+        assert_eq!(true, actual.is_err());
+        assert_eq!(actual.unwrap_err().to_string(), "when `details` field is provided, deprecated `url`, `transport`, `features` and `headers` cannot be specified at line 1 column 1");
+    }
+
+    #[test]
+    fn it_works_on_new_firehose_provider_from_toml() {
+        let actual = toml::from_str(
+            r#"
+                label = "firehose"
+                details = { type = "firehose", url = "http://localhost:9000" }
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            Provider {
+                label: "firehose".to_owned(),
+                details: ProviderDetails::Firehose(FirehoseProvider {
+                    url: "http://localhost:9000".to_owned(),
+                }),
+            },
+            actual
+        );
+    }
+
+    fn read_resource_as_string<P: AsRef<Path>>(path: P) -> String {
+        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        d.push("resources/tests");
+        d.push(path);
+
+        read_to_string(&d).expect(&format!("resource {:?} not found", &d))
+    }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -38,6 +38,8 @@ mod store_builder;
 use config::Config;
 use store_builder::StoreBuilder;
 
+use crate::config::ProviderDetails;
+
 lazy_static! {
     // Default to an Ethereum reorg threshold to 50 blocks
     static ref REORG_THRESHOLD: BlockNumber = env::var("ETHEREUM_REORG_THRESHOLD")
@@ -443,45 +445,47 @@ async fn create_ethereum_networks(
     let mut parsed_networks = EthereumNetworks::new();
     for (name, chain) in config.chains.chains {
         for provider in chain.providers {
-            let capabilities = provider.node_capabilities();
+            if let ProviderDetails::Web3(web3) = provider.details {
+                let capabilities = web3.node_capabilities();
 
-            let logger = logger.new(o!("provider" => provider.label.clone()));
-            info!(
-                logger,
-                "Creating transport";
-                "url" => &provider.url,
-                "capabilities" => capabilities
-            );
+                let logger = logger.new(o!("provider" => provider.label.clone()));
+                info!(
+                    logger,
+                    "Creating transport";
+                    "url" => &web3.url,
+                    "capabilities" => capabilities
+                );
 
-            use crate::config::Transport::*;
+                use crate::config::Transport::*;
 
-            let (transport_event_loop, transport) = match provider.transport {
-                Rpc => Transport::new_rpc(&provider.url, provider.headers),
-                Ipc => Transport::new_ipc(&provider.url),
-                Ws => Transport::new_ws(&provider.url),
-            };
+                let (transport_event_loop, transport) = match web3.transport {
+                    Rpc => Transport::new_rpc(&web3.url, web3.headers),
+                    Ipc => Transport::new_ipc(&web3.url),
+                    Ws => Transport::new_ws(&web3.url),
+                };
 
-            // If we drop the event loop the transport will stop working.
-            // For now it's fine to just leak it.
-            std::mem::forget(transport_event_loop);
+                // If we drop the event loop the transport will stop working.
+                // For now it's fine to just leak it.
+                std::mem::forget(transport_event_loop);
 
-            let supports_eip_1898 = !provider.features.contains("no_eip1898");
+                let supports_eip_1898 = !web3.features.contains("no_eip1898");
 
-            parsed_networks.insert(
-                name.to_string(),
-                capabilities,
-                Arc::new(
-                    graph_chain_ethereum::EthereumAdapter::new(
-                        logger,
-                        provider.label,
-                        &provider.url,
-                        transport,
-                        eth_rpc_metrics.clone(),
-                        supports_eip_1898,
-                    )
-                    .await,
-                ),
-            );
+                parsed_networks.insert(
+                    name.to_string(),
+                    capabilities,
+                    Arc::new(
+                        graph_chain_ethereum::EthereumAdapter::new(
+                            logger,
+                            provider.label,
+                            &web3.url,
+                            transport,
+                            eth_rpc_metrics.clone(),
+                            supports_eip_1898,
+                        )
+                        .await,
+                    ),
+                );
+            }
         }
     }
     parsed_networks.sort();
@@ -704,7 +708,16 @@ fn start_block_ingestor(
     // database.
     assert!(*ANCESTOR_COUNT >= *REORG_THRESHOLD);
 
-    info!(logger, "Starting block ingestors");
+    info!(
+        logger,
+        "Starting block ingestors with {} chains [{}]",
+        chains.len(),
+        chains
+            .keys()
+            .map(|v| v.clone())
+            .collect::<Vec<String>>()
+            .join(", ")
+    );
 
     // Create Ethereum block ingestors and spawn a thread to run each
     chains


### PR DESCRIPTION
**Re-submit of #2647**

There is a backward compatible handling of config that at some point should be converted to the new syntax form. The new syntax form is

```
{ label = "node0", details = { type = "web3", transport = "rpc", url = "...", features = [...] } }
```

While a Firehose provider now looks like:

```
{ label = "firehose0", details = { type = "firehose", url = "..." } }
```

This is for now undocumented and is first step towards Firehose integration in the codebase directly.

##### Update

The `transport` has been fixed to be optional.
