### PR TITLE
ci: Add CircleCI to compare against existing options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,7 @@
+version: 2.1
+orbs:
+    hello: circleci/hello-build@0.0.5
+workflows:
+    "Hello Workflow":
+        jobs:
+          - hello/hello-build


### PR DESCRIPTION
This just adds a job on CircleCI that does nothing for now, so that we don't have errors such as these in all PRs: `ci/circleci: Build Error  — Your tests failed on CircleCI`