### PR TITLE
Fix prefetching bug when selecting by specific attributes: allow `orderBy` 

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1806,6 +1806,14 @@ impl AttributeNames {
         self.insert(&field.name)
     }
 
+    pub fn update_str(&mut self, field_name: &str) {
+        // ignore "meta" field names
+        if field_name.starts_with("__") {
+            return;
+        }
+        self.insert(field_name);
+    }
+
     pub fn extend(&mut self, other: Self) {
         use AttributeNames::*;
         match (self, other) {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1799,7 +1799,7 @@ impl AttributeNames {
     }
 
     /// Adds a attribute name. Ignores meta fields.
-    pub fn update(&mut self, field: &q::Field) {
+    pub fn add(&mut self, field: &q::Field) {
         if Self::is_meta_field(&field.name) {
             return;
         }
@@ -1807,7 +1807,7 @@ impl AttributeNames {
     }
 
     /// Adds a attribute name. Ignores meta fields.
-    pub fn update_str(&mut self, field_name: &str) {
+    pub fn add_str(&mut self, field_name: &str) {
         if Self::is_meta_field(field_name) {
             return;
         }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1799,19 +1799,22 @@ impl AttributeNames {
     }
 
     pub fn update(&mut self, field: &q::Field) {
-        // ignore "meta" field names
-        if field.name.starts_with("__") {
+        if Self::is_meta_field(&field.name) {
             return;
         }
         self.insert(&field.name)
     }
 
     pub fn update_str(&mut self, field_name: &str) {
-        // ignore "meta" field names
-        if field_name.starts_with("__") {
+        if Self::is_meta_field(field_name) {
             return;
         }
         self.insert(field_name);
+    }
+
+    /// Returns `true` for meta field names, `false` otherwise.
+    fn is_meta_field(field_name: &str) -> bool {
+        field_name.starts_with("__")
     }
 
     pub fn extend(&mut self, other: Self) {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1785,7 +1785,7 @@ pub enum AttributeNames {
 }
 
 impl AttributeNames {
-    pub fn insert(&mut self, column_name: &str) {
+    fn insert(&mut self, column_name: &str) {
         match self {
             AttributeNames::All => {
                 let mut set = BTreeSet::new();
@@ -1798,6 +1798,7 @@ impl AttributeNames {
         }
     }
 
+    /// Adds a attribute name. Ignores meta fields.
     pub fn update(&mut self, field: &q::Field) {
         if Self::is_meta_field(&field.name) {
             return;
@@ -1805,6 +1806,7 @@ impl AttributeNames {
         self.insert(&field.name)
     }
 
+    /// Adds a attribute name. Ignores meta fields.
     pub fn update_str(&mut self, field_name: &str) {
         if Self::is_meta_field(field_name) {
             return;

--- a/graph/src/data/graphql/object_or_interface.rs
+++ b/graph/src/data/graphql/object_or_interface.rs
@@ -1,5 +1,6 @@
 use crate::prelude::Schema;
 use crate::{components::store::EntityType, prelude::s};
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 use std::mem;
@@ -29,6 +30,24 @@ impl<'a> Hash for ObjectOrInterface<'a> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         mem::discriminant(self).hash(state);
         self.name().hash(state)
+    }
+}
+
+impl<'a> PartialOrd for ObjectOrInterface<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'a> Ord for ObjectOrInterface<'a> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use ObjectOrInterface::*;
+        match (self, other) {
+            (Object(a), Object(b)) => a.name.cmp(&b.name),
+            (Interface(a), Interface(b)) => a.name.cmp(&b.name),
+            (Interface(_), Object(_)) => Ordering::Less,
+            (Object(_), Interface(_)) => Ordering::Greater,
+        }
     }
 }
 

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -81,6 +81,7 @@ pub enum QueryExecutionError {
     SubgraphManifestResolveError(Arc<SubgraphManifestResolveError>),
     InvalidSubgraphManifest,
     ResultTooBig(usize, usize),
+    UnusedComplementaryField(String, String),
 }
 
 impl QueryExecutionError {
@@ -279,6 +280,7 @@ impl fmt::Display for QueryExecutionError {
             SubgraphManifestResolveError(e) => write!(f, "failed to resolve subgraph manifest: {}", e),
             InvalidSubgraphManifest => write!(f, "invalid subgraph manifest file"),
             ResultTooBig(actual, limit) => write!(f, "the result size of {} is larger than the allowed limit of {}", actual, limit),
+            UnusedComplementaryField(parent, field) => write!(f, "Complementary field \"{}\" was not prefetched by its parent: {}",field, parent),
         }
     }
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -81,7 +81,6 @@ pub enum QueryExecutionError {
     SubgraphManifestResolveError(Arc<SubgraphManifestResolveError>),
     InvalidSubgraphManifest,
     ResultTooBig(usize, usize),
-    UnusedComplementaryField(String, String),
 }
 
 impl QueryExecutionError {
@@ -280,7 +279,6 @@ impl fmt::Display for QueryExecutionError {
             SubgraphManifestResolveError(e) => write!(f, "failed to resolve subgraph manifest: {}", e),
             InvalidSubgraphManifest => write!(f, "invalid subgraph manifest file"),
             ResultTooBig(actual, limit) => write!(f, "the result size of {} is larger than the allowed limit of {}", actual, limit),
-            UnusedComplementaryField(parent, field) => write!(f, "Complementary field \"{}\" was not prefetched by its parent: {}",field, parent),
         }
     }
 }

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -1174,7 +1174,7 @@ fn filter_derived_fields(
                         None // field does not exist
                     }
                 })
-                .for_each(|col| filtered.insert(&col));
+                .for_each(|col| filtered.update_str(&col));
             filtered
         }
     }

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -48,7 +48,7 @@ lazy_static! {
 }
 
 type GroupedFieldSet<'a> = IndexMap<&'a str, CollectedResponseKey<'a>>;
-type ComplementaryFields<'a> = Vec<(ObjectOrInterface<'a>, String)>;
+type ComplementaryFields<'a> = BTreeMap<ObjectOrInterface<'a>, String>;
 
 /// An `ObjectType` with `Hash` and `Eq` derived from the name.
 #[derive(Clone, Debug)]
@@ -905,10 +905,10 @@ fn collect_fields_inner<'a>(
                         ));
                     match arguments {
                         graphql_parser::schema::Value::Enum(complementary_field_name) => {
-                            complementary_fields.push((
+                            complementary_fields.insert(
                                 object_or_interface_for_field,
                                 complementary_field_name.clone(),
-                            ));
+                            );
                         }
                         _ => unimplemented!("unsure on what to do about other variants"),
                     }

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -684,14 +684,16 @@ fn execute_selection_set<'a>(
 
     // Confidence check: all complementary fields must be used, otherwise constructed SQL queries
     // will be malformed.
-    complementary_fields
-        .into_iter()
-        .for_each(|(parent, complementary_field)| {
-            errors.push(QueryExecutionError::UnusedComplementaryField(
-                parent.name().to_string(),
-                complementary_field,
-            ))
-        });
+    if !*DISABLE_EXPERIMENTAL_FEATURE_SELECT_BY_SPECIFIC_ATTRIBUTE_NAMES {
+        complementary_fields
+            .into_iter()
+            .for_each(|(parent, complementary_field)| {
+                errors.push(QueryExecutionError::UnusedComplementaryField(
+                    parent.name().to_string(),
+                    complementary_field,
+                ))
+            });
+    }
 
     if errors.is_empty() {
         Ok(parents)

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -682,8 +682,8 @@ fn execute_selection_set<'a>(
         }
     }
 
-    // Confidence check: all complementary fields must be used, otherwise constructed SQL queries
-    // will be malformed.
+    // Confidence check: all complementary fields must be consumed, otherwise constructed SQL
+    // queries will be malformed.
     if !*DISABLE_EXPERIMENTAL_FEATURE_SELECT_BY_SPECIFIC_ATTRIBUTE_NAMES {
         complementary_fields
             .into_iter()

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -23,7 +23,7 @@ use graph::{
 };
 
 use crate::execution::{ExecutionContext, Resolver};
-use crate::query::ast as qast;
+use crate::query::ast::{self as qast, get_argument_value};
 use crate::runner::ResultSizeMetrics;
 use crate::schema::ast as sast;
 use crate::store::{build_query, StoreResolver};
@@ -48,6 +48,7 @@ lazy_static! {
 }
 
 type GroupedFieldSet<'a> = IndexMap<&'a str, CollectedResponseKey<'a>>;
+type ComplementaryFields<'a> = Vec<(ObjectOrInterface<'a>, String)>;
 
 /// An `ObjectType` with `Hash` and `Eq` derived from the name.
 #[derive(Clone, Debug)]
@@ -555,10 +556,17 @@ fn execute_root_selection_set(
 ) -> Result<Vec<Node>, Vec<QueryExecutionError>> {
     // Obtain the root Query type and fail if there isn't one
     let query_type = ctx.query.schema.query_type.as_ref().into();
-    let grouped_field_set = collect_fields(ctx, query_type, once(selection_set));
+    let (grouped_field_set, _complementary_fields) =
+        collect_fields(ctx, query_type, once(selection_set));
 
     // Execute the root selection set against the root query type
-    execute_selection_set(resolver, ctx, make_root_node(), grouped_field_set)
+    execute_selection_set(
+        resolver,
+        ctx,
+        make_root_node(),
+        grouped_field_set,
+        ComplementaryFields::new(),
+    )
 }
 
 fn check_result_size(logger: &Logger, size: usize) -> Result<(), QueryExecutionError> {
@@ -576,6 +584,7 @@ fn execute_selection_set<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     mut parents: Vec<Node>,
     grouped_field_set: GroupedFieldSet<'a>,
+    complementary_fields: ComplementaryFields,
 ) -> Result<Vec<Node>, Vec<QueryExecutionError>> {
     let schema = &ctx.query.schema;
     let mut errors: Vec<QueryExecutionError> = Vec::new();
@@ -619,7 +628,7 @@ fn execute_selection_set<'a>(
                 &field.name,
             );
             // Group fields with the same response key, so we can execute them together
-            let mut grouped_field_set =
+            let (mut grouped_field_set, new_complementary_fields) =
                 collect_fields(ctx, child_type, fields.iter().map(|f| &f.selection_set));
 
             // "Select by Specific Attribute Names" is an experimental feature and can be disabled completely.
@@ -630,8 +639,11 @@ fn execute_selection_set<'a>(
                 if *DISABLE_EXPERIMENTAL_FEATURE_SELECT_BY_SPECIFIC_ATTRIBUTE_NAMES {
                     BTreeMap::new()
                 } else {
-                    CollectedAttributeNames::consolidate_column_names(&mut grouped_field_set)
-                        .resolve_interfaces(&ctx.query.schema.types_for_interface())
+                    let mut collected =
+                        CollectedAttributeNames::consolidate_column_names(&mut grouped_field_set);
+                    collected.populate_complementary_fields(&complementary_fields);
+                    collected.resolve_interfaces(&ctx.query.schema.types_for_interface())
+                    // )
                 };
 
             match execute_field(
@@ -645,7 +657,13 @@ fn execute_selection_set<'a>(
                 collected_columns,
             ) {
                 Ok(children) => {
-                    match execute_selection_set(resolver, ctx, children, grouped_field_set) {
+                    match execute_selection_set(
+                        resolver,
+                        ctx,
+                        children,
+                        grouped_field_set,
+                        new_complementary_fields,
+                    ) {
                         Ok(children) => {
                             Join::perform(&mut parents, children, response_key);
                             let weight =
@@ -722,7 +740,7 @@ impl<'a> CollectedResponseKey<'a> {
         // collect the column name if field exists in schema
         if schema_field.is_some() {
             self.collected_column_names
-                .update(object_or_interface, &field)
+                .update(object_or_interface, &field);
         }
     }
 }
@@ -755,8 +773,9 @@ fn collect_fields<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     parent_ty: ObjectOrInterface<'a>,
     selection_sets: impl Iterator<Item = &'a q::SelectionSet>,
-) -> GroupedFieldSet<'a> {
+) -> (GroupedFieldSet<'a>, ComplementaryFields<'a>) {
     let mut grouped_fields = IndexMap::new();
+    let mut complementary_fields = ComplementaryFields::new();
 
     for selection_set in selection_sets {
         collect_fields_inner(
@@ -765,6 +784,7 @@ fn collect_fields<'a>(
             selection_set,
             &mut HashSet::new(),
             &mut grouped_fields,
+            &mut complementary_fields,
         );
     }
 
@@ -778,7 +798,7 @@ fn collect_fields<'a>(
         }
     }
 
-    grouped_fields
+    (grouped_fields, complementary_fields)
 }
 
 // When querying an object type, `type_condition` will always be that object type, even if it passes
@@ -792,6 +812,7 @@ fn collect_fields_inner<'a>(
     selection_set: &'a q::SelectionSet,
     visited_fragments: &mut HashSet<&'a str>,
     output: &mut GroupedFieldSet<'a>,
+    complementary_fields: &mut ComplementaryFields<'a>,
 ) {
     fn collect_fragment<'a>(
         ctx: &'a ExecutionContext<impl Resolver>,
@@ -800,6 +821,7 @@ fn collect_fields_inner<'a>(
         frag_selection_set: &'a q::SelectionSet,
         visited_fragments: &mut HashSet<&'a str>,
         output: &mut GroupedFieldSet<'a>,
+        complementary_fields: &mut ComplementaryFields<'a>,
     ) {
         let schema = &ctx.query.schema.document();
         let fragment_ty = match frag_ty_condition {
@@ -820,6 +842,7 @@ fn collect_fields_inner<'a>(
                 &frag_selection_set,
                 visited_fragments,
                 output,
+                complementary_fields,
             );
         } else {
             // This is an interface fragment in the root selection for an interface.
@@ -842,6 +865,7 @@ fn collect_fields_inner<'a>(
                     &frag_selection_set,
                     visited_fragments,
                     output,
+                    complementary_fields,
                 );
             }
         }
@@ -863,6 +887,32 @@ fn collect_fields_inner<'a>(
                     type_condition,
                     field,
                 );
+                if let Some(arguments) = get_argument_value(&field.arguments, "orderBy") {
+                    let schema_field = type_condition.field(&field.name).expect(&format!(
+                        "the field {:?} to exist in {:?}",
+                        &field.name,
+                        &type_condition.name()
+                    ));
+                    let field_name = sast::get_field_name(&schema_field.field_type);
+                    let object_or_interface_for_field = ctx
+                        .query
+                        .schema
+                        .document()
+                        .object_or_interface(&field_name)
+                        .expect(&format!(
+                            "The field {:?} to exist in the Document",
+                            field_name
+                        ));
+                    match arguments {
+                        graphql_parser::schema::Value::Enum(complementary_field_name) => {
+                            complementary_fields.push((
+                                object_or_interface_for_field,
+                                complementary_field_name.clone(),
+                            ));
+                        }
+                        _ => unimplemented!("unsure on what to do about other variants"),
+                    }
+                }
             }
 
             q::Selection::FragmentSpread(spread) => {
@@ -878,6 +928,7 @@ fn collect_fields_inner<'a>(
                         &fragment.selection_set,
                         visited_fragments,
                         output,
+                        complementary_fields,
                     );
                 }
             }
@@ -890,6 +941,7 @@ fn collect_fields_inner<'a>(
                     &fragment.selection_set,
                     visited_fragments,
                     output,
+                    complementary_fields,
                 );
             }
         }
@@ -1000,6 +1052,29 @@ impl<'a> CollectedAttributeNames<'a> {
             .entry(object_or_interface)
             .or_insert(AttributeNames::All)
             .update(field);
+    }
+
+    fn populate_complementary_fields(&mut self, complementary_fields: &ComplementaryFields) {
+        for (parent_field, complementary_field_name) in complementary_fields.iter() {
+            let mut matched = false;
+            dbg!(&parent_field, &complementary_field_name); // "tokens", "price"
+            for (object_or_interface, selected_attributes) in self.0.iter_mut() {
+                dbg!(object_or_interface.name()); // "Token"
+
+                // ALRIGHT, at this moment we have the following:
+                // "Token" waiting to receive new fields
+                // "tokens" signaling the new field "price"
+
+                if object_or_interface == parent_field {
+                    matched = true;
+                    selected_attributes.update_str(&complementary_field_name)
+                }
+            }
+            assert!(
+                matched,
+                "Some complementary field did not found its way to its parent field"
+            );
+        }
     }
 
     /// Consume this instance and transform it into a mapping from

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -755,7 +755,7 @@ impl<'a> CollectedResponseKey<'a> {
         // collect the column name if field exists in schema
         if schema_field.is_some() {
             self.collected_column_names
-                .update(object_or_interface, &field);
+                .update(object_or_interface, &field)
         }
     }
 }

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -902,6 +902,8 @@ fn collect_fields_inner<'a>(
                     type_condition,
                     field,
                 );
+
+                // Collect complementary fields used in the `orderBy` query attribute, if present.
                 if let Some(arguments) = get_argument_value(&field.arguments, "orderBy") {
                     let schema_field = type_condition.field(&field.name).expect(&format!(
                         "the field {:?} to exist in {:?}",
@@ -1069,8 +1071,8 @@ impl<'a> CollectedAttributeNames<'a> {
             .update(field);
     }
 
-    /// Injects complementary fields (collected in upper hierarchical levels of the query) into
-    /// self.
+    /// Injects complementary fields that were collected priviously in upper hierarchical levels of
+    /// the query into `self`.
     fn populate_complementary_fields(
         &mut self,
         complementary_fields: &mut ComplementaryFields<'a>,

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -1068,7 +1068,7 @@ impl<'a> CollectedAttributeNames<'a> {
         self.0
             .entry(object_or_interface)
             .or_insert(AttributeNames::All)
-            .update(field);
+            .add(field);
     }
 
     /// Injects complementary fields that were collected priviously in upper hierarchical levels of
@@ -1081,7 +1081,7 @@ impl<'a> CollectedAttributeNames<'a> {
             if let Some(complementary_field_name) =
                 complementary_fields.remove(&object_or_interface)
             {
-                selected_attributes.update_str(&complementary_field_name)
+                selected_attributes.add_str(&complementary_field_name)
             }
         }
     }
@@ -1174,7 +1174,7 @@ fn filter_derived_fields(
                         None // field does not exist
                     }
                 })
-                .for_each(|col| filtered.update_str(&col));
+                .for_each(|col| filtered.add_str(&col));
             filtered
         }
     }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1609,6 +1609,14 @@ impl<'a> FilterWindow<'a> {
             column_names,
         } = window;
         let table = layout.table_for_entity(&child_type).map(|rc| rc.as_ref())?;
+
+        // Confidence check: ensure that all selected column names exist in the table
+        if let AttributeNames::Select(ref selected_field_names) = column_names {
+            for field in selected_field_names {
+                let _ = table.column_for_field(&field)?;
+            }
+        }
+
         let query_filter = query_filter
             .map(|filter| QueryFilter::new(filter, table))
             .transpose()?;
@@ -2927,9 +2935,8 @@ fn iter_column_names<'a, 'b>(
     attribute_names
         .iter()
         .map(|attribute_name| {
-            table
-                .column_for_field(attribute_name.as_str())
-                .expect("a column for this field")
+            // Unwrapping: We have already checked that all attribute names exist in table
+            table.column_for_field(attribute_name).unwrap()
         })
         .map(|column| column.name.as_str())
         .chain(BASE_SQL_COLUMNS.iter().copied())

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -12,7 +12,6 @@ use diesel::result::{Error as DieselError, QueryResult};
 use diesel::sql_types::{Array, BigInt, Binary, Bool, Integer, Jsonb, Range, Text};
 use diesel::Connection;
 use lazy_static::lazy_static;
-use std::borrow::Cow;
 
 use graph::prelude::{
     anyhow, r, serde_json, Attribute, BlockNumber, ChildMultiplicity, Entity, EntityCollection,

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -12,6 +12,7 @@ use diesel::result::{Error as DieselError, QueryResult};
 use diesel::sql_types::{Array, BigInt, Binary, Bool, Integer, Jsonb, Range, Text};
 use diesel::Connection;
 use lazy_static::lazy_static;
+use std::borrow::Cow;
 
 use graph::prelude::{
     anyhow, r, serde_json, Attribute, BlockNumber, ChildMultiplicity, Entity, EntityCollection,
@@ -90,7 +91,7 @@ lazy_static! {
 
     /// Those are columns that we always want to fetch from the database.
     static ref BASE_SQL_COLUMNS: BTreeSet<String> =
-        ["id"].iter().map(ToString::to_string).collect();
+        ["id", "vid"].iter().map(ToString::to_string).collect();
 }
 
 #[derive(Debug)]
@@ -2877,10 +2878,16 @@ fn write_column_names(
                 .union(&BASE_SQL_COLUMNS)
                 .into_iter()
                 .map(|column_name| {
-                    &table
-                        .column_for_field(&column_name)
-                        .expect("failed to find column for field")
-                        .name
+                    if BASE_SQL_COLUMNS.contains(column_name) {
+                        Cow::Owned(SqlName::verbatim(column_name.to_owned()))
+                    } else {
+                        Cow::Borrowed(
+                            &table
+                                .column_for_field(&column_name)
+                                .expect("failed to find column for field")
+                                .name,
+                        )
+                    }
                 })
                 .peekable();
             while let Some(column_name) = iterator.next() {
@@ -2912,10 +2919,16 @@ fn jsonb_build_object(
                 .union(&BASE_SQL_COLUMNS)
                 .into_iter()
                 .map(|column_name| {
-                    &table
-                        .column_for_field(&column_name)
-                        .expect("failed to find column for field")
-                        .name
+                    if BASE_SQL_COLUMNS.contains(column_name) {
+                        Cow::Owned(SqlName::verbatim(column_name.to_owned()))
+                    } else {
+                        Cow::Borrowed(
+                            &table
+                                .column_for_field(&column_name)
+                                .expect("failed to find column for field")
+                                .name,
+                        )
+                    }
                 })
                 .peekable();
             while let Some(column_name) = iterator.next() {


### PR DESCRIPTION

This fixes errors in prefetching phase for queries that orders the selection set with the `orderBy` attribute.

The changes rely on complementing the selection set with the fields used for ordering. The problematic part is that each visited selection set is unaware of those ordering fields due to them not being in the scope during the recursive invocations of the `execute_selection_set` function.

This led to malformed SQL queries that tried to `ORDER BY` columns that were not being selected in sub-queries.

The solution presented here was to pass those complementary fields as arguments along with the recursive traversal and injecting them into their respective selection sets.
