### PR TITLE
core: when block stream is canceled, we should return early on

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -548,6 +548,11 @@ where
                 // Log and drop the errors from the block_stream
                 // The block stream will continue attempting to produce blocks
                 Some(Err(e)) => {
+                    if block_stream_cancel_handle.is_canceled() {
+                        debug!(&logger, "Subgraph block stream shut down cleanly");
+                        return Ok(());
+                    }
+
                     debug!(
                         &logger,
                         "Block stream produced a non-fatal error";


### PR DESCRIPTION
It appears right now that subgraph keeps running when cancelation operation occurs (at least for FirehoseBockStream, not sure for PollingBlockStream).

Indeed, when a subgraph is canceled, we are currently break from the inner loop just to go back to it and re-try the block stream. However, when the deployment has been canceled, we should exit early on and simply quit at that location.

