### PR TITLE
Fix docker-compose host IP for linux

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     depends_on:
       - ipfs
       - postgres
+    extra_hosts:
+      - host.docker.internal:host-gateway
     environment:
       postgres_host: postgres
       postgres_user: graph-node


### PR DESCRIPTION
This should fix issue https://github.com/docker/for-linux/issues/264

Also file `./docker/setup.sh` shouldn't be needed anymore

This step shouldn't be required anymore https://thegraph.academy/developers/local-development/
![image](https://user-images.githubusercontent.com/2295236/144605318-0550f19b-7b2e-43ad-8e6e-28d589460a7e.png)
