### PR TITLE
graph: fix FirehoseBlockStream re-connection when the cursor is "in memory"

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -203,7 +203,6 @@ impl Chain {
             firehose_endpoint,
             firehose_cursor,
             firehose_mapper,
-            deployment.hash,
             adapter,
             filter,
             start_blocks,

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -144,7 +144,6 @@ impl Blockchain for Chain {
             firehose_endpoint,
             firehose_cursor,
             firehose_mapper,
-            deployment.hash,
             adapter,
             filter,
             start_blocks,

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -608,6 +608,14 @@ where
 
                     deployment_failed.set(0.0);
 
+                    // Notify the BlockStream implementation that a block was succesfully consumed
+                    // and that its internal cursoring mechanism can be saved to memory.
+                    //
+                    // The first `get_mut` is to get the inner `Stream` out of `Cancelable` which
+                    // returns a `TryStreamExt::MapErr` struct and the second `get_mut` is to get
+                    // out the actual `dyn BlockStream` trait on which we can call our method.
+                    block_stream.get_mut().get_mut().notify_block_consumed();
+
                     if needs_restart {
                         // Cancel the stream for real
                         ctx.state

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -11,6 +11,7 @@ use crate::{prelude::*, prometheus::labels};
 pub trait BlockStream<C: Blockchain>:
     Stream<Item = Result<BlockStreamEvent<C>, Error>> + Unpin
 {
+    fn notify_block_consumed(&mut self) {}
 }
 
 pub type FirehoseCursor = Option<String>;

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -17,6 +17,12 @@ pub struct Cancelable<T, C> {
     on_cancel: C,
 }
 
+impl<T, C> Cancelable<T, C> {
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
 /// It's not viable to use `select` directly, so we do a custom implementation.
 impl<S: Stream + Unpin, C: Fn() -> S::Item + Unpin> Stream for Cancelable<S, C> {
     type Item = S::Item;


### PR DESCRIPTION
So we've an architectural problem here where we cannot just save the response's cursor as the active cursor when a response is received in `FirehoseBlockStream`. It's actually the consumer of the stream that should inform us if a block was correctly fully consumed and that the latest cursor should be saved.

Imagine the following situation where we save the cursor right before sending it to the consumer in the `FirehoseBlockStream`. Now, the consumer of our stream receives it properly but fails without having fully processed the block (for example a bug bailed at the very first transaction of a block but there is still N transactions to process in it). Now if this stream reconnects with latest saved cursor, we will actually skip a block because the next block received will be right the saved cursor while we did not fully consumed the block the cursor was at.

To achieve that, we add a `notify_block_consumed` notification like method on the `BlockStream` trait with a default implementation that do nothing. When the instance manager consumed the block completely, it notifies the `BlockStream` implementation that the block was correctly processed. The `FirehoseBlockStream` when it's about to send a block to the consumer, saves the current cursor in its state. When the `notify_block_consumed` is received, it then switch the last seen cursor with the active one ensuring that we do not skip any blocks at all.

