### PR TITLE
Add `subgraphs-for-deployment` explorer route

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1398,10 +1398,10 @@ pub trait StatusStore: Send + Sync + 'static {
     ) -> Result<(Option<String>, Option<String>), StoreError>;
 
     /// Support for the explorer-specific API. Returns a vector of (name, version) of all
-    /// deployments for a given subgraph hash.
-    fn deployments_for_subgraph_id(
+    /// subgraphs for a given deployment hash.
+    fn subgraphs_for_deployment_hash(
         &self,
-        subgraph_id: &str,
+        deployment_hash: &str,
     ) -> Result<Vec<(String, String)>, StoreError>;
 
     /// A value of None indicates that the table is not available. Re-deploying

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1397,6 +1397,13 @@ pub trait StatusStore: Send + Sync + 'static {
         subgraph_id: &str,
     ) -> Result<(Option<String>, Option<String>), StoreError>;
 
+    /// Support for the explorer-specific API. Returns a vector of (name, version) of all
+    /// deployments for a given subgraph hash.
+    fn deployments_for_subgraph_id(
+        &self,
+        subgraph_id: &str,
+    ) -> Result<Vec<(String, String)>, StoreError>;
+
     /// A value of None indicates that the table is not available. Re-deploying
     /// the subgraph fixes this. It is undesirable to force everything to
     /// re-sync from scratch, so existing deployments will continue without a

--- a/server/index-node/src/explorer.rs
+++ b/server/index-node/src/explorer.rs
@@ -103,6 +103,9 @@ where
             ["subgraph-version", version] => self.handle_subgraph_version(version),
             ["subgraph-repo", version] => self.handle_subgraph_repo(version),
             ["entity-count", deployment] => self.handle_entity_count(logger, deployment),
+            ["deployments-for-subgraph", subgraph_id] => {
+                self.handle_deployments_for_subgraph(subgraph_id)
+            }
             _ => handle_not_found(),
         }
     }
@@ -229,6 +232,25 @@ where
                 Ok(vi)
             }
         }
+    }
+
+    fn handle_deployments_for_subgraph(
+        &self,
+        subgraph_id: &str,
+    ) -> Result<Response<Body>, GraphQLServerError> {
+        let name_version_pairs: Vec<q::Value> = self
+            .store
+            .deployments_for_subgraph_id(subgraph_id)?
+            .into_iter()
+            .map(|(name, version)| {
+                object! {
+                    name: name,
+                    version: version
+                }
+            })
+            .collect();
+        let payload = q::Value::List(name_version_pairs);
+        Ok(as_http_response(&payload))
     }
 }
 

--- a/server/index-node/src/explorer.rs
+++ b/server/index-node/src/explorer.rs
@@ -103,8 +103,8 @@ where
             ["subgraph-version", version] => self.handle_subgraph_version(version),
             ["subgraph-repo", version] => self.handle_subgraph_repo(version),
             ["entity-count", deployment] => self.handle_entity_count(logger, deployment),
-            ["deployments-for-subgraph", subgraph_id] => {
-                self.handle_deployments_for_subgraph(subgraph_id)
+            ["subgraphs-for-deployment", deployment_hash] => {
+                self.handle_subgraphs_for_deployment(deployment_hash)
             }
             _ => handle_not_found(),
         }
@@ -234,13 +234,13 @@ where
         }
     }
 
-    fn handle_deployments_for_subgraph(
+    fn handle_subgraphs_for_deployment(
         &self,
-        subgraph_id: &str,
+        deployment_hash: &str,
     ) -> Result<Response<Body>, GraphQLServerError> {
         let name_version_pairs: Vec<q::Value> = self
             .store
-            .deployments_for_subgraph_id(subgraph_id)?
+            .subgraphs_for_deployment_hash(deployment_hash)?
             .into_iter()
             .map(|(name, version)| {
                 object! {

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1196,6 +1196,34 @@ impl<'a> Connection<'a> {
             .unwrap_or((None, None)))
     }
 
+    /// Returns all (deployment_name, version) pairs for a given subgraph id.
+    pub fn deployments_for_subgraph_id(
+        &self,
+        subgraph_id: &str,
+    ) -> Result<Vec<(String, String)>, StoreError> {
+        use subgraph as s;
+        use subgraph_version as v;
+        v::table
+            .inner_join(
+                s::table.on(v::id
+                    .nullable()
+                    .eq(s::current_version)
+                    .or(v::id.nullable().eq(s::pending_version))),
+            )
+            .filter(v::deployment.eq(&subgraph_id))
+            .select((
+                s::name,
+                sql::<Text>(
+                    "(case when subgraphs.subgraph.pending_version = subgraphs.subgraph_version.id then 'pending'
+                           when subgraphs.subgraph.current_version = subgraphs.subgraph_version.id then 'current'
+                           else 'unused'
+                     end) as version",
+                ),
+            ))
+            .get_results(self.conn.as_ref())
+            .map_err(Into::into)
+    }
+
     /// Find all deployments that are not in use and add them to the
     /// `unused_deployments` table. Only values that are available in the
     /// primary will be filled in `unused_deployments`

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1196,10 +1196,10 @@ impl<'a> Connection<'a> {
             .unwrap_or((None, None)))
     }
 
-    /// Returns all (deployment_name, version) pairs for a given subgraph id.
-    pub fn deployments_for_subgraph_id(
+    /// Returns all (subgraph_name, version) pairs for a given deployment hash.
+    pub fn subgraphs_by_deployment_hash(
         &self,
-        subgraph_id: &str,
+        deployment_hash: &str,
     ) -> Result<Vec<(String, String)>, StoreError> {
         use subgraph as s;
         use subgraph_version as v;
@@ -1210,7 +1210,7 @@ impl<'a> Connection<'a> {
                     .eq(s::current_version)
                     .or(v::id.nullable().eq(s::pending_version))),
             )
-            .filter(v::deployment.eq(&subgraph_id))
+            .filter(v::deployment.eq(&deployment_hash))
             .select((
                 s::name,
                 sql::<Text>(

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -108,6 +108,13 @@ impl StatusStore for Store {
         self.subgraph_store.versions_for_subgraph_id(subgraph_id)
     }
 
+    fn deployments_for_subgraph_id(
+        &self,
+        subgraph_id: &str,
+    ) -> Result<Vec<(String, String)>, StoreError> {
+        self.subgraph_store.deployments_for_subgraph_id(subgraph_id)
+    }
+
     fn get_proof_of_indexing<'a>(
         self: Arc<Self>,
         subgraph_id: &'a DeploymentHash,

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -108,11 +108,12 @@ impl StatusStore for Store {
         self.subgraph_store.versions_for_subgraph_id(subgraph_id)
     }
 
-    fn deployments_for_subgraph_id(
+    fn subgraphs_for_deployment_hash(
         &self,
-        subgraph_id: &str,
+        deployment_hash: &str,
     ) -> Result<Vec<(String, String)>, StoreError> {
-        self.subgraph_store.deployments_for_subgraph_id(subgraph_id)
+        self.subgraph_store
+            .subgraphs_for_deployment_hash(deployment_hash)
     }
 
     fn get_proof_of_indexing<'a>(

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -850,12 +850,12 @@ impl SubgraphStoreInner {
         primary.versions_for_subgraph_id(subgraph_id)
     }
 
-    pub(crate) fn deployments_for_subgraph_id(
+    pub(crate) fn subgraphs_for_deployment_hash(
         &self,
-        subgraph_id: &str,
+        deployment_hash: &str,
     ) -> Result<Vec<(String, String)>, StoreError> {
         let primary = self.primary_conn()?;
-        primary.deployments_for_subgraph_id(subgraph_id)
+        primary.subgraphs_by_deployment_hash(deployment_hash)
     }
 
     #[cfg(debug_assertions)]

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -847,8 +847,15 @@ impl SubgraphStoreInner {
         subgraph_id: &str,
     ) -> Result<(Option<String>, Option<String>), StoreError> {
         let primary = self.primary_conn()?;
-
         primary.versions_for_subgraph_id(subgraph_id)
+    }
+
+    pub(crate) fn deployments_for_subgraph_id(
+        &self,
+        subgraph_id: &str,
+    ) -> Result<Vec<(String, String)>, StoreError> {
+        let primary = self.primary_conn()?;
+        primary.deployments_for_subgraph_id(subgraph_id)
     }
 
     #[cfg(debug_assertions)]


### PR DESCRIPTION
This PR adds a new explorer HTTP endpoint for querying deployments for a given subgraph Qm-hash.  

The route is: `/explorer/deployments-for-subgraph/<Qm-hash`.

For example, the following request
```
HTTP GET host:8030/explorer/deployments-for-subgraph/QmTKXLEdMD6Vq7Nwxo8XAfnHpG6H1TzL1AGwiqLpoae3Pb
```
would be responded with a list of all subgraph names and their versions _(`current`, `pending` or `unused`)_ for that subgraph identifier:

```json
[
    {
        "name": "subgraph/name",
        "version": "current"
    }, 
    {
        "name": "another-subgraph/name",
        "version": "pending"
    }
]
```

