### PR TITLE
Fix warnings about fields never being read

### DIFF
--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -60,15 +60,15 @@ impl std::fmt::Debug for MappingTrigger {
         #[derive(Debug)]
         enum MappingTriggerWithoutBlock {
             Log {
-                transaction: Arc<Transaction>,
-                log: Arc<Log>,
-                params: Vec<LogParam>,
+                _transaction: Arc<Transaction>,
+                _log: Arc<Log>,
+                _params: Vec<LogParam>,
             },
             Call {
-                transaction: Arc<Transaction>,
-                call: Arc<EthereumCall>,
-                inputs: Vec<LogParam>,
-                outputs: Vec<LogParam>,
+                _transaction: Arc<Transaction>,
+                _call: Arc<EthereumCall>,
+                _inputs: Vec<LogParam>,
+                _outputs: Vec<LogParam>,
             },
             Block,
         }
@@ -80,9 +80,9 @@ impl std::fmt::Debug for MappingTrigger {
                 log,
                 params,
             } => MappingTriggerWithoutBlock::Log {
-                transaction: transaction.cheap_clone(),
-                log: log.cheap_clone(),
-                params: params.clone(),
+                _transaction: transaction.cheap_clone(),
+                _log: log.cheap_clone(),
+                _params: params.clone(),
             },
             MappingTrigger::Call {
                 block: _,
@@ -91,10 +91,10 @@ impl std::fmt::Debug for MappingTrigger {
                 inputs,
                 outputs,
             } => MappingTriggerWithoutBlock::Call {
-                transaction: transaction.cheap_clone(),
-                call: call.cheap_clone(),
-                inputs: inputs.clone(),
-                outputs: outputs.clone(),
+                _transaction: transaction.cheap_clone(),
+                _call: call.cheap_clone(),
+                _inputs: inputs.clone(),
+                _outputs: outputs.clone(),
             },
             MappingTrigger::Block { block: _ } => MappingTriggerWithoutBlock::Block,
         };

--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -18,7 +18,7 @@ pub struct FirehoseEndpoint {
     pub uri: String,
     pub token: Option<String>,
     channel: Channel,
-    logger: Logger,
+    _logger: Logger,
 }
 
 impl Display for FirehoseEndpoint {
@@ -61,7 +61,7 @@ impl FirehoseEndpoint {
             uri,
             channel,
             token,
-            logger,
+            _logger: logger,
         })
     }
 

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -297,7 +297,7 @@ fn input_value(
 
 #[derive(Clone)]
 pub struct IntrospectionResolver {
-    logger: Logger,
+    _logger: Logger,
     type_objects: TypeObjectsMap,
     directives: r::Value,
 }
@@ -313,7 +313,7 @@ impl IntrospectionResolver {
         let directives = schema_directive_objects(schema, &mut type_objects);
 
         IntrospectionResolver {
-            logger,
+            _logger: logger,
             type_objects,
             directives,
         }

--- a/node/src/manager/commands/copy.rs
+++ b/node/src/manager/commands/copy.rs
@@ -25,6 +25,7 @@ type UtcDateTime = DateTime<Utc>;
 struct CopyState {
     src: i32,
     dst: i32,
+    #[allow(dead_code)]
     target_block_hash: Vec<u8>,
     target_block_number: i32,
     started_at: UtcDateTime,
@@ -35,12 +36,15 @@ struct CopyState {
 #[derive(Queryable, QueryableByName, Debug)]
 #[table_name = "copy_table_state"]
 struct CopyTableState {
+    #[allow(dead_code)]
     id: i32,
     entity_type: String,
+    #[allow(dead_code)]
     dst: i32,
     next_vid: i64,
     target_vid: i64,
     batch_size: i64,
+    #[allow(dead_code)]
     started_at: UtcDateTime,
     finished_at: Option<UtcDateTime>,
     duration_ms: i64,

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -35,10 +35,18 @@ struct StartPayload {
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum IncomingMessage {
-    ConnectionInit { payload: Option<serde_json::Value> },
+    ConnectionInit {
+        #[allow(dead_code)]
+        payload: Option<serde_json::Value>,
+    },
     ConnectionTerminate,
-    Start { id: String, payload: StartPayload },
-    Stop { id: String },
+    Start {
+        id: String,
+        payload: StartPayload,
+    },
+    Stop {
+        id: String,
+    },
 }
 
 impl IncomingMessage {

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -117,6 +117,7 @@ pub fn supports_proof_of_indexing(
     #[derive(Debug, QueryableByName)]
     struct Table {
         #[sql_type = "Text"]
+        #[allow(dead_code)]
         pub table_name: String,
     }
     let query =

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -193,6 +193,7 @@ allow_tables_to_appear_in_same_query!(
 #[table_name = "deployment_schemas"]
 struct Schema {
     id: DeploymentId,
+    #[allow(dead_code)]
     pub created_at: PgTimestamp,
     pub subgraph: String,
     pub name: String,

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -547,7 +547,7 @@ impl Layout {
             tables.push(self.table_for_entity(entity_type)?.as_ref());
         }
         let query = FindManyQuery {
-            namespace: &self.catalog.site.namespace,
+            _namespace: &self.catalog.site.namespace,
             ids_for_type,
             tables,
             block,

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1210,7 +1210,7 @@ impl<'a, Conn> RunQueryDsl<Conn> for FindQuery<'a> {}
 
 #[derive(Debug, Clone, Constructor)]
 pub struct FindManyQuery<'a> {
-    pub(crate) namespace: &'a Namespace,
+    pub(crate) _namespace: &'a Namespace,
     pub(crate) tables: Vec<&'a Table>,
 
     // Maps object name to ids.
@@ -1407,7 +1407,7 @@ impl<'a, Conn> RunQueryDsl<Conn> for InsertQuery<'a> {}
 
 #[derive(Debug, Clone)]
 pub struct ConflictingEntityQuery<'a> {
-    layout: &'a Layout,
+    _layout: &'a Layout,
     tables: Vec<&'a Table>,
     entity_id: &'a str,
 }
@@ -1422,7 +1422,7 @@ impl<'a> ConflictingEntityQuery<'a> {
             .map(|entity| layout.table_for_entity(entity).map(|table| table.as_ref()))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(ConflictingEntityQuery {
-            layout,
+            _layout: layout,
             tables,
             entity_id,
         })

--- a/tests/tests/parallel_tests.rs
+++ b/tests/tests/parallel_tests.rs
@@ -65,7 +65,7 @@ impl IntegrationTestSetup {
 #[derive(Debug)]
 struct TestCommandResults {
     success: bool,
-    exit_code: Option<i32>,
+    _exit_code: Option<i32>,
     stdout: String,
     stderr: String,
 }
@@ -341,7 +341,7 @@ async fn run_test_command(test_setup: &IntegrationTestSetup) -> anyhow::Result<T
 
     Ok(TestCommandResults {
         success: output.status.success(),
-        exit_code: output.status.code(),
+        _exit_code: output.status.code(),
         stdout: pretty_output(&output.stdout, &stdout_tag),
         stderr: pretty_output(&output.stderr, &stderr_tag),
     })


### PR DESCRIPTION
Unused fields were prefixed with an underscore. 

Fields from de/serialization structs kept their names and were annotated with `#[allow(dead_code)]`.