### PR TITLE
Add Prometheus metrics to monitor the notification queue

### DIFF
--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -47,6 +47,13 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         const_labels: HashMap<String, String>,
     ) -> Result<Counter, PrometheusError>;
 
+    fn global_counter_vec(
+        &self,
+        name: &str,
+        help: &str,
+        variable_labels: &[&str],
+    ) -> Result<CounterVec, PrometheusError>;
+
     fn global_deployment_counter(
         &self,
         name: &str,

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -1,5 +1,6 @@
 use graph::components::metrics::{Collector, Counter, Gauge, Opts, PrometheusError};
 use graph::prelude::MetricsRegistry as MetricsRegistryTrait;
+use graph::prometheus::CounterVec;
 
 use std::collections::HashMap;
 
@@ -43,4 +44,15 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
     }
 
     fn unregister(&self, _: Box<dyn Collector>) {}
+
+    fn global_counter_vec(
+        &self,
+        name: &str,
+        help: &str,
+        variable_labels: &[&str],
+    ) -> Result<CounterVec, PrometheusError> {
+        let opts = Opts::new(name, help);
+        let counters = CounterVec::new(opts, variable_labels)?;
+        Ok(counters)
+    }
 }

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -382,6 +382,7 @@ impl Context {
         Arc::new(SubscriptionManager::new(
             self.logger.clone(),
             primary.connection.to_owned(),
+            self.registry.clone(),
         ))
     }
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -212,6 +212,7 @@ async fn main() {
 
         let subscription_manager = store_builder.subscription_manager();
         let chain_head_update_listener = store_builder.chain_head_update_listener();
+        let primary_pool = store_builder.primary_pool();
         let network_store = store_builder.network_store(idents);
 
         // To support the ethereum block ingestor, ethereum networks are referenced both by the
@@ -303,7 +304,12 @@ async fn main() {
 
             // Start a task runner
             let mut job_runner = graph::util::jobs::Runner::new(&logger);
-            register_store_jobs(&mut job_runner, network_store.clone());
+            register_store_jobs(
+                &mut job_runner,
+                network_store.clone(),
+                primary_pool,
+                metrics_registry.clone(),
+            );
             graph::spawn_blocking(job_runner.start());
         }
 

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -41,6 +41,7 @@ impl StoreBuilder {
         let subscription_manager = Arc::new(SubscriptionManager::new(
             logger.cheap_clone(),
             primary_shard.connection.to_owned(),
+            registry.clone(),
         ));
 
         let (store, pools) =

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -156,8 +156,13 @@ impl StoreBuilder {
         let logger = logger.new(o!("component" => "BlockStore"));
 
         let block_store = Arc::new(
-            DieselBlockStore::new(logger, networks, pools.clone())
-                .expect("Creating the BlockStore works"),
+            DieselBlockStore::new(
+                logger,
+                networks,
+                pools.clone(),
+                subgraph_store.notification_sender(),
+            )
+            .expect("Creating the BlockStore works"),
         );
 
         Arc::new(DieselStore::new(subgraph_store, block_store))

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -277,10 +277,6 @@ impl StoreBuilder {
         self.chain_head_update_listener.clone()
     }
 
-    // This is used in the test-store, but rustc keeps complaining that it
-    // is not used
-    #[cfg(debug_assertions)]
-    #[allow(dead_code)]
     pub fn primary_pool(&self) -> ConnectionPool {
         self.pools.get(&*PRIMARY_SHARD).unwrap().clone()
     }

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -5,7 +5,7 @@ use graph::{
         futures03::{self, FutureExt},
         tokio, StoreError,
     },
-    prometheus::GaugeVec,
+    prometheus::{CounterVec, GaugeVec},
 };
 use std::str::FromStr;
 use std::sync::Arc;
@@ -103,7 +103,13 @@ impl ChainHeadUpdateListener {
     pub fn new(logger: &Logger, registry: Arc<dyn MetricsRegistry>, postgres_url: String) -> Self {
         let logger = logger.new(o!("component" => "ChainHeadUpdateListener"));
         let ingestor_metrics = Arc::new(BlockIngestorMetrics::new(registry.clone()));
-
+        let counter = registry
+            .global_counter_vec(
+                "notification_queue_recvd",
+                "Number of messages received through Postgres LISTEN",
+                vec!["channel", "network"].as_slice(),
+            )
+            .unwrap();
         // Create a Postgres notification listener for chain head updates
         let (mut listener, receiver) =
             NotificationListener::new(&logger, postgres_url, CHANNEL_NAME.clone());
@@ -115,6 +121,7 @@ impl ChainHeadUpdateListener {
             &mut listener,
             receiver,
             watchers.cheap_clone(),
+            counter,
         );
 
         ChainHeadUpdateListener {
@@ -133,14 +140,19 @@ impl ChainHeadUpdateListener {
         listener: &mut NotificationListener,
         mut receiver: Receiver<JsonNotification>,
         watchers: Arc<RwLock<BTreeMap<String, Watcher>>>,
+        counter: CounterVec,
     ) {
         // Process chain head updates in a dedicated task
         graph::spawn(async move {
             while let Some(notification) = receiver.recv().await {
                 // Create ChainHeadUpdate from JSON
                 let update: ChainHeadUpdate =
-                    match serde_json::from_value(notification.payload.clone()) {
-                        Ok(update) => update,
+                    match serde_json::from_value::<ChainHeadUpdate>(notification.payload.clone()) {
+                        Ok(update) => {
+                            let labels = [CHANNEL_NAME.as_str(), &update.network_name];
+                            counter.with_label_values(&labels).inc();
+                            update
+                        }
                         Err(e) => {
                             crit!(
                                 logger,

--- a/store/postgres/src/functions.rs
+++ b/store/postgres/src/functions.rs
@@ -8,9 +8,5 @@ sql_function! {
 }
 
 sql_function! {
-    fn pg_notify(channel: Text, msg: Text)
-}
-
-sql_function! {
     fn lower(range: Range<Integer>) -> Integer
 }

--- a/store/postgres/src/jobs.rs
+++ b/store/postgres/src/jobs.rs
@@ -1,17 +1,31 @@
 //! Jobs for database maintenance
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use diesel::{prelude::RunQueryDsl, sql_query, sql_types::Double};
 
-use graph::prelude::{error, Logger};
+use graph::prelude::{error, Logger, MetricsRegistry, StoreError};
+use graph::prometheus::Gauge;
 use graph::util::jobs::{Job, Runner};
 
+use crate::connection_pool::ConnectionPool;
 use crate::{Store, SubgraphStore};
 
-pub fn register(runner: &mut Runner, store: Arc<Store>) {
+pub fn register(
+    runner: &mut Runner,
+    store: Arc<Store>,
+    primary_pool: ConnectionPool,
+    registry: Arc<impl MetricsRegistry>,
+) {
     runner.register(
         Arc::new(VacuumDeploymentsJob::new(store.subgraph_store())),
+        Duration::from_secs(60),
+    );
+
+    runner.register(
+        Arc::new(NotificationQueueUsage::new(primary_pool, registry)),
         Duration::from_secs(60),
     );
 }
@@ -44,6 +58,60 @@ impl Job for VacuumDeploymentsJob {
                     "Vacuum of subgraphs.subgraph_deployment failed: {}", e
                 );
             }
+        }
+    }
+}
+
+struct NotificationQueueUsage {
+    primary: ConnectionPool,
+    usage_gauge: Box<Gauge>,
+}
+
+impl NotificationQueueUsage {
+    fn new(primary: ConnectionPool, registry: Arc<impl MetricsRegistry>) -> Self {
+        let usage_gauge = registry
+            .new_gauge(
+                "notification_queue_usage",
+                "Time series of pg_notification_queue_usage()",
+                HashMap::new(),
+            )
+            .expect("Can register the notification_queue_usage gauge");
+        NotificationQueueUsage {
+            primary,
+            usage_gauge,
+        }
+    }
+
+    async fn update(&self) -> Result<(), StoreError> {
+        #[derive(QueryableByName)]
+        struct Usage {
+            #[sql_type = "Double"]
+            usage: f64,
+        }
+        let usage_gauge = self.usage_gauge.clone();
+        self.primary
+            .with_conn(move |conn, _| {
+                let res = sql_query("select pg_notification_queue_usage() as usage")
+                    .get_result::<Usage>(conn)?;
+                usage_gauge.set(res.usage);
+                Ok(())
+            })
+            .await
+    }
+}
+
+#[async_trait]
+impl Job for NotificationQueueUsage {
+    fn name(&self) -> &str {
+        "Report pg_notification_queue_usage()"
+    }
+
+    async fn run(&self, logger: &Logger) {
+        if let Err(e) = self.update().await {
+            error!(
+                logger,
+                "Update of `notification_queue_usage` gauge failed: {}", e
+            );
         }
     }
 }

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -66,6 +66,7 @@ pub use self::chain_head_listener::ChainHeadUpdateListener;
 pub use self::chain_store::ChainStore;
 pub use self::detail::DeploymentDetail;
 pub use self::jobs::register as register_jobs;
+pub use self::notification_listener::NotificationSender;
 pub use self::primary::UnusedDeployment;
 pub use self::store::Store;
 pub use self::store_events::SubscriptionManager;

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -1,6 +1,6 @@
-use crate::functions::pg_notify;
 use diesel::pg::PgConnection;
 use diesel::select;
+use diesel::sql_types::Text;
 use graph::prelude::tokio::sync::mpsc::error::SendTimeoutError;
 use lazy_static::lazy_static;
 use postgres::Notification;
@@ -378,6 +378,10 @@ impl NotificationSender {
         use diesel::ExpressionMethods;
         use diesel::RunQueryDsl;
         use public::large_notifications::dsl::*;
+
+        sql_function! {
+            fn pg_notify(channel: Text, msg: Text)
+        }
 
         let msg = data.to_string();
 

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -219,6 +219,10 @@ impl SubgraphStore {
     ) -> DynTryFuture<'a, Option<[u8; 32]>> {
         self.inner.clone().get_proof_of_indexing(id, indexer, block)
     }
+
+    pub fn notification_sender(&self) -> Arc<NotificationSender> {
+        self.sender.clone()
+    }
 }
 
 impl std::ops::Deref for SubgraphStore {


### PR DESCRIPTION
This adds the following metrics to help monitor the Postgres notification queue:

* `notification_queue_usage`: gauge between 0 and 1 that shows the result of `pg_notification_queue_usage()`, updated every minute
* `notification_queue_sent`: counter (labeled with channel and network) for the number of messages sent; for the `store_events` channel, the network is `none`
* `notification_queue_recvd`: counter (labeled with channel and network) for the number of messages received; for the `store_events` channel, the network is `none`