### PR TITLE
Add exponential backoff retry for non deterministic errors

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -8,7 +8,7 @@ use graph::data::store::EntityVersion;
 use graph::data::subgraph::{UnifiedMappingApiVersion, MAX_SPEC_VERSION};
 use graph::prelude::TryStreamExt;
 use graph::prelude::{SubgraphInstanceManager as SubgraphInstanceManagerTrait, *};
-use graph::util::lfu_cache::LfuCache;
+use graph::util::{backoff::ExponentialBackoff, lfu_cache::LfuCache};
 use graph::{blockchain::block_stream::BlockStreamMetrics, components::store::WritableStore};
 use graph::{blockchain::block_stream::BlockWithTriggers, data::subgraph::SubgraphFeature};
 use graph::{
@@ -27,8 +27,10 @@ use graph::{
 use lazy_static::lazy_static;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, RwLock};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::task;
+
+const MINUTE: Duration = Duration::from_secs(60);
 
 lazy_static! {
     /// Size limit of the entity LFU cache, in bytes.
@@ -43,6 +45,14 @@ lazy_static! {
     // Used for testing Graph Node itself.
     pub static ref DISABLE_FAIL_FAST: bool =
         std::env::var("GRAPH_DISABLE_FAIL_FAST").is_ok();
+
+    /// Ceiling for the backoff retry of non-deterministic errors, in seconds.
+    pub static ref SUBGRAPH_ERROR_RETRY_CEIL_SECS: Duration =
+        std::env::var("GRAPH_SUBGRAPH_ERROR_RETRY_CEIL_SECS")
+            .unwrap_or((MINUTE * 30).as_secs().to_string())
+            .parse::<u64>()
+            .map(Duration::from_secs)
+            .expect("invalid GRAPH_SUBGRAPH_ERROR_RETRY_CEIL_SECS");
 }
 
 type SharedInstanceKeepAliveMap = Arc<RwLock<HashMap<DeploymentId, CancelGuard>>>;
@@ -462,6 +472,10 @@ where
     let mut should_try_unfail_deterministic = true;
     let mut should_try_unfail_non_deterministic = true;
 
+    // Exponential backoff that starts with two minutes and keeps
+    // increasing its timeout exponentially until it reaches the ceiling.
+    let mut backoff = ExponentialBackoff::new(MINUTE * 2, *SUBGRAPH_ERROR_RETRY_CEIL_SECS);
+
     loop {
         debug!(logger, "Starting or restarting subgraph");
 
@@ -653,6 +667,7 @@ where
                                 // Stop trying to unfail.
                                 should_try_unfail_non_deterministic = false;
                                 deployment_failed.set(0.0);
+                                backoff.reset();
                             }
                         };
                     }
@@ -684,24 +699,74 @@ where
 
                 // Handle unexpected stream errors by marking the subgraph as failed.
                 Err(e) => {
+                    deployment_failed.set(1.0);
+
                     let message = format!("{:#}", e).replace("\n", "\t");
                     let err = anyhow!("{}, code: {}", message, LogCode::SubgraphSyncingFailure);
+                    let deterministic = e.is_deterministic();
 
                     let error = SubgraphError {
                         subgraph_id: id_for_err.clone(),
                         message,
                         block_ptr: Some(block_ptr),
                         handler: None,
-                        deterministic: e.is_deterministic(),
+                        deterministic,
                     };
-                    deployment_failed.set(1.0);
 
-                    store_for_err
-                        .fail_subgraph(error)
-                        .await
-                        .context("Failed to set subgraph status to `failed`")?;
+                    match deterministic {
+                        true => {
+                            // Fail subgraph:
+                            // - Change status/health.
+                            // - Save the error to the database.
+                            store_for_err
+                                .fail_subgraph(error)
+                                .await
+                                .context("Failed to set subgraph status to `failed`")?;
 
-                    return Err(err);
+                            return Err(err);
+                        }
+                        false => {
+                            // Shouldn't fail subgraph if it's already failed for non-deterministic
+                            // reasons.
+                            //
+                            // If we don't do this check we would keep adding the same error to the
+                            // database.
+                            let should_fail_subgraph =
+                                ctx.inputs.store.health(&ctx.inputs.deployment.hash)?
+                                    != SubgraphHealth::Failed;
+
+                            if should_fail_subgraph {
+                                // Fail subgraph:
+                                // - Change status/health.
+                                // - Save the error to the database.
+                                store_for_err
+                                    .fail_subgraph(error)
+                                    .await
+                                    .context("Failed to set subgraph status to `failed`")?;
+                            }
+
+                            // Retry logic below:
+
+                            // Cancel the stream for real.
+                            ctx.state
+                                .instances
+                                .write()
+                                .unwrap()
+                                .remove(&ctx.inputs.deployment.id);
+
+                            error!(logger, "Subgraph failed for non-deterministic error: {}", e;
+                                "attempt" => backoff.attempt,
+                                "retry_delay_s" => backoff.delay().as_secs());
+
+                            // Sleep before restarting.
+                            backoff.sleep_async().await;
+
+                            should_try_unfail_non_deterministic = true;
+
+                            // And restart the subgraph.
+                            break;
+                        }
+                    }
                 }
             }
         }

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -657,7 +657,7 @@ where
                             .store
                             .unfail_non_deterministic_error(&block_ptr)?;
 
-                        match ctx.inputs.store.health(&ctx.inputs.deployment.hash)? {
+                        match ctx.inputs.store.health(&ctx.inputs.deployment.hash).await? {
                             SubgraphHealth::Failed => {
                                 // If the unfail call didn't change the subgraph health, we keep
                                 // `should_try_unfail_non_deterministic` as `true` until it's
@@ -732,7 +732,7 @@ where
                             // If we don't do this check we would keep adding the same error to the
                             // database.
                             let should_fail_subgraph =
-                                ctx.inputs.store.health(&ctx.inputs.deployment.hash)?
+                                ctx.inputs.store.health(&ctx.inputs.deployment.hash).await?
                                     != SubgraphHealth::Failed;
 
                             if should_fail_subgraph {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1075,7 +1075,7 @@ pub trait WritableStore: Send + Sync + 'static {
     /// should only be used for reporting and monitoring
     fn shard(&self) -> &str;
 
-    fn health(&self, id: &DeploymentHash) -> Result<SubgraphHealth, StoreError>;
+    async fn health(&self, id: &DeploymentHash) -> Result<SubgraphHealth, StoreError>;
 }
 
 #[async_trait]
@@ -1267,7 +1267,7 @@ impl WritableStore for MockStore {
         unimplemented!()
     }
 
-    fn health(&self, _: &DeploymentHash) -> Result<SubgraphHealth, StoreError> {
+    async fn health(&self, _: &DeploymentHash) -> Result<SubgraphHealth, StoreError> {
         unimplemented!()
     }
 }

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1074,6 +1074,8 @@ pub trait WritableStore: Send + Sync + 'static {
     /// Report the name of the shard in which the subgraph is stored. This
     /// should only be used for reporting and monitoring
     fn shard(&self) -> &str;
+
+    fn health(&self, id: &DeploymentHash) -> Result<SubgraphHealth, StoreError>;
 }
 
 #[async_trait]
@@ -1262,6 +1264,10 @@ impl WritableStore for MockStore {
     }
 
     fn shard(&self) -> &str {
+        unimplemented!()
+    }
+
+    fn health(&self, _: &DeploymentHash) -> Result<SubgraphHealth, StoreError> {
         unimplemented!()
     }
 }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -44,9 +44,8 @@ impl SubgraphHealth {
 
     pub fn is_failed(&self) -> bool {
         match self {
-            SubgraphHealth::Healthy => false,
-            SubgraphHealth::Unhealthy => false,
             SubgraphHealth::Failed => true,
+            SubgraphHealth::Healthy | SubgraphHealth::Unhealthy => false,
         }
     }
 }

--- a/graph/src/util/backoff.rs
+++ b/graph/src/util/backoff.rs
@@ -45,4 +45,8 @@ impl ExponentialBackoff {
         self.attempt += 1;
         delay
     }
+
+    pub fn reset(&mut self) {
+        self.attempt = 0;
+    }
 }

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -36,10 +36,9 @@ pub enum SubgraphHealth {
 
 impl SubgraphHealth {
     fn is_failed(&self) -> bool {
-        match self {
-            Self::Failed => true,
-            Self::Healthy | Self::Unhealthy => false,
-        }
+        use graph::data::subgraph::schema::SubgraphHealth as H;
+
+        H::from(*self).is_failed()
     }
 }
 

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -626,6 +626,19 @@ fn check_health(
     .map_err(|e| e.into())
 }
 
+pub(crate) fn health(
+    conn: &PgConnection,
+    id: &DeploymentHash,
+) -> Result<SubgraphHealth, StoreError> {
+    use subgraph_deployment as d;
+
+    d::table
+        .filter(d::deployment.eq(id.as_str()))
+        .select(d::health)
+        .get_result(conn)
+        .map_err(|e| e.into())
+}
+
 /// Reverts the errors and updates the subgraph health if necessary.
 pub(crate) fn revert_subgraph_errors(
     conn: &PgConnection,

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1321,48 +1321,43 @@ impl DeploymentStore {
                 // Deployment head (current_ptr) advanced more than the error.
                 // That means it's healthy, and the non-deterministic error got
                 // solved (didn't happen on another try).
-                //
-                // This should be the scenario where the unfail happens, however
-                // for now we unfail in all cases that non-deterministic errors
-                // were found and the deployment head advanced.
                 (Bound::Included(error_block_number), _)
                     if current_ptr.number >= error_block_number =>
                     {
+                        info!(
+                            self.logger,
+                            "Unfailing the deployment status";
+                            "subgraph_id" => deployment_id,
+                        );
+
+                        // Unfail the deployment.
+                        deployment::update_deployment_status(
+                            conn,
+                            deployment_id,
+                            deployment::SubgraphHealth::Healthy,
+                            None,
+                        )?;
+
+                        // Delete the fatal error.
+                        deployment::delete_error(conn, &subgraph_error.id)?;
+
+                        Ok(())
                     }
-                // The deployment head is still before where non-deterministic error happened.
-                //
-                // Technically we shouldn't unfail the subgraph and delete the error
-                // until it's head actually passed the error block range. But for
-                // now we'll only log this and keep the old behavior.
+                // NOOP, the deployment head is still before where non-deterministic error happened.
                 block_range => {
                     info!(
                         self.logger,
-                        "Subgraph error is still ahead of deployment head";
+                        "Subgraph error is still ahead of deployment head, nothing to unfail";
                         "subgraph_id" => deployment_id,
                         "block_number" => format!("{}", current_ptr.number),
                         "block_hash" => format!("{}", current_ptr.hash),
                         "error_block_range" => format!("{:?}", block_range),
                         "error_block_hash" => subgraph_error.block_hash.as_ref().map(|hash| format!("0x{}", hex::encode(hash))),
                     );
+
+                    Ok(())
                 }
-            };
-
-            info!(
-                self.logger,
-                "Unfailing the deployment status";
-                "subgraph_id" => deployment_id,
-            );
-
-            // Unfail the deployment.
-            deployment::update_deployment_status(
-                conn,
-                deployment_id,
-                deployment::SubgraphHealth::Healthy,
-                None,
-            )?;
-
-            // Delete the fatal error.
-            deployment::delete_error(conn, &subgraph_error.id)
+            }
         })
     }
 

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1375,11 +1375,12 @@ impl DeploymentStore {
         });
     }
 
-    pub(crate) fn health(
+    pub(crate) async fn health(
         &self,
         id: &DeploymentHash,
     ) -> Result<deployment::SubgraphHealth, StoreError> {
-        let conn = self.get_conn()?;
-        deployment::health(&conn, id)
+        let id = id.clone();
+        self.with_conn(move |conn, _| deployment::health(&conn, &id).map_err(Into::into))
+            .await
     }
 }

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1379,4 +1379,12 @@ impl DeploymentStore {
                   "shard" => self.pool.shard.as_str())
         });
     }
+
+    pub(crate) fn health(
+        &self,
+        id: &DeploymentHash,
+    ) -> Result<deployment::SubgraphHealth, StoreError> {
+        let conn = self.get_conn()?;
+        deployment::health(&conn, id)
+    }
 }

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1326,8 +1326,11 @@ impl WritableStoreTrait for WritableStore {
         self.site.shard.as_str()
     }
 
-    fn health(&self, id: &DeploymentHash) -> Result<schema::SubgraphHealth, StoreError> {
-        self.retry("health", || self.writable.health(id).map(Into::into))
+    async fn health(&self, id: &DeploymentHash) -> Result<schema::SubgraphHealth, StoreError> {
+        self.retry_async("health", || async {
+            self.writable.health(id).await.map(Into::into)
+        })
+        .await
     }
 }
 

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -16,7 +16,7 @@ use graph::{
     },
     constraint_violation,
     data::query::QueryTarget,
-    data::subgraph::schema::SubgraphError,
+    data::subgraph::schema::{self, SubgraphError},
     data::{
         store::{EntityVersion, Vid},
         subgraph::status,
@@ -1324,6 +1324,10 @@ impl WritableStoreTrait for WritableStore {
 
     fn shard(&self) -> &str {
         self.site.shard.as_str()
+    }
+
+    fn health(&self, id: &DeploymentHash) -> Result<schema::SubgraphHealth, StoreError> {
+        self.retry("health", || self.writable.health(id).map(Into::into))
     }
 }
 

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -966,15 +966,14 @@ fn fail_unfail_non_deterministic_error_noop() {
         // Fail the subgraph with a non-deterministic error, but with an advanced block.
         writable.fail_subgraph(error).await.unwrap();
 
-        // Since the block range of the block won't match the deployment head, this would be NOOP,
-        // but we're skipping the confidence check for now.
+        // Since the block range of the block won't match the deployment head, this will be NOOP.
         writable.unfail_non_deterministic_error(&BLOCKS[1]).unwrap();
 
-        // Unfail ocurrs as expected.
-        assert_eq!(count(), 1);
+        // State continues the same besides a new error added to the database.
+        assert_eq!(count(), 2);
         let vi = get_version_info(&store, NAME);
         assert_eq!(&*NAME, vi.deployment_id.as_str());
-        assert_eq!(false, vi.failed);
+        assert_eq!(true, vi.failed);
         assert_eq!(Some(1), vi.latest_ethereum_block_number);
 
         test_store::remove_subgraphs();


### PR DESCRIPTION
After extensive testing, I think this is finally correct 🙌 

This PR adds an exponential backoff to keep retrying non-deterministic errors until they get solved and the subgraph unfails.

Main changes:

- Re add block range confidence check for non-determinstic errors on unfailure. Aka reversal and fix of this PR: https://github.com/graphprotocol/graph-node/pull/3015
- Use the `ExponentialBackoff` structure to keep retrying non-deterministic errors

Solves #2945 