### PR TITLE
clippy: unneeded `return` statement

### DIFF
--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -410,8 +410,8 @@ impl EthereumBlockFilter {
                     .clone()
                     .into_iter()
                     .any(|block_handler| match block_handler.filter {
-                        Some(ref filter) if *filter == BlockHandlerFilter::Call => return true,
-                        _ => return false,
+                        Some(ref filter) if *filter == BlockHandlerFilter::Call => true,
+                        _ => false,
                     });
 
                 let has_block_handler_without_filter = data_source

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -1080,7 +1080,7 @@ impl PollStateMachine for StateMachine {
 
         match state.new_local_head.poll() {
             // Adding the block is not complete yet, try again later.
-            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            Ok(Async::NotReady) => Ok(Async::NotReady),
 
             // We have the new local block, update it and continue processing blocks.
             Ok(Async::Ready(block_ptr)) => {

--- a/graph/examples/stress.rs
+++ b/graph/examples/stress.rs
@@ -23,7 +23,7 @@ unsafe impl GlobalAlloc for Counter {
         if !ret.is_null() {
             ALLOCATED.fetch_add(layout.size(), SeqCst);
         }
-        return ret;
+        ret
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {

--- a/graph/src/blockchain/firehose_block_stream.rs
+++ b/graph/src/blockchain/firehose_block_stream.rs
@@ -263,5 +263,5 @@ fn wait_duration(attempt_number: u64) -> Duration {
         attempt_number
     };
 
-    return Duration::from_secs(2 << pow);
+    Duration::from_secs(2 << pow)
 }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -918,9 +918,7 @@ fn complete_value(
         }
 
         // If the resolved value is null, return null
-        _ if resolved_value == q::Value::Null => {
-            return Ok(resolved_value);
-        }
+        _ if resolved_value == q::Value::Null => Ok(resolved_value),
 
         // Complete list values
         s::Type::ListType(inner_type) => {

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -625,7 +625,7 @@ impl<'a> CollectedResponseKey<'a> {
                     }
                 }
                 s::TypeDefinition::Scalar(_) | s::TypeDefinition::Enum(_) => {}
-                s::TypeDefinition::Union(_) | s::TypeDefinition::InputObject(_) => return,
+                s::TypeDefinition::Union(_) | s::TypeDefinition::InputObject(_) => {}
             });
 
         // collect the column name if field exists in schema

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -204,7 +204,7 @@ impl StoreResolver {
             );
             return Ok((None, Some(q::Value::Object(map))));
         }
-        return Ok((prefetched_object, None));
+        Ok((prefetched_object, None))
     }
 }
 
@@ -269,7 +269,7 @@ impl Resolver for StoreResolver {
                     derived_from_field.name.to_owned(),
                 ));
             } else {
-                return Ok(children.into_iter().next().unwrap_or(q::Value::Null));
+                Ok(children.into_iter().next().unwrap_or(q::Value::Null))
             }
         } else {
             return Err(QueryExecutionError::ResolveEntitiesError(format!(

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -42,7 +42,5 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
         Gauge::with_opts(opts)
     }
 
-    fn unregister(&self, _: Box<dyn Collector>) {
-        return;
-    }
+    fn unregister(&self, _: Box<dyn Collector>) {}
 }

--- a/runtime/wasm/src/module/stopwatch.rs
+++ b/runtime/wasm/src/module/stopwatch.rs
@@ -25,14 +25,14 @@ impl TimeoutStopwatch {
     /// Returns a new stopwatch.
     pub fn new() -> TimeoutStopwatch {
         let sw: TimeoutStopwatch = Default::default();
-        return sw;
+        sw
     }
 
     /// Returns a new stopwatch which will immediately be started.
     pub fn start_new() -> TimeoutStopwatch {
         let mut sw = TimeoutStopwatch::new();
         sw.start();
-        return sw;
+        sw
     }
 
     /// Starts the stopwatch.
@@ -50,13 +50,9 @@ impl TimeoutStopwatch {
     pub fn elapsed(&self) -> Duration {
         match self.start_time {
             // stopwatch is running
-            Some(t1) => {
-                return t1.elapsed() + self.elapsed;
-            }
+            Some(t1) => t1.elapsed() + self.elapsed,
             // stopwatch is not running
-            None => {
-                return self.elapsed;
-            }
+            None => self.elapsed,
         }
     }
 }

--- a/server/index-node/src/explorer.rs
+++ b/server/index-node/src/explorer.rs
@@ -103,9 +103,7 @@ where
             ["subgraph-version", version] => self.handle_subgraph_version(version),
             ["subgraph-repo", version] => self.handle_subgraph_repo(version),
             ["entity-count", deployment] => self.handle_entity_count(logger, deployment),
-            _ => {
-                return handle_not_found();
-            }
+            _ => handle_not_found(),
         }
     }
 

--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -264,11 +264,11 @@ impl BlockStore {
                     );
                         return false;
                     }
-                    return true;
+                    true
                 }
                 None => {
                     warn!(logger, "Failed to get net version and genesis hash from provider. Assuming it has not changed");
-                    return true;
+                    true
                 }
             }
         }

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1427,7 +1427,7 @@ impl LayoutCache {
             Some(CacheEntry { value, expires }) => {
                 if now <= expires {
                     // Entry is not expired; use it
-                    return Ok(value);
+                    Ok(value)
                 } else {
                     // Only do a cache refresh once; we don't want to have
                     // multiple threads refreshing the same layout
@@ -1448,11 +1448,11 @@ impl LayoutCache {
                             // Update the timestamp so we don't retry
                             // refreshing too often
                             self.cache(value.cheap_clone());
-                            return Ok(value);
+                            Ok(value)
                         }
                         Ok(layout) => {
                             self.cache(layout.cheap_clone());
-                            return Ok(layout);
+                            Ok(layout)
                         }
                     }
                 }
@@ -1460,7 +1460,7 @@ impl LayoutCache {
             None => {
                 let layout = Self::load(conn, site)?;
                 self.cache(layout.cheap_clone());
-                return Ok(layout);
+                Ok(layout)
             }
         }
     }


### PR DESCRIPTION
As previously discussed with @otaviopace,  I believe that having Clippy run as a continue-on-error step on CI could prove quite beneficial.

In order for something like that to happen, we have to fix the present Clippy warnings/errors first. 

This PR is the first of a series of low-hanging fruits that we can pick through `cargo clippy --fix` alone (lints deemed machine-applicable).

This one solves instances of [needless_return](https://rust-lang.github.io/rust-clippy/master/index.html#needless_return)


