### PR TITLE
Small fixes around protobuf generation

### DIFF
--- a/chain/ethereum/build.rs
+++ b/chain/ethereum/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    println!("cargo:rerun-if-changed=proto");
     tonic_build::configure()
         .out_dir("src/protobuf")
         .format(cfg!(debug_assertions)) // Release build environments might not have rustfmt installed

--- a/chain/ethereum/build.rs
+++ b/chain/ethereum/build.rs
@@ -2,7 +2,7 @@ fn main() {
     println!("cargo:rerun-if-changed=proto");
     tonic_build::configure()
         .out_dir("src/protobuf")
-        .format(cfg!(debug_assertions)) // Release build environments might not have rustfmt installed
+        .format(true)
         .compile(&["proto/codec.proto"], &["proto"])
         .expect("Failed to compile StreamingFast Ethereum proto(s)");
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ ARG TAG_NAME=unknown
 ADD . /graph-node
 
 RUN cd /graph-node \
+    && rustup component add rustfmt \
     && RUSTFLAGS="-g" cargo install --locked --path node \
     && cargo clean \
     && objcopy --only-keep-debug /usr/local/cargo/bin/graph-node /usr/local/cargo/bin/graph-node.debug \

--- a/graph/build.rs
+++ b/graph/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    println!("cargo:rerun-if-changed=proto");
     tonic_build::configure()
         .out_dir("src/firehose")
         .format(true)


### PR DESCRIPTION
This fixes two small things:
* only regenerate protobuf definitions if the `.proto` files have changed
* install `rustfmt` in the docker build container so docker builds work again