### PR TITLE
node, store: Actually setup databases in parallel

### DIFF
--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -52,7 +52,7 @@ impl StoreBuilder {
         // attempt doesn't work for all of them because the database is
         // unavailable, they will try again later in the normal course of
         // using the pool
-        join_all(pools.iter().map(|(_, pool)| async move { pool.setup() })).await;
+        join_all(pools.iter().map(|(_, pool)| pool.setup())).await;
 
         let chains = HashMap::from_iter(config.chains.chains.iter().map(|(name, chain)| {
             let shard = ShardName::new(chain.shard.to_string())

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -503,8 +503,14 @@ impl ConnectionPool {
     /// # Panics
     ///
     /// If any errors happen during the migration, the process panics
-    pub fn setup(&self) {
-        self.get_ready().ok();
+    pub async fn setup(&self) {
+        let pool = self.clone();
+        graph::spawn_blocking_allow_panic(move || {
+            pool.get_ready().ok();
+        })
+        .await
+        // propagate panics
+        .unwrap();
     }
 
     pub(crate) async fn query_permit(&self) -> tokio::sync::OwnedSemaphorePermit {


### PR DESCRIPTION
The previous code didn't parallelize setup, since setup makes blocking
calls, and so databases still started up one after the other.

