### PR TITLE
chain/ethereum: Fix ethabi type mismatch error msg

### DIFF
--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -45,7 +45,7 @@ pub enum EthereumContractCallError {
     #[error("ABI error: {0}")]
     ABIError(ABIError),
     /// `Token` is not of expected `ParamType`
-    #[error("type mismatch, token {0:?} is not of kind {0:?}")]
+    #[error("type mismatch, token {0:?} is not of kind {1:?}")]
     TypeError(Token, ParamType),
     #[error("error encoding input call data: {0}")]
     EncodingError(ethabi::Error),


### PR DESCRIPTION
This will help debug this issue: https://github.com/graphprotocol/graph-ts/issues/211.

Before the same parameter would be printed twice like:

```
Failed to call function "hashOrder_" of contract "WyvernExchange": type mismatch, token
Array([Address(0x7be8076f4ea4a4ad08075c2508e481d6c946d12b), Address(0xb13c38273e001f0427c26f15b79b57db90606a91), Address(0x0000000000000000000000000000000000000000), Address(0x0000000000000000000000000000000000000000), Address(0x79986af15539de2db9a5086382daeda917a9cf0c), Address(0x0000000000000000000000000000000000000000), Address(0x0000000000000000000000000000000000000000)])

 is not of kind

Array([Address(0x7be8076f4ea4a4ad08075c2508e481d6c946d12b), Address(0xb13c38273e001f0427c26f15b79b57db90606a91), Address(0x0000000000000000000000000000000000000000), Address(0x0000000000000000000000000000000000000000), Address(0x79986af15539de2db9a5086382daeda917a9cf0c), Address(0x0000000000000000000000000000000000000000), Address(0x0000000000000000000000000000000000000000)])
```
