### PR TITLE
all: Use our own Value enum instead of graphql_parser's Value

### DIFF
--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -2,7 +2,6 @@
 
 use pretty_assertions::assert_eq;
 
-use graph::prelude::q;
 use graph::{components::store::EntityType, data::graphql::object};
 use graph::{data::query::QueryTarget, prelude::*};
 use test_store::*;
@@ -90,7 +89,7 @@ async fn one_interface_one_entity() {
     let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
-        "Object({\"leggeds\": List([Object({\"legs\": Int(Number(3))})])})"
+        "Object({\"leggeds\": List([Object({\"legs\": Int(3)})])})"
     );
 
     // Query by ID.
@@ -101,7 +100,7 @@ async fn one_interface_one_entity() {
     let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
-        "Object({\"legged\": Object({\"legs\": Int(Number(3))})})",
+        "Object({\"legged\": Object({\"legs\": Int(3)})})",
     );
 }
 
@@ -153,7 +152,7 @@ async fn one_interface_multiple_entities() {
     let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
-        "Object({\"leggeds\": List([Object({\"legs\": Int(Number(3))}), Object({\"legs\": Int(Number(4))})])})"
+        "Object({\"leggeds\": List([Object({\"legs\": Int(3)}), Object({\"legs\": Int(4)})])})"
     );
 
     // Test for support issue #32.
@@ -164,7 +163,7 @@ async fn one_interface_multiple_entities() {
     let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
-        "Object({\"legged\": Object({\"legs\": Int(Number(4))})})",
+        "Object({\"legged\": Object({\"legs\": Int(4)})})",
     );
 }
 
@@ -427,7 +426,7 @@ async fn two_interfaces() {
     let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
-        "Object({\"ibars\": List([Object({\"bar\": Int(Number(100))}), Object({\"bar\": Int(Number(200))})]), \
+        "Object({\"ibars\": List([Object({\"bar\": Int(100)}), Object({\"bar\": Int(200)})]), \
                  \"ifoos\": List([Object({\"foo\": String(\"bla\")}), Object({\"foo\": String(\"ble\")})])})"
     );
 }
@@ -466,7 +465,7 @@ async fn interface_non_inline_fragment() {
     let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
-        r#"Object({"leggeds": List([Object({"legs": Int(Number(3)), "name": String("cow")})])})"#,
+        r#"Object({"leggeds": List([Object({"legs": Int(3), "name": String("cow")})])})"#,
     );
 }
 
@@ -502,7 +501,7 @@ async fn interface_inline_fragment() {
     let data = extract_data!(res).unwrap();
     assert_eq!(
         format!("{:?}", data),
-        r#"Object({"leggeds": List([Object({"airspeed": Int(Number(24))}), Object({"name": String("cow")})])})"#
+        r#"Object({"leggeds": List([Object({"airspeed": Int(24)}), Object({"name": String("cow")})])})"#
     );
 }
 
@@ -572,11 +571,11 @@ async fn interface_inline_fragment_with_subquery() {
         "Object({\
          \"leggeds\": List([\
          Object({\
-         \"airspeed\": Int(Number(5)), \
-         \"legs\": Int(Number(2)), \
+         \"airspeed\": Int(5), \
+         \"legs\": Int(2), \
          \"parent\": Object({\"id\": String(\"mama_bird\")})\
          }), \
-         Object({\"legs\": Int(Number(4))})\
+         Object({\"legs\": Int(4)})\
          ])\
          })"
     );
@@ -738,7 +737,7 @@ async fn fragments_dont_panic() {
                     }
                 },
                 object! {
-                    child: q::Value::Null
+                    child: r::Value::Null
                 }
             ]
         }
@@ -809,7 +808,7 @@ async fn fragments_dont_duplicate_data() {
         object! {
             parents: vec![
                 object! {
-                    children: Vec::<q::Value>::new()
+                    children: Vec::<r::Value>::new()
                 },
                 object! {
                     children: vec![
@@ -872,7 +871,7 @@ async fn redundant_fields() {
                     },
                 },
                 object! {
-                    parent: q::Value::Null
+                    parent: r::Value::Null
                 }
             ]
         }
@@ -1247,7 +1246,7 @@ async fn nested_interface_fragments_overlapping() {
 
 #[tokio::test]
 async fn enums() {
-    use graphql_parser::query::Value::Enum;
+    use r::Value::Enum;
     let subgraph_id = "enums";
     let schema = r#"
        enum Direction {
@@ -1307,7 +1306,7 @@ async fn enums() {
 
 #[tokio::test]
 async fn enum_list_filters() {
-    use graphql_parser::query::Value::Enum;
+    use r::Value::Enum;
     let subgraph_id = "enum_list_filters";
     let schema = r#"
        enum Direction {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1370,7 +1370,7 @@ pub trait QueryStore: Send + Sync {
     fn find_query_values(
         &self,
         query: EntityQuery,
-    ) -> Result<Vec<BTreeMap<String, q::Value>>, QueryExecutionError>;
+    ) -> Result<Vec<BTreeMap<String, r::Value>>, QueryExecutionError>;
 
     async fn is_deployment_synced(&self) -> Result<bool, Error>;
 

--- a/graph/src/data/graphql/object_macro.rs
+++ b/graph/src/data/graphql/object_macro.rs
@@ -1,62 +1,70 @@
-use crate::prelude::q::{self, Number};
+use crate::prelude::q;
+use crate::prelude::r;
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
 
 /// Creates a `graphql_parser::query::Value::Object` from key/value pairs.
 /// If you don't need to determine which keys are included dynamically at runtime
 /// consider using the `object! {}` macro instead.
-pub fn object_value(data: Vec<(&str, q::Value)>) -> q::Value {
-    q::Value::Object(BTreeMap::from_iter(
+pub fn object_value(data: Vec<(&str, r::Value)>) -> r::Value {
+    r::Value::Object(BTreeMap::from_iter(
         data.into_iter().map(|(k, v)| (k.to_string(), v)),
     ))
 }
 
 pub trait IntoValue {
-    fn into_value(self) -> q::Value;
+    fn into_value(self) -> r::Value;
 }
 
-impl IntoValue for q::Value {
+impl IntoValue for r::Value {
     #[inline]
-    fn into_value(self) -> q::Value {
+    fn into_value(self) -> r::Value {
         self
     }
 }
 
 impl IntoValue for &'_ str {
     #[inline]
-    fn into_value(self) -> q::Value {
+    fn into_value(self) -> r::Value {
         self.to_owned().into_value()
     }
 }
 
 impl IntoValue for i32 {
     #[inline]
-    fn into_value(self) -> q::Value {
-        q::Value::Int(q::Number::from(self))
+    fn into_value(self) -> r::Value {
+        r::Value::Int(self as i64)
+    }
+}
+
+impl IntoValue for q::Number {
+    #[inline]
+    fn into_value(self) -> r::Value {
+        r::Value::Int(self.as_i64().unwrap())
     }
 }
 
 impl IntoValue for u64 {
     #[inline]
-    fn into_value(self) -> q::Value {
-        q::Value::String(self.to_string())
+    fn into_value(self) -> r::Value {
+        r::Value::String(self.to_string())
     }
 }
 
 impl<T: IntoValue> IntoValue for Option<T> {
     #[inline]
-    fn into_value(self) -> q::Value {
+    fn into_value(self) -> r::Value {
         match self {
             Some(v) => v.into_value(),
-            None => q::Value::Null,
+            None => r::Value::Null,
         }
     }
 }
 
 impl<T: IntoValue> IntoValue for Vec<T> {
     #[inline]
-    fn into_value(self) -> q::Value {
-        q::Value::List(self.into_iter().map(|e| e.into_value()).collect::<Vec<_>>())
+    fn into_value(self) -> r::Value {
+        r::Value::List(self.into_iter().map(|e| e.into_value()).collect::<Vec<_>>())
     }
 }
 
@@ -65,20 +73,15 @@ macro_rules! impl_into_values {
         $(
             impl IntoValue for $T {
                 #[inline]
-                fn into_value(self) -> q::Value {
-                    q::Value::$V(self)
+                fn into_value(self) -> r::Value {
+                    r::Value::$V(self)
                 }
             }
         )+
     };
 }
 
-impl_into_values![
-    (String, String),
-    (f64, Float),
-    (bool, Boolean),
-    (Number, Int)
-];
+impl_into_values![(String, String), (f64, Float), (bool, Boolean)];
 
 /// Creates a `graphql_parser::query::Value::Object` from key/value pairs.
 #[macro_export]
@@ -90,7 +93,7 @@ macro_rules! object {
                 let value = $crate::data::graphql::object_macro::IntoValue::into_value($value);
                 result.insert(stringify!($name).to_string(), value);
             )*
-            ::graphql_parser::query::Value::Object(result)
+            $crate::prelude::r::Value::Object(result)
         }
     };
     ($($name:ident: $value:expr),*) => {

--- a/graph/src/data/graphql/values.rs
+++ b/graph/src/data/graphql/values.rs
@@ -1,49 +1,69 @@
 use anyhow::{anyhow, Error};
 use std::collections::{BTreeMap, HashMap};
+use std::convert::TryFrom;
 use std::str::FromStr;
 
-use crate::prelude::{q, BigInt, Entity};
+use crate::prelude::{r, BigInt, Entity};
 use web3::types::{H160, H256};
 
 pub trait TryFromValue: Sized {
-    fn try_from_value(value: &q::Value) -> Result<Self, Error>;
+    fn try_from_value(value: &r::Value) -> Result<Self, Error>;
 }
 
-impl TryFromValue for q::Value {
-    fn try_from_value(value: &q::Value) -> Result<Self, Error> {
+impl TryFromValue for r::Value {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
         Ok(value.clone())
     }
 }
 
 impl TryFromValue for bool {
-    fn try_from_value(value: &q::Value) -> Result<Self, Error> {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
         match value {
-            q::Value::Boolean(b) => Ok(*b),
+            r::Value::Boolean(b) => Ok(*b),
             _ => Err(anyhow!("Cannot parse value into a boolean: {:?}", value)),
         }
     }
 }
 
 impl TryFromValue for String {
-    fn try_from_value(value: &q::Value) -> Result<Self, Error> {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
         match value {
-            q::Value::String(s) => Ok(s.clone()),
-            q::Value::Enum(s) => Ok(s.clone()),
+            r::Value::String(s) => Ok(s.clone()),
+            r::Value::Enum(s) => Ok(s.clone()),
             _ => Err(anyhow!("Cannot parse value into a string: {:?}", value)),
         }
     }
 }
 
 impl TryFromValue for u64 {
-    fn try_from_value(value: &q::Value) -> Result<Self, Error> {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
         match value {
-            q::Value::Int(n) => n
-                .as_i64()
-                .map(|n| n as u64)
-                .ok_or_else(|| anyhow!("Cannot parse value into an integer/u64: {:?}", n)),
-
+            r::Value::Int(n) => {
+                if *n >= 0 {
+                    Ok(*n as u64)
+                } else {
+                    Err(anyhow!("Cannot parse value into an integer/u64: {:?}", n))
+                }
+            }
             // `BigInt`s are represented as `String`s.
-            q::Value::String(s) => u64::from_str(s).map_err(Into::into),
+            r::Value::String(s) => u64::from_str(s).map_err(Into::into),
+            _ => Err(anyhow!(
+                "Cannot parse value into an integer/u64: {:?}",
+                value
+            )),
+        }
+    }
+}
+
+impl TryFromValue for i32 {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
+        match value {
+            r::Value::Int(n) => {
+                let n = *n;
+                i32::try_from(n).map_err(Error::from)
+            }
+            // `BigInt`s are represented as `String`s.
+            r::Value::String(s) => i32::from_str(s).map_err(Into::into),
             _ => Err(anyhow!(
                 "Cannot parse value into an integer/u64: {:?}",
                 value
@@ -53,9 +73,9 @@ impl TryFromValue for u64 {
 }
 
 impl TryFromValue for H160 {
-    fn try_from_value(value: &q::Value) -> Result<Self, Error> {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
         match value {
-            q::Value::String(s) => {
+            r::Value::String(s) => {
                 // `H160::from_str` takes a hex string with no leading `0x`.
                 let string = s.trim_start_matches("0x");
                 H160::from_str(string).map_err(|e| {
@@ -71,9 +91,9 @@ impl TryFromValue for H160 {
 }
 
 impl TryFromValue for H256 {
-    fn try_from_value(value: &q::Value) -> Result<Self, Error> {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
         match value {
-            q::Value::String(s) => {
+            r::Value::String(s) => {
                 // `H256::from_str` takes a hex string with no leading `0x`.
                 let string = s.trim_start_matches("0x");
                 H256::from_str(string)
@@ -85,9 +105,9 @@ impl TryFromValue for H256 {
 }
 
 impl TryFromValue for BigInt {
-    fn try_from_value(value: &q::Value) -> Result<Self, Error> {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
         match value {
-            q::Value::String(s) => BigInt::from_str(s)
+            r::Value::String(s) => BigInt::from_str(s)
                 .map_err(|e| anyhow!("Cannot parse BigInt value from string `{}`: {}", s, e)),
             _ => Err(anyhow!("Cannot parse value into an BigInt: {:?}", value)),
         }
@@ -98,9 +118,9 @@ impl<T> TryFromValue for Vec<T>
 where
     T: TryFromValue,
 {
-    fn try_from_value(value: &q::Value) -> Result<Self, Error> {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
         match value {
-            q::Value::List(values) => values.iter().try_fold(vec![], |mut values, value| {
+            r::Value::List(values) => values.iter().try_fold(vec![], |mut values, value| {
                 values.push(T::try_from_value(value)?);
                 Ok(values)
             }),
@@ -111,9 +131,9 @@ where
 
 /// Assumes the entity is stored as a JSON string.
 impl TryFromValue for Entity {
-    fn try_from_value(value: &q::Value) -> Result<Self, Error> {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
         match value {
-            q::Value::String(s) => serde_json::from_str(s).map_err(Into::into),
+            r::Value::String(s) => serde_json::from_str(s).map_err(Into::into),
             _ => Err(anyhow!(
                 "Cannot parse entity, value is not a string: {:?}",
                 value
@@ -127,10 +147,10 @@ pub trait ValueMap {
     fn get_optional<T: TryFromValue>(&self, key: &str) -> Result<Option<T>, Error>;
 }
 
-impl ValueMap for q::Value {
+impl ValueMap for r::Value {
     fn get_required<T: TryFromValue>(&self, key: &str) -> Result<T, Error> {
         match self {
-            q::Value::Object(map) => map.get_required(key),
+            r::Value::Object(map) => map.get_required(key),
             _ => Err(anyhow!("value is not a map: {:?}", self)),
         }
     }
@@ -140,13 +160,13 @@ impl ValueMap for q::Value {
         T: TryFromValue,
     {
         match self {
-            q::Value::Object(map) => map.get_optional(key),
+            r::Value::Object(map) => map.get_optional(key),
             _ => Err(anyhow!("value is not a map: {:?}", self)),
         }
     }
 }
 
-impl ValueMap for &BTreeMap<String, q::Value> {
+impl ValueMap for &BTreeMap<String, r::Value> {
     fn get_required<T>(&self, key: &str) -> Result<T, Error>
     where
         T: TryFromValue,
@@ -161,13 +181,13 @@ impl ValueMap for &BTreeMap<String, q::Value> {
         T: TryFromValue,
     {
         self.get(key).map_or(Ok(None), |value| match value {
-            q::Value::Null => Ok(None),
+            r::Value::Null => Ok(None),
             _ => T::try_from_value(value).map(Some).map_err(Into::into),
         })
     }
 }
 
-impl ValueMap for &HashMap<&str, q::Value> {
+impl ValueMap for &HashMap<&str, r::Value> {
     fn get_required<T>(&self, key: &str) -> Result<T, Error>
     where
         T: TryFromValue,
@@ -182,7 +202,7 @@ impl ValueMap for &HashMap<&str, q::Value> {
         T: TryFromValue,
     {
         self.get(key).map_or(Ok(None), |value| match value {
-            q::Value::Null => Ok(None),
+            r::Value::Null => Ok(None),
             _ => T::try_from_value(value).map(Some).map_err(Into::into),
         })
     }
@@ -194,19 +214,19 @@ pub trait ValueList {
         T: TryFromValue;
 }
 
-impl ValueList for q::Value {
+impl ValueList for r::Value {
     fn get_values<T>(&self) -> Result<Vec<T>, Error>
     where
         T: TryFromValue,
     {
         match self {
-            q::Value::List(values) => values.get_values(),
+            r::Value::List(values) => values.get_values(),
             _ => Err(anyhow!("value is not a list: {:?}", self)),
         }
     }
 }
 
-impl ValueList for Vec<q::Value> {
+impl ValueList for Vec<r::Value> {
     fn get_values<T>(&self) -> Result<Vec<T>, Error>
     where
         T: TryFromValue,

--- a/graph/src/data/mod.rs
+++ b/graph/src/data/mod.rs
@@ -15,3 +15,6 @@ pub mod subscription;
 
 /// Data types for dealing with GraphQL values.
 pub mod graphql;
+
+/// Our representation of values for query results and the like
+pub mod value;

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -1,8 +1,5 @@
 use super::error::{QueryError, QueryExecutionError};
-use crate::{
-    data::graphql::SerializableValue,
-    prelude::{q, CacheWeight, DeploymentHash},
-};
+use crate::prelude::{r, CacheWeight, DeploymentHash};
 use http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
     CONTENT_TYPE,
@@ -21,7 +18,7 @@ where
 
     // Unwrap: data is only serialized if it is `Some`.
     for (k, v) in data.as_ref().unwrap() {
-        ser.serialize_entry(k, &SerializableValue(v))?;
+        ser.serialize_entry(k, v)?;
     }
     ser.end()
 }
@@ -36,13 +33,13 @@ where
     let mut ser = serializer.serialize_map(None)?;
     for map in data {
         for (k, v) in map {
-            ser.serialize_entry(k, &SerializableValue(v))?;
+            ser.serialize_entry(k, v)?;
         }
     }
     ser.end()
 }
 
-pub type Data = BTreeMap<String, q::Value>;
+pub type Data = BTreeMap<String, r::Value>;
 
 #[derive(Debug)]
 /// A collection of query results that is serialized as a single result.
@@ -214,11 +211,11 @@ impl QueryResult {
         self.data.is_some()
     }
 
-    pub fn to_result(self) -> Result<Option<q::Value>, Vec<QueryError>> {
+    pub fn to_result(self) -> Result<Option<r::Value>, Vec<QueryError>> {
         if self.has_errors() {
             Err(self.errors)
         } else {
-            Ok(self.data.map(q::Value::Object))
+            Ok(self.data.map(r::Value::Object))
         }
     }
 
@@ -271,12 +268,12 @@ impl From<Data> for QueryResult {
     }
 }
 
-impl TryFrom<q::Value> for QueryResult {
+impl TryFrom<r::Value> for QueryResult {
     type Error = &'static str;
 
-    fn try_from(value: q::Value) -> Result<Self, Self::Error> {
+    fn try_from(value: r::Value) -> Result<Self, Self::Error> {
         match value {
-            q::Value::Object(map) => Ok(QueryResult::from(map)),
+            r::Value::Object(map) => Ok(QueryResult::from(map)),
             _ => Err("only objects can be turned into a QueryResult"),
         }
     }
@@ -305,7 +302,7 @@ fn multiple_data_items() {
 
     fn make_obj(key: &str, value: &str) -> Arc<QueryResult> {
         let mut map = BTreeMap::new();
-        map.insert(key.to_owned(), q::Value::String(value.to_owned()));
+        map.insert(key.to_owned(), r::Value::String(value.to_owned()));
         Arc::new(map.into())
     }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     components::store::{DeploymentLocator, EntityType},
-    prelude::{q, s, CacheWeight, EntityKey, QueryExecutionError},
+    prelude::{q, r, s, CacheWeight, EntityKey, QueryExecutionError},
 };
 use crate::{data::subgraph::DeploymentHash, prelude::EntityChange};
 use anyhow::{anyhow, Error};
@@ -212,28 +212,28 @@ impl StableHash for Value {
 }
 
 impl Value {
-    pub fn from_query_value(value: &q::Value, ty: &s::Type) -> Result<Value, QueryExecutionError> {
+    pub fn from_query_value(value: &r::Value, ty: &s::Type) -> Result<Value, QueryExecutionError> {
         use graphql_parser::schema::Type::{ListType, NamedType, NonNullType};
 
         Ok(match (value, ty) {
             // When dealing with non-null types, use the inner type to convert the value
             (value, NonNullType(t)) => Value::from_query_value(value, t)?,
 
-            (q::Value::List(values), ListType(ty)) => Value::List(
+            (r::Value::List(values), ListType(ty)) => Value::List(
                 values
                     .iter()
                     .map(|value| Self::from_query_value(value, ty))
                     .collect::<Result<Vec<_>, _>>()?,
             ),
 
-            (q::Value::List(values), NamedType(n)) => Value::List(
+            (r::Value::List(values), NamedType(n)) => Value::List(
                 values
                     .iter()
                     .map(|value| Self::from_query_value(value, &NamedType(n.to_string())))
                     .collect::<Result<Vec<_>, _>>()?,
             ),
-            (q::Value::Enum(e), NamedType(_)) => Value::String(e.clone()),
-            (q::Value::String(s), NamedType(n)) => {
+            (r::Value::Enum(e), NamedType(_)) => Value::String(e.clone()),
+            (r::Value::String(s), NamedType(n)) => {
                 // Check if `ty` is a custom scalar type, otherwise assume it's
                 // just a string.
                 match n.as_str() {
@@ -243,14 +243,9 @@ impl Value {
                     _ => Value::String(s.clone()),
                 }
             }
-            (q::Value::Int(i), _) => Value::Int(
-                i.to_owned()
-                    .as_i64()
-                    .ok_or_else(|| QueryExecutionError::NamedTypeError("Int".to_string()))?
-                    as i32,
-            ),
-            (q::Value::Boolean(b), _) => Value::Bool(b.to_owned()),
-            (q::Value::Null, _) => Value::Null,
+            (r::Value::Int(i), _) => Value::Int(*i as i32),
+            (r::Value::Boolean(b), _) => Value::Bool(b.to_owned()),
+            (r::Value::Null, _) => Value::Null,
             _ => {
                 return Err(QueryExecutionError::AttributeTypeError(
                     value.to_string(),
@@ -382,6 +377,23 @@ impl From<Value> for q::Value {
             }
             Value::Bytes(bytes) => q::Value::String(bytes.to_string()),
             Value::BigInt(number) => q::Value::String(number.to_string()),
+        }
+    }
+}
+
+impl From<Value> for r::Value {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::String(s) => r::Value::String(s),
+            Value::Int(i) => r::Value::Int(i as i64),
+            Value::BigDecimal(d) => r::Value::String(d.to_string()),
+            Value::Bool(b) => r::Value::Boolean(b),
+            Value::Null => r::Value::Null,
+            Value::List(values) => {
+                r::Value::List(values.into_iter().map(|value| value.into()).collect())
+            }
+            Value::Bytes(bytes) => r::Value::String(bytes.to_string()),
+            Value::BigInt(number) => r::Value::String(number.to_string()),
         }
     }
 }
@@ -627,7 +639,7 @@ pub trait ToEntityKey {
 
 #[test]
 fn value_bytes() {
-    let graphql_value = q::Value::String("0x8f494c66afc1d3f8ac1b45df21f02a46".to_owned());
+    let graphql_value = r::Value::String("0x8f494c66afc1d3f8ac1b45df21f02a46".to_owned());
     let ty = q::Type::NamedType(BYTES_SCALAR.to_owned());
     let from_query = Value::from_query_value(&graphql_value, &ty).unwrap();
     assert_eq!(
@@ -636,18 +648,18 @@ fn value_bytes() {
             &[143, 73, 76, 102, 175, 193, 211, 248, 172, 27, 69, 223, 33, 240, 42, 70][..]
         ))
     );
-    assert_eq!(q::Value::from(from_query), graphql_value);
+    assert_eq!(r::Value::from(from_query), graphql_value);
 }
 
 #[test]
 fn value_bigint() {
     let big_num = "340282366920938463463374607431768211456";
-    let graphql_value = q::Value::String(big_num.to_owned());
+    let graphql_value = r::Value::String(big_num.to_owned());
     let ty = q::Type::NamedType(BIG_INT_SCALAR.to_owned());
     let from_query = Value::from_query_value(&graphql_value, &ty).unwrap();
     assert_eq!(
         from_query,
         Value::BigInt(FromStr::from_str(big_num).unwrap())
     );
-    assert_eq!(q::Value::from(from_query), graphql_value);
+    assert_eq!(r::Value::from(from_query), graphql_value);
 }

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -19,7 +19,7 @@ use crate::data::{
     schema::{Schema, SchemaImportError, SchemaValidationError},
     subgraph::features::validate_subgraph_features,
 };
-use crate::prelude::CheapClone;
+use crate::prelude::{r, CheapClone};
 use crate::{blockchain::DataSource, data::graphql::TryFromValue};
 use crate::{blockchain::DataSourceTemplate as _, data::query::QueryExecutionError};
 use crate::{
@@ -30,7 +30,7 @@ use crate::{
     },
 };
 
-use crate::prelude::{impl_slog_value, q, BlockNumber, Deserialize, Serialize};
+use crate::prelude::{impl_slog_value, BlockNumber, Deserialize, Serialize};
 
 use std::fmt;
 use std::ops::Deref;
@@ -176,7 +176,7 @@ impl<'de> de::Deserialize<'de> for DeploymentHash {
 }
 
 impl TryFromValue for DeploymentHash {
-    fn try_from_value(value: &q::Value) -> Result<Self, Error> {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
         Self::new(String::try_from_value(value)?)
             .map_err(|s| anyhow!("Invalid subgraph ID `{}`", s))
     }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -82,10 +82,16 @@ impl From<SubgraphHealth> for q::Value {
     }
 }
 
+impl From<SubgraphHealth> for r::Value {
+    fn from(health: SubgraphHealth) -> r::Value {
+        r::Value::Enum(health.into())
+    }
+}
+
 impl TryFromValue for SubgraphHealth {
-    fn try_from_value(value: &q::Value) -> Result<SubgraphHealth, Error> {
+    fn try_from_value(value: &r::Value) -> Result<SubgraphHealth, Error> {
         match value {
-            q::Value::Enum(health) => SubgraphHealth::from_str(health),
+            r::Value::Enum(health) => SubgraphHealth::from_str(health),
             _ => Err(anyhow!(
                 "cannot parse value as SubgraphHealth: `{:?}`",
                 value

--- a/graph/src/data/subgraph/status.rs
+++ b/graph/src/data/subgraph/status.rs
@@ -3,7 +3,7 @@
 use super::schema::{SubgraphError, SubgraphHealth};
 use crate::components::store::DeploymentId;
 use crate::data::graphql::{object, IntoValue};
-use crate::prelude::{q, web3::types::H256, BlockPtr, Value};
+use crate::prelude::{r, web3::types::H256, BlockPtr, Value};
 
 pub enum Filter {
     /// Get all versions for the named subgraph
@@ -36,7 +36,7 @@ impl EthereumBlock {
 }
 
 impl IntoValue for EthereumBlock {
-    fn into_value(self) -> q::Value {
+    fn into_value(self) -> r::Value {
         object! {
             __typename: "EthereumBlock",
             hash: self.0.hash_hex(),
@@ -67,7 +67,7 @@ pub struct ChainInfo {
 }
 
 impl IntoValue for ChainInfo {
-    fn into_value(self) -> q::Value {
+    fn into_value(self) -> r::Value {
         let ChainInfo {
             network,
             chain_head_block,
@@ -109,7 +109,7 @@ pub struct Info {
 }
 
 impl IntoValue for Info {
-    fn into_value(self) -> q::Value {
+    fn into_value(self) -> r::Value {
         let Info {
             id: _,
             subgraph,
@@ -122,7 +122,7 @@ impl IntoValue for Info {
             synced,
         } = self;
 
-        fn subgraph_error_to_value(subgraph_error: SubgraphError) -> q::Value {
+        fn subgraph_error_to_value(subgraph_error: SubgraphError) -> r::Value {
             let SubgraphError {
                 subgraph_id,
                 message,
@@ -139,23 +139,23 @@ impl IntoValue for Info {
                 block: object! {
                     __typename: "Block",
                     number: block_ptr.as_ref().map(|x| x.number),
-                    hash: block_ptr.map(|x| q::Value::from(Value::Bytes(x.hash.into()))),
+                    hash: block_ptr.map(|x| r::Value::from(Value::Bytes(x.hash.into()))),
                 },
                 deterministic: deterministic,
             }
         }
 
-        let non_fatal_errors: Vec<q::Value> = non_fatal_errors
+        let non_fatal_errors: Vec<_> = non_fatal_errors
             .into_iter()
             .map(subgraph_error_to_value)
             .collect();
-        let fatal_error_val = fatal_error.map_or(q::Value::Null, subgraph_error_to_value);
+        let fatal_error_val = fatal_error.map_or(r::Value::Null, subgraph_error_to_value);
 
         object! {
             __typename: "SubgraphIndexingStatus",
             subgraph: subgraph,
             synced: synced,
-            health: q::Value::from(health),
+            health: r::Value::from(health),
             fatalError: fatal_error_val,
             nonFatalErrors: non_fatal_errors,
             chains: chains.into_iter().map(|chain| chain.into_value()).collect::<Vec<_>>(),

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -1,0 +1,196 @@
+use crate::prelude::{q, s, CacheWeight};
+use serde::ser::{SerializeMap, SerializeSeq, Serializer};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::convert::TryFrom;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Int(i64),
+    Float(f64),
+    String(String),
+    Boolean(bool),
+    Null,
+    Enum(String),
+    List(Vec<Value>),
+    Object(BTreeMap<String, Value>),
+}
+
+impl Value {
+    pub fn is_null(&self) -> bool {
+        matches!(self, Value::Null)
+    }
+
+    pub fn coerce_enum(self, using_type: &s::EnumType) -> Result<Value, Value> {
+        match self {
+            Value::Null => Ok(Value::Null),
+            Value::String(name) | Value::Enum(name)
+                if using_type.values.iter().any(|value| value.name == name) =>
+            {
+                Ok(Value::Enum(name))
+            }
+            _ => Err(self),
+        }
+    }
+
+    pub fn coerce_scalar(self, using_type: &s::ScalarType) -> Result<Value, Value> {
+        match (using_type.name.as_str(), self) {
+            (_, Value::Null) => Ok(Value::Null),
+            ("Boolean", Value::Boolean(b)) => Ok(Value::Boolean(b)),
+            ("BigDecimal", Value::Float(f)) => Ok(Value::String(f.to_string())),
+            ("BigDecimal", Value::Int(i)) => Ok(Value::String(i.to_string())),
+            ("BigDecimal", Value::String(s)) => Ok(Value::String(s)),
+            ("Int", Value::Int(num)) => {
+                if i32::min_value() as i64 <= num && num <= i32::max_value() as i64 {
+                    Ok(Value::Int(num))
+                } else {
+                    Err(Value::Int(num))
+                }
+            }
+            ("String", Value::String(s)) => Ok(Value::String(s)),
+            ("ID", Value::String(s)) => Ok(Value::String(s)),
+            ("ID", Value::Int(n)) => Ok(Value::String(n.to_string())),
+            ("Bytes", Value::String(s)) => Ok(Value::String(s)),
+            ("BigInt", Value::String(s)) => Ok(Value::String(s)),
+            ("BigInt", Value::Int(n)) => Ok(Value::String(n.to_string())),
+            (_, v) => Err(v),
+        }
+    }
+}
+
+impl std::fmt::Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Value::Int(ref num) => write!(f, "{}", num),
+            Value::Float(val) => write!(f, "{}", val),
+            Value::String(ref val) => write!(f, "\"{}\"", val.replace('"', "\\\"")),
+            Value::Boolean(true) => write!(f, "true"),
+            Value::Boolean(false) => write!(f, "false"),
+            Value::Null => write!(f, "null"),
+            Value::Enum(ref name) => write!(f, "{}", name),
+            Value::List(ref items) => {
+                write!(f, "[")?;
+                if !items.is_empty() {
+                    write!(f, "{}", items[0])?;
+                    for item in &items[1..] {
+                        write!(f, ", {}", item)?;
+                    }
+                }
+                write!(f, "]")
+            }
+            Value::Object(ref items) => {
+                write!(f, "{{")?;
+                let mut first = true;
+                for (name, value) in items.iter() {
+                    if first {
+                        first = false;
+                    } else {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}: {}", name, value)?;
+                }
+                write!(f, "}}")
+            }
+        }
+    }
+}
+
+impl CacheWeight for Value {
+    fn indirect_weight(&self) -> usize {
+        match self {
+            Value::Boolean(_) | Value::Int(_) | Value::Null | Value::Float(_) => 0,
+            Value::Enum(s) | Value::String(s) => s.indirect_weight(),
+            Value::List(l) => l.indirect_weight(),
+            Value::Object(o) => o.indirect_weight(),
+        }
+    }
+}
+
+impl Serialize for Value {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Value::Boolean(v) => serializer.serialize_bool(*v),
+            Value::Enum(v) => serializer.serialize_str(v),
+            Value::Float(v) => serializer.serialize_f64(*v),
+            Value::Int(v) => serializer.serialize_i64(*v),
+            Value::List(l) => {
+                let mut seq = serializer.serialize_seq(Some(l.len()))?;
+                for v in l {
+                    seq.serialize_element(v)?;
+                }
+                seq.end()
+            }
+            Value::Null => serializer.serialize_none(),
+            Value::String(s) => serializer.serialize_str(s),
+            Value::Object(o) => {
+                let mut map = serializer.serialize_map(Some(o.len()))?;
+                for (k, v) in o {
+                    map.serialize_entry(k, v)?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+impl TryFrom<q::Value> for Value {
+    type Error = q::Value;
+
+    fn try_from(value: q::Value) -> Result<Self, Self::Error> {
+        match value {
+            q::Value::Variable(_) => Err(value),
+            q::Value::Int(ref num) => match num.as_i64() {
+                Some(i) => Ok(Value::Int(i)),
+                None => Err(value),
+            },
+            q::Value::Float(f) => Ok(Value::Float(f)),
+            q::Value::String(s) => Ok(Value::String(s)),
+            q::Value::Boolean(b) => Ok(Value::Boolean(b)),
+            q::Value::Null => Ok(Value::Null),
+            q::Value::Enum(s) => Ok(Value::Enum(s)),
+            q::Value::List(vals) => {
+                let vals: Vec<_> = vals
+                    .into_iter()
+                    .map(Value::try_from)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Value::List(vals))
+            }
+            q::Value::Object(map) => {
+                let mut rmap = BTreeMap::new();
+                for (key, value) in map.into_iter() {
+                    let value = Value::try_from(value)?;
+                    rmap.insert(key, value);
+                }
+                Ok(Value::Object(rmap))
+            }
+        }
+    }
+}
+
+impl From<Value> for q::Value {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Int(i) => q::Value::Int((i as i32).into()),
+            Value::Float(f) => q::Value::Float(f),
+            Value::String(s) => q::Value::String(s),
+            Value::Boolean(b) => q::Value::Boolean(b),
+            Value::Null => q::Value::Null,
+            Value::Enum(s) => q::Value::Enum(s),
+            Value::List(vals) => {
+                let vals: Vec<q::Value> = vals.into_iter().map(q::Value::from).collect();
+                q::Value::List(vals)
+            }
+            Value::Object(map) => {
+                let mut rmap = BTreeMap::new();
+                for (key, value) in map.into_iter() {
+                    let value = q::Value::from(value);
+                    rmap.insert(key, value);
+                }
+                q::Value::Object(rmap)
+            }
+        }
+    }
+}

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -197,4 +197,8 @@ pub mod prelude {
         EnumType, Type, Document, ScalarType, InputValue, DirectiveDefinition,
         UnionType, InputObjectType, EnumValue,
     });
+
+    pub mod r {
+        pub use crate::data::value::Value;
+    }
 }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -136,7 +136,7 @@ impl Default for WeightedResult {
 
 struct HashableQuery<'a> {
     query_schema_id: &'a DeploymentHash,
-    query_variables: &'a HashMap<String, q::Value>,
+    query_variables: &'a HashMap<String, r::Value>,
     query_fragments: &'a HashMap<String, q::FragmentDefinition>,
     selection_set: &'a q::SelectionSet,
     block_ptr: &'a BlockPtr,
@@ -290,7 +290,7 @@ pub fn execute_root_selection_set_uncached(
     ctx: &ExecutionContext<impl Resolver>,
     selection_set: &q::SelectionSet,
     root_type: &s::ObjectType,
-) -> Result<BTreeMap<String, q::Value>, Vec<QueryExecutionError>> {
+) -> Result<BTreeMap<String, r::Value>, Vec<QueryExecutionError>> {
     // Split the top-level fields into introspection fields and
     // regular data fields
     let mut data_set = q::SelectionSet {
@@ -491,9 +491,9 @@ fn execute_selection_set<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     selection_sets: impl Iterator<Item = &'a q::SelectionSet>,
     object_type: &s::ObjectType,
-    prefetched_value: Option<q::Value>,
-) -> Result<q::Value, Vec<QueryExecutionError>> {
-    Ok(q::Value::Object(execute_selection_set_to_map(
+    prefetched_value: Option<r::Value>,
+) -> Result<r::Value, Vec<QueryExecutionError>> {
+    Ok(r::Value::Object(execute_selection_set_to_map(
         ctx,
         selection_sets,
         object_type,
@@ -505,15 +505,15 @@ fn execute_selection_set_to_map<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     selection_sets: impl Iterator<Item = &'a q::SelectionSet>,
     object_type: &s::ObjectType,
-    prefetched_value: Option<q::Value>,
-) -> Result<BTreeMap<String, q::Value>, Vec<QueryExecutionError>> {
+    prefetched_value: Option<r::Value>,
+) -> Result<BTreeMap<String, r::Value>, Vec<QueryExecutionError>> {
     let mut prefetched_object = match prefetched_value {
-        Some(q::Value::Object(object)) => Some(object),
+        Some(r::Value::Object(object)) => Some(object),
         Some(_) => unreachable!(),
         None => None,
     };
     let mut errors: Vec<QueryExecutionError> = Vec::new();
-    let mut result_map: BTreeMap<String, q::Value> = BTreeMap::new();
+    let mut result_map: BTreeMap<String, r::Value> = BTreeMap::new();
 
     // Group fields with the same response key, so we can execute them together
     let grouped_field_set = collect_fields(ctx, object_type, selection_sets);
@@ -697,11 +697,11 @@ fn does_fragment_type_apply(
 fn execute_field(
     ctx: &ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
-    field_value: Option<q::Value>,
+    field_value: Option<r::Value>,
     field: &q::Field,
     field_definition: &s::Field,
     fields: Vec<&q::Field>,
-) -> Result<q::Value, Vec<QueryExecutionError>> {
+) -> Result<r::Value, Vec<QueryExecutionError>> {
     coerce_argument_values(&ctx.query, object_type, field)
         .and_then(|argument_values| {
             resolve_field_value(
@@ -721,12 +721,12 @@ fn execute_field(
 fn resolve_field_value(
     ctx: &ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
-    field_value: Option<q::Value>,
+    field_value: Option<r::Value>,
     field: &q::Field,
     field_definition: &s::Field,
     field_type: &s::Type,
-    argument_values: &HashMap<&str, q::Value>,
-) -> Result<q::Value, Vec<QueryExecutionError>> {
+    argument_values: &HashMap<&str, r::Value>,
+) -> Result<r::Value, Vec<QueryExecutionError>> {
     match field_type {
         s::Type::NonNullType(inner_type) => resolve_field_value(
             ctx,
@@ -764,12 +764,12 @@ fn resolve_field_value(
 fn resolve_field_value_for_named_type(
     ctx: &ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
-    field_value: Option<q::Value>,
+    field_value: Option<r::Value>,
     field: &q::Field,
     field_definition: &s::Field,
     type_name: &str,
-    argument_values: &HashMap<&str, q::Value>,
-) -> Result<q::Value, Vec<QueryExecutionError>> {
+    argument_values: &HashMap<&str, r::Value>,
+) -> Result<r::Value, Vec<QueryExecutionError>> {
     // Try to resolve the type name into the actual type
     let named_type = ctx
         .query
@@ -817,12 +817,12 @@ fn resolve_field_value_for_named_type(
 fn resolve_field_value_for_list_type(
     ctx: &ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
-    field_value: Option<q::Value>,
+    field_value: Option<r::Value>,
     field: &q::Field,
     field_definition: &s::Field,
     inner_type: &s::Type,
-    argument_values: &HashMap<&str, q::Value>,
-) -> Result<q::Value, Vec<QueryExecutionError>> {
+    argument_values: &HashMap<&str, r::Value>,
+) -> Result<r::Value, Vec<QueryExecutionError>> {
     match inner_type {
         s::Type::NonNullType(inner_type) => resolve_field_value_for_list_type(
             ctx,
@@ -902,13 +902,13 @@ fn complete_value(
     field: &q::Field,
     field_type: &s::Type,
     fields: &Vec<&q::Field>,
-    resolved_value: q::Value,
-) -> Result<q::Value, Vec<QueryExecutionError>> {
+    resolved_value: r::Value,
+) -> Result<r::Value, Vec<QueryExecutionError>> {
     match field_type {
         // Fail if the field type is non-null but the value is null
         s::Type::NonNullType(inner_type) => {
             return match complete_value(ctx, field, inner_type, fields, resolved_value)? {
-                q::Value::Null => Err(vec![QueryExecutionError::NonNullError(
+                r::Value::Null => Err(vec![QueryExecutionError::NonNullError(
                     field.position,
                     field.name.to_string(),
                 )]),
@@ -918,19 +918,19 @@ fn complete_value(
         }
 
         // If the resolved value is null, return null
-        _ if resolved_value == q::Value::Null => Ok(resolved_value),
+        _ if resolved_value.is_null() => Ok(resolved_value),
 
         // Complete list values
         s::Type::ListType(inner_type) => {
             match resolved_value {
                 // Complete list values individually
-                q::Value::List(mut values) => {
+                r::Value::List(mut values) => {
                     let mut errors = Vec::new();
 
                     // To avoid allocating a new vector this completes the values in place.
                     for value_place in &mut values {
                         // Put in a placeholder, complete the value, put the completed value back.
-                        let value = std::mem::replace(value_place, q::Value::Null);
+                        let value = std::mem::replace(value_place, r::Value::Null);
                         match complete_value(ctx, field, inner_type, fields, value) {
                             Ok(value) => {
                                 *value_place = value;
@@ -939,7 +939,7 @@ fn complete_value(
                         }
                     }
                     match errors.is_empty() {
-                        true => Ok(q::Value::List(values)),
+                        true => Ok(r::Value::List(values)),
                         false => Err(errors),
                     }
                 }
@@ -958,11 +958,11 @@ fn complete_value(
             match named_type {
                 // Complete scalar values
                 s::TypeDefinition::Scalar(scalar_type) => {
-                    resolved_value.coerce(scalar_type).map_err(|value| {
+                    resolved_value.coerce_scalar(scalar_type).map_err(|value| {
                         vec![QueryExecutionError::ScalarCoercionError(
                             field.position,
                             field.name.to_owned(),
-                            value,
+                            value.into(),
                             scalar_type.name.to_owned(),
                         )]
                     })
@@ -970,11 +970,11 @@ fn complete_value(
 
                 // Complete enum values
                 s::TypeDefinition::Enum(enum_type) => {
-                    resolved_value.coerce(enum_type).map_err(|value| {
+                    resolved_value.coerce_enum(enum_type).map_err(|value| {
                         vec![QueryExecutionError::EnumCoercionError(
                             field.position,
                             field.name.to_owned(),
-                            value,
+                            value.into(),
                             enum_type.name.to_owned(),
                             enum_type
                                 .values
@@ -1029,7 +1029,7 @@ fn complete_value(
 fn resolve_abstract_type<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     abstract_type: &s::TypeDefinition,
-    object_value: &q::Value,
+    object_value: &r::Value,
 ) -> Result<&'a s::ObjectType, Vec<QueryExecutionError>> {
     // Let the resolver handle the type resolution, return an error if the resolution
     // yields nothing
@@ -1047,7 +1047,7 @@ pub fn coerce_argument_values<'a>(
     query: &crate::execution::Query,
     ty: impl Into<ObjectOrInterface<'a>>,
     field: &q::Field,
-) -> Result<HashMap<&'a str, q::Value>, Vec<QueryExecutionError>> {
+) -> Result<HashMap<&'a str, r::Value>, Vec<QueryExecutionError>> {
     let mut coerced_values = HashMap::new();
     let mut errors = vec![];
 
@@ -1063,7 +1063,7 @@ pub fn coerce_argument_values<'a>(
                 if argument_def.name == "text".to_string() {
                     coerced_values.insert(
                         argument_def.name.as_str(),
-                        q::Value::Object(BTreeMap::from_iter(vec![(field.name.clone(), value)])),
+                        r::Value::Object(BTreeMap::from_iter(vec![(field.name.clone(), value)])),
                     );
                 } else {
                     coerced_values.insert(&argument_def.name, value);

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -4,7 +4,7 @@ use crate::execution::ExecutionContext;
 use graph::prelude::{async_trait, q, s, tokio, Error, QueryExecutionError, StoreEventStreamBox};
 use graph::{
     data::graphql::{ext::DocumentExt, ObjectOrInterface},
-    prelude::QueryResult,
+    prelude::{r, QueryResult},
 };
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
@@ -19,36 +19,36 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         &self,
         ctx: &ExecutionContext<Self>,
         selection_set: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>>;
+    ) -> Result<Option<r::Value>, Vec<QueryExecutionError>>;
 
     /// Resolves list of objects, `prefetched_objects` is `Some` if the parent already calculated the value.
     fn resolve_objects(
         &self,
-        prefetched_objects: Option<q::Value>,
+        prefetched_objects: Option<r::Value>,
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError>;
+        arguments: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError>;
 
     /// Resolves an object, `prefetched_object` is `Some` if the parent already calculated the value.
     fn resolve_object(
         &self,
-        prefetched_object: Option<q::Value>,
+        prefetched_object: Option<r::Value>,
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError>;
+        arguments: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError>;
 
     /// Resolves an enum value for a given enum type.
     fn resolve_enum_value(
         &self,
         _field: &q::Field,
         _enum_type: &s::EnumType,
-        value: Option<q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
-        Ok(value.unwrap_or(q::Value::Null))
+        value: Option<r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
+        Ok(value.unwrap_or(r::Value::Null))
     }
 
     /// Resolves a scalar value for a given scalar type.
@@ -57,12 +57,12 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         _parent_object_type: &s::ObjectType,
         _field: &q::Field,
         _scalar_type: &s::ScalarType,
-        value: Option<q::Value>,
-        _argument_values: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
+        value: Option<r::Value>,
+        _argument_values: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
         // This code is duplicated.
         // See also c2112309-44fd-4a84-92a0-5a651e6ed548
-        Ok(value.unwrap_or(q::Value::Null))
+        Ok(value.unwrap_or(r::Value::Null))
     }
 
     /// Resolves a list of enum values for a given enum type.
@@ -70,9 +70,9 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         &self,
         _field: &q::Field,
         _enum_type: &s::EnumType,
-        value: Option<q::Value>,
-    ) -> Result<q::Value, Vec<QueryExecutionError>> {
-        Ok(value.unwrap_or(q::Value::Null))
+        value: Option<r::Value>,
+    ) -> Result<r::Value, Vec<QueryExecutionError>> {
+        Ok(value.unwrap_or(r::Value::Null))
     }
 
     /// Resolves a list of scalar values for a given list type.
@@ -80,9 +80,9 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         &self,
         _field: &q::Field,
         _scalar_type: &s::ScalarType,
-        value: Option<q::Value>,
-    ) -> Result<q::Value, Vec<QueryExecutionError>> {
-        Ok(value.unwrap_or(q::Value::Null))
+        value: Option<r::Value>,
+    ) -> Result<r::Value, Vec<QueryExecutionError>> {
+        Ok(value.unwrap_or(r::Value::Null))
     }
 
     // Resolves an abstract type into the specific type of an object.
@@ -90,12 +90,12 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         &self,
         schema: &'a s::Document,
         _abstract_type: &s::TypeDefinition,
-        object_value: &q::Value,
+        object_value: &r::Value,
     ) -> Option<&'a s::ObjectType> {
         let concrete_type_name = match object_value {
             // All objects contain `__typename`
-            q::Value::Object(data) => match &data["__typename"] {
-                q::Value::String(name) => name.clone(),
+            r::Value::Object(data) => match &data["__typename"] {
+                r::Value::String(name) => name.clone(),
                 _ => unreachable!("__typename must be a string"),
             },
             _ => unreachable!("abstract type value must be an object"),

--- a/graphql/src/query/ast.rs
+++ b/graphql/src/query/ast.rs
@@ -1,4 +1,4 @@
-use graph::prelude::q::*;
+use graph::prelude::{q::*, r};
 use std::collections::HashMap;
 use std::ops::Deref;
 
@@ -64,7 +64,7 @@ pub fn get_argument_value<'a>(arguments: &'a [(String, Value)], name: &str) -> O
 }
 
 /// Returns true if a selection should be skipped (as per the `@skip` directive).
-pub fn skip_selection(selection: &Selection, variables: &HashMap<String, Value>) -> bool {
+pub fn skip_selection(selection: &Selection, variables: &HashMap<String, r::Value>) -> bool {
     match get_directive(selection, "skip".to_string()) {
         Some(directive) => match get_argument_value(&directive.arguments, "if") {
             Some(val) => match val {
@@ -73,7 +73,7 @@ pub fn skip_selection(selection: &Selection, variables: &HashMap<String, Value>)
 
                 // Also skip if @skip(if: $variable) where $variable is true
                 Value::Variable(name) => variables.get(name).map_or(false, |var| match var {
-                    Value::Boolean(v) => v.to_owned(),
+                    r::Value::Boolean(v) => v.to_owned(),
                     _ => false,
                 }),
 
@@ -86,7 +86,7 @@ pub fn skip_selection(selection: &Selection, variables: &HashMap<String, Value>)
 }
 
 /// Returns true if a selection should be included (as per the `@include` directive).
-pub fn include_selection(selection: &Selection, variables: &HashMap<String, Value>) -> bool {
+pub fn include_selection(selection: &Selection, variables: &HashMap<String, r::Value>) -> bool {
     match get_directive(selection, "include".to_string()) {
         Some(directive) => match get_argument_value(&directive.arguments, "if") {
             Some(val) => match val {
@@ -95,7 +95,7 @@ pub fn include_selection(selection: &Selection, variables: &HashMap<String, Valu
 
                 // Also include if @include(if: $variable) where $variable is true
                 Value::Variable(name) => variables.get(name).map_or(false, |var| match var {
-                    Value::Boolean(v) => v.to_owned(),
+                    r::Value::Boolean(v) => v.to_owned(),
                     _ => false,
                 }),
 

--- a/graphql/src/query/ext.rs
+++ b/graphql/src/query/ext.rs
@@ -1,14 +1,13 @@
 //! Extension traits for graphql_parser::query structs
 
+use graph::prelude::TryFromValue;
 use graphql_parser::Pos;
 
 use std::collections::{BTreeMap, HashMap};
-use std::convert::TryFrom;
 
 use anyhow::anyhow;
-use graph::data::graphql::TryFromValue;
 use graph::data::query::QueryExecutionError;
-use graph::prelude::{q, web3::types::H256, BlockNumber, Error};
+use graph::prelude::{q, r, web3::types::H256, BlockNumber, Error};
 
 pub trait ValueExt: Sized {
     fn as_object(&self) -> &BTreeMap<String, q::Value>;
@@ -70,18 +69,19 @@ impl Default for BlockConstraint {
 
 impl TryFromValue for BlockConstraint {
     /// `value` should be the output of input object coercion.
-    fn try_from_value(value: &q::Value) -> Result<Self, Error> {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
         let map = match value {
-            q::Value::Object(map) => map,
-            q::Value::Null => return Ok(Self::default()),
+            r::Value::Object(map) => map,
+            r::Value::Null => return Ok(Self::default()),
             _ => return Err(anyhow!("invalid `BlockConstraint`")),
         };
 
         if let Some(hash) = map.get("hash") {
             Ok(BlockConstraint::Hash(TryFromValue::try_from_value(hash)?))
         } else if let Some(number_value) = map.get("number") {
-            let number: u64 = TryFromValue::try_from_value(number_value)?;
-            Ok(BlockConstraint::Number(TryFrom::try_from(number)?))
+            Ok(BlockConstraint::Number(BlockNumber::try_from_value(
+                number_value,
+            )?))
         } else {
             Err(anyhow!("invalid `BlockConstraint`"))
         }

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -58,6 +58,18 @@ impl TryFrom<&q::Value> for ErrorPolicy {
     }
 }
 
+impl TryFrom<&r::Value> for ErrorPolicy {
+    type Error = anyhow::Error;
+
+    /// `value` should be the output of input value coercion.
+    fn try_from(value: &r::Value) -> Result<Self, Self::Error> {
+        match value {
+            r::Value::Enum(s) => ErrorPolicy::from_str(s),
+            _ => Err(anyhow::anyhow!("invalid `ErrorPolicy`")),
+        }
+    }
+}
+
 /// Derives a full-fledged GraphQL API schema from an input schema.
 ///
 /// The input schema should only have type/enum/interface/union definitions

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -161,9 +161,9 @@ impl StoreResolver {
 
     fn handle_meta(
         &self,
-        prefetched_object: Option<q::Value>,
+        prefetched_object: Option<r::Value>,
         object_type: &ObjectOrInterface<'_>,
-    ) -> Result<(Option<q::Value>, Option<q::Value>), QueryExecutionError> {
+    ) -> Result<(Option<r::Value>, Option<r::Value>), QueryExecutionError> {
         // Pretend that the whole `_meta` field was loaded by prefetch. Eager
         // loading this is ok until we add more information to this field
         // that would force us to query the database; when that happens, we
@@ -180,35 +180,35 @@ impl StoreResolver {
                     if hash_h256 == web3::types::H256::zero() {
                         None
                     } else {
-                        Some(q::Value::String(format!("0x{:x}", hash_h256)))
+                        Some(r::Value::String(format!("0x{:x}", hash_h256)))
                     }
                 })
-                .unwrap_or(q::Value::Null);
+                .unwrap_or(r::Value::Null);
             let number = self
                 .block_ptr
                 .as_ref()
-                .map(|ptr| q::Value::Int((ptr.number as i32).into()))
-                .unwrap_or(q::Value::Null);
+                .map(|ptr| r::Value::Int((ptr.number as i32).into()))
+                .unwrap_or(r::Value::Null);
             let mut map = BTreeMap::new();
             let block = object! {
                 hash: hash,
                 number: number,
                 __typename: BLOCK_FIELD_TYPE
             };
-            map.insert("prefetch:block".to_string(), q::Value::List(vec![block]));
+            map.insert("prefetch:block".to_string(), r::Value::List(vec![block]));
             map.insert(
                 "deployment".to_string(),
-                q::Value::String(self.deployment.to_string()),
+                r::Value::String(self.deployment.to_string()),
             );
             map.insert(
                 "hasIndexingErrors".to_string(),
-                q::Value::Boolean(self.has_non_fatal_errors),
+                r::Value::Boolean(self.has_non_fatal_errors),
             );
             map.insert(
                 "__typename".to_string(),
-                q::Value::String(META_FIELD_TYPE.to_string()),
+                r::Value::String(META_FIELD_TYPE.to_string()),
             );
-            return Ok((None, Some(q::Value::Object(map))));
+            return Ok((None, Some(r::Value::Object(map))));
         }
         Ok((prefetched_object, None))
     }
@@ -226,18 +226,18 @@ impl Resolver for StoreResolver {
         &self,
         ctx: &ExecutionContext<Self>,
         selection_set: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
+    ) -> Result<Option<r::Value>, Vec<QueryExecutionError>> {
         super::prefetch::run(self, ctx, selection_set, &self.result_size).map(Some)
     }
 
     fn resolve_objects(
         &self,
-        prefetched_objects: Option<q::Value>,
+        prefetched_objects: Option<r::Value>,
         field: &q::Field,
         _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
+        _arguments: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
         if let Some(child) = prefetched_objects {
             Ok(child)
         } else {
@@ -252,17 +252,17 @@ impl Resolver for StoreResolver {
 
     fn resolve_object(
         &self,
-        prefetched_object: Option<q::Value>,
+        prefetched_object: Option<r::Value>,
         field: &q::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
+        _arguments: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
         let (prefetched_object, meta) = self.handle_meta(prefetched_object, &object_type)?;
         if let Some(meta) = meta {
             return Ok(meta);
         }
-        if let Some(q::Value::List(children)) = prefetched_object {
+        if let Some(r::Value::List(children)) = prefetched_object {
             if children.len() > 1 {
                 let derived_from_field =
                     sast::get_derived_from_field(object_type, field_definition)
@@ -275,7 +275,7 @@ impl Resolver for StoreResolver {
                     derived_from_field.name.to_owned(),
                 ));
             } else {
-                Ok(children.into_iter().next().unwrap_or(q::Value::Null))
+                Ok(children.into_iter().next().unwrap_or(r::Value::Null))
             }
         } else {
             return Err(QueryExecutionError::ResolveEntitiesError(format!(

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -130,7 +130,7 @@ async fn resolve_field_stream(
     ctx: &ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
     field: &q::Field,
-    _argument_values: HashMap<&str, q::Value>,
+    _argument_values: HashMap<&str, r::Value>,
 ) -> Result<StoreEventStreamBox, SubscriptionError> {
     ctx.resolver
         .resolve_field_stream(&ctx.query.schema.document(), object_type, field)

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use graph::data::graphql::{object, object_value, ObjectOrInterface};
 use graph::prelude::{
-    async_trait, o, q, s, slog, tokio, ApiSchema, DeploymentHash, Logger, Query,
+    async_trait, o, q, r, s, slog, tokio, ApiSchema, DeploymentHash, Logger, Query,
     QueryExecutionError, QueryResult, Schema,
 };
 use graph_graphql::prelude::{
@@ -27,30 +27,30 @@ impl Resolver for MockResolver {
         &self,
         _: &ExecutionContext<Self>,
         _: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
+    ) -> Result<Option<r::Value>, Vec<QueryExecutionError>> {
         Ok(None)
     }
 
     fn resolve_objects<'a>(
         &self,
-        _: Option<q::Value>,
+        _: Option<r::Value>,
         _field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
-        Ok(q::Value::Null)
+        _arguments: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
+        Ok(r::Value::Null)
     }
 
     fn resolve_object(
         &self,
-        __: Option<q::Value>,
+        __: Option<r::Value>,
         _field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
-        Ok(q::Value::Null)
+        _arguments: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
+        Ok(r::Value::Null)
     }
 
     async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit {
@@ -113,313 +113,313 @@ fn mock_schema() -> Schema {
 
 /// Builds the expected result for GraphiQL's introspection query that we are
 /// using for testing.
-fn expected_mock_schema_introspection() -> q::Value {
+fn expected_mock_schema_introspection() -> r::Value {
     let string_type = object! {
-        kind: q::Value::Enum("SCALAR".to_string()),
+        kind: r::Value::Enum("SCALAR".to_string()),
         name: "String",
-        description: q::Value::Null,
-        fields: q::Value::Null,
-        inputFields: q::Value::Null,
-        enumValues: q::Value::Null,
-        interfaces: q::Value::Null,
-        possibleTypes: q::Value::Null,
+        description: r::Value::Null,
+        fields: r::Value::Null,
+        inputFields: r::Value::Null,
+        enumValues: r::Value::Null,
+        interfaces: r::Value::Null,
+        possibleTypes: r::Value::Null,
     };
 
     let id_type = object! {
-        kind: q::Value::Enum("SCALAR".to_string()),
+        kind: r::Value::Enum("SCALAR".to_string()),
         name: "ID",
-        description: q::Value::Null,
-        fields: q::Value::Null,
-        inputFields: q::Value::Null,
-        enumValues: q::Value::Null,
-        interfaces: q::Value::Null,
-        possibleTypes: q::Value::Null,
+        description: r::Value::Null,
+        fields: r::Value::Null,
+        inputFields: r::Value::Null,
+        enumValues: r::Value::Null,
+        interfaces: r::Value::Null,
+        possibleTypes: r::Value::Null,
     };
 
     let int_type = object! {
-        kind: q::Value::Enum("SCALAR".to_string()),
+        kind: r::Value::Enum("SCALAR".to_string()),
         name: "Int",
-        description: q::Value::Null,
-        fields: q::Value::Null,
-        inputFields: q::Value::Null,
-        enumValues: q::Value::Null,
-        interfaces: q::Value::Null,
-        possibleTypes: q::Value::Null,
+        description: r::Value::Null,
+        fields: r::Value::Null,
+        inputFields: r::Value::Null,
+        enumValues: r::Value::Null,
+        interfaces: r::Value::Null,
+        possibleTypes: r::Value::Null,
     };
 
     let boolean_type = object! {
-        kind: q::Value::Enum("SCALAR".to_string()),
+        kind: r::Value::Enum("SCALAR".to_string()),
         name: "Boolean",
-        description: q::Value::Null,
-        fields: q::Value::Null,
-        inputFields: q::Value::Null,
-        enumValues: q::Value::Null,
-        interfaces: q::Value::Null,
-        possibleTypes: q::Value::Null,
+        description: r::Value::Null,
+        fields: r::Value::Null,
+        inputFields: r::Value::Null,
+        enumValues: r::Value::Null,
+        interfaces: r::Value::Null,
+        possibleTypes: r::Value::Null,
     };
 
     let role_type = object! {
-        kind: q::Value::Enum("ENUM".to_string()),
+        kind: r::Value::Enum("ENUM".to_string()),
         name: "Role",
-        description: q::Value::Null,
-        fields: q::Value::Null,
-        inputFields: q::Value::Null,
+        description: r::Value::Null,
+        fields: r::Value::Null,
+        inputFields: r::Value::Null,
         enumValues:
-            q::Value::List(vec![
+            r::Value::List(vec![
                 object! {
                     name: "USER",
-                    description: q::Value::Null,
-                    isDeprecated: q::Value::Boolean(false),
-                    deprecationReason: q::Value::Null,
+                    description: r::Value::Null,
+                    isDeprecated: r::Value::Boolean(false),
+                    deprecationReason: r::Value::Null,
                 },
                 object! {
                     name: "ADMIN",
-                    description: q::Value::Null,
+                    description: r::Value::Null,
                     isDeprecated: false,
-                    deprecationReason: q::Value::Null,
+                    deprecationReason: r::Value::Null,
                 },
             ]),
-        interfaces: q::Value::Null,
-        possibleTypes: q::Value::Null,
+        interfaces: r::Value::Null,
+        possibleTypes: r::Value::Null,
     };
 
     let node_type = object_value(vec![
-        ("kind", q::Value::Enum("INTERFACE".to_string())),
-        ("name", q::Value::String("Node".to_string())),
-        ("description", q::Value::Null),
+        ("kind", r::Value::Enum("INTERFACE".to_string())),
+        ("name", r::Value::String("Node".to_string())),
+        ("description", r::Value::Null),
         (
             "fields",
-            q::Value::List(vec![object_value(vec![
-                ("name", q::Value::String("id".to_string())),
-                ("description", q::Value::Null),
+            r::Value::List(vec![object_value(vec![
+                ("name", r::Value::String("id".to_string())),
+                ("description", r::Value::Null),
                 (
                     "type",
                     object_value(vec![
-                        ("kind", q::Value::Enum("NON_NULL".to_string())),
-                        ("name", q::Value::Null),
+                        ("kind", r::Value::Enum("NON_NULL".to_string())),
+                        ("name", r::Value::Null),
                         (
                             "ofType",
                             object_value(vec![
-                                ("kind", q::Value::Enum("SCALAR".to_string())),
-                                ("name", q::Value::String("ID".to_string())),
-                                ("ofType", q::Value::Null),
+                                ("kind", r::Value::Enum("SCALAR".to_string())),
+                                ("name", r::Value::String("ID".to_string())),
+                                ("ofType", r::Value::Null),
                             ]),
                         ),
                     ]),
                 ),
-                ("args", q::Value::List(vec![])),
-                ("deprecationReason", q::Value::Null),
-                ("isDeprecated", q::Value::Boolean(false)),
+                ("args", r::Value::List(vec![])),
+                ("deprecationReason", r::Value::Null),
+                ("isDeprecated", r::Value::Boolean(false)),
             ])]),
         ),
-        ("inputFields", q::Value::Null),
-        ("enumValues", q::Value::Null),
-        ("interfaces", q::Value::Null),
+        ("inputFields", r::Value::Null),
+        ("enumValues", r::Value::Null),
+        ("interfaces", r::Value::Null),
         (
             "possibleTypes",
-            q::Value::List(vec![object_value(vec![
-                ("kind", q::Value::Enum("OBJECT".to_string())),
-                ("name", q::Value::String("User".to_string())),
-                ("ofType", q::Value::Null),
+            r::Value::List(vec![object_value(vec![
+                ("kind", r::Value::Enum("OBJECT".to_string())),
+                ("name", r::Value::String("User".to_string())),
+                ("ofType", r::Value::Null),
             ])]),
         ),
     ]);
 
     let user_orderby_type = object_value(vec![
-        ("kind", q::Value::Enum("ENUM".to_string())),
-        ("name", q::Value::String("User_orderBy".to_string())),
-        ("description", q::Value::Null),
-        ("fields", q::Value::Null),
-        ("inputFields", q::Value::Null),
+        ("kind", r::Value::Enum("ENUM".to_string())),
+        ("name", r::Value::String("User_orderBy".to_string())),
+        ("description", r::Value::Null),
+        ("fields", r::Value::Null),
+        ("inputFields", r::Value::Null),
         (
             "enumValues",
-            q::Value::List(vec![
+            r::Value::List(vec![
                 object_value(vec![
-                    ("name", q::Value::String("id".to_string())),
-                    ("description", q::Value::Null),
-                    ("isDeprecated", q::Value::Boolean(false)),
-                    ("deprecationReason", q::Value::Null),
+                    ("name", r::Value::String("id".to_string())),
+                    ("description", r::Value::Null),
+                    ("isDeprecated", r::Value::Boolean(false)),
+                    ("deprecationReason", r::Value::Null),
                 ]),
                 object_value(vec![
-                    ("name", q::Value::String("name".to_string())),
-                    ("description", q::Value::Null),
-                    ("isDeprecated", q::Value::Boolean(false)),
-                    ("deprecationReason", q::Value::Null),
+                    ("name", r::Value::String("name".to_string())),
+                    ("description", r::Value::Null),
+                    ("isDeprecated", r::Value::Boolean(false)),
+                    ("deprecationReason", r::Value::Null),
                 ]),
             ]),
         ),
-        ("interfaces", q::Value::Null),
-        ("possibleTypes", q::Value::Null),
+        ("interfaces", r::Value::Null),
+        ("possibleTypes", r::Value::Null),
     ]);
 
     let user_filter_type = object_value(vec![
-        ("kind", q::Value::Enum("INPUT_OBJECT".to_string())),
-        ("name", q::Value::String("User_filter".to_string())),
-        ("description", q::Value::Null),
-        ("fields", q::Value::Null),
+        ("kind", r::Value::Enum("INPUT_OBJECT".to_string())),
+        ("name", r::Value::String("User_filter".to_string())),
+        ("description", r::Value::Null),
+        ("fields", r::Value::Null),
         (
             "inputFields",
-            q::Value::List(vec![
+            r::Value::List(vec![
                 object_value(vec![
-                    ("name", q::Value::String("name_eq".to_string())),
-                    ("description", q::Value::Null),
+                    ("name", r::Value::String("name_eq".to_string())),
+                    ("description", r::Value::Null),
                     (
                         "defaultValue",
-                        q::Value::String("\"default name\"".to_string()),
+                        r::Value::String("\"default name\"".to_string()),
                     ),
                     (
                         "type",
                         object_value(vec![
-                            ("kind", q::Value::Enum("SCALAR".to_string())),
-                            ("name", q::Value::String("String".to_string())),
-                            ("ofType", q::Value::Null),
+                            ("kind", r::Value::Enum("SCALAR".to_string())),
+                            ("name", r::Value::String("String".to_string())),
+                            ("ofType", r::Value::Null),
                         ]),
                     ),
                 ]),
                 object_value(vec![
-                    ("name", q::Value::String("name_not".to_string())),
-                    ("description", q::Value::Null),
-                    ("defaultValue", q::Value::Null),
+                    ("name", r::Value::String("name_not".to_string())),
+                    ("description", r::Value::Null),
+                    ("defaultValue", r::Value::Null),
                     (
                         "type",
                         object_value(vec![
-                            ("kind", q::Value::Enum("SCALAR".to_string())),
-                            ("name", q::Value::String("String".to_string())),
-                            ("ofType", q::Value::Null),
+                            ("kind", r::Value::Enum("SCALAR".to_string())),
+                            ("name", r::Value::String("String".to_string())),
+                            ("ofType", r::Value::Null),
                         ]),
                     ),
                 ]),
             ]),
         ),
-        ("enumValues", q::Value::Null),
-        ("interfaces", q::Value::Null),
-        ("possibleTypes", q::Value::Null),
+        ("enumValues", r::Value::Null),
+        ("interfaces", r::Value::Null),
+        ("possibleTypes", r::Value::Null),
     ]);
 
     let user_type = object_value(vec![
-        ("kind", q::Value::Enum("OBJECT".to_string())),
-        ("name", q::Value::String("User".to_string())),
-        ("description", q::Value::Null),
+        ("kind", r::Value::Enum("OBJECT".to_string())),
+        ("name", r::Value::String("User".to_string())),
+        ("description", r::Value::Null),
         (
             "fields",
-            q::Value::List(vec![
+            r::Value::List(vec![
                 object_value(vec![
-                    ("name", q::Value::String("id".to_string())),
-                    ("description", q::Value::Null),
-                    ("args", q::Value::List(vec![])),
+                    ("name", r::Value::String("id".to_string())),
+                    ("description", r::Value::Null),
+                    ("args", r::Value::List(vec![])),
                     (
                         "type",
                         object_value(vec![
-                            ("kind", q::Value::Enum("NON_NULL".to_string())),
-                            ("name", q::Value::Null),
+                            ("kind", r::Value::Enum("NON_NULL".to_string())),
+                            ("name", r::Value::Null),
                             (
                                 "ofType",
                                 object_value(vec![
-                                    ("kind", q::Value::Enum("SCALAR".to_string())),
-                                    ("name", q::Value::String("ID".to_string())),
-                                    ("ofType", q::Value::Null),
+                                    ("kind", r::Value::Enum("SCALAR".to_string())),
+                                    ("name", r::Value::String("ID".to_string())),
+                                    ("ofType", r::Value::Null),
                                 ]),
                             ),
                         ]),
                     ),
-                    ("isDeprecated", q::Value::Boolean(false)),
-                    ("deprecationReason", q::Value::Null),
+                    ("isDeprecated", r::Value::Boolean(false)),
+                    ("deprecationReason", r::Value::Null),
                 ]),
                 object_value(vec![
-                    ("name", q::Value::String("name".to_string())),
-                    ("description", q::Value::Null),
-                    ("args", q::Value::List(vec![])),
+                    ("name", r::Value::String("name".to_string())),
+                    ("description", r::Value::Null),
+                    ("args", r::Value::List(vec![])),
                     (
                         "type",
                         object_value(vec![
-                            ("kind", q::Value::Enum("NON_NULL".to_string())),
-                            ("name", q::Value::Null),
+                            ("kind", r::Value::Enum("NON_NULL".to_string())),
+                            ("name", r::Value::Null),
                             (
                                 "ofType",
                                 object_value(vec![
-                                    ("kind", q::Value::Enum("SCALAR".to_string())),
-                                    ("name", q::Value::String("String".to_string())),
-                                    ("ofType", q::Value::Null),
+                                    ("kind", r::Value::Enum("SCALAR".to_string())),
+                                    ("name", r::Value::String("String".to_string())),
+                                    ("ofType", r::Value::Null),
                                 ]),
                             ),
                         ]),
                     ),
-                    ("isDeprecated", q::Value::Boolean(false)),
-                    ("deprecationReason", q::Value::Null),
+                    ("isDeprecated", r::Value::Boolean(false)),
+                    ("deprecationReason", r::Value::Null),
                 ]),
                 object_value(vec![
-                    ("name", q::Value::String("role".to_string())),
-                    ("description", q::Value::Null),
-                    ("args", q::Value::List(vec![])),
+                    ("name", r::Value::String("role".to_string())),
+                    ("description", r::Value::Null),
+                    ("args", r::Value::List(vec![])),
                     (
                         "type",
                         object_value(vec![
-                            ("kind", q::Value::Enum("NON_NULL".to_string())),
-                            ("name", q::Value::Null),
+                            ("kind", r::Value::Enum("NON_NULL".to_string())),
+                            ("name", r::Value::Null),
                             (
                                 "ofType",
                                 object_value(vec![
-                                    ("kind", q::Value::Enum("ENUM".to_string())),
-                                    ("name", q::Value::String("Role".to_string())),
-                                    ("ofType", q::Value::Null),
+                                    ("kind", r::Value::Enum("ENUM".to_string())),
+                                    ("name", r::Value::String("Role".to_string())),
+                                    ("ofType", r::Value::Null),
                                 ]),
                             ),
                         ]),
                     ),
-                    ("isDeprecated", q::Value::Boolean(false)),
-                    ("deprecationReason", q::Value::Null),
+                    ("isDeprecated", r::Value::Boolean(false)),
+                    ("deprecationReason", r::Value::Null),
                 ]),
             ]),
         ),
-        ("inputFields", q::Value::Null),
-        ("enumValues", q::Value::Null),
+        ("inputFields", r::Value::Null),
+        ("enumValues", r::Value::Null),
         (
             "interfaces",
-            q::Value::List(vec![object_value(vec![
-                ("kind", q::Value::Enum("INTERFACE".to_string())),
-                ("name", q::Value::String("Node".to_string())),
-                ("ofType", q::Value::Null),
+            r::Value::List(vec![object_value(vec![
+                ("kind", r::Value::Enum("INTERFACE".to_string())),
+                ("name", r::Value::String("Node".to_string())),
+                ("ofType", r::Value::Null),
             ])]),
         ),
-        ("possibleTypes", q::Value::Null),
+        ("possibleTypes", r::Value::Null),
     ]);
 
     let query_type = object_value(vec![
-        ("kind", q::Value::Enum("OBJECT".to_string())),
-        ("name", q::Value::String("Query".to_string())),
-        ("description", q::Value::Null),
+        ("kind", r::Value::Enum("OBJECT".to_string())),
+        ("name", r::Value::String("Query".to_string())),
+        ("description", r::Value::Null),
         (
             "fields",
-            q::Value::List(vec![
+            r::Value::List(vec![
                 object_value(vec![
-                    ("name", q::Value::String("allUsers".to_string())),
-                    ("description", q::Value::Null),
+                    ("name", r::Value::String("allUsers".to_string())),
+                    ("description", r::Value::Null),
                     (
                         "args",
-                        q::Value::List(vec![
+                        r::Value::List(vec![
                             object_value(vec![
-                                ("defaultValue", q::Value::Null),
-                                ("description", q::Value::Null),
-                                ("name", q::Value::String("orderBy".to_string())),
+                                ("defaultValue", r::Value::Null),
+                                ("description", r::Value::Null),
+                                ("name", r::Value::String("orderBy".to_string())),
                                 (
                                     "type",
                                     object_value(vec![
-                                        ("kind", q::Value::Enum("ENUM".to_string())),
-                                        ("name", q::Value::String("User_orderBy".to_string())),
-                                        ("ofType", q::Value::Null),
+                                        ("kind", r::Value::Enum("ENUM".to_string())),
+                                        ("name", r::Value::String("User_orderBy".to_string())),
+                                        ("ofType", r::Value::Null),
                                     ]),
                                 ),
                             ]),
                             object_value(vec![
-                                ("defaultValue", q::Value::Null),
-                                ("description", q::Value::Null),
-                                ("name", q::Value::String("filter".to_string())),
+                                ("defaultValue", r::Value::Null),
+                                ("description", r::Value::Null),
+                                ("name", r::Value::String("filter".to_string())),
                                 (
                                     "type",
                                     object_value(vec![
-                                        ("kind", q::Value::Enum("INPUT_OBJECT".to_string())),
-                                        ("name", q::Value::String("User_filter".to_string())),
-                                        ("ofType", q::Value::Null),
+                                        ("kind", r::Value::Enum("INPUT_OBJECT".to_string())),
+                                        ("name", r::Value::String("User_filter".to_string())),
+                                        ("ofType", r::Value::Null),
                                     ]),
                                 ),
                             ]),
@@ -428,43 +428,43 @@ fn expected_mock_schema_introspection() -> q::Value {
                     (
                         "type",
                         object_value(vec![
-                            ("kind", q::Value::Enum("LIST".to_string())),
-                            ("name", q::Value::Null),
+                            ("kind", r::Value::Enum("LIST".to_string())),
+                            ("name", r::Value::Null),
                             (
                                 "ofType",
                                 object_value(vec![
-                                    ("kind", q::Value::Enum("NON_NULL".to_string())),
-                                    ("name", q::Value::Null),
+                                    ("kind", r::Value::Enum("NON_NULL".to_string())),
+                                    ("name", r::Value::Null),
                                     (
                                         "ofType",
                                         object_value(vec![
-                                            ("kind", q::Value::Enum("OBJECT".to_string())),
-                                            ("name", q::Value::String("User".to_string())),
-                                            ("ofType", q::Value::Null),
+                                            ("kind", r::Value::Enum("OBJECT".to_string())),
+                                            ("name", r::Value::String("User".to_string())),
+                                            ("ofType", r::Value::Null),
                                         ]),
                                     ),
                                 ]),
                             ),
                         ]),
                     ),
-                    ("isDeprecated", q::Value::Boolean(false)),
-                    ("deprecationReason", q::Value::Null),
+                    ("isDeprecated", r::Value::Boolean(false)),
+                    ("deprecationReason", r::Value::Null),
                 ]),
                 object_value(vec![
-                    ("name", q::Value::String("anyUserWithAge".to_string())),
-                    ("description", q::Value::Null),
+                    ("name", r::Value::String("anyUserWithAge".to_string())),
+                    ("description", r::Value::Null),
                     (
                         "args",
-                        q::Value::List(vec![object_value(vec![
-                            ("defaultValue", q::Value::String("99".to_string())),
-                            ("description", q::Value::Null),
-                            ("name", q::Value::String("age".to_string())),
+                        r::Value::List(vec![object_value(vec![
+                            ("defaultValue", r::Value::String("99".to_string())),
+                            ("description", r::Value::Null),
+                            ("name", r::Value::String("age".to_string())),
                             (
                                 "type",
                                 object_value(vec![
-                                    ("kind", q::Value::Enum("SCALAR".to_string())),
-                                    ("name", q::Value::String("Int".to_string())),
-                                    ("ofType", q::Value::Null),
+                                    ("kind", r::Value::Enum("SCALAR".to_string())),
+                                    ("name", r::Value::String("Int".to_string())),
+                                    ("ofType", r::Value::Null),
                                 ]),
                             ),
                         ])]),
@@ -472,38 +472,38 @@ fn expected_mock_schema_introspection() -> q::Value {
                     (
                         "type",
                         object_value(vec![
-                            ("kind", q::Value::Enum("OBJECT".to_string())),
-                            ("name", q::Value::String("User".to_string())),
-                            ("ofType", q::Value::Null),
+                            ("kind", r::Value::Enum("OBJECT".to_string())),
+                            ("name", r::Value::String("User".to_string())),
+                            ("ofType", r::Value::Null),
                         ]),
                     ),
-                    ("isDeprecated", q::Value::Boolean(false)),
-                    ("deprecationReason", q::Value::Null),
+                    ("isDeprecated", r::Value::Boolean(false)),
+                    ("deprecationReason", r::Value::Null),
                 ]),
                 object_value(vec![
-                    ("name", q::Value::String("User".to_string())),
-                    ("description", q::Value::Null),
-                    ("args", q::Value::List(vec![])),
+                    ("name", r::Value::String("User".to_string())),
+                    ("description", r::Value::Null),
+                    ("args", r::Value::List(vec![])),
                     (
                         "type",
                         object_value(vec![
-                            ("kind", q::Value::Enum("OBJECT".to_string())),
-                            ("name", q::Value::String("User".to_string())),
-                            ("ofType", q::Value::Null),
+                            ("kind", r::Value::Enum("OBJECT".to_string())),
+                            ("name", r::Value::String("User".to_string())),
+                            ("ofType", r::Value::Null),
                         ]),
                     ),
-                    ("isDeprecated", q::Value::Boolean(false)),
-                    ("deprecationReason", q::Value::Null),
+                    ("isDeprecated", r::Value::Boolean(false)),
+                    ("deprecationReason", r::Value::Null),
                 ]),
             ]),
         ),
-        ("inputFields", q::Value::Null),
-        ("enumValues", q::Value::Null),
-        ("interfaces", q::Value::List(vec![])),
-        ("possibleTypes", q::Value::Null),
+        ("inputFields", r::Value::Null),
+        ("enumValues", r::Value::Null),
+        ("interfaces", r::Value::List(vec![])),
+        ("possibleTypes", r::Value::Null),
     ]);
 
-    let expected_types = q::Value::List(vec![
+    let expected_types = r::Value::List(vec![
         boolean_type,
         id_type,
         int_type,
@@ -516,25 +516,25 @@ fn expected_mock_schema_introspection() -> q::Value {
         user_orderby_type,
     ]);
 
-    let expected_directives = q::Value::List(vec![object_value(vec![
-        ("name", q::Value::String("language".to_string())),
-        ("description", q::Value::Null),
+    let expected_directives = r::Value::List(vec![object_value(vec![
+        ("name", r::Value::String("language".to_string())),
+        ("description", r::Value::Null),
         (
             "locations",
-            q::Value::List(vec![q::Value::Enum(String::from("FIELD_DEFINITION"))]),
+            r::Value::List(vec![r::Value::Enum(String::from("FIELD_DEFINITION"))]),
         ),
         (
             "args",
-            q::Value::List(vec![object_value(vec![
-                ("name", q::Value::String("language".to_string())),
-                ("description", q::Value::Null),
-                ("defaultValue", q::Value::String("\"English\"".to_string())),
+            r::Value::List(vec![object_value(vec![
+                ("name", r::Value::String("language".to_string())),
+                ("description", r::Value::Null),
+                ("defaultValue", r::Value::String("\"English\"".to_string())),
                 (
                     "type",
                     object_value(vec![
-                        ("kind", q::Value::Enum("SCALAR".to_string())),
-                        ("name", q::Value::String("String".to_string())),
-                        ("ofType", q::Value::Null),
+                        ("kind", r::Value::Enum("SCALAR".to_string())),
+                        ("name", r::Value::String("String".to_string())),
+                        ("ofType", r::Value::Null),
                     ]),
                 ),
             ])]),
@@ -544,10 +544,10 @@ fn expected_mock_schema_introspection() -> q::Value {
     let schema_type = object_value(vec![
         (
             "queryType",
-            object_value(vec![("name", q::Value::String("Query".to_string()))]),
+            object_value(vec![("name", r::Value::String("Query".to_string()))]),
         ),
-        ("mutationType", q::Value::Null),
-        ("subscriptionType", q::Value::Null),
+        ("mutationType", r::Value::Null),
+        ("subscriptionType", r::Value::Null),
         ("types", expected_types),
         ("directives", expected_directives),
     ]);
@@ -1270,12 +1270,12 @@ async fn introspection_possible_types() {
         object_value(vec![(
             "__type",
             object_value(vec![
-                ("name", q::Value::String("RegEntry".to_string())),
+                ("name", r::Value::String("RegEntry".to_string())),
                 (
                     "possibleTypes",
-                    q::Value::List(vec![
-                        object_value(vec![("name", q::Value::String("Meme".to_owned()))]),
-                        object_value(vec![("name", q::Value::String("ParamChange".to_owned()))])
+                    r::Value::List(vec![
+                        object_value(vec![("name", r::Value::String("Meme".to_owned()))]),
+                        object_value(vec![("name", r::Value::String("ParamChange".to_owned()))])
                     ])
                 )
             ])

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -2,6 +2,7 @@
 extern crate pretty_assertions;
 
 use graphql_parser::Pos;
+use std::convert::TryFrom;
 use std::iter::FromIterator;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -19,7 +20,7 @@ use graph::{
         subgraph::SubgraphFeature,
     },
     prelude::{
-        futures03::stream::StreamExt, o, q, serde_json, slog, BlockPtr, DeploymentHash, Entity,
+        futures03::stream::StreamExt, o, q, r, serde_json, slog, BlockPtr, DeploymentHash, Entity,
         EntityKey, EntityOperation, FutureExtension, GraphQlRunner as _, Logger, NodeId, Query,
         QueryError, QueryExecutionError, QueryResult, QueryStoreManager, QueryVariables, Schema,
         SubgraphDeploymentEntity, SubgraphManifest, SubgraphName, SubgraphStore,
@@ -322,65 +323,65 @@ fn can_query_one_to_one_relationship() {
             Some(object_value(vec![
                 (
                     "musicians",
-                    q::Value::List(vec![
+                    r::Value::List(vec![
                         object_value(vec![
-                            ("name", q::Value::String(String::from("John"))),
+                            ("name", r::Value::String(String::from("John"))),
                             (
                                 "mainBand",
                                 object_value(vec![(
                                     "name",
-                                    q::Value::String(String::from("The Musicians")),
+                                    r::Value::String(String::from("The Musicians")),
                                 )]),
                             ),
                         ]),
                         object_value(vec![
-                            ("name", q::Value::String(String::from("Lisa"))),
+                            ("name", r::Value::String(String::from("Lisa"))),
                             (
                                 "mainBand",
                                 object_value(vec![(
                                     "name",
-                                    q::Value::String(String::from("The Musicians")),
+                                    r::Value::String(String::from("The Musicians")),
                                 )]),
                             ),
                         ]),
                         object_value(vec![
-                            ("name", q::Value::String(String::from("Tom"))),
+                            ("name", r::Value::String(String::from("Tom"))),
                             (
                                 "mainBand",
                                 object_value(vec![(
                                     "name",
-                                    q::Value::String(String::from("The Amateurs")),
+                                    r::Value::String(String::from("The Amateurs")),
                                 )]),
                             ),
                         ]),
                         object_value(vec![
-                            ("name", q::Value::String(String::from("Valerie"))),
-                            ("mainBand", q::Value::Null),
+                            ("name", r::Value::String(String::from("Valerie"))),
+                            ("mainBand", r::Value::Null),
                         ]),
                     ])
                 ),
                 (
                     "songStats",
-                    q::Value::List(vec![
+                    r::Value::List(vec![
                         object_value(vec![
-                            ("id", q::Value::String(String::from("s1"))),
-                            ("played", q::Value::Int(q::Number::from(10))),
+                            ("id", r::Value::String(String::from("s1"))),
+                            ("played", r::Value::Int(10)),
                             (
                                 "song",
                                 object_value(vec![
-                                    ("id", q::Value::String(String::from("s1"))),
-                                    ("title", q::Value::String(String::from("Cheesy Tune")))
+                                    ("id", r::Value::String(String::from("s1"))),
+                                    ("title", r::Value::String(String::from("Cheesy Tune")))
                                 ])
                             ),
                         ]),
                         object_value(vec![
-                            ("id", q::Value::String(String::from("s2"))),
-                            ("played", q::Value::Int(q::Number::from(15))),
+                            ("id", r::Value::String(String::from("s2"))),
+                            ("played", r::Value::Int(15)),
                             (
                                 "song",
                                 object_value(vec![
-                                    ("id", q::Value::String(String::from("s2"))),
-                                    ("title", q::Value::String(String::from("Rock Tune")))
+                                    ("id", r::Value::String(String::from("s2"))),
+                                    ("title", r::Value::String(String::from("Rock Tune")))
                                 ])
                             ),
                         ])
@@ -419,29 +420,29 @@ fn can_query_one_to_many_relationships_in_both_directions() {
             extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
-                q::Value::List(vec![
+                r::Value::List(vec![
                     object_value(vec![
-                        ("name", q::Value::String(String::from("John"))),
+                        ("name", r::Value::String(String::from("John"))),
                         (
                             "writtenSongs",
-                            q::Value::List(vec![
+                            r::Value::List(vec![
                                 object_value(vec![
-                                    ("title", q::Value::String(String::from("Cheesy Tune"))),
+                                    ("title", r::Value::String(String::from("Cheesy Tune"))),
                                     (
                                         "writtenBy",
                                         object_value(vec![(
                                             "name",
-                                            q::Value::String(String::from("John")),
+                                            r::Value::String(String::from("John")),
                                         )]),
                                     ),
                                 ]),
                                 object_value(vec![
-                                    ("title", q::Value::String(String::from("Pop Tune"))),
+                                    ("title", r::Value::String(String::from("Pop Tune"))),
                                     (
                                         "writtenBy",
                                         object_value(vec![(
                                             "name",
-                                            q::Value::String(String::from("John")),
+                                            r::Value::String(String::from("John")),
                                         )]),
                                     ),
                                 ]),
@@ -449,40 +450,40 @@ fn can_query_one_to_many_relationships_in_both_directions() {
                         ),
                     ]),
                     object_value(vec![
-                        ("name", q::Value::String(String::from("Lisa"))),
+                        ("name", r::Value::String(String::from("Lisa"))),
                         (
                             "writtenSongs",
-                            q::Value::List(vec![object_value(vec![
-                                ("title", q::Value::String(String::from("Rock Tune"))),
+                            r::Value::List(vec![object_value(vec![
+                                ("title", r::Value::String(String::from("Rock Tune"))),
                                 (
                                     "writtenBy",
                                     object_value(vec![(
                                         "name",
-                                        q::Value::String(String::from("Lisa")),
+                                        r::Value::String(String::from("Lisa")),
                                     )]),
                                 ),
                             ])]),
                         ),
                     ]),
                     object_value(vec![
-                        ("name", q::Value::String(String::from("Tom"))),
+                        ("name", r::Value::String(String::from("Tom"))),
                         (
                             "writtenSongs",
-                            q::Value::List(vec![object_value(vec![
-                                ("title", q::Value::String(String::from("Folk Tune"))),
+                            r::Value::List(vec![object_value(vec![
+                                ("title", r::Value::String(String::from("Folk Tune"))),
                                 (
                                     "writtenBy",
                                     object_value(vec![(
                                         "name",
-                                        q::Value::String(String::from("Tom"))
+                                        r::Value::String(String::from("Tom"))
                                     )]),
                                 ),
                             ])]),
                         ),
                     ]),
                     object_value(vec![
-                        ("name", q::Value::String(String::from("Valerie"))),
-                        ("writtenSongs", q::Value::List(vec![])),
+                        ("name", r::Value::String(String::from("Valerie"))),
+                        ("writtenSongs", r::Value::List(vec![])),
                     ]),
                 ]),
             )])),
@@ -517,24 +518,24 @@ fn can_query_many_to_many_relationship() {
         .await;
 
         let the_musicians = object_value(vec![
-            ("name", q::Value::String(String::from("The Musicians"))),
+            ("name", r::Value::String(String::from("The Musicians"))),
             (
                 "members",
-                q::Value::List(vec![
-                    object_value(vec![("name", q::Value::String(String::from("John")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Lisa")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Tom")))]),
+                r::Value::List(vec![
+                    object_value(vec![("name", r::Value::String(String::from("John")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Lisa")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Tom")))]),
                 ]),
             ),
         ]);
 
         let the_amateurs = object_value(vec![
-            ("name", q::Value::String(String::from("The Amateurs"))),
+            ("name", r::Value::String(String::from("The Amateurs"))),
             (
                 "members",
-                q::Value::List(vec![
-                    object_value(vec![("name", q::Value::String(String::from("John")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Tom")))]),
+                r::Value::List(vec![
+                    object_value(vec![("name", r::Value::String(String::from("John")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Tom")))]),
                 ]),
             ),
         ]);
@@ -543,28 +544,28 @@ fn can_query_many_to_many_relationship() {
             extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
-                q::Value::List(vec![
+                r::Value::List(vec![
                     object_value(vec![
-                        ("name", q::Value::String(String::from("John"))),
+                        ("name", r::Value::String(String::from("John"))),
                         (
                             "bands",
-                            q::Value::List(vec![the_musicians.clone(), the_amateurs.clone()]),
+                            r::Value::List(vec![the_musicians.clone(), the_amateurs.clone()]),
                         ),
                     ]),
                     object_value(vec![
-                        ("name", q::Value::String(String::from("Lisa"))),
-                        ("bands", q::Value::List(vec![the_musicians.clone()])),
+                        ("name", r::Value::String(String::from("Lisa"))),
+                        ("bands", r::Value::List(vec![the_musicians.clone()])),
                     ]),
                     object_value(vec![
-                        ("name", q::Value::String(String::from("Tom"))),
+                        ("name", r::Value::String(String::from("Tom"))),
                         (
                             "bands",
-                            q::Value::List(vec![the_musicians.clone(), the_amateurs.clone()]),
+                            r::Value::List(vec![the_musicians.clone(), the_amateurs.clone()]),
                         ),
                     ]),
                     object_value(vec![
-                        ("name", q::Value::String(String::from("Valerie"))),
-                        ("bands", q::Value::List(vec![])),
+                        ("name", r::Value::String(String::from("Valerie"))),
+                        ("bands", r::Value::List(vec![])),
                     ]),
                 ])
             )]))
@@ -594,7 +595,7 @@ fn query_variables_are_used() {
             Some(QueryVariables::new(HashMap::from_iter(
                 vec![(
                     String::from("where"),
-                    object_value(vec![("name", q::Value::String(String::from("Tom")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Tom")))]),
                 )]
                 .into_iter(),
             ))),
@@ -605,9 +606,9 @@ fn query_variables_are_used() {
             extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
-                q::Value::List(vec![object_value(vec![(
+                r::Value::List(vec![object_value(vec![(
                     "name",
-                    q::Value::String(String::from("Tom"))
+                    r::Value::String(String::from("Tom"))
                 )])],)
             )]))
         );
@@ -636,7 +637,7 @@ fn skip_directive_works_with_query_variables() {
             &deployment.hash,
             query.clone(),
             Some(QueryVariables::new(HashMap::from_iter(
-                vec![(String::from("skip"), q::Value::Boolean(true))].into_iter(),
+                vec![(String::from("skip"), r::Value::Boolean(true))].into_iter(),
             ))),
         )
         .await;
@@ -646,11 +647,11 @@ fn skip_directive_works_with_query_variables() {
             extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
-                q::Value::List(vec![
-                    object_value(vec![("name", q::Value::String(String::from("John")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Lisa")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Tom")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Valerie")))]),
+                r::Value::List(vec![
+                    object_value(vec![("name", r::Value::String(String::from("John")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Lisa")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Tom")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Valerie")))]),
                 ],)
             )]))
         );
@@ -660,7 +661,7 @@ fn skip_directive_works_with_query_variables() {
             &deployment.hash,
             query,
             Some(QueryVariables::new(HashMap::from_iter(
-                vec![(String::from("skip"), q::Value::Boolean(false))].into_iter(),
+                vec![(String::from("skip"), r::Value::Boolean(false))].into_iter(),
             ))),
         )
         .await;
@@ -670,22 +671,22 @@ fn skip_directive_works_with_query_variables() {
             extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
-                q::Value::List(vec![
+                r::Value::List(vec![
                     object_value(vec![
-                        ("id", q::Value::String(String::from("m1"))),
-                        ("name", q::Value::String(String::from("John")))
+                        ("id", r::Value::String(String::from("m1"))),
+                        ("name", r::Value::String(String::from("John")))
                     ]),
                     object_value(vec![
-                        ("id", q::Value::String(String::from("m2"))),
-                        ("name", q::Value::String(String::from("Lisa")))
+                        ("id", r::Value::String(String::from("m2"))),
+                        ("name", r::Value::String(String::from("Lisa")))
                     ]),
                     object_value(vec![
-                        ("id", q::Value::String(String::from("m3"))),
-                        ("name", q::Value::String(String::from("Tom")))
+                        ("id", r::Value::String(String::from("m3"))),
+                        ("name", r::Value::String(String::from("Tom")))
                     ]),
                     object_value(vec![
-                        ("id", q::Value::String(String::from("m4"))),
-                        ("name", q::Value::String(String::from("Valerie")))
+                        ("id", r::Value::String(String::from("m4"))),
+                        ("name", r::Value::String(String::from("Valerie")))
                     ]),
                 ],)
             )]))
@@ -715,7 +716,7 @@ fn include_directive_works_with_query_variables() {
             &deployment.hash,
             query.clone(),
             Some(QueryVariables::new(HashMap::from_iter(
-                vec![(String::from("include"), q::Value::Boolean(true))].into_iter(),
+                vec![(String::from("include"), r::Value::Boolean(true))].into_iter(),
             ))),
         )
         .await;
@@ -725,22 +726,22 @@ fn include_directive_works_with_query_variables() {
             extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
-                q::Value::List(vec![
+                r::Value::List(vec![
                     object_value(vec![
-                        ("id", q::Value::String(String::from("m1"))),
-                        ("name", q::Value::String(String::from("John")))
+                        ("id", r::Value::String(String::from("m1"))),
+                        ("name", r::Value::String(String::from("John")))
                     ]),
                     object_value(vec![
-                        ("id", q::Value::String(String::from("m2"))),
-                        ("name", q::Value::String(String::from("Lisa")))
+                        ("id", r::Value::String(String::from("m2"))),
+                        ("name", r::Value::String(String::from("Lisa")))
                     ]),
                     object_value(vec![
-                        ("id", q::Value::String(String::from("m3"))),
-                        ("name", q::Value::String(String::from("Tom")))
+                        ("id", r::Value::String(String::from("m3"))),
+                        ("name", r::Value::String(String::from("Tom")))
                     ]),
                     object_value(vec![
-                        ("id", q::Value::String(String::from("m4"))),
-                        ("name", q::Value::String(String::from("Valerie")))
+                        ("id", r::Value::String(String::from("m4"))),
+                        ("name", r::Value::String(String::from("Valerie")))
                     ]),
                 ],)
             )]))
@@ -751,7 +752,7 @@ fn include_directive_works_with_query_variables() {
             &deployment.hash,
             query,
             Some(QueryVariables::new(HashMap::from_iter(
-                vec![(String::from("include"), q::Value::Boolean(false))].into_iter(),
+                vec![(String::from("include"), r::Value::Boolean(false))].into_iter(),
             ))),
         )
         .await;
@@ -761,11 +762,11 @@ fn include_directive_works_with_query_variables() {
             extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
-                q::Value::List(vec![
-                    object_value(vec![("name", q::Value::String(String::from("John")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Lisa")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Tom")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Valerie")))]),
+                r::Value::List(vec![
+                    object_value(vec![("name", r::Value::String(String::from("John")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Lisa")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Tom")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Valerie")))]),
                 ],)
             )]))
         );
@@ -1001,9 +1002,9 @@ fn variable_defaults() {
             extract_data!(result),
             Some(object_value(vec![(
                 "bands",
-                q::Value::List(vec![
-                    object_value(vec![("id", q::Value::String(String::from("b2")))]),
-                    object_value(vec![("id", q::Value::String(String::from("b1")))])
+                r::Value::List(vec![
+                    object_value(vec![("id", r::Value::String(String::from("b2")))]),
+                    object_value(vec![("id", r::Value::String(String::from("b1")))])
                 ],)
             )]))
         );
@@ -1013,7 +1014,7 @@ fn variable_defaults() {
             &deployment.hash,
             query,
             Some(QueryVariables::new(HashMap::from_iter(
-                vec![(String::from("orderDir"), q::Value::Null)].into_iter(),
+                vec![(String::from("orderDir"), r::Value::Null)].into_iter(),
             ))),
         )
         .await;
@@ -1022,9 +1023,9 @@ fn variable_defaults() {
             extract_data!(result),
             Some(object_value(vec![(
                 "bands",
-                q::Value::List(vec![
-                    object_value(vec![("id", q::Value::String(String::from("b1")))]),
-                    object_value(vec![("id", q::Value::String(String::from("b2")))])
+                r::Value::List(vec![
+                    object_value(vec![("id", r::Value::String(String::from("b1")))]),
+                    object_value(vec![("id", r::Value::String(String::from("b2")))])
                 ],)
             )]))
         );
@@ -1053,11 +1054,11 @@ fn skip_is_nullable() {
             extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
-                q::Value::List(vec![
-                    object_value(vec![("name", q::Value::String(String::from("John")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Lisa")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Tom")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Valerie")))]),
+                r::Value::List(vec![
+                    object_value(vec![("name", r::Value::String(String::from("John")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Lisa")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Tom")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Valerie")))]),
                 ],)
             )]))
         );
@@ -1086,11 +1087,11 @@ fn first_is_nullable() {
             extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
-                q::Value::List(vec![
-                    object_value(vec![("name", q::Value::String(String::from("John")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Lisa")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Tom")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Valerie")))]),
+                r::Value::List(vec![
+                    object_value(vec![("name", r::Value::String(String::from("John")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Lisa")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Tom")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Valerie")))]),
                 ],)
             )]))
         );
@@ -1117,7 +1118,7 @@ fn nested_variable() {
             &deployment.hash,
             query,
             Some(QueryVariables::new(HashMap::from_iter(
-                vec![(String::from("name"), q::Value::String("Lisa".to_string()))].into_iter(),
+                vec![(String::from("name"), r::Value::String("Lisa".to_string()))].into_iter(),
             ))),
         )
         .await;
@@ -1126,9 +1127,9 @@ fn nested_variable() {
             extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
-                q::Value::List(vec![object_value(vec![(
+                r::Value::List(vec![object_value(vec![(
                     "name",
-                    q::Value::String(String::from("Lisa"))
+                    r::Value::String(String::from("Lisa"))
                 )])])
             )]))
         );
@@ -1209,26 +1210,26 @@ fn can_filter_by_relationship_fields() {
             Some(object_value(vec![
                 (
                     "musicians",
-                    q::Value::List(vec![object_value(vec![
-                        ("id", q::Value::String(String::from("m3"))),
-                        ("name", q::Value::String(String::from("Tom"))),
+                    r::Value::List(vec![object_value(vec![
+                        ("id", r::Value::String(String::from("m3"))),
+                        ("name", r::Value::String(String::from("Tom"))),
                         (
                             "mainBand",
-                            object_value(vec![("id", q::Value::String(String::from("b2")))])
+                            object_value(vec![("id", r::Value::String(String::from("b2")))])
                         )
                     ])])
                 ),
                 (
                     "bands",
-                    q::Value::List(vec![object_value(vec![
-                        ("id", q::Value::String(String::from("b2"))),
-                        ("name", q::Value::String(String::from("The Amateurs"))),
+                    r::Value::List(vec![object_value(vec![
+                        ("id", r::Value::String(String::from("b2"))),
+                        ("name", r::Value::String(String::from("The Amateurs"))),
                         (
                             "originalSongs",
-                            q::Value::List(vec![
-                                object_value(vec![("id", q::Value::String(String::from("s1")))]),
-                                object_value(vec![("id", q::Value::String(String::from("s3")))]),
-                                object_value(vec![("id", q::Value::String(String::from("s4")))]),
+                            r::Value::List(vec![
+                                object_value(vec![("id", r::Value::String(String::from("s1")))]),
+                                object_value(vec![("id", r::Value::String(String::from("s3")))]),
+                                object_value(vec![("id", r::Value::String(String::from("s4")))]),
                             ])
                         )
                     ])])
@@ -1263,10 +1264,10 @@ fn cannot_filter_by_derved_relationship_fields() {
             QueryError::ExecutionError(QueryExecutionError::InvalidArgumentError(_, s, v)) => {
                 assert_eq!(s, "where");
                 assert_eq!(
-                    v,
-                    &object_value(vec![(
+                    r::Value::try_from(v.clone()).unwrap(),
+                    object_value(vec![(
                         "writtenSongs",
-                        q::Value::List(vec![q::Value::String(String::from("s1"))])
+                        r::Value::List(vec![r::Value::String(String::from("s1"))])
                     )]),
                 );
             }
@@ -1329,9 +1330,9 @@ fn subscription_gets_result_even_without_events() {
             extract_data!(result),
             Some(object_value(vec![(
                 "musicians",
-                q::Value::List(vec![
-                    object_value(vec![("name", q::Value::String(String::from("John")))]),
-                    object_value(vec![("name", q::Value::String(String::from("Lisa")))])
+                r::Value::List(vec![
+                    object_value(vec![("name", r::Value::String(String::from("John")))]),
+                    object_value(vec![("name", r::Value::String(String::from("Lisa")))])
                 ])
             )])),
         );
@@ -1363,33 +1364,33 @@ fn can_use_nested_filter() {
             extract_data!(result).unwrap(),
             object_value(vec![(
                 "musicians",
-                q::Value::List(vec![
+                r::Value::List(vec![
                     object_value(vec![
-                        ("name", q::Value::String(String::from("John"))),
+                        ("name", r::Value::String(String::from("John"))),
                         (
                             "bands",
-                            q::Value::List(vec![object_value(vec![(
+                            r::Value::List(vec![object_value(vec![(
                                 "id",
-                                q::Value::String(String::from("b2"))
+                                r::Value::String(String::from("b2"))
                             )])])
                         )
                     ]),
                     object_value(vec![
-                        ("name", q::Value::String(String::from("Lisa"))),
-                        ("bands", q::Value::List(vec![]))
+                        ("name", r::Value::String(String::from("Lisa"))),
+                        ("bands", r::Value::List(vec![]))
                     ]),
                     object_value(vec![
-                        ("name", q::Value::String(String::from("Tom"))),
+                        ("name", r::Value::String(String::from("Tom"))),
                         (
                             "bands",
-                            q::Value::List(vec![object_value(vec![
-                                (("id", q::Value::String(String::from("b2"))))
+                            r::Value::List(vec![object_value(vec![
+                                (("id", r::Value::String(String::from("b2"))))
                             ])])
                         )
                     ]),
                     object_value(vec![
-                        ("name", q::Value::String(String::from("Valerie"))),
-                        ("bands", q::Value::List(vec![]))
+                        ("name", r::Value::String(String::from("Valerie"))),
+                        ("bands", r::Value::List(vec![]))
                     ])
                 ])
             )])
@@ -1400,7 +1401,7 @@ fn can_use_nested_filter() {
 async fn check_musicians_at(
     id: &DeploymentHash,
     query: &str,
-    block_var: Option<(&str, q::Value)>,
+    block_var: Option<(&str, r::Value)>,
     expected: Result<Vec<&str>, &str>,
     qid: &str,
 ) {
@@ -1419,9 +1420,9 @@ async fn check_musicians_at(
         Ok(ids) => {
             let ids: Vec<_> = ids
                 .into_iter()
-                .map(|id| object_value(vec![("id", q::Value::String(String::from(id)))]))
+                .map(|id| object_value(vec![("id", r::Value::String(String::from(id)))]))
                 .collect();
-            let expected = Some(object_value(vec![("musicians", q::Value::List(ids))]));
+            let expected = Some(object_value(vec![("musicians", r::Value::List(ids))]));
             let data = match result.to_result() {
                 Err(errors) => panic!("unexpected error: {:?} ({})\n", errors, qid),
                 Ok(data) => data,
@@ -1533,7 +1534,7 @@ fn query_at_block_with_vars() {
             qid: &str,
         ) {
             let query = "query by_nr($block: Int!) { musicians(block: { number: $block }) { id } }";
-            let number = q::Value::Int(q::Number::from(block));
+            let number = r::Value::Int(block.into());
             let var = Some(("block", number.clone()));
 
             check_musicians_at(&deployment.hash, query, var, expected.clone(), qid).await;
@@ -1541,7 +1542,7 @@ fn query_at_block_with_vars() {
             let query = "query by_nr($block: Block_height!) { musicians(block: $block) { id } }";
             let mut map = BTreeMap::new();
             map.insert("number".to_owned(), number);
-            let block = q::Value::Object(map);
+            let block = r::Value::Object(map);
             let var = Some(("block", block));
 
             check_musicians_at(&deployment.hash, query, var, expected, qid).await;
@@ -1555,7 +1556,7 @@ fn query_at_block_with_vars() {
         ) {
             let query =
                 "query by_hash($block: String!) { musicians(block: { hash: $block }) { id } }";
-            let var = Some(("block", q::Value::String(block.hash.to_owned())));
+            let var = Some(("block", r::Value::String(block.hash.to_owned())));
 
             check_musicians_at(&deployment.hash, query, var, expected, qid).await;
         }
@@ -1681,7 +1682,7 @@ fn can_query_meta() {
         let exp = object! {
             _meta: object! {
                 block: object! {
-                    hash: q::Value::Null,
+                    hash: r::Value::Null,
                     number: 0
                 },
                 deployment: "graphqlTestsQuery"

--- a/node/src/manager/commands/query.rs
+++ b/node/src/manager/commands/query.rs
@@ -1,11 +1,12 @@
 use std::iter::FromIterator;
 use std::{collections::HashMap, sync::Arc};
 
+use graph::prelude::r;
 use graph::{
     data::query::QueryTarget,
     prelude::{
         anyhow::{self, anyhow},
-        q, serde_json, DeploymentHash, GraphQlRunner as _, Query, QueryVariables, SubgraphName,
+        serde_json, DeploymentHash, GraphQlRunner as _, Query, QueryVariables, SubgraphName,
     },
 };
 use graph_graphql::prelude::GraphQlRunner;
@@ -30,15 +31,15 @@ pub async fn run(
     };
 
     let document = graphql_parser::parse_query(&query)?.into_static();
-    let vars: Vec<(String, q::Value)> = vars
+    let vars: Vec<(String, r::Value)> = vars
         .into_iter()
         .map(|v| {
             let mut pair = v.splitn(2, '=').map(|s| s.to_string());
             let key = pair.next();
             let value = pair
                 .next()
-                .map(|s| q::Value::String(s))
-                .unwrap_or(q::Value::Null);
+                .map(|s| r::Value::String(s))
+                .unwrap_or(r::Value::Null);
             match key {
                 Some(key) => Ok((key, value)),
                 None => Err(anyhow!(

--- a/server/http/src/request.rs
+++ b/server/http/src/request.rs
@@ -170,14 +170,14 @@ mod tests {
             .into_static();
         let expected_variables = QueryVariables::new(HashMap::from_iter(
             vec![
-                (String::from("string"), q::Value::String(String::from("s"))),
+                (String::from("string"), r::Value::String(String::from("s"))),
                 (
                     String::from("map"),
-                    q::Value::Object(BTreeMap::from_iter(
-                        vec![(String::from("k"), q::Value::String(String::from("v")))].into_iter(),
+                    r::Value::Object(BTreeMap::from_iter(
+                        vec![(String::from("k"), r::Value::String(String::from("v")))].into_iter(),
                     )),
                 ),
-                (String::from("int"), q::Value::Int(q::Number::from(5))),
+                (String::from("int"), r::Value::Int(5)),
             ]
             .into_iter(),
         ));

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -429,7 +429,7 @@ mod tests {
             QueryResults::from(BTreeMap::from_iter(
                 vec![(
                     String::from("name"),
-                    q::Value::String(String::from("Jordi")),
+                    r::Value::String(String::from("Jordi")),
                 )]
                 .into_iter(),
             ))

--- a/server/http/tests/response.rs
+++ b/server/http/tests/response.rs
@@ -1,7 +1,6 @@
 use graph::data::{graphql::object, query::QueryResults};
 use graph::prelude::*;
 use graph_server_http::test_utils;
-use graphql_parser;
 use std::collections::BTreeMap;
 
 #[test]
@@ -30,10 +29,10 @@ fn canonical_serialization() {
                 // get amended if q::Value ever gets more variants
                 // The order of the variants should be the same as the
                 // order of the tests below
-                use graphql_parser::query::Value::*;
+                use r::Value::*;
                 let _ = match $obj {
-                    Variable(_) | Object(_) | List(_) | Enum(_) | Null | Int(_) | Float(_)
-                    | String(_) | Boolean(_) => (),
+                    Object(_) | List(_) | Enum(_) | Null | Int(_) | Float(_) | String(_)
+                    | Boolean(_) => (),
                 };
             }
             let res = QueryResult::try_from($obj).unwrap();
@@ -55,13 +54,13 @@ fn canonical_serialization() {
     // Value::Enum
     assert_resp!(
         r#"{"data":{"enum_field":"enum"}}"#,
-        object! { enum_field:  q::Value::Enum("enum".to_owned())}
+        object! { enum_field:  r::Value::Enum("enum".to_owned())}
     );
 
     // Value::Null
     assert_resp!(
         r#"{"data":{"nothing":null}}"#,
-        object! { nothing:  q::Value::Null}
+        object! { nothing:  r::Value::Null}
     );
 
     // Value::Int

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -44,16 +44,16 @@ impl GraphQlRunner for TestGraphQlRunner {
                 .unwrap()
                 .get(&String::from("equals"))
                 .unwrap()
-                == &q::Value::String(String::from("John"))
+                == &r::Value::String(String::from("John"))
         {
             BTreeMap::from_iter(
-                vec![(String::from("name"), q::Value::String(String::from("John")))].into_iter(),
+                vec![(String::from("name"), r::Value::String(String::from("John")))].into_iter(),
             )
         } else {
             BTreeMap::from_iter(
                 vec![(
                     String::from("name"),
-                    q::Value::String(String::from("Jordi")),
+                    r::Value::String(String::from("Jordi")),
                 )]
                 .into_iter(),
             )

--- a/server/index-node/src/explorer.rs
+++ b/server/index-node/src/explorer.rs
@@ -1,6 +1,7 @@
 //! Functionality to support the explorer in the hosted service. Everything
 //! in this file is private API and experimental and subject to change at
 //! any time
+use graph::prelude::r;
 use http::{Response, StatusCode};
 use hyper::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
@@ -21,7 +22,7 @@ use graph::{
     },
     data::subgraph::status,
     object,
-    prelude::{lazy_static, q, serde_json, warn, Logger, SerializableValue},
+    prelude::{lazy_static, serde_json, warn, Logger},
     util::timed_cache::TimedCache,
 };
 
@@ -75,9 +76,9 @@ lazy_static! {
 #[derive(Debug)]
 pub struct Explorer<S> {
     store: Arc<S>,
-    versions: TimedCache<String, q::Value>,
+    versions: TimedCache<String, r::Value>,
     version_infos: TimedCache<String, VersionInfo>,
-    entity_counts: TimedCache<String, q::Value>,
+    entity_counts: TimedCache<String, r::Value>,
 }
 
 impl<S> Explorer<S>
@@ -238,7 +239,7 @@ where
         &self,
         deployment_hash: &str,
     ) -> Result<Response<Body>, GraphQLServerError> {
-        let name_version_pairs: Vec<q::Value> = self
+        let name_version_pairs: Vec<r::Value> = self
             .store
             .subgraphs_for_deployment_hash(deployment_hash)?
             .into_iter()
@@ -249,7 +250,7 @@ where
                 }
             })
             .collect();
-        let payload = q::Value::List(name_version_pairs);
+        let payload = r::Value::List(name_version_pairs);
         Ok(as_http_response(&payload))
     }
 }
@@ -263,10 +264,9 @@ fn handle_not_found() -> Result<Response<Body>, GraphQLServerError> {
         .unwrap())
 }
 
-fn as_http_response(value: &q::Value) -> http::Response<Body> {
+fn as_http_response(value: &r::Value) -> http::Response<Body> {
     let status_code = http::StatusCode::OK;
-    let json = serde_json::to_string(&SerializableValue(value))
-        .expect("Failed to serialize response to JSON");
+    let json = serde_json::to_string(&value).expect("Failed to serialize response to JSON");
     http::Response::builder()
         .status(status_code)
         .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")

--- a/server/index-node/src/request.rs
+++ b/server/index-node/src/request.rs
@@ -166,14 +166,14 @@ mod tests {
             .into_static();
         let expected_variables = QueryVariables::new(HashMap::from_iter(
             vec![
-                (String::from("string"), q::Value::String(String::from("s"))),
+                (String::from("string"), r::Value::String(String::from("s"))),
                 (
                     String::from("map"),
-                    q::Value::Object(BTreeMap::from_iter(
-                        vec![(String::from("k"), q::Value::String(String::from("v")))].into_iter(),
+                    r::Value::Object(BTreeMap::from_iter(
+                        vec![(String::from("k"), r::Value::String(String::from("v")))].into_iter(),
                     )),
                 ),
-                (String::from("int"), q::Value::Int(q::Number::from(5))),
+                (String::from("int"), r::Value::Int(5)),
             ]
             .into_iter(),
         ));

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -44,15 +44,15 @@ where
 
     fn resolve_indexing_statuses(
         &self,
-        arguments: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
+        arguments: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
         let deployments = arguments
             .get("subgraphs")
             .map(|value| match value {
-                q::Value::List(ids) => ids
+                r::Value::List(ids) => ids
                     .into_iter()
                     .map(|id| match id {
-                        s::Value::String(s) => s.clone(),
+                        r::Value::String(s) => s.clone(),
                         _ => unreachable!(),
                     })
                     .collect(),
@@ -68,8 +68,8 @@ where
 
     fn resolve_indexing_statuses_for_subgraph_name(
         &self,
-        arguments: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
+        arguments: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
         // Get the subgraph name from the arguments; we can safely use `expect` here
         // because the argument will already have been validated prior to the resolver
         // being called
@@ -92,8 +92,8 @@ where
 
     fn resolve_proof_of_indexing(
         &self,
-        argument_values: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
+        argument_values: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
         let deployment_id = argument_values
             .get_required::<DeploymentHash>("subgraph")
             .expect("Valid subgraphId required");
@@ -120,8 +120,8 @@ where
             .store
             .get_proof_of_indexing(&deployment_id, &indexer, block.clone());
         let poi = match futures::executor::block_on(poi_fut) {
-            Ok(Some(poi)) => q::Value::String(format!("0x{}", hex::encode(&poi))),
-            Ok(None) => q::Value::Null,
+            Ok(Some(poi)) => r::Value::String(format!("0x{}", hex::encode(&poi))),
+            Ok(None) => r::Value::Null,
             Err(e) => {
                 error!(
                     self.logger,
@@ -130,7 +130,7 @@ where
                     "block" => format!("{}", block),
                     "error" => format!("{:?}", e)
                 );
-                q::Value::Null
+                r::Value::Null
             }
         };
 
@@ -139,11 +139,11 @@ where
 
     fn resolve_indexing_status_for_version(
         &self,
-        arguments: &HashMap<&str, q::Value>,
+        arguments: &HashMap<&str, r::Value>,
 
         // If `true` return the current version, if `false` return the pending version.
         current_version: bool,
-    ) -> Result<q::Value, QueryExecutionError> {
+    ) -> Result<r::Value, QueryExecutionError> {
         // We can safely unwrap because the argument is non-nullable and has been validated.
         let subgraph_name = arguments.get_required::<String>("subgraphName").unwrap();
 
@@ -163,13 +163,13 @@ where
             .into_iter()
             .next()
             .map(|info| info.into_value())
-            .unwrap_or(q::Value::Null))
+            .unwrap_or(r::Value::Null))
     }
 
     async fn resolve_subgraph_features(
         &self,
-        arguments: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
+        arguments: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
         // We can safely unwrap because the argument is non-nullable and has been validated.
         let subgraph_id = arguments.get_required::<String>("subgraphId").unwrap();
 
@@ -244,19 +244,19 @@ where
 
         // We then bulid a GraphqQL `Object` value that contains the feature detection and
         // validation results and send it back as a response.
-        let mut response: BTreeMap<String, q::Value> = BTreeMap::new();
+        let mut response: BTreeMap<String, r::Value> = BTreeMap::new();
         response.insert("features".to_string(), features);
         response.insert("errors".to_string(), errors);
         response.insert("network".to_string(), network);
 
-        Ok(q::Value::Object(response))
+        Ok(r::Value::Object(response))
     }
 }
 
 struct ValidationPostProcessResult {
-    features: q::Value,
-    errors: q::Value,
-    network: q::Value,
+    features: r::Value,
+    errors: r::Value,
+    network: r::Value,
 }
 
 fn validate_and_extract_features<C, St>(
@@ -308,16 +308,16 @@ where
     // For this step we must collect whichever results we have into GraphQL `Value` types.
     match subgraph_validation {
         Either::Left(subgraph_manifest) => {
-            let features = q::Value::List(
+            let features = r::Value::List(
                 detect_features(&subgraph_manifest)
                     .map_err(|_| QueryExecutionError::InvalidSubgraphManifest)?
                     .iter()
                     .map(ToString::to_string)
-                    .map(q::Value::String)
+                    .map(r::Value::String)
                     .collect(),
             );
-            let errors = q::Value::List(vec![]);
-            let network = q::Value::String(subgraph_manifest.network_name());
+            let errors = r::Value::List(vec![]);
+            let network = r::Value::String(subgraph_manifest.network_name());
 
             Ok(ValidationPostProcessResult {
                 features,
@@ -326,15 +326,15 @@ where
             })
         }
         Either::Right(errors) => {
-            let features = q::Value::List(vec![]);
-            let errors = q::Value::List(
+            let features = r::Value::List(vec![]);
+            let errors = r::Value::List(
                 errors
                     .iter()
                     .map(ToString::to_string)
-                    .map(q::Value::String)
+                    .map(r::Value::String)
                     .collect(),
             );
-            let network = q::Value::Null;
+            let network = r::Value::Null;
             Ok(ValidationPostProcessResult {
                 features,
                 errors,
@@ -377,7 +377,7 @@ where
         &self,
         _: &ExecutionContext<Self>,
         _: &q::SelectionSet,
-    ) -> Result<Option<q::Value>, Vec<QueryExecutionError>> {
+    ) -> Result<Option<r::Value>, Vec<QueryExecutionError>> {
         Ok(None)
     }
 
@@ -387,9 +387,9 @@ where
         parent_object_type: &s::ObjectType,
         field: &q::Field,
         scalar_type: &s::ScalarType,
-        value: Option<q::Value>,
-        argument_values: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
+        value: Option<r::Value>,
+        argument_values: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
         // Check if we are resolving the proofOfIndexing bytes
         if &parent_object_type.name == "Query"
             && &field.name == "proofOfIndexing"
@@ -402,17 +402,17 @@ where
         // is no way to call back into the default implementation for the trait.
         // So, note that this is duplicated.
         // See also c2112309-44fd-4a84-92a0-5a651e6ed548
-        Ok(value.unwrap_or(q::Value::Null))
+        Ok(value.unwrap_or(r::Value::Null))
     }
 
     fn resolve_objects(
         &self,
-        prefetched_objects: Option<q::Value>,
+        prefetched_objects: Option<r::Value>,
         field: &q::Field,
         _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
+        arguments: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
         match (prefetched_objects, object_type.name(), field.name.as_str()) {
             // The top-level `indexingStatuses` field
             (None, "SubgraphIndexingStatus", "indexingStatuses") => {
@@ -425,18 +425,18 @@ where
             }
 
             // Resolve fields of `Object` values (e.g. the `chains` field of `ChainIndexingStatus`)
-            (value, _, _) => Ok(value.unwrap_or(q::Value::Null)),
+            (value, _, _) => Ok(value.unwrap_or(r::Value::Null)),
         }
     }
 
     fn resolve_object(
         &self,
-        prefetched_object: Option<q::Value>,
+        prefetched_object: Option<r::Value>,
         field: &q::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&str, q::Value>,
-    ) -> Result<q::Value, QueryExecutionError> {
+        arguments: &HashMap<&str, r::Value>,
+    ) -> Result<r::Value, QueryExecutionError> {
         match (prefetched_object, field.name.as_str()) {
             // The top-level `indexingStatusForCurrentVersion` field
             (None, "indexingStatusForCurrentVersion") => {
@@ -454,7 +454,7 @@ where
             }
 
             // Resolve fields of `Object` values (e.g. the `latestBlock` field of `EthereumBlock`)
-            (value, _) => Ok(value.unwrap_or(q::Value::Null)),
+            (value, _) => Ok(value.unwrap_or(r::Value::Null)),
         }
     }
 }

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -36,7 +36,7 @@ impl QueryStoreTrait for QueryStore {
     fn find_query_values(
         &self,
         query: EntityQuery,
-    ) -> Result<Vec<BTreeMap<String, q::Value>>, QueryExecutionError> {
+    ) -> Result<Vec<BTreeMap<String, r::Value>>, QueryExecutionError> {
         assert_eq!(&self.site.deployment, &query.subgraph_id);
         let conn = self
             .store

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -14,7 +14,7 @@ use diesel::Connection;
 use lazy_static::lazy_static;
 
 use graph::prelude::{
-    anyhow, q, serde_json, Attribute, BlockNumber, ChildMultiplicity, Entity, EntityCollection,
+    anyhow, r, serde_json, Attribute, BlockNumber, ChildMultiplicity, Entity, EntityCollection,
     EntityFilter, EntityKey, EntityLink, EntityOrder, EntityRange, EntityWindow, ParentLink,
     QueryExecutionError, StoreError, Value,
 };
@@ -270,7 +270,7 @@ impl ForeignKeyClauses for Column {
     }
 }
 
-pub trait FromEntityData: Default + From<Entity> {
+pub trait FromEntityData: Default {
     type Value: FromColumnValue;
 
     fn insert_entity_data(&mut self, key: String, v: Self::Value);
@@ -284,8 +284,8 @@ impl FromEntityData for Entity {
     }
 }
 
-impl FromEntityData for BTreeMap<String, q::Value> {
-    type Value = q::Value;
+impl FromEntityData for BTreeMap<String, r::Value> {
+    type Value = r::Value;
 
     fn insert_entity_data(&mut self, key: String, v: Self::Value) {
         self.insert(key, v);
@@ -373,9 +373,9 @@ pub trait FromColumnValue: Sized {
     }
 }
 
-impl FromColumnValue for q::Value {
+impl FromColumnValue for r::Value {
     fn is_null(&self) -> bool {
-        self == &q::Value::Null
+        matches!(self, r::Value::Null)
     }
 
     fn null() -> Self {
@@ -383,31 +383,31 @@ impl FromColumnValue for q::Value {
     }
 
     fn from_string(s: String) -> Self {
-        q::Value::String(s)
+        r::Value::String(s)
     }
 
     fn from_bool(b: bool) -> Self {
-        q::Value::Boolean(b)
+        r::Value::Boolean(b)
     }
 
     fn from_i32(i: i32) -> Self {
-        q::Value::Int(i.into())
+        r::Value::Int(i.into())
     }
 
     fn from_big_decimal(d: scalar::BigDecimal) -> Self {
-        q::Value::String(d.to_string())
+        r::Value::String(d.to_string())
     }
 
     fn from_big_int(i: serde_json::Number) -> Result<Self, StoreError> {
-        Ok(q::Value::String(i.to_string()))
+        Ok(r::Value::String(i.to_string()))
     }
 
     fn from_bytes(b: &str) -> Result<Self, StoreError> {
-        Ok(q::Value::String(format!("0x{}", b)))
+        Ok(r::Value::String(format!("0x{}", b)))
     }
 
     fn from_vec(v: Vec<Self>) -> Self {
-        q::Value::List(v)
+        r::Value::List(v)
     }
 }
 


### PR DESCRIPTION
This highly annoying refactor makes it possible to change what we consider a value in query results, how we represent it, and opens up optimizations like interning the keys in maps inside values.

