### PR TITLE
near: Minor cleanups

### DIFF
--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -105,12 +105,6 @@ impl TriggerFilter {
 }
 
 impl bc::TriggerFilter<Chain> for TriggerFilter {
-    fn from_data_sources<'a>(data_sources: impl Iterator<Item = &'a DataSource> + Clone) -> Self {
-        let mut this = Self::default();
-        this.extend(data_sources);
-        this
-    }
-
     fn extend<'a>(&mut self, data_sources: impl Iterator<Item = &'a DataSource> + Clone) {
         self.log
             .extend(EthereumLogFilter::from_data_sources(data_sources.clone()));

--- a/chain/near/src/adapter.rs
+++ b/chain/near/src/adapter.rs
@@ -11,12 +11,6 @@ pub struct TriggerFilter {
 }
 
 impl bc::TriggerFilter<Chain> for TriggerFilter {
-    fn from_data_sources<'a>(data_sources: impl Iterator<Item = &'a DataSource> + Clone) -> Self {
-        let mut this = Self::default();
-        this.extend(data_sources);
-        this
-    }
-
     fn extend<'a>(&mut self, data_sources: impl Iterator<Item = &'a DataSource> + Clone) {
         self.block
             .extend(NearBlockFilter::from_data_sources(data_sources));

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -211,16 +211,12 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
     async fn triggers_in_block(
         &self,
         _logger: &Logger,
-        block: NearBlock,
+        _block: NearBlock,
         _filter: &TriggerFilter,
     ) -> Result<BlockWithTriggers<Chain>, Error> {
-        let block_ptr = BlockPtr::from(&block);
-
-        // FIXME (NEAR): Share implementation with FirehoseMapper::triggers_in_block version
-        Ok(BlockWithTriggers {
-            block,
-            trigger_data: vec![NearTrigger::Block(block_ptr, NearBlockTriggerType::Every)],
-        })
+        // FIXME (NEAR): Share implementation with FirehoseMapper::firehose_triggers_in_block version.
+        // This is currently unreachable since Near does not yet support dynamic data sources.
+        todo!()
     }
 
     async fn is_on_main_chain(&self, _ptr: BlockPtr) -> Result<bool, Error> {


### PR DESCRIPTION
Remove `from_data_sources` implementations since they match the [default implementation](https://github.com/graphprotocol/graph-node/blob/391eb1f2634448f866516529bb9fd8bdc73827bd/graph/src/blockchain/mod.rs#L185). Remove code from `triggers_in_block` since it's duplicated from `firehose_triggers_in_block` and currently dead code.