### PR TITLE
blockchain: Introduce `BlockchainMap` and `BlockchainKind`

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Error};
+use graph::blockchain::BlockchainKind;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::prelude::{
     EthereumCallCache, LightEthereumBlock, LightEthereumBlockExt, StopwatchMetrics,
@@ -112,6 +113,8 @@ impl Chain {
 
 #[async_trait]
 impl Blockchain for Chain {
+    const KIND: BlockchainKind = BlockchainKind::Ethereum;
+
     type Block = BlockFinality;
 
     type DataSource = DataSource;

--- a/chain/ethereum/tests/manifest.rs
+++ b/chain/ethereum/tests/manifest.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use graph::data::subgraph::SPEC_VERSION_0_0_4;
 use graph::prelude::{
-    anyhow, async_trait, tokio, DeploymentHash, Entity, Link, Logger, SubgraphManifest,
+    anyhow, async_trait, serde_yaml, tokio, DeploymentHash, Entity, Link, Logger, SubgraphManifest,
     SubgraphManifestValidationError, UnvalidatedSubgraphManifest,
 };
 use graph::{
@@ -72,7 +73,8 @@ async fn resolve_manifest(text: &str) -> SubgraphManifest<graph_chain_ethereum::
     resolver.add("/ipfs/Qmabi", &ABI);
     resolver.add("/ipfs/Qmmapping", &MAPPING);
 
-    SubgraphManifest::resolve(id, &resolver, &LOGGER)
+    let raw = serde_yaml::from_str(text).unwrap();
+    SubgraphManifest::resolve_from_raw(id, raw, &resolver, &LOGGER, SPEC_VERSION_0_0_4.clone())
         .await
         .expect("Parsing simple manifest works")
 }
@@ -84,9 +86,16 @@ async fn resolve_unvalidated(text: &str) -> UnvalidatedSubgraphManifest<Chain> {
     resolver.add(id.as_str(), &text);
     resolver.add("/ipfs/Qmschema", &GQL_SCHEMA);
 
-    UnvalidatedSubgraphManifest::resolve(id, Arc::new(resolver), &LOGGER)
-        .await
-        .expect("Parsing simple manifest works")
+    let raw = serde_yaml::from_str(text).unwrap();
+    UnvalidatedSubgraphManifest::resolve(
+        id,
+        raw,
+        Arc::new(resolver),
+        &LOGGER,
+        SPEC_VERSION_0_0_4.clone(),
+    )
+    .await
+    .expect("Parsing simple manifest works")
 }
 
 // Some of these manifest tests should be made chain-independent, but for
@@ -348,9 +357,16 @@ schema:
             resolver.add("/ipfs/Qmabi", &ABI);
             resolver.add("/ipfs/Qmschema", &GQL_SCHEMA_FULLTEXT);
 
-            UnvalidatedSubgraphManifest::resolve(id, Arc::new(resolver), &LOGGER)
-                .await
-                .expect("Parsing simple manifest works")
+            let raw = serde_yaml::from_str(YAML).unwrap();
+            UnvalidatedSubgraphManifest::resolve(
+                id,
+                raw,
+                Arc::new(resolver),
+                &LOGGER,
+                SPEC_VERSION_0_0_4.clone(),
+            )
+            .await
+            .expect("Parsing simple manifest works")
         };
 
         assert!(unvalidated
@@ -390,9 +406,16 @@ schema:
             resolver.add("/ipfs/Qmabi", &ABI);
             resolver.add("/ipfs/Qmschema", &GQL_SCHEMA_FULLTEXT);
 
-            UnvalidatedSubgraphManifest::resolve(id, Arc::new(resolver), &LOGGER)
-                .await
-                .expect("Parsing simple manifest works")
+            let raw = serde_yaml::from_str(YAML).unwrap();
+            UnvalidatedSubgraphManifest::resolve(
+                id,
+                raw,
+                Arc::new(resolver),
+                &LOGGER,
+                SPEC_VERSION_0_0_4.clone(),
+            )
+            .await
+            .expect("Parsing simple manifest works")
         };
 
         let error_msg = unvalidated
@@ -456,9 +479,16 @@ dataSources:
             resolver.add("/ipfs/Qmschema", &GQL_SCHEMA);
             resolver.add("/ipfs/Qmmapping", &MAPPING_WITH_IPFS_FUNC_WASM);
 
-            UnvalidatedSubgraphManifest::resolve(id, Arc::new(resolver), &LOGGER)
-                .await
-                .expect("Parsing simple manifest works")
+            let raw = serde_yaml::from_str(YAML).unwrap();
+            UnvalidatedSubgraphManifest::resolve(
+                id,
+                raw,
+                Arc::new(resolver),
+                &LOGGER,
+                SPEC_VERSION_0_0_4.clone(),
+            )
+            .await
+            .expect("Parsing simple manifest works")
         };
 
         let error_msg = unvalidated
@@ -524,9 +554,16 @@ dataSources:
             resolver.add("/ipfs/Qmschema", &GQL_SCHEMA);
             resolver.add("/ipfs/Qmmapping", &MAPPING_WITH_IPFS_FUNC_WASM);
 
-            UnvalidatedSubgraphManifest::resolve(id, Arc::new(resolver), &LOGGER)
-                .await
-                .expect("Parsing simple manifest works")
+            let raw = serde_yaml::from_str(YAML).unwrap();
+            UnvalidatedSubgraphManifest::resolve(
+                id,
+                raw,
+                Arc::new(resolver),
+                &LOGGER,
+                SPEC_VERSION_0_0_4.clone(),
+            )
+            .await
+            .expect("Parsing simple manifest works")
         };
 
         assert!(unvalidated

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -3,34 +3,35 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use graph::blockchain::Blockchain;
+use graph::blockchain::BlockchainKind;
 use graph::blockchain::BlockchainMap;
 use graph::components::store::{DeploymentId, DeploymentLocator, SubscriptionManager};
 use graph::data::subgraph::schema::SubgraphDeploymentEntity;
+use graph::data::subgraph::MAX_SPEC_VERSION;
 use graph::prelude::{
     CreateSubgraphResult, SubgraphAssignmentProvider as SubgraphAssignmentProviderTrait,
     SubgraphRegistrar as SubgraphRegistrarTrait, *,
 };
 
-pub struct SubgraphRegistrar<C, L, P, S, SM> {
+pub struct SubgraphRegistrar<L, P, S, SM> {
     logger: Logger,
     logger_factory: LoggerFactory,
     resolver: Arc<L>,
     provider: Arc<P>,
     store: Arc<S>,
     subscription_manager: Arc<SM>,
-    chains: Arc<BlockchainMap<C>>,
+    chains: Arc<BlockchainMap>,
     node_id: NodeId,
     version_switching_mode: SubgraphVersionSwitchingMode,
     assignment_event_stream_cancel_guard: CancelGuard, // cancels on drop
 }
 
-impl<C, L, P, S, SM> SubgraphRegistrar<C, L, P, S, SM>
+impl<L, P, S, SM> SubgraphRegistrar<L, P, S, SM>
 where
     L: LinkResolver + Clone,
     P: SubgraphAssignmentProviderTrait,
     S: SubgraphStore,
     SM: SubscriptionManager,
-    C: Blockchain,
 {
     pub fn new(
         logger_factory: &LoggerFactory,
@@ -38,7 +39,7 @@ where
         provider: Arc<P>,
         store: Arc<S>,
         subscription_manager: Arc<SM>,
-        chains: Arc<BlockchainMap<C>>,
+        chains: Arc<BlockchainMap>,
         node_id: NodeId,
         version_switching_mode: SubgraphVersionSwitchingMode,
     ) -> Self {
@@ -239,13 +240,12 @@ where
 }
 
 #[async_trait]
-impl<C, L, P, S, SM> SubgraphRegistrarTrait for SubgraphRegistrar<C, L, P, S, SM>
+impl<L, P, S, SM> SubgraphRegistrarTrait for SubgraphRegistrar<L, P, S, SM>
 where
     L: LinkResolver,
     P: SubgraphAssignmentProviderTrait,
     S: SubgraphStore,
     SM: SubscriptionManager,
-    C: Blockchain,
 {
     async fn create_subgraph(
         &self,
@@ -271,46 +271,47 @@ where
             .logger_factory
             .subgraph_logger(&DeploymentLocator::new(DeploymentId(0), hash.clone()));
 
-        let unvalidated = UnvalidatedSubgraphManifest::<graph_chain_ethereum::Chain>::resolve(
-            hash,
-            self.resolver.clone(),
-            &logger,
-        )
-        .map_err(SubgraphRegistrarError::ResolveError)
-        .await?;
+        let raw: serde_yaml::Mapping = {
+            let file_bytes = self
+                .resolver
+                .cat(&logger, &hash.to_ipfs_link())
+                .await
+                .map_err(|e| {
+                    SubgraphRegistrarError::ResolveError(
+                        SubgraphManifestResolveError::ResolveError(e),
+                    )
+                })?;
 
-        let (manifest, validation_warnings) = unvalidated
-            .validate(self.store.clone())
-            .map_err(SubgraphRegistrarError::ManifestValidationError)?;
+            serde_yaml::from_slice(&file_bytes)
+                .map_err(|e| SubgraphRegistrarError::ResolveError(e.into()))?
+        };
 
-        let network_name = manifest.network_name();
+        let kind = BlockchainKind::from_manifest(&raw).map_err(|e| {
+            SubgraphRegistrarError::ResolveError(SubgraphManifestResolveError::ResolveError(e))
+        })?;
 
-        let chain = self
-            .chains
-            .get(&network_name)
-            .ok_or(SubgraphRegistrarError::NetworkNotSupported(
-                network_name.clone(),
-            ))?
-            .cheap_clone();
-
-        let manifest_id = manifest.id.clone();
-        create_subgraph_version(
-            &logger,
-            self.store.clone(),
-            chain,
-            name.clone(),
-            manifest,
-            node_id,
-            self.version_switching_mode,
-        )
-        .await?;
+        match kind {
+            BlockchainKind::Ethereum => {
+                create_subgraph_version::<graph_chain_ethereum::Chain, _, _>(
+                    &logger,
+                    self.store.clone(),
+                    self.chains.cheap_clone(),
+                    name.clone(),
+                    hash.cheap_clone(),
+                    raw,
+                    node_id,
+                    self.version_switching_mode,
+                    self.resolver.cheap_clone(),
+                )
+                .await?
+            }
+        };
 
         debug!(
             &logger,
             "Wrote new subgraph version to store";
             "subgraph_name" => name.to_string(),
-            "subgraph_hash" => manifest_id.to_string(),
-            "validation_warnings" => format!("{:?}", validation_warnings),
+            "subgraph_hash" => hash.to_string(),
         );
 
         Ok(())
@@ -466,15 +467,38 @@ async fn resolve_subgraph_chain_blocks(
     Ok((start_block_ptr, base_ptr))
 }
 
-async fn create_subgraph_version<C: Blockchain>(
+async fn create_subgraph_version<C: Blockchain, S: SubgraphStore, L: LinkResolver>(
     logger: &Logger,
-    store: Arc<impl SubgraphStore>,
-    chain: Arc<C>,
+    store: Arc<S>,
+    chains: Arc<BlockchainMap>,
     name: SubgraphName,
-    manifest: SubgraphManifest<impl Blockchain>,
+    deployment: DeploymentHash,
+    raw: serde_yaml::Mapping,
     node_id: NodeId,
     version_switching_mode: SubgraphVersionSwitchingMode,
+    resolver: Arc<L>,
 ) -> Result<(), SubgraphRegistrarError> {
+    let unvalidated = UnvalidatedSubgraphManifest::<C>::resolve(
+        deployment,
+        raw,
+        resolver,
+        &logger,
+        MAX_SPEC_VERSION.clone(),
+    )
+    .map_err(SubgraphRegistrarError::ResolveError)
+    .await?;
+
+    let manifest = unvalidated
+        .validate(store.cheap_clone())
+        .map_err(SubgraphRegistrarError::ManifestValidationError)?;
+
+    let network_name = manifest.network_name();
+
+    let chain = chains
+        .get::<C>(network_name.clone())
+        .map_err(SubgraphRegistrarError::NetworkNotSupported)?
+        .cheap_clone();
+
     let logger = logger.clone();
     let store = store.clone();
     let deployment_store = store.clone();
@@ -507,7 +531,6 @@ async fn create_subgraph_version<C: Blockchain>(
 
     // Apply the subgraph versioning and deployment operations,
     // creating a new subgraph deployment if one doesn't exist.
-    let network = manifest.network_name();
     let deployment = SubgraphDeploymentEntity::new(&manifest, false, start_block).graft(base_block);
     deployment_store
         .create_subgraph_deployment(
@@ -515,7 +538,7 @@ async fn create_subgraph_version<C: Blockchain>(
             &manifest.schema,
             deployment,
             node_id,
-            network,
+            network_name,
             version_switching_mode,
         )
         .map_err(|e| SubgraphRegistrarError::SubgraphDeploymentError(e))

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -26,14 +26,19 @@ use crate::{
     },
     prelude::{thiserror::Error, LinkResolver},
 };
-use anyhow::Error;
+use anyhow::{anyhow, Context, Error};
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use slog::Logger;
 use slog::{self, SendSyncRefUnwindSafeKV};
-use std::sync::Arc;
-use std::{collections::BTreeMap, fmt::Debug};
-use std::{collections::HashMap, convert::TryFrom};
+use std::{
+    any::Any,
+    collections::{BTreeMap, HashMap},
+    convert::TryFrom,
+    fmt::{self, Debug},
+    str::FromStr,
+    sync::Arc,
+};
 use web3::types::H256;
 
 pub use block_stream::{
@@ -63,6 +68,8 @@ pub trait Block: Send + Sync {
 #[async_trait]
 // This is only `Debug` because some tests require that
 pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
+    const KIND: BlockchainKind;
+
     // The `Clone` bound is used when reprocessing a block, because `triggers_in_block` requires an
     // owned `Block`. It would be good to come up with a way to remove this bound.
     type Block: Block + Clone;
@@ -118,8 +125,6 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
 
     fn runtime_adapter(&self) -> Arc<Self::RuntimeAdapter>;
 }
-
-pub type BlockchainMap<C> = HashMap<String, Arc<C>>;
 
 #[derive(Error, Debug)]
 pub enum IngestorError {
@@ -304,4 +309,74 @@ pub trait RuntimeAdapter<C: Blockchain>: Send + Sync {
 
 pub trait NodeCapabilities<C: Blockchain> {
     fn from_data_sources(data_sources: &[C::DataSource]) -> Self;
+}
+
+/// Blockchain technologies supported by Graph Node.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum BlockchainKind {
+    /// Ethereum itself or chains that are compatible.
+    Ethereum,
+}
+
+impl fmt::Display for BlockchainKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let value = match self {
+            BlockchainKind::Ethereum => "ethereum",
+        };
+        write!(f, "{}", value)
+    }
+}
+
+impl FromStr for BlockchainKind {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ethereum" => Ok(BlockchainKind::Ethereum),
+            _ => Err(anyhow!("unknown blockchain kind {}", s)),
+        }
+    }
+}
+
+impl BlockchainKind {
+    pub fn from_manifest(manifest: &serde_yaml::Mapping) -> Result<Self, Error> {
+        use serde_yaml::Value;
+
+        // The `kind` field of the first data source in the manifest.
+        //
+        // Split by `/` to, for example, read 'ethereum' in 'ethereum/contracts'.
+        manifest
+            .get(&Value::String("dataSources".to_owned()))
+            .and_then(|ds| ds.as_sequence())
+            .and_then(|ds| ds.first())
+            .and_then(|ds| ds.as_mapping())
+            .and_then(|ds| ds.get(&Value::String("kind".to_owned())))
+            .and_then(|kind| kind.as_str())
+            .and_then(|kind| kind.split('/').next())
+            .context("invalid manifest")
+            .and_then(BlockchainKind::from_str)
+    }
+}
+
+/// A collection of blockchains, keyed by `BlockchainKind` and network.
+#[derive(Default)]
+pub struct BlockchainMap(HashMap<(BlockchainKind, String), Arc<dyn Any + Send + Sync>>);
+
+impl BlockchainMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert<C: Blockchain>(&mut self, network: String, chain: Arc<C>) {
+        self.0.insert((C::KIND, network), chain);
+    }
+
+    pub fn get<C: Blockchain>(&self, network: String) -> Result<Arc<C>, Error> {
+        self.0
+            .get(&(C::KIND, network.clone()))
+            .with_context(|| format!("no network {} found on chain {}", network, C::KIND))?
+            .cheap_clone()
+            .downcast()
+            .map_err(|_| anyhow!("unable to downcast, wrong type for blockchain {}", C::KIND))
+    }
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -79,7 +79,7 @@ pub enum QueryExecutionError {
     EventStreamError,
     FulltextQueryRequiresFilter,
     DeploymentReverted,
-    SubgraphManifestResolveError,
+    SubgraphManifestResolveError(Arc<SubgraphManifestResolveError>),
     InvalidSubgraphManifest,
 }
 
@@ -222,7 +222,7 @@ impl fmt::Display for QueryExecutionError {
             TooExpensive => write!(f, "query is too expensive"),
             Throttled=> write!(f, "service is overloaded and can not run the query right now. Please try again in a few minutes"),
             DeploymentReverted => write!(f, "the chain was reorganized while executing the query"),
-            SubgraphManifestResolveError => write!(f, "failed to resolve subgraph manifest"),
+            SubgraphManifestResolveError(e) => write!(f, "failed to resolve subgraph manifest: {}", e),
             InvalidSubgraphManifest => write!(f, "invalid subgraph manifest file"),
         }
     }
@@ -255,6 +255,12 @@ impl From<bigdecimal::ParseBigDecimalError> for QueryExecutionError {
 impl From<StoreError> for QueryExecutionError {
     fn from(e: StoreError) -> Self {
         QueryExecutionError::StoreError(CloneableAnyhowError(Arc::new(e.into())))
+    }
+}
+
+impl From<SubgraphManifestResolveError> for QueryExecutionError {
+    fn from(e: SubgraphManifestResolveError) -> Self {
+        QueryExecutionError::SubgraphManifestResolveError(Arc::new(e))
     }
 }
 


### PR DESCRIPTION
This introduces the `BlockchainMap` in which `Blockchain` instances are stored, keyed by their `BlockchainKind` and network. This is used in the entry points that need to call functions which are generic on `C: Blockchain`, which are: `InstanceManager::start_subgraph`, `SubgraphRegistrar::create_subgraph` and `IndexNodeResolver::resolve_subgraph_features`.

Part of #2732.