### PR TITLE
Hotfix: Fix typo in sql query when fetching transaction receipts

### DIFF
--- a/store/postgres/src/transaction_receipt.rs
+++ b/store/postgres/src/transaction_receipt.rs
@@ -76,7 +76,7 @@ select
     ethereum_hex_to_bytea(receipt ->> 'status') as status
 from (
     select jsonb_array_elements(data -> 'transaction_receipts') as receipt
-    from"#,
+    from "#,
         );
         out.push_sql(&self.blocks_table_name);
         out.push_sql(" where hash = ");


### PR DESCRIPTION
I'm writing a follow up PR with tests for that query.