### PR TITLE
runtime: Add env var for maximum stack size

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -75,6 +75,10 @@ those.
    corresponds to 1GB.
 - `GRAPH_QUERY_CACHE_STALE_PERIOD`: Number of queries after which a cache
   entry can be considered stale. Defaults to 100.
+- `GRAPH_MAX_API_VERSION`: Maximum `apiVersion` supported, if a developer tries to create a subgraph
+  with a higher `apiVersion` than this in their mappings, they'll receive an error. Defaults to `0.0.5`.
+- `GRAPH_RUNTIME_MAX_STACK_SIZE`: Maximum stack size for the WASM runtime, if exceeded the execution
+  stops and an error is thrown. Defaults to 512KiB.
 
 ## GraphQL
 


### PR DESCRIPTION
Just an environment variable to set the maximum stack size for the WASM runtime.
If not set, the default is 512KiB, half of what it was before (default from `wasmtime` crate was 1MiB).