### PR TITLE
store: Allow setting min_idle and idle_timeout

### DIFF
--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -46,10 +46,25 @@ lazy_static::lazy_static! {
             })
             .unwrap_or(0)
     };
+
+    // These environment variables should really be set through the
+    // configuration file; especially for min_idle and idle_timeout, it's
+    // likely that they should be configured differently for each pool
+
     static ref CONNECTION_TIMEOUT: Duration = {
         std::env::var("GRAPH_STORE_CONNECTION_TIMEOUT").ok().map(|s| Duration::from_millis(u64::from_str(&s).unwrap_or_else(|_| {
             panic!("GRAPH_STORE_CONNECTION_TIMEOUT must be a positive number, but is `{}`", s)
         }))).unwrap_or(Duration::from_secs(5))
+    };
+    static ref MIN_IDLE: Option<u32> = {
+        std::env::var("GRAPH_STORE_CONNECTION_MIN_IDLE").ok().map(|s| u32::from_str(&s).unwrap_or_else(|_| {
+           panic!("GRAPH_STORE_CONNECTION_MIN_IDLE must be a positive number but is `{}`", s)
+        }))
+    };
+    static ref IDLE_TIMEOUT: Duration = {
+        std::env::var("GRAPH_STORE_CONNECTION_IDLE_TIMEOUT").ok().map(|s| Duration::from_secs(u64::from_str(&s).unwrap_or_else(|_| {
+            panic!("GRAPH_STORE_CONNECTION_IDLE_TIMEOUT must be a positive number, but is `{}`", s)
+        }))).unwrap_or(Duration::from_secs(600))
     };
 }
 
@@ -609,7 +624,9 @@ impl PoolInner {
             .error_handler(error_handler.clone())
             .event_handler(event_handler.clone())
             .connection_timeout(*CONNECTION_TIMEOUT)
-            .max_size(pool_size);
+            .max_size(pool_size)
+            .min_idle(*MIN_IDLE)
+            .idle_timeout(Some(*IDLE_TIMEOUT));
         let pool = builder.build_unchecked(conn_manager);
         let fdw_pool = fdw_pool_size.map(|pool_size| {
             let conn_manager = ConnectionManager::new(postgres_url.clone());


### PR DESCRIPTION
This introduces two new environment variables that allow setting the
minimum number of idle connections and the timeout when a connection is
considered idle. If the variables are not set, the behavior defaults to the
current behavior of keeping all connections and never reaping idle ones,
and an idle timeout of 10 minutes.

