### PR TITLE
graph, store: bump `num-bigint` and `bigdecimal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,18 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1374191e2dd25f9ae02e3aa95041ed5d747fc77b3c102b49fe2dd9a8117a6244"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.2.6",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "bigdecimal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+dependencies = [
+ "num-bigint 0.4.2",
  "num-integer",
  "num-traits",
  "serde",
@@ -863,12 +874,12 @@ version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bba51ca66f57261fd17cadf8b73e4775cc307d0521d855de3f5de91a8f074e0e"
 dependencies = [
- "bigdecimal",
+ "bigdecimal 0.1.2",
  "bitflags 1.3.1",
  "byteorder",
  "chrono",
  "diesel_derives",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
  "pq-sys",
@@ -1472,7 +1483,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atomic_refcell",
- "bigdecimal",
+ "bigdecimal 0.1.2",
+ "bigdecimal 0.3.0",
  "bytes 1.0.1",
  "chrono",
  "diesel",
@@ -1489,7 +1501,8 @@ dependencies = [
  "lazy_static",
  "maplit",
  "mockall 0.8.3",
- "num-bigint",
+ "num-bigint 0.2.6",
+ "num-bigint 0.4.2",
  "num-traits",
  "num_cpus",
  "parking_lot 0.11.2",
@@ -2722,6 +2735,17 @@ name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2018"
 anyhow = "1.0"
 async-trait = "0.1.50"
 atomic_refcell = "0.1.7"
-bigdecimal = { version = "0.1.0", features = ["serde"] }
+bigdecimal01 = { package = "bigdecimal", version = "0.1.0" }
+bigdecimal = { version = "0.3.0", features = ["serde"] }
+num-bigint02 = { package = "num-bigint", version = "^0.2.6" }
+num-bigint = { version = "^0.4.2", features = ["serde"] }
 bytes = "1.0.1"
 diesel = { version = "1.4.7", features = ["postgres", "serde_json", "numeric", "r2d2", "chrono"] }
 diesel_derives = "1.4"
@@ -29,7 +32,6 @@ futures = "0.1.21"
 graphql-parser = "0.3.0"
 lazy_static = "1.4.0"
 mockall = "0.8.3"
-num-bigint = { version = "^0.2.6", features = ["serde"] }
 num_cpus = "1.13.0"
 num-traits = "0.2.14"
 rand = "0.6.1"

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -91,7 +91,7 @@ impl CacheWeight for BigDecimal {
 
 impl CacheWeight for BigInt {
     fn indirect_weight(&self) -> usize {
-        self.bits() / 8
+        (self.bits() / 8) as usize
     }
 }
 

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -1,6 +1,8 @@
+use std::convert::TryInto;
+use std::{marker::PhantomData, str::FromStr};
+
 use hex_literal::hex;
 use lazy_static::lazy_static;
-use std::{marker::PhantomData, str::FromStr};
 use test_store::*;
 
 use graph::components::store::{
@@ -221,7 +223,14 @@ fn create_test_entity(
         "seconds_age".to_owned(),
         Value::BigInt(BigInt::from(age) * 31557600.into()),
     );
-    test_entity.insert("weight".to_owned(), Value::BigDecimal(weight.into()));
+    test_entity.insert(
+        "weight".to_owned(),
+        Value::BigDecimal(
+            weight
+                .try_into()
+                .expect("failed to convert f64 into big decimal"),
+        ),
+    );
     test_entity.insert("coffee".to_owned(), Value::Bool(coffee));
     test_entity.insert(
         "favorite_color".to_owned(),

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -1,4 +1,6 @@
 //! Test mapping of GraphQL schema to a relational schema
+use std::convert::TryInto;
+
 use diesel::connection::SimpleConnection as _;
 use diesel::pg::PgConnection;
 use graph::prelude::{
@@ -291,7 +293,10 @@ fn insert_user_entity(
         "seconds_age".to_owned(),
         Value::BigInt(BigInt::from(age) * 31557600.into()),
     );
-    user.insert("weight".to_owned(), Value::BigDecimal(weight.into()));
+    user.insert(
+        "weight".to_owned(),
+        Value::BigDecimal(weight.try_into().unwrap()),
+    );
     user.insert("coffee".to_owned(), Value::Bool(coffee));
     user.insert(
         "favorite_color".to_owned(),
@@ -373,7 +378,10 @@ fn update_user_entity(
         "seconds_age".to_owned(),
         Value::BigInt(BigInt::from(age) * 31557600.into()),
     );
-    user.insert("weight".to_owned(), Value::BigDecimal(weight.into()));
+    user.insert(
+        "weight".to_owned(),
+        Value::BigDecimal(weight.try_into().unwrap()),
+    );
     user.insert("coffee".to_owned(), Value::Bool(coffee));
     user.insert(
         "favorite_color".to_owned(),
@@ -1126,7 +1134,7 @@ fn check_find() {
                 vec!["1"],
                 user_query().filter(EntityFilter::Equal(
                     "weight".to_owned(),
-                    Value::BigDecimal(184.4.into()),
+                    Value::BigDecimal(184.4.try_into().unwrap()),
                 )),
             )
             .check(
@@ -1134,7 +1142,7 @@ fn check_find() {
                 user_query()
                     .filter(EntityFilter::Not(
                         "weight".to_owned(),
-                        Value::BigDecimal(184.4.into()),
+                        Value::BigDecimal(184.4.try_into().unwrap()),
                     ))
                     .desc("name"),
             )
@@ -1142,7 +1150,7 @@ fn check_find() {
                 vec!["1"],
                 user_query().filter(EntityFilter::GreaterThan(
                     "weight".to_owned(),
-                    Value::BigDecimal(160.0.into()),
+                    Value::BigDecimal(160.0.try_into().unwrap()),
                 )),
             )
             .check(
@@ -1150,7 +1158,7 @@ fn check_find() {
                 user_query()
                     .filter(EntityFilter::LessThan(
                         "weight".to_owned(),
-                        Value::BigDecimal(160.0.into()),
+                        Value::BigDecimal(160.0.try_into().unwrap()),
                     ))
                     .asc("name"),
             )
@@ -1159,7 +1167,7 @@ fn check_find() {
                 user_query()
                     .filter(EntityFilter::LessThan(
                         "weight".to_owned(),
-                        Value::BigDecimal(160.0.into()),
+                        Value::BigDecimal(160.0.try_into().unwrap()),
                     ))
                     .desc("name"),
             )
@@ -1168,7 +1176,7 @@ fn check_find() {
                 user_query()
                     .filter(EntityFilter::LessThan(
                         "weight".to_owned(),
-                        Value::BigDecimal(161.0.into()),
+                        Value::BigDecimal(161.0.try_into().unwrap()),
                     ))
                     .desc("name")
                     .first(1)
@@ -1180,8 +1188,8 @@ fn check_find() {
                     .filter(EntityFilter::In(
                         "weight".to_owned(),
                         vec![
-                            Value::BigDecimal(184.4.into()),
-                            Value::BigDecimal(111.7.into()),
+                            Value::BigDecimal(184.4.try_into().unwrap()),
+                            Value::BigDecimal(111.7.try_into().unwrap()),
                         ],
                     ))
                     .desc("name")
@@ -1193,8 +1201,8 @@ fn check_find() {
                     .filter(EntityFilter::NotIn(
                         "weight".to_owned(),
                         vec![
-                            Value::BigDecimal(184.4.into()),
-                            Value::BigDecimal(111.7.into()),
+                            Value::BigDecimal(184.4.try_into().unwrap()),
+                            Value::BigDecimal(111.7.try_into().unwrap()),
                         ],
                     ))
                     .desc("name")

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1,9 +1,11 @@
-use graph_mock::MockMetricsRegistry;
-use hex_literal::hex;
-use lazy_static::lazy_static;
+use std::convert::TryInto;
 use std::time::Duration;
 use std::{collections::HashSet, sync::Mutex};
 use std::{marker::PhantomData, str::FromStr};
+
+use graph_mock::MockMetricsRegistry;
+use hex_literal::hex;
+use lazy_static::lazy_static;
 use test_store::*;
 
 use graph::components::store::{DeploymentLocator, WritableStore};
@@ -266,7 +268,10 @@ fn create_test_entity(
         "seconds_age".to_owned(),
         Value::BigInt(BigInt::from(age) * 31557600.into()),
     );
-    test_entity.insert("weight".to_owned(), Value::BigDecimal(weight.into()));
+    test_entity.insert(
+        "weight".to_owned(),
+        Value::BigDecimal(weight.try_into().unwrap()),
+    );
     test_entity.insert("coffee".to_owned(), Value::Bool(coffee));
     test_entity.insert(
         "favorite_color".to_owned(),
@@ -350,7 +355,10 @@ fn get_entity_1() {
             "seconds_age".to_owned(),
             Value::BigInt(BigInt::from(2114359200)),
         );
-        expected_entity.insert("weight".to_owned(), Value::BigDecimal(184.4.into()));
+        expected_entity.insert(
+            "weight".to_owned(),
+            Value::BigDecimal(184.4.try_into().unwrap()),
+        );
         expected_entity.insert("coffee".to_owned(), Value::Bool(false));
         // "favorite_color" was set to `Null` earlier and should be absent
 
@@ -381,7 +389,10 @@ fn get_entity_3() {
             "seconds_age".to_owned(),
             Value::BigInt(BigInt::from(883612800)),
         );
-        expected_entity.insert("weight".to_owned(), Value::BigDecimal(111.7.into()));
+        expected_entity.insert(
+            "weight".to_owned(),
+            Value::BigDecimal(111.7.try_into().unwrap()),
+        );
         expected_entity.insert("coffee".to_owned(), Value::Bool(false));
         // "favorite_color" was set to `Null` earlier and should be absent
 
@@ -656,7 +667,7 @@ fn find() {
                 vec!["1"],
                 user_query().filter(EntityFilter::Equal(
                     "weight".to_owned(),
-                    Value::BigDecimal(184.4.into()),
+                    Value::BigDecimal(184.4.try_into().unwrap()),
                 )),
             )
             .check(
@@ -664,7 +675,7 @@ fn find() {
                 user_query()
                     .filter(EntityFilter::Not(
                         "weight".to_owned(),
-                        Value::BigDecimal(184.4.into()),
+                        Value::BigDecimal(184.4.try_into().unwrap()),
                     ))
                     .desc("name"),
             )
@@ -672,7 +683,7 @@ fn find() {
                 vec!["1"],
                 user_query().filter(EntityFilter::GreaterThan(
                     "weight".to_owned(),
-                    Value::BigDecimal(160.0.into()),
+                    Value::BigDecimal(160.0.try_into().unwrap()),
                 )),
             )
             .check(
@@ -680,7 +691,7 @@ fn find() {
                 user_query()
                     .filter(EntityFilter::LessThan(
                         "weight".to_owned(),
-                        Value::BigDecimal(160.0.into()),
+                        Value::BigDecimal(160.0.try_into().unwrap()),
                     ))
                     .asc("name"),
             )
@@ -689,7 +700,7 @@ fn find() {
                 user_query()
                     .filter(EntityFilter::LessThan(
                         "weight".to_owned(),
-                        Value::BigDecimal(160.0.into()),
+                        Value::BigDecimal(160.0.try_into().unwrap()),
                     ))
                     .desc("name"),
             )
@@ -698,7 +709,7 @@ fn find() {
                 user_query()
                     .filter(EntityFilter::LessThan(
                         "weight".to_owned(),
-                        Value::BigDecimal(161.0.into()),
+                        Value::BigDecimal(161.0.try_into().unwrap()),
                     ))
                     .desc("name")
                     .first(1)
@@ -710,8 +721,8 @@ fn find() {
                     .filter(EntityFilter::In(
                         "weight".to_owned(),
                         vec![
-                            Value::BigDecimal(184.4.into()),
-                            Value::BigDecimal(111.7.into()),
+                            Value::BigDecimal(184.4.try_into().unwrap()),
+                            Value::BigDecimal(111.7.try_into().unwrap()),
                         ],
                     ))
                     .desc("name")
@@ -723,8 +734,8 @@ fn find() {
                     .filter(EntityFilter::NotIn(
                         "weight".to_owned(),
                         vec![
-                            Value::BigDecimal(184.4.into()),
-                            Value::BigDecimal(111.7.into()),
+                            Value::BigDecimal(184.4.try_into().unwrap()),
+                            Value::BigDecimal(111.7.try_into().unwrap()),
                         ],
                     ))
                     .desc("name")


### PR DESCRIPTION
This PR bumps
* `num-bigint` from `^0.2.6` to `^0.4.7`
* `bigdecimal`from `0.1.0` to `0.3.0`

This change has pros and cons, however.

### Pros

* These types have had many optimizations since the versions we're currently using were released:
    * https://github.com/rust-num/num-bigint/pull/216
    * https://github.com/rust-num/num-bigint/pull/199
    * https://github.com/rust-num/num-bigint/pull/171
    * https://github.com/rust-num/num-bigint/pull/142
    * https://github.com/rust-num/num-bigint/pull/141
    * https://github.com/rust-num/num-bigint/pull/62
* We can now use upstream's implementation for `BigDecimal::normalized`.
* `bigdecimal` no longer implements `From<f64>` for `BigDecimal`, which is something that could panic before.
This means that the graph-node-defined `scalar::BigDecimal`  struct now implements `TryFrom<f64>` instead of `From<f64>`

### Cons

* The latest Diesel release still uses `num-bigint 0.2.6` and `bigdecimal 0.1.0`.
This means that we're no longer able to use the Diesel-defined `ToSql<diesel::sql_types::Numeric, _>` and `FromSql<diesel::sql_types::Numeric, _> for BigDecimal` implementations for version 0.3.0 of `BigDecimal` until Diesel upgrades their dependencies. 
In order to maintain support for these traits, I implemented the [BigDecimalRetrocompatibility](https://github.com/graphprotocol/graph-node/blob/6d3eb16a5b28a19e66ce7e3d56b9c6c3ce63faa6/graph/src/data/store/scalar.rs#L156) struct, which has functions for converting to and from versions 0.1 and 0.3 of `BigDecimal`.
API limitations make this operation make heap allocations, although I believe those allocations should be small most of the time.


@tilacog  @lutter @otaviopace @leoyvens 
If you guys believe that this PR is the way to go, I'll add tests for `BigDecimalRetrocompatibility` and further docs on things I changed
