### PR TITLE
ethereum: fix GETH_ETH_CALL_ERRORS_ENV

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -111,10 +111,8 @@ lazy_static! {
     /// Additional deterministic errors that have not yet been hardcoded. Separated by `;`.
     static ref GETH_ETH_CALL_ERRORS_ENV: Vec<String> = {
         std::env::var("GRAPH_GETH_ETH_CALL_ERRORS")
-        .unwrap_or_default()
-        .split(';')
-        .map(ToOwned::to_owned)
-        .collect()
+        .map(|s| s.split(';').filter(|s| s.len() > 0).map(ToOwned::to_owned).collect())
+        .unwrap_or(Vec::new())
     };
 }
 


### PR DESCRIPTION
Previously if `GETH_ETH_CALL_ERRORS_ENV` is not set, then any error returned from eth_call would be considered deterministic. This is because calling `split` on an empty string returns `[""]`, not `[]` ([playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=2909ff731dc3a055983463cfe619f8ff)), and all strings contain `""`. This affects release 0.24 and can cause subgraph failures on subgraphs using contract calls, and most severely incorrect data on subgraphs using `try_` calls, which would return a `reverted` result when it fact it was a spurious error.

This did not affect the hosted service because it has `GETH_ETH_CALL_ERRORS_ENV` set to `"out of gas"`. 
