### PR TITLE
Update block ingestor to fetch receipts in parallel.

### DIFF
--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -627,7 +627,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         &self,
         logger: &Logger,
         block: LightEthereumBlock,
-    ) -> Box<dyn Future<Item = EthereumBlock, Error = bc::IngestorError> + Send>;
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<EthereumBlock, bc::IngestorError>> + Send>>;
 
     /// Load block pointer for the specified `block number`.
     fn block_pointer_from_number(

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -704,7 +704,6 @@ impl IngestorAdapterTrait<Chain> for IngestorAdapter {
         let ethereum_block = self
             .eth_adapter
             .load_full_block(&self.logger, block)
-            .compat()
             .await?;
 
         // We need something that implements `Block` to store the block; the

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1083,7 +1083,12 @@ impl EthereumAdapterTrait for EthereumAdapter {
         let hash_stream = graph::tokio_stream::iter(hashes);
 
         let receipt_stream = graph::tokio_stream::StreamExt::map(hash_stream, move |tx_hash| {
-            resolve_transaction_receipt(web3.clone(), tx_hash.clone(), block_hash, logger.clone())
+            resolve_transaction_receipt(
+                web3.cheap_clone(),
+                tx_hash,
+                block_hash,
+                logger.cheap_clone(),
+            )
         })
         .buffered(*MAX_CONCURRENT_JSON_RPC_CALLS);
 

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1102,6 +1102,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
                 receipt_stream,
             ).boxed()
         } else {
+            // Deprecated batching retrieval of transaction receipts.
             fetch_transaction_receipts_in_batch_with_retry(web3, hashes, block_hash, logger).boxed()
         };
 
@@ -1800,6 +1801,7 @@ async fn filter_call_triggers_from_unsuccessful_transactions(
     Ok(block)
 }
 
+/// Deprecated. Wraps the [`fetch_transaction_receipts_in_batch`] in a retry loop.
 async fn fetch_transaction_receipts_in_batch_with_retry(
     web3: Arc<Web3<Transport>>,
     hashes: Vec<H256>,
@@ -1820,6 +1822,7 @@ async fn fetch_transaction_receipts_in_batch_with_retry(
         .map_err(|_timeout| anyhow!(block_hash).into())
 }
 
+/// Deprecated. Attempts to fetch multiple transaction receipts in a batching contex.
 async fn fetch_transaction_receipts_in_batch(
     web3: Arc<Web3<Transport>>,
     hashes: Vec<H256>,
@@ -1850,6 +1853,7 @@ async fn fetch_transaction_receipts_in_batch(
     Ok(collected)
 }
 
+/// Retries fetching a single transaction receipt.
 async fn fetch_transaction_receipt_with_retry(
     web3: Arc<Web3<Transport>>,
     transaction_hash: H256,

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -29,7 +29,6 @@ use graph::{
 use graph::{
     components::ethereum::*,
     prelude::web3::api::Web3,
-    prelude::web3::transports::batch::Batch,
     prelude::web3::types::{Trace, TraceFilter, TraceFilterBuilder, H160},
 };
 use itertools::Itertools;
@@ -40,7 +39,6 @@ use std::iter::FromIterator;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
-use web3::api::Web3;
 
 use crate::chain::BlockFinality;
 use crate::{
@@ -1798,7 +1796,7 @@ async fn resolve_transaction_receipt(
         .limit(*REQUEST_RETRIES)
         .no_logging()
         .timeout_secs(*JSON_RPC_TIMEOUT)
-        .run(move || web3.eth().transaction_receipt(transaction_hash).compat())
+        .run(move || web3.eth().transaction_receipt(transaction_hash))
         .await;
 
     match retry_result {

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1090,7 +1090,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
         let receipts_future = if *FETCH_RECEIPTS_CONCURRENTLY {
             let hash_stream = graph::tokio_stream::iter(hashes);
             let receipt_stream = graph::tokio_stream::StreamExt::map(hash_stream, move |tx_hash| {
-                resolve_single_transaction_receipt_with_retry(
+                fetch_transaction_receipt_with_retry(
                     web3.cheap_clone(),
                     tx_hash,
                     block_hash,
@@ -1102,7 +1102,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
                 receipt_stream,
             ).boxed()
         } else {
-            resolve_transaction_receipts_in_batch(web3, hashes, block_hash, logger).boxed()
+            fetch_transaction_receipts_in_batch(web3, hashes, block_hash, logger).boxed()
         };
 
         let block_future =
@@ -1800,7 +1800,7 @@ async fn filter_call_triggers_from_unsuccessful_transactions(
     Ok(block)
 }
 
-async fn resolve_transaction_receipts_in_batch(
+async fn fetch_transaction_receipts_in_batch(
     web3: Arc<Web3<Transport>>,
     hashes: Vec<H256>,
     block_hash: H256,
@@ -1830,7 +1830,7 @@ async fn resolve_transaction_receipts_in_batch(
     Ok(collected)
 }
 
-async fn resolve_single_transaction_receipt_with_retry(
+async fn fetch_transaction_receipt_with_retry(
     web3: Arc<Web3<Transport>>,
     transaction_hash: H256,
     block_hash: H256,

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1789,7 +1789,7 @@ async fn resolve_transaction_receipt(
     logger: Logger,
 ) -> Result<TransactionReceipt, IngestorError> {
     let retry_result = retry("batch eth_getTransactionReceipt RPC call", &logger)
-        .limit(16)
+        .limit(*REQUEST_RETRIES)
         .no_logging()
         .timeout_secs(*JSON_RPC_TIMEOUT)
         .run(move || web3.eth().transaction_receipt(transaction_hash).compat())

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1068,93 +1068,73 @@ impl EthereumAdapterTrait for EthereumAdapter {
         }
         let web3 = self.web3.clone();
 
-        // Retry, but eventually give up.
         // A receipt might be missing because the block was uncled, and the
         // transaction never made it back into the main chain.
-        Box::new(
-            retry("batch eth_getTransactionReceipt RPC call", &logger)
-                .limit(*REQUEST_RETRIES)
-                .no_logging()
-                .timeout_secs(*JSON_RPC_TIMEOUT)
-                .run(move || {
-                    let block = block.clone();
 
-                    let receipt_futures = block
-                        .transactions
-                        .iter()
-                        .map(|tx| {
-                            let logger = logger.clone();
-                            let tx_hash = tx.hash;
+        let block = block.clone();
 
-                            web3.eth()
-                                .transaction_receipt(tx_hash)
-                                .from_err()
-                                .map_err(IngestorError::Unknown)
-                                .and_then(move |receipt_opt| {
-                                    receipt_opt.ok_or_else(move || {
-                                        // No receipt was returned.
-                                        //
-                                        // This can be because the Ethereum node no longer
-                                        // considers this block to be part of the main chain,
-                                        // and so the transaction is no longer in the main
-                                        // chain.  Nothing we can do from here except give up
-                                        // trying to ingest this block.
-                                        //
-                                        // This could also be because the receipt is simply not
-                                        // available yet. For that case, we should retry until
-                                        // it becomes available.
-                                        IngestorError::ReceiptUnavailable(block_hash, tx_hash)
-                                    })
-                                })
-                                .and_then(move |receipt| {
-                                    // Check if the receipt has a block hash and is for the right
-                                    // block. Parity nodes seem to return receipts with no block
-                                    // hash when a transaction is no longer in the main chain, so
-                                    // treat that case the same as a receipt being absent entirely.
-                                    if receipt.block_hash != Some(block_hash) {
-                                        info!(
-                                            logger, "receipt block mismatch";
-                                            "receipt_block_hash" =>
-                                            receipt.block_hash.unwrap_or_default().to_string(),
-                                            "block_hash" =>
-                                                block_hash.to_string(),
-                                            "tx_hash" => tx_hash.to_string(),
-                                        );
+        let receipt_futures = block
+            .transactions
+            .iter()
+            .map(|tx| {
+                let logger = logger.clone();
+                let tx_hash = tx.hash;
 
-                                        // If the receipt came from a different block, then the
-                                        // Ethereum node no longer considers this block to be
-                                        // in the main chain.  Nothing we can do from here
-                                        // except give up trying to ingest this block.
-                                        // There is no way to get the transaction receipt from
-                                        // this block.
-                                        Err(IngestorError::BlockUnavailable(block_hash))
-                                    } else {
-                                        Ok(receipt)
-                                    }
-                                })
+                web3.eth()
+                    .transaction_receipt(tx_hash)
+                    .from_err()
+                    .map_err(IngestorError::Unknown)
+                    .and_then(move |receipt_opt| {
+                        receipt_opt.ok_or_else(move || {
+                            // No receipt was returned.
+                            //
+                            // This can be because the Ethereum node no longer
+                            // considers this block to be part of the main chain,
+                            // and so the transaction is no longer in the main
+                            // chain.  Nothing we can do from here except give up
+                            // trying to ingest this block.
+                            //
+                            // This could also be because the receipt is simply not
+                            // available yet. For that case, we should retry until
+                            // it becomes available.
+                            IngestorError::ReceiptUnavailable(block_hash, tx_hash)
                         })
-                        .collect::<Vec<_>>();
-
-                    stream::futures_ordered(receipt_futures)
-                        .collect()
-                        .map(move |transaction_receipts| EthereumBlock {
-                            block: Arc::new(block),
-                            transaction_receipts,
-                        })
-                        .compat()
-                })
-                .map_err(move |e| {
-                    e.into_inner().unwrap_or_else(move || {
-                        anyhow!(
-                            "Ethereum node took too long to return receipts for block {}",
-                            block_hash
-                        )
-                        .into()
                     })
-                })
-                .boxed()
-                .compat(),
-        )
+                    .and_then(move |receipt| {
+                        // Check if the receipt has a block hash and is for the right
+                        // block. Parity nodes seem to return receipts with no block
+                        // hash when a transaction is no longer in the main chain, so
+                        // treat that case the same as a receipt being absent entirely.
+                        if receipt.block_hash != Some(block_hash) {
+                            info!(
+                                logger, "receipt block mismatch";
+                                "receipt_block_hash" =>
+                                receipt.block_hash.unwrap_or_default().to_string(),
+                                "block_hash" =>
+                                    block_hash.to_string(),
+                                "tx_hash" => tx_hash.to_string(),
+                            );
+
+                            // If the receipt came from a different block, then the
+                            // Ethereum node no longer considers this block to be
+                            // in the main chain.  Nothing we can do from here
+                            // except give up trying to ingest this block.
+                            // There is no way to get the transaction receipt from
+                            // this block.
+                            Err(IngestorError::BlockUnavailable(block_hash))
+                        } else {
+                            Ok(receipt)
+                        }
+                    })
+            })
+            .collect::<Vec<_>>();
+
+        Box::new(stream::futures_ordered(receipt_futures).collect().map(
+            move |transaction_receipts| EthereumBlock {
+                block: Arc::new(block),
+                transaction_receipts,
+            },
+        ))
     }
 
     fn block_pointer_from_number(

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -7,7 +7,6 @@ use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::prelude::ethabi::ParamType;
 use graph::prelude::ethabi::Token;
 use graph::prelude::tokio::try_join;
-use graph::prelude::web3::transports::Batch;
 use graph::prelude::StopwatchMetrics;
 use graph::{
     blockchain::{block_stream::BlockWithTriggers, BlockPtr, IngestorError},
@@ -30,6 +29,7 @@ use graph::{
 use graph::{
     components::ethereum::*,
     prelude::web3::api::Web3,
+    prelude::web3::transports::Batch,
     prelude::web3::types::{Trace, TraceFilter, TraceFilterBuilder, H160},
 };
 use itertools::Itertools;

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -107,10 +107,12 @@ lazy_static! {
         .unwrap_or(Vec::new())
     };
 
-    static ref MAX_CONCURRENT_JSON_RPC_CALLS: usize = std::env::var("GRAPH_MAX_CONCURRENT_JSON_RPC_CALLS")
-            .unwrap_or("1000".into())
-            .parse::<usize>()
-            .expect("invalid GRAPH_MAX_CONCURRENT_JSON_RPC_CALLS env var");
+    static ref MAX_CONCURRENT_JSON_RPC_CALLS: usize = std::env::var(
+        "GRAPH_ETHEREUM_BLOCK_INGESTOR_MAX_CONCURRENT_JSON_RPC_CALLS_FOR_TXN_RECEIPTS"
+    )
+        .unwrap_or("1000".into())
+        .parse::<usize>()
+        .expect("invalid GRAPH_ETHEREUM_BLOCK_INGESTOR_MAX_CONCURRENT_JSON_RPC_CALLS_FOR_TXN_RECEIPTS env var");
 
 }
 

--- a/chain/ethereum/src/network_indexer/network_indexer.rs
+++ b/chain/ethereum/src/network_indexer/network_indexer.rs
@@ -204,7 +204,7 @@ fn fetch_block_and_ommers_by_number(
             adapter
                 .clone()
                 .block_by_number(&logger, block_number)
-                .from_err()
+                .map_err(Into::into)
         )
         .and_then(move |block| match block {
             None => {
@@ -224,8 +224,9 @@ fn fetch_block_and_ommers_by_number(
                     fetch_full_block_problems,
                     adapter_for_full_block
                         .load_full_block(&logger_for_full_block, block)
-                        .from_err()
+                        .map_err(Into::into)
                 )
+                .compat()
                 .and_then(move |block| {
                     fetch_ommers(
                         logger_for_ommers.clone(),

--- a/chain/ethereum/tests/network_indexer.rs
+++ b/chain/ethereum/tests/network_indexer.rs
@@ -246,7 +246,7 @@ fn create_mock_ethereum_adapter(
         .expect_load_full_block()
         .returning(move |_, block: LightEthereumBlock| {
             let chains = chains_for_load_full_block.lock().unwrap();
-            Box::new(future::result(
+            Box::pin(std::future::ready(
                 chains
                     .current_chain()
                     .ok_or_else(|| anyhow!("unknown chain {:?}", chains.index()))

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -34,6 +34,9 @@ those.
   subgraph if the limit is reached, but will simply restart the syncing step,
   so it can be low. This limit guards against scenarios such as requesting a
   block hash that has been reorged. Defaults to 10.
+- `GRAPH_ETHEREUM_MAX _CONCURRENT_JSON_RPC_CALLS`: The maximum number of
+   requests in-flight at once against Ethereum per batching context.
+   Defaultso 1,000.
 - `GRAPH_ETHEREUM_CLEANUP_BLOCKS` : Set to `true` to clean up unneeded
   blocks from the cache in the database. When this is `false` or unset (the
   default), blocks will never be removed from the block cache. This setting

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -34,8 +34,9 @@ those.
   subgraph if the limit is reached, but will simply restart the syncing step,
   so it can be low. This limit guards against scenarios such as requesting a
   block hash that has been reorged. Defaults to 10.
-- `GRAPH_ETHEREUM_BLOCK_INGESTOR_MAX_CONCURRENT_JSON_RPC_CALLS`: The maximum
-   number of concurrent requests made against Ethereum during block ingestion.
+- `GRAPH_ETHEREUM_BLOCK_INGESTOR_MAX_CONCURRENT_JSON_RPC_CALLS_FOR_TXN_RECEIPTS`:
+   The maximum number of concurrent requests made against Ethereum for
+   requesting transaction receipts during block ingestion.
    Defaults to 1,000.
 - `GRAPH_ETHEREUM_CLEANUP_BLOCKS` : Set to `true` to clean up unneeded
   blocks from the cache in the database. When this is `false` or unset (the

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -34,8 +34,8 @@ those.
   subgraph if the limit is reached, but will simply restart the syncing step,
   so it can be low. This limit guards against scenarios such as requesting a
   block hash that has been reorged. Defaults to 10.
-- `GRAPH_ETHEREUM_MAX_CONCURRENT_JSON_RPC_CALLS`: The maximum number of
-   requests in-flight at once against Ethereum per batching context.
+- `GRAPH_ETHEREUM_BLOCK_INGESTOR_MAX_CONCURRENT_JSON_RPC_CALLS`: The maximum
+   number of concurrent requests made against Ethereum during block ingestion.
    Defaults to 1,000.
 - `GRAPH_ETHEREUM_CLEANUP_BLOCKS` : Set to `true` to clean up unneeded
   blocks from the cache in the database. When this is `false` or unset (the

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -34,9 +34,9 @@ those.
   subgraph if the limit is reached, but will simply restart the syncing step,
   so it can be low. This limit guards against scenarios such as requesting a
   block hash that has been reorged. Defaults to 10.
-- `GRAPH_ETHEREUM_MAX _CONCURRENT_JSON_RPC_CALLS`: The maximum number of
+- `GRAPH_ETHEREUM_MAX_CONCURRENT_JSON_RPC_CALLS`: The maximum number of
    requests in-flight at once against Ethereum per batching context.
-   Defaultso 1,000.
+   Defaults to 1,000.
 - `GRAPH_ETHEREUM_CLEANUP_BLOCKS` : Set to `true` to clean up unneeded
   blocks from the cache in the database. When this is `false` or unset (the
   default), blocks will never be removed from the block cache. This setting

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -154,6 +154,12 @@ impl From<Error> for IngestorError {
     }
 }
 
+impl From<web3::Error> for IngestorError {
+    fn from(e: web3::Error) -> Self {
+        IngestorError::Unknown(anyhow::anyhow!(e))
+    }
+}
+
 #[async_trait]
 pub trait IngestorAdapter<C: Blockchain> {
     fn logger(&self) -> &Logger;


### PR DESCRIPTION
Replaces `Web3:Batch` with buffered, concurrent RPC calls when fetching transaction receipts for a block.

The `fn load_full_block` was updated to use `std::future::Future` and the actual handling of fetching transaction receipts was moved to a dedicated function called `fn resolve_transaction_receipts`, which uses a retry strategy for each request.

Fixes #3018
