### PR TITLE
graph, graphql: introduce GraphQL spec-compliant `validation` phase and rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,6 +1564,7 @@ dependencies = [
  "graph",
  "graph-chain-ethereum",
  "graphql-parser",
+ "graphql-tools",
  "indexmap",
  "lazy_static",
  "once_cell",
@@ -1794,6 +1795,15 @@ checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
  "combine",
  "thiserror",
+]
+
+[[package]]
+name = "graphql-tools"
+version = "0.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47ccdd42a537f86a915d9ca4c5880005183d6eb544b86d9e924511942a00647"
+dependencies = [
+ "graphql-parser",
 ]
 
 [[package]]

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -279,9 +279,11 @@ async fn follow_interface_reference_invalid() {
         .unwrap();
 
     match &res.to_result().unwrap_err()[0] {
-        QueryError::ExecutionError(QueryExecutionError::UnknownField(_, type_name, field_name)) => {
-            assert_eq!(type_name, "Legged");
-            assert_eq!(field_name, "parent");
+        QueryError::ExecutionError(QueryExecutionError::ValidationError(_, error_message)) => {
+            assert_eq!(
+                error_message,
+                "Cannot query field \"parent\" on type \"Legged\"."
+            );
         }
         e => panic!("error {} is not the expected one", e),
     }
@@ -1424,7 +1426,7 @@ async fn recursive_fragment() {
         .await
         .unwrap();
     let data = res.to_result().unwrap_err()[0].to_string();
-    assert_eq!(data, "query has fragment cycle including `FooFrag`");
+    assert_eq!(data, "Cannot spread fragment \"FooFrag\" within itself.");
 
     let co_recursive = "
         query {
@@ -1451,5 +1453,8 @@ async fn recursive_fragment() {
         .await
         .unwrap();
     let data = res.to_result().unwrap_err()[0].to_string();
-    assert_eq!(data, "query has fragment cycle including `BarFrag`");
+    assert_eq!(
+        data,
+        "Cannot spread fragment \"BarFrag\" within itself via \"FooFrag\"."
+    );
 }

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -41,6 +41,7 @@ pub enum QueryExecutionError {
     AbstractTypeError(String),
     InvalidArgumentError(Pos, String, q::Value),
     MissingArgumentError(Pos, String),
+    ValidationError(Option<Pos>, String),
     InvalidVariableTypeError(Pos, String),
     MissingVariableError(Pos, String),
     ResolveEntitiesError(String),
@@ -137,6 +138,7 @@ impl QueryExecutionError {
             | DeploymentReverted
             | SubgraphManifestResolveError(_)
             | InvalidSubgraphManifest
+            | ValidationError(_, _)
             | ResultTooBig(_, _) => false,
         }
     }
@@ -160,6 +162,9 @@ impl fmt::Display for QueryExecutionError {
             OperationNameRequired => write!(f, "Operation name required"),
             OperationNotFound(s) => {
                 write!(f, "Operation name not found `{}`", s)
+            }
+            ValidationError(_pos, message) => {
+                write!(f, "{}", message)
             }
             NotSupported(s) => write!(f, "Not supported: {}", s),
             NoRootSubscriptionObjectType => {

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -8,6 +8,7 @@ crossbeam = "0.8"
 futures01 = { package="futures", version="0.1.29" }
 graph = { path = "../graph" }
 graphql-parser = "0.4.0"
+graphql-tools = "0.0.15"
 indexmap = "1.7"
 Inflector = "0.11.3"
 lazy_static = "1.2.0"

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -895,17 +895,18 @@ fn query_complexity_subscriptions() {
                 "subscription {
                 musicians(orderBy: id) {
                     name
-                    bands(first: 100, orderBy: id) {
+                    t1: bands(first: 100, orderBy: id) {
                         name
                         members(first: 100, orderBy: id) {
                             name
                         }
                     }
-                }
-                __schema {
-                    types {
-                        name
-                    }
+                    t2: bands(first: 200, orderBy: id) {
+                      name
+                      members(first: 100, orderBy: id) {
+                          name
+                      }
+                  }
                 }
             }",
             )
@@ -932,12 +933,12 @@ fn query_complexity_subscriptions() {
             result_size: result_size_metrics(),
         };
 
-        // The extra introspection causes the complexity to go over.
         let result = execute_subscription(Subscription { query }, schema, options);
+
         match result {
-            Err(SubscriptionError::GraphQLError(e)) => match e[0] {
-                QueryExecutionError::TooComplex(1_010_200, _) => (), // Expected
-                _ => panic!("did not catch complexity"),
+            Err(SubscriptionError::GraphQLError(e)) => match &e[0] {
+                QueryExecutionError::TooComplex(3_030_100, _) => (), // Expected
+                e => panic!("did not catch complexity: {:?}", e),
             },
             _ => panic!("did not catch complexity"),
         }


### PR DESCRIPTION
## Background

While @lutter worked on a refactor for the GraphQL execution (https://github.com/graphprotocol/graph-node/pull/3005), we needed a way to make sure some aspects of execution are valid after merging the refactor PR. 

We also noticed that the current implementation of the GraphQL engine does not include a validation phase (https://github.com/graphprotocol/graph-node/issues/3013). 

This PR uses `graphq-tools` crate (https://github.com/dotansimha/graphql-tools-rs, a set of utils on top of `graphql_parser` crate) for validations, using visitor pattern (similar to GraphQL-JS ecosystem). 

The following rules are now running: 

- `UniqueOperationNames` (https://spec.graphql.org/draft/#sec-Operation-Name-Uniqueness)
- `SingleFieldSubscriptions` (https://spec.graphql.org/draft/#sec-Operation-Name-Uniqueness)
- `KnownTypeNames` (https://spec.graphql.org/draft/#sec-Fragment-Spread-Type-Existence)
- `VariablesAreInputTypes` (https://spec.graphql.org/draft/#sec-Variables-Are-Input-Types)
- `FieldsOnCorrectType` (https://spec.graphql.org/draft/#sec-Field-Selections)
- `LoneAnonymousOperation` (https://spec.graphql.org/draft/#sec-Lone-Anonymous-Operation)
- `FragmentsOnCompositeTypes` (https://spec.graphql.org/draft/#sec-Fragments-On-Composite-Types)
- `OverlappingFieldsCanBeMerged` (https://spec.graphql.org/draft/#sec-Field-Selection-Merging)
- `NoUnusedFragments` (https://spec.graphql.org/draft/#sec-Fragments-Must-Be-Used)
- `KnownFragmentNamesRule` (https://spec.graphql.org/draft/#sec-Fragment-spread-target-defined)
- `LeafFieldSelections` (https://spec.graphql.org/draft/#sec-Leaf-Field-Selections)
- `UniqueFragmentNames` (https://spec.graphql.org/draft/#sec-Fragment-Name-Uniqueness)
- `NoFragmentsCycle` (https://spec.graphql.org/draft/#sec-Fragment-spreads-must-not-form-cycles)
- `PossibleFragmentSpreads` (https://spec.graphql.org/draft/#sec-Fragment-spread-is-possible)
- `NoUnusedVariables` (https://spec.graphql.org/draft/#sec-All-Variables-Used)
- `NoUndefinedVariables` (https://spec.graphql.org/draft/#sec-All-Variable-Uses-Defined)
- `KnownArgumentNames` (https://spec.graphql.org/draft/#sec-Argument-Names , https://spec.graphql.org/draft/#sec-Directives-Are-In-Valid-Locations)
- `UniqueArgumentNames` (https://spec.graphql.org/draft/#sec-Argument-Names)
- `UniqueVariableNames` (https://spec.graphql.org/draft/#sec-Variable-Uniqueness)
- `ProvidedRequiredArguments` (https://spec.graphql.org/draft/#sec-Required-Arguments)

The following spec rules are not part of this PR:
- `ExecutableDefinitions` (not actually needed, because of `graphql_parser` nature)
- `ValuesOfCorrectType` (WIP - not sure yet about requirement by `graph-node`)
- `VariablesInAllowedPosition` (WIP - might be needed by `graph-node`)
- `UniqueInputFieldNames`  (blocked by https://github.com/graphql-rust/graphql-parser/issues/59)
- `KnownDirectives` - not needed at the moment by `graph-node`.
- `UniqueDirectivesPerLocation` - not needed at the moment by `graph-node`.

## Changes in the PR

A `ValidationPlan` struct is now constructed in a static way, including all the rules, and can be disabled using the env var `DISABLE_GRAPHQL_VALIDATIONS=true`.

If there are any validation rules selected, the query fails with a standard error, based on the GraphQL spec:

![image](https://user-images.githubusercontent.com/3680083/146011658-9e0d47a4-4f52-43e4-9619-24053c10a8b4.png)

![image](https://user-images.githubusercontent.com/3680083/146011747-32c15f96-b0b1-4243-9992-946bd1d31570.png)

![image](https://user-images.githubusercontent.com/3680083/146013128-1588a1ee-69c1-47d7-99d0-2883804fc28e.png)

![image](https://user-images.githubusercontent.com/3680083/146034667-73718b8e-392e-4be3-97f7-90789ce0075b.png)

![image](https://user-images.githubusercontent.com/3680083/146034915-85946a53-b08a-4451-a2b2-fd5046f79f61.png)


## Future tasks

- We can consider moving complexity checks and a few more validations into an actual `ValidationRule` and use it there, it should make the GraphQL layer a bit more generic. 
- Drop `validate_fields` since it's covered by new validations. 

## TODO

- [x] Implement `validate` flow based on the spec
- [x] Support `graphql_parser` `Document` 
- [x] Implement initial implementation of `OverlappingFieldsCanBeMerged` 
- [x] Improve `OverlappingFieldsCanBeMerged` implementation
- [x] Add more crucial validation rules

