### PR TITLE
Automatically remove unused deployments

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -166,3 +166,9 @@ those.
   decisions. Set to `true` to turn simulation on, defaults to `false`
 - `GRAPH_STORE_CONNECTION_TIMEOUT`: How long to wait to connect to a
   database before assuming the database is down in ms. Defaults to 5000ms.
+- `GRAPH_REMOVE_UNUSED_INTERVAL`: How long to wait before removing an
+  unused deployment. The system periodically checks and marks deployments
+  that are not used by any subgraphs any longer. Once a deployment has been
+  identified as unused, `graph-node` will wait at least this long before
+  actually deleting the data (value is in minutes, defaults to 360, i.e. 6
+  hours)

--- a/node/src/manager/commands/unused_deployments.rs
+++ b/node/src/manager/commands/unused_deployments.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Instant};
 
-use graph::prelude::anyhow::Error;
+use graph::prelude::{anyhow::Error, chrono};
 use graph_store_postgres::{unused, SubgraphStore, UnusedDeployment};
 
 use crate::manager::display::List;
@@ -77,8 +77,13 @@ pub fn remove(
     store: Arc<SubgraphStore>,
     count: usize,
     deployment: Option<String>,
+    older: Option<chrono::Duration>,
 ) -> Result<(), Error> {
-    let unused = store.list_unused_deployments(unused::Filter::New)?;
+    let filter = match older {
+        Some(duration) => unused::Filter::UnusedLongerThan(duration),
+        None => unused::Filter::New,
+    };
+    let unused = store.list_unused_deployments(filter)?;
     let unused = match &deployment {
         None => unused,
         Some(deployment) => unused

--- a/store/postgres/src/jobs.rs
+++ b/store/postgres/src/jobs.rs
@@ -1,17 +1,25 @@
 //! Jobs for database maintenance
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use diesel::{prelude::RunQueryDsl, sql_query, sql_types::Double};
 
-use graph::prelude::{error, Logger, MetricsRegistry, StoreError};
+use graph::env::env_var;
+use graph::prelude::{chrono, error, lazy_static, Logger, MetricsRegistry, StoreError};
 use graph::prometheus::Gauge;
 use graph::util::jobs::{Job, Runner};
 
 use crate::connection_pool::ConnectionPool;
-use crate::{Store, SubgraphStore};
+use crate::{unused, Store, SubgraphStore};
+
+lazy_static! {
+    static ref UNUSED_INTERVAL: chrono::Duration = {
+        let interval: u32 = env_var("GRAPH_REMOVE_UNUSED_INTERVAL", 360);
+        chrono::Duration::minutes(interval as i64)
+    };
+}
 
 pub fn register(
     runner: &mut Runner,
@@ -33,6 +41,12 @@ pub fn register(
         Arc::new(MirrorPrimary::new(store.subgraph_store())),
         Duration::from_secs(15 * 60),
     );
+
+    // Remove unused deployments every 2 hours
+    runner.register(
+        Arc::new(UnusedJob::new(store.subgraph_store())),
+        Duration::from_secs(2 * 60 * 60),
+    )
 }
 
 /// A job that vacuums `subgraphs.subgraph_deployment`. With a large number
@@ -139,5 +153,64 @@ impl Job for MirrorPrimary {
 
     async fn run(&self, logger: &Logger) {
         self.store.mirror_primary_tables(logger).await;
+    }
+}
+
+struct UnusedJob {
+    store: Arc<SubgraphStore>,
+}
+
+impl UnusedJob {
+    fn new(store: Arc<SubgraphStore>) -> UnusedJob {
+        UnusedJob { store }
+    }
+}
+
+#[async_trait]
+impl Job for UnusedJob {
+    fn name(&self) -> &str {
+        "Record and remove unused deployments"
+    }
+
+    /// Record unused deployments and remove ones that were recorded at
+    /// least `UNUSED_INTERVAL` ago
+    async fn run(&self, logger: &Logger) {
+        // Work on removing about 5 minutes
+        const REMOVAL_DEADLINE: Duration = Duration::from_secs(5 * 60);
+
+        let start = Instant::now();
+
+        if let Err(e) = self.store.record_unused_deployments() {
+            error!(logger, "failed to record unused deployments"; "error" => e.to_string());
+            return;
+        }
+
+        let remove = match self
+            .store
+            .list_unused_deployments(unused::Filter::UnusedLongerThan(*UNUSED_INTERVAL))
+        {
+            Ok(remove) => remove,
+            Err(e) => {
+                error!(logger, "failed to list removable deployments"; "error" => e.to_string());
+                return;
+            }
+        };
+
+        for deployment in remove {
+            match self.store.remove_deployment(deployment.id) {
+                Ok(()) => { /* ignore */ }
+                Err(e) => {
+                    error!(logger, "failed to remove unused deployment";
+                                   "sgd" => deployment.id.to_string(),
+                                   "deployment" => deployment.deployment,
+                                   "error" => e.to_string());
+                }
+            }
+            // Stop working on removing after a while to not block other
+            // jobs for too long
+            if start.elapsed() > REMOVAL_DEADLINE {
+                return;
+            }
+        }
     }
 }

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -125,11 +125,16 @@ pub trait DeploymentPlacer {
 
 /// Tools for managing unused deployments
 pub mod unused {
+    use graph::prelude::chrono::Duration;
+
     pub enum Filter {
         /// List all unused deployments
         All,
         /// List only deployments that are unused but have not been removed yet
         New,
+        /// List only deployments that were recorded as unused at least this
+        /// long ago but have not been removed at
+        UnusedLongerThan(Duration),
     }
 }
 


### PR DESCRIPTION
With these changes, `graph-node` will automatically remove unused deployments, and it therefore won't be necessary to manually run `graphman unused record` and `graphman unused remove`. When a deployment is detected to be unused, `graph-node` will wait for `GRAPH_REMOVE_UNUSED_INTERVAL` minutes (default: 6hrs) before actually deleting the deployment's data. 

As a reminder, a deployment is considered unused if it is neither the current or pending version of a subgraph, and also not assigned to any indexing node.