### PR TITLE
blockchain, near: Remove near::MappingTrigger

### DIFF
--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -9,7 +9,6 @@ use graph::runtime::AscHeap;
 use graph::runtime::AscPtr;
 use graph::runtime::DeterministicHostError;
 use graph::semver::Version;
-use graph::slog::{o, SendSyncRefUnwindSafeKV};
 use std::convert::TryFrom;
 use std::ops::Deref;
 use std::{cmp::Ordering, sync::Arc};
@@ -20,9 +19,6 @@ use web3::types::U256;
 use web3::types::U64;
 use web3::types::{Address, Block, Log, Transaction, H256};
 
-use crate::data_source::MappingBlockHandler;
-use crate::data_source::MappingCallHandler;
-use crate::data_source::MappingEventHandler;
 use crate::runtime::abi::AscEthereumCall;
 use crate::runtime::abi::AscEthereumCall_0_0_3;
 use crate::runtime::abi::AscEthereumEvent;
@@ -38,7 +34,6 @@ pub enum MappingTrigger {
         transaction: Arc<Transaction>,
         log: Arc<Log>,
         params: Vec<LogParam>,
-        handler: MappingEventHandler,
     },
     Call {
         block: Arc<LightEthereumBlock>,
@@ -46,11 +41,9 @@ pub enum MappingTrigger {
         call: Arc<EthereumCall>,
         inputs: Vec<LogParam>,
         outputs: Vec<LogParam>,
-        handler: MappingCallHandler,
     },
     Block {
         block: Arc<LightEthereumBlock>,
-        handler: MappingBlockHandler,
     },
 }
 
@@ -63,18 +56,14 @@ impl std::fmt::Debug for MappingTrigger {
                 transaction: Arc<Transaction>,
                 log: Arc<Log>,
                 params: Vec<LogParam>,
-                handler: MappingEventHandler,
             },
             Call {
                 transaction: Arc<Transaction>,
                 call: Arc<EthereumCall>,
                 inputs: Vec<LogParam>,
                 outputs: Vec<LogParam>,
-                handler: MappingCallHandler,
             },
-            Block {
-                handler: MappingBlockHandler,
-            },
+            Block,
         }
 
         let trigger_without_block = match self {
@@ -83,12 +72,10 @@ impl std::fmt::Debug for MappingTrigger {
                 transaction,
                 log,
                 params,
-                handler,
             } => MappingTriggerWithoutBlock::Log {
                 transaction: transaction.cheap_clone(),
                 log: log.cheap_clone(),
                 params: params.clone(),
-                handler: handler.clone(),
             },
             MappingTrigger::Call {
                 block: _,
@@ -96,17 +83,13 @@ impl std::fmt::Debug for MappingTrigger {
                 call,
                 inputs,
                 outputs,
-                handler,
             } => MappingTriggerWithoutBlock::Call {
                 transaction: transaction.cheap_clone(),
                 call: call.cheap_clone(),
                 inputs: inputs.clone(),
                 outputs: outputs.clone(),
-                handler: handler.clone(),
             },
-            MappingTrigger::Block { block: _, handler } => MappingTriggerWithoutBlock::Block {
-                handler: handler.clone(),
-            },
+            MappingTrigger::Block { block: _ } => MappingTriggerWithoutBlock::Block,
         };
 
         write!(f, "{:?}", trigger_without_block)
@@ -114,28 +97,6 @@ impl std::fmt::Debug for MappingTrigger {
 }
 
 impl blockchain::MappingTrigger for MappingTrigger {
-    fn handler_name(&self) -> &str {
-        match self {
-            MappingTrigger::Log { handler, .. } => &handler.handler,
-            MappingTrigger::Call { handler, .. } => &handler.handler,
-            MappingTrigger::Block { handler, .. } => &handler.handler,
-        }
-    }
-
-    fn logging_extras(&self) -> Box<dyn SendSyncRefUnwindSafeKV> {
-        match self {
-            MappingTrigger::Log { handler, log, .. } => Box::new(o! {
-                "signature" => handler.event.to_string(),
-                "address" => format!("{}", &log.address),
-            }),
-            MappingTrigger::Call { handler, call, .. } => Box::new(o! {
-                "function" => handler.function.to_string(),
-                "to" => format!("{}", &call.to),
-            }),
-            MappingTrigger::Block { .. } => Box::new(o! {}),
-        }
-    }
-
     fn to_asc_ptr<H: AscHeap>(self, heap: &mut H) -> Result<AscPtr<()>, DeterministicHostError> {
         Ok(match self {
             MappingTrigger::Log {
@@ -143,7 +104,6 @@ impl blockchain::MappingTrigger for MappingTrigger {
                 transaction,
                 log,
                 params,
-                handler: _,
             } => {
                 if heap.api_version() >= Version::new(0, 0, 2) {
                     asc_new::<AscEthereumEvent<AscEthereumTransaction_0_0_2>, _, _>(
@@ -181,7 +141,6 @@ impl blockchain::MappingTrigger for MappingTrigger {
                 call,
                 inputs,
                 outputs,
-                handler: _,
             } => {
                 let call = EthereumCallData {
                     to: call.to,
@@ -197,7 +156,7 @@ impl blockchain::MappingTrigger for MappingTrigger {
                     asc_new::<AscEthereumCall, _, _>(heap, &call)?.erase()
                 }
             }
-            MappingTrigger::Block { block, handler: _ } => {
+            MappingTrigger::Block { block } => {
                 let block = EthereumBlockData::from(block.as_ref());
                 asc_new(heap, &block)?.erase()
             }

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 
 use crate::capabilities::NodeCapabilities;
 use crate::data_source::{DataSourceTemplate, UnresolvedDataSourceTemplate};
-use crate::trigger::{NearBlockTriggerType, NearTrigger};
+use crate::trigger::NearTrigger;
 use crate::RuntimeAdapter;
 use crate::{
     codec,
@@ -86,7 +86,7 @@ impl Blockchain for Chain {
 
     type TriggerData = crate::trigger::NearTrigger;
 
-    type MappingTrigger = crate::trigger::MappingTrigger;
+    type MappingTrigger = crate::trigger::NearTrigger;
 
     type TriggerFilter = crate::adapter::TriggerFilter;
 
@@ -328,11 +328,11 @@ impl FirehoseMapper {
                 .map(|v| H256::from_slice(&v.bytes.clone())),
             parent_number: header.prev_hash.as_ref().map(|_| header.prev_height),
         };
-        let block_ptr = BlockPtr::from(&near_block);
 
         Ok(BlockWithTriggers {
-            block: near_block,
-            trigger_data: vec![NearTrigger::Block(block_ptr, NearBlockTriggerType::Every)],
+            // TODO: Find the best place to introduce an `Arc` and avoid this clone.
+            block: near_block.clone(),
+            trigger_data: vec![NearTrigger::Block(Arc::new(near_block))],
         })
     }
 }

--- a/chain/near/src/lib.rs
+++ b/chain/near/src/lib.rs
@@ -12,7 +12,6 @@ pub use self::runtime::RuntimeAdapter;
 
 // ETHDEP: These concrete types should probably not be exposed.
 pub use data_source::{DataSource, DataSourceTemplate};
-pub use trigger::MappingTrigger;
 
 pub use crate::adapter::{NearAdapter as NearAdapterTrait, TriggerFilter};
 pub use crate::chain::Chain;

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -6,6 +6,7 @@ use anyhow::Error;
 use async_trait::async_trait;
 use futures::sync::mpsc;
 
+use crate::blockchain::TriggerWithHandler;
 use crate::prelude::*;
 use crate::{blockchain::Blockchain, components::subgraph::SharedProofOfIndexing};
 use crate::{components::metrics::HistogramVec, runtime::DeterministicHostError};
@@ -47,13 +48,13 @@ pub trait RuntimeHost<C: Blockchain>: Send + Sync + 'static {
         trigger: &C::TriggerData,
         block: Arc<C::Block>,
         logger: &Logger,
-    ) -> Result<Option<C::MappingTrigger>, Error>;
+    ) -> Result<Option<TriggerWithHandler<C>>, Error>;
 
     async fn process_mapping_trigger(
         &self,
         logger: &Logger,
         block_ptr: BlockPtr,
-        trigger: C::MappingTrigger,
+        trigger: TriggerWithHandler<C>,
         state: BlockState<C>,
         proof_of_indexing: SharedProofOfIndexing,
     ) -> Result<BlockState<C>, MappingError>;

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -5,9 +5,9 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use futures::sync::mpsc::Sender;
 use futures03::channel::oneshot::channel;
-use graph::blockchain::HostFn;
 use graph::blockchain::RuntimeAdapter;
-use graph::blockchain::{Blockchain, DataSource, MappingTrigger as _};
+use graph::blockchain::{Blockchain, DataSource};
+use graph::blockchain::{HostFn, TriggerWithHandler};
 use graph::components::store::SubgraphStore;
 use graph::components::subgraph::{MappingError, SharedProofOfIndexing};
 use graph::prelude::{
@@ -154,7 +154,7 @@ where
         &self,
         logger: &Logger,
         state: BlockState<C>,
-        trigger: C::MappingTrigger,
+        trigger: TriggerWithHandler<C>,
         block_ptr: BlockPtr,
         proof_of_indexing: SharedProofOfIndexing,
     ) -> Result<BlockState<C>, MappingError> {
@@ -216,7 +216,7 @@ impl<C: Blockchain> RuntimeHostTrait<C> for RuntimeHost<C> {
         trigger: &C::TriggerData,
         block: Arc<C::Block>,
         logger: &Logger,
-    ) -> Result<Option<C::MappingTrigger>, Error> {
+    ) -> Result<Option<TriggerWithHandler<C>>, Error> {
         self.data_source.match_and_decode(trigger, block, logger)
     }
 
@@ -224,7 +224,7 @@ impl<C: Blockchain> RuntimeHostTrait<C> for RuntimeHost<C> {
         &self,
         logger: &Logger,
         block_ptr: BlockPtr,
-        trigger: C::MappingTrigger,
+        trigger: TriggerWithHandler<C>,
         state: BlockState<C>,
         proof_of_indexing: SharedProofOfIndexing,
     ) -> Result<BlockState<C>, MappingError> {

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -1,7 +1,7 @@
 use crate::module::{ExperimentalFeatures, WasmInstance};
 use futures::sync::mpsc;
 use futures03::channel::oneshot::Sender;
-use graph::blockchain::{Blockchain, HostFn};
+use graph::blockchain::{Blockchain, HostFn, TriggerWithHandler};
 use graph::components::subgraph::{MappingError, SharedProofOfIndexing};
 use graph::prelude::*;
 use std::collections::BTreeMap;
@@ -97,7 +97,7 @@ pub fn spawn_module<C: Blockchain>(
 
 pub struct MappingRequest<C: Blockchain> {
     pub(crate) ctx: MappingContext<C>,
-    pub(crate) trigger: C::MappingTrigger,
+    pub(crate) trigger: TriggerWithHandler<C>,
     pub(crate) result_sender: Sender<Result<BlockState<C>, MappingError>>,
 }
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 use std::rc::Rc;
 use std::time::Instant;
 
-use graph::blockchain::{Blockchain, HostFnCtx, MappingTrigger};
+use graph::blockchain::{Blockchain, HostFnCtx, TriggerWithHandler};
 use graph::runtime::HostExportError;
 use never::Never;
 use semver::Version;
@@ -109,7 +109,7 @@ impl<C: Blockchain> WasmInstance<C> {
 
     pub(crate) fn handle_trigger(
         mut self,
-        trigger: C::MappingTrigger,
+        trigger: TriggerWithHandler<C>,
     ) -> Result<BlockState<C>, MappingError> {
         let handler_name = trigger.handler_name().to_owned();
         let asc_trigger = trigger.to_asc_ptr(&mut self)?;


### PR DESCRIPTION
The distinction between TriggerData and MappingTrigger seems mostly accidental, this moves towards unification by making them both NearTrigger for Near.

This is done by adding a TriggerWithHandler, which is a reusable type that carries most MappingTrigger responsibilities. This ended up also simplifying the ethereum MappingTrigger a bit, which we eventually may also unify with the TriggerData.

This also removes `NearBlockTriggerType`, its analogous to how ethereum does it but that doesn't make much sense to me either, it seems more logical that TriggerData should carry only the payload for the trigger rather than filtering information from the data source.

