### PR TITLE
Serialize the BigInt bytes to the correct endianess expected by BigInt

### DIFF
--- a/chain/near/src/runtime/abi.rs
+++ b/chain/near/src/runtime/abi.rs
@@ -618,8 +618,9 @@ impl ToAscObj<Uint8Array> for codec::BigInt {
         &self,
         heap: &mut H,
     ) -> Result<Uint8Array, DeterministicHostError> {
-        // FIXME (NEAR): Hopefully the bytes here fits the BigInt format expected in `graph-node`,
-        //               will need to validate that in the subgraph directly.
-        self.bytes.to_asc_obj(heap)
+        // Bytes are reversed to align with BigInt bytes endianess
+        let reversed: Vec<u8> = self.bytes.iter().rev().map(|x| *x).collect();
+
+        reversed.to_asc_obj(heap)
     }
 }


### PR DESCRIPTION
The received bytes from the Firehose NEAR blocks are not in the endianess expected directly by the `BigInt` within AssemblyScript. To fix the issue, we simply reverse the bytes prior turning them into the `Uint8Array` AscObj which ultimately get written to the WASM memory.

While the original issue listed `gasPrice` a being problematic, the bug actually affected all `BigInt` types coming from the Firehose NEAR blocks which means quite a lot of fields.

All NEAR subgraphs using such affected fields will need to be re-synced from their `startBlock`.

Fixes #2955

