### PR TITLE
Allow placing new deployments onto one of several shards

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -159,6 +159,10 @@ deployment should be stored, which defaults to `primary`, and a list of
 mentioned in `indexers`. The names for the indexers must be the same names
 that are passed with `--node-id` when those index nodes are started.
 
+Instead of a fixed `shard`, it is also possible to use a list of `shards`;
+in that case, the system uses the shard from the given list with the fewest
+active deployments in it.
+
 ```toml
 [deployment]
 [[deployment.rule]]
@@ -174,6 +178,7 @@ match = { network = [ "xdai", "poa-core" ] }
 indexers = [ "index_node_other_0" ]
 [[deployment.rule]]
 # There's no 'match', so any subgraph matches
+shards = [ "sharda", "shardb" ]
 indexers = [
     "index_node_community_0",
     "index_node_community_1",

--- a/node/resources/tests/full_config.toml
+++ b/node/resources/tests/full_config.toml
@@ -35,7 +35,7 @@ match = { name = "^custom/.*" }
 indexers = [ "index_custom_0" ]
 
 [[deployment.rule]]
-shard = "shard_a"
+shards = [ "primary", "shard_a" ]
 indexers = [ "index_node_1_a",
              "index_node_2_a",
              "index_node_3_a" ]

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1,8 +1,14 @@
 use graph::{
+    anyhow::Error,
     blockchain::{block_ingestor::CLEANUP_BLOCKS, BlockchainKind},
     prelude::{
         anyhow::{anyhow, bail, Context, Result},
-        info, serde_json, Logger, NodeId,
+        info,
+        serde::{
+            de::{self, value, SeqAccess, Visitor},
+            Deserialize, Deserializer, Serialize,
+        },
+        serde_json, Logger, NodeId, StoreError,
     },
 };
 use graph_chain_ethereum::NodeCapabilities;
@@ -10,7 +16,6 @@ use graph_store_postgres::{DeploymentPlacer, Shard as ShardName, PRIMARY_SHARD};
 
 use http::{HeaderMap, Uri};
 use regex::Regex;
-use serde::{Deserialize, Serialize};
 use std::fs::read_to_string;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -109,12 +114,10 @@ impl Config {
 
         // Check that deployment rules only reference existing stores and chains
         for (i, rule) in self.deployment.rules.iter().enumerate() {
-            if !self.stores.contains_key(&rule.shard) {
-                return Err(anyhow!(
-                    "unknown shard {} in deployment rule {}",
-                    rule.shard,
-                    i
-                ));
+            for shard in &rule.shards {
+                if !self.stores.contains_key(shard) {
+                    return Err(anyhow!("unknown shard {} in deployment rule {}", shard, i));
+                }
             }
             if let Some(networks) = &rule.pred.network {
                 for network in networks.to_vec() {
@@ -809,7 +812,7 @@ impl DeploymentPlacer for Deployment {
         // rather than crashing the node and burying the crash in the logs
         let placement = match self.rules.iter().find(|rule| rule.matches(name, network)) {
             Some(rule) => {
-                let shard = ShardName::new(rule.shard.clone()).map_err(|e| e.to_string())?;
+                let shards = rule.shard_names().map_err(|e| e.to_string())?;
                 let indexers: Vec<_> = rule
                     .indexers
                     .iter()
@@ -818,7 +821,7 @@ impl DeploymentPlacer for Deployment {
                             .map_err(|()| format!("{} is not a valid node name", idx))
                     })
                     .collect::<Result<Vec<_>, _>>()?;
-                Some((vec![shard], indexers))
+                Some((shards, indexers))
             }
             None => None,
         };
@@ -830,8 +833,13 @@ impl DeploymentPlacer for Deployment {
 struct Rule {
     #[serde(rename = "match", default)]
     pred: Predicate,
-    #[serde(default = "primary_store")]
-    shard: String,
+    // For backwards compatibility, we also accept 'shard' for the shards
+    #[serde(
+        alias = "shard",
+        default = "primary_store",
+        deserialize_with = "string_or_vec"
+    )]
+    shards: Vec<String>,
     indexers: Vec<String>,
 }
 
@@ -844,6 +852,14 @@ impl Rule {
         self.pred.matches(name, network)
     }
 
+    fn shard_names(&self) -> Result<Vec<ShardName>, StoreError> {
+        self.shards
+            .iter()
+            .cloned()
+            .map(ShardName::new)
+            .collect::<Result<_, _>>()
+    }
+
     fn validate(&self) -> Result<()> {
         if self.indexers.is_empty() {
             return Err(anyhow!("useless rule without indexers"));
@@ -851,8 +867,7 @@ impl Rule {
         for indexer in &self.indexers {
             NodeId::new(indexer).map_err(|()| anyhow!("invalid node id {}", &indexer))?;
         }
-        ShardName::new(self.shard.clone())
-            .map_err(|e| anyhow!("illegal name for store shard `{}`: {}", &self.shard, e))?;
+        self.shard_names().map_err(Error::from)?;
         Ok(())
     }
 }
@@ -943,12 +958,44 @@ fn no_name() -> Regex {
     Regex::new(NO_NAME).unwrap()
 }
 
-fn primary_store() -> String {
-    PRIMARY_SHARD.to_string()
+fn primary_store() -> Vec<String> {
+    vec![PRIMARY_SHARD.to_string()]
 }
 
 fn one() -> usize {
     1
+}
+
+// From https://github.com/serde-rs/serde/issues/889#issuecomment-295988865
+fn string_or_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StringOrVec;
+
+    impl<'de> Visitor<'de> for StringOrVec {
+        type Value = Vec<String>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or list of strings")
+        }
+
+        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(vec![s.to_owned()])
+        }
+
+        fn visit_seq<S>(self, seq: S) -> Result<Self::Value, S::Error>
+        where
+            S: SeqAccess<'de>,
+        {
+            Deserialize::deserialize(value::SeqAccessDeserializer::new(seq))
+        }
+    }
+
+    deserializer.deserialize_any(StringOrVec)
 }
 
 #[cfg(test)]

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -798,7 +798,11 @@ impl Deployment {
 }
 
 impl DeploymentPlacer for Deployment {
-    fn place(&self, name: &str, network: &str) -> Result<Option<(ShardName, Vec<NodeId>)>, String> {
+    fn place(
+        &self,
+        name: &str,
+        network: &str,
+    ) -> Result<Option<(Vec<ShardName>, Vec<NodeId>)>, String> {
         // Errors here are really programming errors. We should have validated
         // everything already so that the various conversions can't fail. We
         // still return errors so that they bubble up to the deployment request
@@ -814,7 +818,7 @@ impl DeploymentPlacer for Deployment {
                             .map_err(|()| format!("{} is not a valid node name", idx))
                     })
                     .collect::<Result<Vec<_>, _>>()?;
-                Some((shard, indexers))
+                Some((vec![shard], indexers))
             }
             None => None,
         };

--- a/node/src/manager/commands/config.rs
+++ b/node/src/manager/commands/config.rs
@@ -15,11 +15,12 @@ pub fn place(placer: &dyn DeploymentPlacer, name: &str, network: &str) -> Result
                 "no matching placement rule; default placement from JSON RPC call would be used"
             );
         }
-        Some((shard, nodes)) => {
+        Some((shards, nodes)) => {
             let nodes: Vec<_> = nodes.into_iter().map(|n| n.to_string()).collect();
+            let shards: Vec<_> = shards.into_iter().map(|s| s.to_string()).collect();
             println!("subgraph: {}", name);
             println!("network:  {}", network);
-            println!("shard:    {}", shard);
+            println!("shard:    {}", shards.join(", "));
             println!("nodes:    {}", nodes.join(", "));
         }
     }

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1241,6 +1241,40 @@ impl<'a> Connection<'a> {
             })
     }
 
+    /// Return the shard that has the fewest deployments out of the given
+    /// `shards`. If `shards` is empty, return `None`
+    ///
+    /// Usage of a shard is taken to be the number of assigned deployments
+    /// that are stored in it. Unassigned deployments are ignored; in
+    /// particular, that ignores deployments that are going to be removed
+    /// soon.
+    pub fn least_used_shard(&self, shards: &[Shard]) -> Result<Option<Shard>, StoreError> {
+        use deployment_schemas as ds;
+        use subgraph_deployment_assignment as a;
+
+        let used = ds::table
+            .inner_join(a::table.on(a::id.eq(ds::id)))
+            .filter(ds::shard.eq(any(shards)))
+            .select((ds::shard, sql("count(*)")))
+            .group_by(ds::shard)
+            .order_by(sql::<i64>("count(*)"))
+            .load::<(String, i64)>(self.conn.as_ref())?;
+
+        let missing = shards
+            .into_iter()
+            .filter(|shard| !used.iter().any(|(s, _)| s == shard.as_str()))
+            .map(|shard| (shard.as_str(), 0));
+
+        used.iter()
+            .map(|(shard, count)| (shard.as_str(), *count))
+            .chain(missing)
+            .min_by(|(_, a), (_, b)| a.cmp(b))
+            .map(|(shard, _)| Shard::new(shard.to_string()))
+            .transpose()
+            // This can't really happen since we filtered by valid shards
+            .map_err(|e| constraint_violation!("database has illegal shard name: {}", e))
+    }
+
     #[cfg(debug_assertions)]
     pub fn versions_for_subgraph(
         &self,

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -117,7 +117,8 @@ impl ToSql<Text, Pg> for Shard {
 /// indexers that should index it. The deployment should then be assigned to
 /// one of the returned indexers.
 pub trait DeploymentPlacer {
-    fn place(&self, name: &str, network: &str) -> Result<Option<(Shard, Vec<NodeId>)>, String>;
+    fn place(&self, name: &str, network: &str)
+        -> Result<Option<(Vec<Shard>, Vec<NodeId>)>, String>;
 }
 
 /// Tools for managing unused deployments
@@ -382,6 +383,31 @@ impl SubgraphStoreInner {
         store.find_layout(site)
     }
 
+    fn place_on_node(
+        &self,
+        mut nodes: Vec<NodeId>,
+        default_node: NodeId,
+    ) -> Result<NodeId, StoreError> {
+        match nodes.len() {
+            0 => {
+                // This is really a configuration error
+                Ok(default_node)
+            }
+            1 => Ok(nodes.pop().unwrap()),
+            _ => {
+                let conn = self.primary_conn()?;
+
+                // unwrap is fine since nodes is not empty
+                let node = conn.least_assigned_node(&nodes)?.unwrap();
+                Ok(node)
+            }
+        }
+    }
+
+    fn place_in_shard(&self, mut shards: Vec<Shard>) -> Result<Shard, StoreError> {
+        Ok(shards.pop().unwrap())
+    }
+
     fn place(
         &self,
         name: &SubgraphName,
@@ -402,16 +428,10 @@ impl SubgraphStoreInner {
 
         match placement {
             None => Ok((PRIMARY_SHARD.clone(), default_node)),
-            Some((_, nodes)) if nodes.is_empty() => {
-                // This is really a configuration error
-                Ok((PRIMARY_SHARD.clone(), default_node))
-            }
-            Some((shard, mut nodes)) if nodes.len() == 1 => Ok((shard, nodes.pop().unwrap())),
-            Some((shard, nodes)) => {
-                let conn = self.primary_conn()?;
+            Some((shards, nodes)) => {
+                let node = self.place_on_node(nodes, default_node)?;
+                let shard = self.place_in_shard(shards)?;
 
-                // unwrap is fine since nodes is not empty
-                let node = conn.least_assigned_node(&nodes)?.unwrap();
                 Ok((shard, node))
             }
         }

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -111,11 +111,12 @@ impl ToSql<Text, Pg> for Shard {
     }
 }
 
-/// Decide where a new deployment should be placed based on the subgraph name
-/// and the network it is indexing. If the deployment can be placed, returns
-/// the name of the database shard for the deployment and the names of the
-/// indexers that should index it. The deployment should then be assigned to
-/// one of the returned indexers.
+/// Decide where a new deployment should be placed based on the subgraph
+/// name and the network it is indexing. If the deployment can be placed,
+/// returns a list of eligible database shards for the deployment and the
+/// names of the indexers that should index it. The deployment should then
+/// be assigned to one of the returned indexers and placed into one of the
+/// shards.
 pub trait DeploymentPlacer {
     fn place(&self, name: &str, network: &str)
         -> Result<Option<(Vec<Shard>, Vec<NodeId>)>, String>;

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -81,7 +81,7 @@ impl Shard {
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
         {
             return Err(StoreError::InvalidIdentifier(format!(
-                "shard names must only contain lowercase alphanumeric characters or '_'"
+                "shard name `{}` is invalid: shard names must only contain lowercase alphanumeric characters or '_'", name
             )));
         }
         Ok(Shard(name))

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -142,7 +142,7 @@ pub fn remove_subgraphs() {
         .expect("deleting test entities succeeds");
 }
 
-pub fn place(name: &str) -> Result<Option<(Shard, Vec<NodeId>)>, String> {
+pub fn place(name: &str) -> Result<Option<(Vec<Shard>, Vec<NodeId>)>, String> {
     CONFIG.deployment.place(name, NETWORK_NAME)
 }
 


### PR DESCRIPTION
With this change, deployment rules in `graph-node.toml` accept multiple shards, e.g. with
```
[[deployment.rule]]
shards = [ "primary", "shard_a" ]
indexers = [ "index_node_1_a",
             "index_node_2_a",
             "index_node_3_a" ]
```

Similar to how multiple index nodes are used, when a rule specifies multiple shards, the deployment is placed into the least used shard.