### PR TITLE
Remove `number_gte` constraint from `_Meta_`

### DIFF
--- a/graphql/src/schema/meta.graphql
+++ b/graphql/src/schema/meta.graphql
@@ -20,8 +20,6 @@ type _Block_ {
   hash: Bytes
   "The block number"
   number: Int!
-  "The minimum block number"
-  number_gte: Int!
 }
 
 enum _SubgraphErrorPolicy_ {


### PR DESCRIPTION
This field should only be present in the generated `Block_height` type.

