### PR TITLE
Fix hard-coded retry limits being used instead of REQUEST_RETRIES

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -494,7 +494,7 @@ impl EthereumAdapter {
                 Ok(_) | Err(EthereumContractCallError::Revert(_)) => false,
                 Err(_) => true,
             })
-            .limit(10)
+            .limit(*REQUEST_RETRIES)
             .timeout_secs(*JSON_RPC_TIMEOUT)
             .run(move || {
                 let req = CallRequest {
@@ -1063,7 +1063,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
         // transaction never made it back into the main chain.
         Box::new(
             retry("batch eth_getTransactionReceipt RPC call", &logger)
-                .limit(16)
+                .limit(*REQUEST_RETRIES)
                 .no_logging()
                 .timeout_secs(*JSON_RPC_TIMEOUT)
                 .run(move || {


### PR DESCRIPTION
Currently the following retries use hard-coded retry limits that cannot be configured:

- `eth_call RPC call`: `10`
- `batch eth_getTransactionReceipt RPC call`: `16`

This PR fixes it by replacing the hard-coded values with `*REQUEST_RETRIES`.