### PR TITLE
[WIP] store: index only a prefix of byte fields

### DIFF
--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -54,6 +54,7 @@ const DELETE_OPERATION_CHUNK_SIZE: usize = 1_000;
 /// This also makes sure that we do not put strings into a BTree index that's
 /// bigger than Postgres' limit on such strings which is about 2k
 pub const STRING_PREFIX_SIZE: usize = 256;
+pub const BYTE_ARRAY_PREFIX_SIZE: usize = 256;
 
 lazy_static! {
     /// Deprecated; use 'graphman stats account-like' instead. A list of
@@ -1067,6 +1068,11 @@ impl Column {
         named_type(&self.field_type) == "String" && !self.is_list()
     }
 
+    /// Checks if this column's type is a binary string (Postgres' `bytea`)
+    pub fn is_binary_string(&self) -> bool {
+        named_type(&self.field_type) == "Bytes" && !self.is_list()
+    }
+
     pub fn is_assignable_from(&self, source: &Self, object: &EntityType) -> Option<String> {
         if !self.is_nullable() && source.is_nullable() {
             Some(format!(
@@ -1315,6 +1321,13 @@ impl Table {
                 // STRING_PREFIX_SIZE characters
                 let index_expr = if column.is_text() {
                     format!("left({}, {})", column.name.quoted(), STRING_PREFIX_SIZE)
+                } else if column.is_binary_string() {
+                    // Should be equivalent to `left`, but for byte arrays
+                    format!(
+                        "substring({} from 1 for {})",
+                        column.name.quoted(),
+                        BYTE_ARRAY_PREFIX_SIZE
+                    )
                 } else {
                     column.name.quoted()
                 };
@@ -1699,7 +1712,7 @@ create index attr_1_3_scalar_big_decimal
 create index attr_1_4_scalar_string
     on sgd0815.\"scalar\" using btree(left(\"string\", 256));
 create index attr_1_5_scalar_bytes
-    on sgd0815.\"scalar\" using btree(\"bytes\");
+    on sgd0815.\"scalar\" using btree(substring(\"bytes\" from 1 for 256));
 create index attr_1_6_scalar_big_int
     on sgd0815.\"scalar\" using btree(\"big_int\");
 create index attr_1_7_scalar_color


### PR DESCRIPTION
Closes #2287

Changes:

* Similar to what was done in #1138, byte fields are now indexed by their prefixes instead of their full value as to avoid `btree`'s limitation of index size.
    * Truncation done [here](https://github.com/graphprotocol/graph-node/blob/d6afa12d80f6f2a7482e5fc0f75ba33959262e18/store/postgres/src/relational.rs#L1324)
- [WIP] Use `PrefixComparison` for bytes as well