### PR TITLE
Use push_sql instead of push_identifier

### DIFF
--- a/store/postgres/src/transaction_receipt.rs
+++ b/store/postgres/src/transaction_receipt.rs
@@ -78,7 +78,7 @@ from (
     select jsonb_array_elements(data -> 'transaction_receipts') as receipt
     from"#,
         );
-        out.push_identifier(&self.blocks_table_name)?;
+        out.push_sql(&self.blocks_table_name);
         out.push_sql(" where hash = ");
         out.push_bind_param::<Binary, _>(&self.block_hash)?;
         out.push_sql(") as temp;");


### PR DESCRIPTION
This fixes a bug introduced in PR #2708 that led PostgreSQL to quote the `"public.ethereum_blocks"` table and ignore its namespace, treating its fully qualified name as a single string. 