### PR TITLE
runtime: Don't unwrap the result of `_start`

### DIFF
--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -537,8 +537,7 @@ impl<C: Blockchain> WasmInstance<C> {
                     .get_func("_start")
                     .context("`_start` function not found")?
                     .typed::<(), ()>()?
-                    .call(())
-                    .unwrap();
+                    .call(())?;
             }
         }
 


### PR DESCRIPTION
It can panic if there is a trap when initializing an AS global variable.