### PR TITLE
Refactor GraphQL execution

### DIFF
--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -553,7 +553,7 @@ async fn interface_inline_fragment_with_subquery() {
     .unwrap();
     let data = extract_data!(res).unwrap();
     let exp = object! {
-        leggeds: vec![ object!{ airspeed: 5, legs: 2, parent: object! { id: "mama_bird" } },
+        leggeds: vec![ object!{ legs: 2, airspeed: 5, parent: object! { id: "mama_bird" } },
                        object!{ legs: 4 }]
     };
     assert_eq!(data, exp);

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -67,7 +67,8 @@ async fn one_interface_zero_entities() {
         .unwrap();
 
     let data = extract_data!(res).unwrap();
-    assert_eq!(format!("{:?}", data), "Object({\"leggeds\": List([])})")
+    let exp = object! { leggeds: Vec::<r::Value>::new() };
+    assert_eq!(data, exp);
 }
 
 #[tokio::test]
@@ -87,10 +88,8 @@ async fn one_interface_one_entity() {
         .await
         .unwrap();
     let data = extract_data!(res).unwrap();
-    assert_eq!(
-        format!("{:?}", data),
-        "Object({\"leggeds\": List([Object({\"legs\": Int(3)})])})"
-    );
+    let exp = object! { leggeds: vec![ object!{ legs: 3 }]};
+    assert_eq!(data, exp);
 
     // Query by ID.
     let query = "query { legged(id: \"1\") { legs } }";
@@ -98,10 +97,8 @@ async fn one_interface_one_entity() {
         .await
         .unwrap();
     let data = extract_data!(res).unwrap();
-    assert_eq!(
-        format!("{:?}", data),
-        "Object({\"legged\": Object({\"legs\": Int(3)})})",
-    );
+    let exp = object! { legged: object! { legs: 3 }};
+    assert_eq!(data, exp);
 }
 
 #[tokio::test]
@@ -121,10 +118,8 @@ async fn one_interface_one_entity_typename() {
         .await
         .unwrap();
     let data = extract_data!(res).unwrap();
-    assert_eq!(
-        format!("{:?}", data),
-        "Object({\"leggeds\": List([Object({\"__typename\": String(\"Animal\")})])})"
-    )
+    let exp = object! { leggeds: vec![ object!{ __typename: "Animal" } ]};
+    assert_eq!(data, exp);
 }
 
 #[tokio::test]
@@ -150,10 +145,8 @@ async fn one_interface_multiple_entities() {
         .await
         .unwrap();
     let data = extract_data!(res).unwrap();
-    assert_eq!(
-        format!("{:?}", data),
-        "Object({\"leggeds\": List([Object({\"legs\": Int(3)}), Object({\"legs\": Int(4)})])})"
-    );
+    let exp = object! { leggeds: vec![ object! { legs: 3 }, object! { legs: 4 }]};
+    assert_eq!(data, exp);
 
     // Test for support issue #32.
     let query = "query { legged(id: \"2\") { legs } }";
@@ -161,10 +154,8 @@ async fn one_interface_multiple_entities() {
         .await
         .unwrap();
     let data = extract_data!(res).unwrap();
-    assert_eq!(
-        format!("{:?}", data),
-        "Object({\"legged\": Object({\"legs\": Int(4)})})",
-    );
+    let exp = object! { legged: object! { legs: 4 }};
+    assert_eq!(data, exp);
 }
 
 #[tokio::test]
@@ -187,10 +178,8 @@ async fn reference_interface() {
         .unwrap();
 
     let data = extract_data!(res).unwrap();
-    assert_eq!(
-        format!("{:?}", data),
-        "Object({\"leggeds\": List([Object({\"leg\": Object({\"id\": String(\"1\")})})])})"
-    )
+    let exp = object! { leggeds: vec![ object!{ leg: object! { id: "1" } }] };
+    assert_eq!(data, exp);
 }
 
 #[tokio::test]
@@ -253,13 +242,15 @@ async fn reference_interface_derived() {
         .unwrap();
 
     let data = extract_data!(res).unwrap();
-    assert_eq!(
-        format!("{:?}", data),
-        "Object({\"events\": List([\
-            Object({\"id\": String(\"buy\"), \"transaction\": Object({\"id\": String(\"txn\")})}), \
-            Object({\"id\": String(\"gift\"), \"transaction\": Object({\"id\": String(\"txn\")})}), \
-            Object({\"id\": String(\"sell1\"), \"transaction\": Object({\"id\": String(\"txn\")})}), \
-            Object({\"id\": String(\"sell2\"), \"transaction\": Object({\"id\": String(\"txn\")})})])})");
+    let exp = object! {
+        events: vec![
+            object! { id: "buy", transaction: object! { id: "txn" } },
+            object! { id: "gift", transaction: object! { id: "txn" } },
+            object! { id: "sell1", transaction: object! { id: "txn" } },
+            object! { id: "sell2", transaction: object! { id: "txn" } }
+        ]
+    };
+    assert_eq!(data, exp);
 }
 
 #[tokio::test]
@@ -323,10 +314,10 @@ async fn follow_interface_reference() {
         .unwrap();
 
     let data = extract_data!(res).unwrap();
-    assert_eq!(
-        format!("{:?}", data),
-        "Object({\"legged\": Object({\"parent\": Object({\"id\": String(\"parent\")})})})"
-    )
+    let exp = object! {
+        legged: object! { parent: object! { id: "parent" } }
+    };
+    assert_eq!(data, exp)
 }
 
 #[tokio::test]
@@ -426,11 +417,11 @@ async fn two_interfaces() {
         .await
         .unwrap();
     let data = extract_data!(res).unwrap();
-    assert_eq!(
-        format!("{:?}", data),
-        "Object({\"ibars\": List([Object({\"bar\": Int(100)}), Object({\"bar\": Int(200)})]), \
-                 \"ifoos\": List([Object({\"foo\": String(\"bla\")}), Object({\"foo\": String(\"ble\")})])})"
-    );
+    let exp = object! {
+        ibars: vec![ object! { bar: 100 }, object! { bar: 200 }],
+        ifoos: vec![ object! { foo: "bla" }, object! { foo: "ble" } ]
+    };
+    assert_eq!(data, exp);
 }
 
 #[tokio::test]
@@ -454,10 +445,8 @@ async fn interface_non_inline_fragment() {
         .await
         .unwrap();
     let data = extract_data!(res).unwrap();
-    assert_eq!(
-        format!("{:?}", data),
-        r#"Object({"leggeds": List([Object({"name": String("cow")})])})"#
-    );
+    let exp = object! { leggeds: vec![ object! { name: "cow" } ]};
+    assert_eq!(data, exp);
 
     // Query the fragment and something else.
     let query = "query { leggeds { legs, ...frag } } fragment frag on Animal { name }";
@@ -465,10 +454,8 @@ async fn interface_non_inline_fragment() {
         .await
         .unwrap();
     let data = extract_data!(res).unwrap();
-    assert_eq!(
-        format!("{:?}", data),
-        r#"Object({"leggeds": List([Object({"legs": Int(3), "name": String("cow")})])})"#,
-    );
+    let exp = object! { leggeds: vec![ object!{ legs: 3, name: "cow" } ]};
+    assert_eq!(data, exp);
 }
 
 #[tokio::test]
@@ -501,10 +488,8 @@ async fn interface_inline_fragment() {
         .await
         .unwrap();
     let data = extract_data!(res).unwrap();
-    assert_eq!(
-        format!("{:?}", data),
-        r#"Object({"leggeds": List([Object({"airspeed": Int(24)}), Object({"name": String("cow")})])})"#
-    );
+    let exp = object! { leggeds: vec![ object!{ airspeed: 24 }, object! { name: "cow" }]};
+    assert_eq!(data, exp);
 }
 
 #[tokio::test]
@@ -567,20 +552,11 @@ async fn interface_inline_fragment_with_subquery() {
     .await
     .unwrap();
     let data = extract_data!(res).unwrap();
-
-    assert_eq!(
-        format!("{:?}", data),
-        "Object({\
-         \"leggeds\": List([\
-         Object({\
-         \"airspeed\": Int(5), \
-         \"legs\": Int(2), \
-         \"parent\": Object({\"id\": String(\"mama_bird\")})\
-         }), \
-         Object({\"legs\": Int(4)})\
-         ])\
-         })"
-    );
+    let exp = object! {
+        leggeds: vec![ object!{ airspeed: 5, legs: 2, parent: object! { id: "mama_bird" } },
+                       object!{ legs: 4 }]
+    };
+    assert_eq!(data, exp);
 }
 
 #[tokio::test]

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1713,12 +1713,11 @@ impl AttributeNames {
         }
     }
 
-    /// Adds a attribute name. Ignores meta fields.
-    pub fn add(&mut self, field: &q::Field) {
-        if Self::is_meta_field(&field.name) {
+    pub fn update(&mut self, field_name: &str) {
+        if Self::is_meta_field(field_name) {
             return;
         }
-        self.insert(&field.name)
+        self.insert(&field_name)
     }
 
     /// Adds a attribute name. Ignores meta fields.

--- a/graph/src/data/graphql/ext.rs
+++ b/graph/src/data/graphql/ext.rs
@@ -348,6 +348,41 @@ impl DirectiveFinder for Vec<Directive> {
     }
 }
 
+pub trait TypeDefinitionExt {
+    fn name(&self) -> &str;
+
+    // Return `true` if this is the definition of a type from the
+    // introspection schema
+    fn is_introspection(&self) -> bool {
+        self.name().starts_with("__")
+    }
+}
+
+impl TypeDefinitionExt for TypeDefinition {
+    fn name(&self) -> &str {
+        match self {
+            TypeDefinition::Scalar(t) => &t.name,
+            TypeDefinition::Object(t) => &t.name,
+            TypeDefinition::Interface(t) => &t.name,
+            TypeDefinition::Union(t) => &t.name,
+            TypeDefinition::Enum(t) => &t.name,
+            TypeDefinition::InputObject(t) => &t.name,
+        }
+    }
+}
+
+pub trait FieldExt {
+    // Return `true` if this is the name of one of the query fields from the
+    // introspection schema
+    fn is_introspection(&self) -> bool;
+}
+
+impl FieldExt for Field {
+    fn is_introspection(&self) -> bool {
+        &self.name == "__schema" || &self.name == "__type"
+    }
+}
+
 #[cfg(test)]
 mod directive_finder_tests {
     use graphql_parser::parse_schema;

--- a/graph/src/data/graphql/mod.rs
+++ b/graph/src/data/graphql/mod.rs
@@ -31,3 +31,4 @@ pub use object_or_interface::ObjectOrInterface;
 pub mod object_macro;
 pub use crate::object;
 pub use object_macro::{object_value, IntoValue};
+pub mod visitor;

--- a/graph/src/data/graphql/mod.rs
+++ b/graph/src/data/graphql/mod.rs
@@ -31,4 +31,3 @@ pub use object_or_interface::ObjectOrInterface;
 pub mod object_macro;
 pub use crate::object;
 pub use object_macro::{object_value, IntoValue};
-pub mod visitor;

--- a/graph/src/data/graphql/object_macro.rs
+++ b/graph/src/data/graphql/object_macro.rs
@@ -1,13 +1,13 @@
+use crate::data::value::Object;
 use crate::prelude::q;
 use crate::prelude::r;
-use std::collections::BTreeMap;
 use std::iter::FromIterator;
 
 /// Creates a `graphql_parser::query::Value::Object` from key/value pairs.
 /// If you don't need to determine which keys are included dynamically at runtime
 /// consider using the `object! {}` macro instead.
 pub fn object_value(data: Vec<(&str, r::Value)>) -> r::Value {
-    r::Value::Object(BTreeMap::from_iter(
+    r::Value::Object(Object::from_iter(
         data.into_iter().map(|(k, v)| (k.to_string(), v)),
     ))
 }
@@ -93,7 +93,7 @@ macro_rules! object {
                 let value = $crate::data::graphql::object_macro::IntoValue::into_value($value);
                 result.insert(stringify!($name).to_string(), value);
             )*
-            $crate::prelude::r::Value::Object(result)
+            $crate::prelude::r::Value::object(result)
         }
     };
     ($($name:ident: $value:expr),*) => {

--- a/graph/src/data/graphql/object_macro.rs
+++ b/graph/src/data/graphql/object_macro.rs
@@ -83,17 +83,17 @@ macro_rules! impl_into_values {
 
 impl_into_values![(String, String), (f64, Float), (bool, Boolean)];
 
-/// Creates a `graphql_parser::query::Value::Object` from key/value pairs.
+/// Creates a `data::value::Value::Object` from key/value pairs.
 #[macro_export]
 macro_rules! object {
     ($($name:ident: $value:expr,)*) => {
         {
-            let mut result = ::std::collections::BTreeMap::new();
+            let mut result = $crate::data::value::Object::new();
             $(
                 let value = $crate::data::graphql::object_macro::IntoValue::into_value($value);
                 result.insert(stringify!($name).to_string(), value);
             )*
-            $crate::prelude::r::Value::object(result)
+            $crate::prelude::r::Value::Object(result)
         }
     };
     ($($name:ident: $value:expr),*) => {

--- a/graph/src/data/graphql/values.rs
+++ b/graph/src/data/graphql/values.rs
@@ -1,8 +1,9 @@
 use anyhow::{anyhow, Error};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::str::FromStr;
 
+use crate::data::value::Object;
 use crate::prelude::{r, BigInt, Entity};
 use web3::types::{H160, H256};
 
@@ -166,7 +167,7 @@ impl ValueMap for r::Value {
     }
 }
 
-impl ValueMap for &BTreeMap<String, r::Value> {
+impl ValueMap for &Object {
     fn get_required<T>(&self, key: &str) -> Result<T, Error>
     where
         T: TryFromValue,

--- a/graph/src/data/introspection.graphql
+++ b/graph/src/data/introspection.graphql
@@ -1,0 +1,98 @@
+# A GraphQL introspection schema for inclusion in a subgraph's API schema.
+# The schema differs from the 'standard' introspection schema in that it
+# doesn't have a Query type nor scalar declarations as they come from the
+# API schema.
+
+type __Schema {
+  types: [__Type!]!
+  queryType: __Type!
+  mutationType: __Type
+  subscriptionType: __Type
+  directives: [__Directive!]!
+}
+
+type __Type {
+  kind: __TypeKind!
+  name: String
+  description: String
+
+  # OBJECT and INTERFACE only
+  fields(includeDeprecated: Boolean = false): [__Field!]
+
+  # OBJECT only
+  interfaces: [__Type!]
+
+  # INTERFACE and UNION only
+  possibleTypes: [__Type!]
+
+  # ENUM only
+  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+
+  # INPUT_OBJECT only
+  inputFields: [__InputValue!]
+
+  # NON_NULL and LIST only
+  ofType: __Type
+}
+
+type __Field {
+  name: String!
+  description: String
+  args: [__InputValue!]!
+  type: __Type!
+  isDeprecated: Boolean!
+  deprecationReason: String
+}
+
+type __InputValue {
+  name: String!
+  description: String
+  type: __Type!
+  defaultValue: String
+}
+
+type __EnumValue {
+  name: String!
+  description: String
+  isDeprecated: Boolean!
+  deprecationReason: String
+}
+
+enum __TypeKind {
+  SCALAR
+  OBJECT
+  INTERFACE
+  UNION
+  ENUM
+  INPUT_OBJECT
+  LIST
+  NON_NULL
+}
+
+type __Directive {
+  name: String!
+  description: String
+  locations: [__DirectiveLocation!]!
+  args: [__InputValue!]!
+}
+
+enum __DirectiveLocation {
+  QUERY
+  MUTATION
+  SUBSCRIPTION
+  FIELD
+  FRAGMENT_DEFINITION
+  FRAGMENT_SPREAD
+  INLINE_FRAGMENT
+  SCHEMA
+  SCALAR
+  OBJECT
+  FIELD_DEFINITION
+  ARGUMENT_DEFINITION
+  INTERFACE
+  UNION
+  ENUM
+  ENUM_VALUE
+  INPUT_OBJECT
+  INPUT_FIELD_DEFINITION
+}

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -1,4 +1,5 @@
 use super::error::{QueryError, QueryExecutionError};
+use crate::data::value::Object;
 use crate::prelude::{r, CacheWeight, DeploymentHash};
 use http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
@@ -6,7 +7,6 @@ use http::header::{
 };
 use serde::ser::*;
 use serde::Serialize;
-use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
@@ -39,7 +39,7 @@ where
     ser.end()
 }
 
-pub type Data = BTreeMap<String, r::Value>;
+pub type Data = Object;
 
 #[derive(Debug)]
 /// A collection of query results that is serialized as a single result.
@@ -270,8 +270,8 @@ impl From<Vec<QueryExecutionError>> for QueryResult {
     }
 }
 
-impl From<Data> for QueryResult {
-    fn from(val: Data) -> Self {
+impl From<Object> for QueryResult {
+    fn from(val: Object) -> Self {
         QueryResult::new(val)
     }
 }
@@ -309,7 +309,7 @@ fn multiple_data_items() {
     use serde_json::json;
 
     fn make_obj(key: &str, value: &str) -> Arc<QueryResult> {
-        let mut map = BTreeMap::new();
+        let mut map = Object::new();
         map.insert(key.to_owned(), r::Value::String(value.to_owned()));
         Arc::new(map.into())
     }

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::iter::FromIterator;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Object(BTreeMap<String, Value>);
 
 impl Object {
@@ -73,6 +73,12 @@ impl CacheWeight for Object {
 impl Default for Object {
     fn default() -> Self {
         Self(BTreeMap::default())
+    }
+}
+
+impl std::fmt::Debug for Object {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -5,24 +5,41 @@ use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::iter::FromIterator;
 
+const TOMBSTONE_KEY: &str = "*dead*";
+
+#[derive(Clone, Debug, PartialEq)]
+struct Entry {
+    key: String,
+    value: Value,
+}
+
 #[derive(Clone, PartialEq)]
-pub struct Object(BTreeMap<String, Value>);
+pub struct Object(Vec<Entry>);
 
 impl Object {
     pub fn new() -> Self {
-        Self(BTreeMap::default())
+        Self(Vec::new())
     }
 
     pub fn get(&self, key: &str) -> Option<&Value> {
-        self.0.get(key)
+        self.0
+            .iter()
+            .find(|entry| entry.key == key)
+            .map(|entry| &entry.value)
     }
 
     pub fn remove(&mut self, key: &str) -> Option<Value> {
-        self.0.remove(key)
+        self.0
+            .iter_mut()
+            .find(|entry| entry.key == key)
+            .map(|entry| {
+                entry.key = TOMBSTONE_KEY.to_string();
+                std::mem::replace(&mut entry.value, Value::Null)
+            })
     }
 
-    pub fn iter(&self) -> std::collections::btree_map::Iter<String, Value> {
-        self.into_iter()
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Value)> {
+        ObjectIter::new(self)
     }
 
     fn len(&self) -> usize {
@@ -34,33 +51,92 @@ impl Object {
     }
 
     pub fn insert(&mut self, key: String, value: Value) -> Option<Value> {
-        self.0.insert(key, value)
+        match self.0.iter_mut().find(|entry| &entry.key == &key) {
+            Some(entry) => Some(std::mem::replace(&mut entry.value, value)),
+            None => {
+                self.0.push(Entry { key, value });
+                None
+            }
+        }
     }
 }
 
 impl FromIterator<(String, Value)> for Object {
     fn from_iter<T: IntoIterator<Item = (String, Value)>>(iter: T) -> Self {
-        Object(BTreeMap::from_iter(iter))
+        let mut items: Vec<_> = Vec::new();
+        for (key, value) in iter {
+            items.push(Entry { key, value })
+        }
+        Object(items)
+    }
+}
+
+pub struct ObjectOwningIter {
+    iter: std::vec::IntoIter<Entry>,
+}
+
+impl Iterator for ObjectOwningIter {
+    type Item = (String, Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(entry) = self.iter.next() {
+            if &entry.key != TOMBSTONE_KEY {
+                return Some((entry.key, entry.value));
+            }
+        }
+        None
     }
 }
 
 impl IntoIterator for Object {
     type Item = (String, Value);
 
-    type IntoIter = std::collections::btree_map::IntoIter<String, Value>;
+    type IntoIter = ObjectOwningIter;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        ObjectOwningIter {
+            iter: self.0.into_iter(),
+        }
+    }
+}
+
+pub struct ObjectIter<'a> {
+    iter: std::slice::Iter<'a, Entry>,
+}
+
+impl<'a> ObjectIter<'a> {
+    fn new(object: &'a Object) -> Self {
+        Self {
+            iter: object.0.as_slice().iter(),
+        }
+    }
+}
+impl<'a> Iterator for ObjectIter<'a> {
+    type Item = (&'a String, &'a Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(entry) = self.iter.next() {
+            if &entry.key != TOMBSTONE_KEY {
+                return Some((&entry.key, &entry.value));
+            }
+        }
+        None
     }
 }
 
 impl<'a> IntoIterator for &'a Object {
-    type Item = (&'a String, &'a Value);
+    type Item = <ObjectIter<'a> as Iterator>::Item;
 
-    type IntoIter = std::collections::btree_map::Iter<'a, String, Value>;
+    type IntoIter = ObjectIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
+        ObjectIter::new(self)
+    }
+}
+
+impl CacheWeight for Entry {
+    fn indirect_weight(&self) -> usize {
+        self.key.indirect_weight() + self.value.indirect_weight()
     }
 }
 
@@ -72,7 +148,7 @@ impl CacheWeight for Object {
 
 impl Default for Object {
     fn default() -> Self {
-        Self(BTreeMap::default())
+        Self(Vec::default())
     }
 }
 
@@ -96,7 +172,11 @@ pub enum Value {
 
 impl Value {
     pub fn object(map: BTreeMap<String, Value>) -> Self {
-        Value::Object(Object(map))
+        let items = map
+            .into_iter()
+            .map(|(key, value)| Entry { key, value })
+            .collect();
+        Value::Object(Object(items))
     }
 
     pub fn is_null(&self) -> bool {

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -184,7 +184,7 @@ pub mod prelude {
     static_graphql!(q, query, {
         Document, Value, OperationDefinition, InlineFragment, TypeCondition,
         FragmentSpread, Field, Selection, SelectionSet, FragmentDefinition,
-        Directive, VariableDefinition, Type,
+        Directive, VariableDefinition, Type, Query,
     });
     static_graphql!(s, schema, {
         Field, Directive, InterfaceType, ObjectType, Value, TypeDefinition,

--- a/graphql/src/execution/ast.rs
+++ b/graphql/src/execution/ast.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, ops::Deref};
 
 use graph::{
     components::store::EntityType,
-    data::graphql::{DocumentExt, ObjectOrInterface},
+    data::graphql::ObjectOrInterface,
     prelude::{anyhow, q, r, s, ApiSchema, QueryExecutionError, ValueMap},
 };
 use graphql_parser::Pos;
@@ -318,8 +318,6 @@ pub(crate) fn resolve_object_types(
 ) -> Result<HashSet<ObjectType>, QueryExecutionError> {
     let mut set = HashSet::new();
     match schema
-        .schema
-        .document
         .get_named_type(name)
         .ok_or_else(|| QueryExecutionError::AbstractTypeError(name.to_string()))?
     {

--- a/graphql/src/execution/ast.rs
+++ b/graphql/src/execution/ast.rs
@@ -22,7 +22,10 @@ use crate::schema::ast::ObjectType;
 #[derive(Debug, Clone, PartialEq)]
 pub struct SelectionSet {
     // Map object types to the list of fields that should be selected for
-    // them
+    // them. In most cases, this will have a single entry. If the
+    // `SelectionSet` is attached to a field with an interface or union
+    // type, it will have an entry for each object type implementing that
+    // interface or being part of the union
     items: Vec<(ObjectType, Vec<Field>)>,
 }
 
@@ -96,6 +99,10 @@ impl SelectionSet {
     }
 
     /// Iterate over all fields for the given object type
+    ///
+    /// # Panics
+    /// If this `SelectionSet` does not have an entry for `obj_type`, this
+    /// method will panic
     pub fn fields_for(&self, obj_type: &ObjectType) -> impl Iterator<Item = &Field> {
         let item = self
             .items
@@ -254,7 +261,7 @@ impl ValueMap for Field {
 
 /// A set of object types, generated from resolving interfaces into the
 /// object types that implement them, and possibly narrowing further when
-/// expanding fragments with type conitions
+/// expanding fragments with type conditions
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum ObjectTypeSet {
     Any,

--- a/graphql/src/execution/ast.rs
+++ b/graphql/src/execution/ast.rs
@@ -7,7 +7,7 @@ use graph::{
 };
 use graphql_parser::Pos;
 
-use crate::schema::ast::ObjectCondition;
+use crate::schema::ast::ObjectType;
 
 /// A selection set is a table that maps object types to the fields that
 /// should be selected for objects of that type. The types are always
@@ -300,7 +300,7 @@ impl ObjectTypeSet {
 pub(crate) fn resolve_object_types<'a>(
     schema: &'a Schema,
     name: &str,
-) -> Result<HashSet<ObjectCondition<'a>>, QueryExecutionError> {
+) -> Result<HashSet<ObjectType<'a>>, QueryExecutionError> {
     let mut set = HashSet::new();
     match schema
         .document

--- a/graphql/src/execution/ast.rs
+++ b/graphql/src/execution/ast.rs
@@ -1,109 +1,153 @@
-use std::ops::Deref;
+use std::{collections::HashSet, ops::Deref};
 
-use graph::prelude::{q, r};
+use graph::{
+    components::store::EntityType,
+    data::graphql::{DocumentExt, ObjectOrInterface},
+    prelude::{q, r, s, QueryExecutionError, Schema},
+};
 use graphql_parser::Pos;
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct FragmentDefinition {
-    pub position: Pos,
-    pub name: String,
-    pub type_condition: TypeCondition,
-    pub directives: Vec<Directive>,
-    pub selection_set: SelectionSet,
-}
+use crate::schema::ast::ObjectCondition;
 
+/// A selection set is a table that maps object types to the fields that
+/// should be selected for objects of that type. The types are always
+/// concrete object types, never interface or union types. When a
+/// `SelectionSet` is constructed, fragments must already have been resolved
+/// as it only allows using fields.
+///
+/// The set of types that a `SelectionSet` can accommodate must be set at
+/// the time the `SelectionSet` is constructed. It is not possible to add
+/// more types to it, but it is possible to add fields for all known types
+/// or only some of them
 #[derive(Debug, Clone, PartialEq)]
 pub struct SelectionSet {
-    span: (Pos, Pos),
-    items: Vec<Selection>,
+    // Map object types to the list of fields that should be selected for
+    // them
+    items: Vec<(String, Vec<Field>)>,
 }
 
 impl SelectionSet {
-    pub fn new(span: (Pos, Pos), items: Vec<Selection>) -> Self {
-        SelectionSet { span, items }
+    /// Create a new `SelectionSet` that can handle the given types
+    pub fn new(types: Vec<String>) -> Self {
+        let items = types.into_iter().map(|name| (name, Vec::new())).collect();
+        SelectionSet { items }
     }
 
+    /// Create a new `SelectionSet` that can handle the same types as
+    /// `other`, but ignore all fields from `other`
     pub fn empty_from(other: &SelectionSet) -> Self {
-        SelectionSet {
-            span: other.span.clone(),
-            items: Vec::new(),
-        }
+        let items = other
+            .items
+            .iter()
+            .map(|(name, _)| (name.clone(), Vec::new()))
+            .collect();
+        SelectionSet { items }
     }
 
+    /// Return `true` if this selection set does not select any fields for
+    /// its types
     pub fn is_empty(&self) -> bool {
-        self.items.is_empty()
+        self.items.iter().all(|(_, fields)| fields.is_empty())
     }
 
-    pub fn included(&self) -> impl Iterator<Item = &Selection> {
-        self.items.iter().filter(|selection| selection.selected())
+    /// If the selection set contains a single field across all its types,
+    /// return it. Otherwise, return `None`
+    pub fn single_field(&self) -> Option<&Field> {
+        let mut iter = self.items.iter();
+        let field = match iter.next() {
+            Some((_, fields)) => {
+                if fields.len() != 1 {
+                    return None;
+                } else {
+                    &fields[0]
+                }
+            }
+            None => return None,
+        };
+        for (_, fields) in iter {
+            if fields.len() != 1 {
+                return None;
+            }
+            if &fields[0] != field {
+                return None;
+            }
+        }
+        return Some(field);
     }
 
-    pub fn selections(&self) -> impl Iterator<Item = &Selection> {
-        self.items.iter()
+    /// Iterate over all types and the fields for those types
+    pub fn fields(&self) -> impl Iterator<Item = (&str, impl Iterator<Item = &Field>)> {
+        self.items
+            .iter()
+            .map(|(name, fields)| (name.as_str(), fields.iter()))
     }
 
-    pub fn push(&mut self, field: Field) {
-        self.items.push(Selection::Field(field))
+    /// Iterate over all types and the fields that are not leaf fields, i.e.
+    /// whose selection sets are not empty
+    pub fn interior_fields(&self) -> impl Iterator<Item = (&str, impl Iterator<Item = &Field>)> {
+        self.items.iter().map(|(name, fields)| {
+            (
+                name.as_str(),
+                fields.iter().filter(|field| !field.is_leaf()),
+            )
+        })
     }
-}
 
-impl Extend<Selection> for SelectionSet {
-    fn extend<T: IntoIterator<Item = Selection>>(&mut self, iter: T) {
-        self.items.extend(iter)
+    /// Iterate over all fields for the given object type
+    pub fn fields_for(&self, obj_type: &s::ObjectType) -> impl Iterator<Item = &Field> {
+        let item = self
+            .items
+            .iter()
+            .find(|(name, _)| name == &obj_type.name)
+            .expect("there is an entry for the type");
+        item.1.iter()
     }
-}
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum Selection {
-    Field(Field),
-    FragmentSpread(FragmentSpread),
-    InlineFragment(InlineFragment),
-}
-
-impl Selection {
-    /// Looks up a directive in a selection, if it is provided.
-    pub fn get_directive(&self, name: &str) -> Option<&Directive> {
-        match self {
-            Selection::Field(field) => field
-                .directives
-                .iter()
-                .find(|directive| directive.name == name),
-            _ => None,
+    /// Append the field for all the sets' types
+    pub fn push(&mut self, new_field: &Field) {
+        for (_, fields) in &mut self.items {
+            Self::merge_field(fields, new_field.clone());
         }
     }
 
-    /// Returns true if a selection should be skipped (as per the `@skip` directive).
-    fn skip(&self) -> bool {
-        match self.get_directive("skip") {
-            Some(directive) => match directive.argument_value("if") {
-                Some(val) => match val {
-                    // Skip if @skip(if: true)
-                    r::Value::Boolean(skip_if) => *skip_if,
-                    _ => false,
-                },
-                None => true,
-            },
-            None => false,
+    /// Append the fields for all the sets' types
+    pub fn push_fields(&mut self, fields: Vec<&Field>) {
+        for field in fields {
+            self.push(field);
         }
     }
 
-    /// Returns true if a selection should be included (as per the `@include` directive).
-    fn include(&self) -> bool {
-        match self.get_directive("include") {
-            Some(directive) => match directive.argument_value("if") {
-                Some(val) => match val {
-                    // Include if @include(if: true)
-                    r::Value::Boolean(include) => *include,
-                    _ => false,
-                },
-                None => true,
-            },
-            None => true,
+    /// Merge `self` with the fields from `other`, which must have the same,
+    /// or a subset of, the types of `self`. The `directives` are added to
+    /// `self`'s directives so that they take precedence over existing
+    /// directives with the same name
+    pub fn merge(&mut self, other: SelectionSet, directives: Vec<Directive>) {
+        for (other_name, other_fields) in other.items {
+            let item = self
+                .items
+                .iter_mut()
+                .find(|(name, _)| &other_name == name)
+                .expect("all possible types are already in items");
+            for mut other_field in other_fields {
+                other_field.prepend_directives(directives.clone());
+                Self::merge_field(&mut item.1, other_field);
+            }
         }
     }
 
-    fn selected(&self) -> bool {
-        !self.skip() && self.include()
+    fn merge_field(fields: &mut Vec<Field>, new_field: Field) {
+        match fields
+            .iter_mut()
+            .find(|field| field.response_key() == new_field.response_key())
+        {
+            Some(field) => {
+                // TODO: check that _field and new_field are mergeable, in
+                // particular that their name, directives and arguments are
+                // compatible
+                field.selection_set.merge(new_field.selection_set, vec![]);
+            }
+            None => fields.push(new_field),
+        }
     }
 }
 
@@ -115,15 +159,38 @@ pub struct Directive {
 }
 
 impl Directive {
-    /// Looks up the value of an argument in a vector of (name, value) tuples.
+    /// Looks up the value of an argument of this directive
     pub fn argument_value(&self, name: &str) -> Option<&r::Value> {
         self.arguments
             .iter()
             .find(|(n, _)| n == name)
             .map(|(_, v)| v)
     }
+
+    fn eval_if(&self) -> bool {
+        match self.argument_value("if") {
+            None => true,
+            Some(r::Value::Boolean(b)) => *b,
+            Some(_) => false,
+        }
+    }
+
+    /// Return `true` if this directive says that we should not include the
+    /// field it is attached to. That is the case if the directive is
+    /// `include` and its `if` condition is `false`, or if it is `skip` and
+    /// its `if` condition is `true`. In all other cases, return `false`
+    pub fn skip(&self) -> bool {
+        match self.name.as_str() {
+            "include" => !self.eval_if(),
+            "skip" => self.eval_if(),
+            _ => false,
+        }
+    }
 }
 
+/// A field to execute as part of a query. When the field is constructed by
+/// `Query::new`, variables are interpolated, and argument values have
+/// already been coerced to the appropriate types for the field argument
 #[derive(Debug, Clone, PartialEq)]
 pub struct Field {
     pub position: Pos,
@@ -135,7 +202,8 @@ pub struct Field {
 }
 
 impl Field {
-    /// Returns the response key of a field, which is either its name or its alias (if there is one).
+    /// Returns the response key of a field, which is either its name or its
+    /// alias (if there is one).
     pub fn response_key(&self) -> &str {
         self.alias
             .as_ref()
@@ -143,38 +211,120 @@ impl Field {
             .unwrap_or(self.name.as_str())
     }
 
-    /// Looks up the value of an argument in a vector of (name, value) tuples.
+    /// Looks up the value of an argument for this field
     pub fn argument_value(&self, name: &str) -> Option<&r::Value> {
         self.arguments
             .iter()
             .find(|(n, _)| n == name)
             .map(|(_, v)| v)
     }
-}
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct FragmentSpread {
-    pub position: Pos,
-    pub fragment_name: String,
-    pub directives: Vec<Directive>,
-}
+    fn prepend_directives(&mut self, mut directives: Vec<Directive>) {
+        // TODO: check that the new directives don't conflict with existing
+        // directives
+        std::mem::swap(&mut self.directives, &mut directives);
+        self.directives.extend(directives);
+    }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum TypeCondition {
-    On(String),
-}
-
-impl From<q::TypeCondition> for TypeCondition {
-    fn from(type_cond: q::TypeCondition) -> Self {
-        let q::TypeCondition::On(name) = type_cond;
-        TypeCondition::On(name)
+    fn is_leaf(&self) -> bool {
+        self.selection_set.is_empty()
     }
 }
 
+/// A set of object types, generated from resolving interfaces into the
+/// object types that implement them, and possibly narrowing further when
+/// expanding fragments with type conitions
 #[derive(Debug, Clone, PartialEq)]
-pub struct InlineFragment {
-    pub position: Pos,
-    pub type_condition: Option<TypeCondition>,
-    pub directives: Vec<Directive>,
-    pub selection_set: SelectionSet,
+pub enum ObjectTypeSet {
+    Any,
+    Only(HashSet<String>),
+}
+
+impl ObjectTypeSet {
+    pub fn convert(
+        schema: &Schema,
+        type_cond: Option<&q::TypeCondition>,
+    ) -> Result<ObjectTypeSet, QueryExecutionError> {
+        match type_cond {
+            Some(q::TypeCondition::On(name)) => Self::from_name(schema, name),
+            None => Ok(ObjectTypeSet::Any),
+        }
+    }
+
+    pub fn from_name(schema: &Schema, name: &str) -> Result<ObjectTypeSet, QueryExecutionError> {
+        let set = resolve_object_types(schema, name)?
+            .into_iter()
+            .map(|ty| ty.name().to_string())
+            .collect();
+        Ok(ObjectTypeSet::Only(set))
+    }
+
+    fn matches_name(&self, name: &str) -> bool {
+        match self {
+            ObjectTypeSet::Any => true,
+            ObjectTypeSet::Only(set) => set.contains(name),
+        }
+    }
+
+    pub fn intersect(self, other: &ObjectTypeSet) -> ObjectTypeSet {
+        match self {
+            ObjectTypeSet::Any => other.clone(),
+            ObjectTypeSet::Only(set) => ObjectTypeSet::Only(
+                set.into_iter()
+                    .filter(|ty| other.matches_name(ty))
+                    .collect(),
+            ),
+        }
+    }
+
+    /// Return a list of the object type names that are in this type set and
+    /// are also implementations of `current_type`
+    pub fn type_names(
+        &self,
+        schema: &Schema,
+        current_type: ObjectOrInterface<'_>,
+    ) -> Result<Vec<String>, QueryExecutionError> {
+        Ok(resolve_object_types(schema, current_type.name())?
+            .into_iter()
+            .map(|obj| obj.name().to_string())
+            .filter(|name| match self {
+                ObjectTypeSet::Any => true,
+                ObjectTypeSet::Only(set) => set.contains(name.as_str()),
+            })
+            .collect::<Vec<String>>())
+    }
+}
+
+/// Look up the type `name` from the schema and resolve interfaces
+/// and unions until we are left with a set of concrete object types
+pub(crate) fn resolve_object_types<'a>(
+    schema: &'a Schema,
+    name: &str,
+) -> Result<HashSet<ObjectCondition<'a>>, QueryExecutionError> {
+    let mut set = HashSet::new();
+    match schema
+        .document
+        .get_named_type(name)
+        .ok_or_else(|| QueryExecutionError::AbstractTypeError(name.to_string()))?
+    {
+        s::TypeDefinition::Interface(intf) => {
+            for obj_ty in &schema.types_for_interface()[&EntityType::new(intf.name.to_string())] {
+                set.insert(obj_ty.into());
+            }
+        }
+        s::TypeDefinition::Union(tys) => {
+            for ty in &tys.types {
+                set.extend(resolve_object_types(schema, ty)?)
+            }
+        }
+        s::TypeDefinition::Object(ty) => {
+            set.insert(ty.into());
+        }
+        s::TypeDefinition::Scalar(_)
+        | s::TypeDefinition::Enum(_)
+        | s::TypeDefinition::InputObject(_) => {
+            return Err(QueryExecutionError::NamedTypeError(name.to_string()));
+        }
+    }
+    Ok(set)
 }

--- a/graphql/src/execution/ast.rs
+++ b/graphql/src/execution/ast.rs
@@ -1,0 +1,141 @@
+use std::ops::Deref;
+
+use graph::prelude::{q, r};
+use graphql_parser::Pos;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FragmentDefinition {
+    pub position: Pos,
+    pub name: String,
+    pub type_condition: TypeCondition,
+    pub directives: Vec<Directive>,
+    pub selection_set: SelectionSet,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectionSet {
+    pub span: (Pos, Pos),
+    pub items: Vec<Selection>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Selection {
+    Field(Field),
+    FragmentSpread(FragmentSpread),
+    InlineFragment(InlineFragment),
+}
+
+impl Selection {
+    /// Looks up a directive in a selection, if it is provided.
+    pub fn get_directive(&self, name: &str) -> Option<&Directive> {
+        match self {
+            Selection::Field(field) => field
+                .directives
+                .iter()
+                .find(|directive| directive.name == name),
+            _ => None,
+        }
+    }
+
+    /// Returns true if a selection should be skipped (as per the `@skip` directive).
+    pub fn skip(&self) -> bool {
+        match self.get_directive("skip") {
+            Some(directive) => match directive.argument_value("if") {
+                Some(val) => match val {
+                    // Skip if @skip(if: true)
+                    r::Value::Boolean(skip_if) => *skip_if,
+                    _ => false,
+                },
+                None => true,
+            },
+            None => false,
+        }
+    }
+
+    /// Returns true if a selection should be included (as per the `@include` directive).
+    pub fn include(&self) -> bool {
+        match self.get_directive("include") {
+            Some(directive) => match directive.argument_value("if") {
+                Some(val) => match val {
+                    // Include if @include(if: true)
+                    r::Value::Boolean(include) => *include,
+                    _ => false,
+                },
+                None => true,
+            },
+            None => true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Directive {
+    pub position: Pos,
+    pub name: String,
+    pub arguments: Vec<(String, r::Value)>,
+}
+
+impl Directive {
+    /// Looks up the value of an argument in a vector of (name, value) tuples.
+    pub fn argument_value(&self, name: &str) -> Option<&r::Value> {
+        self.arguments
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, v)| v)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Field {
+    pub position: Pos,
+    pub alias: Option<String>,
+    pub name: String,
+    pub arguments: Vec<(String, r::Value)>,
+    pub directives: Vec<Directive>,
+    pub selection_set: SelectionSet,
+}
+
+impl Field {
+    /// Returns the response key of a field, which is either its name or its alias (if there is one).
+    pub fn response_key(&self) -> &str {
+        self.alias
+            .as_ref()
+            .map(Deref::deref)
+            .unwrap_or(self.name.as_str())
+    }
+
+    /// Looks up the value of an argument in a vector of (name, value) tuples.
+    pub fn argument_value(&self, name: &str) -> Option<&r::Value> {
+        self.arguments
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, v)| v)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FragmentSpread {
+    pub position: Pos,
+    pub fragment_name: String,
+    pub directives: Vec<Directive>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TypeCondition {
+    On(String),
+}
+
+impl From<q::TypeCondition> for TypeCondition {
+    fn from(type_cond: q::TypeCondition) -> Self {
+        let q::TypeCondition::On(name) = type_cond;
+        TypeCondition::On(name)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InlineFragment {
+    pub position: Pos,
+    pub type_condition: Option<TypeCondition>,
+    pub directives: Vec<Directive>,
+    pub selection_set: SelectionSet,
+}

--- a/graphql/src/execution/ast.rs
+++ b/graphql/src/execution/ast.rs
@@ -14,8 +14,21 @@ pub struct FragmentDefinition {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SelectionSet {
-    pub span: (Pos, Pos),
+    span: (Pos, Pos),
     pub items: Vec<Selection>,
+}
+
+impl SelectionSet {
+    pub fn new(span: (Pos, Pos), items: Vec<Selection>) -> Self {
+        SelectionSet { span, items }
+    }
+
+    pub fn empty_from(other: &SelectionSet) -> Self {
+        SelectionSet {
+            span: other.span.clone(),
+            items: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -282,14 +282,8 @@ pub fn execute_root_selection_set_uncached(
 ) -> Result<Object, Vec<QueryExecutionError>> {
     // Split the top-level fields into introspection fields and
     // regular data fields
-    let mut data_set = a::SelectionSet {
-        span: selection_set.span,
-        items: Vec::new(),
-    };
-    let mut intro_set = a::SelectionSet {
-        span: selection_set.span,
-        items: Vec::new(),
-    };
+    let mut data_set = a::SelectionSet::empty_from(selection_set);
+    let mut intro_set = a::SelectionSet::empty_from(selection_set);
     let mut meta_items = Vec::new();
 
     for (_, fields) in collect_fields(ctx, root_type, iter::once(selection_set)) {

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -264,7 +264,7 @@ where
         ExecutionContext {
             logger: self.logger.cheap_clone(),
             resolver: introspection_resolver,
-            query: self.query.as_introspection_query(),
+            query: self.query.cheap_clone(),
             deadline: self.deadline,
             max_first: std::u32::MAX,
             max_skip: std::u32::MAX,

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -554,7 +554,7 @@ fn execute_field(
     field: &a::Field,
     field_definition: &s::Field,
 ) -> Result<r::Value, Vec<QueryExecutionError>> {
-    coerce_argument_values(&ctx.query, object_type, field)
+    coerce_argument_values(&ctx.query.schema, object_type, field)
         .and_then(|argument_values| {
             resolve_field_value(
                 ctx,
@@ -895,14 +895,14 @@ fn resolve_abstract_type<'a>(
 
 /// Coerces argument values into GraphQL values.
 pub fn coerce_argument_values<'a>(
-    query: &crate::execution::Query,
+    schema: &ApiSchema,
     ty: impl Into<ObjectOrInterface<'a>>,
     field: &a::Field,
 ) -> Result<HashMap<&'a str, r::Value>, Vec<QueryExecutionError>> {
     let mut coerced_values = HashMap::new();
     let mut errors = vec![];
 
-    let resolver = |name: &str| query.schema.document().get_named_type(name);
+    let resolver = |name: &str| schema.document().get_named_type(name);
 
     for argument_def in sast::get_argument_definitions(ty, &field.name)
         .into_iter()

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -5,15 +5,13 @@ use graph::{
     prelude::{s, CheapClone},
     util::timed_rw_lock::TimedMutex,
 };
-use indexmap::IndexMap;
 use lazy_static::lazy_static;
 use stable_hash::crypto::SetHasher;
 use stable_hash::prelude::*;
 use stable_hash::utils::stable_hash;
-use std::borrow::ToOwned;
-use std::collections::{HashMap, HashSet};
-use std::iter;
+use std::collections::HashMap;
 use std::time::Instant;
+use std::{borrow::ToOwned, collections::HashSet};
 
 use graph::data::graphql::*;
 use graph::data::query::CacheStatus;
@@ -136,7 +134,6 @@ impl Default for WeightedResult {
 
 struct HashableQuery<'a> {
     query_schema_id: &'a DeploymentHash,
-    query_fragments: &'a HashMap<String, a::FragmentDefinition>,
     selection_set: &'a a::SelectionSet,
     block_ptr: &'a BlockPtr,
 }
@@ -162,13 +159,6 @@ impl StableHash for HashableQuery<'_> {
         self.query_schema_id
             .stable_hash(sequence_number.next_child(), state);
 
-        // Not stable! Uses to_string()
-        self.query_fragments
-            .iter()
-            .map(|(k, v)| (k, format!("{:?}", v)))
-            .collect::<HashMap<_, _>>()
-            .stable_hash(sequence_number.next_child(), state);
-
         // Not stable! Uses to_string
         format!("{:?}", self.selection_set).stable_hash(sequence_number.next_child(), state);
 
@@ -187,7 +177,6 @@ fn cache_key(
     // Otherwise, incorrect results may be returned.
     let query = HashableQuery {
         query_schema_id: ctx.query.schema.id(),
-        query_fragments: &ctx.query.fragments,
         selection_set,
         block_ptr,
     };
@@ -275,7 +264,7 @@ where
     }
 }
 
-pub fn execute_root_selection_set_uncached(
+pub(crate) fn execute_root_selection_set_uncached(
     ctx: &ExecutionContext<impl Resolver>,
     selection_set: &a::SelectionSet,
     root_type: &s::ObjectType,
@@ -286,18 +275,16 @@ pub fn execute_root_selection_set_uncached(
     let mut intro_set = a::SelectionSet::empty_from(selection_set);
     let mut meta_items = Vec::new();
 
-    for (_, fields) in collect_fields(ctx, root_type, iter::once(selection_set)) {
-        let name = fields[0].name.clone();
-        let selections = fields.into_iter().map(|f| a::Selection::Field(f.clone()));
+    for field in selection_set.fields_for(root_type) {
         // See if this is an introspection or data field. We don't worry about
         // non-existent fields; those will cause an error later when we execute
         // the data_set SelectionSet
-        if is_introspection_field(&name) {
-            intro_set.extend(selections)
-        } else if &name == META_FIELD_NAME {
-            meta_items.extend(selections)
+        if is_introspection_field(&field.name) {
+            intro_set.push(field)
+        } else if &field.name == META_FIELD_NAME {
+            meta_items.push(field)
         } else {
-            data_set.extend(selections)
+            data_set.push(field)
         }
     }
 
@@ -306,8 +293,8 @@ pub fn execute_root_selection_set_uncached(
         Object::default()
     } else {
         let initial_data = ctx.resolver.prefetch(&ctx, &data_set)?;
-        data_set.extend(meta_items);
-        execute_selection_set_to_map(&ctx, iter::once(&data_set), root_type, initial_data)?
+        data_set.push_fields(meta_items);
+        execute_selection_set_to_map(&ctx, &data_set, root_type, initial_data)?
     };
 
     // Resolve introspection fields, if there are any
@@ -316,7 +303,7 @@ pub fn execute_root_selection_set_uncached(
 
         values.extend(execute_selection_set_to_map(
             &ictx,
-            iter::once(&intro_set),
+            ctx.query.selection_set.as_ref(),
             &*INTROSPECTION_QUERY_TYPE,
             None,
         )?);
@@ -326,7 +313,7 @@ pub fn execute_root_selection_set_uncached(
 }
 
 /// Executes the root selection set of a query.
-pub async fn execute_root_selection_set<R: Resolver>(
+pub(crate) async fn execute_root_selection_set<R: Resolver>(
     ctx: Arc<ExecutionContext<R>>,
     selection_set: Arc<a::SelectionSet>,
     root_type: Arc<s::ObjectType>,
@@ -472,13 +459,13 @@ pub async fn execute_root_selection_set<R: Resolver>(
 /// Allows passing in a parent value during recursive processing of objects and their fields.
 fn execute_selection_set<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
-    selection_sets: impl Iterator<Item = &'a a::SelectionSet>,
+    selection_set: &'a a::SelectionSet,
     object_type: &s::ObjectType,
     prefetched_value: Option<r::Value>,
 ) -> Result<r::Value, Vec<QueryExecutionError>> {
     Ok(r::Value::Object(execute_selection_set_to_map(
         ctx,
-        selection_sets,
+        selection_set,
         object_type,
         prefetched_value,
     )?))
@@ -486,7 +473,7 @@ fn execute_selection_set<'a>(
 
 fn execute_selection_set_to_map<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
-    selection_sets: impl Iterator<Item = &'a a::SelectionSet>,
+    selection_set: &'a a::SelectionSet,
     object_type: &s::ObjectType,
     prefetched_value: Option<r::Value>,
 ) -> Result<Object, Vec<QueryExecutionError>> {
@@ -498,14 +485,11 @@ fn execute_selection_set_to_map<'a>(
     let mut errors: Vec<QueryExecutionError> = Vec::new();
     let mut result_map = Object::new();
 
-    // Group fields with the same response key, so we can execute them together
-    let grouped_field_set = collect_fields(ctx, object_type, selection_sets);
-
     // Gather fields that appear more than once with the same response key.
     let multiple_response_keys = {
         let mut multiple_response_keys = HashSet::new();
         let mut fields = HashSet::new();
-        for field in grouped_field_set.iter().map(|(_, f)| f.iter()).flatten() {
+        for field in selection_set.fields_for(object_type) {
             if !fields.insert(field.name.as_str()) {
                 multiple_response_keys.insert(field.name.as_str());
             }
@@ -514,7 +498,7 @@ fn execute_selection_set_to_map<'a>(
     };
 
     // Process all field groups in order
-    for (response_key, fields) in grouped_field_set {
+    for field in selection_set.fields_for(object_type) {
         match ctx.deadline {
             Some(deadline) if deadline < Instant::now() => {
                 errors.push(QueryExecutionError::Timeout);
@@ -523,8 +507,10 @@ fn execute_selection_set_to_map<'a>(
             _ => (),
         }
 
+        let response_key = field.response_key();
+
         // Unwrap: The query was validated to contain only valid fields.
-        let field = sast::get_field(object_type, &fields[0].name).unwrap();
+        let field_type = sast::get_field(object_type, &field.name).unwrap();
 
         // Check if we have the value already.
         let field_value = prefetched_object
@@ -537,13 +523,13 @@ fn execute_selection_set_to_map<'a>(
 
                 // Scalars and scalar lists are associated to the field name.
                 // If the field has more than one response key, we have to clone.
-                match multiple_response_keys.contains(fields[0].name.as_str()) {
-                    false => o.remove(&fields[0].name),
-                    true => o.get(&fields[0].name).cloned(),
+                match multiple_response_keys.contains(field.name.as_str()) {
+                    false => o.remove(&field.name),
+                    true => o.get(&field.name).cloned(),
                 }
             })
             .flatten();
-        match execute_field(&ctx, object_type, field_value, &fields[0], field, fields) {
+        match execute_field(&ctx, object_type, field_value, field, field_type) {
             Ok(v) => {
                 result_map.insert(response_key.to_owned(), v);
             }
@@ -560,116 +546,6 @@ fn execute_selection_set_to_map<'a>(
     }
 }
 
-/// Collects fields from selection sets. Returns a map from response key to fields. There will
-/// typically be a single field for a response key. If there are multiple, the overall execution
-/// logic will effectively merged them into the output for the response key.
-pub fn collect_fields<'a>(
-    ctx: &'a ExecutionContext<impl Resolver>,
-    object_type: &s::ObjectType,
-    selection_sets: impl Iterator<Item = &'a a::SelectionSet>,
-) -> IndexMap<&'a str, Vec<&'a a::Field>> {
-    let mut grouped_fields = IndexMap::new();
-    collect_fields_inner(
-        ctx,
-        object_type,
-        selection_sets,
-        &mut HashSet::new(),
-        &mut grouped_fields,
-    );
-    grouped_fields
-}
-
-pub fn collect_fields_inner<'a>(
-    ctx: &'a ExecutionContext<impl Resolver>,
-    object_type: &s::ObjectType,
-    selection_sets: impl Iterator<Item = &'a a::SelectionSet>,
-    visited_fragments: &mut HashSet<&'a str>,
-    output: &mut IndexMap<&'a str, Vec<&'a a::Field>>,
-) {
-    for selection_set in selection_sets {
-        // Only consider selections that are not skipped and should be included
-        for selection in selection_set.included() {
-            match selection {
-                a::Selection::Field(ref field) => {
-                    let response_key = field.response_key();
-                    output.entry(response_key).or_default().push(field);
-                }
-
-                a::Selection::FragmentSpread(spread) => {
-                    // Only consider the fragment if it hasn't already been included,
-                    // as would be the case if the same fragment spread ...Foo appeared
-                    // twice in the same selection set.
-                    //
-                    // Note: This will skip both duplicate fragments and will break cycles,
-                    // so we support fragments even though the GraphQL spec prohibits them.
-                    if visited_fragments.insert(&spread.fragment_name) {
-                        let fragment = ctx.query.get_fragment(&spread.fragment_name);
-                        if does_fragment_type_apply(ctx, object_type, &fragment.type_condition) {
-                            // We have a fragment that applies to the current object type,
-                            // collect fields recursively
-                            collect_fields_inner(
-                                ctx,
-                                object_type,
-                                iter::once(&fragment.selection_set),
-                                visited_fragments,
-                                output,
-                            );
-                        }
-                    }
-                }
-
-                a::Selection::InlineFragment(fragment) => {
-                    let applies = match &fragment.type_condition {
-                        Some(cond) => does_fragment_type_apply(ctx, object_type, &cond),
-                        None => true,
-                    };
-
-                    if applies {
-                        collect_fields_inner(
-                            ctx,
-                            object_type,
-                            iter::once(&fragment.selection_set),
-                            visited_fragments,
-                            output,
-                        )
-                    }
-                }
-            };
-        }
-    }
-}
-
-/// Determines whether a fragment is applicable to the given object type.
-fn does_fragment_type_apply(
-    ctx: &ExecutionContext<impl Resolver>,
-    object_type: &s::ObjectType,
-    fragment_type: &a::TypeCondition,
-) -> bool {
-    // This is safe to do, as TypeCondition only has a single `On` variant.
-    let a::TypeCondition::On(ref name) = fragment_type;
-
-    // Resolve the type the fragment applies to based on its name
-    let named_type = ctx.query.schema.document().get_named_type(name);
-
-    match named_type {
-        // The fragment applies to the object type if its type is the same object type
-        Some(s::TypeDefinition::Object(ot)) => object_type == ot,
-
-        // The fragment also applies to the object type if its type is an interface
-        // that the object type implements
-        Some(s::TypeDefinition::Interface(it)) => {
-            object_type.implements_interfaces.contains(&it.name)
-        }
-
-        // The fragment also applies to an object type if its type is a union that
-        // the object type is one of the possible types for
-        Some(s::TypeDefinition::Union(ut)) => ut.types.contains(&object_type.name),
-
-        // In all other cases, the fragment does not apply
-        _ => false,
-    }
-}
-
 /// Executes a field.
 fn execute_field(
     ctx: &ExecutionContext<impl Resolver>,
@@ -677,7 +553,6 @@ fn execute_field(
     field_value: Option<r::Value>,
     field: &a::Field,
     field_definition: &s::Field,
-    fields: Vec<&a::Field>,
 ) -> Result<r::Value, Vec<QueryExecutionError>> {
     coerce_argument_values(&ctx.query, object_type, field)
         .and_then(|argument_values| {
@@ -691,7 +566,7 @@ fn execute_field(
                 &argument_values,
             )
         })
-        .and_then(|value| complete_value(ctx, field, &field_definition.field_type, &fields, value))
+        .and_then(|value| complete_value(ctx, field, &field_definition.field_type, value))
 }
 
 /// Resolves the value of a field.
@@ -878,13 +753,12 @@ fn complete_value(
     ctx: &ExecutionContext<impl Resolver>,
     field: &a::Field,
     field_type: &s::Type,
-    fields: &Vec<&a::Field>,
     resolved_value: r::Value,
 ) -> Result<r::Value, Vec<QueryExecutionError>> {
     match field_type {
         // Fail if the field type is non-null but the value is null
         s::Type::NonNullType(inner_type) => {
-            return match complete_value(ctx, field, inner_type, fields, resolved_value)? {
+            return match complete_value(ctx, field, inner_type, resolved_value)? {
                 r::Value::Null => Err(vec![QueryExecutionError::NonNullError(
                     field.position,
                     field.name.to_string(),
@@ -908,7 +782,7 @@ fn complete_value(
                     for value_place in &mut values {
                         // Put in a placeholder, complete the value, put the completed value back.
                         let value = std::mem::replace(value_place, r::Value::Null);
-                        match complete_value(ctx, field, inner_type, fields, value) {
+                        match complete_value(ctx, field, inner_type, value) {
                             Ok(value) => {
                                 *value_place = value;
                             }
@@ -965,7 +839,7 @@ fn complete_value(
                 // Complete object types recursively
                 s::TypeDefinition::Object(object_type) => execute_selection_set(
                     ctx,
-                    fields.iter().map(|f| &f.selection_set),
+                    &field.selection_set,
                     object_type,
                     Some(resolved_value),
                 ),
@@ -976,7 +850,7 @@ fn complete_value(
 
                     execute_selection_set(
                         ctx,
-                        fields.iter().map(|f| &f.selection_set),
+                        &field.selection_set,
                         object_type,
                         Some(resolved_value),
                     )
@@ -988,7 +862,7 @@ fn complete_value(
 
                     execute_selection_set(
                         ctx,
-                        fields.iter().map(|f| &f.selection_set),
+                        &field.selection_set,
                         object_type,
                         Some(resolved_value),
                     )

--- a/graphql/src/execution/mod.rs
+++ b/graphql/src/execution/mod.rs
@@ -5,6 +5,9 @@ mod query;
 /// Common trait for field resolvers used in the execution.
 mod resolver;
 
+/// Our representation of a query AST
+pub mod ast;
+
 use stable_hash::{crypto::SetHasher, StableHasher};
 
 pub use self::execution::*;

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -257,13 +257,14 @@ impl Query {
 
         let root_type = self.schema.query_type.as_ref();
         for field in self.selection_set.fields_for(root_type) {
-            let args = match crate::execution::coerce_argument_values(self, root_type, field) {
-                Ok(args) => args,
-                Err(errs) => {
-                    errors.extend(errs);
-                    continue;
-                }
-            };
+            let args =
+                match crate::execution::coerce_argument_values(&self.schema, root_type, field) {
+                    Ok(args) => args,
+                    Err(errs) => {
+                        errors.extend(errs);
+                        continue;
+                    }
+                };
 
             let bc = match args.get("block") {
                 Some(bc) => BlockConstraint::try_from_value(bc).map_err(|_| {

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -295,10 +295,7 @@ impl Query {
 
             let (selection_set, error_policy) = bcs.entry(bc).or_insert_with(|| {
                 (
-                    a::SelectionSet {
-                        span: self.selection_set.span,
-                        items: vec![],
-                    },
+                    a::SelectionSet::empty_from(&self.selection_set),
                     field_error_policy,
                 )
             });
@@ -800,7 +797,7 @@ impl RawQuery {
                     }
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            Ok(a::SelectionSet { span, items })
+            Ok(a::SelectionSet::new(span, items))
         }
 
         fn expand_directives(

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -246,18 +246,21 @@ impl Query {
         Ok(Arc::new(query))
     }
 
-    /// Return the block constraint for the toplevel query field(s), merging the selection sets of
-    /// fields that have the same block constraint.
+    /// Return the block constraint for the toplevel query field(s), merging
+    /// consecutive fields that have the same block constraint, while making
+    /// sure that the fields appear in the same order as they did in the
+    /// query
     ///
-    /// Also returns the combined error policy for those fields, which is `Deny` if any field is
-    /// `Deny` and `Allow` otherwise.
+    /// Also returns the combined error policy for those fields, which is
+    /// `Deny` if any field is `Deny` and `Allow` otherwise.
     pub fn block_constraint(
         &self,
-    ) -> Result<HashMap<BlockConstraint, (a::SelectionSet, ErrorPolicy)>, Vec<QueryExecutionError>>
+    ) -> Result<Vec<(BlockConstraint, (a::SelectionSet, ErrorPolicy))>, Vec<QueryExecutionError>>
     {
-        let mut bcs = HashMap::new();
+        let mut bcs: Vec<(BlockConstraint, (a::SelectionSet, ErrorPolicy))> = Vec::new();
 
         let root_type = self.schema.query_type.as_ref();
+        let mut prev_bc: Option<BlockConstraint> = None;
         for field in self.selection_set.fields_for(root_type) {
             let bc = match field.argument_value("block") {
                 Some(bc) => BlockConstraint::try_from_value(bc).map_err(|_| {
@@ -281,16 +284,19 @@ impl Query {
                 None => ErrorPolicy::Deny,
             };
 
-            let (selection_set, error_policy) = bcs.entry(bc).or_insert_with(|| {
-                (
-                    a::SelectionSet::empty_from(&self.selection_set),
-                    field_error_policy,
-                )
-            });
-            selection_set.push(field);
-            if field_error_policy == ErrorPolicy::Deny {
-                *error_policy = ErrorPolicy::Deny;
+            let next_bc = Some(bc.clone());
+            if prev_bc == next_bc {
+                let (selection_set, error_policy) = &mut bcs.last_mut().unwrap().1;
+                selection_set.push(field);
+                if field_error_policy == ErrorPolicy::Deny {
+                    *error_policy = ErrorPolicy::Deny;
+                }
+            } else {
+                let mut selection_set = a::SelectionSet::empty_from(&self.selection_set);
+                selection_set.push(field);
+                bcs.push((bc, (selection_set, field_error_policy)))
             }
+            prev_bc = next_bc;
         }
         Ok(bcs)
     }

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -879,7 +879,7 @@ impl Transform {
     ) -> Result<a::SelectionSet, Vec<QueryExecutionError>> {
         let q::SelectionSet { span: _, items } = set;
         // check_complexity already checked for cycles in fragment
-        // expansion, i.e. situations where a named fragment includs itself
+        // expansion, i.e. situations where a named fragment includes itself
         // recursively. We still want to guard against spreading the same
         // fragment twice at the same level in the query
         let mut visited_fragments = HashSet::new();

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -24,11 +24,7 @@ use crate::{execution::get_field, schema::api::ErrorPolicy};
 
 lazy_static! {
     static ref GRAPHQL_VALIDATION_PLAN: ValidationPlan = ValidationPlan::from(
-        if std::env::var("DISABLE_GRAPHQL_VALIDATIONS")
-            .unwrap_or_else(|_| "false".into())
-            .parse::<bool>()
-            .unwrap_or_else(|_| false)
-        {
+        if std::env::var("ENABLE_GRAPHQL_VALIDATIONS").ok().is_none() {
             vec![]
         } else {
             vec![

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -18,7 +18,6 @@ use graph::data::schema::ApiSchema;
 use graph::prelude::{info, o, q, r, s, BlockNumber, CheapClone, Logger, TryFromValue};
 
 use crate::introspection::introspection_schema;
-use crate::query::ext::ValueExt;
 use crate::query::{ast as qast, ext::BlockConstraint};
 use crate::schema::ast as sast;
 use crate::{
@@ -116,9 +115,7 @@ impl<'a> std::fmt::Display for SelectedFields<'a> {
 pub struct Query {
     /// The schema against which to execute the query
     pub schema: Arc<ApiSchema>,
-    /// The variables for the query, coerced into proper values
-    pub variables: HashMap<String, r::Value>,
-    /// The root selection set of the query
+    /// The root selection set of the query. All variable references have already been resolved
     pub selection_set: Arc<q::SelectionSet>,
     /// The ShapeHash of the original query
     pub shape_hash: u64,
@@ -231,7 +228,6 @@ impl Query {
 
         let query = Self {
             schema: raw_query.schema,
-            variables: raw_query.variables,
             fragments: raw_query.fragments,
             selection_set: Arc::new(raw_query.selection_set),
             shape_hash: query.shape_hash,
@@ -324,7 +320,6 @@ impl Query {
 
         Arc::new(Self {
             schema: Arc::new(introspection_schema),
-            variables: self.variables.clone(),
             fragments: self.fragments.clone(),
             selection_set: self.selection_set.clone(),
             shape_hash: self.shape_hash,
@@ -469,7 +464,7 @@ fn coerce_variable(
 
     let resolver = |name: &str| schema.document().get_named_type(name);
 
-    coerce_value(value, &variable_def.var_type, &resolver, &HashMap::new()).map_err(|value| {
+    coerce_value(value, &variable_def.var_type, &resolver).map_err(|value| {
         vec![QueryExecutionError::InvalidArgumentError(
             variable_def.position,
             variable_def.name.to_owned(),

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -18,6 +18,7 @@ use graph::data::schema::ApiSchema;
 use graph::prelude::{info, o, q, r, s, BlockNumber, CheapClone, Logger, TryFromValue};
 
 use crate::introspection::introspection_schema;
+use crate::query::ext::ValueExt;
 use crate::query::{ast as qast, ext::BlockConstraint};
 use crate::schema::ast as sast;
 use crate::{
@@ -214,7 +215,7 @@ impl Query {
         let start = Instant::now();
         // Use an intermediate struct so we can modify the query before
         // enclosing it in an Arc
-        let raw_query = RawQuery {
+        let mut raw_query = RawQuery {
             schema,
             variables,
             selection_set,
@@ -226,6 +227,7 @@ impl Query {
         // overflow from invalid queries.
         let complexity = raw_query.check_complexity(max_complexity, max_depth)?;
         raw_query.validate_fields()?;
+        raw_query.expand_variables()?;
 
         let query = Self {
             schema: raw_query.schema,
@@ -725,5 +727,98 @@ impl RawQuery {
                 }
                 errors
             })
+    }
+
+    fn expand_variables(&mut self) -> Result<(), QueryExecutionError> {
+        fn expand_field(
+            field: &mut q::Field,
+            vars: &HashMap<String, r::Value>,
+        ) -> Result<(), QueryExecutionError> {
+            expand_arguments(&mut field.arguments, &field.position, vars)?;
+            expand_directives(&mut field.directives, vars)?;
+            expand_selection_set(&mut field.selection_set, vars)
+        }
+
+        fn expand_selection_set(
+            set: &mut q::SelectionSet,
+            vars: &HashMap<String, r::Value>,
+        ) -> Result<(), QueryExecutionError> {
+            for sel in &mut set.items {
+                match sel {
+                    q::Selection::Field(field) => expand_field(field, vars)?,
+                    q::Selection::FragmentSpread(spread) => {
+                        expand_directives(&mut spread.directives, vars)?;
+                    }
+                    q::Selection::InlineFragment(frag) => {
+                        expand_directives(&mut frag.directives, vars)?;
+                        expand_selection_set(&mut frag.selection_set, vars)?;
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        fn expand_directives(
+            dirs: &mut Vec<q::Directive>,
+            vars: &HashMap<String, r::Value>,
+        ) -> Result<(), QueryExecutionError> {
+            for dir in dirs {
+                expand_arguments(&mut dir.arguments, &dir.position, vars)?;
+            }
+            Ok(())
+        }
+
+        fn expand_arguments(
+            args: &mut Vec<(String, q::Value)>,
+            pos: &Pos,
+            vars: &HashMap<String, r::Value>,
+        ) -> Result<(), QueryExecutionError> {
+            for arg in args {
+                expand_value(&mut arg.1, pos, vars)?;
+            }
+            Ok(())
+        }
+
+        fn expand_value(
+            val: &mut q::Value,
+            pos: &Pos,
+            vars: &HashMap<String, r::Value>,
+        ) -> Result<(), QueryExecutionError> {
+            match val {
+                q::Value::Variable(ref var) => {
+                    let newval = match vars.get(var) {
+                        Some(val) => q::Value::from(val.clone()),
+                        None => {
+                            return Err(QueryExecutionError::MissingVariableError(
+                                pos.clone(),
+                                var.to_string(),
+                            ))
+                        }
+                    };
+                    *val = newval;
+                    Ok(())
+                }
+                q::Value::Int(_)
+                | q::Value::Float(_)
+                | q::Value::String(_)
+                | q::Value::Boolean(_)
+                | q::Value::Null
+                | q::Value::Enum(_) => Ok(()),
+                q::Value::List(ref mut vals) => {
+                    for mut val in vals.iter_mut() {
+                        expand_value(&mut val, pos, vars)?;
+                    }
+                    Ok(())
+                }
+                q::Value::Object(obj) => {
+                    for mut val in obj.values_mut() {
+                        expand_value(&mut val, pos, vars)?;
+                    }
+                    Ok(())
+                }
+            }
+        }
+
+        expand_selection_set(&mut self.selection_set, &self.variables)
     }
 }

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -211,26 +211,37 @@ impl Query {
             "query_id" => query_id.clone()
         ));
 
-        let mut query = Self {
+        let start = Instant::now();
+        // Use an intermediate struct so we can modify the query before
+        // enclosing it in an Arc
+        let raw_query = RawQuery {
             schema,
             variables,
-            fragments,
-            selection_set: Arc::new(selection_set),
-            shape_hash: query.shape_hash,
-            kind,
-            network,
+            selection_set,
             logger,
-            start: Instant::now(),
-            query_text: query.query_text.cheap_clone(),
-            variables_text: query.variables_text.cheap_clone(),
-            query_id,
-            complexity: 0,
+            fragments,
         };
 
         // It's important to check complexity first, so `validate_fields` doesn't risk a stack
         // overflow from invalid queries.
-        query.check_complexity(max_complexity, max_depth)?;
-        query.validate_fields()?;
+        let complexity = raw_query.check_complexity(max_complexity, max_depth)?;
+        raw_query.validate_fields()?;
+
+        let query = Self {
+            schema: raw_query.schema,
+            variables: raw_query.variables,
+            fragments: raw_query.fragments,
+            selection_set: Arc::new(raw_query.selection_set),
+            shape_hash: query.shape_hash,
+            kind,
+            network,
+            logger: raw_query.logger,
+            start,
+            query_text: query.query_text.cheap_clone(),
+            variables_text: query.variables_text.cheap_clone(),
+            query_id,
+            complexity,
+        };
 
         Ok(Arc::new(query))
     }
@@ -383,12 +394,107 @@ impl Query {
             );
         }
     }
+}
 
+/// Coerces variable values for an operation.
+pub fn coerce_variables(
+    schema: &ApiSchema,
+    operation: &q::OperationDefinition,
+    mut variables: Option<QueryVariables>,
+) -> Result<HashMap<String, r::Value>, Vec<QueryExecutionError>> {
+    let mut coerced_values = HashMap::new();
+    let mut errors = vec![];
+
+    for variable_def in qast::get_variable_definitions(operation)
+        .into_iter()
+        .flatten()
+    {
+        // Skip variable if it has an invalid type
+        if !sast::is_input_type(schema.document(), &variable_def.var_type) {
+            errors.push(QueryExecutionError::InvalidVariableTypeError(
+                variable_def.position,
+                variable_def.name.to_owned(),
+            ));
+            continue;
+        }
+
+        let value = variables
+            .as_mut()
+            .and_then(|vars| vars.remove(&variable_def.name));
+
+        let value = match value.or_else(|| {
+            variable_def
+                .default_value
+                .clone()
+                .map(r::Value::try_from)
+                .transpose()
+                .unwrap()
+        }) {
+            // No variable value provided and no default for non-null type, fail
+            None => {
+                if sast::is_non_null_type(&variable_def.var_type) {
+                    errors.push(QueryExecutionError::MissingVariableError(
+                        variable_def.position,
+                        variable_def.name.to_owned(),
+                    ));
+                };
+                continue;
+            }
+            Some(value) => value,
+        };
+
+        // We have a variable value, attempt to coerce it to the value type
+        // of the variable definition
+        coerced_values.insert(
+            variable_def.name.to_owned(),
+            coerce_variable(schema, variable_def, value.into())?,
+        );
+    }
+
+    if errors.is_empty() {
+        Ok(coerced_values)
+    } else {
+        Err(errors)
+    }
+}
+
+fn coerce_variable(
+    schema: &ApiSchema,
+    variable_def: &q::VariableDefinition,
+    value: q::Value,
+) -> Result<r::Value, Vec<QueryExecutionError>> {
+    use crate::values::coercion::coerce_value;
+
+    let resolver = |name: &str| schema.document().get_named_type(name);
+
+    coerce_value(value, &variable_def.var_type, &resolver, &HashMap::new()).map_err(|value| {
+        vec![QueryExecutionError::InvalidArgumentError(
+            variable_def.position,
+            variable_def.name.to_owned(),
+            value.clone(),
+        )]
+    })
+}
+
+struct RawQuery {
+    /// The schema against which to execute the query
+    schema: Arc<ApiSchema>,
+    /// The variables for the query, coerced into proper values
+    variables: HashMap<String, r::Value>,
+    /// The root selection set of the query
+    selection_set: q::SelectionSet,
+
+    pub logger: Logger,
+
+    fragments: HashMap<String, q::FragmentDefinition>,
+}
+
+impl RawQuery {
     fn check_complexity(
-        &mut self,
+        &self,
         max_complexity: Option<u64>,
         max_depth: u8,
-    ) -> Result<(), Vec<QueryExecutionError>> {
+    ) -> Result<u64, Vec<QueryExecutionError>> {
         let complexity = self.complexity(max_depth).map_err(|e| vec![e])?;
         if let Some(max_complexity) = max_complexity {
             if complexity > max_complexity {
@@ -398,8 +504,113 @@ impl Query {
                 )]);
             }
         }
-        self.complexity = complexity;
-        Ok(())
+        Ok(complexity)
+    }
+
+    fn complexity_inner<'a>(
+        &'a self,
+        ty: &s::TypeDefinition,
+        selection_set: &'a q::SelectionSet,
+        max_depth: u8,
+        depth: u8,
+        visited_fragments: &'a HashSet<&'a str>,
+    ) -> Result<u64, ComplexityError> {
+        use ComplexityError::*;
+
+        if depth >= max_depth {
+            return Err(TooDeep);
+        }
+
+        selection_set
+            .items
+            .iter()
+            .try_fold(0, |total_complexity, selection| {
+                let schema = self.schema.document();
+                match selection {
+                    q::Selection::Field(field) => {
+                        // Empty selection sets are the base case.
+                        if field.selection_set.items.is_empty() {
+                            return Ok(total_complexity);
+                        }
+
+                        // Get field type to determine if this is a collection query.
+                        let s_field = match ty {
+                            s::TypeDefinition::Object(t) => get_field(t, &field.name),
+                            s::TypeDefinition::Interface(t) => get_field(t, &field.name),
+
+                            // `Scalar` and `Enum` cannot have selection sets.
+                            // `InputObject` can't appear in a selection.
+                            // `Union` is not yet supported.
+                            s::TypeDefinition::Scalar(_)
+                            | s::TypeDefinition::Enum(_)
+                            | s::TypeDefinition::InputObject(_)
+                            | s::TypeDefinition::Union(_) => None,
+                        }
+                        .ok_or(Invalid)?;
+
+                        let field_complexity = self.complexity_inner(
+                            &get_named_type(schema, s_field.field_type.get_base_type())
+                                .ok_or(Invalid)?,
+                            &field.selection_set,
+                            max_depth,
+                            depth + 1,
+                            visited_fragments,
+                        )?;
+
+                        // Non-collection queries pass through.
+                        if !sast::is_list_or_non_null_list_field(&s_field) {
+                            return Ok(total_complexity + field_complexity);
+                        }
+
+                        // For collection queries, check the `first` argument.
+                        let max_entities = qast::get_argument_value(&field.arguments, "first")
+                            .and_then(|arg| match arg {
+                                q::Value::Int(n) => Some(n.as_i64()? as u64),
+                                _ => None,
+                            })
+                            .unwrap_or(100);
+                        max_entities
+                            .checked_add(
+                                max_entities.checked_mul(field_complexity).ok_or(Overflow)?,
+                            )
+                            .ok_or(Overflow)
+                    }
+                    q::Selection::FragmentSpread(fragment) => {
+                        let def = self.fragments.get(&fragment.fragment_name).unwrap();
+                        let q::TypeCondition::On(type_name) = &def.type_condition;
+                        let ty = get_named_type(schema, &type_name).ok_or(Invalid)?;
+
+                        // Copy `visited_fragments` on write.
+                        let mut visited_fragments = visited_fragments.clone();
+                        if !visited_fragments.insert(&fragment.fragment_name) {
+                            return Err(CyclicalFragment(fragment.fragment_name.clone()));
+                        }
+                        self.complexity_inner(
+                            &ty,
+                            &def.selection_set,
+                            max_depth,
+                            depth + 1,
+                            &visited_fragments,
+                        )
+                    }
+                    q::Selection::InlineFragment(fragment) => {
+                        let ty = match &fragment.type_condition {
+                            Some(q::TypeCondition::On(type_name)) => {
+                                get_named_type(schema, &type_name).ok_or(Invalid)?
+                            }
+                            _ => ty.clone(),
+                        };
+                        self.complexity_inner(
+                            &ty,
+                            &fragment.selection_set,
+                            max_depth,
+                            depth + 1,
+                            visited_fragments,
+                        )
+                    }
+                }
+                .and_then(|complexity| total_complexity.checked_add(complexity).ok_or(Overflow))
+            })
     }
 
     /// See https://developer.github.com/v4/guides/resource-limitations/.
@@ -515,190 +726,4 @@ impl Query {
                 errors
             })
     }
-
-    fn complexity_inner<'a>(
-        &'a self,
-        ty: &s::TypeDefinition,
-        selection_set: &'a q::SelectionSet,
-        max_depth: u8,
-        depth: u8,
-        visited_fragments: &'a HashSet<&'a str>,
-    ) -> Result<u64, ComplexityError> {
-        use ComplexityError::*;
-
-        if depth >= max_depth {
-            return Err(TooDeep);
-        }
-
-        selection_set
-            .items
-            .iter()
-            .try_fold(0, |total_complexity, selection| {
-                let schema = self.schema.document();
-                match selection {
-                    q::Selection::Field(field) => {
-                        // Empty selection sets are the base case.
-                        if field.selection_set.items.is_empty() {
-                            return Ok(total_complexity);
-                        }
-
-                        // Get field type to determine if this is a collection query.
-                        let s_field = match ty {
-                            s::TypeDefinition::Object(t) => get_field(t, &field.name),
-                            s::TypeDefinition::Interface(t) => get_field(t, &field.name),
-
-                            // `Scalar` and `Enum` cannot have selection sets.
-                            // `InputObject` can't appear in a selection.
-                            // `Union` is not yet supported.
-                            s::TypeDefinition::Scalar(_)
-                            | s::TypeDefinition::Enum(_)
-                            | s::TypeDefinition::InputObject(_)
-                            | s::TypeDefinition::Union(_) => None,
-                        }
-                        .ok_or(Invalid)?;
-
-                        let field_complexity = self.complexity_inner(
-                            &get_named_type(schema, s_field.field_type.get_base_type())
-                                .ok_or(Invalid)?,
-                            &field.selection_set,
-                            max_depth,
-                            depth + 1,
-                            visited_fragments,
-                        )?;
-
-                        // Non-collection queries pass through.
-                        if !sast::is_list_or_non_null_list_field(&s_field) {
-                            return Ok(total_complexity + field_complexity);
-                        }
-
-                        // For collection queries, check the `first` argument.
-                        let max_entities = qast::get_argument_value(&field.arguments, "first")
-                            .and_then(|arg| match arg {
-                                q::Value::Int(n) => Some(n.as_i64()? as u64),
-                                _ => None,
-                            })
-                            .unwrap_or(100);
-                        max_entities
-                            .checked_add(
-                                max_entities.checked_mul(field_complexity).ok_or(Overflow)?,
-                            )
-                            .ok_or(Overflow)
-                    }
-                    q::Selection::FragmentSpread(fragment) => {
-                        let def = self.get_fragment(&fragment.fragment_name);
-                        let q::TypeCondition::On(type_name) = &def.type_condition;
-                        let ty = get_named_type(schema, &type_name).ok_or(Invalid)?;
-
-                        // Copy `visited_fragments` on write.
-                        let mut visited_fragments = visited_fragments.clone();
-                        if !visited_fragments.insert(&fragment.fragment_name) {
-                            return Err(CyclicalFragment(fragment.fragment_name.clone()));
-                        }
-                        self.complexity_inner(
-                            &ty,
-                            &def.selection_set,
-                            max_depth,
-                            depth + 1,
-                            &visited_fragments,
-                        )
-                    }
-                    q::Selection::InlineFragment(fragment) => {
-                        let ty = match &fragment.type_condition {
-                            Some(q::TypeCondition::On(type_name)) => {
-                                get_named_type(schema, &type_name).ok_or(Invalid)?
-                            }
-                            _ => ty.clone(),
-                        };
-                        self.complexity_inner(
-                            &ty,
-                            &fragment.selection_set,
-                            max_depth,
-                            depth + 1,
-                            visited_fragments,
-                        )
-                    }
-                }
-                .and_then(|complexity| total_complexity.checked_add(complexity).ok_or(Overflow))
-            })
-    }
-}
-
-/// Coerces variable values for an operation.
-pub fn coerce_variables(
-    schema: &ApiSchema,
-    operation: &q::OperationDefinition,
-    mut variables: Option<QueryVariables>,
-) -> Result<HashMap<String, r::Value>, Vec<QueryExecutionError>> {
-    let mut coerced_values = HashMap::new();
-    let mut errors = vec![];
-
-    for variable_def in qast::get_variable_definitions(operation)
-        .into_iter()
-        .flatten()
-    {
-        // Skip variable if it has an invalid type
-        if !sast::is_input_type(schema.document(), &variable_def.var_type) {
-            errors.push(QueryExecutionError::InvalidVariableTypeError(
-                variable_def.position,
-                variable_def.name.to_owned(),
-            ));
-            continue;
-        }
-
-        let value = variables
-            .as_mut()
-            .and_then(|vars| vars.remove(&variable_def.name));
-
-        let value = match value.or_else(|| {
-            variable_def
-                .default_value
-                .clone()
-                .map(r::Value::try_from)
-                .transpose()
-                .unwrap()
-        }) {
-            // No variable value provided and no default for non-null type, fail
-            None => {
-                if sast::is_non_null_type(&variable_def.var_type) {
-                    errors.push(QueryExecutionError::MissingVariableError(
-                        variable_def.position,
-                        variable_def.name.to_owned(),
-                    ));
-                };
-                continue;
-            }
-            Some(value) => value,
-        };
-
-        // We have a variable value, attempt to coerce it to the value type
-        // of the variable definition
-        coerced_values.insert(
-            variable_def.name.to_owned(),
-            coerce_variable(schema, variable_def, value.into())?,
-        );
-    }
-
-    if errors.is_empty() {
-        Ok(coerced_values)
-    } else {
-        Err(errors)
-    }
-}
-
-fn coerce_variable(
-    schema: &ApiSchema,
-    variable_def: &q::VariableDefinition,
-    value: q::Value,
-) -> Result<r::Value, Vec<QueryExecutionError>> {
-    use crate::values::coercion::coerce_value;
-
-    let resolver = |name: &str| schema.document().get_named_type(name);
-
-    coerce_value(value, &variable_def.var_type, &resolver, &HashMap::new()).map_err(|value| {
-        vec![QueryExecutionError::InvalidArgumentError(
-            variable_def.position,
-            variable_def.name.to_owned(),
-            value.clone(),
-        )]
-    })
 }

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -2,7 +2,7 @@ use graphql_parser::Pos;
 use graphql_tools::validation::rules::*;
 use graphql_tools::validation::validate::{validate, ValidationPlan};
 use lazy_static::lazy_static;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::Instant;
@@ -17,6 +17,7 @@ use graph::data::query::{Query as GraphDataQuery, QueryVariables};
 use graph::data::schema::ApiSchema;
 use graph::prelude::{info, o, q, r, s, BlockNumber, CheapClone, Logger, TryFromValue};
 
+use crate::execution::ast as a;
 use crate::introspection::introspection_schema;
 use crate::query::{ast as qast, ext::BlockConstraint};
 use crate::schema::ast as sast;
@@ -80,21 +81,21 @@ enum Kind {
 /// uses ',' to separate key/value pairs.
 /// If `SelectionSet` is `None`, log `*` to indicate that the query was
 /// for the entire selection set of the query
-struct SelectedFields<'a>(&'a q::SelectionSet);
+struct SelectedFields<'a>(&'a a::SelectionSet);
 
 impl<'a> std::fmt::Display for SelectedFields<'a> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         let mut first = true;
         for item in &self.0.items {
             match item {
-                q::Selection::Field(field) => {
+                a::Selection::Field(field) => {
                     if !first {
                         write!(fmt, ";")?;
                     }
                     first = false;
                     write!(fmt, "{}", field.alias.as_ref().unwrap_or(&field.name))?
                 }
-                q::Selection::FragmentSpread(_) | q::Selection::InlineFragment(_) => {
+                a::Selection::FragmentSpread(_) | a::Selection::InlineFragment(_) => {
                     /* nothing */
                 }
             }
@@ -116,7 +117,7 @@ pub struct Query {
     /// The schema against which to execute the query
     pub schema: Arc<ApiSchema>,
     /// The root selection set of the query. All variable references have already been resolved
-    pub selection_set: Arc<q::SelectionSet>,
+    pub selection_set: Arc<a::SelectionSet>,
     /// The ShapeHash of the original query
     pub shape_hash: u64,
 
@@ -126,7 +127,7 @@ pub struct Query {
 
     start: Instant,
 
-    pub(crate) fragments: HashMap<String, q::FragmentDefinition>,
+    pub(crate) fragments: HashMap<String, a::FragmentDefinition>,
     kind: Kind,
 
     /// Used only for logging; if logging is configured off, these will
@@ -212,11 +213,10 @@ impl Query {
         let start = Instant::now();
         // Use an intermediate struct so we can modify the query before
         // enclosing it in an Arc
-        let mut raw_query = RawQuery {
-            schema,
+        let raw_query = RawQuery {
+            schema: schema.cheap_clone(),
             variables,
             selection_set,
-            logger,
             fragments,
         };
 
@@ -224,16 +224,16 @@ impl Query {
         // overflow from invalid queries.
         let complexity = raw_query.check_complexity(max_complexity, max_depth)?;
         raw_query.validate_fields()?;
-        raw_query.expand_variables()?;
+        let (selection_set, fragments) = raw_query.expand_variables()?;
 
         let query = Self {
-            schema: raw_query.schema,
-            fragments: raw_query.fragments,
-            selection_set: Arc::new(raw_query.selection_set),
+            schema,
+            fragments,
+            selection_set: Arc::new(selection_set),
             shape_hash: query.shape_hash,
             kind,
             network,
-            logger: raw_query.logger,
+            logger,
             start,
             query_text: query.query_text.cheap_clone(),
             variables_text: query.variables_text.cheap_clone(),
@@ -251,9 +251,9 @@ impl Query {
     /// `Deny` and `Allow` otherwise.
     pub fn block_constraint(
         &self,
-    ) -> Result<HashMap<BlockConstraint, (q::SelectionSet, ErrorPolicy)>, Vec<QueryExecutionError>>
+    ) -> Result<HashMap<BlockConstraint, (a::SelectionSet, ErrorPolicy)>, Vec<QueryExecutionError>>
     {
-        use graphql_parser::query::Selection::Field;
+        use a::Selection::Field;
 
         let mut bcs = HashMap::new();
         let mut errors = Vec::new();
@@ -295,7 +295,7 @@ impl Query {
 
             let (selection_set, error_policy) = bcs.entry(bc).or_insert_with(|| {
                 (
-                    q::SelectionSet {
+                    a::SelectionSet {
                         span: self.selection_set.span,
                         items: vec![],
                     },
@@ -336,7 +336,7 @@ impl Query {
 
     /// Should only be called for fragments that exist in the query, and therefore have been
     /// validated to exist. Panics otherwise.
-    pub fn get_fragment(&self, name: &str) -> &q::FragmentDefinition {
+    pub fn get_fragment(&self, name: &str) -> &a::FragmentDefinition {
         self.fragments.get(name).unwrap()
     }
 
@@ -375,7 +375,7 @@ impl Query {
     /// `selection_set` was cached
     pub fn log_cache_status(
         &self,
-        selection_set: &q::SelectionSet,
+        selection_set: &a::SelectionSet,
         block: BlockNumber,
         start: Instant,
         cache_status: String,
@@ -458,7 +458,7 @@ pub fn coerce_variables(
 fn coerce_variable(
     schema: &ApiSchema,
     variable_def: &q::VariableDefinition,
-    value: q::Value,
+    value: r::Value,
 ) -> Result<r::Value, Vec<QueryExecutionError>> {
     use crate::values::coercion::coerce_value;
 
@@ -468,7 +468,7 @@ fn coerce_variable(
         vec![QueryExecutionError::InvalidArgumentError(
             variable_def.position,
             variable_def.name.to_owned(),
-            value.clone(),
+            value.into(),
         )]
     })
 }
@@ -480,8 +480,6 @@ struct RawQuery {
     variables: HashMap<String, r::Value>,
     /// The root selection set of the query
     selection_set: q::SelectionSet,
-
-    pub logger: Logger,
 
     fragments: HashMap<String, q::FragmentDefinition>,
 }
@@ -724,96 +722,191 @@ impl RawQuery {
             })
     }
 
-    fn expand_variables(&mut self) -> Result<(), QueryExecutionError> {
+    fn expand_variables(
+        self,
+    ) -> Result<(a::SelectionSet, HashMap<String, a::FragmentDefinition>), QueryExecutionError>
+    {
         fn expand_field(
-            field: &mut q::Field,
+            field: q::Field,
             vars: &HashMap<String, r::Value>,
-        ) -> Result<(), QueryExecutionError> {
-            expand_arguments(&mut field.arguments, &field.position, vars)?;
-            expand_directives(&mut field.directives, vars)?;
-            expand_selection_set(&mut field.selection_set, vars)
+        ) -> Result<a::Field, QueryExecutionError> {
+            let q::Field {
+                position,
+                alias,
+                name,
+                arguments,
+                directives,
+                selection_set,
+            } = field;
+            let arguments = expand_arguments(arguments, &position, vars)?;
+            let directives = expand_directives(directives, vars)?;
+            let selection_set = expand_selection_set(selection_set, vars)?;
+            Ok(a::Field {
+                position,
+                alias,
+                name,
+                arguments,
+                directives,
+                selection_set,
+            })
         }
 
         fn expand_selection_set(
-            set: &mut q::SelectionSet,
+            set: q::SelectionSet,
             vars: &HashMap<String, r::Value>,
-        ) -> Result<(), QueryExecutionError> {
-            for sel in &mut set.items {
-                match sel {
-                    q::Selection::Field(field) => expand_field(field, vars)?,
+        ) -> Result<a::SelectionSet, QueryExecutionError> {
+            let q::SelectionSet { span, items } = set;
+            let items = items
+                .into_iter()
+                .map(|sel| match sel {
+                    q::Selection::Field(field) => {
+                        expand_field(field, vars).map(a::Selection::Field)
+                    }
                     q::Selection::FragmentSpread(spread) => {
-                        expand_directives(&mut spread.directives, vars)?;
+                        let q::FragmentSpread {
+                            position,
+                            fragment_name,
+                            directives,
+                        } = spread;
+                        expand_directives(directives, vars).map(|directives| {
+                            a::Selection::FragmentSpread(a::FragmentSpread {
+                                position,
+                                fragment_name,
+                                directives,
+                            })
+                        })
                     }
                     q::Selection::InlineFragment(frag) => {
-                        expand_directives(&mut frag.directives, vars)?;
-                        expand_selection_set(&mut frag.selection_set, vars)?;
+                        let q::InlineFragment {
+                            position,
+                            type_condition,
+                            directives,
+                            selection_set,
+                        } = frag;
+                        expand_directives(directives, vars).and_then(|directives| {
+                            expand_selection_set(selection_set, vars).map(|selection_set| {
+                                let type_condition = type_condition.map(|type_condition| {
+                                    let q::TypeCondition::On(name) = type_condition;
+                                    a::TypeCondition::On(name)
+                                });
+                                a::Selection::InlineFragment(a::InlineFragment {
+                                    position,
+                                    type_condition,
+                                    directives,
+                                    selection_set,
+                                })
+                            })
+                        })
                     }
-                }
-            }
-            Ok(())
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(a::SelectionSet { span, items })
         }
 
         fn expand_directives(
-            dirs: &mut Vec<q::Directive>,
+            dirs: Vec<q::Directive>,
             vars: &HashMap<String, r::Value>,
-        ) -> Result<(), QueryExecutionError> {
-            for dir in dirs {
-                expand_arguments(&mut dir.arguments, &dir.position, vars)?;
-            }
-            Ok(())
+        ) -> Result<Vec<a::Directive>, QueryExecutionError> {
+            dirs.into_iter()
+                .map(|dir| {
+                    let q::Directive {
+                        name,
+                        position,
+                        arguments,
+                    } = dir;
+                    expand_arguments(arguments, &position, vars).map(|arguments| a::Directive {
+                        name,
+                        position,
+                        arguments,
+                    })
+                })
+                .collect()
         }
 
         fn expand_arguments(
-            args: &mut Vec<(String, q::Value)>,
+            args: Vec<(String, q::Value)>,
             pos: &Pos,
             vars: &HashMap<String, r::Value>,
-        ) -> Result<(), QueryExecutionError> {
-            for arg in args {
-                expand_value(&mut arg.1, pos, vars)?;
-            }
-            Ok(())
+        ) -> Result<Vec<(String, r::Value)>, QueryExecutionError> {
+            args.into_iter()
+                .map(|(name, val)| expand_value(val, pos, vars).map(|val| (name, val)))
+                .collect()
         }
 
         fn expand_value(
-            val: &mut q::Value,
+            value: q::Value,
             pos: &Pos,
             vars: &HashMap<String, r::Value>,
-        ) -> Result<(), QueryExecutionError> {
-            match val {
-                q::Value::Variable(ref var) => {
-                    let newval = match vars.get(var) {
-                        Some(val) => q::Value::from(val.clone()),
-                        None => {
-                            return Err(QueryExecutionError::MissingVariableError(
-                                pos.clone(),
-                                var.to_string(),
-                            ))
-                        }
-                    };
-                    *val = newval;
-                    Ok(())
+        ) -> Result<r::Value, QueryExecutionError> {
+            match value {
+                q::Value::Variable(var) => match vars.get(&var) {
+                    Some(val) => Ok(val.clone()),
+                    None => Err(QueryExecutionError::MissingVariableError(
+                        pos.clone(),
+                        var.to_string(),
+                    )),
+                },
+                q::Value::Int(ref num) => Ok(r::Value::Int(
+                    num.as_i64().expect("q::Value::Int contains an i64"),
+                )),
+                q::Value::Float(f) => Ok(r::Value::Float(f)),
+                q::Value::String(s) => Ok(r::Value::String(s)),
+                q::Value::Boolean(b) => Ok(r::Value::Boolean(b)),
+                q::Value::Null => Ok(r::Value::Null),
+                q::Value::Enum(s) => Ok(r::Value::Enum(s)),
+                q::Value::List(vals) => {
+                    let vals: Vec<_> = vals
+                        .into_iter()
+                        .map(|val| expand_value(val, pos, vars))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok(r::Value::List(vals))
                 }
-                q::Value::Int(_)
-                | q::Value::Float(_)
-                | q::Value::String(_)
-                | q::Value::Boolean(_)
-                | q::Value::Null
-                | q::Value::Enum(_) => Ok(()),
-                q::Value::List(ref mut vals) => {
-                    for mut val in vals.iter_mut() {
-                        expand_value(&mut val, pos, vars)?;
+                q::Value::Object(map) => {
+                    let mut rmap = BTreeMap::new();
+                    for (key, value) in map.into_iter() {
+                        let value = expand_value(value, pos, vars)?;
+                        rmap.insert(key, value);
                     }
-                    Ok(())
-                }
-                q::Value::Object(obj) => {
-                    for mut val in obj.values_mut() {
-                        expand_value(&mut val, pos, vars)?;
-                    }
-                    Ok(())
+                    Ok(r::Value::object(rmap))
                 }
             }
         }
 
-        expand_selection_set(&mut self.selection_set, &self.variables)
+        fn expand_fragments(
+            fragments: HashMap<String, q::FragmentDefinition>,
+            vars: &HashMap<String, r::Value>,
+        ) -> Result<HashMap<String, a::FragmentDefinition>, QueryExecutionError> {
+            let mut new_fragments = HashMap::new();
+            for (type_name, def) in fragments {
+                let q::FragmentDefinition {
+                    position,
+                    name,
+                    type_condition,
+                    directives,
+                    selection_set,
+                } = def;
+                let directives = expand_directives(directives, vars)?;
+                let selection_set = expand_selection_set(selection_set, vars)?;
+                let def = a::FragmentDefinition {
+                    position,
+                    name,
+                    type_condition: type_condition.into(),
+                    directives,
+                    selection_set,
+                };
+                new_fragments.insert(type_name, def);
+            }
+            Ok(new_fragments)
+        }
+
+        let RawQuery {
+            schema: _,
+            variables,
+            selection_set,
+            fragments,
+        } = self;
+        expand_selection_set(selection_set, &variables).and_then(|selection_set| {
+            expand_fragments(fragments, &variables).map(|fragments| (selection_set, fragments))
+        })
     }
 }

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -86,7 +86,7 @@ struct SelectedFields<'a>(&'a a::SelectionSet);
 impl<'a> std::fmt::Display for SelectedFields<'a> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         let mut first = true;
-        for item in &self.0.items {
+        for item in self.0.selections() {
             match item {
                 a::Selection::Field(field) => {
                     if !first {
@@ -258,7 +258,7 @@ impl Query {
         let mut bcs = HashMap::new();
         let mut errors = Vec::new();
 
-        for field in self.selection_set.items.iter().filter_map(|sel| match sel {
+        for field in self.selection_set.selections().filter_map(|sel| match sel {
             Field(f) => Some(f),
             _ => None,
         }) {
@@ -299,7 +299,7 @@ impl Query {
                     field_error_policy,
                 )
             });
-            selection_set.items.push(Field(field.clone()));
+            selection_set.push(field.clone());
             if field_error_policy == ErrorPolicy::Deny {
                 *error_policy = ErrorPolicy::Deny;
             }

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -10,10 +10,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use std::{collections::hash_map::DefaultHasher, convert::TryFrom};
 
-use graph::data::graphql::{
-    ext::{DocumentExt, TypeExt},
-    ObjectOrInterface,
-};
+use graph::data::graphql::{ext::TypeExt, ObjectOrInterface};
 use graph::data::query::QueryExecutionError;
 use graph::data::query::{Query as GraphDataQuery, QueryVariables};
 use graph::data::schema::ApiSchema;
@@ -23,10 +20,7 @@ use crate::execution::ast as a;
 use crate::query::{ast as qast, ext::BlockConstraint};
 use crate::schema::ast as sast;
 use crate::values::coercion;
-use crate::{
-    execution::{get_field, get_named_type, object_or_interface},
-    schema::api::ErrorPolicy,
-};
+use crate::{execution::get_field, schema::api::ErrorPolicy};
 
 lazy_static! {
     static ref GRAPHQL_VALIDATION_PLAN: ValidationPlan = ValidationPlan::from(
@@ -209,8 +203,8 @@ impl Query {
 
         let start = Instant::now();
         let root_type = match kind {
-            Kind::Query => schema.document().get_root_query_type().unwrap(),
-            Kind::Subscription => schema.document().get_root_subscription_type().unwrap(),
+            Kind::Query => schema.query_type.as_ref(),
+            Kind::Subscription => schema.subscription_type.as_ref().unwrap(),
         };
         // Use an intermediate struct so we can modify the query before
         // enclosing it in an Arc
@@ -368,7 +362,7 @@ pub fn coerce_variables(
         .flatten()
     {
         // Skip variable if it has an invalid type
-        if !sast::is_input_type(schema.document(), &variable_def.var_type) {
+        if !schema.is_input_type(&variable_def.var_type) {
             errors.push(QueryExecutionError::InvalidVariableTypeError(
                 variable_def.position,
                 variable_def.name.to_owned(),
@@ -423,7 +417,7 @@ fn coerce_variable(
 ) -> Result<r::Value, Vec<QueryExecutionError>> {
     use crate::values::coercion::coerce_value;
 
-    let resolver = |name: &str| schema.document().get_named_type(name);
+    let resolver = |name: &str| schema.get_named_type(name);
 
     coerce_value(value, &variable_def.var_type, &resolver).map_err(|value| {
         vec![QueryExecutionError::InvalidArgumentError(
@@ -482,7 +476,6 @@ impl<'s> RawQuery<'s> {
             .items
             .iter()
             .try_fold(0, |total_complexity, selection| {
-                let schema = self.schema.document();
                 match selection {
                     q::Selection::Field(field) => {
                         // Empty selection sets are the base case.
@@ -506,7 +499,8 @@ impl<'s> RawQuery<'s> {
                         .ok_or(Invalid)?;
 
                         let field_complexity = self.complexity_inner(
-                            &get_named_type(schema, s_field.field_type.get_base_type())
+                            self.schema
+                                .get_named_type(s_field.field_type.get_base_type())
                                 .ok_or(Invalid)?,
                             &field.selection_set,
                             max_depth,
@@ -535,7 +529,7 @@ impl<'s> RawQuery<'s> {
                     q::Selection::FragmentSpread(fragment) => {
                         let def = self.fragments.get(&fragment.fragment_name).unwrap();
                         let q::TypeCondition::On(type_name) = &def.type_condition;
-                        let ty = get_named_type(schema, &type_name).ok_or(Invalid)?;
+                        let ty = self.schema.get_named_type(&type_name).ok_or(Invalid)?;
 
                         // Copy `visited_fragments` on write.
                         let mut visited_fragments = visited_fragments.clone();
@@ -553,12 +547,12 @@ impl<'s> RawQuery<'s> {
                     q::Selection::InlineFragment(fragment) => {
                         let ty = match &fragment.type_condition {
                             Some(q::TypeCondition::On(type_name)) => {
-                                get_named_type(schema, &type_name).ok_or(Invalid)?
+                                self.schema.get_named_type(type_name).ok_or(Invalid)?
                             }
-                            _ => ty.clone(),
+                            _ => ty,
                         };
                         self.complexity_inner(
-                            &ty,
+                            ty,
                             &fragment.selection_set,
                             max_depth,
                             depth + 1,
@@ -575,7 +569,7 @@ impl<'s> RawQuery<'s> {
     /// If the query is invalid, returns `Ok(0)` so that execution proceeds and
     /// gives a proper error.
     fn complexity(&self, max_depth: u8) -> Result<u64, QueryExecutionError> {
-        let root_type = sast::get_root_query_type_def(self.schema.document()).unwrap();
+        let root_type = self.schema.get_root_query_type_def().unwrap();
 
         match self.complexity_inner(
             root_type,
@@ -597,7 +591,7 @@ impl<'s> RawQuery<'s> {
     }
 
     fn validate_fields(&self) -> Result<(), Vec<QueryExecutionError>> {
-        let root_type = self.schema.document().get_root_query_type().unwrap();
+        let root_type = self.schema.query_type.as_ref();
 
         let errors =
             self.validate_fields_inner(&"Query".to_owned(), root_type.into(), &self.selection_set);
@@ -615,8 +609,6 @@ impl<'s> RawQuery<'s> {
         ty: ObjectOrInterface<'_>,
         selection_set: &q::SelectionSet,
     ) -> Vec<QueryExecutionError> {
-        let schema = self.schema.document();
-
         selection_set
             .items
             .iter()
@@ -625,9 +617,9 @@ impl<'s> RawQuery<'s> {
                     q::Selection::Field(field) => match get_field(ty, &field.name) {
                         Some(s_field) => {
                             let base_type = s_field.field_type.get_base_type();
-                            if get_named_type(schema, base_type).is_none() {
+                            if self.schema.get_named_type(base_type).is_none() {
                                 errors.push(QueryExecutionError::NamedTypeError(base_type.into()));
-                            } else if let Some(ty) = object_or_interface(schema, base_type) {
+                            } else if let Some(ty) = self.schema.object_or_interface(base_type) {
                                 errors.extend(self.validate_fields_inner(
                                     base_type,
                                     ty,
@@ -645,7 +637,7 @@ impl<'s> RawQuery<'s> {
                         match self.fragments.get(&fragment.fragment_name) {
                             Some(frag) => {
                                 let q::TypeCondition::On(type_name) = &frag.type_condition;
-                                match object_or_interface(schema, type_name) {
+                                match self.schema.object_or_interface(type_name) {
                                     Some(ty) => errors.extend(self.validate_fields_inner(
                                         type_name,
                                         ty,
@@ -663,7 +655,7 @@ impl<'s> RawQuery<'s> {
                     }
                     q::Selection::InlineFragment(fragment) => match &fragment.type_condition {
                         Some(q::TypeCondition::On(type_name)) => {
-                            match object_or_interface(schema, type_name) {
+                            match self.schema.object_or_interface(type_name) {
                                 Some(ty) => errors.extend(self.validate_fields_inner(
                                     type_name,
                                     ty,
@@ -797,7 +789,7 @@ impl Transform {
     ) -> Result<(), Vec<QueryExecutionError>> {
         let mut errors = vec![];
 
-        let resolver = |name: &str| self.schema.document().get_named_type(name);
+        let resolver = |name: &str| self.schema.get_named_type(name);
 
         for argument_def in sast::get_argument_definitions(ty, field_name)
             .into_iter()
@@ -864,7 +856,7 @@ impl Transform {
             let field_type = parent_type.field(&name).expect("field names are valid");
             let ty = field_type.field_type.get_base_type();
             let type_set = a::ObjectTypeSet::from_name(&self.schema, ty)?;
-            let ty = self.schema.document().object_or_interface(ty).unwrap();
+            let ty = self.schema.object_or_interface(ty).unwrap();
             self.expand_selection_set(selection_set, &type_set, ty)?
         };
 
@@ -966,7 +958,6 @@ impl Transform {
         let ty = match frag_cond {
             Some(q::TypeCondition::On(name)) => self
                 .schema
-                .document()
                 .object_or_interface(name)
                 .expect("type names on fragment spreads are valid"),
             None => ty,

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,6 +1,3 @@
-use std::collections::HashMap;
-
-use crate::execution::ExecutionContext;
 use graph::components::store::UnitStream;
 use graph::prelude::{async_trait, s, tokio, Error, QueryExecutionError};
 use graph::{
@@ -8,7 +5,7 @@ use graph::{
     prelude::{r, QueryResult},
 };
 
-use crate::execution::ast as a;
+use crate::execution::{ast as a, ExecutionContext};
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
 #[async_trait]
@@ -31,7 +28,6 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         field: &a::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&str, r::Value>,
     ) -> Result<r::Value, QueryExecutionError>;
 
     /// Resolves an object, `prefetched_object` is `Some` if the parent already calculated the value.
@@ -41,7 +37,6 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         field: &a::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&str, r::Value>,
     ) -> Result<r::Value, QueryExecutionError>;
 
     /// Resolves an enum value for a given enum type.
@@ -61,7 +56,6 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         _field: &a::Field,
         _scalar_type: &s::ScalarType,
         value: Option<r::Value>,
-        _argument_values: &HashMap<&str, r::Value>,
     ) -> Result<r::Value, QueryExecutionError> {
         // This code is duplicated.
         // See also c2112309-44fd-4a84-92a0-5a651e6ed548

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,5 +1,5 @@
 use graph::components::store::UnitStream;
-use graph::prelude::{async_trait, s, tokio, Error, QueryExecutionError};
+use graph::prelude::{async_trait, s, tokio, ApiSchema, Error, QueryExecutionError};
 use graph::{
     data::graphql::{ext::DocumentExt, ObjectOrInterface},
     prelude::{r, QueryResult},
@@ -108,7 +108,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
     // Resolves a change stream for a given field.
     fn resolve_field_stream(
         &self,
-        _schema: &s::Document,
+        _schema: &ApiSchema,
         _object_type: &s::ObjectType,
         _field: &a::Field,
     ) -> Result<UnitStream, QueryExecutionError> {

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -2,11 +2,13 @@ use std::collections::HashMap;
 
 use crate::execution::ExecutionContext;
 use graph::components::store::UnitStream;
-use graph::prelude::{async_trait, q, s, tokio, Error, QueryExecutionError};
+use graph::prelude::{async_trait, s, tokio, Error, QueryExecutionError};
 use graph::{
     data::graphql::{ext::DocumentExt, ObjectOrInterface},
     prelude::{r, QueryResult},
 };
+
+use crate::execution::ast as a;
 
 /// A GraphQL resolver that can resolve entities, enum values, scalar types and interfaces/unions.
 #[async_trait]
@@ -19,14 +21,14 @@ pub trait Resolver: Sized + Send + Sync + 'static {
     fn prefetch(
         &self,
         ctx: &ExecutionContext<Self>,
-        selection_set: &q::SelectionSet,
+        selection_set: &a::SelectionSet,
     ) -> Result<Option<r::Value>, Vec<QueryExecutionError>>;
 
     /// Resolves list of objects, `prefetched_objects` is `Some` if the parent already calculated the value.
     fn resolve_objects(
         &self,
         prefetched_objects: Option<r::Value>,
-        field: &q::Field,
+        field: &a::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&str, r::Value>,
@@ -36,7 +38,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
     fn resolve_object(
         &self,
         prefetched_object: Option<r::Value>,
-        field: &q::Field,
+        field: &a::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&str, r::Value>,
@@ -45,7 +47,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
     /// Resolves an enum value for a given enum type.
     fn resolve_enum_value(
         &self,
-        _field: &q::Field,
+        _field: &a::Field,
         _enum_type: &s::EnumType,
         value: Option<r::Value>,
     ) -> Result<r::Value, QueryExecutionError> {
@@ -56,7 +58,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
     fn resolve_scalar_value(
         &self,
         _parent_object_type: &s::ObjectType,
-        _field: &q::Field,
+        _field: &a::Field,
         _scalar_type: &s::ScalarType,
         value: Option<r::Value>,
         _argument_values: &HashMap<&str, r::Value>,
@@ -69,7 +71,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
     /// Resolves a list of enum values for a given enum type.
     fn resolve_enum_values(
         &self,
-        _field: &q::Field,
+        _field: &a::Field,
         _enum_type: &s::EnumType,
         value: Option<r::Value>,
     ) -> Result<r::Value, Vec<QueryExecutionError>> {
@@ -79,7 +81,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
     /// Resolves a list of scalar values for a given list type.
     fn resolve_scalar_values(
         &self,
-        _field: &q::Field,
+        _field: &a::Field,
         _scalar_type: &s::ScalarType,
         value: Option<r::Value>,
     ) -> Result<r::Value, Vec<QueryExecutionError>> {
@@ -114,7 +116,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         &self,
         _schema: &s::Document,
         _object_type: &s::ObjectType,
-        _field: &q::Field,
+        _field: &a::Field,
     ) -> Result<UnitStream, QueryExecutionError> {
         Err(QueryExecutionError::NotSupported(String::from(
             "Resolving field streams is not supported by this resolver",

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,7 +1,7 @@
 use graph::components::store::UnitStream;
 use graph::prelude::{async_trait, s, tokio, ApiSchema, Error, QueryExecutionError};
 use graph::{
-    data::graphql::{ext::DocumentExt, ObjectOrInterface},
+    data::graphql::ObjectOrInterface,
     prelude::{r, QueryResult},
 };
 
@@ -85,7 +85,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
     // Resolves an abstract type into the specific type of an object.
     fn resolve_abstract_type<'a>(
         &self,
-        schema: &'a s::Document,
+        schema: &'a ApiSchema,
         _abstract_type: &s::TypeDefinition,
         object_value: &r::Value,
     ) -> Option<&'a s::ObjectType> {

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -95,7 +95,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
     ) -> Option<&'a s::ObjectType> {
         let concrete_type_name = match object_value {
             // All objects contain `__typename`
-            r::Value::Object(data) => match &data["__typename"] {
+            r::Value::Object(data) => match &data.get("__typename").unwrap() {
                 r::Value::String(name) => name.clone(),
                 _ => unreachable!("__typename must be a string"),
             },

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -1,6 +1,6 @@
 use graph::data::graphql::ext::{FieldExt, TypeDefinitionExt};
 use graphql_parser::Pos;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use graph::data::graphql::{object, DocumentExt, ObjectOrInterface};
 use graph::prelude::*;
@@ -376,7 +376,6 @@ impl Resolver for IntrospectionResolver {
         field: &a::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&str, r::Value>,
     ) -> Result<r::Value, QueryExecutionError> {
         match field.name.as_str() {
             "possibleTypes" => {
@@ -418,12 +417,11 @@ impl Resolver for IntrospectionResolver {
         field: &a::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        arguments: &HashMap<&str, r::Value>,
     ) -> Result<r::Value, QueryExecutionError> {
         let object = match field.name.as_str() {
             "__schema" => self.schema_object(),
             "__type" => {
-                let name = arguments.get("name").ok_or_else(|| {
+                let name = field.argument_value("name").ok_or_else(|| {
                     QueryExecutionError::MissingArgumentError(
                         Pos::default(),
                         "missing argument `name` in `__type(name: String!)`".to_owned(),

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use graph::data::graphql::{object, DocumentExt, ObjectOrInterface};
 use graph::prelude::*;
 
+use crate::execution::ast as a;
 use crate::prelude::*;
 use crate::schema::ast as sast;
 
@@ -359,7 +360,7 @@ impl Resolver for IntrospectionResolver {
     fn prefetch(
         &self,
         _: &ExecutionContext<Self>,
-        _: &q::SelectionSet,
+        _: &a::SelectionSet,
     ) -> Result<Option<r::Value>, Vec<QueryExecutionError>> {
         Ok(None)
     }
@@ -367,7 +368,7 @@ impl Resolver for IntrospectionResolver {
     fn resolve_objects(
         &self,
         prefetched_objects: Option<r::Value>,
-        field: &q::Field,
+        field: &a::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&str, r::Value>,
@@ -409,7 +410,7 @@ impl Resolver for IntrospectionResolver {
     fn resolve_object(
         &self,
         prefetched_object: Option<r::Value>,
-        field: &q::Field,
+        field: &a::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&str, r::Value>,

--- a/graphql/src/introspection/schema.rs
+++ b/graphql/src/introspection/schema.rs
@@ -1,12 +1,16 @@
+use std::sync::Arc;
+
 use graphql_parser;
 
 use graph::data::graphql::ext::DocumentExt;
 use graph::data::graphql::ext::ObjectTypeExt;
 use graph::data::schema::{ApiSchema, Schema};
 use graph::data::subgraph::DeploymentHash;
-use graph::prelude::s::{Document, ObjectType};
+use graph::prelude::s::Document;
 
 use lazy_static::lazy_static;
+
+use crate::schema::ast as sast;
 
 const INTROSPECTION_SCHEMA: &str = "
 scalar Boolean
@@ -117,8 +121,12 @@ enum __DirectiveLocation {
 lazy_static! {
     pub static ref INTROSPECTION_DOCUMENT: Document =
         graphql_parser::parse_schema(INTROSPECTION_SCHEMA).unwrap();
-    pub static ref INTROSPECTION_QUERY_TYPE: &'static ObjectType =
-        INTROSPECTION_DOCUMENT.get_root_query_type().unwrap();
+    pub static ref INTROSPECTION_QUERY_TYPE: sast::ObjectType = sast::ObjectType::from(Arc::new(
+        INTROSPECTION_DOCUMENT
+            .get_root_query_type()
+            .unwrap()
+            .clone()
+    ));
 }
 
 pub fn introspection_schema(id: DeploymentHash) -> ApiSchema {

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -30,7 +30,7 @@ pub mod prelude {
     pub use super::introspection::{introspection_schema, IntrospectionResolver};
     pub use super::query::{execute_query, ext::BlockConstraint, QueryExecutionOptions};
     pub use super::schema::{api_schema, APISchemaError};
-    pub use super::store::{build_query, StoreResolver};
+    pub use super::store::StoreResolver;
     pub use super::subscription::SubscriptionExecutionOptions;
     pub use super::values::MaybeCoercible;
 

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -26,7 +26,7 @@ mod runner;
 
 /// Prelude that exports the most important traits and types.
 pub mod prelude {
-    pub use super::execution::{ExecutionContext, Query, Resolver};
+    pub use super::execution::{ast as a, ExecutionContext, Query, Resolver};
     pub use super::introspection::{introspection_schema, IntrospectionResolver};
     pub use super::query::{execute_query, ext::BlockConstraint, QueryExecutionOptions};
     pub use super::schema::{api_schema, APISchemaError};

--- a/graphql/src/query/ast.rs
+++ b/graphql/src/query/ast.rs
@@ -1,5 +1,4 @@
-use graph::prelude::{q::*, r};
-use std::collections::HashMap;
+use graph::prelude::q::*;
 use std::ops::Deref;
 
 use graph::prelude::QueryExecutionError;
@@ -64,18 +63,14 @@ pub fn get_argument_value<'a>(arguments: &'a [(String, Value)], name: &str) -> O
 }
 
 /// Returns true if a selection should be skipped (as per the `@skip` directive).
-pub fn skip_selection(selection: &Selection, variables: &HashMap<String, r::Value>) -> bool {
+pub fn skip_selection(selection: &Selection) -> bool {
     match get_directive(selection, "skip".to_string()) {
         Some(directive) => match get_argument_value(&directive.arguments, "if") {
             Some(val) => match val {
                 // Skip if @skip(if: true)
                 Value::Boolean(skip_if) => *skip_if,
 
-                // Also skip if @skip(if: $variable) where $variable is true
-                Value::Variable(name) => variables.get(name).map_or(false, |var| match var {
-                    r::Value::Boolean(v) => v.to_owned(),
-                    _ => false,
-                }),
+                Value::Variable(_) => unreachable!("variables have already been resolved"),
 
                 _ => false,
             },
@@ -86,18 +81,14 @@ pub fn skip_selection(selection: &Selection, variables: &HashMap<String, r::Valu
 }
 
 /// Returns true if a selection should be included (as per the `@include` directive).
-pub fn include_selection(selection: &Selection, variables: &HashMap<String, r::Value>) -> bool {
+pub fn include_selection(selection: &Selection) -> bool {
     match get_directive(selection, "include".to_string()) {
         Some(directive) => match get_argument_value(&directive.arguments, "if") {
             Some(val) => match val {
                 // Include if @include(if: true)
                 Value::Boolean(include) => *include,
 
-                // Also include if @include(if: $variable) where $variable is true
-                Value::Variable(name) => variables.get(name).map_or(false, |var| match var {
-                    r::Value::Boolean(v) => v.to_owned(),
-                    _ => false,
-                }),
+                Value::Variable(_) => unreachable!("variables have already been resolved"),
 
                 _ => false,
             },

--- a/graphql/src/query/ast.rs
+++ b/graphql/src/query/ast.rs
@@ -62,63 +62,6 @@ pub fn get_argument_value<'a>(arguments: &'a [(String, Value)], name: &str) -> O
     arguments.iter().find(|(n, _)| n == name).map(|(_, v)| v)
 }
 
-/// Returns true if a selection should be skipped (as per the `@skip` directive).
-pub fn skip_selection(selection: &Selection) -> bool {
-    match get_directive(selection, "skip".to_string()) {
-        Some(directive) => match get_argument_value(&directive.arguments, "if") {
-            Some(val) => match val {
-                // Skip if @skip(if: true)
-                Value::Boolean(skip_if) => *skip_if,
-
-                Value::Variable(_) => unreachable!("variables have already been resolved"),
-
-                _ => false,
-            },
-            None => true,
-        },
-        None => false,
-    }
-}
-
-/// Returns true if a selection should be included (as per the `@include` directive).
-pub fn include_selection(selection: &Selection) -> bool {
-    match get_directive(selection, "include".to_string()) {
-        Some(directive) => match get_argument_value(&directive.arguments, "if") {
-            Some(val) => match val {
-                // Include if @include(if: true)
-                Value::Boolean(include) => *include,
-
-                Value::Variable(_) => unreachable!("variables have already been resolved"),
-
-                _ => false,
-            },
-            None => true,
-        },
-        None => true,
-    }
-}
-
-/// Returns the response key of a field, which is either its name or its alias (if there is one).
-pub fn get_response_key(field: &Field) -> &str {
-    field
-        .alias
-        .as_ref()
-        .map(Deref::deref)
-        .unwrap_or(field.name.as_str())
-}
-
-/// Returns up the fragment with the given name, if it exists.
-pub fn get_fragment<'a>(document: &'a Document, name: &String) -> Option<&'a FragmentDefinition> {
-    document
-        .definitions
-        .iter()
-        .filter_map(|d| match d {
-            Definition::Fragment(fd) => Some(fd),
-            _ => None,
-        })
-        .find(|fd| &fd.name == name)
-}
-
 /// Returns the variable definitions for an operation.
 pub fn get_variable_definitions(
     operation: &OperationDefinition,

--- a/graphql/src/query/ext.rs
+++ b/graphql/src/query/ext.rs
@@ -54,7 +54,7 @@ impl ValueExt for q::Value {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum BlockConstraint {
     Hash(H256),
     Number(BlockNumber),

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,10 +1,10 @@
-use graph::prelude::{q, BlockPtr, CheapClone, QueryExecutionError, QueryResult};
+use graph::prelude::{BlockPtr, CheapClone, QueryExecutionError, QueryResult};
 use std::sync::Arc;
 use std::time::Instant;
 
 use graph::data::graphql::effort::LoadManager;
 
-use crate::execution::*;
+use crate::execution::{ast as a, *};
 
 /// Utilities for working with GraphQL query ASTs.
 pub mod ast;
@@ -33,7 +33,7 @@ pub struct QueryExecutionOptions<R> {
 /// If the query is not cacheable, the `Arc` may be unwrapped.
 pub async fn execute_query<R>(
     query: Arc<Query>,
-    selection_set: Option<q::SelectionSet>,
+    selection_set: Option<a::SelectionSet>,
     block_ptr: Option<BlockPtr>,
     options: QueryExecutionOptions<R>,
 ) -> Arc<QueryResult>

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -61,7 +61,7 @@ where
         .unwrap_or_else(|| query.selection_set.cheap_clone());
 
     // Execute top-level `query { ... }` and `{ ... }` expressions.
-    let query_type = ctx.query.schema.query_type.cheap_clone();
+    let query_type = ctx.query.schema.query_type.cheap_clone().into();
     let start = Instant::now();
     let result = execute_root_selection_set(
         ctx.cheap_clone(),

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -73,9 +73,8 @@ impl TryFrom<&r::Value> for ErrorPolicy {
 /// Derives a full-fledged GraphQL API schema from an input schema.
 ///
 /// The input schema should only have type/enum/interface/union definitions
-/// and must not include a root Query type. This Query type is derived,
-/// with all its fields and their input arguments, based on the existing
-/// types.
+/// and must not include a root Query type. This Query type is derived, with
+/// all its fields and their input arguments, based on the existing types.
 pub fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
     // Refactor: Take `input_schema` by value.
     let object_types = input_schema.get_object_type_definitions();
@@ -531,9 +530,9 @@ fn add_query_type(
 
     let mut fields = object_types
         .iter()
-        .map(|t| &t.name)
+        .map(|t| t.name.as_str())
         .filter(|name| !name.eq(&SCHEMA_TYPE_NAME))
-        .chain(interface_types.iter().map(|t| &t.name))
+        .chain(interface_types.iter().map(|t| t.name.as_str()))
         .flat_map(|name| query_fields_for_type(name))
         .collect::<Vec<Field>>();
     let mut fulltext_fields = schema

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -53,47 +53,47 @@ pub(crate) fn parse_field_as_filter(key: &str) -> (String, FilterOp) {
 
 /// An `ObjectType` with `Hash` and `Eq` derived from the name.
 #[derive(Clone, Debug)]
-pub(crate) struct ObjectCondition<'a>(&'a s::ObjectType);
+pub(crate) struct ObjectType<'a>(&'a s::ObjectType);
 
-impl<'a> Ord for ObjectCondition<'a> {
+impl<'a> Ord for ObjectType<'a> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.0.name.cmp(&other.0.name)
     }
 }
 
-impl<'a> PartialOrd for ObjectCondition<'a> {
+impl<'a> PartialOrd for ObjectType<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.0.name.cmp(&other.0.name))
     }
 }
 
-impl std::hash::Hash for ObjectCondition<'_> {
+impl std::hash::Hash for ObjectType<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.name.hash(state)
     }
 }
 
-impl PartialEq for ObjectCondition<'_> {
+impl PartialEq for ObjectType<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.0.name.eq(&other.0.name)
     }
 }
 
-impl Eq for ObjectCondition<'_> {}
+impl Eq for ObjectType<'_> {}
 
-impl<'a> From<&'a s::ObjectType> for ObjectCondition<'a> {
+impl<'a> From<&'a s::ObjectType> for ObjectType<'a> {
     fn from(object: &'a s::ObjectType) -> Self {
-        ObjectCondition(object)
+        ObjectType(object)
     }
 }
 
-impl<'a> From<ObjectCondition<'a>> for ObjectOrInterface<'a> {
-    fn from(cond: ObjectCondition<'a>) -> Self {
+impl<'a> From<ObjectType<'a>> for ObjectOrInterface<'a> {
+    fn from(cond: ObjectType<'a>) -> Self {
         ObjectOrInterface::Object(cond.0)
     }
 }
 
-impl ObjectCondition<'_> {
+impl ObjectType<'_> {
     pub fn name(&self) -> &str {
         &self.0.name
     }

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -1,14 +1,15 @@
-use anyhow::anyhow;
-use graph::data::graphql::ext::DirectiveFinder;
 use graphql_parser::Pos;
 use lazy_static::lazy_static;
 use std::ops::Deref;
 use std::str::FromStr;
 
-use crate::query::ast as qast;
+use graph::data::graphql::ext::DirectiveFinder;
 use graph::data::graphql::{DocumentExt, ObjectOrInterface};
-use graph::prelude::s::{Value, *};
-use graph::prelude::*;
+use graph::data::store;
+use graph::prelude::anyhow::{anyhow, Context};
+use graph::prelude::{s, Entity, EntityKey, Error, ValueType};
+
+use crate::query::ast as qast;
 
 pub(crate) enum FilterOp {
     Not,
@@ -98,10 +99,10 @@ impl ObjectCondition<'_> {
     }
 }
 
-pub fn get_root_query_type_def(schema: &Document) -> Option<&TypeDefinition> {
+pub fn get_root_query_type_def(schema: &s::Document) -> Option<&s::TypeDefinition> {
     schema.definitions.iter().find_map(|d| match d {
-        Definition::TypeDefinition(def @ TypeDefinition::Object(_)) => match def {
-            TypeDefinition::Object(t) if t.name == "Query" => Some(def),
+        s::Definition::TypeDefinition(def @ s::TypeDefinition::Object(_)) => match def {
+            s::TypeDefinition::Object(t) if t.name == "Query" => Some(def),
             _ => None,
         },
         _ => None,
@@ -109,19 +110,22 @@ pub fn get_root_query_type_def(schema: &Document) -> Option<&TypeDefinition> {
 }
 
 /// Returns all type definitions in the schema.
-pub fn get_type_definitions(schema: &Document) -> Vec<&TypeDefinition> {
+pub fn get_type_definitions(schema: &s::Document) -> Vec<&s::TypeDefinition> {
     schema
         .definitions
         .iter()
         .filter_map(|d| match d {
-            Definition::TypeDefinition(typedef) => Some(typedef),
+            s::Definition::TypeDefinition(typedef) => Some(typedef),
             _ => None,
         })
         .collect()
 }
 
 /// Returns the object type with the given name.
-pub fn get_object_type_mut<'a>(schema: &'a mut Document, name: &str) -> Option<&'a mut ObjectType> {
+pub fn get_object_type_mut<'a>(
+    schema: &'a mut s::Document,
+    name: &str,
+) -> Option<&'a mut s::ObjectType> {
     use graphql_parser::schema::TypeDefinition::*;
 
     get_named_type_definition_mut(schema, name).and_then(|type_def| match type_def {
@@ -132,9 +136,9 @@ pub fn get_object_type_mut<'a>(schema: &'a mut Document, name: &str) -> Option<&
 
 /// Returns the interface type with the given name.
 pub fn get_interface_type_mut<'a>(
-    schema: &'a mut Document,
+    schema: &'a mut s::Document,
     name: &str,
-) -> Option<&'a mut InterfaceType> {
+) -> Option<&'a mut s::InterfaceType> {
     use graphql_parser::schema::TypeDefinition::*;
 
     get_named_type_definition_mut(schema, name).and_then(|type_def| match type_def {
@@ -147,13 +151,13 @@ pub fn get_interface_type_mut<'a>(
 pub fn get_field<'a>(
     object_type: impl Into<ObjectOrInterface<'a>>,
     name: &str,
-) -> Option<&'a Field> {
+) -> Option<&'a s::Field> {
     lazy_static! {
-        pub static ref TYPENAME_FIELD: Field = Field {
+        pub static ref TYPENAME_FIELD: s::Field = s::Field {
             position: Pos::default(),
             description: None,
             name: "__typename".to_owned(),
-            field_type: Type::NonNullType(Box::new(Type::NamedType("String".to_owned()))),
+            field_type: s::Type::NonNullType(Box::new(s::Type::NamedType("String".to_owned()))),
             arguments: vec![],
             directives: vec![],
         };
@@ -171,66 +175,66 @@ pub fn get_field<'a>(
 }
 
 /// Returns the value type for a GraphQL field type.
-pub fn get_field_value_type(field_type: &Type) -> Result<ValueType, Error> {
+pub fn get_field_value_type(field_type: &s::Type) -> Result<ValueType, Error> {
     match field_type {
-        Type::NamedType(ref name) => ValueType::from_str(&name),
-        Type::NonNullType(inner) => get_field_value_type(&inner),
-        Type::ListType(_) => Err(anyhow!("Only scalar values are supported in this context")),
+        s::Type::NamedType(ref name) => ValueType::from_str(&name),
+        s::Type::NonNullType(inner) => get_field_value_type(&inner),
+        s::Type::ListType(_) => Err(anyhow!("Only scalar values are supported in this context")),
     }
 }
 
 /// Returns the value type for a GraphQL field type.
-pub fn get_field_name(field_type: &Type) -> String {
+pub fn get_field_name(field_type: &s::Type) -> String {
     match field_type {
-        Type::NamedType(name) => name.to_string(),
-        Type::NonNullType(inner) => get_field_name(&inner),
-        Type::ListType(inner) => get_field_name(&inner),
+        s::Type::NamedType(name) => name.to_string(),
+        s::Type::NonNullType(inner) => get_field_name(&inner),
+        s::Type::ListType(inner) => get_field_name(&inner),
     }
 }
 
 /// Returns a mutable version of the type with the given name.
 pub fn get_named_type_definition_mut<'a>(
-    schema: &'a mut Document,
+    schema: &'a mut s::Document,
     name: &str,
-) -> Option<&'a mut TypeDefinition> {
+) -> Option<&'a mut s::TypeDefinition> {
     schema
         .definitions
         .iter_mut()
         .filter_map(|def| match def {
-            Definition::TypeDefinition(typedef) => Some(typedef),
+            s::Definition::TypeDefinition(typedef) => Some(typedef),
             _ => None,
         })
         .find(|typedef| match typedef {
-            TypeDefinition::Object(t) => &t.name == name,
-            TypeDefinition::Enum(t) => &t.name == name,
-            TypeDefinition::InputObject(t) => &t.name == name,
-            TypeDefinition::Interface(t) => &t.name == name,
-            TypeDefinition::Scalar(t) => &t.name == name,
-            TypeDefinition::Union(t) => &t.name == name,
+            s::TypeDefinition::Object(t) => &t.name == name,
+            s::TypeDefinition::Enum(t) => &t.name == name,
+            s::TypeDefinition::InputObject(t) => &t.name == name,
+            s::TypeDefinition::Interface(t) => &t.name == name,
+            s::TypeDefinition::Scalar(t) => &t.name == name,
+            s::TypeDefinition::Union(t) => &t.name == name,
         })
 }
 
 /// Returns the name of a type.
-pub fn get_type_name(t: &TypeDefinition) -> &str {
+pub fn get_type_name(t: &s::TypeDefinition) -> &str {
     match t {
-        TypeDefinition::Enum(t) => &t.name,
-        TypeDefinition::InputObject(t) => &t.name,
-        TypeDefinition::Interface(t) => &t.name,
-        TypeDefinition::Object(t) => &t.name,
-        TypeDefinition::Scalar(t) => &t.name,
-        TypeDefinition::Union(t) => &t.name,
+        s::TypeDefinition::Enum(t) => &t.name,
+        s::TypeDefinition::InputObject(t) => &t.name,
+        s::TypeDefinition::Interface(t) => &t.name,
+        s::TypeDefinition::Object(t) => &t.name,
+        s::TypeDefinition::Scalar(t) => &t.name,
+        s::TypeDefinition::Union(t) => &t.name,
     }
 }
 
 /// Returns the description of a type.
-pub fn get_type_description(t: &TypeDefinition) -> &Option<String> {
+pub fn get_type_description(t: &s::TypeDefinition) -> &Option<String> {
     match t {
-        TypeDefinition::Enum(t) => &t.description,
-        TypeDefinition::InputObject(t) => &t.description,
-        TypeDefinition::Interface(t) => &t.description,
-        TypeDefinition::Object(t) => &t.description,
-        TypeDefinition::Scalar(t) => &t.description,
-        TypeDefinition::Union(t) => &t.description,
+        s::TypeDefinition::Enum(t) => &t.description,
+        s::TypeDefinition::InputObject(t) => &t.description,
+        s::TypeDefinition::Interface(t) => &t.description,
+        s::TypeDefinition::Object(t) => &t.description,
+        s::TypeDefinition::Scalar(t) => &t.description,
+        s::TypeDefinition::Union(t) => &t.description,
     }
 }
 
@@ -238,13 +242,13 @@ pub fn get_type_description(t: &TypeDefinition) -> &Option<String> {
 pub fn get_argument_definitions<'a>(
     object_type: impl Into<ObjectOrInterface<'a>>,
     name: &str,
-) -> Option<&'a Vec<InputValue>> {
+) -> Option<&'a Vec<s::InputValue>> {
     lazy_static! {
-        pub static ref NAME_ARGUMENT: Vec<InputValue> = vec![InputValue {
+        pub static ref NAME_ARGUMENT: Vec<s::InputValue> = vec![s::InputValue {
             position: Pos::default(),
             description: None,
             name: "name".to_owned(),
-            value_type: Type::NonNullType(Box::new(Type::NamedType("String".to_owned()))),
+            value_type: s::Type::NonNullType(Box::new(s::Type::NamedType("String".to_owned()))),
             default_value: None,
             directives: vec![],
         }];
@@ -260,26 +264,29 @@ pub fn get_argument_definitions<'a>(
 
 /// Returns the type definition that a field type corresponds to.
 pub fn get_type_definition_from_field<'a>(
-    schema: &'a Document,
-    field: &Field,
-) -> Option<&'a TypeDefinition> {
+    schema: &'a s::Document,
+    field: &s::Field,
+) -> Option<&'a s::TypeDefinition> {
     get_type_definition_from_type(schema, &field.field_type)
 }
 
 /// Returns the type definition for a type.
 pub fn get_type_definition_from_type<'a>(
-    schema: &'a Document,
-    t: &Type,
-) -> Option<&'a TypeDefinition> {
+    schema: &'a s::Document,
+    t: &s::Type,
+) -> Option<&'a s::TypeDefinition> {
     match t {
-        Type::NamedType(name) => schema.get_named_type(name),
-        Type::ListType(inner) => get_type_definition_from_type(schema, inner),
-        Type::NonNullType(inner) => get_type_definition_from_type(schema, inner),
+        s::Type::NamedType(name) => schema.get_named_type(name),
+        s::Type::ListType(inner) => get_type_definition_from_type(schema, inner),
+        s::Type::NonNullType(inner) => get_type_definition_from_type(schema, inner),
     }
 }
 
 /// Looks up a directive in a object type, if it is provided.
-pub fn get_object_type_directive(object_type: &ObjectType, name: String) -> Option<&Directive> {
+pub fn get_object_type_directive(
+    object_type: &s::ObjectType,
+    name: String,
+) -> Option<&s::Directive> {
     object_type
         .directives
         .iter()
@@ -287,9 +294,9 @@ pub fn get_object_type_directive(object_type: &ObjectType, name: String) -> Opti
 }
 
 // Returns true if the given type is a non-null type.
-pub fn is_non_null_type(t: &Type) -> bool {
+pub fn is_non_null_type(t: &s::Type) -> bool {
     match t {
-        Type::NonNullType(_) => true,
+        s::Type::NonNullType(_) => true,
         _ => false,
     }
 }
@@ -298,46 +305,42 @@ pub fn is_non_null_type(t: &Type) -> bool {
 ///
 /// Uses the algorithm outlined on
 /// https://facebook.github.io/graphql/draft/#IsInputType().
-pub fn is_input_type(schema: &Document, t: &Type) -> bool {
-    use graphql_parser::schema::TypeDefinition::*;
-
+pub fn is_input_type(schema: &s::Document, t: &s::Type) -> bool {
     match t {
-        Type::NamedType(name) => {
+        s::Type::NamedType(name) => {
             let named_type = schema.get_named_type(name);
             named_type.map_or(false, |type_def| match type_def {
-                Scalar(_) | Enum(_) | InputObject(_) => true,
+                s::TypeDefinition::Scalar(_)
+                | s::TypeDefinition::Enum(_)
+                | s::TypeDefinition::InputObject(_) => true,
                 _ => false,
             })
         }
-        Type::ListType(inner) => is_input_type(schema, inner),
-        Type::NonNullType(inner) => is_input_type(schema, inner),
+        s::Type::ListType(inner) => is_input_type(schema, inner),
+        s::Type::NonNullType(inner) => is_input_type(schema, inner),
     }
 }
 
-pub fn is_entity_type(schema: &Document, t: &Type) -> bool {
-    use graphql_parser::schema::Type::*;
-
+pub fn is_entity_type(schema: &s::Document, t: &s::Type) -> bool {
     match t {
-        NamedType(name) => schema
+        s::Type::NamedType(name) => schema
             .get_named_type(&name)
             .map_or(false, is_entity_type_definition),
-        ListType(inner_type) => is_entity_type(schema, inner_type),
-        NonNullType(inner_type) => is_entity_type(schema, inner_type),
+        s::Type::ListType(inner_type) => is_entity_type(schema, inner_type),
+        s::Type::NonNullType(inner_type) => is_entity_type(schema, inner_type),
     }
 }
 
-pub fn is_entity_type_definition(type_def: &TypeDefinition) -> bool {
-    use graphql_parser::schema::TypeDefinition::*;
-
+pub fn is_entity_type_definition(type_def: &s::TypeDefinition) -> bool {
     match type_def {
         // Entity types are obvious
-        Object(object_type) => {
+        s::TypeDefinition::Object(object_type) => {
             get_object_type_directive(object_type, String::from("entity")).is_some()
         }
 
         // For now, we'll assume that only entities can implement interfaces;
         // thus, any interface type definition is automatically an entity type
-        Interface(_) => true,
+        s::TypeDefinition::Interface(_) => true,
 
         // Everything else (unions, scalars, enums) are not considered entity
         // types for now
@@ -345,42 +348,38 @@ pub fn is_entity_type_definition(type_def: &TypeDefinition) -> bool {
     }
 }
 
-pub fn is_list_or_non_null_list_field(field: &Field) -> bool {
-    use graphql_parser::schema::Type::*;
-
+pub fn is_list_or_non_null_list_field(field: &s::Field) -> bool {
     match &field.field_type {
-        ListType(_) => true,
-        NonNullType(inner_type) => match inner_type.deref() {
-            ListType(_) => true,
+        s::Type::ListType(_) => true,
+        s::Type::NonNullType(inner_type) => match inner_type.deref() {
+            s::Type::ListType(_) => true,
             _ => false,
         },
         _ => false,
     }
 }
 
-fn unpack_type<'a>(schema: &'a Document, t: &Type) -> Option<&'a TypeDefinition> {
-    use graphql_parser::schema::Type::*;
-
+fn unpack_type<'a>(schema: &'a s::Document, t: &s::Type) -> Option<&'a s::TypeDefinition> {
     match t {
-        NamedType(name) => schema.get_named_type(&name),
-        ListType(inner_type) => unpack_type(schema, inner_type),
-        NonNullType(inner_type) => unpack_type(schema, inner_type),
+        s::Type::NamedType(name) => schema.get_named_type(&name),
+        s::Type::ListType(inner_type) => unpack_type(schema, inner_type),
+        s::Type::NonNullType(inner_type) => unpack_type(schema, inner_type),
     }
 }
 
 pub fn get_referenced_entity_type<'a>(
-    schema: &'a Document,
-    field: &Field,
-) -> Option<&'a TypeDefinition> {
+    schema: &'a s::Document,
+    field: &s::Field,
+) -> Option<&'a s::TypeDefinition> {
     unpack_type(schema, &field.field_type).filter(|ty| is_entity_type_definition(ty))
 }
 
-pub fn get_input_object_definitions(schema: &Document) -> Vec<InputObjectType> {
+pub fn get_input_object_definitions(schema: &s::Document) -> Vec<s::InputObjectType> {
     schema
         .definitions
         .iter()
         .filter_map(|d| match d {
-            Definition::TypeDefinition(TypeDefinition::InputObject(t)) => Some(t.clone()),
+            s::Definition::TypeDefinition(s::TypeDefinition::InputObject(t)) => Some(t.clone()),
             _ => None,
         })
         .collect()
@@ -388,19 +387,256 @@ pub fn get_input_object_definitions(schema: &Document) -> Vec<InputObjectType> {
 
 /// If the field has a `@derivedFrom(field: "foo")` directive, obtain the
 /// name of the field (e.g. `"foo"`)
-pub fn get_derived_from_directive<'a>(field_definition: &Field) -> Option<&Directive> {
+pub fn get_derived_from_directive<'a>(field_definition: &s::Field) -> Option<&s::Directive> {
     field_definition.find_directive("derivedFrom")
 }
 
 pub fn get_derived_from_field<'a>(
     object_type: impl Into<ObjectOrInterface<'a>>,
-    field_definition: &'a Field,
-) -> Option<&'a Field> {
+    field_definition: &'a s::Field,
+) -> Option<&'a s::Field> {
     get_derived_from_directive(field_definition)
         .and_then(|directive| qast::get_argument_value(&directive.arguments, "field"))
         .and_then(|value| match value {
-            Value::String(s) => Some(s),
+            s::Value::String(s) => Some(s),
             _ => None,
         })
         .and_then(|derived_from_field_name| get_field(object_type, derived_from_field_name))
+}
+
+fn scalar_value_type(schema: &s::Document, field_type: &s::Type) -> ValueType {
+    use s::TypeDefinition as t;
+    match field_type {
+        s::Type::NamedType(name) => {
+            ValueType::from_str(&name).unwrap_or_else(|_| match schema.get_named_type(name) {
+                Some(t::Object(_)) | Some(t::Interface(_)) | Some(t::Enum(_)) => ValueType::String,
+                Some(t::Scalar(_)) => unreachable!("user-defined scalars are not used"),
+                Some(t::Union(_)) => unreachable!("unions are not used"),
+                Some(t::InputObject(_)) => unreachable!("inputObjects are not used"),
+                None => unreachable!("names of field types have been validated"),
+            })
+        }
+        s::Type::NonNullType(inner) => scalar_value_type(schema, inner),
+        s::Type::ListType(inner) => scalar_value_type(schema, inner),
+    }
+}
+
+pub fn is_list(field_type: &s::Type) -> bool {
+    match field_type {
+        s::Type::NamedType(_) => false,
+        s::Type::NonNullType(inner) => is_list(inner),
+        s::Type::ListType(_) => true,
+    }
+}
+
+fn is_assignable(value: &store::Value, scalar_type: &ValueType, is_list: bool) -> bool {
+    match (value, scalar_type) {
+        (store::Value::String(_), ValueType::String)
+        | (store::Value::BigDecimal(_), ValueType::BigDecimal)
+        | (store::Value::BigInt(_), ValueType::BigInt)
+        | (store::Value::Bool(_), ValueType::Boolean)
+        | (store::Value::Bytes(_), ValueType::Bytes)
+        | (store::Value::Int(_), ValueType::Int)
+        | (store::Value::Null, _) => true,
+        (store::Value::List(values), _) if is_list => values
+            .iter()
+            .all(|value| is_assignable(value, scalar_type, false)),
+        _ => false,
+    }
+}
+
+pub fn validate_entity(
+    schema: &s::Document,
+    key: &EntityKey,
+    entity: &Entity,
+) -> Result<(), anyhow::Error> {
+    let object_type_definitions = schema.get_object_type_definitions();
+    let object_type = object_type_definitions
+        .iter()
+        .find(|object_type| key.entity_type.as_str() == &object_type.name)
+        .with_context(|| {
+            format!(
+                "Entity {}[{}]: unknown entity type `{}`",
+                key.entity_type, key.entity_id, key.entity_type
+            )
+        })?;
+
+    for field in &object_type.fields {
+        let is_derived = field.is_derived();
+        match (entity.get(&field.name), is_derived) {
+            (Some(value), false) => {
+                let scalar_type = scalar_value_type(schema, &field.field_type);
+                if is_list(&field.field_type) {
+                    // Check for inhomgeneous lists to produce a better
+                    // error message for them; other problems, like
+                    // assigning a scalar to a list will be caught below
+                    if let store::Value::List(elts) = value {
+                        for (index, elt) in elts.iter().enumerate() {
+                            if !is_assignable(elt, &scalar_type, false) {
+                                anyhow::bail!(
+                                    "Entity {}[{}]: field `{}` is of type {}, but the value `{}` \
+                                    contains a {} at index {}",
+                                    key.entity_type,
+                                    key.entity_id,
+                                    field.name,
+                                    &field.field_type,
+                                    value,
+                                    elt.type_name(),
+                                    index
+                                );
+                            }
+                        }
+                    }
+                }
+                if !is_assignable(value, &scalar_type, is_list(&field.field_type)) {
+                    anyhow::bail!(
+                        "Entity {}[{}]: the value `{}` for field `{}` must have type {} but has type {}",
+                        key.entity_type,
+                        key.entity_id,
+                        value,
+                        field.name,
+                        &field.field_type,
+                        value.type_name()
+                    );
+                }
+            }
+            (None, false) => {
+                if is_non_null_type(&field.field_type) {
+                    anyhow::bail!(
+                        "Entity {}[{}]: missing value for non-nullable field `{}`",
+                        key.entity_type,
+                        key.entity_id,
+                        field.name,
+                    );
+                }
+            }
+            (Some(_), true) => {
+                anyhow::bail!(
+                    "Entity {}[{}]: field `{}` is derived and can not be set",
+                    key.entity_type,
+                    key.entity_id,
+                    field.name,
+                );
+            }
+            (None, true) => {
+                // derived fields should not be set
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn entity_validation() {
+    use graph::prelude::DeploymentHash;
+
+    fn make_thing(name: &str) -> Entity {
+        let mut thing = Entity::new();
+        thing.set("id", name);
+        thing.set("name", name);
+        thing.set("stuff", "less");
+        thing.set("favorite_color", "red");
+        thing.set("things", store::Value::List(vec![]));
+        thing
+    }
+
+    fn check(thing: Entity, errmsg: &str) {
+        const DOCUMENT: &str = "
+      enum Color { red, yellow, blue }
+      interface Stuff { id: ID!, name: String! }
+      type Cruft @entity {
+          id: ID!,
+          thing: Thing!
+      }
+      type Thing @entity {
+          id: ID!,
+          name: String!,
+          favorite_color: Color,
+          stuff: Stuff,
+          things: [Thing!]!
+          # Make sure we do not validate derived fields; it's ok
+          # to store a thing with a null Cruft
+          cruft: Cruft! @derivedFrom(field: \"thing\")
+      }";
+        let subgraph = DeploymentHash::new("doesntmatter").unwrap();
+        let schema =
+            graph::prelude::Schema::parse(DOCUMENT, subgraph).expect("Failed to parse test schema");
+        let id = thing.id().unwrap_or("none".to_owned());
+        let key = EntityKey::data(
+            DeploymentHash::new("doesntmatter").unwrap(),
+            "Thing".to_owned(),
+            id.to_owned(),
+        );
+
+        let err = validate_entity(&schema.document, &key, &thing);
+        if errmsg == "" {
+            assert!(
+                err.is_ok(),
+                "checking entity {}: expected ok but got {}",
+                id,
+                err.unwrap_err()
+            );
+        } else {
+            if let Err(e) = err {
+                assert_eq!(errmsg, e.to_string(), "checking entity {}", id);
+            } else {
+                panic!(
+                    "Expected error `{}` but got ok when checking entity {}",
+                    errmsg, id
+                );
+            }
+        }
+    }
+
+    let mut thing = make_thing("t1");
+    thing.set("things", store::Value::from(vec!["thing1", "thing2"]));
+    check(thing, "");
+
+    let thing = make_thing("t2");
+    check(thing, "");
+
+    let mut thing = make_thing("t3");
+    thing.remove("name");
+    check(
+        thing,
+        "Entity Thing[t3]: missing value for non-nullable field `name`",
+    );
+
+    let mut thing = make_thing("t4");
+    thing.remove("things");
+    check(
+        thing,
+        "Entity Thing[t4]: missing value for non-nullable field `things`",
+    );
+
+    let mut thing = make_thing("t5");
+    thing.set("name", store::Value::Int(32));
+    check(
+        thing,
+        "Entity Thing[t5]: the value `32` for field `name` must \
+         have type String! but has type Int",
+    );
+
+    let mut thing = make_thing("t6");
+    thing.set(
+        "things",
+        store::Value::List(vec!["thing1".into(), 17.into()]),
+    );
+    check(
+        thing,
+        "Entity Thing[t6]: field `things` is of type [Thing!]!, \
+         but the value `[thing1, 17]` contains a Int at index 1",
+    );
+
+    let mut thing = make_thing("t7");
+    thing.remove("favorite_color");
+    thing.remove("stuff");
+    check(thing, "");
+
+    let mut thing = make_thing("t8");
+    thing.set("cruft", "wat");
+    check(
+        thing,
+        "Entity Thing[t8]: field `cruft` is derived and can not be set",
+    );
 }

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -111,16 +111,6 @@ impl ObjectType {
     }
 }
 
-pub fn get_root_query_type_def(schema: &s::Document) -> Option<&s::TypeDefinition> {
-    schema.definitions.iter().find_map(|d| match d {
-        s::Definition::TypeDefinition(def @ s::TypeDefinition::Object(_)) => match def {
-            s::TypeDefinition::Object(t) if t.name == "Query" => Some(def),
-            _ => None,
-        },
-        _ => None,
-    })
-}
-
 /// Returns all type definitions in the schema.
 pub fn get_type_definitions(schema: &s::Document) -> Vec<&s::TypeDefinition> {
     schema
@@ -205,7 +195,7 @@ pub fn get_field_name(field_type: &s::Type) -> String {
 }
 
 /// Returns a mutable version of the type with the given name.
-pub fn get_named_type_definition_mut<'a>(
+fn get_named_type_definition_mut<'a>(
     schema: &'a mut s::Document,
     name: &str,
 ) -> Option<&'a mut s::TypeDefinition> {
@@ -238,18 +228,6 @@ pub fn get_type_name(t: &s::TypeDefinition) -> &str {
     }
 }
 
-/// Returns the description of a type.
-pub fn get_type_description(t: &s::TypeDefinition) -> &Option<String> {
-    match t {
-        s::TypeDefinition::Enum(t) => &t.description,
-        s::TypeDefinition::InputObject(t) => &t.description,
-        s::TypeDefinition::Interface(t) => &t.description,
-        s::TypeDefinition::Object(t) => &t.description,
-        s::TypeDefinition::Scalar(t) => &t.description,
-        s::TypeDefinition::Union(t) => &t.description,
-    }
-}
-
 /// Returns the argument definitions for a field of an object type.
 pub fn get_argument_definitions<'a>(
     object_type: impl Into<ObjectOrInterface<'a>>,
@@ -272,14 +250,6 @@ pub fn get_argument_definitions<'a>(
     } else {
         get_field(object_type, name).map(|field| &field.arguments)
     }
-}
-
-/// Returns the type definition that a field type corresponds to.
-pub fn get_type_definition_from_field<'a>(
-    schema: &'a s::Document,
-    field: &s::Field,
-) -> Option<&'a s::TypeDefinition> {
-    get_type_definition_from_type(schema, &field.field_type)
 }
 
 /// Returns the type definition for a type.
@@ -384,17 +354,6 @@ pub fn get_referenced_entity_type<'a>(
     field: &s::Field,
 ) -> Option<&'a s::TypeDefinition> {
     unpack_type(schema, &field.field_type).filter(|ty| is_entity_type_definition(ty))
-}
-
-pub fn get_input_object_definitions(schema: &s::Document) -> Vec<s::InputObjectType> {
-    schema
-        .definitions
-        .iter()
-        .filter_map(|d| match d {
-            s::Definition::TypeDefinition(s::TypeDefinition::InputObject(t)) => Some(t.clone()),
-            _ => None,
-        })
-        .collect()
 }
 
 /// If the field has a `@derivedFrom(field: "foo")` directive, obtain the

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -92,6 +92,12 @@ impl<'a> From<ObjectCondition<'a>> for ObjectOrInterface<'a> {
     }
 }
 
+impl ObjectCondition<'_> {
+    pub fn name(&self) -> &str {
+        &self.0.name
+    }
+}
+
 pub fn get_root_query_type_def(schema: &Document) -> Option<&TypeDefinition> {
     schema.definitions.iter().find_map(|d| match d {
         Definition::TypeDefinition(def @ TypeDefinition::Object(_)) => match def {

--- a/graphql/src/store/mod.rs
+++ b/graphql/src/store/mod.rs
@@ -2,5 +2,5 @@ mod prefetch;
 mod query;
 mod resolver;
 
-pub use self::query::{build_query, parse_subgraph_id};
+pub use self::query::parse_subgraph_id;
 pub use self::resolver::StoreResolver;

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -366,25 +366,17 @@ impl<'a> Join<'a> {
     /// Construct a `Join` based on the parent field pointing to the child
     fn new(
         schema: &'a ApiSchema,
-        parent_type: ObjectOrInterface<'a>,
+        parent_type: &'a s::ObjectType,
         child_type: ObjectOrInterface<'a>,
         field_name: &str,
     ) -> Self {
-        let parent_types = parent_type
-            .object_types(schema.schema())
-            .expect("the name of the parent type is valid");
         let child_types = child_type
             .object_types(schema.schema())
             .expect("the name of the child type is valid");
 
-        let conds = parent_types
+        let conds = child_types
             .iter()
-            .flat_map::<Vec<_>, _>(|parent_type| {
-                child_types
-                    .iter()
-                    .map(|child_type| JoinCond::new(parent_type, child_type, field_name))
-                    .collect()
-            })
+            .map(|child_type| JoinCond::new(parent_type, child_type, field_name))
             .collect();
 
         Join { child_type, conds }
@@ -576,7 +568,7 @@ fn execute_selection_set<'a>(
 
             let join = Join::new(
                 ctx.query.schema.as_ref(),
-                object_type.into(),
+                object_type,
                 child_type,
                 &field.name,
             );

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -18,14 +18,13 @@ use graph::{components::store::EntityType, data::graphql::*};
 use graph::{
     data::graphql::ext::DirectiveFinder,
     prelude::{
-        q, s, ApiSchema, AttributeNames, BlockNumber, ChildMultiplicity, EntityCollection,
+        s, ApiSchema, AttributeNames, BlockNumber, ChildMultiplicity, EntityCollection,
         EntityFilter, EntityLink, EntityOrder, EntityWindow, Logger, ParentLink,
         QueryExecutionError, QueryStore, StoreError, Value as StoreValue, WindowAttribute,
     },
 };
 
-use crate::execution::{ExecutionContext, Resolver};
-use crate::query::ast::{self as qast, get_argument_value};
+use crate::execution::{ast as a, ExecutionContext, Resolver};
 use crate::runner::ResultSizeMetrics;
 use crate::schema::ast as sast;
 use crate::store::{build_query, StoreResolver};
@@ -537,7 +536,7 @@ impl<'a> Join<'a> {
 pub fn run(
     resolver: &StoreResolver,
     ctx: &ExecutionContext<impl Resolver>,
-    selection_set: &q::SelectionSet,
+    selection_set: &a::SelectionSet,
     result_size: &ResultSizeMetrics,
 ) -> Result<r::Value, Vec<QueryExecutionError>> {
     execute_root_selection_set(resolver, ctx, selection_set).map(|nodes| {
@@ -556,7 +555,7 @@ pub fn run(
 fn execute_root_selection_set(
     resolver: &StoreResolver,
     ctx: &ExecutionContext<impl Resolver>,
-    selection_set: &q::SelectionSet,
+    selection_set: &a::SelectionSet,
 ) -> Result<Vec<Node>, Vec<QueryExecutionError>> {
     // Obtain the root Query type and fail if there isn't one
     let query_type = ctx.query.schema.query_type.as_ref().into();
@@ -717,8 +716,8 @@ fn execute_selection_set<'a>(
 #[derive(Default, Debug)]
 struct CollectedResponseKey<'a> {
     iface_cond: Option<&'a s::InterfaceType>,
-    iface_fields: Vec<&'a q::Field>,
-    obj_types: IndexMap<ObjectCondition<'a>, Vec<&'a q::Field>>,
+    iface_fields: Vec<&'a a::Field>,
+    obj_types: IndexMap<ObjectCondition<'a>, Vec<&'a a::Field>>,
     collected_column_names: CollectedAttributeNames<'a>,
 }
 
@@ -727,7 +726,7 @@ impl<'a> CollectedResponseKey<'a> {
         &mut self,
         document: &s::Document,
         object_or_interface: ObjectOrInterface<'a>,
-        field: &'a q::Field,
+        field: &'a a::Field,
     ) {
         let schema_field = object_or_interface.field(&field.name);
         schema_field
@@ -766,7 +765,7 @@ impl<'a> CollectedResponseKey<'a> {
 }
 
 impl<'a> IntoIterator for CollectedResponseKey<'a> {
-    type Item = (ObjectOrInterface<'a>, Vec<&'a q::Field>);
+    type Item = (ObjectOrInterface<'a>, Vec<&'a a::Field>);
     type IntoIter = Box<dyn Iterator<Item = Self::Item> + 'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -792,7 +791,7 @@ impl<'a> IntoIterator for CollectedResponseKey<'a> {
 fn collect_fields<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     parent_ty: ObjectOrInterface<'a>,
-    selection_sets: impl Iterator<Item = &'a q::SelectionSet>,
+    selection_sets: impl Iterator<Item = &'a a::SelectionSet>,
 ) -> (GroupedFieldSet<'a>, ComplementaryFields<'a>) {
     let mut grouped_fields = IndexMap::new();
     let mut complementary_fields = ComplementaryFields::new();
@@ -829,7 +828,7 @@ fn collect_fields<'a>(
 fn collect_fields_inner<'a>(
     ctx: &'a ExecutionContext<impl Resolver>,
     type_condition: ObjectOrInterface<'a>,
-    selection_set: &'a q::SelectionSet,
+    selection_set: &'a a::SelectionSet,
     visited_fragments: &mut HashSet<&'a str>,
     output: &mut GroupedFieldSet<'a>,
     complementary_fields: &mut ComplementaryFields<'a>,
@@ -837,8 +836,8 @@ fn collect_fields_inner<'a>(
     fn collect_fragment<'a>(
         ctx: &'a ExecutionContext<impl Resolver>,
         outer_type_condition: ObjectOrInterface<'a>,
-        frag_ty_condition: Option<&'a q::TypeCondition>,
-        frag_selection_set: &'a q::SelectionSet,
+        frag_ty_condition: Option<&'a a::TypeCondition>,
+        frag_selection_set: &'a a::SelectionSet,
         visited_fragments: &mut HashSet<&'a str>,
         output: &mut GroupedFieldSet<'a>,
         complementary_fields: &mut ComplementaryFields<'a>,
@@ -846,7 +845,7 @@ fn collect_fields_inner<'a>(
         let schema = &ctx.query.schema.document();
         let fragment_ty = match frag_ty_condition {
             // Unwrap: Validation ensures this interface exists.
-            Some(q::TypeCondition::On(ty_name)) if outer_type_condition.is_interface() => {
+            Some(a::TypeCondition::On(ty_name)) if outer_type_condition.is_interface() => {
                 schema.object_or_interface(ty_name).unwrap()
             }
             _ => outer_type_condition,
@@ -895,13 +894,13 @@ fn collect_fields_inner<'a>(
     let selections = selection_set
         .items
         .iter()
-        .filter(|selection| !qast::skip_selection(selection))
-        .filter(|selection| qast::include_selection(selection));
+        .filter(|selection| !selection.skip())
+        .filter(|selection| selection.include());
 
     for selection in selections {
         match selection {
-            q::Selection::Field(ref field) => {
-                let response_key = qast::get_response_key(field);
+            a::Selection::Field(ref field) => {
+                let response_key = field.response_key();
                 output.entry(response_key).or_default().collect_field(
                     &ctx.query.schema.document(),
                     type_condition,
@@ -910,7 +909,7 @@ fn collect_fields_inner<'a>(
 
                 // Collect complementary fields used in the `orderBy` query attribute, if present.
                 if !*DISABLE_EXPERIMENTAL_FEATURE_SELECT_BY_SPECIFIC_ATTRIBUTE_NAMES {
-                    if let Some(arguments) = get_argument_value(&field.arguments, "orderBy") {
+                    if let Some(argument) = field.argument_value("orderBy") {
                         let schema_field = type_condition.field(&field.name).expect(&format!(
                             "the field {:?} to exist in {:?}",
                             &field.name,
@@ -926,20 +925,20 @@ fn collect_fields_inner<'a>(
                                 "The field {:?} to exist in the Document",
                                 field_name
                             ));
-                        match arguments {
-                            graphql_parser::schema::Value::Enum(complementary_field_name) => {
+                        match argument {
+                            r::Value::Enum(complementary_field_name) => {
                                 complementary_fields.insert(
                                     object_or_interface_for_field,
                                     complementary_field_name.clone(),
                                 );
                             }
-                            _ => unimplemented!("unsure on what to do about other variants"),
+                            _ => unreachable!("query processing should have coerced to an enum"),
                         }
                     }
                 }
             }
 
-            q::Selection::FragmentSpread(spread) => {
+            a::Selection::FragmentSpread(spread) => {
                 // Only consider the fragment if it hasn't already been included,
                 // as would be the case if the same fragment spread ...Foo appeared
                 // twice in the same selection set
@@ -957,7 +956,7 @@ fn collect_fields_inner<'a>(
                 }
             }
 
-            q::Selection::InlineFragment(fragment) => {
+            a::Selection::InlineFragment(fragment) => {
                 collect_fragment(
                     ctx,
                     type_condition,
@@ -979,7 +978,7 @@ fn execute_field(
     object_type: ObjectOrInterface<'_>,
     parents: &Vec<&mut Node>,
     join: &Join<'_>,
-    field: &q::Field,
+    field: &a::Field,
     field_definition: &s::Field,
     collected_column_names: AttributeNamesByObjectType<'_>,
 ) -> Result<Vec<Node>, Vec<QueryExecutionError>> {
@@ -1071,11 +1070,11 @@ type AttributeNamesByObjectType<'a> = BTreeMap<ObjectCondition<'a>, AttributeNam
 struct CollectedAttributeNames<'a>(HashMap<ObjectOrInterface<'a>, AttributeNames>);
 
 impl<'a> CollectedAttributeNames<'a> {
-    fn update(&mut self, object_or_interface: ObjectOrInterface<'a>, field: &q::Field) {
+    fn update(&mut self, object_or_interface: ObjectOrInterface<'a>, field: &a::Field) {
         self.0
             .entry(object_or_interface)
             .or_insert(AttributeNames::All)
-            .add(field);
+            .update(&field.name);
     }
 
     /// Injects complementary fields that were collected priviously in upper hierarchical levels of

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -639,7 +639,7 @@ fn execute_selection_set<'a>(
 struct CollectedResponseKey<'a> {
     iface_cond: Option<&'a s::InterfaceType>,
     iface_fields: Vec<&'a a::Field>,
-    obj_types: IndexMap<sast::ObjectCondition<'a>, Vec<&'a a::Field>>,
+    obj_types: IndexMap<sast::ObjectType<'a>, Vec<&'a a::Field>>,
     collected_column_names: CollectedAttributeNames<'a>,
 }
 
@@ -753,7 +753,7 @@ fn fetch(
 
 /// Represents a finished column collection operation, mapping each object type to the final set of
 /// selected SQL columns.
-type AttributeNamesByObjectType<'a> = BTreeMap<sast::ObjectCondition<'a>, AttributeNames>;
+type AttributeNamesByObjectType<'a> = BTreeMap<sast::ObjectType<'a>, AttributeNames>;
 
 #[derive(Debug, Default, Clone)]
 struct CollectedAttributeNames<'a>(HashMap<ObjectOrInterface<'a>, AttributeNames>);

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -7,7 +7,6 @@ use graph::data::value::Object;
 use graph::prelude::{r, CacheWeight};
 use graph::slog::warn;
 use graph::util::cache_weight;
-use indexmap::IndexMap;
 use lazy_static::lazy_static;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
@@ -625,38 +624,6 @@ fn execute_selection_set<'a>(
         Ok(parents)
     } else {
         Err(errors)
-    }
-}
-
-/// If the top-level selection is on an object, there will be a single entry in `obj_types` with all
-/// the collected fields.
-///
-/// The interesting case is if the top-level selection is an interface. `iface_cond` will be the
-/// interface type and `iface_fields` the selected fields on the interface. `obj_types` are the
-/// fields selected on objects by fragments. In `collect_fields`, the `iface_fields` will then be
-/// merged into each entry in `obj_types`. See also: e0d6da3e-60cf-41a5-b83c-b60a7a766d4a
-#[derive(Default, Debug)]
-struct CollectedResponseKey<'a> {
-    iface_cond: Option<&'a s::InterfaceType>,
-    iface_fields: Vec<&'a a::Field>,
-    obj_types: IndexMap<sast::ObjectType<'a>, Vec<&'a a::Field>>,
-    collected_column_names: SelectedAttributes<'a>,
-}
-
-impl<'a> IntoIterator for CollectedResponseKey<'a> {
-    type Item = (ObjectOrInterface<'a>, Vec<&'a a::Field>);
-    type IntoIter = Box<dyn Iterator<Item = Self::Item> + 'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        // Make sure the interface fields are processed first.
-        // See also: e0d6da3e-60cf-41a5-b83c-b60a7a766d4a
-        let iface_fields = self.iface_fields;
-        Box::new(
-            self.iface_cond
-                .map(|cond| (ObjectOrInterface::Interface(cond), iface_fields))
-                .into_iter()
-                .chain(self.obj_types.into_iter().map(|(c, f)| (c.into(), f))),
-        )
     }
 }
 

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -630,7 +630,8 @@ fn execute_field(
     field_definition: &s::Field,
     selected_attrs: SelectedAttributes<'_>,
 ) -> Result<Vec<Node>, Vec<QueryExecutionError>> {
-    let argument_values = crate::execution::coerce_argument_values(&ctx.query, object_type, field)?;
+    let argument_values =
+        crate::execution::coerce_argument_values(&ctx.query.schema, object_type, field)?;
     let multiplicity = if sast::is_list_or_non_null_list_field(field_definition) {
         ChildMultiplicity::Many
     } else {

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -895,8 +895,8 @@ fn collect_fields_inner<'a>(
     let selections = selection_set
         .items
         .iter()
-        .filter(|selection| !qast::skip_selection(selection, &ctx.query.variables))
-        .filter(|selection| qast::include_selection(selection, &ctx.query.variables));
+        .filter(|selection| !qast::skip_selection(selection))
+        .filter(|selection| qast::include_selection(selection));
 
     for selection in selections {
         match selection {

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -557,7 +557,6 @@ fn execute_selection_set<'a>(
                 .field(&field.name)
                 .expect("field names are valid");
             let child_type = schema
-                .document()
                 .object_or_interface(field_type.field_type.get_base_type())
                 .expect("we only collect fields that are objects or interfaces");
 

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{anyhow, Error};
 use graph::constraint_violation;
+use graph::data::value::Object;
 use graph::prelude::{r, CacheWeight};
 use graph::slog::warn;
 use graph::util::cache_weight;
@@ -208,7 +209,7 @@ impl From<Node> for r::Value {
         for (key, nodes) in node.children.into_iter() {
             map.insert(format!("prefetch:{}", key), node_list_as_value(nodes));
         }
-        r::Value::Object(map)
+        r::Value::object(map)
     }
 }
 
@@ -541,8 +542,7 @@ pub fn run(
 ) -> Result<r::Value, Vec<QueryExecutionError>> {
     execute_root_selection_set(resolver, ctx, selection_set).map(|nodes| {
         result_size.observe(nodes.weight());
-        let map = BTreeMap::default();
-        r::Value::Object(nodes.into_iter().fold(map, |mut map, node| {
+        r::Value::Object(nodes.into_iter().fold(Object::default(), |mut map, node| {
             // For root nodes, we only care about the children
             for (key, nodes) in node.children.into_iter() {
                 map.insert(format!("prefetch:{}", key), node_list_as_value(nodes));

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -890,14 +890,7 @@ fn collect_fields_inner<'a>(
         }
     }
 
-    // Only consider selections that are not skipped and should be included
-    let selections = selection_set
-        .items
-        .iter()
-        .filter(|selection| !selection.skip())
-        .filter(|selection| selection.include());
-
-    for selection in selections {
+    for selection in selection_set.included() {
         match selection {
             a::Selection::Field(ref field) => {
                 let response_key = field.response_key();

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -327,7 +327,7 @@ pub fn collect_entities_from_query_field(
 
                     // If the query field has a non-empty selection set, this means we
                     // need to recursively process it
-                    for selection in field.selection_set.items.iter() {
+                    for selection in field.selection_set.selections() {
                         if let a::Selection::Field(sub_field) = selection {
                             queue.push_back((object_type, sub_field))
                         }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -327,10 +327,8 @@ pub fn collect_entities_from_query_field(
 
                     // If the query field has a non-empty selection set, this means we
                     // need to recursively process it
-                    for selection in field.selection_set.selections() {
-                        if let a::Selection::Field(sub_field) = selection {
-                            queue.push_back((object_type, sub_field))
-                        }
+                    for sub_field in field.selection_set.fields_for(object_type) {
+                        queue.push_back((object_type, sub_field))
                     }
                 }
             }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::mem::discriminant;
 
+use graph::data::value::Object;
 use graph::prelude::*;
 use graph::{components::store::EntityType, data::graphql::ObjectOrInterface};
 
@@ -125,7 +126,7 @@ fn build_filter(
 }
 
 fn build_fulltext_filter_from_object(
-    object: &BTreeMap<String, r::Value>,
+    object: &Object,
 ) -> Result<Option<EntityFilter>, QueryExecutionError> {
     object.iter().next().map_or(
         Err(QueryExecutionError::FulltextQueryRequiresFilter),
@@ -145,7 +146,7 @@ fn build_fulltext_filter_from_object(
 /// Parses a GraphQL input object into an EntityFilter, if present.
 fn build_filter_from_object(
     entity: ObjectOrInterface,
-    object: &BTreeMap<String, r::Value>,
+    object: &Object,
 ) -> Result<Option<EntityFilter>, QueryExecutionError> {
     Ok(Some(EntityFilter::And({
         object
@@ -242,7 +243,7 @@ fn build_order_by(
 }
 
 fn build_fulltext_order_by_from_object(
-    object: &BTreeMap<String, r::Value>,
+    object: &Object,
 ) -> Result<Option<(String, ValueType)>, QueryExecutionError> {
     object.iter().next().map_or(
         Err(QueryExecutionError::FulltextQueryRequiresFilter),
@@ -345,6 +346,7 @@ pub fn collect_entities_from_query_field(
 mod tests {
     use graph::{
         components::store::EntityType,
+        data::value::Object,
         prelude::s::{Directive, Field, InputValue, ObjectType, Type, Value as SchemaValue},
     };
     use graphql_parser::Pos;
@@ -724,7 +726,7 @@ mod tests {
         let mut args = default_arguments();
         args.insert(
             &whre,
-            r::Value::Object(BTreeMap::from_iter(vec![(
+            r::Value::Object(Object::from_iter(vec![(
                 "name_ends_with".to_string(),
                 r::Value::String("ello".to_string()),
             )])),

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -7,7 +7,7 @@ use graph::{components::store::EntityType, data::graphql::ObjectOrInterface};
 
 use crate::execution::ast as a;
 use crate::schema::ast as sast;
-use crate::store::prefetch::ObjectCondition;
+use crate::schema::ast::ObjectCondition;
 
 #[derive(Debug)]
 enum OrderDirection {
@@ -18,7 +18,7 @@ enum OrderDirection {
 /// Builds a EntityQuery from GraphQL arguments.
 ///
 /// Panics if `entity` is not present in `schema`.
-pub fn build_query<'a>(
+pub(crate) fn build_query<'a>(
     entity: impl Into<ObjectOrInterface<'a>>,
     block: BlockNumber,
     arguments: &HashMap<&str, r::Value>,

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -7,7 +7,7 @@ use graph::{components::store::EntityType, data::graphql::ObjectOrInterface};
 
 use crate::execution::ast as a;
 use crate::schema::ast as sast;
-use crate::schema::ast::ObjectCondition;
+use crate::schema::ast::ObjectType;
 
 #[derive(Debug)]
 enum OrderDirection {
@@ -25,7 +25,7 @@ pub(crate) fn build_query<'a>(
     types_for_interface: &'a BTreeMap<EntityType, Vec<s::ObjectType>>,
     max_first: u32,
     max_skip: u32,
-    mut column_names: BTreeMap<ObjectCondition<'a>, AttributeNames>,
+    mut column_names: BTreeMap<ObjectType<'a>, AttributeNames>,
 ) -> Result<EntityQuery, QueryExecutionError> {
     let entity = entity.into();
     let entity_types = EntityCollection::All(match &entity {

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -305,9 +305,7 @@ pub(crate) fn collect_entities_from_query_field(
         if let Some(field_type) = sast::get_field(&object_type, &field.name) {
             // Check if the field type corresponds to a type definition (in a valid schema,
             // this should always be the case)
-            if let Some(type_definition) =
-                sast::get_type_definition_from_field(schema.document(), field_type)
-            {
+            if let Some(type_definition) = schema.get_type_definition_from_field(field_type) {
                 // If the field's type definition is an object type, extract that type
                 if let s::TypeDefinition::Object(object_type) = type_definition {
                     // Only collect whether the field's type has an @entity directive

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -5,6 +5,7 @@ use graph::data::value::Object;
 use graph::prelude::*;
 use graph::{components::store::EntityType, data::graphql::ObjectOrInterface};
 
+use crate::execution::ast as a;
 use crate::schema::ast as sast;
 use crate::store::prefetch::ObjectCondition;
 
@@ -295,7 +296,7 @@ pub fn parse_subgraph_id<'a>(
 pub fn collect_entities_from_query_field(
     schema: &s::Document,
     object_type: &s::ObjectType,
-    field: &q::Field,
+    field: &a::Field,
 ) -> BTreeSet<SubscriptionFilter> {
     // Output entities
     let mut entities = HashSet::new();
@@ -327,7 +328,7 @@ pub fn collect_entities_from_query_field(
                     // If the query field has a non-empty selection set, this means we
                     // need to recursively process it
                     for selection in field.selection_set.items.iter() {
-                        if let q::Selection::Field(sub_field) = selection {
+                        if let a::Selection::Field(sub_field) = selection {
                             queue.push_back((object_type, sub_field))
                         }
                     }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::mem::discriminant;
 
 use graph::data::value::Object;
@@ -21,7 +21,7 @@ enum OrderDirection {
 pub(crate) fn build_query<'a>(
     entity: impl Into<ObjectOrInterface<'a>>,
     block: BlockNumber,
-    arguments: &HashMap<&str, r::Value>,
+    field: &a::Field,
     types_for_interface: &'a BTreeMap<EntityType, Vec<s::ObjectType>>,
     max_first: u32,
     max_skip: u32,
@@ -47,13 +47,13 @@ pub(crate) fn build_query<'a>(
             .collect(),
     });
     let mut query = EntityQuery::new(parse_subgraph_id(entity)?, block, entity_types)
-        .range(build_range(arguments, max_first, max_skip)?);
-    if let Some(filter) = build_filter(entity, arguments)? {
+        .range(build_range(field, max_first, max_skip)?);
+    if let Some(filter) = build_filter(entity, field)? {
         query = query.filter(filter);
     }
     let order = match (
-        build_order_by(entity, arguments)?,
-        build_order_direction(arguments)?,
+        build_order_by(entity, field)?,
+        build_order_direction(field)?,
     ) {
         (Some((attr, value_type)), OrderDirection::Ascending) => {
             EntityOrder::Ascending(attr, value_type)
@@ -69,11 +69,11 @@ pub(crate) fn build_query<'a>(
 
 /// Parses GraphQL arguments into a EntityRange, if present.
 fn build_range(
-    arguments: &HashMap<&str, r::Value>,
+    field: &a::Field,
     max_first: u32,
     max_skip: u32,
 ) -> Result<EntityRange, QueryExecutionError> {
-    let first = match arguments.get("first") {
+    let first = match field.argument_value("first") {
         Some(r::Value::Int(n)) => {
             let n = *n;
             if n > 0 && n <= (max_first as i64) {
@@ -88,7 +88,7 @@ fn build_range(
         _ => unreachable!("first is an Int with a default value"),
     };
 
-    let skip = match arguments.get("skip") {
+    let skip = match field.argument_value("skip") {
         Some(r::Value::Int(n)) => {
             let n = *n;
             if n >= 0 && n <= (max_skip as i64) {
@@ -112,12 +112,12 @@ fn build_range(
 /// Parses GraphQL arguments into an EntityFilter, if present.
 fn build_filter(
     entity: ObjectOrInterface,
-    arguments: &HashMap<&str, r::Value>,
+    field: &a::Field,
 ) -> Result<Option<EntityFilter>, QueryExecutionError> {
-    match arguments.get("where") {
+    match field.argument_value("where") {
         Some(r::Value::Object(object)) => build_filter_from_object(entity, object),
         Some(r::Value::Null) => Ok(None),
-        None => match arguments.get("text") {
+        None => match field.argument_value("text") {
             Some(r::Value::Object(filter)) => build_fulltext_filter_from_object(filter),
             None => Ok(None),
             _ => Err(QueryExecutionError::InvalidFilterError),
@@ -219,9 +219,9 @@ fn list_values(value: Value, filter_type: &str) -> Result<Vec<Value>, QueryExecu
 /// Parses GraphQL arguments into an field name to order by, if present.
 fn build_order_by(
     entity: ObjectOrInterface,
-    arguments: &HashMap<&str, r::Value>,
+    field: &a::Field,
 ) -> Result<Option<(String, ValueType)>, QueryExecutionError> {
-    match arguments.get("orderBy") {
+    match field.argument_value("orderBy") {
         Some(r::Value::Enum(name)) => {
             let field = sast::get_field(entity, name).ok_or_else(|| {
                 QueryExecutionError::EntityFieldError(entity.name().to_owned(), name.clone())
@@ -235,7 +235,7 @@ fn build_order_by(
                     )
                 })
         }
-        _ => match arguments.get("text") {
+        _ => match field.argument_value("text") {
             Some(r::Value::Object(filter)) => build_fulltext_order_by_from_object(filter),
             None => Ok(None),
             _ => Err(QueryExecutionError::InvalidFilterError),
@@ -259,11 +259,9 @@ fn build_fulltext_order_by_from_object(
 }
 
 /// Parses GraphQL arguments into a EntityOrder, if present.
-fn build_order_direction(
-    arguments: &HashMap<&str, r::Value>,
-) -> Result<OrderDirection, QueryExecutionError> {
-    Ok(arguments
-        .get("orderDirection")
+fn build_order_direction(field: &a::Field) -> Result<OrderDirection, QueryExecutionError> {
+    Ok(field
+        .argument_value("orderDirection")
         .map(|value| match value {
             r::Value::Enum(name) if name == "asc" => OrderDirection::Ascending,
             r::Value::Enum(name) if name == "desc" => OrderDirection::Descending,
@@ -346,14 +344,19 @@ mod tests {
     use graph::{
         components::store::EntityType,
         data::value::Object,
-        prelude::s::{Directive, Field, InputValue, ObjectType, Type, Value as SchemaValue},
+        prelude::{
+            r, AttributeNames, EntityCollection, EntityFilter, EntityRange, Value, ValueType,
+            BLOCK_NUMBER_MAX,
+        },
+        prelude::{
+            s::{self, Directive, Field, InputValue, ObjectType, Type, Value as SchemaValue},
+            EntityOrder,
+        },
     };
     use graphql_parser::Pos;
-    use std::collections::{BTreeMap, HashMap};
+    use std::{collections::BTreeMap, iter::FromIterator};
 
-    use graph::prelude::*;
-
-    use super::build_query;
+    use super::{a, build_query};
 
     fn default_object() -> ObjectType {
         let subgraph_id_argument = (
@@ -418,13 +421,33 @@ mod tests {
         }
     }
 
-    fn default_arguments<'a>() -> HashMap<&'a str, r::Value> {
-        let mut map = HashMap::new();
-        let first = "first";
-        let skip = "skip";
-        map.insert(first, r::Value::Int(100.into()));
-        map.insert(skip, r::Value::Int(0.into()));
-        map
+    fn default_field() -> a::Field {
+        let arguments = vec![
+            ("first".to_string(), r::Value::Int(100.into())),
+            ("skip".to_string(), r::Value::Int(0.into())),
+        ];
+        a::Field {
+            position: Default::default(),
+            alias: None,
+            name: "aField".to_string(),
+            arguments,
+            directives: vec![],
+            selection_set: a::SelectionSet::new(vec!["SomeType".to_string()]),
+        }
+    }
+
+    fn default_field_with(arg_name: &str, arg_value: r::Value) -> a::Field {
+        let mut field = default_field();
+        field.arguments.push((arg_name.to_string(), arg_value));
+        field
+    }
+
+    fn default_field_with_vec(args: Vec<(&str, r::Value)>) -> a::Field {
+        let mut field = default_field();
+        for (name, value) in args {
+            field.arguments.push((name.to_string(), value));
+        }
+        field
     }
 
     #[test]
@@ -433,7 +456,7 @@ mod tests {
             build_query(
                 &object("Entity1"),
                 BLOCK_NUMBER_MAX,
-                &default_arguments(),
+                &default_field(),
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -447,7 +470,7 @@ mod tests {
             build_query(
                 &object("Entity2"),
                 BLOCK_NUMBER_MAX,
-                &default_arguments(),
+                &default_field(),
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -465,7 +488,7 @@ mod tests {
             build_query(
                 &default_object(),
                 BLOCK_NUMBER_MAX,
-                &default_arguments(),
+                &default_field(),
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -479,14 +502,12 @@ mod tests {
 
     #[test]
     fn build_query_parses_order_by_from_enum_values_correctly() {
-        let order_by = "orderBy".to_string();
-        let mut args = default_arguments();
-        args.insert(&order_by, r::Value::Enum("name".to_string()));
+        let field = default_field_with("orderBy", r::Value::Enum("name".to_string()));
         assert_eq!(
             build_query(
                 &default_object(),
                 BLOCK_NUMBER_MAX,
-                &args,
+                &field,
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -497,13 +518,12 @@ mod tests {
             EntityOrder::Ascending("name".to_string(), ValueType::String)
         );
 
-        let mut args = default_arguments();
-        args.insert(&order_by, r::Value::Enum("email".to_string()));
+        let field = default_field_with("orderBy", r::Value::Enum("email".to_string()));
         assert_eq!(
             build_query(
                 &default_object(),
                 BLOCK_NUMBER_MAX,
-                &args,
+                &field,
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -517,14 +537,12 @@ mod tests {
 
     #[test]
     fn build_query_ignores_order_by_from_non_enum_values() {
-        let order_by = "orderBy".to_string();
-        let mut args = default_arguments();
-        args.insert(&order_by, r::Value::String("name".to_string()));
+        let field = default_field_with("orderBy", r::Value::String("name".to_string()));
         assert_eq!(
             build_query(
                 &default_object(),
                 BLOCK_NUMBER_MAX,
-                &args,
+                &field,
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -535,13 +553,12 @@ mod tests {
             EntityOrder::Default
         );
 
-        let mut args = default_arguments();
-        args.insert(&order_by, r::Value::String("email".to_string()));
+        let field = default_field_with("orderBy", r::Value::String("email".to_string()));
         assert_eq!(
             build_query(
                 &default_object(),
                 BLOCK_NUMBER_MAX,
-                &args,
+                &field,
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -555,16 +572,15 @@ mod tests {
 
     #[test]
     fn build_query_parses_order_direction_from_enum_values_correctly() {
-        let order_by = "orderBy".to_string();
-        let order_direction = "orderDirection".to_string();
-        let mut args = default_arguments();
-        args.insert(&order_by, r::Value::Enum("name".to_string()));
-        args.insert(&order_direction, r::Value::Enum("asc".to_string()));
+        let field = default_field_with_vec(vec![
+            ("orderBy", r::Value::Enum("name".to_string())),
+            ("orderDirection", r::Value::Enum("asc".to_string())),
+        ]);
         assert_eq!(
             build_query(
                 &default_object(),
                 BLOCK_NUMBER_MAX,
-                &args,
+                &field,
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -575,14 +591,15 @@ mod tests {
             EntityOrder::Ascending("name".to_string(), ValueType::String)
         );
 
-        let mut args = default_arguments();
-        args.insert(&order_by, r::Value::Enum("name".to_string()));
-        args.insert(&order_direction, r::Value::Enum("desc".to_string()));
+        let field = default_field_with_vec(vec![
+            ("orderBy", r::Value::Enum("name".to_string())),
+            ("orderDirection", r::Value::Enum("desc".to_string())),
+        ]);
         assert_eq!(
             build_query(
                 &default_object(),
                 BLOCK_NUMBER_MAX,
-                &args,
+                &field,
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -593,17 +610,18 @@ mod tests {
             EntityOrder::Descending("name".to_string(), ValueType::String)
         );
 
-        let mut args = default_arguments();
-        args.insert(&order_by, r::Value::Enum("name".to_string()));
-        args.insert(
-            &order_direction,
-            r::Value::Enum("descending...".to_string()),
-        );
+        let field = default_field_with_vec(vec![
+            ("orderBy", r::Value::Enum("name".to_string())),
+            (
+                "orderDirection",
+                r::Value::Enum("descending...".to_string()),
+            ),
+        ]);
         assert_eq!(
             build_query(
                 &default_object(),
                 BLOCK_NUMBER_MAX,
-                &args,
+                &field,
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -615,16 +633,15 @@ mod tests {
         );
 
         // No orderBy -> EntityOrder::Default
-        let mut args = default_arguments();
-        args.insert(
-            &order_direction,
+        let field = default_field_with(
+            "orderDirection",
             r::Value::Enum("descending...".to_string()),
         );
         assert_eq!(
             build_query(
                 &default_object(),
                 BLOCK_NUMBER_MAX,
-                &args,
+                &field,
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -637,53 +654,12 @@ mod tests {
     }
 
     #[test]
-    fn build_query_ignores_order_direction_from_non_enum_values() {
-        let order_by = "orderBy".to_string();
-        let order_direction = "orderDirection".to_string();
-        let mut args = default_arguments();
-        args.insert(&order_by, r::Value::Enum("name".to_string()));
-        args.insert(&order_direction, r::Value::String("asc".to_string()));
-        assert_eq!(
-            build_query(
-                &default_object(),
-                BLOCK_NUMBER_MAX,
-                &args,
-                &BTreeMap::new(),
-                std::u32::MAX,
-                std::u32::MAX,
-                Default::default()
-            )
-            .unwrap()
-            .order,
-            EntityOrder::Ascending("name".to_string(), ValueType::String)
-        );
-
-        let mut args = default_arguments();
-        args.insert(&order_by, r::Value::Enum("name".to_string()));
-        args.insert(&order_direction, r::Value::String("desc".to_string()));
-        assert_eq!(
-            build_query(
-                &default_object(),
-                BLOCK_NUMBER_MAX,
-                &args,
-                &BTreeMap::new(),
-                std::u32::MAX,
-                std::u32::MAX,
-                Default::default()
-            )
-            .unwrap()
-            .order,
-            EntityOrder::Ascending("name".to_string(), ValueType::String)
-        );
-    }
-
-    #[test]
     fn build_query_yields_default_range_if_none_is_present() {
         assert_eq!(
             build_query(
                 &default_object(),
                 BLOCK_NUMBER_MAX,
-                &default_arguments(),
+                &default_field(),
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -697,14 +673,14 @@ mod tests {
 
     #[test]
     fn build_query_yields_default_first_if_only_skip_is_present() {
-        let skip = "skip".to_string();
-        let mut args = default_arguments();
-        args.insert(&skip, r::Value::Int(50));
+        let mut field = default_field();
+        field.arguments = vec![("skip".to_string(), r::Value::Int(50))];
+
         assert_eq!(
             build_query(
                 &default_object(),
                 BLOCK_NUMBER_MAX,
-                &args,
+                &field,
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
@@ -721,10 +697,8 @@ mod tests {
 
     #[test]
     fn build_query_yields_filters() {
-        let whre = "where".to_string();
-        let mut args = default_arguments();
-        args.insert(
-            &whre,
+        let query_field = default_field_with(
+            "where",
             r::Value::Object(Object::from_iter(vec![(
                 "name_ends_with".to_string(),
                 r::Value::String("ello".to_string()),
@@ -737,7 +711,7 @@ mod tests {
                     ..default_object()
                 },
                 BLOCK_NUMBER_MAX,
-                &args,
+                &query_field,
                 &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::result;
 use std::sync::Arc;
 
@@ -250,7 +250,6 @@ impl Resolver for StoreResolver {
         field: &a::Field,
         _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&str, r::Value>,
     ) -> Result<r::Value, QueryExecutionError> {
         if let Some(child) = prefetched_objects {
             Ok(child)
@@ -270,7 +269,6 @@ impl Resolver for StoreResolver {
         field: &a::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&str, r::Value>,
     ) -> Result<r::Value, QueryExecutionError> {
         let (prefetched_object, meta) = self.handle_meta(prefetched_object, &object_type)?;
         if let Some(meta) = meta {

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -301,11 +301,12 @@ impl Resolver for StoreResolver {
 
     fn resolve_field_stream(
         &self,
-        schema: &s::Document,
+        schema: &ApiSchema,
         object_type: &s::ObjectType,
         field: &a::Field,
     ) -> result::Result<UnitStream, QueryExecutionError> {
         // Collect all entities involved in the query field
+        let object_type = schema.object_type(object_type).into();
         let entities = collect_entities_from_query_field(schema, object_type, field);
 
         // Subscribe to the store and return the entity change stream

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::result;
 use std::sync::Arc;
 
+use graph::data::value::Object;
 use graph::data::{
     graphql::{object, ObjectOrInterface},
     schema::META_FIELD_TYPE,
@@ -220,7 +221,7 @@ impl StoreResolver {
                 "__typename".to_string(),
                 r::Value::String(META_FIELD_TYPE.to_string()),
             );
-            return Ok((None, Some(r::Value::Object(map))));
+            return Ok((None, Some(r::Value::object(map))));
         }
         Ok((prefetched_object, None))
     }
@@ -328,8 +329,9 @@ impl Resolver for StoreResolver {
             // or a different field queried under the response key `_meta`.
             ErrorPolicy::Deny => {
                 let data = result.take_data();
-                let meta = data.and_then(|mut d| d.remove_entry("_meta"));
-                result.set_data(meta.map(|m| BTreeMap::from_iter(Some(m))));
+                let meta =
+                    data.and_then(|d| d.get("_meta").map(|m| ("_meta".to_string(), m.clone())));
+                result.set_data(meta.map(|m| Object::from_iter(Some(m))));
             }
             ErrorPolicy::Allow => (),
         }

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -10,6 +10,7 @@ use graph::data::{
 use graph::prelude::*;
 use graph::{components::store::*, data::schema::BLOCK_FIELD_TYPE};
 
+use crate::execution::ast as a;
 use crate::query::ext::BlockConstraint;
 use crate::runner::ResultSizeMetrics;
 use crate::schema::ast as sast;
@@ -238,7 +239,7 @@ impl Resolver for StoreResolver {
     fn prefetch(
         &self,
         ctx: &ExecutionContext<Self>,
-        selection_set: &q::SelectionSet,
+        selection_set: &a::SelectionSet,
     ) -> Result<Option<r::Value>, Vec<QueryExecutionError>> {
         super::prefetch::run(self, ctx, selection_set, &self.result_size).map(Some)
     }
@@ -246,7 +247,7 @@ impl Resolver for StoreResolver {
     fn resolve_objects(
         &self,
         prefetched_objects: Option<r::Value>,
-        field: &q::Field,
+        field: &a::Field,
         _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&str, r::Value>,
@@ -266,7 +267,7 @@ impl Resolver for StoreResolver {
     fn resolve_object(
         &self,
         prefetched_object: Option<r::Value>,
-        field: &q::Field,
+        field: &a::Field,
         field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&str, r::Value>,
@@ -304,7 +305,7 @@ impl Resolver for StoreResolver {
         &self,
         schema: &s::Document,
         object_type: &s::ObjectType,
-        field: &q::Field,
+        field: &a::Field,
     ) -> result::Result<UnitStream, QueryExecutionError> {
         // Collect all entities involved in the query field
         let entities = collect_entities_from_query_field(schema, object_type, field);

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::result::Result;
 use std::time::{Duration, Instant};
 
@@ -119,17 +118,13 @@ fn create_source_event_stream(
         }
     };
 
-    let argument_values =
-        coerce_argument_values(&ctx.query.schema, subscription_type.as_ref(), field)?;
-
-    resolve_field_stream(&ctx, &subscription_type, field, argument_values)
+    resolve_field_stream(&ctx, &subscription_type, field)
 }
 
 fn resolve_field_stream(
     ctx: &ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
     field: &a::Field,
-    _argument_values: HashMap<&str, r::Value>,
 ) -> Result<UnitStream, SubscriptionError> {
     ctx.resolver
         .resolve_field_stream(&ctx.query.schema.document(), object_type, field)

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -119,7 +119,8 @@ fn create_source_event_stream(
         }
     };
 
-    let argument_values = coerce_argument_values(&ctx.query, subscription_type.as_ref(), field)?;
+    let argument_values =
+        coerce_argument_values(&ctx.query.schema, subscription_type.as_ref(), field)?;
 
     resolve_field_stream(&ctx, &subscription_type, field, argument_values)
 }

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -8,6 +8,7 @@ use graph::{components::store::SubscriptionManager, prelude::*};
 
 use crate::runner::ResultSizeMetrics;
 use crate::{
+    execution::ast as a,
     execution::*,
     prelude::{BlockConstraint, StoreResolver},
     schema::api::ErrorPolicy,
@@ -130,7 +131,7 @@ fn create_source_event_stream(
 fn resolve_field_stream(
     ctx: &ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
-    field: &q::Field,
+    field: &a::Field,
     _argument_values: HashMap<&str, r::Value>,
 ) -> Result<UnitStream, SubscriptionError> {
     ctx.resolver

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::iter;
 use std::result::Result;
 use std::time::{Duration, Instant};
 
@@ -107,22 +106,19 @@ fn create_source_event_stream(
         .as_ref()
         .ok_or(QueryExecutionError::NoRootSubscriptionObjectType)?;
 
-    let grouped_field_set = collect_fields(
-        &ctx,
-        &subscription_type,
-        iter::once(ctx.query.selection_set.as_ref()),
-    );
-
-    if grouped_field_set.is_empty() {
+    let field = if ctx.query.selection_set.is_empty() {
         return Err(SubscriptionError::from(QueryExecutionError::EmptyQuery));
-    } else if grouped_field_set.len() > 1 {
-        return Err(SubscriptionError::from(
-            QueryExecutionError::MultipleSubscriptionFields,
-        ));
-    }
+    } else {
+        match ctx.query.selection_set.single_field() {
+            Some(field) => field,
+            None => {
+                return Err(SubscriptionError::from(
+                    QueryExecutionError::MultipleSubscriptionFields,
+                ));
+            }
+        }
+    };
 
-    let fields = grouped_field_set.get_index(0).unwrap();
-    let field = fields.1[0];
     let argument_values = coerce_argument_values(&ctx.query, subscription_type.as_ref(), field)?;
 
     resolve_field_stream(&ctx, &subscription_type, field, argument_values)

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -127,7 +127,7 @@ fn resolve_field_stream(
     field: &a::Field,
 ) -> Result<UnitStream, SubscriptionError> {
     ctx.resolver
-        .resolve_field_stream(&ctx.query.schema.document(), object_type, field)
+        .resolve_field_stream(&ctx.query.schema, object_type, field)
         .map_err(SubscriptionError::from)
 }
 
@@ -219,7 +219,7 @@ async fn execute_subscription_event(
     execute_root_selection_set(
         ctx.cheap_clone(),
         ctx.query.selection_set.cheap_clone(),
-        subscription_type,
+        subscription_type.into(),
         block_ptr,
     )
     .await

--- a/graphql/src/values/coercion.rs
+++ b/graphql/src/values/coercion.rs
@@ -89,7 +89,7 @@ fn coerce_to_definition<'a>(
                         },
                     );
                 }
-                Ok(r::Value::Object(coerced_object))
+                Ok(r::Value::object(coerced_object))
             }
             _ => Err(value),
         },

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate pretty_assertions;
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use graph::data::graphql::{object, object_value, ObjectOrInterface};
@@ -37,7 +36,6 @@ impl Resolver for MockResolver {
         _field: &a::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&str, r::Value>,
     ) -> Result<r::Value, QueryExecutionError> {
         Ok(r::Value::Null)
     }
@@ -48,7 +46,6 @@ impl Resolver for MockResolver {
         _field: &a::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
-        _arguments: &HashMap<&str, r::Value>,
     ) -> Result<r::Value, QueryExecutionError> {
         Ok(r::Value::Null)
     }

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -6,11 +6,11 @@ use std::sync::Arc;
 
 use graph::data::graphql::{object, object_value, ObjectOrInterface};
 use graph::prelude::{
-    async_trait, o, q, r, s, slog, tokio, ApiSchema, DeploymentHash, Logger, Query,
+    async_trait, o, r, s, slog, tokio, ApiSchema, DeploymentHash, Logger, Query,
     QueryExecutionError, QueryResult, Schema,
 };
 use graph_graphql::prelude::{
-    api_schema, execute_query, ExecutionContext, Query as PreparedQuery, QueryExecutionOptions,
+    a, api_schema, execute_query, ExecutionContext, Query as PreparedQuery, QueryExecutionOptions,
     Resolver,
 };
 use test_store::LOAD_MANAGER;
@@ -26,7 +26,7 @@ impl Resolver for MockResolver {
     fn prefetch(
         &self,
         _: &ExecutionContext<Self>,
-        _: &q::SelectionSet,
+        _: &a::SelectionSet,
     ) -> Result<Option<r::Value>, Vec<QueryExecutionError>> {
         Ok(None)
     }
@@ -34,7 +34,7 @@ impl Resolver for MockResolver {
     fn resolve_objects<'a>(
         &self,
         _: Option<r::Value>,
-        _field: &q::Field,
+        _field: &a::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&str, r::Value>,
@@ -45,7 +45,7 @@ impl Resolver for MockResolver {
     fn resolve_object(
         &self,
         __: Option<r::Value>,
-        _field: &q::Field,
+        _field: &a::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         _arguments: &HashMap<&str, r::Value>,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -117,8 +117,8 @@ fn expected_mock_schema_introspection() -> r::Value {
         description: r::Value::Null,
         fields: r::Value::Null,
         inputFields: r::Value::Null,
-        enumValues: r::Value::Null,
         interfaces: r::Value::Null,
+        enumValues: r::Value::Null,
         possibleTypes: r::Value::Null,
     };
 
@@ -128,8 +128,8 @@ fn expected_mock_schema_introspection() -> r::Value {
         description: r::Value::Null,
         fields: r::Value::Null,
         inputFields: r::Value::Null,
-        enumValues: r::Value::Null,
         interfaces: r::Value::Null,
+        enumValues: r::Value::Null,
         possibleTypes: r::Value::Null,
     };
 
@@ -139,8 +139,8 @@ fn expected_mock_schema_introspection() -> r::Value {
         description: r::Value::Null,
         fields: r::Value::Null,
         inputFields: r::Value::Null,
-        enumValues: r::Value::Null,
         interfaces: r::Value::Null,
+        enumValues: r::Value::Null,
         possibleTypes: r::Value::Null,
     };
 
@@ -150,8 +150,8 @@ fn expected_mock_schema_introspection() -> r::Value {
         description: r::Value::Null,
         fields: r::Value::Null,
         inputFields: r::Value::Null,
-        enumValues: r::Value::Null,
         interfaces: r::Value::Null,
+        enumValues: r::Value::Null,
         possibleTypes: r::Value::Null,
     };
 
@@ -161,6 +161,7 @@ fn expected_mock_schema_introspection() -> r::Value {
         description: r::Value::Null,
         fields: r::Value::Null,
         inputFields: r::Value::Null,
+        interfaces: r::Value::Null,
         enumValues:
             r::Value::List(vec![
                 object! {
@@ -176,7 +177,6 @@ fn expected_mock_schema_introspection() -> r::Value {
                     deprecationReason: r::Value::Null,
                 },
             ]),
-        interfaces: r::Value::Null,
         possibleTypes: r::Value::Null,
     };
 
@@ -189,6 +189,7 @@ fn expected_mock_schema_introspection() -> r::Value {
             r::Value::List(vec![object_value(vec![
                 ("name", r::Value::String("id".to_string())),
                 ("description", r::Value::Null),
+                ("args", r::Value::List(vec![])),
                 (
                     "type",
                     object_value(vec![
@@ -204,14 +205,13 @@ fn expected_mock_schema_introspection() -> r::Value {
                         ),
                     ]),
                 ),
-                ("args", r::Value::List(vec![])),
-                ("deprecationReason", r::Value::Null),
                 ("isDeprecated", r::Value::Boolean(false)),
+                ("deprecationReason", r::Value::Null),
             ])]),
         ),
         ("inputFields", r::Value::Null),
-        ("enumValues", r::Value::Null),
         ("interfaces", r::Value::Null),
+        ("enumValues", r::Value::Null),
         (
             "possibleTypes",
             r::Value::List(vec![object_value(vec![
@@ -228,6 +228,7 @@ fn expected_mock_schema_introspection() -> r::Value {
         ("description", r::Value::Null),
         ("fields", r::Value::Null),
         ("inputFields", r::Value::Null),
+        ("interfaces", r::Value::Null),
         (
             "enumValues",
             r::Value::List(vec![
@@ -245,7 +246,6 @@ fn expected_mock_schema_introspection() -> r::Value {
                 ]),
             ]),
         ),
-        ("interfaces", r::Value::Null),
         ("possibleTypes", r::Value::Null),
     ]);
 
@@ -261,22 +261,21 @@ fn expected_mock_schema_introspection() -> r::Value {
                     ("name", r::Value::String("name_eq".to_string())),
                     ("description", r::Value::Null),
                     (
-                        "defaultValue",
-                        r::Value::String("\"default name\"".to_string()),
-                    ),
-                    (
                         "type",
                         object_value(vec![
                             ("kind", r::Value::Enum("SCALAR".to_string())),
                             ("name", r::Value::String("String".to_string())),
                             ("ofType", r::Value::Null),
                         ]),
+                    ),
+                    (
+                        "defaultValue",
+                        r::Value::String("\"default name\"".to_string()),
                     ),
                 ]),
                 object_value(vec![
                     ("name", r::Value::String("name_not".to_string())),
                     ("description", r::Value::Null),
-                    ("defaultValue", r::Value::Null),
                     (
                         "type",
                         object_value(vec![
@@ -285,11 +284,12 @@ fn expected_mock_schema_introspection() -> r::Value {
                             ("ofType", r::Value::Null),
                         ]),
                     ),
+                    ("defaultValue", r::Value::Null),
                 ]),
             ]),
         ),
-        ("enumValues", r::Value::Null),
         ("interfaces", r::Value::Null),
+        ("enumValues", r::Value::Null),
         ("possibleTypes", r::Value::Null),
     ]);
 
@@ -369,7 +369,6 @@ fn expected_mock_schema_introspection() -> r::Value {
             ]),
         ),
         ("inputFields", r::Value::Null),
-        ("enumValues", r::Value::Null),
         (
             "interfaces",
             r::Value::List(vec![object_value(vec![
@@ -378,6 +377,7 @@ fn expected_mock_schema_introspection() -> r::Value {
                 ("ofType", r::Value::Null),
             ])]),
         ),
+        ("enumValues", r::Value::Null),
         ("possibleTypes", r::Value::Null),
     ]);
 
@@ -395,9 +395,8 @@ fn expected_mock_schema_introspection() -> r::Value {
                         "args",
                         r::Value::List(vec![
                             object_value(vec![
-                                ("defaultValue", r::Value::Null),
-                                ("description", r::Value::Null),
                                 ("name", r::Value::String("orderBy".to_string())),
+                                ("description", r::Value::Null),
                                 (
                                     "type",
                                     object_value(vec![
@@ -406,11 +405,11 @@ fn expected_mock_schema_introspection() -> r::Value {
                                         ("ofType", r::Value::Null),
                                     ]),
                                 ),
+                                ("defaultValue", r::Value::Null),
                             ]),
                             object_value(vec![
-                                ("defaultValue", r::Value::Null),
-                                ("description", r::Value::Null),
                                 ("name", r::Value::String("filter".to_string())),
+                                ("description", r::Value::Null),
                                 (
                                     "type",
                                     object_value(vec![
@@ -419,6 +418,7 @@ fn expected_mock_schema_introspection() -> r::Value {
                                         ("ofType", r::Value::Null),
                                     ]),
                                 ),
+                                ("defaultValue", r::Value::Null),
                             ]),
                         ]),
                     ),
@@ -453,9 +453,8 @@ fn expected_mock_schema_introspection() -> r::Value {
                     (
                         "args",
                         r::Value::List(vec![object_value(vec![
-                            ("defaultValue", r::Value::String("99".to_string())),
-                            ("description", r::Value::Null),
                             ("name", r::Value::String("age".to_string())),
+                            ("description", r::Value::Null),
                             (
                                 "type",
                                 object_value(vec![
@@ -464,6 +463,7 @@ fn expected_mock_schema_introspection() -> r::Value {
                                     ("ofType", r::Value::Null),
                                 ]),
                             ),
+                            ("defaultValue", r::Value::String("99".to_string())),
                         ])]),
                     ),
                     (
@@ -495,8 +495,8 @@ fn expected_mock_schema_introspection() -> r::Value {
             ]),
         ),
         ("inputFields", r::Value::Null),
-        ("enumValues", r::Value::Null),
         ("interfaces", r::Value::List(vec![])),
+        ("enumValues", r::Value::Null),
         ("possibleTypes", r::Value::Null),
     ]);
 
@@ -525,7 +525,6 @@ fn expected_mock_schema_introspection() -> r::Value {
             r::Value::List(vec![object_value(vec![
                 ("name", r::Value::String("language".to_string())),
                 ("description", r::Value::Null),
-                ("defaultValue", r::Value::String("\"English\"".to_string())),
                 (
                     "type",
                     object_value(vec![
@@ -534,6 +533,7 @@ fn expected_mock_schema_introspection() -> r::Value {
                         ("ofType", r::Value::Null),
                     ]),
                 ),
+                ("defaultValue", r::Value::String("\"English\"".to_string())),
             ])]),
         ),
     ])]);

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1,13 +1,14 @@
 #[macro_use]
 extern crate pretty_assertions;
 
+use graph::data::value::Object;
 use graphql_parser::Pos;
 use std::convert::TryFrom;
 use std::iter::FromIterator;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap},
     marker::PhantomData,
 };
 
@@ -1538,7 +1539,7 @@ fn query_at_block_with_vars() {
             check_musicians_at(&deployment.hash, query, var, expected.clone(), qid).await;
 
             let query = "query by_nr($block: Block_height!) { musicians(block: $block) { id } }";
-            let mut map = BTreeMap::new();
+            let mut map = Object::new();
             map.insert("number".to_owned(), number);
             let block = r::Value::Object(map);
             let var = Some(("block", block));

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -366,7 +366,6 @@ fn can_query_one_to_one_relationship() {
                     r::Value::List(vec![
                         object_value(vec![
                             ("id", r::Value::String(String::from("s1"))),
-                            ("played", r::Value::Int(10)),
                             (
                                 "song",
                                 object_value(vec![
@@ -374,10 +373,10 @@ fn can_query_one_to_one_relationship() {
                                     ("title", r::Value::String(String::from("Cheesy Tune")))
                                 ])
                             ),
+                            ("played", r::Value::Int(10)),
                         ]),
                         object_value(vec![
                             ("id", r::Value::String(String::from("s2"))),
-                            ("played", r::Value::Int(15)),
                             (
                                 "song",
                                 object_value(vec![
@@ -385,6 +384,7 @@ fn can_query_one_to_one_relationship() {
                                     ("title", r::Value::String(String::from("Rock Tune")))
                                 ])
                             ),
+                            ("played", r::Value::Int(15)),
                         ])
                     ])
                 )
@@ -1677,12 +1677,12 @@ fn can_query_meta() {
         let result = execute_query_document(&deployment.hash, query).await;
         let exp = object! {
             _meta: object! {
+                deployment: "graphqlTestsQuery",
                 block: object! {
                     hash: "0x8511fa04b64657581e3f00e14543c1d522d5d7e771b54aa3060b662ade47da13",
                     number: 1,
                     __typename: "_Block_"
                 },
-                deployment: "graphqlTestsQuery",
                 __typename: "_Meta_"
             },
         };
@@ -1697,11 +1697,11 @@ fn can_query_meta() {
         let result = execute_query_document(&deployment.hash, query).await;
         let exp = object! {
             _meta: object! {
+                deployment: "graphqlTestsQuery",
                 block: object! {
                     hash: r::Value::Null,
                     number: 0
                 },
-                deployment: "graphqlTestsQuery"
             },
         };
         assert_eq!(extract_data!(result), Some(exp));
@@ -1716,11 +1716,11 @@ fn can_query_meta() {
         let result = execute_query_document(&deployment.hash, query).await;
         let exp = object! {
             _meta: object! {
+                deployment: "graphqlTestsQuery",
                 block: object! {
                     hash: "0xbd34884280958002c51d3f7b5f853e6febeba33de0f40d15b0363006533c924f",
                     number: 0
                 },
-                deployment: "graphqlTestsQuery"
             },
         };
         assert_eq!(extract_data!(result), Some(exp));

--- a/server/http/src/request.rs
+++ b/server/http/src/request.rs
@@ -69,9 +69,12 @@ impl Future for GraphQLRequest {
 mod tests {
     use graphql_parser;
     use hyper;
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
 
-    use graph::{data::query::QueryTarget, prelude::*};
+    use graph::{
+        data::{query::QueryTarget, value::Object},
+        prelude::*,
+    };
 
     use super::GraphQLRequest;
 
@@ -173,7 +176,7 @@ mod tests {
                 (String::from("string"), r::Value::String(String::from("s"))),
                 (
                     String::from("map"),
-                    r::Value::Object(BTreeMap::from_iter(
+                    r::Value::Object(Object::from_iter(
                         vec![(String::from("k"), r::Value::String(String::from("v")))].into_iter(),
                     )),
                 ),

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -387,10 +387,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use graph::data::value::Object;
     use http::status::StatusCode;
     use hyper::service::Service;
     use hyper::{Body, Method, Request};
-    use std::collections::BTreeMap;
 
     use graph::data::{
         graphql::effort::LoadManager,
@@ -426,7 +426,7 @@ mod tests {
         }
 
         async fn run_query(self: Arc<Self>, _query: Query, _target: QueryTarget) -> QueryResults {
-            QueryResults::from(BTreeMap::from_iter(
+            QueryResults::from(Object::from_iter(
                 vec![(
                     String::from("name"),
                     r::Value::String(String::from("Jordi")),

--- a/server/http/tests/response.rs
+++ b/server/http/tests/response.rs
@@ -1,11 +1,11 @@
+use graph::data::value::Object;
 use graph::data::{graphql::object, query::QueryResults};
 use graph::prelude::*;
 use graph_server_http::test_utils;
-use std::collections::BTreeMap;
 
 #[test]
 fn generates_200_for_query_results() {
-    let data = BTreeMap::new();
+    let data = Object::new();
     let query_result = QueryResults::from(data).as_http_response();
     test_utils::assert_expected_headers(&query_result);
     test_utils::assert_successful_response(query_result);
@@ -13,7 +13,7 @@ fn generates_200_for_query_results() {
 
 #[test]
 fn generates_valid_json_for_an_empty_result() {
-    let data = BTreeMap::new();
+    let data = Object::new();
     let query_result = QueryResults::from(data).as_http_response();
     test_utils::assert_expected_headers(&query_result);
     let data = test_utils::assert_successful_response(query_result);

--- a/server/http/tests/response.rs
+++ b/server/http/tests/response.rs
@@ -43,10 +43,11 @@ fn canonical_serialization() {
 
     // Value::Variable: nothing to check, not used in a response
 
-    // Value::Object: Insertion order of keys does not matter
+    // Value::Object: Insertion order of keys matters
     let first_second = r#"{"data":{"first":"first","second":"second"}}"#;
+    let second_first = r#"{"data":{"second":"second","first":"first"}}"#;
     assert_resp!(first_second, object! { first: "first", second: "second" });
-    assert_resp!(first_second, object! { second: "second", first: "first" });
+    assert_resp!(second_first, object! { second: "second", first: "first" });
 
     // Value::List
     assert_resp!(r#"{"data":{"ary":[1,2]}}"#, object! { ary: vec![1,2] });
@@ -81,6 +82,6 @@ fn canonical_serialization() {
     // Value::Boolean
     assert_resp!(
         r#"{"data":{"no":false,"yes":true}}"#,
-        object! { yes: true, no: false }
+        object! { no: false, yes: true }
     );
 }

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -1,11 +1,11 @@
 use http::StatusCode;
 use hyper::{Body, Client, Request};
-use std::collections::BTreeMap;
 use std::time::Duration;
 
 use graph::data::{
     graphql::effort::LoadManager,
     query::{QueryResults, QueryTarget},
+    value::Object,
 };
 use graph::prelude::*;
 
@@ -46,11 +46,11 @@ impl GraphQlRunner for TestGraphQlRunner {
                 .unwrap()
                 == &r::Value::String(String::from("John"))
         {
-            BTreeMap::from_iter(
+            Object::from_iter(
                 vec![(String::from("name"), r::Value::String(String::from("John")))].into_iter(),
             )
         } else {
-            BTreeMap::from_iter(
+            Object::from_iter(
                 vec![(
                     String::from("name"),
                     r::Value::String(String::from("Jordi")),

--- a/server/index-node/src/request.rs
+++ b/server/index-node/src/request.rs
@@ -70,9 +70,9 @@ impl Future for IndexNodeRequest {
 mod tests {
     use graphql_parser;
     use hyper;
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
 
-    use graph::prelude::*;
+    use graph::{data::value::Object, prelude::*};
 
     use super::IndexNodeRequest;
 
@@ -169,7 +169,7 @@ mod tests {
                 (String::from("string"), r::Value::String(String::from("s"))),
                 (
                     String::from("map"),
-                    r::Value::Object(BTreeMap::from_iter(
+                    r::Value::Object(Object::from_iter(
                         vec![(String::from("k"), r::Value::String(String::from("v")))].into_iter(),
                     )),
                 ),

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -10,7 +10,7 @@ use graph::{
     components::store::StatusStore,
     data::graphql::{IntoValue, ObjectOrInterface, ValueMap},
 };
-use graph_graphql::prelude::{ExecutionContext, Resolver};
+use graph_graphql::prelude::{a, ExecutionContext, Resolver};
 use std::convert::TryInto;
 use web3::types::{Address, H256};
 
@@ -377,7 +377,7 @@ where
     fn prefetch(
         &self,
         _: &ExecutionContext<Self>,
-        _: &q::SelectionSet,
+        _: &a::SelectionSet,
     ) -> Result<Option<r::Value>, Vec<QueryExecutionError>> {
         Ok(None)
     }
@@ -386,7 +386,7 @@ where
     fn resolve_scalar_value(
         &self,
         parent_object_type: &s::ObjectType,
-        field: &q::Field,
+        field: &a::Field,
         scalar_type: &s::ScalarType,
         value: Option<r::Value>,
         argument_values: &HashMap<&str, r::Value>,
@@ -409,7 +409,7 @@ where
     fn resolve_objects(
         &self,
         prefetched_objects: Option<r::Value>,
-        field: &q::Field,
+        field: &a::Field,
         _field_definition: &s::Field,
         object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&str, r::Value>,
@@ -433,7 +433,7 @@ where
     fn resolve_object(
         &self,
         prefetched_object: Option<r::Value>,
-        field: &q::Field,
+        field: &a::Field,
         _field_definition: &s::Field,
         _object_type: ObjectOrInterface<'_>,
         arguments: &HashMap<&str, r::Value>,

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -1,6 +1,7 @@
 use either::Either;
 use graph::blockchain::{Blockchain, BlockchainKind};
-use std::collections::{BTreeMap, HashMap};
+use graph::data::value::Object;
+use std::collections::HashMap;
 
 use graph::data::subgraph::features::detect_features;
 use graph::data::subgraph::{status, MAX_SPEC_VERSION};
@@ -244,7 +245,7 @@ where
 
         // We then bulid a GraphqQL `Object` value that contains the feature detection and
         // validation results and send it back as a response.
-        let mut response: BTreeMap<String, r::Value> = BTreeMap::new();
+        let mut response = Object::new();
         response.insert("features".to_string(), features);
         response.insert("errors".to_string(), errors);
         response.insert("network".to_string(), network);

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1475,9 +1475,7 @@ fn subgraph_schema_types_have_subgraph_id_directive() {
             .api_schema(&deployment.hash)
             .expect("test subgraph should have a schema");
         for typedef in schema
-            .document()
-            .definitions
-            .iter()
+            .definitions()
             .filter_map(|def| match def {
                 s::Definition::TypeDefinition(typedef) => Some(typedef),
                 _ => None,

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1,3 +1,4 @@
+use graph::data::graphql::ext::TypeDefinitionExt;
 use graph_chain_ethereum::{Mapping, MappingABI};
 use graph_mock::MockMetricsRegistry;
 use hex_literal::hex;
@@ -1481,6 +1482,7 @@ fn subgraph_schema_types_have_subgraph_id_directive() {
                 s::Definition::TypeDefinition(typedef) => Some(typedef),
                 _ => None,
             })
+            .filter(|typedef| !typedef.is_introspection())
         {
             // Verify that all types have a @subgraphId directive on them
             let directive = match typedef {


### PR DESCRIPTION
Refactor how we execute GraphQL queries by transforming the AST we get from `graphql_parser` into a form that is easier to execute. The preprocessing step that translates from `graphql_parser`'s AST to our AST does the following:

* interpolate variables
* coerce argument values to their correct type
* expand fragments so that our selection sets only contain fields
* resolve interfaces (and unions) into their constituent object types

This removes a lot of hard-to-follow code in query execution, especially in `prefetch`.

Besides these simplifications, this PR also fixes a few bugs, and changes the order in which fields appear in the response to what the GraphQL spec mandates. This is a breaking change for the network, as it changes the hash for semantically equivalent query responses (cc @That3Percent on rolling this out on the network)

The refactored code also makes a few weaknesses of the current query execution visible, in particular, field merges (from users specifying the same field multiple times, or from fragment expansion) continue to use a yolo strategy that is not entirely standard conformant. This needs to be addressed in a separate PR.

Fixes #2961.