### PR TITLE
[WIP] Data syncing for dispute service.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
  "serde_urlencoded",
  "thiserror",
  "tokio 1.8.1",
- "tokio-util 0.6.3",
+ "tokio-util 0.6.7",
  "url 2.2.1",
  "winapi 0.3.9",
 ]
@@ -1279,6 +1279,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
+name = "flate2"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,7 +1606,7 @@ dependencies = [
  "priority-queue",
  "prometheus",
  "rand 0.6.5",
- "reqwest",
+ "reqwest 0.10.10",
  "semver 1.0.3",
  "serde",
  "serde_derive",
@@ -1720,6 +1732,7 @@ dependencies = [
  "diesel",
  "env_logger 0.8.2",
  "fail",
+ "flate2",
  "futures 0.3.13",
  "git-testament",
  "graph",
@@ -1736,7 +1749,9 @@ dependencies = [
  "graphql-parser",
  "http 0.1.21",
  "lazy_static",
+ "rand 0.8.4",
  "regex",
+ "reqwest 0.11.4",
  "serde",
  "serde_regex",
  "shellexpand",
@@ -1970,7 +1985,7 @@ dependencies = [
  "indexmap",
  "slab 0.4.2",
  "tokio 1.8.1",
- "tokio-util 0.6.3",
+ "tokio-util 0.6.7",
  "tracing",
 ]
 
@@ -2225,6 +2240,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.1",
+ "hyper 0.14.5",
+ "native-tls",
+ "tokio 1.8.1",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "hyper-unix-connector"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,7 +2273,7 @@ checksum = "a42ebaad57c538d4ae7331331511bb4abaadcb7286d8ebf13cb4371fdea90e3b"
 dependencies = [
  "const_fn_assert",
  "num-traits",
- "rand 0.8.3",
+ "rand 0.8.4",
  "static_assertions",
 ]
 
@@ -3188,7 +3216,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.8.3",
+ "rand 0.8.4",
  "sha2",
  "stringprep",
 ]
@@ -3468,9 +3496,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
@@ -3757,6 +3785,41 @@ dependencies = [
  "serde_urlencoded",
  "tokio 0.2.25",
  "tokio-tls 0.3.1",
+ "url 2.2.1",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.0.1",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http 0.2.3",
+ "http-body 0.4.0",
+ "hyper 0.14.5",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log 0.4.11",
+ "mime 0.3.16",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding 2.1.0",
+ "pin-project-lite 0.2.6",
+ "serde",
+ "serde_urlencoded",
+ "tokio 1.8.1",
+ "tokio-native-tls",
  "url 2.2.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4707,6 +4770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.8.1",
+]
+
+[[package]]
 name = "tokio-postgres"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4726,7 +4799,7 @@ dependencies = [
  "postgres-types",
  "socket2 0.4.0",
  "tokio 1.8.1",
- "tokio-util 0.6.3",
+ "tokio-util 0.6.7",
 ]
 
 [[package]]
@@ -4768,7 +4841,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.6",
  "tokio 1.8.1",
- "tokio-util 0.6.3",
+ "tokio-util 0.6.7",
 ]
 
 [[package]]
@@ -4934,9 +5007,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.3"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
  "bytes 1.0.1",
  "futures-core",
@@ -5521,7 +5594,7 @@ dependencies = [
  "mach",
  "memoffset 0.6.3",
  "more-asserts",
- "rand 0.8.3",
+ "rand 0.8.4",
  "region",
  "thiserror",
  "wasmtime-environ",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,6 +17,7 @@ clap = "2.33.3"
 env_logger = "0.8.2"
 git-testament = "0.2"
 graphql-parser = "0.3"
+flate2 = "1.0"
 futures = { version = "0.3.1", features = ["compat"] }
 lazy_static = "1.2.0"
 url = "2.2.1"
@@ -41,6 +42,8 @@ shellexpand = "2.1.0"
 diesel = "1.4.7"
 fail = "0.4"
 http = "0.1.21" # must be compatible with the version rust-web3 uses
+reqwest = { version = "0.11.4", features = ["blocking", "multipart"]}
+rand = "0.8.4"
 
 [dev-dependencies]
 assert_cli = "0.6"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,7 +17,6 @@ clap = "2.33.3"
 env_logger = "0.8.2"
 git-testament = "0.2"
 graphql-parser = "0.3"
-flate2 = "1.0"
 futures = { version = "0.3.1", features = ["compat"] }
 lazy_static = "1.2.0"
 url = "2.2.1"
@@ -46,6 +45,8 @@ reqwest = { version = "0.11.4", features = ["blocking", "multipart", "json"]}
 rand = "0.8.4"
 tar = "0.4.35"
 postgres = "0.19.1"
+walkdir = "2.3.2"
+zip = "0.5.13"
 
 [dev-dependencies]
 assert_cli = "0.6"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -42,8 +42,10 @@ shellexpand = "2.1.0"
 diesel = "1.4.7"
 fail = "0.4"
 http = "0.1.21" # must be compatible with the version rust-web3 uses
-reqwest = { version = "0.11.4", features = ["blocking", "multipart"]}
+reqwest = { version = "0.11.4", features = ["blocking", "multipart", "json"]}
 rand = "0.8.4"
+tar = "0.4.35"
+postgres = "0.19.1"
 
 [dev-dependencies]
 assert_cli = "0.6"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -47,6 +47,7 @@ tar = "0.4.35"
 postgres = "0.19.1"
 walkdir = "2.3.2"
 zip = "0.5.13"
+csv = "1.1.6"
 
 [dev-dependencies]
 assert_cli = "0.6"

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -341,6 +341,8 @@ pub enum DumpPoiCommand {
         subgraph_name: Option<String>,
         #[structopt(short = "v", long)]
         debug: bool,
+        #[structopt(short = "h", long, default_value = "http://localhost:8000")]
+        host: String,
     },
     SyncEntities {
         #[structopt(short = "s", long)]
@@ -353,6 +355,8 @@ pub enum DumpPoiCommand {
         subgraph_name: Option<String>,
         #[structopt(short = "v", long)]
         debug: bool,
+        #[structopt(short = "h", long, default_value = "http://localhost:8000")]
+        host: String,
     }, // Upload {
        //     file_path: String,
        // }
@@ -642,6 +646,7 @@ async fn main() {
                     indexer_id,
                     subgraph_name,
                     debug,
+                    host,
                 } => {
                     println!("Dumping subgraph deployment {}", subgraph_deployment);
                     commands::dump_poi::sync_poi(
@@ -651,6 +656,7 @@ async fn main() {
                         subgraph_deployment,
                         subgraph_name,
                         debug,
+                        host,
                     )
                 }
                 SyncEntities {
@@ -659,6 +665,7 @@ async fn main() {
                     indexer_id,
                     subgraph_name,
                     debug,
+                    host,
                 } => commands::dump_poi::sync_entities(
                     ctx.primary_pool(),
                     dispute_id,
@@ -666,6 +673,7 @@ async fn main() {
                     subgraph_deployment,
                     subgraph_name,
                     debug,
+                    host,
                 ),
             }
         }

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -156,6 +156,8 @@ pub enum Command {
     Chain(ChainCommand),
     /// Manipulate internal subgraph statistics
     Stats(StatsCommand),
+    /// Persist relevant dispute data
+    DumpPoi(DumpPoiCommand),
 }
 
 impl Command {
@@ -323,6 +325,23 @@ pub enum StatsCommand {
         /// The name of a table to fully count
         table: Option<String>,
     },
+}
+
+#[derive(Clone, Debug, StructOpt)]
+pub enum DumpPoiCommand {
+    /// Given a subgraph name or a subgraph deployment id dump its poi table and call cache.
+    Dump {
+        subgraph_deployment: String,
+        dispute_id: String,
+        indexer_id: String,
+        subgraph_name: Option<String>,
+    },
+    GetDivergentBlocks {
+        dispute_id: String,
+        indexer_id: String,
+    }, // Upload {
+       //     file_path: String,
+       // }
 }
 
 impl From<Opt> for config::Opt {
@@ -596,6 +615,34 @@ async fn main() {
                     commands::stats::account_like(ctx.pools(), clear, table)
                 }
                 Show { nsp, table } => commands::stats::show(ctx.pools(), nsp, table),
+            }
+        }
+
+        DumpPoi(cmd) => {
+            use DumpPoiCommand::*;
+
+            match cmd {
+                Dump {
+                    subgraph_deployment,
+                    dispute_id,
+                    indexer_id,
+                    subgraph_name,
+                } => {
+                    println!("Dumping subgraph deployment {}", subgraph_deployment);
+                    commands::dump_poi::run(
+                        ctx.primary_pool(),
+                        dispute_id,
+                        indexer_id,
+                        subgraph_deployment,
+                        subgraph_name,
+                    )
+                }
+                GetDivergentBlocks {
+                    dispute_id,
+                    indexer_id,
+                } => {
+                    commands::dump_poi::get_divergent_blocks(
+                }
             }
         }
     };

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -331,14 +331,28 @@ pub enum StatsCommand {
 pub enum DumpPoiCommand {
     /// Given a subgraph name or a subgraph deployment id dump its poi table and call cache.
     Dump {
+        #[structopt(short = "s", long)]
         subgraph_deployment: String,
+        #[structopt(short = "d", long)]
         dispute_id: String,
+        #[structopt(short = "i", long)]
         indexer_id: String,
+        #[structopt(short = "n", long)]
         subgraph_name: Option<String>,
+        #[structopt(short = "v", long)]
+        debug: bool,
     },
-    GetDivergentBlocks {
+    SyncEntities {
+        #[structopt(short = "s", long)]
+        subgraph_deployment: String,
+        #[structopt(short = "d", long)]
         dispute_id: String,
+        #[structopt(short = "i", long)]
         indexer_id: String,
+        #[structopt(short = "n", long)]
+        subgraph_name: Option<String>,
+        #[structopt(short = "v", long)]
+        debug: bool,
     }, // Upload {
        //     file_path: String,
        // }
@@ -627,22 +641,32 @@ async fn main() {
                     dispute_id,
                     indexer_id,
                     subgraph_name,
+                    debug,
                 } => {
                     println!("Dumping subgraph deployment {}", subgraph_deployment);
-                    commands::dump_poi::run(
+                    commands::dump_poi::sync_poi(
                         ctx.primary_pool(),
                         dispute_id,
                         indexer_id,
                         subgraph_deployment,
                         subgraph_name,
+                        debug,
                     )
                 }
-                GetDivergentBlocks {
+                SyncEntities {
+                    subgraph_deployment,
                     dispute_id,
                     indexer_id,
-                } => {
-                    commands::dump_poi::get_divergent_blocks(
-                }
+                    subgraph_name,
+                    debug,
+                } => commands::dump_poi::sync_entities(
+                    ctx.primary_pool(),
+                    dispute_id,
+                    indexer_id,
+                    subgraph_deployment,
+                    subgraph_name,
+                    debug,
+                ),
             }
         }
     };

--- a/node/src/manager/commands/dump_poi.rs
+++ b/node/src/manager/commands/dump_poi.rs
@@ -1,0 +1,388 @@
+use diesel::r2d2::{ConnectionManager, PooledConnection};
+use diesel::result::Error as PgError;
+use diesel::sql_types::{Integer, Text};
+use diesel::PgConnection;
+use diesel::{sql_query, RunQueryDsl};
+use postgres::{Client as PGClient, NoTls, Row};
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use graph::data::subgraph::DeploymentHash;
+use graph::prelude::{anyhow, SubgraphName};
+use graph_store_postgres::command_support::catalog as store_catalog;
+use graph_store_postgres::connection_pool::ConnectionPool;
+
+use serde::Deserialize;
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+
+//Nothing here requires async
+use reqwest::blocking::multipart;
+use reqwest::blocking::Client;
+
+/*
+Process:
+0. Dump your poi table and post it to a remote store with metadata pertinent to indexer.
+1. Poll external api for divergent block.
+2. Use divergent block to filter for entity updates, external data sources, and the ethereum call cache.
+3. Post this data back to dispute service.
+4. Wait for arbitration.
+*/
+
+//Modify this to run sql query that dumps database of poi to a file. Return the file location.
+
+//Create a directory for local dumps if doesn't exist. Make the dump database contain a directory with the deployment id.
+
+//@TODO: Allow for a subgraph name to be used for dumping. Allow for potential disputes in the indexer to be used too.
+
+pub fn run(
+    pool: ConnectionPool,
+    dispute_id: String,
+    indexer_id: String,
+    deployment_id: String,
+    subgraph_name: Option<String>,
+) -> Result<(), anyhow::Error> {
+    let foreign_server = pool.connection_detail()?;
+    let synchronous_client = PGClient::connect(
+        &format!(
+            "host={} user={} password={} port={} dbname={}",
+            foreign_server.host,
+            foreign_server.user,
+            foreign_server.password,
+            foreign_server.port,
+            foreign_server.dbname
+        ),
+        NoTls,
+    );
+    let pooled_connection = pool.get()?;
+
+    let connection = store_catalog::Connection::new(&pooled_connection);
+
+    let deployment_hash = match subgraph_name {
+        Some(name) => {
+            connection.current_deployment_for_subgraph(SubgraphName::new(name).unwrap())?
+        }
+        None => DeploymentHash::new(deployment_id).unwrap(),
+    };
+
+    let deployment_hash_string = deployment_hash.as_str();
+    let subgraph_schema_name =
+        get_subgraph_schema_name(&pooled_connection, &deployment_hash_string)?;
+
+    println!("creating dump directory {}", &deployment_hash_string);
+    let directory = create_dump_directory(deployment_hash_string)?;
+    let poi_records = get_poi(&pooled_connection, &subgraph_schema_name)?;
+    let tmp_filepath = dump_poi(&directory, poi_records)?;
+    let compressed_filepath = compress_directory("poi", tmp_filepath)?;
+    upload_file_to_endpoint(&compressed_filepath, indexer_id, dispute_id)?;
+    delete_directory(directory)?;
+
+    Ok(())
+}
+
+/// Create a directory to store files for upload
+fn create_dump_directory(deployment_id: &str) -> Result<String, anyhow::Error> {
+    let path = format!("../../../poi_dump/{}", deployment_id);
+    fs::create_dir_all(&path)?;
+    Ok(path)
+}
+
+/// Compress contents of a directory
+fn compress_directory(path: &str, kind: String) -> Result<String, anyhow::Error> {
+    let tar_path = format!("{}.tar.gz", path);
+    let tar_gz = File::create(&tar_path)?;
+
+    let enc = GzEncoder::new(tar_gz, Compression::default());
+    let mut tar = tar::Builder::new(enc);
+    tar.append_dir_all(kind, path)?;
+    Ok(tar_path)
+}
+
+/// Remove file after its been uploaded
+fn delete_directory(directory: String) -> Result<(), anyhow::Error> {
+    fs::remove_dir_all(directory)?;
+    Ok(())
+}
+
+#[derive(Queryable, QueryableByName)]
+pub struct PoiRecord {
+    #[sql_type = "Text"]
+    digest: String,
+    #[sql_type = "Text"]
+    id: String,
+    #[sql_type = "Integer"]
+    vid: i32,
+    #[sql_type = "Text"]
+    block_range: String,
+}
+
+/// Gather a set of poi query records
+pub fn get_poi(
+    conn: &PooledConnection<ConnectionManager<PgConnection>>,
+    subgraph_name: &str,
+) -> Result<Vec<PoiRecord>, anyhow::Error> {
+    let raw_query = format!(
+        "SELECT encode(poi2$.digest,'hex') as digest, id,vid, CAST(block_range as text) from {}.poi2$",
+        subgraph_name
+    );
+
+    let poi_queryset = sql_query(raw_query).load::<PoiRecord>(conn).unwrap();
+    return Ok(poi_queryset);
+}
+
+#[derive(Queryable, QueryableByName)]
+struct SubgraphNameRecord {
+    #[sql_type = "Text"]
+    subgraph_name: String,
+}
+
+/// Schema is required for querying entities and POI
+fn get_subgraph_schema_name(
+    conn: &PooledConnection<ConnectionManager<PgConnection>>,
+    deployment_id: &str,
+) -> Result<String, anyhow::Error> {
+    let raw_query = format!(
+        "SELECT name from deployment_schemas WHERE subgraph = {} LIMIT 1",
+        deployment_id
+    );
+    let name_result = sql_query(raw_query).get_result::<SubgraphNameRecord>(conn)?;
+
+    Ok(name_result.subgraph_name)
+}
+
+#[derive(Queryable, QueryableByName)]
+struct ChainNameSpaceRecord {
+    #[sql_type = "Text"]
+    namespace: String,
+}
+
+/// Chain namespace is required for querying call cache
+fn get_subgraph_network_chain(
+    conn: &PooledConnection<ConnectionManager<PgConnection>>,
+    deployment_id: &str,
+) -> Result<String, anyhow::Error> {
+    let raw_query = format!(
+        "SELECT namespace from chains where name = (SELECT network from deployment_schemas WHERE subgraph = {} LIMIT 1)",
+        deployment_id
+    );
+    let name_result = sql_query(raw_query).get_result::<ChainNameSpaceRecord>(conn)?;
+
+    Ok(name_result.namespace)
+}
+
+fn dump_poi(
+    directory: &str,
+    poi_records: std::vec::Vec<PoiRecord>,
+) -> Result<String, anyhow::Error> {
+    println!("dumping poi");
+    let filepath = format!("{}/poi.csv", directory);
+    let f = File::create(&filepath).expect("Unable to create file");
+    let mut file_buffer = BufWriter::new(f);
+    write!(file_buffer, "digest, id, vid, block_range\n").expect("Unable to write header");
+    for poi in &poi_records {
+        write!(
+            file_buffer,
+            "{},{},{},{}\n",
+            poi.digest, poi.id, poi.vid, poi.block_range
+        )
+        .expect("unable to write row");
+    }
+    return Ok(filepath);
+}
+
+/// ## Takes a filepath and sends to the dispute service for persistence.
+/// ### @TODO: Upon completion delete the file?
+pub fn upload_file_to_endpoint(
+    fp: &str,
+    indexer_id: String,
+    dispute_id: String,
+) -> Result<(), anyhow::Error> {
+    let form = multipart::Form::new().file("file", fp)?;
+    let client = Client::new();
+    let res = client
+        .post("http://localhost:8000/upload")
+        .header("Indexer-node", indexer_id)
+        .header("Dispute-hash", dispute_id)
+        .multipart(form)
+        .send()?;
+
+    if res.status().is_success() {
+        println!("success!");
+    } else if res.status().is_server_error() {
+        println!("server error! {:?}", res.status());
+    } else {
+        println!("Something else happened. Status: {:?}", res.status());
+    }
+
+    Ok(())
+}
+
+pub fn get_divergent_blocks(
+    dispute_id: String,
+    indexer_id: String,
+) -> Result<Vec<i32>, anyhow::Error> {
+    #[derive(Deserialize)]
+    struct DivergentBlockResponse {
+        indexer_id: String,
+        divergent_blocks: Vec<i32>,
+    }
+
+    let client = Client::new();
+    let res = client
+        .get("http://localhost:8000/divergent_blocks")
+        .header("Indexer-node", indexer_id)
+        .header("Dispute-hash", dispute_id)
+        .send()?;
+
+    if res.status().is_success() {
+        println!("success!");
+    } else if res.status().is_server_error() {
+        println!("server error! {:?}", res.status());
+    } else {
+        println!("Something else happened. Status: {:?}", res.status());
+    }
+
+    let json: DivergentBlockResponse = res.json()?;
+    //get result as json and parse out divergent_blocks
+
+    return Ok(json.divergent_blocks);
+}
+
+#[derive(Queryable, QueryableByName)]
+pub struct CallCacheRecord {
+    #[sql_type = "Text"]
+    id: String,
+    #[sql_type = "Text"]
+    return_value: String,
+    #[sql_type = "Text"]
+    contract_address: String,
+    #[sql_type = "Integer"]
+    block_number: i32,
+}
+
+pub fn get_call_cache(
+    conn: &PooledConnection<ConnectionManager<PgConnection>>,
+    chain_namespace: &str,
+    divergent_block: i32,
+) -> Result<Vec<CallCacheRecord>, anyhow::Error> {
+    let raw_query = format!(
+        "SELECT encode(id,'hex') as id, encode(return_value,'hex') as \
+        return_value,encode(contract_address,'hex') as contract_address,\
+        block_number from {}.call_cache WHERE block_number = {}",
+        chain_namespace, divergent_block
+    );
+
+    let callcache_queryset = sql_query(raw_query).load::<CallCacheRecord>(conn).unwrap();
+    return Ok(callcache_queryset);
+}
+
+fn dump_call_cache(
+    directory: &str,
+    callcache_records: std::vec::Vec<CallCacheRecord>,
+) -> Result<String, anyhow::Error> {
+    println!("dumping call cache");
+    let filepath = format!("{}/call_cache.csv", directory);
+    let f = File::create(&filepath).expect("Unable to create file");
+    let mut file_buffer = BufWriter::new(f);
+    write!(
+        file_buffer,
+        "id, return_value, contract_address, block_number\n"
+    )
+    .expect("Unable to write header");
+    for cc in &callcache_records {
+        write!(
+            file_buffer,
+            "{},{},{},{}\n",
+            cc.id, cc.return_value, cc.contract_address, cc.block_number
+        )
+        .expect("unable to write row");
+    }
+    return Ok(filepath);
+}
+
+#[derive(Queryable, QueryableByName)]
+pub struct TableName {
+    #[sql_type = "Text"]
+    tablename: String,
+}
+
+/// Get all tables present in the subgraph schema. Will be used for dumping data
+fn get_subgraph_tables(
+    conn: &PooledConnection<ConnectionManager<PgConnection>>,
+    subgraph_schema_name: &str,
+) -> Result<Vec<TableName>, anyhow::Error> {
+    let query = format!(
+        "select tablename from pg_tables where schemaname='{}'",
+        subgraph_schema_name
+    );
+
+    let subgraph_tables = sql_query(query).get_results::<TableName>(conn).unwrap();
+    return Ok(subgraph_tables);
+}
+
+/// Gathers entries from entity tables that contain the divergent block if in closed interval
+/// Diesel isn't of any use here because this is dynamic.
+/// Also need to catch the columns for passing to csv
+fn get_filtered_subgraph_table_rows(
+    raw_client: &mut PGClient,
+    table_name: String,
+    schema_name: String,
+    divergent_block: i32,
+) -> Result<(Vec<Row>,Vec<Row>), anyhow::Error> {
+    //we won't know the type of this
+
+    let column_query = "SELECT column_name FROM information_schema.columns WHERE table_schema = '$1'
+     AND table_name   = '$2'
+       ORDER by ordinal_position";
+
+    let columns = raw_client.query(column_query, &[&schema_name,&table_name])?;
+
+    let entity_query = 
+    "select * from $1.$2 as $2 WHERE ($3 <@ $2.block_range AND upper_inc($2.block_range)) OR ($3 = lower($2.block_range))";
+    let rows = raw_client.query(entity_query, &[&schema_name,&table_name,&divergent_block])?;
+
+    Ok((columns,rows))
+}
+
+fn dump_divergent_entities(
+    directory: &str,
+    table_columns: Vec<Row>,
+    table_records: Vec<Row>,
+    table_name: String,
+) -> Result<String, anyhow::Error> {
+    println!("dumping divergent entities");
+
+    let filepath = format!("{}/{}.csv", directory,table_name);
+    let f = File::create(&filepath).expect("Unable to create file");
+    let mut file_buffer = BufWriter::new(f);
+
+
+    let mut header = vec![];
+    let first_row = table_records.first().unwrap();
+    for (colIndex, column) in first_row.columns().iter().enumerate() {
+        header.push(column.name());
+    }
+
+    write!(
+        file_buffer,
+        "{}\n",header.join(",")
+    )
+    .expect("Unable to write header");
+
+
+    for row in table_records {
+        let mut row_as_vec_string :Vec<&str> = vec![];
+
+        for idx in 0..row.len(){
+            let row_item = row.get(idx);
+            row_as_vec_string.push(row_item);
+        }
+        write!(
+            file_buffer,
+            "{}\n",
+            row_as_vec_string.join(",")
+        )
+        .expect("unable to write row");
+    }
+    return Ok(filepath);
+}

--- a/node/src/manager/commands/mod.rs
+++ b/node/src/manager/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod chain;
 pub mod config;
 pub mod copy;
 pub mod create;
+pub mod dump_poi;
 pub mod info;
 pub mod listen;
 pub mod query;


### PR DESCRIPTION
`graphman` addendum to allow an indexer to sync their data for arbitration. 

How to run: 
1. `graphman` requires that you have a valid `GRAPH_NODE_CONFIG` . You can find an example one in `graph-node/store/test-store/config.simple.toml`
> export `GRAPH_NODE_CONFIG=/path_to/graph-node/store/test-store/config.simple.toml`
2. Submit your POI to the service:
> `graphman dump-poi dump -d $DISPUTE_ID -i $INDEXER_ID -s $SUBGRAPH_DEPLOYMENT  -h $DISPUTE_SERVICE_HOST -v`
3. Once analysis has been completed on the POI you will be able to sync your entities
> `graphman dump-poi sync-entities -d $DISPUTE_ID -i $INDEXER_ID -s $SUBGRAPH_DEPLOYMENT  -h $DISPUTE_SERVICE_HOST   -v`

