### PR TITLE
ethereum: Consider 'out of gas' as a deterministic eth_call error

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -125,14 +125,8 @@ const GETH_ETH_CALL_ERRORS: &[&str] = &[
     "invalid opcode",
     // Ethereum says 1024 is the stack sizes limit, so this is deterministic.
     "stack limit reached 1024",
-    // "out of gas" is commented out because Erigon has not yet bumped the default gas limit to 50
-    // million. It can be added through `GETH_ETH_CALL_ERRORS_ENV` if not using Erigon. Once
-    // https://github.com/ledgerwatch/erigon/pull/2572 has been released and indexers have updated,
-    // this can be uncommented.
-    //
     // See f0af4ab0-6b7c-4b68-9141-5b79346a5f61 for why the gas limit is considered deterministic.
-
-    // "out of gas",
+    "out of gas",
 ];
 
 impl CheapClone for EthereumAdapter {
@@ -521,6 +515,9 @@ impl EthereumAdapter {
                         const PARITY_BAD_JUMP_PREFIX: &str = "Bad jump";
                         const PARITY_STACK_LIMIT_PREFIX: &str = "Out of stack";
 
+                        // See f0af4ab0-6b7c-4b68-9141-5b79346a5f61.
+                        const PARITY_OUT_OF_GAS: &str = "Out of gas";
+
                         const GANACHE_VM_EXECUTION_ERROR: i64 = -32000;
                         const GANACHE_REVERT_MESSAGE: &str =
                             "VM Exception while processing transaction: revert";
@@ -569,7 +566,8 @@ impl EthereumAdapter {
                                             || data.starts_with(PARITY_BAD_JUMP_PREFIX)
                                             || data.starts_with(PARITY_STACK_LIMIT_PREFIX)
                                             || data == PARITY_BAD_INSTRUCTION_FE
-                                            || data == PARITY_BAD_INSTRUCTION_FD =>
+                                            || data == PARITY_BAD_INSTRUCTION_FD
+                                            || data == PARITY_OUT_OF_GAS =>
                                     {
                                         let reason = if data == PARITY_BAD_INSTRUCTION_FE {
                                             PARITY_BAD_INSTRUCTION_FE.to_owned()

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -104,9 +104,7 @@ lazy_static! {
     /// with the default. This means that we do not support indexing against a Geth node with
     /// `RPCGasCap` set below 50 million.
     // See also f0af4ab0-6b7c-4b68-9141-5b79346a5f61.
-    static ref ETH_CALL_GAS: u32 = std::env::var("GRAPH_ETH_CALL_GAS")
-                                    .map(|s| s.parse::<u32>().expect("invalid GRAPH_ETH_CALL_GAS env var"))
-                                    .unwrap_or(50_000_000);
+    static ref ETH_CALL_GAS: u32 = graph::env::unsafe_env_var("GRAPH_ETH_CALL_GAS", 50_000_000);
 
     /// Additional deterministic errors that have not yet been hardcoded. Separated by `;`.
     static ref GETH_ETH_CALL_ERRORS_ENV: Vec<String> = {

--- a/graph/src/env.rs
+++ b/graph/src/env.rs
@@ -1,0 +1,37 @@
+use std::{
+    env::VarError,
+    str::FromStr,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+pub static UNSAFE_CONFIG: AtomicBool = AtomicBool::new(false);
+
+/// Panics if:
+/// - The value is not UTF8.
+/// - The value cannot be parsed as T.
+/// - The value differs from the default, and `--unsafe-config` flag is not set.
+pub fn unsafe_env_var<E: std::error::Error + Send + Sync, T: FromStr<Err = E> + Eq>(
+    name: &'static str,
+    default_value: T,
+) -> T {
+    let var = match std::env::var(name) {
+        Ok(var) => var,
+        Err(VarError::NotPresent) => return default_value,
+        Err(VarError::NotUnicode(_)) => panic!("environment variable {} is not UTF8", name),
+    };
+
+    let value = var
+        .parse::<T>()
+        .unwrap_or_else(|e| panic!("failed to parse environment variable {}: {}", name, e));
+
+    if !UNSAFE_CONFIG.load(Ordering::SeqCst) && value != default_value {
+        panic!(
+            "unsafe environment variable {} is set. The recommended action is to unset it. \
+             If this is not an indexer on the network, \
+             you may provide the `--unsafe-config` to allow setting this variable.",
+            name
+        )
+    }
+
+    value
+}

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -24,6 +24,9 @@ pub mod runtime;
 
 pub mod firehose;
 
+/// Helpers for parsing environment variables.
+pub mod env;
+
 /// Module with mocks for different parts of the system.
 pub mod mock {
     pub use crate::components::store::MockStore;

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -36,6 +36,7 @@ pub struct Opt {
     pub ethereum_rpc: Vec<String>,
     pub ethereum_ws: Vec<String>,
     pub ethereum_ipc: Vec<String>,
+    pub unsafe_config: bool,
 }
 
 impl Default for Opt {
@@ -51,6 +52,7 @@ impl Default for Opt {
             ethereum_rpc: vec![],
             ethereum_ws: vec![],
             ethereum_ipc: vec![],
+            unsafe_config: false,
         }
     }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -7,6 +7,7 @@ use lazy_static::lazy_static;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::atomic;
 use std::time::Duration;
 use std::{collections::HashMap, env};
 use structopt::StructOpt;
@@ -112,6 +113,11 @@ async fn main() {
         "Graph Node version: {}",
         render_testament!(TESTAMENT)
     );
+
+    if opt.unsafe_config {
+        warn!(logger, "allowing unsafe configurations");
+        graph::env::UNSAFE_CONFIG.store(true, atomic::Ordering::SeqCst);
+    }
 
     let config = match Config::load(&logger, &opt.clone().into()) {
         Err(e) => {
@@ -853,6 +859,7 @@ mod test {
             ethereum_rpc: network_args,
             ethereum_ws: vec![],
             ethereum_ipc: vec![],
+            unsafe_config: false,
         };
 
         let config = Config::load(&logger, &opt).expect("can create config");

--- a/node/src/opt.rs
+++ b/node/src/opt.rs
@@ -198,6 +198,11 @@ pub struct Opt {
                 (e.g. 'ethereum/mainnet')."
     )]
     pub network_subgraphs: Vec<String>,
+    #[structopt(
+        long,
+        help = "Allows setting configurations that may result in incorrect Proofs of Indexing."
+    )]
+    pub unsafe_config: bool,
 }
 
 impl From<Opt> for config::Opt {
@@ -213,8 +218,10 @@ impl From<Opt> for config::Opt {
             ethereum_rpc,
             ethereum_ws,
             ethereum_ipc,
+            unsafe_config,
             ..
         } = opt;
+
         config::Opt {
             postgres_url,
             config,
@@ -226,6 +233,7 @@ impl From<Opt> for config::Opt {
             ethereum_rpc,
             ethereum_ws,
             ethereum_ipc,
+            unsafe_config,
         }
     }
 }


### PR DESCRIPTION
This would make setting the `GRAPH_ETH_CALL_GAS` env var a major footgun, but still it makes sense to keep it around for debugging purposes. So this introduces the `--unsafe-config` flag, which is required to be able to set `GRAPH_ETH_CALL_GAS` to anything different from the default value.

@otaviopace @azf20 