### PR TITLE
Chain head watcher fallback

### DIFF
--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -1,6 +1,7 @@
 use anyhow::Error;
 use async_trait::async_trait;
 use futures03::Stream;
+use tokio::sync::watch;
 
 use super::{Block, BlockPtr, Blockchain};
 use crate::components::store::BlockNumber;
@@ -118,13 +119,9 @@ impl BlockStreamMetrics {
     }
 }
 
-/// Notifications about the chain head advancing. The block ingestor sends
-/// an update on this stream whenever the head of the underlying chain
-/// changes. The updates have no payload, receivers should call
-/// `Store::chain_head_ptr` to check what the latest block is.
-pub type ChainHeadUpdateStream = Box<dyn Stream<Item = ()> + Send + Unpin>;
-
 pub trait ChainHeadUpdateListener: Send + Sync + 'static {
-    /// Subscribe to chain head updates for the given network.
-    fn subscribe(&self, network: String) -> ChainHeadUpdateStream;
+    /// Subscribe to chain head updates for the given network. The block ingestor sends an update on
+    /// this stream whenever the head of the underlying chain changes. The updates have no payload,
+    /// receivers should call `Store::chain_head_ptr` to check what the latest block is.
+    fn subscribe(&self, network: String) -> watch::Receiver<()>;
 }

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -36,10 +36,7 @@ use std::{collections::BTreeMap, fmt::Debug};
 use std::{collections::HashMap, convert::TryFrom};
 use web3::types::H256;
 
-pub use block_stream::{
-    BlockStream, BlockStreamMetrics, ChainHeadUpdateListener, ChainHeadUpdateStream,
-    TriggersAdapter,
-};
+pub use block_stream::{BlockStream, BlockStreamMetrics, ChainHeadUpdateListener, TriggersAdapter};
 pub use polling_block_stream::PollingBlockStream;
 pub use types::{BlockHash, BlockPtr};
 

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -1,7 +1,4 @@
-use graph::{
-    blockchain::ChainHeadUpdateStream, parking_lot::Mutex, prelude::StoreError,
-    prometheus::GaugeVec,
-};
+use graph::{parking_lot::Mutex, prelude::StoreError, prometheus::GaugeVec};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -17,7 +14,6 @@ use graph::prelude::serde::{Deserialize, Serialize};
 use graph::prelude::serde_json::{self, json};
 use graph::prelude::tokio::sync::{mpsc::Receiver, watch};
 use graph::prelude::{crit, o, CheapClone, Logger, MetricsRegistry};
-use graph::tokio_stream::wrappers::WatchStream;
 
 lazy_static! {
     pub static ref CHANNEL_NAME: SafeChannelName =
@@ -155,16 +151,13 @@ impl ChainHeadUpdateListener {
 }
 
 impl ChainHeadUpdateListenerTrait for ChainHeadUpdateListener {
-    fn subscribe(&self, network_name: String) -> ChainHeadUpdateStream {
-        let update_receiver = self
-            .watchers
+    fn subscribe(&self, network_name: String) -> watch::Receiver<()> {
+        self.watchers
             .lock()
             .entry(network_name)
             .or_insert_with(|| Watcher::new())
             .receiver
-            .clone();
-
-        Box::new(WatchStream::new(update_receiver))
+            .clone()
     }
 }
 


### PR DESCRIPTION
A re-implementation of #2378, since we've again seen the chain head update stream have issues in production in heavily loaded nodes, post the tokio upgrade. Generally it seems like a good idea to be robust to the listener going down, though this will likely work differently after the block stream is pipelined. Resolves #2714.