### PR TITLE
Make graph-node more robust in the face of shards being down or restarting

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -135,7 +135,7 @@ impl Chain {
         let chain_store = self.chain_store().clone();
         let writable = self
             .subgraph_store
-            .writable(&deployment)
+            .writable(logger.clone(), &deployment)
             .expect(&format!("no store for deployment `{}`", deployment.hash));
         let chain_head_update_stream = self
             .chain_head_update_listener
@@ -189,7 +189,10 @@ impl Chain {
             .new(o!("component" => "FirehoseBlockStream"));
 
         let firehose_mapper = Arc::new(FirehoseMapper {});
-        let firehose_cursor = self.subgraph_store.writable(&deployment)?.block_cursor()?;
+        let firehose_cursor = self
+            .subgraph_store
+            .writable(logger.clone(), &deployment)?
+            .block_cursor()?;
 
         Ok(Box::new(FirehoseBlockStream::new(
             firehose_endpoint,

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1361,9 +1361,10 @@ impl EthereumAdapterTrait for EthereumAdapter {
         chain_store: Arc<dyn ChainStore>,
         block_hashes: HashSet<H256>,
     ) -> Box<dyn Stream<Item = LightEthereumBlock, Error = Error> + Send> {
+        let block_hashes: Vec<_> = block_hashes.iter().cloned().collect();
         // Search for the block in the store first then use json-rpc as a backup.
         let mut blocks = chain_store
-            .blocks(block_hashes.iter().cloned().collect())
+            .blocks(&block_hashes)
             .map_err(|e| error!(&logger, "Error accessing block cache {}", e))
             .unwrap_or_default();
 

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -107,7 +107,7 @@ fn load_local_head(context: &Context) -> LocalHeadFuture {
         future::result(
             context
                 .store
-                .writable_for_network_indexer(&context.subgraph_id)
+                .writable_for_network_indexer(context.logger.clone(), &context.subgraph_id)
                 .map_err(Error::from)
                 .and_then(|store| store.block_ptr().map_err(Error::from))
         )
@@ -1169,7 +1169,7 @@ impl NetworkIndexer {
         ));
 
         let writable = store
-            .writable_for_network_indexer(&subgraph_id)
+            .writable_for_network_indexer(logger.clone(), &subgraph_id)
             .expect("can get writable store");
         let block_writer = Arc::new(BlockWriter::new(
             subgraph_id.clone(),

--- a/chain/ethereum/src/network_indexer/subgraph.rs
+++ b/chain/ethereum/src/network_indexer/subgraph.rs
@@ -9,7 +9,7 @@ fn check_subgraph_exists(
     store: Arc<dyn SubgraphStore>,
     subgraph_id: DeploymentHash,
 ) -> impl Future<Item = bool, Error = Error> {
-    future::result(store.is_deployed(&subgraph_id))
+    future::result(store.is_deployed(&subgraph_id).map_err(Error::from))
 }
 
 fn create_subgraph(

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -134,7 +134,10 @@ impl Blockchain for Chain {
             .new(o!("component" => "FirehoseBlockStream"));
 
         let firehose_mapper = Arc::new(FirehoseMapper {});
-        let firehose_cursor = self.subgraph_store.writable(&deployment)?.block_cursor()?;
+        let firehose_cursor = self
+            .subgraph_store
+            .writable(logger.clone(), &deployment)?
+            .block_cursor()?;
 
         Ok(Box::new(FirehoseBlockStream::new(
             firehose_endpoint,

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -267,7 +267,7 @@ where
     ) -> Result<(), Error> {
         let subgraph_store = self.subgraph_store.cheap_clone();
         let registry = self.metrics_registry.cheap_clone();
-        let store = self.subgraph_store.writable(&deployment)?;
+        let store = self.subgraph_store.writable(logger.clone(), &deployment)?;
 
         // Start the subgraph deployment before reading dynamic data
         // sources; if the subgraph is a graft or a copy, starting it will

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -663,6 +663,12 @@ impl From<Error> for BlockProcessingError {
     }
 }
 
+impl From<StoreError> for BlockProcessingError {
+    fn from(e: StoreError) -> Self {
+        BlockProcessingError::Unknown(e.into())
+    }
+}
+
 /// Processes a block and returns the updated context and a boolean flag indicating
 /// whether new dynamic data sources have been added to the subgraph.
 async fn process_block<T: RuntimeHostBuilder<C>, C: Blockchain>(

--- a/graph/src/blockchain/polling_block_stream.rs
+++ b/graph/src/blockchain/polling_block_stream.rs
@@ -468,7 +468,7 @@ where
 
     /// Set subgraph deployment entity synced flag if and only if the subgraph block pointer is
     /// caught up to the head block pointer.
-    fn update_subgraph_synced_status(&self) -> Result<(), Error> {
+    fn update_subgraph_synced_status(&self) -> Result<(), StoreError> {
         let head_ptr_opt = self.chain_store.chain_head_ptr()?;
         let subgraph_ptr = self.subgraph_store.block_ptr()?;
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -964,9 +964,12 @@ pub trait SubgraphStore: Send + Sync + 'static {
     fn api_schema(&self, subgraph_id: &DeploymentHash) -> Result<Arc<ApiSchema>, StoreError>;
 
     /// Return a `WritableStore` that is used for indexing subgraphs. Only
-    /// code that is part of indexing a subgraph should ever use this.
+    /// code that is part of indexing a subgraph should ever use this. The
+    /// `logger` will be used to log important messages related to the
+    /// subgraph
     fn writable(
         &self,
+        logger: Logger,
         deployment: &DeploymentLocator,
     ) -> Result<Arc<dyn WritableStore>, StoreError>;
 
@@ -976,6 +979,7 @@ pub trait SubgraphStore: Send + Sync + 'static {
     /// `writable` should be used instead
     fn writable_for_network_indexer(
         &self,
+        logger: Logger,
         id: &DeploymentHash,
     ) -> Result<Arc<dyn WritableStore>, StoreError>;
 
@@ -1144,7 +1148,11 @@ impl SubgraphStore for MockStore {
         unimplemented!()
     }
 
-    fn writable(&self, _: &DeploymentLocator) -> Result<Arc<dyn WritableStore>, StoreError> {
+    fn writable(
+        &self,
+        _: Logger,
+        _: &DeploymentLocator,
+    ) -> Result<Arc<dyn WritableStore>, StoreError> {
         Ok(Arc::new(MockStore::new()))
     }
 
@@ -1158,6 +1166,7 @@ impl SubgraphStore for MockStore {
 
     fn writable_for_network_indexer(
         &self,
+        _: Logger,
         _: &DeploymentHash,
     ) -> Result<Arc<dyn WritableStore>, StoreError> {
         unimplemented!()

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1299,7 +1299,7 @@ pub trait ChainStore: Send + Sync + 'static {
     fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error>;
 
     /// Returns the blocks present in the store.
-    fn blocks(&self, hashes: Vec<H256>) -> Result<Vec<LightEthereumBlock>, Error>;
+    fn blocks(&self, hashes: &[H256]) -> Result<Vec<LightEthereumBlock>, Error>;
 
     /// Get the `offset`th ancestor of `block_hash`, where offset=0 means the block matching
     /// `block_hash` and offset=1 means its parent. Returns None if unable to complete due to

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1013,7 +1013,7 @@ pub trait WritableStore: Send + Sync + 'static {
     /// Set subgraph status to failed with the given error as the cause.
     async fn fail_subgraph(&self, error: SubgraphError) -> Result<(), StoreError>;
 
-    fn supports_proof_of_indexing<'a>(self: Arc<Self>) -> DynTryFuture<'a, bool>;
+    async fn supports_proof_of_indexing(&self) -> Result<bool, StoreError>;
 
     /// Looks up an entity using the given store key at the latest block.
     fn get(&self, key: &EntityKey) -> Result<Option<Entity>, QueryExecutionError>;
@@ -1191,7 +1191,7 @@ impl WritableStore for MockStore {
         unimplemented!()
     }
 
-    fn supports_proof_of_indexing<'a>(self: Arc<Self>) -> DynTryFuture<'a, bool> {
+    async fn supports_proof_of_indexing(&self) -> Result<bool, StoreError> {
         unimplemented!()
     }
 
@@ -1402,12 +1402,12 @@ pub trait StatusStore: Send + Sync + 'static {
     /// re-sync from scratch, so existing deployments will continue without a
     /// Proof of Indexing. Once all subgraphs have been re-deployed the Option
     /// can be removed.
-    fn get_proof_of_indexing<'a>(
-        self: Arc<Self>,
-        subgraph_id: &'a DeploymentHash,
-        indexer: &'a Option<Address>,
+    async fn get_proof_of_indexing(
+        &self,
+        subgraph_id: &DeploymentHash,
+        indexer: &Option<Address>,
         block: BlockPtr,
-    ) -> DynTryFuture<'a, Option<[u8; 32]>>;
+    ) -> Result<Option<[u8; 32]>, StoreError>;
 }
 
 /// An entity operation that can be transacted into the store; as opposed to

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -989,6 +989,10 @@ pub trait SubgraphStore: Send + Sync + 'static {
     fn locators(&self, hash: &str) -> Result<Vec<DeploymentLocator>, StoreError>;
 }
 
+/// A view of the store for indexing. All indexing-related operations need
+/// to go through this trait. Methods in this trait will never return a
+/// `StoreError::DatabaseUnavailable`. Instead, they will retry the
+/// operation indefinitely until it succeeds.
 #[async_trait]
 pub trait WritableStore: Send + Sync + 'static {
     /// Get a pointer to the most recently processed block in the subgraph.

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -43,7 +43,6 @@ pub enum QueryExecutionError {
     MissingArgumentError(Pos, String),
     InvalidVariableTypeError(Pos, String),
     MissingVariableError(Pos, String),
-    ResolveEntityError(DeploymentHash, String, String, String),
     ResolveEntitiesError(String),
     OrderByNotSupportedError(String, String),
     OrderByNotSupportedForType(String),
@@ -129,9 +128,6 @@ impl fmt::Display for QueryExecutionError {
             }
             MissingVariableError(_, s) => {
                 write!(f, "No value provided for required variable `{}`", s)
-            }
-            ResolveEntityError(_, entity, id, e) => {
-                write!(f, "Failed to get `{}` entity with ID `{}` from store: {}", entity, id, e)
             }
             ResolveEntitiesError(e) => {
                 write!(f, "Failed to get entities from store: {}", e)

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -8,11 +8,14 @@ use itertools::Itertools;
 use serde::de;
 use serde::{Deserialize, Serialize};
 use stable_hash::prelude::*;
-use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
 use std::fmt;
 use std::iter::FromIterator;
 use std::str::FromStr;
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap},
+};
 use strum::AsStaticRef as _;
 use strum_macros::AsStaticStr;
 
@@ -517,7 +520,7 @@ impl Entity {
         self.0.remove(key)
     }
 
-    pub fn contains_key(&mut self, key: &str) -> bool {
+    pub fn contains_key(&self, key: &str) -> bool {
         self.0.contains_key(key)
     }
 
@@ -583,6 +586,12 @@ impl From<Entity> for q::Value {
 impl From<HashMap<Attribute, Value>> for Entity {
     fn from(m: HashMap<Attribute, Value>) -> Entity {
         Entity(m)
+    }
+}
+
+impl<'a> From<&'a Entity> for Cow<'a, Entity> {
+    fn from(entity: &'a Entity) -> Self {
+        Cow::Borrowed(entity)
     }
 }
 

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -167,7 +167,7 @@ impl<'a, C: Blockchain> From<&'a super::SubgraphManifest<C>> for SubgraphManifes
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SubgraphError {
     pub subgraph_id: DeploymentHash,
     pub message: String,

--- a/graph/src/util/backoff.rs
+++ b/graph/src/util/backoff.rs
@@ -1,0 +1,48 @@
+use std::time::Duration;
+
+/// Facilitate sleeping with an exponential backoff. Sleep durations will
+/// increase by a factor of 2 from `base` until they reach `ceiling`, at
+/// which point any call to `sleep` or `sleep_async` will sleep for
+/// `ceiling`
+pub struct ExponentialBackoff {
+    pub attempt: u64,
+    base: Duration,
+    ceiling: Duration,
+}
+
+impl ExponentialBackoff {
+    pub fn new(base: Duration, ceiling: Duration) -> Self {
+        ExponentialBackoff {
+            attempt: 0,
+            base,
+            ceiling,
+        }
+    }
+
+    /// Record that we made an attempt and sleep for the appropriate amount
+    /// of time. Do not use this from async contexts since it uses
+    /// `thread::sleep`
+    pub fn sleep(&mut self) {
+        std::thread::sleep(self.next_attempt());
+    }
+
+    /// Record that we made an attempt and sleep for the appropriate amount
+    /// of time
+    pub async fn sleep_async(&mut self) {
+        tokio::time::sleep(self.next_attempt()).await
+    }
+
+    pub fn delay(&self) -> Duration {
+        let mut delay = self.base.saturating_mul(1 << self.attempt);
+        if delay > self.ceiling {
+            delay = self.ceiling;
+        }
+        delay
+    }
+
+    fn next_attempt(&mut self) -> Duration {
+        let delay = self.delay();
+        self.attempt += 1;
+        delay
+    }
+}

--- a/graph/src/util/mod.rs
+++ b/graph/src/util/mod.rs
@@ -17,3 +17,6 @@ pub mod cache_weight;
 pub mod timed_rw_lock;
 
 pub mod jobs;
+
+/// Increasingly longer sleeps to back off some repeated operation
+pub mod backoff;

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -1,4 +1,5 @@
 use lazy_static::lazy_static;
+use slog::{o, Logger};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -30,7 +31,8 @@ fn sort_by_entity_key(mut mods: Vec<EntityModification>) -> Vec<EntityModificati
 
 #[test]
 fn empty_cache_modifications() {
-    let store = MockStore::new().writable(&*DEPLOYMENT).unwrap();
+    let logger = Logger::root(slog::Discard, o!());
+    let store = MockStore::new().writable(logger, &*DEPLOYMENT).unwrap();
     let cache = EntityCache::new(store.clone());
     let result = cache.as_modifications();
     assert_eq!(result.unwrap().modifications, vec![]);

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -50,7 +50,7 @@ mock! {
 
 #[async_trait]
 impl SubgraphStore for MockStore {
-    fn find_ens_name(&self, _hash: &str) -> Result<Option<String>, QueryExecutionError> {
+    fn find_ens_name(&self, _hash: &str) -> Result<Option<String>, StoreError> {
         unimplemented!()
     }
 
@@ -105,11 +105,11 @@ impl SubgraphStore for MockStore {
         todo!()
     }
 
-    fn is_deployed(&self, _: &DeploymentHash) -> Result<bool, Error> {
+    fn is_deployed(&self, _: &DeploymentHash) -> Result<bool, StoreError> {
         todo!()
     }
 
-    fn least_block_ptr(&self, _: &DeploymentHash) -> Result<Option<BlockPtr>, Error> {
+    fn least_block_ptr(&self, _: &DeploymentHash) -> Result<Option<BlockPtr>, StoreError> {
         unimplemented!()
     }
 

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -27,7 +27,7 @@ mock! {
 
         fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error>;
 
-        fn blocks(&self, hashes: Vec<H256>) -> Result<Vec<LightEthereumBlock>, Error>;
+        fn blocks(&self, hashes: &[H256]) -> Result<Vec<LightEthereumBlock>, Error>;
 
         fn ancestor_block(
             &self,

--- a/mock/src/store.rs
+++ b/mock/src/store.rs
@@ -100,6 +100,7 @@ impl SubgraphStore for MockStore {
 
     fn writable(
         &self,
+        _: Logger,
         _: &DeploymentLocator,
     ) -> Result<Arc<dyn graph::components::store::WritableStore>, StoreError> {
         todo!()
@@ -115,6 +116,7 @@ impl SubgraphStore for MockStore {
 
     fn writable_for_network_indexer(
         &self,
+        _: Logger,
         _: &DeploymentHash,
     ) -> Result<Arc<dyn graph::components::store::WritableStore>, StoreError> {
         unimplemented!()

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -485,7 +485,7 @@ async fn main() {
         }
         Ok(node) => node,
     };
-    let ctx = Context::new(logger, node, config);
+    let ctx = Context::new(logger.clone(), node, config);
 
     use Command::*;
     let result = match opt.cmd {
@@ -532,7 +532,9 @@ async fn main() {
         }
         Remove { name } => commands::remove::run(ctx.subgraph_store(), name),
         Create { name } => commands::create::run(ctx.subgraph_store(), name),
-        Unassign { id, shard } => commands::assign::unassign(ctx.subgraph_store(), id, shard),
+        Unassign { id, shard } => {
+            commands::assign::unassign(logger.clone(), ctx.subgraph_store(), id, shard)
+        }
         Reassign { id, node, shard } => {
             commands::assign::reassign(ctx.subgraph_store(), id, node, shard)
         }

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -1,11 +1,15 @@
 use std::sync::Arc;
 
-use graph::prelude::{anyhow::anyhow, Error, NodeId, SubgraphStore as _};
+use graph::{
+    prelude::{anyhow::anyhow, Error, NodeId, SubgraphStore as _},
+    slog::Logger,
+};
 use graph_store_postgres::SubgraphStore;
 
 use crate::manager::deployment::locate;
 
 pub fn unassign(
+    logger: Logger,
     store: Arc<SubgraphStore>,
     hash: String,
     shard: Option<String>,
@@ -13,7 +17,7 @@ pub fn unassign(
     let deployment = locate(store.as_ref(), hash, shard)?;
 
     println!("unassigning {}", deployment);
-    store.writable(&deployment)?.unassign_subgraph()?;
+    store.writable(logger, &deployment)?.unassign_subgraph()?;
 
     Ok(())
 }

--- a/node/src/manager/commands/chain.rs
+++ b/node/src/manager/commands/chain.rs
@@ -12,7 +12,10 @@ use graph_store_postgres::{
 };
 
 pub fn list(primary: ConnectionPool, store: Arc<BlockStore>) -> Result<(), Error> {
-    let mut chains = block_store::load_chains(&primary)?;
+    let mut chains = {
+        let conn = primary.get()?;
+        block_store::load_chains(&conn)?
+    };
     chains.sort_by_key(|chain| chain.name.clone());
 
     if !chains.is_empty() {

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -9,6 +9,7 @@ use graph_chain_ethereum::{
 use graph_runtime_wasm::{HostExports, MappingContext};
 use semver::Version;
 use std::str::FromStr;
+use test_store::LOGGER;
 use web3::types::Address;
 
 fn mock_host_exports(
@@ -90,7 +91,10 @@ pub fn mock_context(
             store.clone(),
             api_version,
         )),
-        state: BlockState::new(store.writable(&deployment).unwrap(), Default::default()),
+        state: BlockState::new(
+            store.writable(LOGGER.clone(), &deployment).unwrap(),
+            Default::default(),
+        ),
         proof_of_indexing: None,
         host_fns: Arc::new(Vec::new()),
     }

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 pub mod common;
 #[cfg(test)]
 mod test;

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -13,7 +13,7 @@ use hex;
 use semver::Version;
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
-use test_store::STORE;
+use test_store::{LOGGER, STORE};
 use web3::types::H160;
 
 use crate::common::{mock_context, mock_data_source};
@@ -858,7 +858,7 @@ fn test_entity_store(api_version: Version) {
     load_and_set_user_name(&mut module, "steve", "Steve-O");
 
     // We need to empty the cache for the next test
-    let writable = store.writable(&deployment).unwrap();
+    let writable = store.writable(LOGGER.clone(), &deployment).unwrap();
     let cache = std::mem::replace(
         &mut module.instance_ctx_mut().ctx.state.entity_cache,
         EntityCache::new(writable.clone()),

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -116,10 +116,9 @@ where
             .get_optional::<Address>("indexer")
             .expect("Invalid indexer");
 
-        let poi_fut =
-            self.store
-                .clone()
-                .get_proof_of_indexing(&deployment_id, &indexer, block.clone());
+        let poi_fut = self
+            .store
+            .get_proof_of_indexing(&deployment_id, &indexer, block.clone());
         let poi = match futures::executor::block_on(poi_fut) {
             Ok(Some(poi)) => q::Value::String(format!("0x{}", hex::encode(&poi))),
             Ok(None) => q::Value::Null,

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -507,7 +507,7 @@ mod data {
             &self,
             conn: &PgConnection,
             chain: &str,
-            hashes: Vec<H256>,
+            hashes: &[H256],
         ) -> Result<Vec<LightEthereumBlock>, Error> {
             use diesel::dsl::any;
 
@@ -1375,7 +1375,7 @@ impl ChainStoreTrait for ChainStore {
             .map_err(Error::from)
     }
 
-    fn blocks(&self, hashes: Vec<H256>) -> Result<Vec<LightEthereumBlock>, Error> {
+    fn blocks(&self, hashes: &[H256]) -> Result<Vec<LightEthereumBlock>, Error> {
         let conn = self.get_conn()?;
         self.storage.blocks(&conn, &self.chain, hashes)
     }

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -232,6 +232,8 @@ impl ForeignServer {
             "dynamic_ethereum_contract_data_source",
             "table_stats",
             "subgraph_deployment_assignment",
+            "subgraph",
+            "subgraph_version",
         ] {
             let create_stmt =
                 catalog::create_foreign_table(conn, "subgraphs", table_name, &nsp, &self.name)?;

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -231,6 +231,7 @@ impl ForeignServer {
             "subgraph_error",
             "dynamic_ethereum_contract_data_source",
             "table_stats",
+            "subgraph_deployment_assignment",
         ] {
             let create_stmt =
                 catalog::create_foreign_table(conn, "subgraphs", table_name, &nsp, &self.name)?;

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -468,13 +468,6 @@ impl ConnectionPool {
         self.get_ready()?.get()
     }
 
-    pub fn get_with_timeout_warning(
-        &self,
-        logger: &Logger,
-    ) -> Result<PooledConnection<ConnectionManager<PgConnection>>, StoreError> {
-        self.get_ready()?.get_with_timeout_warning(logger)
-    }
-
     /// Get a connection from the pool for foreign data wrapper access;
     /// since that pool can be very contended, periodically log that we are
     /// still waiting for a connection

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -773,7 +773,7 @@ impl PoolInner {
             // closure failed.
             let conn = pool
                 .get()
-                .map_err(|e| CancelableError::Error(StoreError::Unknown(e.into())))?;
+                .map_err(|_| CancelableError::Error(StoreError::DatabaseUnavailable))?;
 
             // It is possible time has passed while establishing a connection.
             // Time to check for cancel.
@@ -798,7 +798,7 @@ impl PoolInner {
     }
 
     pub fn get(&self) -> Result<PooledConnection<ConnectionManager<PgConnection>>, StoreError> {
-        self.pool.get().map_err(|e| StoreError::Unknown(e.into()))
+        self.pool.get().map_err(|_| StoreError::DatabaseUnavailable)
     }
 
     pub fn get_with_timeout_warning(

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -219,7 +219,7 @@ pub fn features(conn: &PgConnection, site: &Site) -> Result<BTreeSet<SubgraphFea
 pub fn forward_block_ptr(
     conn: &PgConnection,
     id: &DeploymentHash,
-    ptr: BlockPtr,
+    ptr: &BlockPtr,
 ) -> Result<(), StoreError> {
     use crate::diesel::BoolExpressionMethods;
     use subgraph_deployment as d;
@@ -282,7 +282,7 @@ pub fn get_subgraph_firehose_cursor(
 pub fn update_firehose_cursor(
     conn: &PgConnection,
     id: &DeploymentHash,
-    cursor: &String,
+    cursor: &str,
 ) -> Result<(), StoreError> {
     use subgraph_deployment as d;
 
@@ -450,7 +450,7 @@ pub fn exists_and_synced(conn: &PgConnection, id: &str) -> Result<bool, StoreErr
 }
 
 // Does nothing if the error already exists. Returns the error id.
-fn insert_subgraph_error(conn: &PgConnection, error: SubgraphError) -> anyhow::Result<String> {
+fn insert_subgraph_error(conn: &PgConnection, error: &SubgraphError) -> anyhow::Result<String> {
     use subgraph_error as e;
 
     let error_id = hex::encode(&stable_hash::utils::stable_hash::<SetHasher, _>(&error));
@@ -464,7 +464,7 @@ fn insert_subgraph_error(conn: &PgConnection, error: SubgraphError) -> anyhow::R
 
     let block_num = match &block_ptr {
         None => {
-            assert_eq!(deterministic, false);
+            assert_eq!(*deterministic, false);
             crate::block_range::BLOCK_UNVERSIONED
         }
         Some(block) => crate::block_range::block_number(block),
@@ -489,7 +489,7 @@ fn insert_subgraph_error(conn: &PgConnection, error: SubgraphError) -> anyhow::R
 pub fn fail(
     conn: &PgConnection,
     id: &DeploymentHash,
-    error: SubgraphError,
+    error: &SubgraphError,
 ) -> Result<(), StoreError> {
     use subgraph_deployment as d;
 
@@ -584,7 +584,7 @@ pub fn unfail(conn: &PgConnection, id: &DeploymentHash) -> Result<(), StoreError
 pub(crate) fn insert_subgraph_errors(
     conn: &PgConnection,
     id: &DeploymentHash,
-    deterministic_errors: Vec<SubgraphError>,
+    deterministic_errors: &[SubgraphError],
     block: BlockNumber,
 ) -> Result<(), StoreError> {
     for error in deterministic_errors {

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -483,7 +483,7 @@ impl DeploymentStore {
 
     /// Deprecated. Use `with_conn` instead.
     fn get_conn(&self) -> Result<PooledConnection<ConnectionManager<PgConnection>>, StoreError> {
-        self.conn.get_with_timeout_warning(&self.logger)
+        self.conn.get()
     }
 
     /// Panics if `idx` is not a valid index for a read only pool.

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -817,7 +817,7 @@ impl DeploymentStore {
     pub(crate) fn get_many(
         &self,
         site: Arc<Site>,
-        ids_for_type: BTreeMap<&EntityType, Vec<&str>>,
+        ids_for_type: &BTreeMap<&EntityType, Vec<&str>>,
     ) -> Result<BTreeMap<EntityType, Vec<Entity>>, StoreError> {
         if ids_for_type.is_empty() {
             return Ok(BTreeMap::new());

--- a/store/postgres/src/dynds.rs
+++ b/store/postgres/src/dynds.rs
@@ -113,7 +113,7 @@ pub fn load(conn: &PgConnection, id: &str) -> Result<Vec<StoredDynamicDataSource
 pub(crate) fn insert(
     conn: &PgConnection,
     deployment: &DeploymentHash,
-    data_sources: Vec<StoredDynamicDataSource>,
+    data_sources: &[StoredDynamicDataSource],
     block_ptr: &BlockPtr,
 ) -> Result<usize, StoreError> {
     use dynamic_ethereum_contract_data_source as decds;
@@ -152,7 +152,7 @@ pub(crate) fn insert(
                 decds::context.eq(context),
                 decds::address.eq(address),
                 decds::abi.eq(abi),
-                decds::start_block.eq(start_block as i32),
+                decds::start_block.eq(start_block),
                 decds::ethereum_block_number.eq(sql(&format!("{}::numeric", block_ptr.number))),
                 decds::ethereum_block_hash.eq(block_ptr.hash_slice()),
             ))

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -56,7 +56,7 @@ pub mod layout_for_tests {
     pub use crate::catalog::set_account_like;
     pub use crate::chain_store::test_support as chain_support;
     pub use crate::primary::{
-        make_dummy_site, Connection, Namespace, EVENT_TAP, EVENT_TAP_ENABLED,
+        make_dummy_site, Connection, Mirror, Namespace, EVENT_TAP, EVENT_TAP_ENABLED,
     };
     pub use crate::relational::*;
 }

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -85,7 +85,7 @@ impl NotificationListener {
     //
     /// The listener will handle dropping the database connection by
     /// indefinitely trying to reconnect to the database. Users of the
-    /// listener have now way to find out whether the connection had been
+    /// listener have no way to find out whether the connection had been
     /// dropped and was reestablished.
     pub fn new(
         logger: &Logger,

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -81,6 +81,11 @@ impl NotificationListener {
     /// channel.
     ///
     /// Must call `.start()` to begin receiving notifications on the returned receiver.
+    //
+    /// The listener will handle dropping the database connection by
+    /// indefinitely trying to reconnect to the database. Users of the
+    /// listener have now way to find out whether the connection had been
+    /// dropped and was reestablished.
     pub fn new(
         logger: &Logger,
         postgres_url: String,
@@ -120,6 +125,34 @@ impl NotificationListener {
         Arc<AtomicBool>,
         Arc<Barrier>,
     ) {
+        /// Connect to the database at `postgres_url` and do a `LISTEN
+        /// {channel_name}`. If that fails, retry with exponential backoff
+        /// with a delay between 1s and 32s
+        fn connect_and_listen(logger: &Logger, postgres_url: &str, channel_name: &str) -> Client {
+            let mut attempt: usize = 0;
+            loop {
+                let res = Client::connect(postgres_url, NoTls).and_then(|mut conn| {
+                    conn.execute(format!("LISTEN {}", channel_name).as_str(), &[])?;
+                    Ok(conn)
+                });
+                match res {
+                    Err(e) => {
+                        let delay = Duration::from_secs(1 << attempt);
+                        error!(logger, "Failed to connect notification listener: {}", e;
+                                       "attempt" => attempt,
+                                       "retry_delay_s" => delay.as_secs());
+                        if attempt < 5 {
+                            attempt = attempt + 1;
+                        }
+                        thread::sleep(delay);
+                    }
+                    Ok(conn) => {
+                        return conn;
+                    }
+                }
+            }
+        }
+
         let logger = logger.new(o!(
             "component" => "NotificationListener",
             "channel" => channel_name.0.clone()
@@ -144,13 +177,8 @@ impl NotificationListener {
         let worker_handle = graph::spawn_thread("notification_listener", move || {
             // We exit the process on panic so unwind safety is irrelevant.
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-                // Connect to Postgres
-                let mut conn = Client::connect(postgres_url.as_str(), NoTls)
-                    .expect("failed to connect notification listener to Postgres");
-
-                // Subscribe to the notification channel in Postgres
-                conn.execute(format!("LISTEN {}", channel_name.0).as_str(), &[])
-                    .expect("failed to listen to Postgres notifications");
+                let mut connected = true;
+                let mut conn = connect_and_listen(&logger, postgres_url.as_str(), &channel_name.0);
 
                 // Wait until the listener has been started
                 barrier.wait();
@@ -159,6 +187,12 @@ impl NotificationListener {
 
                 // Read notifications until the thread is to be terminated
                 while !terminate.load(Ordering::SeqCst) {
+                    if !connected {
+                        conn = connect_and_listen(&logger, postgres_url.as_str(), &channel_name.0);
+                        debug!(logger, "Reconnected notification listener");
+                        connected = true;
+                    }
+
                     let queue_size = conn.notifications().len();
                     if queue_size > 1000 && queue_size > max_queue_size_seen {
                         debug!(logger, "Large notification queue to process";
@@ -176,27 +210,28 @@ impl NotificationListener {
                     //
                     // We batch notifications such that we do not wait for
                     // longer than 500ms for new notifications to arrive,
-                    // but limit the size of each batch to 64 to guarantee
+                    // but limit the size of each batch to 128 to guarantee
                     // progress on a busy system
                     let notifications: Vec<_> = conn
                         .notifications()
                         .timeout_iter(Duration::from_millis(500))
                         .iterator()
+                        .take(128)
                         .filter_map(|item| match item {
                             Ok(msg) => Some(msg),
                             Err(e) => {
-                                let msg = format!("{}", e);
-                                crit!(logger, "Error receiving message"; "error" => &msg);
-                                eprintln!(
-                                    "Connection to Postgres lost while listening for events. \
-                             Aborting to avoid inconsistent state. ({})",
-                                    msg
-                                );
-                                std::process::abort();
+                                // When there's an error, process whatever
+                                // notifications we've picked up so far, and
+                                // cause the start of the loop to reconnect
+                                if connected {
+                                    let msg = format!("{}", e);
+                                    crit!(logger, "Error receiving message"; "error" => &msg);
+                                }
+                                connected = false;
+                                None
                             }
                         })
                         .filter(|notification| notification.channel() == channel_name.0)
-                        .take(64)
                         .collect();
 
                     // Read notifications until there hasn't been one for 500ms

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1420,7 +1420,11 @@ impl Mirror {
         // constraint on `deployment_schemas` and is tiny, therefore it's
         // easiest to just mirror it
         const PUBLIC_TABLES: [&str; 3] = ["chains", "deployment_schemas", "active_copies"];
-        const SUBGRAPHS_TABLES: [&str; 1] = ["subgraph_deployment_assignment"];
+        const SUBGRAPHS_TABLES: [&str; 3] = [
+            "subgraph_deployment_assignment",
+            "subgraph",
+            "subgraph_version",
+        ];
 
         fn copy_table(
             conn: &PgConnection,

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -216,6 +216,8 @@ pub struct UnusedDeployment {
 /// A namespace (schema) in the database
 pub struct Namespace(String);
 
+pub const NAMESPACE_PUBLIC: &str = "public";
+
 impl Namespace {
     pub fn new(s: String) -> Result<Self, String> {
         // Normal database namespaces must be of the form `sgd[0-9]+`

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -219,7 +219,10 @@ pub struct UnusedDeployment {
 /// A namespace (schema) in the database
 pub struct Namespace(String);
 
+/// The name of the `public` schema in Postgres
 pub const NAMESPACE_PUBLIC: &str = "public";
+/// The name of the `subgraphs` schema in Postgres
+pub const NAMESPACE_SUBGRAPHS: &str = "subgraphs";
 
 impl Namespace {
     pub fn new(s: String) -> Result<Self, String> {
@@ -1064,20 +1067,6 @@ impl<'a> Connection<'a> {
             .transpose()
     }
 
-    pub fn assignments(&self, node: &NodeId) -> Result<Vec<Site>, StoreError> {
-        use deployment_schemas as ds;
-        use subgraph_deployment_assignment as a;
-
-        ds::table
-            .inner_join(a::table.on(a::id.eq(ds::id)))
-            .filter(a::node_id.eq(node.as_str()))
-            .select(ds::all_columns)
-            .load::<Schema>(self.conn.as_ref())?
-            .into_iter()
-            .map(|schema| Site::try_from(schema))
-            .collect::<Result<Vec<Site>, _>>()
-    }
-
     pub fn fill_assignments(
         &self,
         mut infos: Vec<status::Info>,
@@ -1431,6 +1420,7 @@ impl Mirror {
         // constraint on `deployment_schemas` and is tiny, therefore it's
         // easiest to just mirror it
         const PUBLIC_TABLES: [&str; 3] = ["chains", "deployment_schemas", "active_copies"];
+        const SUBGRAPHS_TABLES: [&str; 1] = ["subgraph_deployment_assignment"];
 
         fn copy_table(
             conn: &PgConnection,
@@ -1452,6 +1442,11 @@ impl Mirror {
         let tables = PUBLIC_TABLES
             .iter()
             .map(|name| (NAMESPACE_PUBLIC, name))
+            .chain(
+                SUBGRAPHS_TABLES
+                    .iter()
+                    .map(|name| (NAMESPACE_SUBGRAPHS, name)),
+            )
             .map(|(nsp, name)| format!("{}.{}", nsp, name))
             .join(", ");
         let query = format!("truncate table {};", tables);
@@ -1465,6 +1460,14 @@ impl Mirror {
                 table_name,
             )?;
         }
+        for table_name in SUBGRAPHS_TABLES {
+            copy_table(
+                conn,
+                &ForeignServer::metadata_schema(&*PRIMARY_SHARD),
+                NAMESPACE_SUBGRAPHS,
+                table_name,
+            )?;
+        }
         Ok(())
     }
 
@@ -1474,5 +1477,21 @@ impl Mirror {
         // Will not panic since the constructor ensures we always have a
         // primary
         &self.pools[0]
+    }
+
+    pub fn assignments(&self, node: &NodeId) -> Result<Vec<Site>, StoreError> {
+        self.read(|conn| {
+            use deployment_schemas as ds;
+            use subgraph_deployment_assignment as a;
+
+            ds::table
+                .inner_join(a::table.on(a::id.eq(ds::id)))
+                .filter(a::node_id.eq(node.as_str()))
+                .select(ds::all_columns)
+                .load::<Schema>(conn)?
+                .into_iter()
+                .map(|schema| Site::try_from(schema))
+                .collect::<Result<Vec<Site>, _>>()
+        })
     }
 }

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -377,6 +377,263 @@ pub fn make_dummy_site(deployment: DeploymentHash, namespace: Namespace, network
     }
 }
 
+/// Queries that we need for both the `Connection` and the `Mirror`. Since
+/// they will also be used by `Mirror`, they can only use tables that are
+/// mirrored through `Mirror::refresh_tables` and must be queries, i.e.,
+/// read-only
+mod queries {
+    use diesel::dsl::{any, exists, sql};
+    use diesel::pg::PgConnection;
+    use diesel::prelude::{
+        ExpressionMethods, JoinOnDsl, NullableExpressionMethods, OptionalExtension, QueryDsl,
+        RunQueryDsl,
+    };
+    use graph::prelude::NodeId;
+    use graph::{
+        constraint_violation,
+        data::subgraph::status,
+        prelude::{DeploymentHash, StoreError, SubgraphName},
+    };
+    use std::{collections::HashMap, convert::TryFrom, convert::TryInto};
+
+    use crate::Shard;
+
+    use super::{DeploymentId, Schema, Site};
+
+    // These are the only tables that functions in this module may use. If
+    // additional tables are needed, they need to be set up for mirroring
+    // first
+    use super::deployment_schemas as ds;
+    use super::subgraph as s;
+    use super::subgraph_deployment_assignment as a;
+    use super::subgraph_version as v;
+
+    pub(super) fn find_active_site(
+        conn: &PgConnection,
+        subgraph: &DeploymentHash,
+    ) -> Result<Option<Site>, StoreError> {
+        let schema = ds::table
+            .filter(ds::subgraph.eq(subgraph.to_string()))
+            .filter(ds::active.eq(true))
+            .first::<Schema>(conn)
+            .optional()?;
+        schema.map(|schema| schema.try_into()).transpose()
+    }
+
+    pub(super) fn find_site_by_ref(
+        conn: &PgConnection,
+        id: DeploymentId,
+    ) -> Result<Option<Site>, StoreError> {
+        let schema = ds::table.find(id).first::<Schema>(conn).optional()?;
+        schema.map(|schema| schema.try_into()).transpose()
+    }
+
+    pub(super) fn subgraph_exists(
+        conn: &PgConnection,
+        name: &SubgraphName,
+    ) -> Result<bool, StoreError> {
+        Ok(
+            diesel::select(exists(s::table.filter(s::name.eq(name.as_str()))))
+                .get_result::<bool>(conn)?,
+        )
+    }
+
+    pub(super) fn current_deployment_for_subgraph(
+        conn: &PgConnection,
+        name: &SubgraphName,
+    ) -> Result<DeploymentHash, StoreError> {
+        let id = v::table
+            .inner_join(s::table.on(s::current_version.eq(v::id.nullable())))
+            .filter(s::name.eq(name.as_str()))
+            .select(v::deployment)
+            .first::<String>(conn)
+            .optional()?;
+        match id {
+            Some(id) => DeploymentHash::new(id)
+                .map_err(|id| constraint_violation!("illegal deployment id: {}", id)),
+            None => Err(StoreError::QueryExecutionError(format!(
+                "Subgraph `{}` not found",
+                name.as_str()
+            ))),
+        }
+    }
+
+    pub(super) fn deployments_for_subgraph(
+        conn: &PgConnection,
+        name: &str,
+    ) -> Result<Vec<Site>, StoreError> {
+        ds::table
+            .inner_join(v::table.on(ds::subgraph.eq(v::deployment)))
+            .inner_join(s::table.on(v::subgraph.eq(s::id)))
+            .filter(s::name.eq(name))
+            .filter(ds::active)
+            .order_by(v::created_at.asc())
+            .select(ds::all_columns)
+            .load::<Schema>(conn)?
+            .into_iter()
+            .map(|schema| Site::try_from(schema))
+            .collect::<Result<Vec<Site>, _>>()
+    }
+
+    pub(super) fn subgraph_version(
+        conn: &PgConnection,
+        name: &str,
+        use_current: bool,
+    ) -> Result<Option<Site>, StoreError> {
+        let deployment = if use_current {
+            ds::table
+                .select(ds::all_columns)
+                .inner_join(v::table.on(ds::subgraph.eq(v::deployment)))
+                .inner_join(s::table.on(s::current_version.eq(v::id.nullable())))
+                .filter(s::name.eq(&name))
+                .filter(ds::active)
+                .first::<Schema>(conn)
+        } else {
+            ds::table
+                .select(ds::all_columns)
+                .inner_join(v::table.on(ds::subgraph.eq(v::deployment)))
+                .inner_join(s::table.on(s::pending_version.eq(v::id.nullable())))
+                .filter(s::name.eq(&name))
+                .filter(ds::active)
+                .first::<Schema>(conn)
+        };
+        deployment
+            .optional()?
+            .map(|schema| Site::try_from(schema))
+            .transpose()
+    }
+
+    /// Find sites by their subgraph deployment hashes. If `ids` is empty,
+    /// return all sites
+    pub(super) fn find_sites(
+        conn: &PgConnection,
+        ids: &[String],
+        only_active: bool,
+    ) -> Result<Vec<Site>, StoreError> {
+        let schemas = if ids.is_empty() {
+            if only_active {
+                ds::table.filter(ds::active).load::<Schema>(conn)?
+            } else {
+                ds::table.load::<Schema>(conn)?
+            }
+        } else {
+            if only_active {
+                ds::table
+                    .filter(ds::active)
+                    .filter(ds::subgraph.eq_any(ids))
+                    .load::<Schema>(conn)?
+            } else {
+                ds::table
+                    .filter(ds::subgraph.eq_any(ids))
+                    .load::<Schema>(conn)?
+            }
+        };
+        schemas
+            .into_iter()
+            .map(|schema| schema.try_into())
+            .collect()
+    }
+
+    /// Find sites by their subgraph deployment ids. If `ids` is empty,
+    /// return no sites
+    pub(super) fn find_sites_by_id(
+        conn: &PgConnection,
+        ids: &[DeploymentId],
+    ) -> Result<Vec<Site>, StoreError> {
+        let schemas = ds::table.filter(ds::id.eq_any(ids)).load::<Schema>(conn)?;
+        schemas
+            .into_iter()
+            .map(|schema| schema.try_into())
+            .collect()
+    }
+
+    pub(super) fn find_site_in_shard(
+        conn: &PgConnection,
+        subgraph: &DeploymentHash,
+        shard: &Shard,
+    ) -> Result<Option<Site>, StoreError> {
+        let schema = ds::table
+            .filter(ds::subgraph.eq(subgraph.as_str()))
+            .filter(ds::shard.eq(shard.as_str()))
+            .first::<Schema>(conn)
+            .optional()?;
+        schema.map(|schema| schema.try_into()).transpose()
+    }
+
+    pub(super) fn assignments(conn: &PgConnection, node: &NodeId) -> Result<Vec<Site>, StoreError> {
+        ds::table
+            .inner_join(a::table.on(a::id.eq(ds::id)))
+            .filter(a::node_id.eq(node.as_str()))
+            .select(ds::all_columns)
+            .load::<Schema>(conn)?
+            .into_iter()
+            .map(|schema| Site::try_from(schema))
+            .collect::<Result<Vec<Site>, _>>()
+    }
+
+    pub(super) fn fill_assignments(
+        conn: &PgConnection,
+        infos: &mut [status::Info],
+    ) -> Result<(), StoreError> {
+        let ids: Vec<_> = infos.iter().map(|info| &info.subgraph).collect();
+        let nodes: HashMap<_, _> = a::table
+            .inner_join(ds::table.on(ds::id.eq(a::id)))
+            .filter(ds::subgraph.eq(any(ids)))
+            .select((ds::subgraph, a::node_id))
+            .load::<(String, String)>(conn)?
+            .into_iter()
+            .collect();
+        for mut info in infos {
+            info.node = nodes.get(&info.subgraph).map(|s| s.clone());
+        }
+        Ok(())
+    }
+
+    pub(super) fn assigned_node(
+        conn: &PgConnection,
+        site: &Site,
+    ) -> Result<Option<NodeId>, StoreError> {
+        a::table
+            .filter(a::id.eq(site.id))
+            .select(a::node_id)
+            .first::<String>(conn)
+            .optional()?
+            .map(|node| {
+                NodeId::new(&node).map_err(|()| {
+                    constraint_violation!(
+                        "invalid node id `{}` in assignment for `{}`",
+                        node,
+                        site.deployment
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    pub(super) fn version_info(
+        conn: &PgConnection,
+        version: &str,
+    ) -> Result<Option<(String, String)>, StoreError> {
+        Ok(v::table
+            .select((v::deployment, sql("created_at::text")))
+            .filter(v::id.eq(version))
+            .first::<(String, String)>(conn)
+            .optional()?)
+    }
+
+    pub(super) fn versions_for_subgraph_id(
+        conn: &PgConnection,
+        subgraph_id: &str,
+    ) -> Result<(Option<String>, Option<String>), StoreError> {
+        Ok(s::table
+            .select((s::current_version.nullable(), s::pending_version.nullable()))
+            .filter(s::id.eq(subgraph_id))
+            .first::<(Option<String>, Option<String>)>(conn)
+            .optional()?
+            .unwrap_or((None, None)))
+    }
+}
+
 /// A wrapper for a database connection that provides access to functionality
 /// that works only on the primary database
 pub struct Connection<'a> {
@@ -396,29 +653,6 @@ impl<'a> Connection<'a> {
         E: From<diesel::result::Error>,
     {
         self.conn.transaction(f)
-    }
-
-    pub fn current_deployment_for_subgraph(
-        &self,
-        name: SubgraphName,
-    ) -> Result<DeploymentHash, StoreError> {
-        use subgraph as s;
-        use subgraph_version as v;
-
-        let id = v::table
-            .inner_join(s::table.on(s::current_version.eq(v::id.nullable())))
-            .filter(s::name.eq(name.as_str()))
-            .select(v::deployment)
-            .first::<String>(self.conn.as_ref())
-            .optional()?;
-        match id {
-            Some(id) => DeploymentHash::new(id)
-                .map_err(|id| constraint_violation!("illegal deployment id: {}", id)),
-            None => Err(StoreError::QueryExecutionError(format!(
-                "Subgraph `{}` not found",
-                name.as_str()
-            ))),
-        }
     }
 
     /// Signal any copy process that might be copying into one of these
@@ -702,15 +936,6 @@ impl<'a> Connection<'a> {
         }
     }
 
-    pub fn subgraph_exists(&self, name: &SubgraphName) -> Result<bool, StoreError> {
-        use subgraph as s;
-
-        Ok(
-            diesel::select(exists(s::table.filter(s::name.eq(name.as_str()))))
-                .get_result::<bool>(self.conn.as_ref())?,
-        )
-    }
-
     pub fn reassign_subgraph(
         &self,
         site: &Site,
@@ -826,18 +1051,24 @@ impl<'a> Connection<'a> {
         subgraph: &DeploymentHash,
         network: String,
     ) -> Result<Site, StoreError> {
-        if let Some(site) = self.find_active_site(subgraph)? {
+        if let Some(site) = queries::find_active_site(self.conn.as_ref(), subgraph)? {
             return Ok(site);
         }
 
         self.create_site(shard, subgraph.clone(), network, true)
     }
 
+    pub fn assigned_node(&self, site: &Site) -> Result<Option<NodeId>, StoreError> {
+        queries::assigned_node(self.conn.as_ref(), site)
+    }
+
     /// Create a copy of the site `src` in the shard `shard`, but mark it as
     /// not active. If there already is a site in `shard`, return that
     /// instead.
     pub fn copy_site(&self, src: &Site, shard: Shard) -> Result<Site, StoreError> {
-        if let Some(site) = self.find_site_in_shard(&src.deployment, &shard)? {
+        if let Some(site) =
+            queries::find_site_in_shard(self.conn.as_ref(), &src.deployment, &shard)?
+        {
             return Ok(site);
         }
 
@@ -890,36 +1121,6 @@ impl<'a> Connection<'a> {
         })
     }
 
-    pub fn find_active_site(&self, subgraph: &DeploymentHash) -> Result<Option<Site>, StoreError> {
-        let schema = deployment_schemas::table
-            .filter(deployment_schemas::subgraph.eq(subgraph.to_string()))
-            .filter(deployment_schemas::active.eq(true))
-            .first::<Schema>(self.conn.as_ref())
-            .optional()?;
-        schema.map(|schema| schema.try_into()).transpose()
-    }
-
-    pub fn find_site_in_shard(
-        &self,
-        subgraph: &DeploymentHash,
-        shard: &Shard,
-    ) -> Result<Option<Site>, StoreError> {
-        let schema = deployment_schemas::table
-            .filter(deployment_schemas::subgraph.eq(subgraph.as_str()))
-            .filter(deployment_schemas::shard.eq(shard.as_str()))
-            .first::<Schema>(self.conn.as_ref())
-            .optional()?;
-        schema.map(|schema| schema.try_into()).transpose()
-    }
-
-    pub fn find_site_by_ref(&self, id: DeploymentId) -> Result<Option<Site>, StoreError> {
-        let schema = deployment_schemas::table
-            .find(id)
-            .first::<Schema>(self.conn.as_ref())
-            .optional()?;
-        schema.map(|schema| schema.try_into()).transpose()
-    }
-
     pub fn find_site_by_name(&self, name: &str) -> Result<Option<Site>, StoreError> {
         let schema = deployment_schemas::table
             .filter(deployment_schemas::name.eq(name))
@@ -934,51 +1135,6 @@ impl<'a> Connection<'a> {
         ds::table
             .filter(ds::network.eq(network))
             .load::<Schema>(self.conn.as_ref())?
-            .into_iter()
-            .map(|schema| schema.try_into())
-            .collect()
-    }
-
-    /// Find sites by their subgraph deployment hashes. If `ids` is empty,
-    /// return all sites
-    pub fn find_sites(&self, ids: Vec<String>, only_active: bool) -> Result<Vec<Site>, StoreError> {
-        use deployment_schemas as ds;
-
-        let schemas = if ids.is_empty() {
-            if only_active {
-                ds::table
-                    .filter(ds::active)
-                    .load::<Schema>(self.conn.as_ref())?
-            } else {
-                ds::table.load::<Schema>(self.conn.as_ref())?
-            }
-        } else {
-            if only_active {
-                ds::table
-                    .filter(ds::active)
-                    .filter(ds::subgraph.eq_any(ids))
-                    .load::<Schema>(self.conn.as_ref())?
-            } else {
-                ds::table
-                    .filter(ds::subgraph.eq_any(ids))
-                    .load::<Schema>(self.conn.as_ref())?
-            }
-        };
-        schemas
-            .into_iter()
-            .map(|schema| schema.try_into())
-            .collect()
-    }
-
-    /// Find sites by their subgraph deployment ids. If `ids` is empty,
-    /// return all sites
-    pub fn find_sites_by_id(&self, ids: Vec<DeploymentId>) -> Result<Vec<Site>, StoreError> {
-        use deployment_schemas as ds;
-
-        let schemas = ds::table
-            .filter(ds::id.eq_any(ids))
-            .load::<Schema>(self.conn.as_ref())?;
-        schemas
             .into_iter()
             .map(|schema| schema.try_into())
             .collect()
@@ -1047,97 +1203,6 @@ impl<'a> Connection<'a> {
             })
     }
 
-    pub fn assigned_node(&self, site: &Site) -> Result<Option<NodeId>, StoreError> {
-        use subgraph_deployment_assignment as a;
-
-        a::table
-            .filter(a::id.eq(site.id))
-            .select(a::node_id)
-            .first::<String>(self.conn.as_ref())
-            .optional()?
-            .map(|node| {
-                NodeId::new(&node).map_err(|()| {
-                    constraint_violation!(
-                        "invalid node id `{}` in assignment for `{}`",
-                        node,
-                        site.deployment
-                    )
-                })
-            })
-            .transpose()
-    }
-
-    pub fn fill_assignments(
-        &self,
-        mut infos: Vec<status::Info>,
-    ) -> Result<Vec<status::Info>, StoreError> {
-        use deployment_schemas as ds;
-        use subgraph_deployment_assignment as a;
-
-        let ids: Vec<_> = infos.iter().map(|info| &info.subgraph).collect();
-        let nodes: HashMap<_, _> = a::table
-            .inner_join(ds::table.on(ds::id.eq(a::id)))
-            .filter(ds::subgraph.eq(any(ids)))
-            .select((ds::subgraph, a::node_id))
-            .load::<(String, String)>(self.conn.as_ref())?
-            .into_iter()
-            .collect();
-        for mut info in &mut infos {
-            info.node = nodes.get(&info.subgraph).map(|s| s.clone());
-        }
-        Ok(infos)
-    }
-
-    pub(crate) fn deployments_for_subgraph(&self, name: String) -> Result<Vec<Site>, StoreError> {
-        use deployment_schemas as ds;
-        use subgraph as s;
-        use subgraph_version as v;
-
-        ds::table
-            .inner_join(v::table.on(ds::subgraph.eq(v::deployment)))
-            .inner_join(s::table.on(v::subgraph.eq(s::id)))
-            .filter(s::name.eq(&name))
-            .filter(ds::active)
-            .order_by(v::created_at.asc())
-            .select(ds::all_columns)
-            .load::<Schema>(self.conn.as_ref())?
-            .into_iter()
-            .map(|schema| Site::try_from(schema))
-            .collect::<Result<Vec<Site>, _>>()
-    }
-
-    pub fn subgraph_version(
-        &self,
-        name: String,
-        use_current: bool,
-    ) -> Result<Option<Site>, StoreError> {
-        use deployment_schemas as ds;
-        use subgraph as s;
-        use subgraph_version as v;
-
-        let deployment = if use_current {
-            ds::table
-                .select(ds::all_columns)
-                .inner_join(v::table.on(ds::subgraph.eq(v::deployment)))
-                .inner_join(s::table.on(s::current_version.eq(v::id.nullable())))
-                .filter(s::name.eq(&name))
-                .filter(ds::active)
-                .first::<Schema>(self.conn.as_ref())
-        } else {
-            ds::table
-                .select(ds::all_columns)
-                .inner_join(v::table.on(ds::subgraph.eq(v::deployment)))
-                .inner_join(s::table.on(s::pending_version.eq(v::id.nullable())))
-                .filter(s::name.eq(&name))
-                .filter(ds::active)
-                .first::<Schema>(self.conn.as_ref())
-        };
-        deployment
-            .optional()?
-            .map(|schema| Site::try_from(schema))
-            .transpose()
-    }
-
     #[cfg(debug_assertions)]
     pub fn versions_for_subgraph(
         &self,
@@ -1162,30 +1227,6 @@ impl<'a> Connection<'a> {
             .filter(v::id.eq(name))
             .first::<String>(self.conn.as_ref())
             .optional()?)
-    }
-
-    pub fn version_info(&self, version: &str) -> Result<Option<(String, String)>, StoreError> {
-        use subgraph_version as v;
-
-        Ok(v::table
-            .select((v::deployment, sql("created_at::text")))
-            .filter(v::id.eq(version))
-            .first::<(String, String)>(self.conn.as_ref())
-            .optional()?)
-    }
-
-    pub fn versions_for_subgraph_id(
-        &self,
-        subgraph_id: &str,
-    ) -> Result<(Option<String>, Option<String>), StoreError> {
-        use subgraph as s;
-
-        Ok(s::table
-            .select((s::current_version.nullable(), s::pending_version.nullable()))
-            .filter(s::id.eq(subgraph_id))
-            .first::<(Option<String>, Option<String>)>(self.conn.as_ref())
-            .optional()?
-            .unwrap_or((None, None)))
     }
 
     /// Find all deployments that are not in use and add them to the
@@ -1394,7 +1435,8 @@ impl Mirror {
     /// tables that are mirrored through `refresh_tables`
     pub(crate) fn read<'a, T>(
         &self,
-        f: impl 'a + Fn(&PooledConnection<ConnectionManager<PgConnection>>) -> Result<T, StoreError>,
+        mut f: impl 'a
+            + FnMut(&PooledConnection<ConnectionManager<PgConnection>>) -> Result<T, StoreError>,
     ) -> Result<T, StoreError> {
         for pool in &self.pools {
             let conn = match pool.get() {
@@ -1484,18 +1526,76 @@ impl Mirror {
     }
 
     pub fn assignments(&self, node: &NodeId) -> Result<Vec<Site>, StoreError> {
-        self.read(|conn| {
-            use deployment_schemas as ds;
-            use subgraph_deployment_assignment as a;
+        self.read(|conn| queries::assignments(conn, node))
+    }
 
-            ds::table
-                .inner_join(a::table.on(a::id.eq(ds::id)))
-                .filter(a::node_id.eq(node.as_str()))
-                .select(ds::all_columns)
-                .load::<Schema>(conn)?
-                .into_iter()
-                .map(|schema| Site::try_from(schema))
-                .collect::<Result<Vec<Site>, _>>()
-        })
+    pub fn assigned_node(&self, site: &Site) -> Result<Option<NodeId>, StoreError> {
+        self.read(|conn| queries::assigned_node(conn, site))
+    }
+
+    pub fn find_active_site(&self, subgraph: &DeploymentHash) -> Result<Option<Site>, StoreError> {
+        self.read(|conn| queries::find_active_site(conn, subgraph))
+    }
+
+    pub fn find_site_by_ref(&self, id: DeploymentId) -> Result<Option<Site>, StoreError> {
+        self.read(|conn| queries::find_site_by_ref(conn, id))
+    }
+
+    pub fn current_deployment_for_subgraph(
+        &self,
+        name: &SubgraphName,
+    ) -> Result<DeploymentHash, StoreError> {
+        self.read(|conn| queries::current_deployment_for_subgraph(conn, &name))
+    }
+
+    pub fn deployments_for_subgraph(&self, name: &str) -> Result<Vec<Site>, StoreError> {
+        self.read(|conn| queries::deployments_for_subgraph(conn, name))
+    }
+
+    pub fn subgraph_exists(&self, name: &SubgraphName) -> Result<bool, StoreError> {
+        self.read(|conn| queries::subgraph_exists(conn, name))
+    }
+
+    pub fn subgraph_version(
+        &self,
+        name: &str,
+        use_current: bool,
+    ) -> Result<Option<Site>, StoreError> {
+        self.read(|conn| queries::subgraph_version(conn, name, use_current))
+    }
+
+    /// Find sites by their subgraph deployment hashes. If `ids` is empty,
+    /// return all sites
+    pub fn find_sites(&self, ids: &[String], only_active: bool) -> Result<Vec<Site>, StoreError> {
+        self.read(|conn| queries::find_sites(conn, ids, only_active))
+    }
+
+    /// Find sites by their subgraph deployment ids. If `ids` is empty,
+    /// return no sites
+    pub fn find_sites_by_id(&self, ids: &[DeploymentId]) -> Result<Vec<Site>, StoreError> {
+        self.read(|conn| queries::find_sites_by_id(conn, ids))
+    }
+
+    pub fn fill_assignments(&self, infos: &mut [status::Info]) -> Result<(), StoreError> {
+        self.read(|conn| queries::fill_assignments(conn, infos))
+    }
+
+    pub fn version_info(&self, version: &str) -> Result<Option<(String, String)>, StoreError> {
+        self.read(|conn| queries::version_info(conn, version))
+    }
+
+    pub fn versions_for_subgraph_id(
+        &self,
+        subgraph_id: &str,
+    ) -> Result<(Option<String>, Option<String>), StoreError> {
+        self.read(|conn| queries::versions_for_subgraph_id(conn, subgraph_id))
+    }
+
+    pub fn find_site_in_shard(
+        &self,
+        subgraph: &DeploymentHash,
+        shard: &Shard,
+    ) -> Result<Option<Site>, StoreError> {
+        self.read(|conn| queries::find_site_in_shard(conn, subgraph, shard))
     }
 }

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -54,7 +54,7 @@ impl QueryStoreTrait for QueryStore {
             .await?)
     }
 
-    fn block_ptr(&self) -> Result<Option<BlockPtr>, Error> {
+    fn block_ptr(&self) -> Result<Option<BlockPtr>, StoreError> {
         self.store.block_ptr(&self.site)
     }
 

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -534,7 +534,7 @@ impl Layout {
     pub fn find_many<'a>(
         &self,
         conn: &PgConnection,
-        ids_for_type: BTreeMap<&EntityType, Vec<&str>>,
+        ids_for_type: &BTreeMap<&EntityType, Vec<&str>>,
         block: BlockNumber,
     ) -> Result<BTreeMap<EntityType, Vec<Entity>>, StoreError> {
         if ids_for_type.is_empty() {

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -13,6 +13,7 @@ use graph::prelude::{q, s, StopwatchMetrics};
 use graph::slog::warn;
 use inflector::Inflector;
 use lazy_static::lazy_static;
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::{From, TryFrom};
 use std::env;
@@ -560,11 +561,11 @@ impl Layout {
         Ok(entities_for_type)
     }
 
-    pub fn insert(
-        &self,
+    pub fn insert<'a>(
+        &'a self,
         conn: &PgConnection,
-        entity_type: &EntityType,
-        entities: &mut [(EntityKey, Entity)],
+        entity_type: &'a EntityType,
+        entities: &'a mut [(&'a EntityKey, Cow<'a, Entity>)],
         block: BlockNumber,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
@@ -675,11 +676,11 @@ impl Layout {
             .collect()
     }
 
-    pub fn update(
-        &self,
+    pub fn update<'a>(
+        &'a self,
         conn: &PgConnection,
-        entity_type: &EntityType,
-        entities: &mut [(EntityKey, Entity)],
+        entity_type: &'a EntityType,
+        entities: &'a mut [(&'a EntityKey, Cow<'a, Entity>)],
         block: BlockNumber,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
@@ -711,7 +712,7 @@ impl Layout {
         &self,
         conn: &PgConnection,
         entity_type: &EntityType,
-        entity_ids: &[String],
+        entity_ids: &[&str],
         block: BlockNumber,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1188,7 +1188,7 @@ pub struct FindManyQuery<'a> {
     pub(crate) tables: Vec<&'a Table>,
 
     // Maps object name to ids.
-    pub(crate) ids_for_type: BTreeMap<&'a EntityType, Vec<&'a str>>,
+    pub(crate) ids_for_type: &'a BTreeMap<&'a EntityType, Vec<&'a str>>,
     pub(crate) block: BlockNumber,
 }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -108,14 +108,15 @@ impl StatusStore for Store {
         self.subgraph_store.versions_for_subgraph_id(subgraph_id)
     }
 
-    fn get_proof_of_indexing<'a>(
-        self: Arc<Self>,
-        subgraph_id: &'a DeploymentHash,
-        indexer: &'a Option<Address>,
+    async fn get_proof_of_indexing(
+        &self,
+        subgraph_id: &DeploymentHash,
+        indexer: &Option<Address>,
         block: BlockPtr,
-    ) -> graph::prelude::DynTryFuture<'a, Option<[u8; 32]>> {
+    ) -> Result<Option<[u8; 32]>, StoreError> {
         self.subgraph_store
             .get_proof_of_indexing(subgraph_id, indexer, block)
+            .await
     }
 
     async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit {

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1119,12 +1119,9 @@ impl WritableStore {
     /// return `Ok(())`
     fn try_send_store_event(&self, event: StoreEvent) -> Result<(), StoreError> {
         if *SEND_SUBSCRIPTION_NOTIFICATIONS {
-            self.store
-                .send_store_event(&event)
-                .map_err(
-                    |e| error!(self.logger, "Could not send store event"; "error" => e.to_string()),
-                )
-                .ok();
+            let _ = self.store.send_store_event(&event).map_err(
+                |e| error!(self.logger, "Could not send store event"; "error" => e.to_string()),
+            );
             Ok(())
         } else {
             Ok(())

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -235,7 +235,6 @@ impl std::ops::Deref for SubgraphStore {
 }
 
 pub struct SubgraphStoreInner {
-    logger: Logger,
     mirror: PrimaryMirror,
     stores: HashMap<Shard, Arc<DeploymentStore>>,
     /// Cache for the mapping from deployment id to shard/namespace/id. Only
@@ -294,9 +293,7 @@ impl SubgraphStoreInner {
             },
         ));
         let sites = TimedCache::new(SITES_CACHE_TTL);
-        let logger = logger.new(o!("shard" => PRIMARY_SHARD.to_string()));
         SubgraphStoreInner {
-            logger,
             mirror,
             stores,
             sites,
@@ -628,10 +625,7 @@ impl SubgraphStoreInner {
     /// of connections in between getting the first one and trying to get the
     /// second one.
     fn primary_conn(&self) -> Result<primary::Connection, StoreError> {
-        let conn = self
-            .mirror
-            .primary()
-            .get_with_timeout_warning(&self.logger)?;
+        let conn = self.mirror.primary().get()?;
         Ok(primary::Connection::new(conn))
     }
 

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -22,8 +22,8 @@ use graph::{
     prelude::SubgraphDeploymentEntity,
     prelude::{
         anyhow, futures03::future::join_all, lazy_static, o, web3::types::Address, ApiSchema,
-        BlockPtr, DeploymentHash, DynTryFuture, Entity, EntityKey, EntityModification, Error,
-        Logger, NodeId, QueryExecutionError, Schema, StopwatchMetrics, StoreError, SubgraphName,
+        BlockPtr, DeploymentHash, Entity, EntityKey, EntityModification, Error, Logger, NodeId,
+        QueryExecutionError, Schema, StopwatchMetrics, StoreError, SubgraphName,
         SubgraphStore as SubgraphStoreTrait, SubgraphVersionSwitchingMode,
     },
     util::timed_cache::TimedCache,
@@ -211,13 +211,13 @@ impl SubgraphStore {
         }
     }
 
-    pub(crate) fn get_proof_of_indexing<'a>(
+    pub(crate) async fn get_proof_of_indexing(
         &self,
-        id: &'a DeploymentHash,
-        indexer: &'a Option<Address>,
+        id: &DeploymentHash,
+        indexer: &Option<Address>,
         block: BlockPtr,
-    ) -> DynTryFuture<'a, Option<[u8; 32]>> {
-        self.inner.clone().get_proof_of_indexing(id, indexer, block)
+    ) -> Result<Option<[u8; 32]>, StoreError> {
+        self.inner.get_proof_of_indexing(id, indexer, block).await
     }
 
     pub fn notification_sender(&self) -> Arc<NotificationSender> {
@@ -869,14 +869,14 @@ impl SubgraphStoreInner {
         self.send_store_event(&event)
     }
 
-    pub(crate) fn get_proof_of_indexing<'a>(
-        self: Arc<Self>,
-        id: &'a DeploymentHash,
-        indexer: &'a Option<Address>,
+    pub(crate) async fn get_proof_of_indexing(
+        &self,
+        id: &DeploymentHash,
+        indexer: &Option<Address>,
         block: BlockPtr,
-    ) -> DynTryFuture<'a, Option<[u8; 32]>> {
+    ) -> Result<Option<[u8; 32]>, StoreError> {
         let (store, site) = self.store(&id).unwrap();
-        store.clone().get_proof_of_indexing(site, indexer, block)
+        store.get_proof_of_indexing(site, indexer, block).await
     }
 
     // Only used by tests
@@ -1112,10 +1112,10 @@ impl WritableStoreTrait for WritableStore {
             .await
     }
 
-    fn supports_proof_of_indexing<'a>(self: Arc<Self>) -> DynTryFuture<'a, bool> {
+    async fn supports_proof_of_indexing(&self) -> Result<bool, StoreError> {
         self.writable
-            .clone()
             .supports_proof_of_indexing(self.site.clone())
+            .await
     }
 
     fn get(&self, key: &EntityKey) -> Result<Option<Entity>, QueryExecutionError> {

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -899,6 +899,12 @@ impl SubgraphStoreInner {
             .as_ref()
             .map(|site| site.into()))
     }
+
+    pub fn mirror_primary_tables(&self, logger: &Logger) {
+        for store in self.stores.values() {
+            store.mirror_primary_tables(logger);
+        }
+    }
 }
 
 #[async_trait::async_trait]

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1135,15 +1135,14 @@ impl WritableStoreTrait for WritableStore {
             same_subgraph(&mods, &self.site.deployment),
             "can only transact operations within one shard"
         );
-
         let event = self.writable.transact_block_operations(
             self.site.clone(),
-            block_ptr_to,
-            firehose_cursor,
-            mods,
+            &block_ptr_to,
+            firehose_cursor.as_deref(),
+            &mods,
             stopwatch.cheap_clone(),
-            data_sources,
-            deterministic_errors,
+            &data_sources,
+            &deterministic_errors,
         )?;
 
         let _section = stopwatch.start_section("send_store_event");

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -23,8 +23,8 @@ use graph::{
     prelude::{
         anyhow, futures03::future::join_all, lazy_static, o, web3::types::Address, ApiSchema,
         BlockPtr, DeploymentHash, Entity, EntityKey, EntityModification, Error, Logger, NodeId,
-        QueryExecutionError, Schema, StopwatchMetrics, StoreError, SubgraphName,
-        SubgraphStore as SubgraphStoreTrait, SubgraphVersionSwitchingMode,
+        Schema, StopwatchMetrics, StoreError, SubgraphName, SubgraphStore as SubgraphStoreTrait,
+        SubgraphVersionSwitchingMode,
     },
     slog::{error, warn},
     util::{backoff::ExponentialBackoff, timed_cache::TimedCache},
@@ -879,7 +879,7 @@ impl SubgraphStoreInner {
     pub fn find(
         &self,
         query: graph::prelude::EntityQuery,
-    ) -> Result<Vec<Entity>, QueryExecutionError> {
+    ) -> Result<Vec<Entity>, graph::prelude::QueryExecutionError> {
         let (store, site) = self.store(&query.subgraph_id)?;
         store.find(site, query)
     }

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -236,7 +236,6 @@ impl std::ops::Deref for SubgraphStore {
 pub struct SubgraphStoreInner {
     logger: Logger,
     mirror: PrimaryMirror,
-    primary: ConnectionPool,
     stores: HashMap<Shard, Arc<DeploymentStore>>,
     /// Cache for the mapping from deployment id to shard/namespace/id. Only
     /// active sites are cached here to ensure we have a unique mapping from
@@ -270,11 +269,6 @@ impl SubgraphStoreInner {
         placer: Arc<dyn DeploymentPlacer + Send + Sync + 'static>,
         sender: Arc<NotificationSender>,
     ) -> Self {
-        let primary = stores
-            .iter()
-            .find(|(name, _, _, _)| name == &*PRIMARY_SHARD)
-            .map(|(_, pool, _, _)| pool.clone())
-            .expect("we always have a primary shard");
         let mirror = {
             let pools = HashMap::from_iter(
                 stores
@@ -303,7 +297,6 @@ impl SubgraphStoreInner {
         SubgraphStoreInner {
             logger,
             mirror,
-            primary,
             stores,
             sites,
             placer,
@@ -339,8 +332,8 @@ impl SubgraphStoreInner {
             return Ok(site);
         }
 
-        let conn = self.primary_conn()?;
-        let site = conn
+        let site = self
+            .mirror
             .find_active_site(id)?
             .ok_or_else(|| StoreError::DeploymentNotFound(id.to_string()))?;
         let site = Arc::new(site);
@@ -354,8 +347,8 @@ impl SubgraphStoreInner {
             return Ok(site);
         }
 
-        let conn = self.primary_conn()?;
-        let site = conn
+        let site = self
+            .mirror
             .find_site_by_ref(id)?
             .ok_or_else(|| StoreError::DeploymentNotFound(id.to_string()))?;
         let site = Arc::new(site);
@@ -532,7 +525,7 @@ impl SubgraphStoreInner {
         // The very last thing we do when we set up a copy here is assign it
         // to a node. Therefore, if `dst` is already assigned, this function
         // should not have been called.
-        if let Some(node) = self.primary_conn()?.assigned_node(dst.as_ref())? {
+        if let Some(node) = self.mirror.assigned_node(dst.as_ref())? {
             return Err(StoreError::Unknown(anyhow!(
                 "can not copy into deployment {} since it is already assigned to node `{}`",
                 dst_loc,
@@ -634,7 +627,10 @@ impl SubgraphStoreInner {
     /// of connections in between getting the first one and trying to get the
     /// second one.
     fn primary_conn(&self) -> Result<primary::Connection, StoreError> {
-        let conn = self.primary.get_with_timeout_warning(&self.logger)?;
+        let conn = self
+            .mirror
+            .primary()
+            .get_with_timeout_warning(&self.logger)?;
         Ok(primary::Connection::new(conn))
     }
 
@@ -644,10 +640,7 @@ impl SubgraphStoreInner {
         for_subscription: bool,
     ) -> Result<(Arc<DeploymentStore>, Arc<Site>, ReplicaId), StoreError> {
         let id = match target {
-            QueryTarget::Name(name) => {
-                let conn = self.primary_conn()?;
-                conn.transaction(|| conn.current_deployment_for_subgraph(name))?
-            }
+            QueryTarget::Name(name) => self.mirror.current_deployment_for_subgraph(&name)?,
             QueryTarget::Deployment(id) => id,
         };
 
@@ -743,7 +736,7 @@ impl SubgraphStoreInner {
         let store = self.for_site(site.as_ref())?;
 
         // Check that deployment is not assigned
-        match self.primary_conn()?.assigned_node(site.as_ref())? {
+        match self.mirror.assigned_node(site.as_ref())? {
             Some(node) => {
                 return Err(constraint_violation!(
                     "deployment {} can not be removed since it is assigned to node {}",
@@ -777,14 +770,14 @@ impl SubgraphStoreInner {
     pub(crate) fn status(&self, filter: status::Filter) -> Result<Vec<status::Info>, StoreError> {
         let sites = match filter {
             status::Filter::SubgraphName(name) => {
-                let deployments = self.primary_conn()?.deployments_for_subgraph(name)?;
+                let deployments = self.mirror.deployments_for_subgraph(&name)?;
                 if deployments.is_empty() {
                     return Ok(Vec::new());
                 }
                 deployments
             }
             status::Filter::SubgraphVersion(name, use_current) => {
-                let deployment = self.primary_conn()?.subgraph_version(name, use_current)?;
+                let deployment = self.mirror.subgraph_version(&name, use_current)?;
                 match deployment {
                     Some(deployment) => vec![deployment],
                     None => {
@@ -793,11 +786,11 @@ impl SubgraphStoreInner {
                 }
             }
             status::Filter::Deployments(deployments) => {
-                self.primary_conn()?.find_sites(deployments, true)?
+                self.mirror.find_sites(&deployments, true)?
             }
             status::Filter::DeploymentIds(ids) => {
-                let ids = ids.into_iter().map(|id| id.into()).collect();
-                self.primary_conn()?.find_sites_by_id(ids)?
+                let ids: Vec<_> = ids.into_iter().map(|id| id.into()).collect();
+                self.mirror.find_sites_by_id(&ids)?
             }
         };
 
@@ -812,12 +805,12 @@ impl SubgraphStoreInner {
                 .ok_or(StoreError::UnknownShard(shard.to_string()))?;
             infos.extend(store.deployment_statuses(&sites)?);
         }
-        let infos = self.primary_conn()?.fill_assignments(infos)?;
+        self.mirror.fill_assignments(&mut infos)?;
         Ok(infos)
     }
 
     pub(crate) fn version_info(&self, version: &str) -> Result<VersionInfo, StoreError> {
-        if let Some((deployment_id, created_at)) = self.primary_conn()?.version_info(version)? {
+        if let Some((deployment_id, created_at)) = self.mirror.version_info(version)? {
             let id = DeploymentHash::new(deployment_id.clone())
                 .map_err(|id| constraint_violation!("illegal deployment id {}", id))?;
             let (store, site) = self.store(&id)?;
@@ -856,9 +849,7 @@ impl SubgraphStoreInner {
         &self,
         subgraph_id: &str,
     ) -> Result<(Option<String>, Option<String>), StoreError> {
-        let primary = self.primary_conn()?;
-
-        primary.versions_for_subgraph_id(subgraph_id)
+        self.mirror.versions_for_subgraph_id(subgraph_id)
     }
 
     #[cfg(debug_assertions)]
@@ -904,7 +895,7 @@ impl SubgraphStoreInner {
         shard: Shard,
     ) -> Result<Option<DeploymentLocator>, StoreError> {
         Ok(self
-            .primary_conn()?
+            .mirror
             .find_site_in_shard(hash, &shard)?
             .as_ref()
             .map(|site| site.into()))
@@ -972,8 +963,7 @@ impl SubgraphStoreTrait for SubgraphStore {
 
     fn assigned_node(&self, deployment: &DeploymentLocator) -> Result<Option<NodeId>, StoreError> {
         let site = self.find_site(deployment.id.into())?;
-        let primary = self.primary_conn()?;
-        primary.assigned_node(site.as_ref())
+        self.mirror.assigned_node(site.as_ref())
     }
 
     fn assignments(&self, node: &NodeId) -> Result<Vec<DeploymentLocator>, StoreError> {
@@ -983,8 +973,7 @@ impl SubgraphStoreTrait for SubgraphStore {
     }
 
     fn subgraph_exists(&self, name: &SubgraphName) -> Result<bool, StoreError> {
-        let primary = self.primary_conn()?;
-        primary.subgraph_exists(name)
+        self.mirror.subgraph_exists(name)
     }
 
     fn input_schema(&self, id: &DeploymentHash) -> Result<Arc<Schema>, StoreError> {
@@ -1031,8 +1020,8 @@ impl SubgraphStoreTrait for SubgraphStore {
     /// Find the deployment locators for the subgraph with the given hash
     fn locators(&self, hash: &str) -> Result<Vec<DeploymentLocator>, StoreError> {
         Ok(self
-            .primary_conn()?
-            .find_sites(vec![hash.to_string()], false)?
+            .mirror
+            .find_sites(&vec![hash.to_string()], false)?
             .iter()
             .map(|site| site.into())
             .collect())

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -33,7 +33,7 @@ use store::StoredDynamicDataSource;
 use crate::{
     connection_pool::ConnectionPool,
     primary,
-    primary::{DeploymentId, Site},
+    primary::{DeploymentId, Mirror as PrimaryMirror, Site},
     relational::Layout,
     NotificationSender,
 };
@@ -235,6 +235,7 @@ impl std::ops::Deref for SubgraphStore {
 
 pub struct SubgraphStoreInner {
     logger: Logger,
+    mirror: PrimaryMirror,
     primary: ConnectionPool,
     stores: HashMap<Shard, Arc<DeploymentStore>>,
     /// Cache for the mapping from deployment id to shard/namespace/id. Only
@@ -274,6 +275,14 @@ impl SubgraphStoreInner {
             .find(|(name, _, _, _)| name == &*PRIMARY_SHARD)
             .map(|(_, pool, _, _)| pool.clone())
             .expect("we always have a primary shard");
+        let mirror = {
+            let pools = HashMap::from_iter(
+                stores
+                    .iter()
+                    .map(|(name, pool, _, _)| (name.clone(), pool.clone())),
+            );
+            PrimaryMirror::new(&pools)
+        };
         let stores = HashMap::from_iter(stores.into_iter().map(
             |(name, main_pool, read_only_pools, weights)| {
                 let logger = logger.new(o!("shard" => name.to_string()));
@@ -293,6 +302,7 @@ impl SubgraphStoreInner {
         let logger = logger.new(o!("shard" => PRIMARY_SHARD.to_string()));
         SubgraphStoreInner {
             logger,
+            mirror,
             primary,
             stores,
             sites,
@@ -967,8 +977,7 @@ impl SubgraphStoreTrait for SubgraphStore {
     }
 
     fn assignments(&self, node: &NodeId) -> Result<Vec<DeploymentLocator>, StoreError> {
-        let primary = self.primary_conn()?;
-        primary
+        self.mirror
             .assignments(node)
             .map(|sites| sites.iter().map(|site| site.into()).collect())
     }

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -296,12 +296,12 @@ fn check_graft(
     transact_entity_operations(&store, &deployment, BLOCKS[2].clone(), vec![op]).unwrap();
 
     store
-        .writable(&deployment)?
+        .writable(LOGGER.clone(), &deployment)?
         .revert_block_operations(BLOCKS[1].clone())
         .expect("We can revert a block we just created");
 
     let err = store
-        .writable(&deployment)?
+        .writable(LOGGER.clone(), &deployment)?
         .revert_block_operations(BLOCKS[0].clone())
         .expect_err("Reverting past graft point is not allowed");
 
@@ -352,7 +352,7 @@ fn copy() {
             store.copy_deployment(&src, dst_shard, NODE_ID.clone(), BLOCKS[1].clone())?;
 
         store
-            .writable(&deployment)?
+            .writable(LOGGER.clone(), &deployment)?
             .start_subgraph_deployment(&*LOGGER)?;
 
         store.activate(&deployment)?;

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -778,7 +778,7 @@ fn layout_cache() {
     run_test_with_conn(|conn| {
         let id = DeploymentHash::new("primaryLayoutCache").unwrap();
         let _loc = create_test_subgraph(&id, THINGS_GQL);
-        let site = Arc::new(primary_connection().find_active_site(&id).unwrap().unwrap());
+        let site = Arc::new(primary_mirror().find_active_site(&id).unwrap().unwrap());
         let table_name = SqlName::verbatim("scalar".to_string());
 
         let cache = LayoutCache::new(Duration::from_millis(10));

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -12,6 +12,7 @@ use graph_store_postgres::layout_for_tests::LayoutCache;
 use graph_store_postgres::layout_for_tests::SqlName;
 use hex_literal::hex;
 use lazy_static::lazy_static;
+use std::borrow::Cow;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::thread::sleep;
@@ -202,7 +203,7 @@ fn insert_entity(
     entity_type: &str,
     mut entities: Vec<Entity>,
 ) {
-    let mut entities_with_keys = entities
+    let entities_with_keys_owned = entities
         .drain(..)
         .map(|entity| {
             let key = EntityKey::data(
@@ -213,6 +214,10 @@ fn insert_entity(
             (key, entity)
         })
         .collect::<Vec<(EntityKey, Entity)>>();
+    let mut entities_with_keys: Vec<_> = entities_with_keys_owned
+        .iter()
+        .map(|(key, entity)| (key, Cow::from(entity)))
+        .collect();
     let entity_type = EntityType::from(entity_type);
     let errmsg = format!(
         "Failed to insert entities {}[{:?}]",
@@ -227,7 +232,7 @@ fn insert_entity(
             &MOCK_STOPWATCH,
         )
         .expect(&errmsg);
-    assert_eq!(inserted, entities_with_keys.len());
+    assert_eq!(inserted, entities_with_keys_owned.len());
 }
 
 fn update_entity(
@@ -236,7 +241,7 @@ fn update_entity(
     entity_type: &str,
     mut entities: Vec<Entity>,
 ) {
-    let mut entities_with_keys: Vec<(EntityKey, Entity)> = entities
+    let entities_with_keys_owned: Vec<(EntityKey, Entity)> = entities
         .drain(..)
         .map(|entity| {
             let key = EntityKey::data(
@@ -246,6 +251,10 @@ fn update_entity(
             );
             (key, entity)
         })
+        .collect();
+    let mut entities_with_keys: Vec<_> = entities_with_keys_owned
+        .iter()
+        .map(|(key, entity)| (key, Cow::from(entity)))
         .collect();
 
     let entity_type = EntityType::from(entity_type);
@@ -263,7 +272,7 @@ fn update_entity(
             &MOCK_STOPWATCH,
         )
         .expect(&errmsg);
-    assert_eq!(updated, entities_with_keys.len());
+    assert_eq!(updated, entities_with_keys_owned.len());
 }
 
 fn insert_user_entity(
@@ -537,21 +546,16 @@ fn update() {
         );
 
         let entity_type = EntityType::from("Scalar");
-        let mut entities = vec![(key, entity)];
+        let mut entities = vec![(&key, Cow::from(&entity))];
         layout
             .update(&conn, &entity_type, &mut entities, 0, &MOCK_STOPWATCH)
             .expect("Failed to update");
-
-        // The missing 'strings' will show up as Value::Null in the
-        // loaded entity
-        let entity_again = &mut entities.get_mut(0).unwrap().1;
-        entity_again.set("strings", Value::Null);
 
         let actual = layout
             .find(conn, &*SCALAR, "one", BLOCK_NUMBER_MAX)
             .expect("Failed to read Scalar[one]")
             .unwrap();
-        assert_entity_eq!(scrub(&entity_again), actual);
+        assert_entity_eq!(scrub(&entity), actual);
     });
 }
 
@@ -597,9 +601,10 @@ fn update_many() {
             })
             .collect();
 
-        let mut entities: Vec<(EntityKey, Entity)> = keys
-            .into_iter()
-            .zip(vec![one, two, three].into_iter())
+        let entities_vec = vec![one, two, three];
+        let mut entities: Vec<(&EntityKey, Cow<'_, Entity>)> = keys
+            .iter()
+            .zip(entities_vec.iter().map(|e| Cow::Borrowed(e)))
             .collect();
 
         layout
@@ -669,9 +674,15 @@ fn serialize_bigdecimal() {
                 entity.id().unwrap().clone(),
             );
             let entity_type = EntityType::from("Scalar");
-            let mut entities = vec![(key, entity.clone())];
+            let mut entities = vec![(&key, Cow::Borrowed(&entity))];
             layout
-                .update(&conn, &entity_type, &mut entities, 0, &MOCK_STOPWATCH)
+                .update(
+                    &conn,
+                    &entity_type,
+                    entities.as_mut_slice(),
+                    0,
+                    &MOCK_STOPWATCH,
+                )
                 .expect("Failed to update");
 
             let actual = layout
@@ -722,7 +733,7 @@ fn delete() {
             "no such entity".to_owned(),
         );
         let entity_type = EntityType::from("Scalar");
-        let mut entity_keys = vec![key.entity_id];
+        let mut entity_keys = vec![key.entity_id.as_str()];
         let count = layout
             .delete(
                 &conn,
@@ -738,7 +749,7 @@ fn delete() {
         // Delete entity two
         entity_keys
             .get_mut(0)
-            .map(|key| *key = "two".to_owned())
+            .map(|key| *key = "two")
             .expect("Failed to update key");
 
         let count = layout
@@ -764,7 +775,7 @@ fn insert_many_and_delete_many() {
 
         // Delete entities with ids equal to "two" and "three"
         let entity_type = EntityType::from("Scalar");
-        let entity_keys = vec!["two".to_string(), "three".to_string()];
+        let entity_keys = vec!["two", "three"];
         let num_removed = layout
             .delete(&conn, &entity_type, &entity_keys, 1, &MOCK_STOPWATCH)
             .expect("Failed to delete");

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -4,6 +4,7 @@ use diesel::pg::PgConnection;
 use graph_mock::MockMetricsRegistry;
 use hex_literal::hex;
 use lazy_static::lazy_static;
+use std::borrow::Cow;
 use std::{collections::BTreeMap, sync::Arc};
 
 use graph::prelude::{
@@ -90,10 +91,16 @@ fn insert_entity(conn: &PgConnection, layout: &Layout, entity_type: &str, entity
     );
 
     let entity_type = EntityType::from(entity_type);
-    let mut entities = vec![(key.clone(), entity)];
+    let mut entities = vec![(&key, Cow::from(&entity))];
     let errmsg = format!("Failed to insert entity {}[{}]", entity_type, key.entity_id);
     layout
-        .insert(&conn, &entity_type, &mut entities, 0, &MOCK_STOPWATCH)
+        .insert(
+            &conn,
+            &entity_type,
+            entities.as_mut_slice(),
+            0,
+            &MOCK_STOPWATCH,
+        )
         .expect(&errmsg);
 }
 
@@ -284,7 +291,7 @@ fn update() {
 
         let entity_id = entity.id().unwrap().clone();
         let entity_type = key.entity_type.clone();
-        let mut entities = vec![(key, entity)];
+        let mut entities = vec![(&key, Cow::from(&entity))];
         layout
             .update(&conn, &entity_type, &mut entities, 1, &MOCK_STOPWATCH)
             .expect("Failed to update");
@@ -294,8 +301,7 @@ fn update() {
             .expect("Failed to read Thing[deadbeef]")
             .unwrap();
 
-        let entity = &entities.first().unwrap().1;
-        assert_entity_eq!(scrub(&entity), actual);
+        assert_entity_eq!(entity, actual);
     });
 }
 
@@ -316,7 +322,7 @@ fn delete() {
             "ffff".to_owned(),
         );
         let entity_type = key.entity_type.clone();
-        let mut entity_keys = vec![key.entity_id.clone()];
+        let mut entity_keys = vec![key.entity_id.as_str()];
         let count = layout
             .delete(&conn, &entity_type, &entity_keys, 1, &MOCK_STOPWATCH)
             .expect("Failed to delete");
@@ -325,7 +331,7 @@ fn delete() {
         // Delete entity two
         entity_keys
             .get_mut(0)
-            .map(|key| *key = TWO_ID.to_owned())
+            .map(|key| *key = TWO_ID)
             .expect("Failed to update entity types");
         let count = layout
             .delete(&conn, &entity_type, &entity_keys, 1, &MOCK_STOPWATCH)

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -258,7 +258,7 @@ fn find_many() {
         id_map.insert(&*THING, vec![ID, ID2, "badd"]);
 
         let entities = layout
-            .find_many(conn, id_map, BLOCK_NUMBER_MAX)
+            .find_many(conn, &id_map, BLOCK_NUMBER_MAX)
             .expect("Failed to read many things");
         assert_eq!(1, entities.len());
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -136,7 +136,7 @@ where
         let deployment = insert_test_data(subgraph_store.clone());
         let writable = store
             .subgraph_store()
-            .writable(&deployment)
+            .writable(LOGGER.clone(), &deployment)
             .expect("we can get a writable store");
 
         // Run test

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -157,7 +157,7 @@ fn create_subgraph() {
 
     fn deployment_synced(store: &Arc<SubgraphStore>, deployment: &DeploymentLocator) {
         store
-            .writable(deployment)
+            .writable(LOGGER.clone(), deployment)
             .expect("can get writable")
             .deployment_synced()
             .unwrap();
@@ -384,7 +384,7 @@ fn status() {
 
         store
             .subgraph_store()
-            .writable(&deployment)
+            .writable(LOGGER.clone(), &deployment)
             .expect("can get writable")
             .fail_subgraph(error)
             .await
@@ -526,7 +526,7 @@ fn fatal_vs_non_fatal() {
 
         store
             .subgraph_store()
-            .writable(&deployment)
+            .writable(LOGGER.clone(), &deployment)
             .expect("can get writable")
             .fail_subgraph(error())
             .await
@@ -565,7 +565,7 @@ fn fail_unfail() {
 
         let writable = store
             .subgraph_store()
-            .writable(&deployment)
+            .writable(LOGGER.clone(), &deployment)
             .expect("can get writable");
         writable.fail_subgraph(error).await.unwrap();
 

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -21,9 +21,11 @@ use graph_store_postgres::layout_for_tests::FAKE_NETWORK_SHARED;
 use graph_store_postgres::{connection_pool::ConnectionPool, Shard, SubscriptionManager};
 use graph_store_postgres::{
     BlockStore as DieselBlcokStore, DeploymentPlacer, SubgraphStore as DieselSubgraphStore,
+    PRIMARY_SHARD,
 };
 use hex_literal::hex;
 use lazy_static::lazy_static;
+use std::collections::HashMap;
 use std::time::Instant;
 use std::{collections::BTreeSet, env};
 use std::{marker::PhantomData, sync::Mutex};
@@ -496,4 +498,10 @@ fn build_store() -> (Arc<Store>, ConnectionPool, Config, Arc<SubscriptionManager
 pub fn primary_connection() -> graph_store_postgres::layout_for_tests::Connection<'static> {
     let conn = PRIMARY_POOL.get().unwrap();
     graph_store_postgres::layout_for_tests::Connection::new(conn)
+}
+
+pub fn primary_mirror() -> graph_store_postgres::layout_for_tests::Mirror {
+    let pool = PRIMARY_POOL.clone();
+    let map = HashMap::from_iter(Some((PRIMARY_SHARD.clone(), pool)));
+    graph_store_postgres::layout_for_tests::Mirror::new(&map)
 }

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -178,7 +178,7 @@ pub fn create_subgraph(
         SubgraphVersionSwitchingMode::Instant,
     )?;
     SUBGRAPH_STORE
-        .writable(&deployment)?
+        .writable(LOGGER.clone(), &deployment)?
         .start_subgraph_deployment(&*LOGGER)?;
     Ok(deployment)
 }
@@ -213,7 +213,7 @@ pub fn transact_errors(
     );
     store
         .subgraph_store()
-        .writable(&deployment)?
+        .writable(LOGGER.clone(), &deployment)?
         .transact_block_operations(
             block_ptr_to,
             None,
@@ -241,7 +241,7 @@ pub fn transact_entities_and_dynamic_data_sources(
     data_sources: Vec<StoredDynamicDataSource>,
     ops: Vec<EntityOperation>,
 ) -> Result<(), StoreError> {
-    let store = store.writable(&deployment)?;
+    let store = store.writable(LOGGER.clone(), &deployment)?;
     let mut entity_cache = EntityCache::new(store.clone());
     entity_cache.append(ops);
     let mods = entity_cache
@@ -267,7 +267,7 @@ pub fn transact_entities_and_dynamic_data_sources(
 pub fn revert_block(store: &Arc<Store>, deployment: &DeploymentLocator, ptr: &BlockPtr) {
     store
         .subgraph_store()
-        .writable(deployment)
+        .writable(LOGGER.clone(), deployment)
         .expect("can get writable")
         .revert_block_operations(ptr.clone())
         .unwrap();


### PR DESCRIPTION
This PR is a continuation of PR #2727 and rounds out the story of making `graph-node` handle shards being down during startup and during normal operation more gracefully, including coming back to a sane state when a failed shard comes back up. Even so, it's probably a good idea to restart `graph-node` after a shard restarted.

The basic ideas behind these changes are:
- queries should fail fast if they involve a failed shard
- queries should only fail if they involve a failed shard
- when the primary fails, queries against other shards should still work (achieved with home-grown table replication)
- indexing operations in a failed shard retry and block indefinitely
- indexing operations in other shards are not affected by a shard failure, even when the primary failed
- indexing will not make progress if the failed shard contains the block store for the subgraph's network, but will resume when the block store becomes available again

Testing these things is unfortunately a very manual process. Testing was done under very little load, and it's possible that this did not reveal issues that only appear under high loads. Here are my notes on what I tested:

## Setup
- three shards: `primary`, `sharda`, and `shardb`
- block store also in `primary`
- one simple subgraph (`dice2win`) indexing in each shard

## Notes
- indexing service API returns errors when any shard is down if that shard is needed to form response
- not clear how all this works under high load

## Scenarios
### `sharda` is down on startup
- [X] graph-node starts up
- [X] queries against `primary` and `shardb` work
- [X] queries against `sharda` fail fast
- [X] indexing in `primary` and `shardb` continues
- [X] queries against `sharda` work after it comes back up
- [X] indexing in `sharda` resumes when `sharda` comes back up

### `sharda` goes down during operation
- [X] queries against `primary` and `shardb` work
- [X] queries against `sharda` fail fast
- [X] indexing in `primary` and `shardb` continues
- [X] queries against `sharda` work after it comes back up
- [X] indexing in `sharda` resumes when `sharda` comes back up

### `primary` is down on startup
- [X] graph-node starts up
- [X] queries against `sharda` and `shardb` work
- [X] queries against `primary` fail fast
- [X] queries against `primary` work after it comes back up
- [X] indexing resumes when `primary` comes back up

### `primary` goes down during operation
- [X] queries against `sharda` and `shardb` work
- [X] queries against `primary` fail fast
- [X] queries against `primary` work after it comes back up
- [X] indexing resumes when `primary` comes back up
