### PR TITLE
Initial addition of FirehoseBlockIngestor for NEAR (and other Firehose chains)

### DIFF
--- a/chain/near/proto/codec.proto
+++ b/chain/near/proto/codec.proto
@@ -12,6 +12,16 @@ message Block {
   repeated StateChangeWithCause state_changes = 5;
 }
 
+// HeaderOnlyBlock is a standard [Block] structure where all other fields are
+// removed so that hydrating that object from a [Block] bytes payload will
+// drastically reduced allocated memory required to hold the full block.
+//
+// This can be used to unpack a [Block] when only the [BlockHeader] information
+// is required and greatly reduced required memory.
+message HeaderOnlyBlock {
+  BlockHeader header = 2;
+}
+
 message StateChangeWithCause {
   StateChangeValue value = 1;
   StateChangeCause cause = 2;

--- a/chain/near/src/codec.rs
+++ b/chain/near/src/codec.rs
@@ -2,7 +2,7 @@
 mod pbcodec;
 
 use graph::{
-    blockchain::Block as Blockchainblock,
+    blockchain::Block as BlockchainBlock,
     blockchain::BlockPtr,
     prelude::{hex, web3::types::H256, BlockNumber},
 };
@@ -53,7 +53,7 @@ impl<'a> From<&'a Block> for BlockPtr {
     }
 }
 
-impl Blockchainblock for Block {
+impl BlockchainBlock for Block {
     fn number(&self) -> i32 {
         BlockNumber::try_from(self.header().height).unwrap()
     }

--- a/chain/near/src/codec.rs
+++ b/chain/near/src/codec.rs
@@ -23,18 +23,28 @@ impl LowerHex for &CryptoHash {
     }
 }
 
+impl BlockHeader {
+    pub fn parent_ptr(&self) -> Option<BlockPtr> {
+        match (self.prev_hash.as_ref(), self.prev_height) {
+            (Some(hash), number) => Some(BlockPtr::from((hash.into(), number))),
+            _ => None,
+        }
+    }
+}
+
+impl<'a> From<&'a BlockHeader> for BlockPtr {
+    fn from(b: &'a BlockHeader) -> BlockPtr {
+        BlockPtr::from((b.hash.as_ref().unwrap().into(), b.height))
+    }
+}
+
 impl Block {
     pub fn header(&self) -> &BlockHeader {
         self.header.as_ref().unwrap()
     }
 
     pub fn parent_ptr(&self) -> Option<BlockPtr> {
-        let header = self.header();
-
-        match (header.prev_hash.as_ref(), header.prev_height) {
-            (Some(hash), number) => Some(BlockPtr::from((hash.into(), number))),
-            _ => None,
-        }
+        self.header().parent_ptr()
     }
 }
 
@@ -46,10 +56,7 @@ impl From<Block> for BlockPtr {
 
 impl<'a> From<&'a Block> for BlockPtr {
     fn from(b: &'a Block) -> BlockPtr {
-        let header = b.header();
-        let hash: H256 = header.hash.as_ref().unwrap().into();
-
-        BlockPtr::from((hash, header.height))
+        BlockPtr::from(b.header())
     }
 }
 
@@ -64,6 +71,32 @@ impl BlockchainBlock for Block {
 
     fn parent_ptr(&self) -> Option<BlockPtr> {
         self.parent_ptr()
+    }
+}
+
+impl HeaderOnlyBlock {
+    pub fn header(&self) -> &BlockHeader {
+        self.header.as_ref().unwrap()
+    }
+}
+
+impl<'a> From<&'a HeaderOnlyBlock> for BlockPtr {
+    fn from(b: &'a HeaderOnlyBlock) -> BlockPtr {
+        BlockPtr::from(b.header())
+    }
+}
+
+impl BlockchainBlock for HeaderOnlyBlock {
+    fn number(&self) -> i32 {
+        BlockNumber::try_from(self.header().height).unwrap()
+    }
+
+    fn ptr(&self) -> BlockPtr {
+        self.into()
+    }
+
+    fn parent_ptr(&self) -> Option<BlockPtr> {
+        self.header().parent_ptr()
     }
 }
 

--- a/chain/near/src/lib.rs
+++ b/chain/near/src/lib.rs
@@ -8,3 +8,4 @@ mod trigger;
 
 pub use crate::chain::Chain;
 pub use codec::Block;
+pub use codec::HeaderOnlyBlock;

--- a/chain/near/src/lib.rs
+++ b/chain/near/src/lib.rs
@@ -7,3 +7,4 @@ mod runtime;
 mod trigger;
 
 pub use crate::chain::Chain;
+pub use codec::Block;

--- a/chain/near/src/protobuf/sf.near.codec.v1.rs
+++ b/chain/near/src/protobuf/sf.near.codec.v1.rs
@@ -11,6 +11,17 @@ pub struct Block {
     #[prost(message, repeated, tag = "5")]
     pub state_changes: ::prost::alloc::vec::Vec<StateChangeWithCause>,
 }
+/// HeaderOnlyBlock is a standard [Block] structure where all other fields are
+/// removed so that hydrating that object from a [Block] bytes payload will
+/// drastically reduced allocated memory required to hold the full block.
+///
+/// This can be used to unpack a [Block] when only the [BlockHeader] information
+/// is required and greatly reduced required memory.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HeaderOnlyBlock {
+    #[prost(message, optional, tag = "2")]
+    pub header: ::core::option::Option<BlockHeader>,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StateChangeWithCause {
     #[prost(message, optional, tag = "1")]

--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Error};
 use futures03::StreamExt;
 use slog::trace;
 use tonic::Streaming;
+
 pub struct FirehoseBlockIngestor<M>
 where
     M: prost::Message + BlockchainBlock + Default + 'static,
@@ -54,6 +55,7 @@ where
                 .endpoint
                 .clone()
                 .stream_blocks(bstream::BlocksRequestV2 {
+                    // Starts at current HEAD block of the chain (viewed from Firehose side)
                     start_block_num: -1,
                     start_cursor: latest_cursor.clone(),
                     fork_steps: vec![
@@ -65,7 +67,10 @@ where
                 .await;
 
             match result {
-                Ok(stream) => latest_cursor = self.process_blocks(latest_cursor, stream).await,
+                Ok(stream) => {
+                    // Consume the stream of blocks until an error is hit
+                    latest_cursor = self.process_blocks(latest_cursor, stream).await
+                }
                 Err(e) => {
                     error!(self.logger, "Unable to connect to endpoint: {:?}", e);
                 }
@@ -91,11 +96,16 @@ where
         }
     }
 
+    /// Consumes the incoming stream of blocks infinitely until it hits an error. In which case
+    /// the error is logged right away and the latest available cursor is returned
+    /// upstream for future consumption.
     async fn process_blocks(
         &self,
         cursor: String,
         mut stream: Streaming<bstream::BlockResponseV2>,
     ) -> String {
+        use bstream::ForkStep::*;
+
         let mut latest_cursor = cursor;
 
         while let Some(message) = stream.next().await {
@@ -105,13 +115,13 @@ where
                         .expect("Fork step should always match to known value");
 
                     let result = match step {
-                        bstream::ForkStep::StepNew => self.process_new_block(&v).await,
-                        bstream::ForkStep::StepUndo => {
+                        StepNew => self.process_new_block(&v).await,
+                        StepUndo => {
                             trace!(self.logger, "Received undo block to ingest, skipping");
                             Ok(())
                         }
-                        _ => panic!(
-                            "We explicitely requested StepNew|StepUndo but received something else"
+                        StepIrreversible | StepUnknown => panic!(
+                            "We explicitly requested StepNew|StepUndo but received something else"
                         ),
                     };
 

--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -1,0 +1,157 @@
+use std::{marker::PhantomData, sync::Arc, time::Duration};
+
+use crate::{
+    blockchain::Block as BlockchainBlock,
+    components::store::ChainStore,
+    firehose::{bstream, decode_firehose_block, endpoints::FirehoseEndpoint},
+    prelude::{error, info, Logger},
+    util::backoff::ExponentialBackoff,
+};
+use anyhow::{Context, Error};
+use futures03::StreamExt;
+use slog::trace;
+use tonic::Streaming;
+pub struct FirehoseBlockIngestor<M>
+where
+    M: prost::Message + BlockchainBlock + Default + 'static,
+{
+    ancestor_count: i32,
+    chain_store: Arc<dyn ChainStore>,
+    endpoint: Arc<FirehoseEndpoint>,
+    logger: Logger,
+
+    phantom: PhantomData<M>,
+}
+
+impl<M> FirehoseBlockIngestor<M>
+where
+    M: prost::Message + BlockchainBlock + Default + 'static,
+{
+    pub fn new(
+        ancestor_count: i32,
+        chain_store: Arc<dyn ChainStore>,
+        endpoint: Arc<FirehoseEndpoint>,
+        logger: Logger,
+    ) -> FirehoseBlockIngestor<M> {
+        FirehoseBlockIngestor {
+            ancestor_count,
+            chain_store,
+            endpoint,
+            logger,
+            phantom: PhantomData {},
+        }
+    }
+
+    pub async fn run(self) {
+        let mut latest_cursor = self.fetch_head_cursor().await;
+        let mut backoff =
+            ExponentialBackoff::new(Duration::from_millis(250), Duration::from_secs(30));
+
+        loop {
+            info!(
+                self.logger,
+                "Blockstream disconnected, connecting"; "endpoint uri" => format_args!("{}", self.endpoint), "cursor" => format_args!("{}", latest_cursor),
+            );
+
+            let result = self
+                .endpoint
+                .clone()
+                .stream_blocks(bstream::BlocksRequestV2 {
+                    start_block_num: -1,
+                    start_cursor: latest_cursor.clone(),
+                    fork_steps: vec![
+                        bstream::ForkStep::StepNew as i32,
+                        bstream::ForkStep::StepUndo as i32,
+                    ],
+                    ..Default::default()
+                })
+                .await;
+
+            match result {
+                Ok(stream) => latest_cursor = self.process_blocks(latest_cursor, stream).await,
+                Err(e) => {
+                    error!(self.logger, "Unable to connect to endpoint: {:?}", e);
+                }
+            }
+
+            // If we reach this point, we must wait a bit before retrying
+            backoff.sleep_async().await;
+        }
+    }
+
+    async fn fetch_head_cursor(&self) -> String {
+        let mut backoff =
+            ExponentialBackoff::new(Duration::from_millis(250), Duration::from_secs(30));
+        loop {
+            match self.chain_store.clone().chain_head_cursor() {
+                Ok(cursor) => return cursor.unwrap_or_else(|| "".to_string()),
+                Err(e) => {
+                    error!(self.logger, "Fetching chain head cursor failed: {:?}", e);
+
+                    backoff.sleep_async().await;
+                }
+            }
+        }
+    }
+
+    async fn process_blocks(
+        &self,
+        cursor: String,
+        mut stream: Streaming<bstream::BlockResponseV2>,
+    ) -> String {
+        let mut latest_cursor = cursor;
+
+        while let Some(message) = stream.next().await {
+            match message {
+                Ok(v) => {
+                    if let Err(e) = self.process_block(&v).await {
+                        error!(self.logger, "Process block failed: {:?}", e);
+                        break;
+                    }
+
+                    latest_cursor = v.cursor;
+                }
+                Err(e) => {
+                    info!(
+                        self.logger,
+                        "An error occurred while streaming blocks: {}", e
+                    );
+                    break;
+                }
+            }
+        }
+
+        error!(
+            self.logger,
+            "Stream blocks complete unexpectedly, expecting stream to always stream blocks"
+        );
+        latest_cursor
+    }
+
+    async fn process_block(&self, response: &bstream::BlockResponseV2) -> Result<(), Error> {
+        let block = decode_firehose_block::<M>(response)
+            .context("Mapping firehose block to blockchain::Block")?;
+
+        trace!(self.logger, "Received block to ingest {}", block.ptr());
+
+        self.chain_store
+            .clone()
+            .upsert_block(block.clone())
+            .await
+            .context("Inserting blockchain::Block in chain store")?;
+
+        self.chain_store
+            .clone()
+            .attempt_chain_head_update(self.ancestor_count)
+            .await
+            .context("Updating chain head update")?;
+
+        self.chain_store
+            .clone()
+            .set_chain_head_cursor(response.cursor.clone())
+            .await
+            .context("Updating chain head cursor")?;
+
+        Ok(())
+    }
+}

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod block_ingestor;
 pub mod block_stream;
+pub mod firehose_block_ingestor;
 pub mod firehose_block_stream;
 pub mod polling_block_stream;
 mod types;

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1324,8 +1324,15 @@ pub trait ChainStore: Send + Sync + 'static {
     /// The head block cursor will be None on initial set up.
     fn chain_head_cursor(&self) -> Result<Option<String>, Error>;
 
-    /// Set the current head block cursor for this chain.
-    async fn set_chain_head_cursor(self: Arc<Self>, cursor: String) -> Result<(), Error>;
+    /// This method does actually three operations:
+    /// - Upserts received block into blocks table
+    /// - Update chain head block into networks table
+    /// - Update chain head cursor into networks table
+    async fn set_chain_head(
+        self: Arc<Self>,
+        block: Arc<dyn Block>,
+        cursor: String,
+    ) -> Result<(), Error>;
 
     /// Returns the blocks present in the store.
     fn blocks(&self, hashes: &[H256]) -> Result<Vec<serde_json::Value>, Error>;

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1318,8 +1318,6 @@ pub trait ChainStore: Send + Sync + 'static {
     fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error>;
 
     /// Get the current head block cursor for this chain.
-    /// Any changes to the head block cursor will be to a block with a larger block number, never
-    /// to a block with a smaller or equal block number.
     ///
     /// The head block cursor will be None on initial set up.
     fn chain_head_cursor(&self) -> Result<Option<String>, Error>;

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1317,6 +1317,16 @@ pub trait ChainStore: Send + Sync + 'static {
     /// The head block pointer will be None on initial set up.
     fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error>;
 
+    /// Get the current head block cursor for this chain.
+    /// Any changes to the head block cursor will be to a block with a larger block number, never
+    /// to a block with a smaller or equal block number.
+    ///
+    /// The head block cursor will be None on initial set up.
+    fn chain_head_cursor(&self) -> Result<Option<String>, Error>;
+
+    /// Set the current head block cursor for this chain.
+    async fn set_chain_head_cursor(self: Arc<Self>, cursor: String) -> Result<(), Error>;
+
     /// Returns the blocks present in the store.
     fn blocks(&self, hashes: &[H256]) -> Result<Vec<serde_json::Value>, Error>;
 

--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -1,5 +1,12 @@
-use crate::cheap_clone::CheapClone;
+use crate::{
+    blockchain::Block as BlockchainBlock,
+    blockchain::BlockPtr,
+    cheap_clone::CheapClone,
+    firehose::decode_firehose_block,
+    prelude::{debug, info},
+};
 use anyhow::Context;
+use futures03::StreamExt;
 use http::uri::{Scheme, Uri};
 use rand::prelude::IteratorRandom;
 use slog::Logger;
@@ -63,6 +70,50 @@ impl FirehoseEndpoint {
             token,
             _logger: logger,
         })
+    }
+
+    pub async fn genesis_block_ptr<M>(&self, logger: &Logger) -> Result<BlockPtr, anyhow::Error>
+    where
+        M: prost::Message + BlockchainBlock + Default + 'static,
+    {
+        let token_metadata = match self.token.clone() {
+            Some(token) => Some(MetadataValue::from_str(token.as_str())?),
+            None => None,
+        };
+
+        let mut client = bstream::block_stream_v2_client::BlockStreamV2Client::with_interceptor(
+            self.channel.cheap_clone(),
+            move |mut r: Request<()>| match token_metadata.as_ref() {
+                Some(t) => {
+                    r.metadata_mut().insert("authorization", t.clone());
+                    Ok(r)
+                }
+                _ => Ok(r),
+            },
+        );
+
+        debug!(logger, "Connecting to firehose to retrieve genesis block");
+        let response_stream = client
+            .blocks(bstream::BlocksRequestV2 {
+                start_block_num: 0,
+                details: bstream::BlockDetails::Light as i32,
+                fork_steps: vec![bstream::ForkStep::StepIrreversible as i32],
+                ..Default::default()
+            })
+            .await?;
+
+        let mut block_stream = response_stream.into_inner();
+
+        info!(logger, "Requesting genesis block from firehose");
+        let next = block_stream.next().await;
+
+        match next {
+            Some(Ok(v)) => Ok(decode_firehose_block::<M>(&v)?.ptr()),
+            Some(Err(e)) => Err(anyhow::format_err!("firehose error {}", e)),
+            None => Err(anyhow::format_err!(
+                "firehose should have returned one block for genesis block request"
+            )),
+        }
     }
 
     pub async fn stream_blocks(

--- a/graph/src/firehose/helpers.rs
+++ b/graph/src/firehose/helpers.rs
@@ -1,0 +1,19 @@
+use std::sync::Arc;
+
+use super::bstream;
+use crate::blockchain::Block as BlockchainBlock;
+use anyhow::Error;
+
+pub fn decode_firehose_block<M>(
+    block_response: &bstream::BlockResponseV2,
+) -> Result<Arc<dyn BlockchainBlock>, Error>
+where
+    M: prost::Message + BlockchainBlock + Default + 'static,
+{
+    let any_block = block_response
+        .block
+        .as_ref()
+        .expect("block payload information should always be present");
+
+    Ok(Arc::new(M::decode(any_block.value.as_ref())?))
+}

--- a/graph/src/firehose/mod.rs
+++ b/graph/src/firehose/mod.rs
@@ -2,7 +2,10 @@
 mod pbbstream;
 
 pub mod endpoints;
+mod helpers;
 
 pub mod bstream {
     pub use super::pbbstream::*;
 }
+
+pub use helpers::decode_firehose_block;

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,6 +1,7 @@
 use ethereum::{EthereumNetworks, NodeCapabilities, ProviderEthRpcMetrics};
 use futures::future::join_all;
 use git_testament::{git_testament, render_testament};
+use graph::blockchain::firehose_block_ingestor::FirehoseBlockIngestor;
 use graph::firehose::endpoints::{FirehoseEndpoint, FirehoseNetworkEndpoints, FirehoseNetworks};
 use graph::{ipfs_client::IpfsClient, prometheus::Registry};
 use lazy_static::lazy_static;
@@ -16,7 +17,7 @@ use tokio::sync::mpsc;
 
 use graph::blockchain::block_ingestor::BlockIngestor;
 use graph::blockchain::{
-    BlockHash, Blockchain as _, BlockchainKind, BlockchainMap, ChainIdentifier,
+    Block as BlockchainBlock, Blockchain, BlockchainKind, BlockchainMap, ChainIdentifier,
 };
 use graph::components::store::BlockStore;
 use graph::data::graphql::effort::LoadManager;
@@ -24,7 +25,7 @@ use graph::log::logger;
 use graph::prelude::{IndexNodeServer as _, JsonRpcServer as _, *};
 use graph::util::security::SafeDisplay;
 use graph_chain_ethereum::{self as ethereum, network_indexer, EthereumAdapterTrait, Transport};
-use graph_chain_near::{self as near};
+use graph_chain_near::{self as near, Block as NearFirehoseBlock};
 use graph_core::{
     LinkResolver, MetricsRegistry, SubgraphAssignmentProvider as IpfsSubgraphAssignmentProvider,
     SubgraphInstanceManager, SubgraphRegistrar as IpfsSubgraphRegistrar,
@@ -65,7 +66,7 @@ lazy_static! {
 /// How long we will hold up node startup to get the net version and genesis
 /// hash from the client. If we can't get it within that time, we'll try and
 /// continue regardless.
-const ETH_NET_VERSION_WAIT_TIME: Duration = Duration::from_secs(30);
+const NET_VERSION_WAIT_TIME: Duration = Duration::from_secs(30);
 
 git_testament!(TESTAMENT);
 
@@ -200,7 +201,7 @@ async fn main() {
             .expect("Failed to parse Ethereum networks")
     };
 
-    let firehose_networks_by_kind = if query_only {
+    let mut firehose_networks_by_kind = if query_only {
         BTreeMap::new()
     } else {
         create_firehose_networks(logger.clone(), metrics_registry.clone(), &config)
@@ -228,14 +229,15 @@ async fn main() {
         let mut blockchain_map = BlockchainMap::new();
 
         let (eth_networks, ethereum_idents) = connect_networks(&logger, eth_networks).await;
-        let near_idents =
-            compute_near_network_identifiers(firehose_networks_by_kind.get(&BlockchainKind::Near));
+        let (near_networks, near_idents) = connect_firehose_networks::<NearFirehoseBlock>(
+            &logger,
+            firehose_networks_by_kind
+                .remove(&BlockchainKind::Near)
+                .unwrap_or_else(|| FirehoseNetworks::new()),
+        )
+        .await;
 
-        let network_identifiers = ethereum_idents
-            .into_iter()
-            .chain(near_idents.into_iter())
-            .collect();
-
+        let network_identifiers = ethereum_idents.into_iter().chain(near_idents).collect();
         let network_store = store_builder.network_store(network_identifiers);
 
         let ethereum_chains = ethereum_networks_as_chains(
@@ -250,10 +252,10 @@ async fn main() {
             &logger_factory,
         );
 
-        near_networks_as_chains(
+        let near_chains = near_networks_as_chains(
             &mut blockchain_map,
             &logger,
-            firehose_networks_by_kind.get(&BlockchainKind::Near),
+            &near_networks,
             network_store.as_ref(),
             &logger_factory,
         );
@@ -331,6 +333,15 @@ async fn main() {
                 let block_polling_interval = Duration::from_millis(opt.ethereum_polling_interval);
 
                 start_block_ingestor(&logger, block_polling_interval, ethereum_chains);
+            }
+
+            if near_chains.len() > 0 {
+                start_firehose_block_ingestor::<_, NearFirehoseBlock>(
+                    3,
+                    &logger,
+                    &network_store,
+                    near_chains,
+                );
             }
 
             // Start a task runner
@@ -590,31 +601,31 @@ async fn create_firehose_networks(
     Ok(networks_by_kind)
 }
 
+// The status of a provider that we learned from connecting to it
+#[derive(PartialEq)]
+enum ProviderNetworkStatus {
+    Broken {
+        network: String,
+        provider: String,
+    },
+    Version {
+        network: String,
+        ident: ChainIdentifier,
+    },
+}
+
 /// Try to connect to all the providers in `eth_networks` and get their net
 /// version and genesis block. Return the same `eth_networks` and the
 /// retrieved net identifiers grouped by network name. Remove all providers
 /// for which trying to connect resulted in an error from the returned
 /// `EthereumNetworks`, since it's likely pointless to try and connect to
 /// them. If the connection attempt to a provider times out after
-/// `ETH_NET_VERSION_WAIT_TIME`, keep the provider, but don't report a
+/// `NET_VERSION_WAIT_TIME`, keep the provider, but don't report a
 /// version for it.
 async fn connect_networks(
     logger: &Logger,
     mut eth_networks: EthereumNetworks,
 ) -> (EthereumNetworks, Vec<(String, Vec<ChainIdentifier>)>) {
-    // The status of a provider that we learned from connecting to it
-    #[derive(PartialEq)]
-    enum Status {
-        Broken {
-            network: String,
-            provider: String,
-        },
-        Version {
-            network: String,
-            ident: ChainIdentifier,
-        },
-    }
-
     // This has one entry for each provider, and therefore multiple entries
     // for each network
     let statuses = join_all(
@@ -630,7 +641,7 @@ async fn connect_networks(
                     logger, "Connecting to Ethereum to get network identifier";
                     "capabilities" => &capabilities
                 );
-                match tokio::time::timeout(ETH_NET_VERSION_WAIT_TIME, eth_adapter.net_identifiers())
+                match tokio::time::timeout(NET_VERSION_WAIT_TIME, eth_adapter.net_identifiers())
                     .await
                     .map_err(Error::from)
                 {
@@ -639,7 +650,7 @@ async fn connect_networks(
                     Ok(Err(e)) | Err(e) => {
                         error!(logger, "Connection to provider failed. Not using this provider";
                                        "error" =>  e.to_string());
-                        Status::Broken {
+                        ProviderNetworkStatus::Broken {
                             network,
                             provider: eth_adapter.provider().to_string(),
                         }
@@ -651,7 +662,7 @@ async fn connect_networks(
                             "network_version" => &ident.net_version,
                             "capabilities" => &capabilities
                         );
-                        Status::Version { network, ident }
+                        ProviderNetworkStatus::Version { network, ident }
                     }
                 }
             }),
@@ -664,10 +675,10 @@ async fn connect_networks(
             .into_iter()
             .fold(HashMap::new(), |mut networks, status| {
                 match status {
-                    Status::Broken { network, provider } => {
+                    ProviderNetworkStatus::Broken { network, provider } => {
                         eth_networks.remove(&network, &provider)
                     }
-                    Status::Version { network, ident } => {
+                    ProviderNetworkStatus::Version { network, ident } => {
                         networks.entry(network.to_string()).or_default().push(ident)
                     }
                 }
@@ -677,35 +688,90 @@ async fn connect_networks(
     (eth_networks, idents)
 }
 
-// FIXME (NEAR): This is quite wrong, will need a refactor to remove the need to have a `ChainIdentifier`
-//               to create an actual `NetworkStore` (see `store_builder.network_store`).
-fn compute_near_network_identifiers(
-    firehose_networks: Option<&FirehoseNetworks>,
-) -> Vec<(String, Vec<ChainIdentifier>)> {
-    match firehose_networks {
-        None => vec![],
-        Some(v) => v
+/// Try to connect to all the providers in `firehose_networks` and get their net
+/// version and genesis block. Return the same `eth_networks` and the
+/// retrieved net identifiers grouped by network name. Remove all providers
+/// for which trying to connect resulted in an error from the returned
+/// `EthereumNetworks`, since it's likely pointless to try and connect to
+/// them. If the connection attempt to a provider times out after
+/// `NET_VERSION_WAIT_TIME`, keep the provider, but don't report a
+/// version for it.
+async fn connect_firehose_networks<M>(
+    logger: &Logger,
+    mut firehose_networks: FirehoseNetworks,
+) -> (FirehoseNetworks, Vec<(String, Vec<ChainIdentifier>)>)
+where
+    M: prost::Message + BlockchainBlock + Default + 'static,
+{
+    // This has one entry for each provider, and therefore multiple entries
+    // for each network
+    let statuses = join_all(
+        firehose_networks
             .flatten()
             .into_iter()
-            .map(|(name, endpoint)| {
-                (
-                    name,
-                    ChainIdentifier {
-                        genesis_block_hash: BlockHash::from(vec![]),
-                        net_version: endpoint.provider.clone(),
-                    },
+            .map(|(network_name, endpoint)| (network_name, endpoint, logger.clone()))
+            .map(|(network, endpoint, logger)| async move {
+                let logger = logger.new(o!("provider" => endpoint.provider.to_string()));
+                info!(
+                    logger, "Connecting to Firehose to get network identifier";
+                    "url" => &endpoint.uri,
+                );
+                match tokio::time::timeout(
+                    NET_VERSION_WAIT_TIME,
+                    endpoint.genesis_block_ptr::<M>(&logger),
                 )
-            })
-            .fold(
-                HashMap::<String, Vec<ChainIdentifier>>::new(),
-                |mut networks, (name, endpoint)| {
-                    networks.entry(name.to_string()).or_default().push(endpoint);
-                    networks
-                },
-            )
+                .await
+                .map_err(Error::from)
+                {
+                    // An `Err` means a timeout, an `Ok(Err)` means some other error (maybe a typo
+                    // on the URL)
+                    Ok(Err(e)) | Err(e) => {
+                        error!(logger, "Connection to provider failed. Not using this provider";
+                                       "error" =>  e.to_string());
+                        ProviderNetworkStatus::Broken {
+                            network,
+                            provider: endpoint.provider.to_string(),
+                        }
+                    }
+                    Ok(Ok(ptr)) => {
+                        info!(
+                            logger,
+                            "Connected to Firehose";
+                            "uri" => &endpoint.uri,
+                            "genesis_block_hash" => &ptr.hash_hex(),
+                            "genesis_block_number" => ptr.block_number(),
+
+                        );
+
+                        let ident = ChainIdentifier {
+                            net_version: "0".to_string(),
+                            genesis_block_hash: ptr.hash,
+                        };
+
+                        ProviderNetworkStatus::Version { network, ident }
+                    }
+                }
+            }),
+    )
+    .await;
+
+    // Group identifiers by network name
+    let idents: HashMap<String, Vec<ChainIdentifier>> =
+        statuses
             .into_iter()
-            .collect(),
-    }
+            .fold(HashMap::new(), |mut networks, status| {
+                match status {
+                    ProviderNetworkStatus::Broken { network, provider } => {
+                        firehose_networks.remove(&network, &provider)
+                    }
+                    ProviderNetworkStatus::Version { network, ident } => {
+                        networks.entry(network.to_string()).or_default().push(ident)
+                    }
+                }
+                networks
+            });
+    let idents: Vec<_> = idents.into_iter().collect();
+    (firehose_networks, idents)
 }
 
 fn create_ipfs_clients(logger: &Logger, ipfs_addresses: &Vec<String>) -> Vec<IpfsClient> {
@@ -840,51 +906,49 @@ fn ethereum_networks_as_chains(
 fn near_networks_as_chains(
     blockchain_map: &mut BlockchainMap,
     logger: &Logger,
-    firehose_networks: Option<&FirehoseNetworks>,
+    firehose_networks: &FirehoseNetworks,
     store: &Store,
     logger_factory: &LoggerFactory,
-) -> HashMap<String, Arc<near::Chain>> {
-    match firehose_networks {
-        None => HashMap::new(),
-        Some(v) => {
-            let chains: Vec<_> = v
-                .networks
-                .iter()
-                .filter_map(|(network_name, firehose_endpoints)| {
-                    store
-                        .block_store()
-                        .chain_store(network_name)
-                        .map(|chain_store| (network_name, chain_store, firehose_endpoints))
-                        .or_else(|| {
-                            error!(
-                                logger,
-                                "No store configured for NEAR chain {}; ignoring this chain",
-                                network_name
-                            );
-                            None
-                        })
+) -> HashMap<String, FirehoseChain<near::Chain>> {
+    let chains: Vec<_> = firehose_networks
+        .networks
+        .iter()
+        .filter_map(|(network_name, firehose_endpoints)| {
+            store
+                .block_store()
+                .chain_store(network_name)
+                .map(|chain_store| (network_name, chain_store, firehose_endpoints))
+                .or_else(|| {
+                    error!(
+                        logger,
+                        "No store configured for NEAR chain {}; ignoring this chain", network_name
+                    );
+                    None
                 })
-                .map(|(network_name, chain_store, firehose_endpoints)| {
-                    (
+        })
+        .map(|(network_name, chain_store, firehose_endpoints)| {
+            (
+                network_name.clone(),
+                FirehoseChain {
+                    chain: Arc::new(near::Chain::new(
+                        logger_factory.clone(),
                         network_name.clone(),
-                        Arc::new(near::Chain::new(
-                            logger_factory.clone(),
-                            network_name.clone(),
-                            chain_store,
-                            store.subgraph_store(),
-                            firehose_endpoints.clone(),
-                        )),
-                    )
-                })
-                .collect();
+                        chain_store,
+                        store.subgraph_store(),
+                        firehose_endpoints.clone(),
+                    )),
+                    firehose_endpoints: firehose_endpoints.clone(),
+                },
+            )
+        })
+        .collect();
 
-            for (network_name, chain) in chains.iter().cloned() {
-                blockchain_map.insert::<graph_chain_near::Chain>(network_name, chain)
-            }
-
-            HashMap::from_iter(chains)
-        }
+    for (network_name, firehose_chain) in chains.iter() {
+        blockchain_map
+            .insert::<graph_chain_near::Chain>(network_name.clone(), firehose_chain.chain.clone())
     }
+
+    HashMap::from_iter(chains)
 }
 
 fn start_block_ingestor(
@@ -936,6 +1000,65 @@ fn start_block_ingestor(
         });
 }
 
+#[derive(Clone)]
+struct FirehoseChain<C: Blockchain> {
+    chain: Arc<C>,
+    firehose_endpoints: FirehoseNetworkEndpoints,
+}
+
+fn start_firehose_block_ingestor<C, M>(
+    ancestor_block: i32,
+    logger: &Logger,
+    store: &Store,
+    chains: HashMap<String, FirehoseChain<C>>,
+) where
+    C: Blockchain,
+    M: prost::Message + BlockchainBlock + Default + 'static,
+{
+    info!(
+        logger,
+        "Starting firehose block ingestors with {} chains [{}]",
+        chains.len(),
+        chains
+            .keys()
+            .map(|v| v.clone())
+            .collect::<Vec<String>>()
+            .join(", ")
+    );
+
+    // Create Firehose block ingestors and spawn a thread to run each
+    chains
+        .iter()
+        .for_each(|(network_name, chain)| {
+            info!(
+                logger,
+                "Starting firehose block ingestor for network";
+                "network_name" => &network_name
+            );
+
+            let endpoint = chain
+                .firehose_endpoints
+                .random()
+                .expect("One Firehose endpoint should exist at that execution point");
+
+            match store.block_store().chain_store(network_name.as_ref()) {
+                Some(s) => {
+                    let block_ingestor = FirehoseBlockIngestor::<M>::new(
+                        ancestor_block,
+                        s,
+                        endpoint.clone(),
+                        logger.new(o!("component" => "FirehoseBlockIngestor", "provider" => endpoint.provider.clone())),
+                    );
+
+                    // Run the Firehose block ingestor in the background
+                    graph::spawn(block_ingestor.run());
+                },
+                None => {
+                    error!(logger, "Not starting firehose block ingestor (no chain store available)"; "network_name" => &network_name);
+                }
+            }
+        });
+}
 #[cfg(test)]
 mod test {
     use super::create_ethereum_networks;

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -336,13 +336,11 @@ async fn main() {
                 start_block_ingestor(&logger, block_polling_interval, ethereum_chains);
             }
 
-            if near_chains.len() > 0 {
-                start_firehose_block_ingestor::<_, NearFirehoseHeaderOnlyBlock>(
-                    &logger,
-                    &network_store,
-                    near_chains,
-                );
-            }
+            start_firehose_block_ingestor::<_, NearFirehoseHeaderOnlyBlock>(
+                &logger,
+                &network_store,
+                near_chains,
+            );
 
             // Start a task runner
             let mut job_runner = graph::util::jobs::Runner::new(&logger);

--- a/store/postgres/migrations/2021-12-02-212506_chain_store_firehose_cursor/down.sql
+++ b/store/postgres/migrations/2021-12-02-212506_chain_store_firehose_cursor/down.sql
@@ -1,2 +1,6 @@
+update public.ethereum_networks
+    set genesis_block_hash = '0000000000000000000000000000000000000000000000000000000000000000'
+    where name = 'near-mainnet';
+
 alter table public.ethereum_networks
     drop column head_block_cursor;

--- a/store/postgres/migrations/2021-12-02-212506_chain_store_firehose_cursor/down.sql
+++ b/store/postgres/migrations/2021-12-02-212506_chain_store_firehose_cursor/down.sql
@@ -1,0 +1,2 @@
+alter table public.ethereum_networks
+    drop column head_block_cursor;

--- a/store/postgres/migrations/2021-12-02-212506_chain_store_firehose_cursor/up.sql
+++ b/store/postgres/migrations/2021-12-02-212506_chain_store_firehose_cursor/up.sql
@@ -1,0 +1,2 @@
+alter table public.ethereum_networks
+    add column head_block_cursor text default null;

--- a/store/postgres/migrations/2021-12-02-212506_chain_store_firehose_cursor/up.sql
+++ b/store/postgres/migrations/2021-12-02-212506_chain_store_firehose_cursor/up.sql
@@ -1,2 +1,6 @@
 alter table public.ethereum_networks
     add column head_block_cursor text default null;
+
+update public.ethereum_networks
+    set genesis_block_hash = 'a7110b9052e1be68f7fa8bb4065bf54e731205801878e708db7464ec4b9b8014'
+    where name = 'near-mainnet';

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -40,6 +40,7 @@ mod public {
             head_block_number -> Nullable<BigInt>,
             net_version -> Varchar,
             genesis_block_hash -> Varchar,
+            head_block_cursor -> Nullable<Varchar>,
         }
     }
 }
@@ -1410,6 +1411,41 @@ impl ChainStoreTrait for ChainStore {
                     .and_then(|opt| opt)
             })
             .map_err(Error::from)
+    }
+
+    fn chain_head_cursor(&self) -> Result<Option<String>, Error> {
+        use public::ethereum_networks::dsl::*;
+
+        ethereum_networks
+            .select(head_block_cursor)
+            .filter(name.eq(&self.chain))
+            .load::<Option<String>>(&*self.get_conn()?)
+            .map(|rows| {
+                rows.first()
+                    .map(|cursor_opt| cursor_opt.as_ref().map(|cursor| cursor.clone()))
+                    .and_then(|opt| opt)
+            })
+            .map_err(Error::from)
+    }
+
+    async fn set_chain_head_cursor(self: Arc<Self>, cursor: String) -> Result<(), Error> {
+        use public::ethereum_networks as n;
+
+        let pool = self.pool.clone();
+
+        pool.with_conn(move |conn, _| {
+            conn.transaction(|| -> Result<(), StoreError> {
+                update(n::table.filter(n::name.eq(&self.chain)))
+                    .set(n::head_block_cursor.eq(cursor))
+                    .execute(conn)?;
+
+                Ok(())
+            })
+            .map_err(CancelableError::from)
+        })
+        .await?;
+
+        Ok(())
     }
 
     fn blocks(&self, hashes: &[H256]) -> Result<Vec<json::Value>, Error> {


### PR DESCRIPTION
The actual FirehoseBlockIngestor is generic enough to be re-usable on all chains that have Firehose support. This is the initial implementation that just follow chain head and update the head blocks. Rather naive in its approach right now.

Current limitations that I would like to discuss:
- ~Chain net_version and genesis_hash already exist with a default value. Now the value is fetched from Firehose correctly so there is a mismatch. How we should handle that, just delete the prior record "manually" before deploying? Automatically override if current value is XYZ? I would opt for the latter~. Going to fix it in the migrations that adds the `head_block_cursor` directly.
- ~Still need to discuss how we want to handler backfilling. There is different options available: backfill straight inside graph-node with a different cursor, backfill with graph-man in parallel fashion, backfill on demand when requestion block number to block hash~. Backfilling will be managed directly by `graph-node`. Two "stream" will fill concurrently, one from live tracking chain head, the other one from genesis up to joint point with live "stream". PR will be submitted independently for this feature.
- ~Currently doing 3 calls to database: upsert_block, attemp_chain_update and set_head_cursor, I would like to refactor that inside 1 efficient transaction instead (if possible, wanted to discuss that first before doing it).~ Merged in a single transaction with `undo` doing nothing and `new` block always updating `head_chain_block` without dealing with ancestor blocks and the like.

