### PR TITLE
clippy: single-character string constant used as pattern

### DIFF
--- a/chain/ethereum/src/capabilities.rs
+++ b/chain/ethereum/src/capabilities.rs
@@ -44,7 +44,7 @@ impl FromStr for NodeCapabilities {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let capabilities: BTreeSet<&str> = s.split(",").collect();
+        let capabilities: BTreeSet<&str> = s.split(',').collect();
         Ok(NodeCapabilities {
             archive: capabilities.contains("archive"),
             traces: capabilities.contains("traces"),

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -359,7 +359,7 @@ impl DataSource {
 
                 // Extract the event name; if there is no '(' in the signature,
                 // `event_name` will be empty and not match any events, so that's ok
-                let parens = signature.find("(").unwrap_or(0);
+                let parens = signature.find('(').unwrap_or(0);
                 let event_name = &signature[0..parens];
 
                 let matching_events = self

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -206,7 +206,7 @@ impl SubgraphName {
         }
 
         // Parse into components and validate each
-        for part in s.split("/") {
+        for part in s.split('/') {
             // Each part must be non-empty and not too long
             if part.is_empty() || part.len() > 32 {
                 return Err(());

--- a/graph/src/log/mod.rs
+++ b/graph/src/log/mod.rs
@@ -378,7 +378,7 @@ impl ser::Serializer for KeyValueSerializer {
 fn log_query_timing(kind: &str) -> bool {
     env::var("GRAPH_LOG_QUERY_TIMING")
         .unwrap_or_default()
-        .split(",")
+        .split(',')
         .any(|v| v == kind)
 }
 

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -431,7 +431,7 @@ impl ChainSection {
                     return Err(anyhow!("Ethereum node URL cannot be an empty string"));
                 }
 
-                let colon = rest.find(":").ok_or_else(|| {
+                let colon = rest.find(':').ok_or_else(|| {
                     return anyhow!(
                         "A network name must be provided alongside the \
                          Ethereum node location. Try e.g. 'mainnet:URL'."

--- a/runtime/wasm/src/to_from/mod.rs
+++ b/runtime/wasm/src/to_from/mod.rs
@@ -109,7 +109,7 @@ impl FromAscObj<AscString> for String {
             .map_err(|e| DeterministicHostError(e.into()))?;
 
         // Strip null characters since they are not accepted by Postgres.
-        if string.contains("\u{0000}") {
+        if string.contains('\u{0000}') {
             string = string.replace("\u{0000}", "");
         }
         Ok(string)

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -59,7 +59,7 @@ where
         }
 
         let path_segments = {
-            let mut segments = path.split("/");
+            let mut segments = path.split('/');
 
             // Remove leading '/'
             let first_segment = segments.next();

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -158,7 +158,7 @@ pub fn server_options(
         .srvoptions
         .into_iter()
         .filter_map(|opt| {
-            let mut parts = opt.splitn(2, "=");
+            let mut parts = opt.splitn(2, '=');
             let key = parts.next();
             let value = parts.next().map(|value| value.to_string());
 

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -71,7 +71,7 @@ lazy_static! {
             // qualified name
             env::var("GRAPH_ACCOUNT_TABLES")
                 .ok()
-                .map(|v| v.split(",").map(|s| format!("\"{}\"", s.replace(".", "\".\""))).collect())
+                .map(|v| v.split(',').map(|s| format!("\"{}\"", s.replace(".", "\".\""))).collect())
                 .unwrap_or(HashSet::new())
     };
 


### PR DESCRIPTION
Continuation of #2816

As previously discussed with @otaviopace,  I believe that having Clippy run as a continue-on-error step on CI could prove quite beneficial.

In order for something like that to happen, we have to fix the present Clippy warnings/errors first. 

This PR is the third in a series of low-hanging fruits that we can pick through `cargo clippy --fix` alone (lints deemed machine-applicable).

This one solves instances of [single_char_pattern](https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern)
