### PR TITLE
store: Improve the performance of BlockStore.chain_head_pointers

### DIFF
--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -1255,12 +1255,14 @@ impl ChainStore {
         })
     }
 
-    pub fn chain_head_pointers(&self) -> Result<HashMap<String, BlockPtr>, StoreError> {
+    pub fn chain_head_pointers(
+        conn: &PgConnection,
+    ) -> Result<HashMap<String, BlockPtr>, StoreError> {
         use public::ethereum_networks as n;
 
         let pointers: Vec<(String, BlockPtr)> = n::table
             .select((n::name, n::head_block_hash, n::head_block_number))
-            .load::<(String, Option<String>, Option<i64>)>(&self.get_conn()?)?
+            .load::<(String, Option<String>, Option<i64>)>(conn)?
             .into_iter()
             .filter_map(|(name, hash, number)| match (hash, number) {
                 (Some(hash), Some(number)) => Some((name, hash, number)),


### PR DESCRIPTION
This function is called a lot; each call to the indexing status API results
in a call to this function. This change improves two aspects of the
implementation:

* the function caused a `select * from ethereum_networks` for each chain;
  since that query returns the head for all networks in a shard, this query
  was run too often
* the function is called very frequently, even though the information only
  changes relatively rarely. The result is now cached for 2s to reduce the
  number of queries that need to be made

