### PR TITLE
store: Allow disabling some notifications

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -105,6 +105,10 @@ those.
 - `GRAPH_SQL_STATEMENT_TIMEOUT`: the maximum number of seconds an
   individual SQL query is allowed to take during GraphQL
   execution. Default: unlimited
+- `GRAPH_DISABLE_SUBSCRIPTION_NOTIFICATIONS`: disables the internal
+  mechanism that is used to trigger updates on GraphQL subscriptions. When
+  this variable is set to any value, `graph-node` will still accept GraphQL
+  subscriptions, but they won't receive any updates.
 
 ## Miscellaneous
 


### PR DESCRIPTION
The notifications we send when transacting entity changes are only needed
for updating GraphQL subscriptions. When that is not needed, disabling
these notifications will reduce the load on Postgres' message queue

