### PR TITLE
Improve our CacheWeight estimates

### DIFF
--- a/graph/examples/stress.rs
+++ b/graph/examples/stress.rs
@@ -500,35 +500,32 @@ pub fn main() {
     // different types of cache entries. Uncomment one of the 'let mut cacheable'
     // lines
     if opt.template == "vec" {
-        // With Vec<usize> we stay within between opt.cache_size and 3*opt.cache_size
-        // Larger heap factors for very small arrays
+        // The weight of Vec<usize> is precise. The additional memory that
+        // the cache uses must be solely due to the memory for the cache
+        // itself
+        //
         // obj_size  |  heap factor
-        //   10      |     4.02
-        //   20      |     2.39
-        //   30      |     2.40
-        //   50      |     1.76
-        //  100      |     1.38
-        // 1000      |     1.05
+        //   10      |     2.5
+        //   20      |     1.9
+        //   30      |     1.8
+        //   50      |     1.3
+        //  100      |     1.3
+        // 1000      |     1.1
         stress::<Vec<usize>>(&opt);
     } else if opt.template == "hashmap" {
-        // Cache HashMap<String, String>
-        // The heap factor ranges between 2.23 (size 3) and 1.06 (size 100)
-        //let mut cacheable: Cacheable<HashMap<String, String>> = Cacheable::new(opt.obj_size);
+        // The heap factor ranges between 1.9 (size 3) and 1.06 (size 100)
         stress::<HashMap<String, String>>(&opt);
     } else if opt.template == "valuemap" {
         // Cache BTreeMap<String, Value>
         // obj_size  |  heap factor
-        //    3      |     16.51
-        //    5      |     12.07
-        //   10      |      4.64
-        //   50      |      3.07
-        //  100      |      2.94
+        //    3      |      1.3
+        //    5      |      1.5
+        //   10      |      1.5
+        //   50      |      1.2
+        //  100      |      0.9
         //
-        // The above is for a weight calculation that does not take the
-        // allocated, unused space in the BTree into account. With a guess
-        // at those, the above heap factors range from 1.14 to 0.88, with the
-        // exception of obj_size 0 where we get a factor of 2.88, but that
-        // must be caused by some other effect
+        // For small maps (say, up to about 20 entries), the weight is an
+        // accurate estimation of the map's allocation
         stress::<ValueMap>(&opt);
     } else if opt.template == "string" {
         stress::<String>(&opt);

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -2,7 +2,10 @@ use crate::{
     components::store::EntityType,
     prelude::{q, BigDecimal, BigInt, EntityKey, Value},
 };
-use std::{collections::BTreeMap, mem};
+use std::{
+    collections::{BTreeMap, HashMap},
+    mem,
+};
 
 /// Estimate of how much memory a value consumes.
 /// Useful for measuring the size of caches.
@@ -33,46 +36,16 @@ impl<T: CacheWeight> CacheWeight for Vec<T> {
     }
 }
 
-/// Estimate the size of the BTreeMap `map` ignoring the size of any keys
-/// and values
-pub fn btree_node_size<T, U>(map: &BTreeMap<T, U>) -> usize {
-    // It is not possible to know how many nodes a BTree has, as `BTreeMap`
-    // does not expose its depth or any other detail about the true size
-    // of the BTree. We estimate that size, assuming the worst case, i.e.,
-    // the sparsest BTree
-
-    // This is std::collections::btree::node::CAPACITY which is not a public
-    // constant.
-    const NODE_CAPACITY: usize = 11;
-
-    // A BTree with just one page needs room for at least NODE_CAPACITY
-    // key/value entries in its root node, except for the empty tree, which
-    // takes no space. If there is more than a root node, at worst,
-    // each page is half full
-    let kv_slots = if map.is_empty() {
-        0
-    } else if map.len() < NODE_CAPACITY {
-        NODE_CAPACITY
-    } else {
-        2 * map.len()
-    };
-
-    // Size of the vectors in all BTree nodes in the tree
-    kv_slots * (mem::size_of::<T>() + mem::size_of::<U>())
-        + mem::size_of::<Vec<T>>()
-        + mem::size_of::<Vec<U>>()
-}
-
-impl<T: CacheWeight, U: CacheWeight> CacheWeight for std::collections::BTreeMap<T, U> {
+impl<T: CacheWeight, U: CacheWeight> CacheWeight for BTreeMap<T, U> {
     fn indirect_weight(&self) -> usize {
         self.iter()
-            .map(|(key, value)| key.weight() + value.weight())
+            .map(|(key, value)| key.indirect_weight() + value.indirect_weight())
             .sum::<usize>()
-            + btree_node_size(self)
+            + btree::node_size(self)
     }
 }
 
-impl<T: CacheWeight, U: CacheWeight> CacheWeight for std::collections::HashMap<T, U> {
+impl<T: CacheWeight, U: CacheWeight> CacheWeight for HashMap<T, U> {
     fn indirect_weight(&self) -> usize {
         self.iter()
             .map(|(key, value)| key.indirect_weight() + value.indirect_weight())
@@ -169,4 +142,100 @@ fn big_decimal_cache_weight() {
     // 22.4548 has 18 bits as binary, so 3 bytes.
     let n = BigDecimal::from_str("22.454800000000").unwrap();
     assert_eq!(n.indirect_weight(), 3);
+}
+
+/// Helpers to estimate the size of a `BTreeMap`. Everything in this module,
+/// except for `node_size()` is copied from `std::collections::btree`.
+///
+/// It is not possible to know how many nodes a BTree has, as
+/// `BTreeMap` does not expose its depth or any other detail about
+/// the true size of the BTree. We estimate that size, assuming the
+/// average case, i.e., a BTree where every node has the average
+/// between the minimum and maximum number of entries per node, i.e.,
+/// the average of (B-1) and (2*B-1) entries, which we call
+/// `NODE_FILL`. The number of leaf nodes in the tree is then the
+/// number of entries divided by `NODE_FILL`, and the number of
+/// interior nodes can be determined by dividing the number of nodes
+/// at the child level by `NODE_FILL`
+
+/// The other difficulty is that the structs with which `BTreeMap`
+/// represents internal and leaf nodes are not public, so we can't
+/// get their size with `std::mem::size_of`; instead, we base our
+/// estimates of their size on the current `std` code, assuming that
+/// these structs will not change
+
+pub mod btree {
+    use std::collections::BTreeMap;
+    use std::mem;
+    use std::{mem::MaybeUninit, ptr::NonNull};
+
+    const B: usize = 6;
+    const CAPACITY: usize = 2 * B - 1;
+
+    /// Assume BTree nodes are this full (average of minimum and maximum fill)
+    const NODE_FILL: usize = ((B - 1) + (2 * B - 1)) / 2;
+
+    type BoxedNode<K, V> = NonNull<LeafNode<K, V>>;
+
+    struct InternalNode<K, V> {
+        _data: LeafNode<K, V>,
+
+        /// The pointers to the children of this node. `len + 1` of these are considered
+        /// initialized and valid, except that near the end, while the tree is held
+        /// through borrow type `Dying`, some of these pointers are dangling.
+        _edges: [MaybeUninit<BoxedNode<K, V>>; 2 * B],
+    }
+
+    struct LeafNode<K, V> {
+        /// We want to be covariant in `K` and `V`.
+        _parent: Option<NonNull<InternalNode<K, V>>>,
+
+        /// This node's index into the parent node's `edges` array.
+        /// `*node.parent.edges[node.parent_idx]` should be the same thing as `node`.
+        /// This is only guaranteed to be initialized when `parent` is non-null.
+        _parent_idx: MaybeUninit<u16>,
+
+        /// The number of keys and values this node stores.
+        _len: u16,
+
+        /// The arrays storing the actual data of the node. Only the first `len` elements of each
+        /// array are initialized and valid.
+        _keys: [MaybeUninit<K>; CAPACITY],
+        _vals: [MaybeUninit<V>; CAPACITY],
+    }
+
+    /// Estimate the size of the BTreeMap `map` ignoring the size of any keys
+    /// and values
+    pub fn node_size<K, V>(map: &BTreeMap<K, V>) -> usize {
+        // Measure the size of internal and leaf nodes directly - that's why
+        // we copied all this code from `std`
+        let ln_sz = mem::size_of::<LeafNode<K, V>>();
+        let in_sz = mem::size_of::<InternalNode<K, V>>();
+
+        // Estimate the number of internal and leaf nodes based on the only
+        // thing we can measure about a BTreeMap, the number of entries in
+        // it, and use our `NODE_FILL` assumption to estimate how the tree
+        // is structured. We try to be very good for small maps, since
+        // that's what we use most often in our code. This estimate is only
+        // for the indirect weight of the `BTreeMap`
+        let (leaves, int_nodes) = if map.is_empty() {
+            // An empty tree has no indirect weight
+            (0, 0)
+        } else if map.len() <= CAPACITY {
+            // We only have the root node
+            (1, 0)
+        } else {
+            // Estimate based on our `NODE_FILL` assumption
+            let leaves = map.len() / NODE_FILL + 1;
+            let mut prev_level = leaves / NODE_FILL + 1;
+            let mut int_nodes = prev_level;
+            while prev_level > 1 {
+                int_nodes += prev_level;
+                prev_level = prev_level / NODE_FILL + 1;
+            }
+            (leaves, int_nodes)
+        };
+
+        leaves * ln_sz + int_nodes * in_sz
+    }
 }

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -9,7 +9,7 @@ use std::{collections::BTreeMap, mem};
 pub trait CacheWeight {
     /// Total weight of the value.
     fn weight(&self) -> usize {
-        mem::size_of_val(&self) + self.indirect_weight()
+        mem::size_of_val(self) + self.indirect_weight()
     }
 
     /// The weight of values pointed to by this value but logically owned by it, which is not

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Error};
 use graph::constraint_violation;
 use graph::prelude::{r, CacheWeight};
 use graph::slog::warn;
-use graph::util::cache_weight::btree_node_size;
+use graph::util::cache_weight;
 use indexmap::IndexMap;
 use lazy_static::lazy_static;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -156,7 +156,7 @@ impl From<BTreeMap<String, r::Value>> for Node {
 
 impl CacheWeight for Node {
     fn indirect_weight(&self) -> usize {
-        self.children_weight + btree_node_size(&self.children)
+        self.children_weight + cache_weight::btree::node_size(&self.children)
     }
 }
 


### PR DESCRIPTION
This PR does the following:

* fix a bug in `CacheWeight.weight` that caused us to assume any struct has size 8
* improve the estimate for `BTreeMap` by following the structure of a B-Tree much more closely; that is now precise for maps up to size about 20
* improve the `stress` example to make it a little more versatile and representative of real-life data that we cache