### PR TITLE
Optionally validate subgraph graft base

### DIFF
--- a/chain/ethereum/tests/manifest.rs
+++ b/chain/ethereum/tests/manifest.rs
@@ -166,7 +166,7 @@ specVersion: 0.0.2
         // would be a bit more work; we just want to make sure that
         // graft-related checks work
         let msg = unvalidated
-            .validate(store.clone())
+            .validate(store.clone(), true)
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| matches!(e, SubgraphManifestValidationError::GraftBaseInvalid(_)))
@@ -186,7 +186,7 @@ specVersion: 0.0.2
         // Validation against subgraph that has not reached the graft point fails
         let unvalidated = resolve_unvalidated(YAML).await;
         let msg = unvalidated
-            .validate(store)
+            .validate(store, true)
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| matches!(e, SubgraphManifestValidationError::GraftBaseInvalid(_)))
@@ -254,7 +254,7 @@ graft:
         let store = store.subgraph_store();
         let unvalidated = resolve_unvalidated(YAML).await;
         let error_msg = unvalidated
-            .validate(store.clone())
+            .validate(store.clone(), true)
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -290,7 +290,7 @@ graft:
         let store = store.subgraph_store();
         let unvalidated = resolve_unvalidated(YAML).await;
         assert!(unvalidated
-            .validate(store.clone())
+            .validate(store.clone(), true)
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -320,7 +320,7 @@ schema:
         let store = store.subgraph_store();
         let unvalidated = resolve_unvalidated(YAML).await;
         assert!(unvalidated
-            .validate(store.clone())
+            .validate(store.clone(), true)
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -370,7 +370,7 @@ schema:
         };
 
         assert!(unvalidated
-            .validate(store.clone())
+            .validate(store.clone(), true)
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -419,7 +419,7 @@ schema:
         };
 
         let error_msg = unvalidated
-            .validate(store.clone())
+            .validate(store.clone(), true)
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -492,7 +492,7 @@ dataSources:
         };
 
         let error_msg = unvalidated
-            .validate(store.clone())
+            .validate(store.clone(), true)
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -567,7 +567,7 @@ dataSources:
         };
 
         assert!(unvalidated
-            .validate(store.clone())
+            .validate(store.clone(), true)
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -595,7 +595,7 @@ schema:
         let store = store.subgraph_store();
         let unvalidated = resolve_unvalidated(YAML).await;
         assert!(unvalidated
-            .validate(store.clone())
+            .validate(store.clone(), true)
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -489,7 +489,7 @@ async fn create_subgraph_version<C: Blockchain, S: SubgraphStore, L: LinkResolve
     .await?;
 
     let manifest = unvalidated
-        .validate(store.cheap_clone())
+        .validate(store.cheap_clone(), true)
         .map_err(SubgraphRegistrarError::ManifestValidationError)?;
 
     let network_name = manifest.network_name();

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -607,9 +607,13 @@ impl<C: Blockchain> UnvalidatedSubgraphManifest<C> {
         ))
     }
 
+    /// Validates the subgraph manifest file.
+    ///
+    /// Graft base validation will be skipped if the parameter `validate_graft_base` is false.
     pub fn validate<S: SubgraphStore>(
         self,
         store: Arc<S>,
+        validate_graft_base: bool,
     ) -> Result<SubgraphManifest<C>, Vec<SubgraphManifestValidationError>> {
         let (schemas, _) = self.0.schema.resolve_schema_references(store.clone());
 
@@ -661,7 +665,9 @@ impl<C: Blockchain> UnvalidatedSubgraphManifest<C> {
                     "Grafting of subgraphs is currently disabled".to_owned(),
                 ));
             }
-            errors.extend(graft.validate(store));
+            if validate_graft_base {
+                errors.extend(graft.validate(store));
+            }
         }
 
         // Validate subgraph feature usage and declaration.

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -222,7 +222,7 @@ where
         // `validate` also validates subgraph features), so we must filter them out to build our
         // response.
         let subgraph_validation: Either<_, _> =
-            match unvalidated_subgraph_manifest.validate(self.subgraph_store.clone()) {
+            match unvalidated_subgraph_manifest.validate(self.subgraph_store.clone(), false) {
                 Ok(subgraph_manifest) => Either::Left(subgraph_manifest),
                 Err(validation_errors) => {
                     // We must ensure that all the errors are of the `FeatureValidationError`


### PR DESCRIPTION
-------

This PR adds a flag parameter to the `UnvalidatedSubgraphManifest::validate` function to skip graft base validation. At the moment, this will only be used by the feature detection GraphqQL endpoint to statically validate a manifest so it can properly inspect its features.