### PR TITLE
Fix unfail mechanism based of determinism

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -607,8 +607,10 @@ where
                     {
                         // This reverts the deployment head to the parent_ptr if
                         // deterministic errors happened.
+                        //
                         // There's no point in calling it if we have no current or parent block
-                        // pointers.
+                        // pointers, because there would be: no block to revert to or to search
+                        // errors from (first execution).
                         ctx.inputs
                             .store
                             .unfail_deterministic_error(&current_ptr, &parent_ptr)?;

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -458,7 +458,7 @@ where
     let store_for_err = ctx.inputs.store.cheap_clone();
     let logger = ctx.state.logger.cheap_clone();
     let id_for_err = ctx.inputs.deployment.hash.clone();
-    let mut first_run = true;
+    let mut should_try_unfail = true;
 
     loop {
         debug!(logger, "Starting or restarting subgraph");
@@ -597,8 +597,8 @@ where
             // to move past errors.
             //
             // As an optimization we check this only on the first run.
-            if first_run {
-                first_run = false;
+            if should_try_unfail {
+                should_try_unfail = false;
 
                 let (current_ptr, parent_ptr) = match ctx.inputs.store.block_ptr()? {
                     Some(current_ptr) => {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1016,14 +1016,17 @@ pub trait WritableStore: Send + Sync + 'static {
     /// `block_ptr_to` must point to the parent block of the subgraph block pointer.
     fn revert_block_operations(&self, block_ptr_to: BlockPtr) -> Result<(), StoreError>;
 
-    /// This method:
-    /// - Sets the SubgraphDeployment status accordingly to it's SubgraphErrors
-    /// - Reverts block operations to the parent block if necessary
-    fn unfail(
+    /// If a deterministic error happened, this function reverts the block operations from the
+    /// current block to the previous block.
+    fn unfail_deterministic_error(
         &self,
-        current_ptr: Option<BlockPtr>,
-        parent_ptr: Option<BlockPtr>,
+        current_ptr: &BlockPtr,
+        parent_ptr: &BlockPtr,
     ) -> Result<(), StoreError>;
+
+    /// If a non-deterministic error happened and the current deployment head is past the error
+    /// block range, this function unfails the subgraph and deletes the error.
+    fn unfail_non_deterministic_error(&self, current_ptr: &BlockPtr) -> Result<(), StoreError>;
 
     /// Set subgraph status to failed with the given error as the cause.
     async fn fail_subgraph(&self, error: SubgraphError) -> Result<(), StoreError>;
@@ -1203,7 +1206,11 @@ impl WritableStore for MockStore {
         unimplemented!()
     }
 
-    fn unfail(&self, _: Option<BlockPtr>, _: Option<BlockPtr>) -> Result<(), StoreError> {
+    fn unfail_deterministic_error(&self, _: &BlockPtr, _: &BlockPtr) -> Result<(), StoreError> {
+        unimplemented!()
+    }
+
+    fn unfail_non_deterministic_error(&self, _: &BlockPtr) -> Result<(), StoreError> {
         unimplemented!()
     }
 

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1,4 +1,4 @@
-use detail::{DeploymentDetail, ErrorDetail};
+use detail::DeploymentDetail;
 use diesel::connection::SimpleConnection;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
@@ -1170,29 +1170,21 @@ impl DeploymentStore {
         Ok(())
     }
 
-    /// This should be called once per subgraph on `graph-node` initialization,
-    /// before processing the first block on start.
-    ///
-    /// It does nothing if there's no fatal error for a subgraph, or the blocks received are `None`.
-    /// It branches behavior based of if the fatal error is deterministic or not, read the specific
-    /// functions down below.
-    pub(crate) fn unfail(
+    // If the current block of the deployment is the same as the fatal error,
+    // we revert all block operations to it's parent/previous block.
+    //
+    // This should be called once per subgraph on `graph-node` initialization,
+    // before processing the first block on start.
+    pub(crate) fn unfail_deterministic_error(
         &self,
         site: Arc<Site>,
-        current_ptr: Option<&BlockPtr>,
-        parent_ptr: Option<&BlockPtr>,
+        current_ptr: &BlockPtr,
+        parent_ptr: &BlockPtr,
     ) -> Result<(), StoreError> {
-        let current_ptr = match current_ptr {
-            Some(current_ptr) => current_ptr,
-            // No current head pointer, nothing to do
-            None => return Ok(()),
-        };
-
         let conn = &self.get_conn()?;
+        let deployment_id = &site.deployment;
 
         conn.transaction(|| {
-            let deployment_id = &site.deployment;
-
             // We'll only unfail subgraphs that had fatal errors
             let fatal_error_id = match deployment::get_fatal_error_id(conn, deployment_id)? {
                 Some(fatal_error_id) => fatal_error_id,
@@ -1202,147 +1194,136 @@ impl DeploymentStore {
 
             let subgraph_error = detail::error(conn, &fatal_error_id)?;
 
-            match subgraph_error.deterministic {
-                true => self.unfail_deterministic_error(
-                    conn,
-                    site,
-                    current_ptr,
-                    parent_ptr,
-                    &subgraph_error,
-                ),
-                false => self.unfail_non_deterministic_error(
-                    conn,
-                    deployment_id,
-                    current_ptr,
-                    &subgraph_error,
-                ),
+            // Confidence check
+            if !subgraph_error.deterministic {
+                return Ok(());// Nothing to do
             }
-        })
-    }
 
-    // If the current block of the deployment is the same as the fatal error,
-    // we revert all block operations to it's parent/previous block.
-    fn unfail_deterministic_error(
-        &self,
-        conn: &PgConnection,
-        site: Arc<Site>,
-        current_ptr: &BlockPtr,
-        parent_ptr: Option<&BlockPtr>,
-        subgraph_error: &ErrorDetail,
-    ) -> Result<(), StoreError> {
-        let parent_ptr = match parent_ptr {
-            Some(parent_ptr) => parent_ptr,
-            // At first block of chain (no parent), nothing to revert
-            None => return Ok(()),
-        };
+            use deployment::SubgraphHealth::*;
+            // Decide status based on if there are any errors for the previous/parent block
+            let prev_health =
+                if deployment::has_non_fatal_errors(conn, deployment_id, Some(parent_ptr.number))? {
+                    Unhealthy
+                } else {
+                    Healthy
+                };
 
-        let deployment_id = &site.deployment;
+            match &subgraph_error.block_hash {
+                // The error happened for the current deployment head.
+                // We should revert everything (deployment head, subgraph errors, etc)
+                // to the previous/parent hash/block.
+                Some(bytes) if bytes == current_ptr.hash.as_slice() => {
+                    info!(
+                        self.logger,
+                        "Reverting errored block";
+                        "subgraph_id" => deployment_id,
+                        "from_block_number" => format!("{}", current_ptr.number),
+                        "from_block_hash" => format!("{}", current_ptr.hash),
+                        "to_block_number" => format!("{}", parent_ptr.number),
+                        "to_block_hash" => format!("{}", parent_ptr.hash),
+                    );
 
-        use deployment::SubgraphHealth::*;
-        // Decide status based on if there are any errors for the previous/parent block
-        let prev_health =
-            if deployment::has_non_fatal_errors(conn, deployment_id, Some(parent_ptr.number))? {
-                Unhealthy
-            } else {
-                Healthy
+                    // We ignore the StoreEvent that's being returned, we'll not use it.
+                    let _ = self.revert_block_operations(site.clone(), parent_ptr.clone())?;
+
+                    // Unfail the deployment.
+                    deployment::update_deployment_status(conn, deployment_id, prev_health, None)?;
+                }
+                // Found error, but not for deployment head, we don't need to
+                // revert the block operations.
+                //
+                // If you find this warning in the logs, something is wrong, this
+                // shoudn't happen.
+                Some(hash_bytes) => {
+                    warn!(self.logger, "Subgraph error does not have same block hash as deployment head";
+                        "subgraph_id" => deployment_id,
+                        "error_id" => &subgraph_error.id,
+                        "error_block_hash" => format!("0x{}", hex::encode(&hash_bytes)),
+                        "deployment_head" => format!("{}", current_ptr.hash),
+                    );
+                }
+                // Same as branch above, if you find this warning in the logs,
+                // something is wrong, this shouldn't happen.
+                None => {
+                    warn!(self.logger, "Subgraph error should have block hash";
+                        "subgraph_id" => deployment_id,
+                        "error_id" => &subgraph_error.id,
+                    );
+                }
             };
 
-        match &subgraph_error.block_hash {
-            // The error happened for the current deployment head.
-            // We should revert everything (deployment head, subgraph errors, etc)
-            // to the previous/parent hash/block.
-            Some(bytes) if bytes == current_ptr.hash.as_slice() => {
-                info!(
-                    self.logger,
-                    "Reverting errored block";
-                    "subgraph_id" => deployment_id,
-                    "from_block_number" => format!("{}", current_ptr.number),
-                    "from_block_hash" => format!("{}", current_ptr.hash),
-                    "to_block_number" => format!("{}", parent_ptr.number),
-                    "to_block_hash" => format!("{}", parent_ptr.hash),
-                );
-
-                // We ignore the StoreEvent that's being returned, we'll not use it.
-                let _ = self.revert_block_operations(site.clone(), parent_ptr.clone())?;
-
-                // Unfail the deployment.
-                deployment::update_deployment_status(conn, deployment_id, prev_health, None)?;
-            }
-            // Found error, but not for deployment head, we don't need to
-            // revert the block operations.
-            //
-            // If you find this warning in the logs, something is wrong, this
-            // shoudn't happen.
-            Some(hash_bytes) => {
-                warn!(self.logger, "Subgraph error does not have same block hash as deployment head";
-                    "subgraph_id" => deployment_id,
-                    "error_id" => &subgraph_error.id,
-                    "error_block_hash" => format!("0x{}", hex::encode(&hash_bytes)),
-                    "deployment_head" => format!("{}", current_ptr.hash),
-                );
-            }
-            // Same as branch above, if you find this warning in the logs,
-            // something is wrong, this shouldn't happen.
-            None => {
-                warn!(self.logger, "Subgraph error should have block hash";
-                    "subgraph_id" => deployment_id,
-                    "error_id" => &subgraph_error.id,
-                );
-            }
-        };
-
-        Ok(())
+            Ok(())
+        })
     }
 
     // If a non-deterministic error happens and the deployment head advances,
     // we should unfail the subgraph (status: Healthy, failed: false) and delete
     // the error itself.
-    fn unfail_non_deterministic_error(
+    //
+    // This should be called after successfully processing a block for a subgraph.
+    pub(crate) fn unfail_non_deterministic_error(
         &self,
-        conn: &PgConnection,
-        deployment_id: &DeploymentHash,
+        site: Arc<Site>,
         current_ptr: &BlockPtr,
-        subgraph_error: &ErrorDetail,
     ) -> Result<(), StoreError> {
-        match subgraph_error.block_range {
-            // Deployment head (current_ptr) advanced more than the error.
-            // That means it's healthy, and the non-deterministic error got
-            // solved (didn't happen on another try).
-            (Bound::Included(error_block_number), _)
-                if current_ptr.number >= error_block_number =>
-            {
-                info!(
-                    self.logger,
-                    "Unfailing the deployment status";
-                    "subgraph_id" => deployment_id,
-                );
+        let conn = &self.get_conn()?;
+        let deployment_id = &site.deployment;
 
-                // Unfail the deployment.
-                deployment::update_deployment_status(
-                    conn,
-                    deployment_id,
-                    deployment::SubgraphHealth::Healthy,
-                    None,
-                )?;
+        conn.transaction(|| {
+            // We'll only unfail subgraphs that had fatal errors
+            let fatal_error_id = match deployment::get_fatal_error_id(conn, deployment_id)? {
+                Some(fatal_error_id) => fatal_error_id,
+                // If the subgraph is not failed then there is nothing to do.
+                None => return Ok(()),
+            };
 
-                // Delete the fatal error.
-                deployment::delete_error(conn, &subgraph_error.id)
+            let subgraph_error = detail::error(conn, &fatal_error_id)?;
+
+            // Confidence check
+            if subgraph_error.deterministic {
+                return Ok(());// Nothing to do
             }
-            // NOOP, the deployment head is still before where non-deterministic error happened.
-            block_range => {
-                info!(
-                    self.logger,
-                    "Subgraph error is still ahead of deployment head, nothing to unfail";
-                    "subgraph_id" => deployment_id,
-                    "block_number" => format!("{}", current_ptr.number),
-                    "block_hash" => format!("{}", current_ptr.hash),
-                    "error_block_range" => format!("{:?}", block_range),
-                    "error_block_hash" => subgraph_error.block_hash.as_ref().map(|hash| format!("0x{}", hex::encode(hash))),
-                );
 
-                Ok(())
+            match subgraph_error.block_range {
+                // Deployment head (current_ptr) advanced more than the error.
+                // That means it's healthy, and the non-deterministic error got
+                // solved (didn't happen on another try).
+                (Bound::Included(error_block_number), _)
+                    if current_ptr.number >= error_block_number =>
+                    {
+                        info!(
+                            self.logger,
+                            "Unfailing the deployment status";
+                            "subgraph_id" => deployment_id,
+                        );
+
+                        // Unfail the deployment.
+                        deployment::update_deployment_status(
+                            conn,
+                            deployment_id,
+                            deployment::SubgraphHealth::Healthy,
+                            None,
+                        )?;
+
+                        // Delete the fatal error.
+                        deployment::delete_error(conn, &subgraph_error.id)
+                    }
+                // NOOP, the deployment head is still before where non-deterministic error happened.
+                block_range => {
+                    info!(
+                        self.logger,
+                        "Subgraph error is still ahead of deployment head, nothing to unfail";
+                        "subgraph_id" => deployment_id,
+                        "block_number" => format!("{}", current_ptr.number),
+                        "block_hash" => format!("{}", current_ptr.hash),
+                        "error_block_range" => format!("{:?}", block_range),
+                        "error_block_hash" => subgraph_error.block_hash.as_ref().map(|hash| format!("0x{}", hex::encode(hash))),
+                    );
+
+                    Ok(())
+                    }
             }
-        }
+        })
     }
 
     #[cfg(debug_assertions)]

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1191,13 +1191,11 @@ impl DeploymentStore {
 
         conn.transaction(|| {
             // We'll only unfail subgraphs that had fatal errors
-            let fatal_error_id = match deployment::get_fatal_error_id(conn, deployment_id)? {
-                Some(fatal_error_id) => fatal_error_id,
+            let subgraph_error = match detail::fatal_error(conn, deployment_id)? {
+                Some(fatal_error) => fatal_error,
                 // If the subgraph is not failed then there is nothing to do.
                 None => return Ok(()),
             };
-
-            let subgraph_error = detail::error(conn, &fatal_error_id)?;
 
             // Confidence check
             if !subgraph_error.deterministic {
@@ -1281,13 +1279,11 @@ impl DeploymentStore {
 
         conn.transaction(|| {
             // We'll only unfail subgraphs that had fatal errors
-            let fatal_error_id = match deployment::get_fatal_error_id(conn, deployment_id)? {
-                Some(fatal_error_id) => fatal_error_id,
+            let subgraph_error = match detail::fatal_error(conn, deployment_id)? {
+                Some(fatal_error) => fatal_error,
                 // If the subgraph is not failed then there is nothing to do.
                 None => return Ok(()),
             };
-
-            let subgraph_error = detail::error(conn, &fatal_error_id)?;
 
             // Confidence check
             if subgraph_error.deterministic {

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1,4 +1,4 @@
-use detail::{DeploymentDetail, ErrorDetail};
+use detail::DeploymentDetail;
 use diesel::connection::SimpleConnection;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
@@ -1170,16 +1170,22 @@ impl DeploymentStore {
         Ok(())
     }
 
-    // Base for unfail logic, basically it early returns / does nothing if:
+    // If the current block of the deployment is the same as the fatal error,
+    // we revert all block operations to it's parent/previous block.
     //
-    // - There's no fatal error for a subgraph
-    // - The error's determinism isn't the same as the one requested
+    // This should be called once per subgraph on `graph-node` initialization,
+    // before processing the first block on start.
     //
-    // Otherwise it calls the provided closure/function with the subgraph error.
-    fn unfail_error<F>(&self, site: &Arc<Site>, deterministic: bool, f: F) -> Result<(), StoreError>
-    where
-        F: Fn(&PgConnection, &DeploymentHash, &ErrorDetail) -> Result<(), StoreError>,
-    {
+    // It will do nothing (early return) if:
+    //
+    // - There's no fatal error for the subgraph
+    // - The error is NOT deterministic
+    pub(crate) fn unfail_deterministic_error(
+        &self,
+        site: Arc<Site>,
+        current_ptr: &BlockPtr,
+        parent_ptr: &BlockPtr,
+    ) -> Result<(), StoreError> {
         let conn = &self.get_conn()?;
         let deployment_id = &site.deployment;
 
@@ -1194,26 +1200,10 @@ impl DeploymentStore {
             let subgraph_error = detail::error(conn, &fatal_error_id)?;
 
             // Confidence check
-            if subgraph_error.deterministic != deterministic {
+            if !subgraph_error.deterministic {
                 return Ok(()); // Nothing to do
             }
 
-            f(conn, deployment_id, &subgraph_error)
-        })
-    }
-
-    // If the current block of the deployment is the same as the fatal error,
-    // we revert all block operations to it's parent/previous block.
-    //
-    // This should be called once per subgraph on `graph-node` initialization,
-    // before processing the first block on start.
-    pub(crate) fn unfail_deterministic_error(
-        &self,
-        site: Arc<Site>,
-        current_ptr: &BlockPtr,
-        parent_ptr: &BlockPtr,
-    ) -> Result<(), StoreError> {
-        self.unfail_error(&site, true, |conn, deployment_id, subgraph_error| {
             use deployment::SubgraphHealth::*;
             // Decide status based on if there are any errors for the previous/parent block
             let prev_health =
@@ -1276,12 +1266,34 @@ impl DeploymentStore {
     // the error itself.
     //
     // This should be called after successfully processing a block for a subgraph.
+    //
+    // It will do nothing (early return) if:
+    //
+    // - There's no fatal error for the subgraph
+    // - The error IS deterministic
     pub(crate) fn unfail_non_deterministic_error(
         &self,
         site: Arc<Site>,
         current_ptr: &BlockPtr,
     ) -> Result<(), StoreError> {
-        self.unfail_error(&site, false, |conn, deployment_id, subgraph_error| {
+        let conn = &self.get_conn()?;
+        let deployment_id = &site.deployment;
+
+        conn.transaction(|| {
+            // We'll only unfail subgraphs that had fatal errors
+            let fatal_error_id = match deployment::get_fatal_error_id(conn, deployment_id)? {
+                Some(fatal_error_id) => fatal_error_id,
+                // If the subgraph is not failed then there is nothing to do.
+                None => return Ok(()),
+            };
+
+            let subgraph_error = detail::error(conn, &fatal_error_id)?;
+
+            // Confidence check
+            if subgraph_error.deterministic {
+                return Ok(()); // Nothing to do
+            }
+
             match subgraph_error.block_range {
                 // Deployment head (current_ptr) advanced more than the error.
                 // That means it's healthy, and the non-deterministic error got

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -2,8 +2,8 @@
 use crate::primary::Site;
 use crate::{
     deployment::{
-        graph_node_versions, subgraph_deployment, subgraph_error, subgraph_manifest,
-        SubgraphHealth as HealthType,
+        get_fatal_error_id, graph_node_versions, subgraph_deployment, subgraph_error,
+        subgraph_manifest, SubgraphHealth as HealthType,
     },
     primary::DeploymentId,
 };
@@ -11,6 +11,7 @@ use diesel::pg::PgConnection;
 use diesel::prelude::{
     ExpressionMethods, JoinOnDsl, NullableExpressionMethods, QueryDsl, RunQueryDsl,
 };
+use diesel::OptionalExtension;
 use diesel_derives::Associations;
 use git_testament::{git_testament, git_testament_macros};
 use graph::{
@@ -80,12 +81,26 @@ pub(crate) struct ErrorDetail {
     pub block_range: (Bound<i32>, Bound<i32>),
 }
 
-pub(crate) fn error(conn: &PgConnection, error_id: &str) -> Result<ErrorDetail, StoreError> {
+fn error(conn: &PgConnection, error_id: &str) -> Result<Option<ErrorDetail>, StoreError> {
     use subgraph_error as e;
     e::table
         .filter(e::id.eq(error_id))
         .get_result(conn)
+        .optional()
         .map_err(StoreError::from)
+}
+
+pub(crate) fn fatal_error(
+    conn: &PgConnection,
+    deployment_id: &DeploymentHash,
+) -> Result<Option<ErrorDetail>, StoreError> {
+    let fatal_error_id = match get_fatal_error_id(conn, deployment_id)? {
+        Some(fatal_error_id) => fatal_error_id,
+        // No fatal error found.
+        None => return Ok(None),
+    };
+
+    error(conn, &fatal_error_id)
 }
 
 struct DetailAndError<'a>(DeploymentDetail, Option<ErrorDetail>, &'a Vec<Arc<Site>>);

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1188,17 +1188,21 @@ impl WritableStoreTrait for WritableStore {
         })
     }
 
-    fn unfail(
+    fn unfail_deterministic_error(
         &self,
-        current_ptr: Option<BlockPtr>,
-        parent_ptr: Option<BlockPtr>,
+        current_ptr: &BlockPtr,
+        parent_ptr: &BlockPtr,
     ) -> Result<(), StoreError> {
-        self.retry("unfail", || {
-            let current_ptr = current_ptr.as_ref();
-            let parent_ptr = parent_ptr.as_ref();
-
+        self.retry("unfail_deterministic_error", || {
             self.writable
-                .unfail(self.site.clone(), current_ptr, parent_ptr)
+                .unfail_deterministic_error(self.site.clone(), current_ptr, parent_ptr)
+        })
+    }
+
+    fn unfail_non_deterministic_error(&self, current_ptr: &BlockPtr) -> Result<(), StoreError> {
+        self.retry("unfail_non_deterministic_error", || {
+            self.writable
+                .unfail_non_deterministic_error(self.site.clone(), current_ptr)
         })
     }
 

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -1,5 +1,8 @@
 use graph::{
-    components::store::{DeploymentLocator, StatusStore},
+    components::{
+        server::index_node::VersionInfo,
+        store::{DeploymentLocator, StatusStore},
+    },
     data::subgraph::schema::SubgraphError,
     data::subgraph::schema::SubgraphHealth,
     prelude::EntityChange,
@@ -39,6 +42,13 @@ fn unassigned(deployment: &DeploymentLocator) -> EntityChange {
         deployment: deployment.clone(),
         operation: EntityChangeOperation::Removed,
     }
+}
+
+fn get_version_info(store: &Store, subgraph_name: &str) -> VersionInfo {
+    let primary = primary_connection();
+    let (current, _) = primary.versions_for_subgraph(subgraph_name).unwrap();
+    let current = current.unwrap();
+    store.version_info(&current).unwrap()
 }
 
 #[test]
@@ -426,11 +436,7 @@ fn version_info() {
         )
         .unwrap();
 
-        let primary = primary_connection();
-        let (current, _) = primary.versions_for_subgraph(&*NAME).unwrap();
-        let current = current.unwrap();
-
-        let vi = store.version_info(&current).unwrap();
+        let vi = get_version_info(&store, NAME);
         assert_eq!(&*NAME, vi.deployment_id.as_str());
         assert_eq!(false, vi.synced);
         assert_eq!(false, vi.failed);
@@ -550,15 +556,18 @@ fn fatal_vs_non_fatal() {
 }
 
 #[test]
-fn fail_unfail() {
+fn fail_unfail_deterministic_error() {
+    const NAME: &str = "failUnfailDeterministic";
+
     fn setup() -> DeploymentLocator {
-        let id = DeploymentHash::new("failUnfail").unwrap();
+        let id = DeploymentHash::new(NAME).unwrap();
         remove_subgraphs();
         create_test_subgraph(&id, SUBGRAPH_GQL)
     }
 
     run_test_sequentially(|store| async move {
         let deployment = setup();
+
         let query_store = store
             .query_store(deployment.hash.cheap_clone().into(), false)
             .await
@@ -573,8 +582,12 @@ fn fail_unfail() {
         )
         .unwrap();
 
-        // We don't have any errors.
+        // We don't have any errors and the subgraph is healthy.
         assert!(!query_store.has_non_fatal_errors(None).await.unwrap());
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(false, vi.failed);
+        assert_eq!(Some(0), vi.latest_ethereum_block_number);
 
         // Process the second block.
         transact_entity_operations(
@@ -587,6 +600,10 @@ fn fail_unfail() {
 
         // Still no fatal errors.
         assert!(!query_store.has_non_fatal_errors(None).await.unwrap());
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(false, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
 
         let error = SubgraphError {
             subgraph_id: deployment.hash.clone(),
@@ -601,18 +618,363 @@ fn fail_unfail() {
             .writable(LOGGER.clone(), deployment.id)
             .await
             .expect("can get writable");
+
+        // Fail the subgraph with a deterministic error.
+        writable.fail_subgraph(error).await.unwrap();
+
+        // Now we have a fatal error because the subgraph failed.
+        assert!(query_store.has_non_fatal_errors(None).await.unwrap());
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(true, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
+
+        // Unfail the subgraph.
+        writable
+            .unfail_deterministic_error(&BLOCKS[1], &BLOCKS[0])
+            .unwrap();
+
+        // We don't have fatal errors anymore and the block got reverted.
+        assert!(!query_store.has_non_fatal_errors(None).await.unwrap());
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(false, vi.failed);
+        assert_eq!(Some(0), vi.latest_ethereum_block_number);
+
+        test_store::remove_subgraphs();
+    })
+}
+
+#[test]
+fn fail_unfail_deterministic_error_noop() {
+    const NAME: &str = "failUnfailDeterministicNoop";
+
+    fn setup() -> DeploymentLocator {
+        let id = DeploymentHash::new(NAME).unwrap();
+        remove_subgraphs();
+        create_test_subgraph(&id, SUBGRAPH_GQL)
+    }
+
+    run_test_sequentially(|store| async move {
+        let deployment = setup();
+
+        let count = || -> usize {
+            let store = store.subgraph_store();
+            store.error_count(&deployment.hash).unwrap()
+        };
+
+        // Process the first block.
+        transact_entity_operations(
+            &store.subgraph_store(),
+            &deployment,
+            BLOCKS[0].clone(),
+            vec![],
+        )
+        .unwrap();
+
+        // We don't have any errors and the subgraph is healthy.
+        assert_eq!(count(), 0);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(false, vi.failed);
+        assert_eq!(Some(0), vi.latest_ethereum_block_number);
+
+        // Process the second block.
+        transact_entity_operations(
+            &store.subgraph_store(),
+            &deployment,
+            BLOCKS[1].clone(),
+            vec![],
+        )
+        .unwrap();
+
+        // Still no fatal errors.
+        assert_eq!(count(), 0);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(false, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
+
+        let writable = store
+            .subgraph_store()
+            .writable(LOGGER.clone(), deployment.id)
+            .await
+            .expect("can get writable");
+
+        // Run unfail with no errors results in NOOP.
+        writable
+            .unfail_deterministic_error(&BLOCKS[1], &BLOCKS[0])
+            .unwrap();
+
+        // Nothing to unfail, state continues the same.
+        assert_eq!(count(), 0);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(false, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
+
+        let error = SubgraphError {
+            subgraph_id: deployment.hash.clone(),
+            message: "test".to_string(),
+            block_ptr: Some(BLOCKS[1].clone()),
+            handler: None,
+            deterministic: false, // wrong determinism
+        };
+
+        // Fail the subraph with a NON-deterministic error.
+        writable.fail_subgraph(error).await.unwrap();
+
+        // Now we have a fatal error because the subgraph failed.
+        assert_eq!(count(), 1);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(true, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
+
+        // Running unfail_deterministic_error against a NON-deterministic error will do nothing.
+        writable
+            .unfail_deterministic_error(&BLOCKS[1], &BLOCKS[0])
+            .unwrap();
+
+        // State continues the same, nothing happened.
+        // Neither the block got reverted or error deleted.
+        assert_eq!(count(), 1);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(true, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
+
+        let error = SubgraphError {
+            subgraph_id: deployment.hash.clone(),
+            message: "test".to_string(),
+            block_ptr: Some(BLOCKS[2].clone()), // wrong block
+            handler: None,
+            deterministic: true, // right determinism
+        };
+
+        // Fail the subgraph with an advanced block.
+        writable.fail_subgraph(error).await.unwrap();
+
+        // Running unfail_deterministic_error won't do anything,
+        // the hashes won't match and there's nothing to revert.
+        writable
+            .unfail_deterministic_error(&BLOCKS[1], &BLOCKS[0])
+            .unwrap();
+
+        // State continues the same.
+        // Neither the block got reverted or error deleted.
+        assert_eq!(count(), 2);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(true, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
+
+        test_store::remove_subgraphs();
+    })
+}
+
+#[test]
+fn fail_unfail_non_deterministic_error() {
+    const NAME: &str = "failUnfailNonDeterministic";
+
+    fn setup() -> DeploymentLocator {
+        let id = DeploymentHash::new(NAME).unwrap();
+        remove_subgraphs();
+        create_test_subgraph(&id, SUBGRAPH_GQL)
+    }
+
+    run_test_sequentially(|store| async move {
+        let deployment = setup();
+
+        let count = || -> usize {
+            let store = store.subgraph_store();
+            store.error_count(&deployment.hash).unwrap()
+        };
+
+        // Process the first block.
+        transact_entity_operations(
+            &store.subgraph_store(),
+            &deployment,
+            BLOCKS[0].clone(),
+            vec![],
+        )
+        .unwrap();
+
+        // We don't have any errors.
+        assert_eq!(count(), 0);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(false, vi.failed);
+        assert_eq!(Some(0), vi.latest_ethereum_block_number);
+
+        let error = SubgraphError {
+            subgraph_id: deployment.hash.clone(),
+            message: "test".to_string(),
+            block_ptr: Some(BLOCKS[1].clone()),
+            handler: None,
+            deterministic: false,
+        };
+
+        let writable = store
+            .subgraph_store()
+            .writable(LOGGER.clone(), deployment.id)
+            .await
+            .expect("can get writable");
+
+        // Fail subgraph with a non-deterministic error.
+        writable.fail_subgraph(error).await.unwrap();
+
+        // Now we have a fatal error because the subgraph failed.
+        assert_eq!(count(), 1);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(true, vi.failed);
+        assert_eq!(Some(0), vi.latest_ethereum_block_number);
+
+        // Process the second block.
+        transact_entity_operations(
+            &store.subgraph_store(),
+            &deployment,
+            BLOCKS[1].clone(),
+            vec![],
+        )
+        .unwrap();
+
+        // Subgraph failed but it's deployment head pointer advanced.
+        assert_eq!(count(), 1);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(true, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
+
+        // Unfail the subgraph and delete the fatal error.
+        writable.unfail_non_deterministic_error(&BLOCKS[1]).unwrap();
+
+        // We don't have fatal errors anymore and the subgraph is healthy.
+        assert_eq!(count(), 0);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(false, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
+
+        test_store::remove_subgraphs();
+    })
+}
+
+#[test]
+fn fail_unfail_non_deterministic_error_noop() {
+    const NAME: &str = "failUnfailNonDeterministicNoop";
+
+    fn setup() -> DeploymentLocator {
+        let id = DeploymentHash::new(NAME).unwrap();
+        remove_subgraphs();
+        create_test_subgraph(&id, SUBGRAPH_GQL)
+    }
+
+    run_test_sequentially(|store| async move {
+        let deployment = setup();
+
+        let count = || -> usize {
+            let store = store.subgraph_store();
+            store.error_count(&deployment.hash).unwrap()
+        };
+
+        // Process the first block.
+        transact_entity_operations(
+            &store.subgraph_store(),
+            &deployment,
+            BLOCKS[0].clone(),
+            vec![],
+        )
+        .unwrap();
+
+        // We don't have any errors and the subgraph is healthy.
+        assert_eq!(count(), 0);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(false, vi.failed);
+        assert_eq!(Some(0), vi.latest_ethereum_block_number);
+
+        // Process the second block.
+        transact_entity_operations(
+            &store.subgraph_store(),
+            &deployment,
+            BLOCKS[1].clone(),
+            vec![],
+        )
+        .unwrap();
+
+        // Still no errors.
+        assert_eq!(count(), 0);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(false, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
+
+        let writable = store
+            .subgraph_store()
+            .writable(LOGGER.clone(), deployment.id)
+            .await
+            .expect("can get writable");
+
+        // Running unfail without any errors will do nothing.
+        writable.unfail_non_deterministic_error(&BLOCKS[1]).unwrap();
+
+        // State continues the same, nothing happened.
+        assert_eq!(count(), 0);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(false, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
+
+        let error = SubgraphError {
+            subgraph_id: deployment.hash.clone(),
+            message: "test".to_string(),
+            block_ptr: Some(BLOCKS[1].clone()),
+            handler: None,
+            deterministic: true, // wrong determinism
+        };
+
+        // Fail the subgraph with a DETERMININISTIC error.
         writable.fail_subgraph(error).await.unwrap();
 
         // We now have a fatal error because the subgraph failed.
-        assert!(query_store.has_non_fatal_errors(None).await.unwrap());
+        assert_eq!(count(), 1);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(true, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
 
-        // This will unfail the subgraph and delete the fatal error.
-        writable
-            .unfail(Some(BLOCKS[1].clone()), Some(BLOCKS[0].clone()))
-            .unwrap();
+        // Running unfail_non_deterministic_error will be NOOP, the error is deterministic.
+        writable.unfail_non_deterministic_error(&BLOCKS[1]).unwrap();
 
-        // We don't have fatal errors anymore.
-        assert!(!query_store.has_non_fatal_errors(None).await.unwrap());
+        // Nothing happeened, state continues the same.
+        assert_eq!(count(), 1);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(true, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
+
+        let error = SubgraphError {
+            subgraph_id: deployment.hash.clone(),
+            message: "test".to_string(),
+            block_ptr: Some(BLOCKS[2].clone()), // wrong block
+            handler: None,
+            deterministic: false, // right determinism
+        };
+
+        // Fail the subgraph with a non-deterministic error, but with an advanced block.
+        writable.fail_subgraph(error).await.unwrap();
+
+        // Since the block range of the block won't match the deployment head, this will be NOOP.
+        writable.unfail_non_deterministic_error(&BLOCKS[1]).unwrap();
+
+        // State continues the same besides a new error added to the database.
+        assert_eq!(count(), 2);
+        let vi = get_version_info(&store, NAME);
+        assert_eq!(&*NAME, vi.deployment_id.as_str());
+        assert_eq!(true, vi.failed);
+        assert_eq!(Some(1), vi.latest_ethereum_block_number);
 
         test_store::remove_subgraphs();
     })


### PR DESCRIPTION
Before the "PoI for failed subgraphs" feature, where we advance the
deployment head a block if the error is deterministic, we would do
the `unfail` logic after a block is successfully processed, like this:

```rust
match process_block() {
  Ok(needs_restart) => {
    if first_run {
      store.unfail();
    }
    // ...
  }
  // ...
}
```

With this feature the `unfail` mechanism had to change, we did that by
changing two things about it:

- It would run before `process_block`
- Making it revert to the parent block if the error was deterministic

This worked fine for deterministic cases, however for non-deterministic
ones we faced an issue.

We need to run `unfail` after `process_block` went successful (returned
`Ok`). This is necessary because we can only unfail the deployment if
the subgraph actually advanced past the error block range.

Example with the `unfail` previous to this commit:

- Subgraph state:
  - failed
  - deployment head at 1399
  - non-determinstic error happened at 1400
- Once the index-node gets restarted, `unfail` would run, but nothing
  would happen since the deployment head only advances after a
  successful `process_block` execution.
- Subgraph would continue to advance it's pointer but `unfail` wouldn't
  run anymore (only once at start). This would make the subgraph be in
  the `failed` state, but advancing it's pointer normally.

To fix the issue, we need to run `unfail` for non-deterministic errors
**after** the `process_block` went successful:

- Subgraph state:
  - failed
  - deployment head at 1399
  - non-determinstic error happened at 1400
- Once the index-node gets restarted, `unfail_determinstic_error` would
  run and be NOOP, then the next block would be processed (1400), the
  error can be fixed (non-deterministic) when `process_block` gets to
  run and returns `Ok`, then `unfail_non_determinstic_error` executes
  and **unfails** the subgraph finally 🙌
- Subgraph continues to advance it's pointer and the status is correct
