### PR TITLE
build: Fix issues post-firehose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
   THEGRAPH_STORE_POSTGRES_DIESEL_URL: "postgresql://postgres:postgres@localhost:5432/graph_node_test"
-  GRAPH_MAX_SPEC_VERSION: "0.0.4"
 
 jobs:
   unit-tests:
@@ -63,7 +62,6 @@ jobs:
         uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
-          CARGO_INCREMENTAL: 0
         with:
           command: test
           args: --verbose --workspace --exclude graph-tests -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,9 @@ members = [
 [patch.crates-io]
 # Include protection against stack overflow when parsing from this PR: https://github.com/graphql-rust/graphql-parser/commit/45167b53e9533c331298683577ba8df7e43480ac
 graphql-parser = {git="https://github.com/graphql-rust/graphql-parser", rev="45167b53e9533c331298683577ba8df7e43480ac"}
+
+# Incremental compilation on Rust 1.55 causes an ICE on build. As soon as graph node builds again, these can be removed.
+[profile.dev]
+incremental = false
+[profile.test]
+incremental = false

--- a/chain/ethereum/build.rs
+++ b/chain/ethereum/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     tonic_build::configure()
         .out_dir("src/protobuf")
-        .format(true)
+        .format(cfg!(debug_assertions)) // Release build environments might not have rustfmt installed
         .compile(&["proto/codec.proto"], &["proto"])
         .expect("Failed to compile StreamingFast Ethereum proto(s)");
 }


### PR DESCRIPTION
Fixes a couple of issues falling out from https://github.com/graphprotocol/graph-node/pull/2716. One is the build failing with incremental compilation, which is fixed by disabling that. The other is having rustfmt as a build-time dependency, which is failing the docker build, this is worked around by formatting the tonic generated file only in debug builds.