### PR TITLE
Add a 'deployment_failed' metric

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -362,6 +362,7 @@ where
             registry.clone(),
             &deployment.hash,
             manifest.network_name(),
+            store.shard().to_string(),
             stopwatch_metrics,
         ));
 

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -555,6 +555,7 @@ where
             }
 
             let start = Instant::now();
+            let deployment_failed = ctx.block_stream_metrics.deployment_failed.clone();
 
             let res = process_block(
                 &logger,
@@ -579,6 +580,7 @@ where
 
                         ctx.inputs.store.unfail()?;
                     }
+                    deployment_failed.set(0.0);
 
                     if needs_restart {
                         // Cancel the stream for real
@@ -613,6 +615,7 @@ where
                         handler: None,
                         deterministic: e.is_deterministic(),
                     };
+                    deployment_failed.set(1.0);
 
                     store_for_err
                         .fail_subgraph(error)

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -84,6 +84,7 @@ pub enum BlockStreamEvent<C: Blockchain> {
 #[derive(Clone)]
 pub struct BlockStreamMetrics {
     pub deployment_head: Box<Gauge>,
+    pub deployment_failed: Box<Gauge>,
     pub reverted_blocks: Box<Gauge>,
     pub stopwatch: StopwatchMetrics,
 }
@@ -107,11 +108,19 @@ impl BlockStreamMetrics {
             .new_gauge(
                 "deployment_head",
                 "Track the head block number for a deployment",
-                labels,
+                labels.clone(),
             )
             .expect("failed to create `deployment_head` gauge");
+        let deployment_failed = registry
+            .new_gauge(
+                "deployment_failed",
+                "Boolean gauge to indicate whether the deployment has failed (1 == failed)",
+                labels,
+            )
+            .expect("failed to create `deployment_failed` gauge");
         Self {
             deployment_head,
+            deployment_failed,
             reverted_blocks,
             stopwatch,
         }

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -94,6 +94,7 @@ impl BlockStreamMetrics {
         registry: Arc<impl MetricsRegistry>,
         deployment_id: &DeploymentHash,
         network: String,
+        shard: String,
         stopwatch: StopwatchMetrics,
     ) -> Self {
         let reverted_blocks = registry
@@ -103,7 +104,11 @@ impl BlockStreamMetrics {
                 deployment_id.as_str(),
             )
             .expect("Failed to create `deployment_reverted_blocks` gauge");
-        let labels = labels! { String::from("deployment") => deployment_id.to_string(), String::from("network") => network };
+        let labels = labels! {
+            String::from("deployment") => deployment_id.to_string(),
+            String::from("network") => network,
+            String::from("shard") => shard
+        };
         let deployment_head = registry
             .new_gauge(
                 "deployment_head",

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1039,6 +1039,10 @@ pub trait WritableStore: Send + Sync + 'static {
 
     /// Load the dynamic data sources for the given deployment
     async fn load_dynamic_data_sources(&self) -> Result<Vec<StoredDynamicDataSource>, StoreError>;
+
+    /// Report the name of the shard in which the subgraph is stored. This
+    /// should only be used for reporting and monitoring
+    fn shard(&self) -> &str;
 }
 
 #[async_trait]
@@ -1209,6 +1213,10 @@ impl WritableStore for MockStore {
     }
 
     fn deployment_synced(&self) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn shard(&self) -> &str {
         unimplemented!()
     }
 }

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1143,6 +1143,10 @@ impl WritableStoreTrait for WritableStore {
 
         Ok(self.store.send_store_event(&event)?)
     }
+
+    fn shard(&self) -> &str {
+        self.site.shard.as_str()
+    }
 }
 
 fn same_subgraph(mods: &Vec<EntityModification>, id: &DeploymentHash) -> bool {


### PR DESCRIPTION
That makes it possible to distinguish between failed and not-failed subgraphs in Prometheus