### PR TITLE
Report nondeterministic errors as unattestable

### DIFF
--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -87,7 +87,43 @@ impl QueryExecutionError {
     pub fn is_attestable(&self) -> bool {
         use self::QueryExecutionError::*;
         match self {
+            OperationNameRequired
+            | OperationNotFound(_)
+            | NotSupported(_)
+            | NoRootSubscriptionObjectType
+            | NonNullError(_, _)
+            | ListValueError(_, _)
+            | NamedTypeError(_)
+            | AbstractTypeError(_)
+            | InvalidArgumentError(_, _, _)
+            | MissingArgumentError(_, _)
+            | InvalidVariableTypeError(_, _)
+            | MissingVariableError(_, _)
+            | OrderByNotSupportedError(_, _)
+            | OrderByNotSupportedForType(_)
+            | FilterNotSupportedError(_, _)
+            | UnknownField(_, _, _)
+            | EmptyQuery
+            | MultipleSubscriptionFields
+            | SubgraphDeploymentIdError(_)
+            | RangeArgumentsError(_, _, _)
+            | InvalidFilterError
+            | EntityFieldError(_, _)
+            | ListTypesError(_, _)
+            | ListFilterError(_)
+            | ValueParseError(_, _)
+            | AttributeTypeError(_, _)
+            | EntityParseError(_)
+            | EmptySelectionSet(_)
+            | AmbiguousDerivedFromResult(_, _, _, _)
+            | Unimplemented(_)
+            | EnumCoercionError(_, _, _, _, _)
+            | ScalarCoercionError(_, _, _, _)
+            | CyclicalFragment(_)
+            | UndefinedFragment(_)
+            | FulltextQueryRequiresFilter => true,
             ResolveEntitiesError(_)
+            | StoreError(_)
             | Timeout
             | TooComplex(_, _)
             | TooDeep(_)
@@ -100,7 +136,6 @@ impl QueryExecutionError {
             | SubgraphManifestResolveError(_)
             | InvalidSubgraphManifest
             | ResultTooBig(_, _) => false,
-            _ => true,
         }
     }
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -91,8 +91,6 @@ impl QueryExecutionError {
             | OperationNotFound(_)
             | NotSupported(_)
             | NoRootSubscriptionObjectType
-            | NonNullError(_, _)
-            | ListValueError(_, _)
             | NamedTypeError(_)
             | AbstractTypeError(_)
             | InvalidArgumentError(_, _, _)
@@ -106,25 +104,27 @@ impl QueryExecutionError {
             | EmptyQuery
             | MultipleSubscriptionFields
             | SubgraphDeploymentIdError(_)
-            | RangeArgumentsError(_, _, _)
             | InvalidFilterError
             | EntityFieldError(_, _)
             | ListTypesError(_, _)
             | ListFilterError(_)
-            | ValueParseError(_, _)
             | AttributeTypeError(_, _)
-            | EntityParseError(_)
             | EmptySelectionSet(_)
-            | AmbiguousDerivedFromResult(_, _, _, _)
             | Unimplemented(_)
-            | EnumCoercionError(_, _, _, _, _)
-            | ScalarCoercionError(_, _, _, _)
             | CyclicalFragment(_)
             | UndefinedFragment(_)
             | FulltextQueryRequiresFilter => true,
-            ResolveEntitiesError(_)
+            NonNullError(_, _)
+            | ListValueError(_, _)
+            | ResolveEntitiesError(_)
+            | RangeArgumentsError(_, _, _)
+            | ValueParseError(_, _)
+            | EntityParseError(_)
             | StoreError(_)
             | Timeout
+            | EnumCoercionError(_, _, _, _, _)
+            | ScalarCoercionError(_, _, _, _)
+            | AmbiguousDerivedFromResult(_, _, _, _)
             | TooComplex(_, _)
             | TooDeep(_)
             | IncorrectPrefetchResult { .. }

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -163,6 +163,10 @@ impl QueryResults {
             .header(ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type, User-Agent")
             .header(ACCESS_CONTROL_ALLOW_METHODS, "GET, OPTIONS, POST")
             .header(CONTENT_TYPE, "application/json")
+            .header(
+                "Graph-Attestable",
+                self.results.iter().all(|r| r.is_attestable()).to_string(),
+            )
             .body(T::from(json))
             .unwrap()
     }
@@ -209,6 +213,10 @@ impl QueryResult {
 
     pub fn has_data(&self) -> bool {
         self.data.is_some()
+    }
+
+    pub fn is_attestable(&self) -> bool {
+        self.errors.iter().all(|err| err.is_attestable())
     }
 
     pub fn to_result(self) -> Result<Option<r::Value>, Vec<QueryError>> {


### PR DESCRIPTION
This change sets the Graph-Attestable header on query results to signal
to the indexer-service whether it should include an attestation for the
client. Unattestable responses are those that are nondeterministic,
according to [GIP 20](https://hackmd.io/@CGmldHLrTRaYRnAva-HoPQ/S1W2vMjEt).

