### PR TITLE
runtime: Improved performance of `to_asc_bytes` implementation of AscType derive macro

### DIFF
--- a/runtime/derive/src/lib.rs
+++ b/runtime/derive/src/lib.rs
@@ -69,11 +69,12 @@ fn asc_type_derive_struct(item_struct: ItemStruct) -> TokenStream {
     TokenStream::from(quote! {
         impl#impl_generics AscType for #struct_name#ty_generics #where_clause {
             fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
-               let mut bytes = Vec::new();
+                let in_memory_byte_count = std::mem::size_of::<Self>();
+                let mut bytes = Vec::with_capacity(in_memory_byte_count);
                 #(bytes.extend_from_slice(&self.#field_names.to_asc_bytes()?);)*
 
                 // Assert that the struct has no padding.
-                assert_eq!(bytes.len(), std::mem::size_of::<Self>());
+                assert_eq!(bytes.len(), in_memory_byte_count);
                 Ok(bytes)
             }
 


### PR DESCRIPTION
Currently to serialize a structure to a bytes buffer, we start with an empty buffer, extend it multiple time, one for each field of the struct and then checking that the byte count is equal to the memory size of struct in Rust memory. This creates N allocations, N being determined on the implementation of `extend_from_slice` but at worst could be `len(fields)`.

Since we know the size of bytes required in advanced, we should instead directly allocate the right amount of bytes. This will remove some useless allocations and should improve performances.

