### PR TITLE
fix firehose UNDO case on old blocks

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -597,13 +597,10 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
                     number: block.number as i32,
                 },
                 FirehoseCursor::Some(response.cursor.clone()),
-                match block.header {
-                    Some(header) => Some(BlockPtr {
-                        hash: BlockHash::from(header.parent_hash),
-                        number: (block.number as i32) - 1,
-                    }),
-                    None => None,
-                },
+                Some(BlockPtr {
+                    hash: BlockHash::from(block.header.unwrap().parent_hash),
+                    number: (block.number.checked_sub(1).unwrap() as i32), // Will never receive undo on blocknum 0
+                }),
             )),
 
             bstream::ForkStep::StepIrreversible => {

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -597,6 +597,13 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
                     number: block.number as i32,
                 },
                 FirehoseCursor::Some(response.cursor.clone()),
+                match block.header {
+                    Some(header) => Some(BlockPtr {
+                        hash: BlockHash::from(header.parent_hash),
+                        number: (block.number as i32) - 1,
+                    }),
+                    None => None,
+                },
             )),
 
             bstream::ForkStep::StepIrreversible => {

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -285,6 +285,7 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
                         number: header.height as i32,
                     },
                     Some(response.cursor.clone()),
+                    None, // FIXME: we should get the parent block pointer when we have access to parent block height
                 ))
             }
 

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -102,7 +102,8 @@ pub enum FirehoseError {
 pub enum BlockStreamEvent<C: Blockchain> {
     // The payload is the current subgraph head pointer, which should be reverted, such that the
     // parent of the current subgraph head becomes the new subgraph head.
-    Revert(BlockPtr, FirehoseCursor),
+    // An optional pointer to the parent block will save a round trip operation when reverting.
+    Revert(BlockPtr, FirehoseCursor, Option<BlockPtr>),
 
     ProcessBlock(BlockWithTriggers<C>, FirehoseCursor),
 }

--- a/graph/src/blockchain/polling_block_stream.rs
+++ b/graph/src/blockchain/polling_block_stream.rs
@@ -546,6 +546,7 @@ impl<C: Blockchain> Stream for PollingBlockStream<C> {
                             break Poll::Ready(Some(Ok(BlockStreamEvent::Revert(
                                 block,
                                 FirehoseCursor::None,
+                                None,
                             ))));
                         }
                         Poll::Pending => {


### PR DESCRIPTION
When firehose sends an undo event from an older block, the
instance-manager would try to fetch the block from RPC to
retrieve its parent block info.

Now, the firehose will include the parent's hash and num in
the Revert event to remove that extraneous RPC call

