### PR TITLE
Update graphql-parser to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,8 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "graphql-parser"
-version = "0.3.0"
-source = "git+https://github.com/graphql-rust/graphql-parser?rev=45167b53e9533c331298683577ba8df7e43480ac#45167b53e9533c331298683577ba8df7e43480ac"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
  "combine",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,6 @@ members = [
     "tests",
 ]
 
-
-[patch.crates-io]
-# Include protection against stack overflow when parsing from this PR: https://github.com/graphql-rust/graphql-parser/commit/45167b53e9533c331298683577ba8df7e43480ac
-graphql-parser = {git="https://github.com/graphql-rust/graphql-parser", rev="45167b53e9533c331298683577ba8df7e43480ac"}
-
 # Incremental compilation on Rust 1.55 causes an ICE on build. As soon as graph node builds again, these can be removed.
 [profile.dev]
 incremental = false

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,6 +29,6 @@ graph-mock = { path = "../mock" }
 walkdir = "2.3.2"
 test-store = { path = "../store/test-store" }
 hex = "0.4.3"
-graphql-parser = "0.3"
+graphql-parser = "0.4.0"
 pretty_assertions = "1.0.0"
 anyhow = "1.0"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -26,7 +26,7 @@ hex = "0.4.3"
 http = "0.2.3"
 fail = { version = "0.5", features = ["failpoints"] }
 futures = "0.1.21"
-graphql-parser = "0.3.0"
+graphql-parser = "0.4.0"
 lazy_static = "1.4.0"
 mockall = "0.8.3"
 num-bigint = { version = "^0.2.6", features = ["serde"] }

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 crossbeam = "0.8"
 futures01 = { package="futures", version="0.1.29" }
 graph = { path = "../graph" }
-graphql-parser = "0.3"
+graphql-parser = "0.4.0"
 indexmap = "1.7"
 Inflector = "0.11.3"
 lazy_static = "1.2.0"

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -144,6 +144,7 @@ fn add_directives(schema: &mut Document) {
         name: "entity".to_owned(),
         arguments: vec![],
         locations: vec![DirectiveLocation::Object],
+        repeatable: false,
     });
 
     let derived_from = Definition::DirectiveDefinition(DirectiveDefinition {
@@ -159,6 +160,7 @@ fn add_directives(schema: &mut Document) {
             directives: vec![],
         }],
         locations: vec![DirectiveLocation::FieldDefinition],
+        repeatable: false,
     });
 
     let subgraph_id = Definition::DirectiveDefinition(DirectiveDefinition {
@@ -174,6 +176,7 @@ fn add_directives(schema: &mut Document) {
             directives: vec![],
         }],
         locations: vec![DirectiveLocation::Object],
+        repeatable: false,
     });
 
     schema.definitions.push(entity);

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/bin/manager.rs"
 clap = "2.33.3"
 env_logger = "0.9.0"
 git-testament = "0.2"
-graphql-parser = "0.3"
+graphql-parser = "0.4.0"
 futures = { version = "0.3.1", features = ["compat"] }
 lazy_static = "1.2.0"
 url = "2.2.1"

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.21"
-graphql-parser = "0.3"
+graphql-parser = "0.4.0"
 http = "0.2"
 hyper = "0.14"
 serde = "1.0"

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -9,7 +9,7 @@ graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
 graph-chain-ethereum = { path = "../../chain/ethereum" }
 graph-chain-near = { path = "../../chain/near" }
-graphql-parser = "0.3"
+graphql-parser = "0.4.0"
 http = "0.2"
 hyper = "0.14"
 serde = "1.0"

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 futures = "0.1.23"
 graph = { path = "../../graph" }
-graphql-parser = "0.3"
+graphql-parser = "0.4.0"
 http = "0.2"
 lazy_static = "1.2.0"
 serde = "1.0"

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -17,7 +17,7 @@ fallible-iterator = "0.2.0"
 futures = "0.1.21"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
-graphql-parser = "0.3"
+graphql-parser = "0.4.0"
 Inflector = "0.11.3"
 lazy_static = "1.1"
 lru_time_cache = "0.11"
@@ -37,7 +37,7 @@ hex = "0.4.3"
 
 [dev-dependencies]
 clap = "2.33.3"
-graphql-parser = "0.3"
+graphql-parser = "0.4.0"
 test-store = { path = "../test-store" }
 hex-literal = "0.3"
 graph-chain-ethereum = { path = "../../chain/ethereum" }

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -7,7 +7,7 @@ description = "Provides static store instance for tests."
 
 [dependencies]
 graph-graphql = { path = "../../graphql" }
-graphql-parser = "0.3"
+graphql-parser = "0.4.0"
 graph-mock = { path = "../../mock" }
 graph-node = { path = "../../node" }
 graph = { path = "../../graph" }


### PR DESCRIPTION
v0.4 was released a few days ago, here's the changeset: https://github.com/graphql-rust/graphql-parser/releases/tag/v0.4.0 

It also includes a bugfix we needed (so we no longer need a patch in the root Cargo file). 

Also, there was a minor breaking change to Directive, I added a `repeatable: false` to all existing directives, to preserve to previous behavior. 
