### PR TITLE
store: Fix firehose migration syntax

### DIFF
--- a/store/postgres/migrations/2021-07-09-144144_firehose_cursor/down.sql
+++ b/store/postgres/migrations/2021-07-09-144144_firehose_cursor/down.sql
@@ -1,2 +1,2 @@
 alter table subgraphs.subgraph_deployment
-    drop column firehose_cursor text;
+    drop column firehose_cursor;


### PR DESCRIPTION
Removes extra 'text' type.

@tilacog made this snippet to show the migration fails: https://dbfiddle.uk/?rdbms=postgres_12&fiddle=5f8f28f9afb8eae17c481e2f3c0fb777