### PR TITLE
clippy: using `clone` on type that implements the `Copy` trait

### DIFF
--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -150,7 +150,7 @@ impl EthereumLogFilter {
                 // The `Log` matches the filter either if the filter contains
                 // a (contract address, event signature) pair that matches the
                 // `Log`, or if the filter contains wildcard event that matches.
-                let contract = LogFilterNode::Contract(log.address.clone());
+                let contract = LogFilterNode::Contract(log.address);
                 let event = LogFilterNode::Event(*sig);
                 self.contracts_and_events_graph
                     .all_edges()
@@ -334,8 +334,7 @@ impl EthereumCallFilter {
                 .get_mut(&address)
             {
                 Some((existing_start_block, existing_sigs)) => {
-                    *existing_start_block =
-                        cmp::min(proposed_start_block, existing_start_block.clone());
+                    *existing_start_block = cmp::min(proposed_start_block, *existing_start_block);
                     existing_sigs.extend(new_sigs);
                 }
                 None => {

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1243,7 +1243,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
                     .timeout_secs(60)
                     .run(move || {
                         web3.eth()
-                            .uncle(block_hash.clone().into(), index.into())
+                            .uncle(block_hash.into(), index.into())
                             .map_err(move |e| {
                                 anyhow!(
                                     "could not get uncle {} for block {:?} ({} uncles): {}",
@@ -1760,7 +1760,7 @@ async fn filter_call_triggers_from_unsuccessful_transactions(
         .transaction_receipts_in_block(&block.ptr().hash_as_h256())
         .await?
         .into_iter()
-        .map(|receipt| (receipt.transaction_hash.clone(), receipt))
+        .map(|receipt| (receipt.transaction_hash, receipt))
         .collect::<BTreeMap<H256, LightTransactionReceipt>>();
 
     // Do we have a receipt for each transaction under analysis?

--- a/chain/ethereum/src/network.rs
+++ b/chain/ethereum/src/network.rs
@@ -110,7 +110,7 @@ impl EthereumNetworks {
                     .map(move |network_adapter| {
                         (
                             network_name.clone(),
-                            network_adapter.capabilities.clone(),
+                            network_adapter.capabilities,
                             network_adapter.adapter.clone(),
                         )
                     })

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -144,7 +144,7 @@ fn eth_call(
     };
 
     let call = EthereumContractCall {
-        address: unresolved_call.contract_address.clone(),
+        address: unresolved_call.contract_address,
         block_ptr: block_ptr.cheap_clone(),
         function: function.clone(),
         args: unresolved_call.function_args.clone(),

--- a/chain/ethereum/tests/network_indexer.rs
+++ b/chain/ethereum/tests/network_indexer.rs
@@ -127,11 +127,11 @@ fn create_chain(n: u64, parent: Option<&BlockWithOmmers>) -> Vec<BlockWithOmmers
             // parent was passed in; otherwise we're dealing with
             // the genesis block
             if let Some(parent_block) = parent {
-                block.parent_hash = parent_block.inner().hash.unwrap().clone();
+                block.parent_hash = parent_block.inner().hash.unwrap();
             }
         } else {
             // Set the parent hash for all blocks but the genesis block
-            block.parent_hash = blocks.last().unwrap().block.block.hash.clone().unwrap();
+            block.parent_hash = blocks.last().unwrap().block.block.hash.unwrap();
         }
 
         blocks.push(BlockWithOmmers {
@@ -747,7 +747,7 @@ fn indexing_identifies_common_ancestor_correctly_despite_ommers() {
 
         // Make it so that #5' has #4 as an uncle
         Arc::get_mut(&mut fork1[5].block.block).unwrap().uncles =
-            vec![initial_chain[4].inner().hash.clone().unwrap()];
+            vec![initial_chain[4].inner().hash.unwrap()];
         fork1[5].ommers = vec![initial_chain[4].block.block.as_ref().clone().into()];
 
         // Create fork 2 (blocks #0 - #4, #5'', #6''); this fork includes the

--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -221,7 +221,7 @@ impl LinkResolverTrait for LinkResolver {
 
         let path = path.clone();
         let this = self.clone();
-        let timeout = self.timeout.clone();
+        let timeout = self.timeout;
         let logger = logger.clone();
         let data = retry_policy(self.retry, "ipfs.cat", &logger)
             .run(move || {

--- a/graph/src/blockchain/firehose_block_stream.rs
+++ b/graph/src/blockchain/firehose_block_stream.rs
@@ -244,7 +244,7 @@ impl<C: Blockchain, F: FirehoseMapper<C>> FirehoseBlockStream<C, F> {
     /// uses an exponential backoff strategy to retry with incremental longer delays.
     fn schedule_error_retry<T>(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         self.connection_attempts += 1;
-        let wait_duration = wait_duration(self.connection_attempts.clone());
+        let wait_duration = wait_duration(self.connection_attempts);
 
         let waker = cx.waker().clone();
         tokio::spawn(async move {

--- a/graph/src/data/graphql/effort.rs
+++ b/graph/src/data/graphql/effort.rs
@@ -279,7 +279,7 @@ impl LoadManager {
                         labels,
                     )
                     .expect("Failed to register query_counter metric");
-                (s.clone(), counter)
+                (*s, counter)
             })
             .collect::<HashMap<_, _>>();
 

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -294,11 +294,11 @@ pub fn execute_root_selection_set_uncached(
     // Split the top-level fields into introspection fields and
     // regular data fields
     let mut data_set = q::SelectionSet {
-        span: selection_set.span.clone(),
+        span: selection_set.span,
         items: Vec::new(),
     };
     let mut intro_set = q::SelectionSet {
-        span: selection_set.span.clone(),
+        span: selection_set.span,
         items: Vec::new(),
     };
     let mut meta_items = Vec::new();
@@ -962,7 +962,7 @@ fn complete_value(
                 s::TypeDefinition::Scalar(scalar_type) => {
                     resolved_value.coerce(scalar_type).map_err(|value| {
                         vec![QueryExecutionError::ScalarCoercionError(
-                            field.position.clone(),
+                            field.position,
                             field.name.to_owned(),
                             value,
                             scalar_type.name.to_owned(),
@@ -974,7 +974,7 @@ fn complete_value(
                 s::TypeDefinition::Enum(enum_type) => {
                     resolved_value.coerce(enum_type).map_err(|value| {
                         vec![QueryExecutionError::EnumCoercionError(
-                            field.position.clone(),
+                            field.position,
                             field.name.to_owned(),
                             value,
                             enum_type.name.to_owned(),

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -235,7 +235,7 @@ impl Query {
             let (selection_set, error_policy) = bcs.entry(bc).or_insert_with(|| {
                 (
                     q::SelectionSet {
-                        span: self.selection_set.span.clone(),
+                        span: self.selection_set.span,
                         items: vec![],
                     },
                     field_error_policy,

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -283,7 +283,7 @@ where
                 logger: self.logger.clone(),
                 store,
                 subscription_manager: self.subscription_manager.cheap_clone(),
-                timeout: GRAPHQL_QUERY_TIMEOUT.clone(),
+                timeout: *GRAPHQL_QUERY_TIMEOUT,
                 max_complexity: *GRAPHQL_MAX_COMPLEXITY,
                 max_depth: *GRAPHQL_MAX_DEPTH,
                 max_first: *GRAPHQL_MAX_FIRST,

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -263,7 +263,7 @@ impl Resolver for StoreResolver {
                         .expect("only derived fields can lead to multiple children here");
 
                 return Err(QueryExecutionError::AmbiguousDerivedFromResult(
-                    field.position.clone(),
+                    field.position,
                     field.name.to_owned(),
                     object_type.name().to_owned(),
                     derived_from_field.name.to_owned(),

--- a/graphql/src/values/coercion.rs
+++ b/graphql/src/values/coercion.rs
@@ -120,7 +120,7 @@ pub(crate) fn coerce_input_value<'a>(
         None => {
             return if schema::ast::is_non_null_type(&def.value_type) {
                 Err(QueryExecutionError::MissingArgumentError(
-                    def.position.clone(),
+                    def.position,
                     def.name.to_owned(),
                 ))
             } else {
@@ -132,11 +132,7 @@ pub(crate) fn coerce_input_value<'a>(
 
     Ok(Some(
         coerce_value(value, &def.value_type, resolver, variable_values).map_err(|val| {
-            QueryExecutionError::InvalidArgumentError(
-                def.position.clone(),
-                def.name.to_owned(),
-                val,
-            )
+            QueryExecutionError::InvalidArgumentError(def.position, def.name.to_owned(), val)
         })?,
     ))
 }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -294,7 +294,7 @@ impl PoolSize {
 
         let pool_size = match self {
             None => bail!("missing pool size for {}", connection),
-            Fixed(s) => s.clone(),
+            Fixed(s) => *s,
             Rule(rules) => rules.iter().map(|rule| rule.size).min().unwrap_or(0u32),
         };
 
@@ -313,7 +313,7 @@ impl PoolSize {
         use PoolSize::*;
         match self {
             None => unreachable!("validation ensures we have a pool size"),
-            Fixed(s) => Ok(s.clone()),
+            Fixed(s) => Ok(*s),
             Rule(rules) => rules
                 .iter()
                 .find(|rule| rule.matches(node.as_str()))

--- a/node/src/manager/commands/copy.rs
+++ b/node/src/manager/commands/copy.rs
@@ -207,8 +207,8 @@ pub fn status(pools: HashMap<Shard, ConnectionPool>, dst: i32) -> Result<(), Err
     }
 
     fn duration(start: &UtcDateTime, end: &Option<UtcDateTime>) -> String {
-        let start = start.clone();
-        let end = end.clone();
+        let start = *start;
+        let end = *end;
 
         let end = end.unwrap_or(UtcDateTime::from(SystemTime::now()));
         let duration = end - start;

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -290,7 +290,7 @@ impl<C: Blockchain> HostExports<C> {
                     ctx.derive_with_empty_block_state(),
                     host_metrics.clone(),
                     module.timeout,
-                    module.experimental_features.clone(),
+                    module.experimental_features,
                 )?;
                 let result = module.handle_json_callback(&callback, &sv.value, &user_data)?;
                 // Log progress every 15s

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -67,7 +67,7 @@ pub fn spawn_module<C: Blockchain>(
                     ctx,
                     host_metrics.cheap_clone(),
                     timeout,
-                    experimental_features.clone(),
+                    experimental_features,
                 )?;
                 section.end();
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -57,13 +57,13 @@ impl GraphQLServiceMetrics {
     pub fn observe_query_execution_time(&self, duration: f64, deployment_id: String) {
         self.query_execution_time
             .with_label_values(vec![deployment_id.as_ref()].as_slice())
-            .observe(duration.clone());
+            .observe(duration);
     }
 
     pub fn observe_failed_query_execution_time(&self, duration: f64, deployment_id: String) {
         self.failed_query_execution_time
             .with_label_values(vec![deployment_id.as_ref()].as_slice())
-            .observe(duration.clone());
+            .observe(duration);
     }
 }
 

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -712,7 +712,7 @@ impl DeploymentStore {
         indexer: &'a Option<Address>,
         block: BlockPtr,
     ) -> DynTryFuture<'a, Option<[u8; 32]>> {
-        let indexer = indexer.clone();
+        let indexer = *indexer;
         let site3 = site.clone();
         let site4 = site.clone();
         let store = self.clone();

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -456,7 +456,7 @@ impl<'a> Connection<'a> {
             .collect();
 
         // Stop ongoing copies
-        let removed_ids: Vec<_> = removed.iter().map(|(id, _)| id.clone()).collect();
+        let removed_ids: Vec<_> = removed.iter().map(|(id, _)| *id).collect();
         self.cancel_copies(removed_ids)?;
 
         let events = removed
@@ -1024,7 +1024,7 @@ impl<'a> Connection<'a> {
 
         assigned
             .iter()
-            .map(|(node, count)| (node.as_str(), count.clone()))
+            .map(|(node, count)| (node.as_str(), *count))
             .chain(missing)
             .min_by(|(_, a), (_, b)| a.cmp(b))
             .map(|(node, _)| NodeId::new(node).map_err(|()| node))

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -890,7 +890,7 @@ impl ColumnType {
 
         // See if its an object type defined in the schema
         if let Some(id_type) = id_types.get(&EntityType::new(name.to_string())) {
-            return Ok(id_type.clone().into());
+            return Ok((*id_type).into());
         }
 
         // Check if it's an enum, and if it is, return an appropriate

--- a/store/postgres/tests/chain_head.rs
+++ b/store/postgres/tests/chain_head.rs
@@ -284,7 +284,7 @@ fn ancestor_block_simple() {
         check_ancestor(&store, &*BLOCK_THREE, 2, &*BLOCK_ONE)?;
 
         for offset in [6, 7, 8, 50].iter() {
-            let offset = offset.clone();
+            let offset = *offset;
             let res = store.ancestor_block(BLOCK_FIVE.block_ptr(), offset);
             assert!(res.is_err());
         }

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -161,7 +161,7 @@ lazy_static! {
         );
         entity.set("string", "scalar");
         entity.set("strings", strings);
-        entity.set("bytes", (*BYTES_VALUE).clone());
+        entity.set("bytes", *BYTES_VALUE);
         entity.set("byteArray", byte_array);
         let big_int = (*LARGE_INT).clone();
         entity.set("bigInt", big_int.clone());

--- a/tests/tests/common/helpers.rs
+++ b/tests/tests/common/helpers.rs
@@ -126,7 +126,7 @@ pub fn make_ganache_uri(ganache_ports: &MappedPorts) -> (u16, String) {
         .get(&GANACHE_DEFAULT_PORT)
         .expect("failed to fetch Ganache port from mapped ports");
     let uri = format!("test:http://{host}:{port}", host = "localhost", port = port);
-    (port.clone(), uri)
+    (*port, uri)
 }
 
 pub fn contains_subslice<T: PartialEq>(data: &[T], needle: &[T]) -> bool {


### PR DESCRIPTION
Continuation of #2816

As previously discussed with @otaviopace,  I believe that having Clippy run as a continue-on-error step on CI could prove quite beneficial.

In order for something like that to happen, we have to fix the present Clippy warnings/errors first. 

This PR is the second in a series of low-hanging fruits that we can pick through `cargo clippy --fix` alone (lints deemed machine-applicable).

This one solves instances of [clone_on_copy](https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy)


