### PR TITLE
store: When refreshing a layout, also account for a change in site

### DIFF
--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -303,7 +303,7 @@ impl ToSql<Integer, Pg> for DeploymentId {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 /// Details about a deployment and the shard in which it is stored. We need
 /// the database namespace for the deployment as that information is only
 /// stored in the primary database.


### PR DESCRIPTION
This can happen when a deployment is deleted and then recreated. Without
this change, the Layout would continue to refer to the old site, leading to
an error during querying or indexing.

