### PR TITLE
feat: Support http get

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,6 +1618,7 @@ dependencies = [
  "lazy_static",
  "lru_time_cache",
  "pretty_assertions 1.0.0",
+ "reqwest",
  "semver 1.0.4",
  "serde",
  "serde_json",

--- a/chain/ethereum/tests/manifest.rs
+++ b/chain/ethereum/tests/manifest.rs
@@ -55,6 +55,13 @@ impl LinkResolverTrait for TextResolver {
             .map(Clone::clone)
     }
 
+    async fn http_get(&self, _logger: &Logger, link: &Link) -> Result<Vec<u8>, anyhow::Error> {
+        self.texts
+            .get(&link.link)
+            .ok_or(anyhow!("No text for {}", &link.link))
+            .map(Clone::clone)
+    }
+
     async fn json_stream(
         &self,
         _logger: &Logger,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 async-trait = "0.1.50"
 atomic_refcell = "0.1.8"
 bytes = "0.5"
+reqwest = { version = "0.11", features = ["json"] }
 futures01 = { package="futures", version="0.1.31" }
 futures = { version="0.3.4", features=["compat"] }
 graph = { path = "../graph" }

--- a/graph/src/components/link_resolver.rs
+++ b/graph/src/components/link_resolver.rs
@@ -36,6 +36,9 @@ pub trait LinkResolver: Send + Sync + 'static {
     /// Fetches the link contents as bytes.
     async fn cat(&self, logger: &Logger, link: &Link) -> Result<Vec<u8>, Error>;
 
+    /// Fetches the link contents as bytes.
+    async fn http_get(&self, logger: &Logger, link: &Link) -> Result<Vec<u8>, Error>;
+
     /// Read the contents of `link` and deserialize them into a stream of JSON
     /// values. The values must each be on a single line; newlines are significant
     /// as they are used to split the file contents and each line is deserialized

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -246,6 +246,10 @@ impl<C: Blockchain> HostExports<C> {
         ))
     }
 
+    pub(crate) fn http_get(&self, logger: &Logger, link: String) -> Result<Vec<u8>, anyhow::Error> {
+        block_on03(self.link_resolver.http_get(logger, &Link { link }))
+    }
+
     pub(crate) fn ipfs_cat(&self, logger: &Logger, link: String) -> Result<Vec<u8>, anyhow::Error> {
         block_on03(self.link_resolver.cat(logger, &Link { link }))
     }


### PR DESCRIPTION
Since most of the community NFT (Non-fungible token), ERC721 protocol and ERC1155 protocol, define to store metadata in off-chain data, and most of them are provided in the form of http protocol. So add http get to better support NFT (Non-fungible token).