### PR TITLE
Re-written FirehoseBlockStream using `async-stream`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,7 @@ version = "0.25.0"
 dependencies = [
  "Inflector",
  "anyhow",
+ "async-stream",
  "async-trait",
  "atomic_refcell",
  "bigdecimal",

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -671,14 +671,6 @@ where
                         };
                     }
 
-                    // Notify the BlockStream implementation that a block was succesfully consumed
-                    // and that its internal cursoring mechanism can be saved to memory.
-                    //
-                    // The first `get_mut` is to get the inner `Stream` out of `Cancelable` which
-                    // returns a `TryStreamExt::MapErr` struct and the second `get_mut` is to get
-                    // out the actual `dyn BlockStream` trait on which we can call our method.
-                    block_stream.get_mut().get_mut().notify_block_consumed();
-
                     if needs_restart {
                         // Cancel the stream for real
                         ctx.state

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1.50"
+async-stream = "0.3"
 atomic_refcell = "0.1.8"
 bigdecimal = { version = "0.1.0", features = ["serde"] }
 bytes = "1.0.1"

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -11,7 +11,6 @@ use crate::{prelude::*, prometheus::labels};
 pub trait BlockStream<C: Blockchain>:
     Stream<Item = Result<BlockStreamEvent<C>, Error>> + Unpin
 {
-    fn notify_block_consumed(&mut self) {}
 }
 
 pub type FirehoseCursor = Option<String>;

--- a/graph/src/blockchain/firehose_block_stream.rs
+++ b/graph/src/blockchain/firehose_block_stream.rs
@@ -1,56 +1,26 @@
-use futures03::{FutureExt, Stream, StreamExt};
+use async_stream::try_stream;
+use futures03::{Stream, StreamExt};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
 use crate::firehose::endpoints::FirehoseEndpoint;
 use crate::prelude::*;
+use crate::util::backoff::ExponentialBackoff;
 
 use super::block_stream::{BlockStream, BlockStreamEvent, FirehoseMapper};
 use super::Blockchain;
 use crate::firehose::bstream;
 
-pub struct FirehoseBlockStreamContext<C, F>
+pub struct FirehoseBlockStream<C: Blockchain> {
+    stream: Pin<Box<dyn Stream<Item = Result<BlockStreamEvent<C>, Error>>>>,
+}
+
+impl<C> FirehoseBlockStream<C>
 where
     C: Blockchain,
-    F: FirehoseMapper<C>,
 {
-    active_cursor: Option<String>,
-    last_seen_cursor: Option<String>,
-    mapper: Arc<F>,
-    adapter: Arc<C::TriggersAdapter>,
-    filter: Arc<C::TriggerFilter>,
-    start_blocks: Vec<BlockNumber>,
-    logger: Logger,
-}
-
-enum BlockStreamState {
-    Disconnected,
-    Connecting(
-        Pin<
-            Box<
-                dyn futures03::Future<
-                    Output = Result<tonic::Streaming<bstream::BlockResponseV2>, anyhow::Error>,
-                >,
-            >,
-        >,
-    ),
-    Connected(tonic::Streaming<bstream::BlockResponseV2>),
-}
-
-pub struct FirehoseBlockStream<C: Blockchain, F: FirehoseMapper<C>> {
-    endpoint: Arc<FirehoseEndpoint>,
-    state: BlockStreamState,
-    ctx: FirehoseBlockStreamContext<C, F>,
-    connection_attempts: u64,
-}
-
-impl<C, F> FirehoseBlockStream<C, F>
-where
-    C: Blockchain,
-    F: FirehoseMapper<C>,
-{
-    pub fn new(
+    pub fn new<F>(
         endpoint: Arc<FirehoseEndpoint>,
         cursor: Option<String>,
         mapper: Arc<F>,
@@ -58,215 +28,113 @@ where
         filter: Arc<C::TriggerFilter>,
         start_blocks: Vec<BlockNumber>,
         logger: Logger,
-    ) -> Self {
+    ) -> Self
+    where
+        F: FirehoseMapper<C> + 'static,
+    {
+        let start_block_num: BlockNumber = start_blocks
+            .into_iter()
+            .min()
+            // Firehose knows where to start the stream for the specific chain, 0 here means
+            // start at Genesis block.
+            .unwrap_or(0);
+
         FirehoseBlockStream {
-            endpoint,
-            state: BlockStreamState::Disconnected,
-            ctx: FirehoseBlockStreamContext {
-                active_cursor: cursor,
-                last_seen_cursor: None,
+            stream: Box::pin(stream_blocks(
+                endpoint,
+                cursor,
                 mapper,
-                logger,
                 adapter,
                 filter,
-                start_blocks,
-            },
-            connection_attempts: 0,
+                start_block_num,
+                logger,
+            )),
         }
     }
 }
 
-impl<C: Blockchain, F: FirehoseMapper<C>> BlockStream<C> for FirehoseBlockStream<C, F> {
-    fn notify_block_consumed(&mut self) {
-        if self.ctx.last_seen_cursor.is_none() {
+fn stream_blocks<C: Blockchain, F: FirehoseMapper<C>>(
+    endpoint: Arc<FirehoseEndpoint>,
+    cursor: Option<String>,
+    mapper: Arc<F>,
+    adapter: Arc<C::TriggersAdapter>,
+    filter: Arc<C::TriggerFilter>,
+    start_block_num: BlockNumber,
+    logger: Logger,
+) -> impl Stream<Item = Result<BlockStreamEvent<C>, Error>> {
+    use bstream::ForkStep::*;
+
+    try_stream! {
+        let mut latest_cursor = cursor.unwrap_or_else(|| "".to_string());
+        let mut backoff = ExponentialBackoff::new(Duration::from_millis(500), Duration::from_secs(45));
+
+        loop {
             info!(
-                self.ctx.logger,
-                "Received block consumed notification without a last seen cursor present, skipping"
+                &logger,
+                "Blockstream disconnected, connecting";
+                "endpoint_uri" => format_args!("{}", endpoint),
+                "start_block" => start_block_num,
+                "cursor" => &latest_cursor,
             );
-            return;
-        }
 
-        // Last seen cursor becomes active by swapping it with active
-        std::mem::swap(&mut self.ctx.active_cursor, &mut self.ctx.last_seen_cursor);
-        self.ctx.last_seen_cursor = None;
+            let result = endpoint
+            .clone()
+            .stream_blocks(bstream::BlocksRequestV2 {
+                start_block_num: start_block_num as i64,
+                start_cursor: latest_cursor.clone(),
+                fork_steps: vec![StepNew as i32, StepUndo as i32],
+                ..Default::default()
+            }).await;
+
+            match result {
+                Ok(stream) => {
+                    info!(&logger, "Blockstream connected");
+                    backoff.reset();
+
+                    for await response in stream {
+                        match response {
+                            Ok(v) => {
+                                match mapper.to_block_stream_event(&logger, &v, &adapter, &filter) {
+                                    Ok(event) => {
+                                        yield event;
+
+                                        latest_cursor = v.cursor;
+                                    },
+                                    Err(e) => {
+                                        error!(
+                                            logger,
+                                            "Mapping block to BlockStreamEvent failed: {:?}", e
+                                        );
+                                        break;
+                                    }
+                                }
+                            },
+                            Err(e) => {
+                                info!(logger, "An error occurred while streaming blocks: {:?}", e);
+                                break;
+                            }
+                        }
+                    }
+
+                    error!(logger, "Stream blocks complete unexpectedly, expecting stream to always stream blocks");
+                },
+                Err(e) => {
+                    error!(logger, "Unable to connect to endpoint: {:?}", e);
+                }
+            }
+
+            // If we reach this point, we must wait a bit before retrying
+            backoff.sleep_async().await;
+        }
     }
 }
 
-impl<C: Blockchain, F: FirehoseMapper<C>> Stream for FirehoseBlockStream<C, F> {
+impl<C: Blockchain> Stream for FirehoseBlockStream<C> {
     type Item = Result<BlockStreamEvent<C>, Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        loop {
-            match &mut self.state {
-                BlockStreamState::Disconnected => {
-                    let start_block_num: BlockNumber = self
-                        .ctx
-                        .start_blocks
-                        .iter()
-                        .min()
-                        .map(|x| *x)
-                        // Firehose knows where to start the stream for the specific chain, 0 here means
-                        // start at Genesis block.
-                        .unwrap_or(0);
-
-                    info!(
-                        self.ctx.logger,
-                        "Blockstream disconnected, connecting";
-                        "endpoint_uri" => format_args!("{}", self.endpoint),
-                        "start_block" => start_block_num,
-                        "cursor" => match &self.ctx.active_cursor {
-                            Some(v) => v.clone(),
-                            None => "<None>".to_string(),
-                        },
-                    );
-
-                    let future = self
-                        .endpoint
-                        .clone()
-                        .stream_blocks(bstream::BlocksRequestV2 {
-                            start_block_num: start_block_num as i64,
-                            start_cursor: match &self.ctx.active_cursor {
-                                Some(c) => c.clone(),
-                                None => "".to_string(),
-                            },
-                            fork_steps: vec![
-                                bstream::ForkStep::StepNew as i32,
-                                bstream::ForkStep::StepUndo as i32,
-                            ],
-                            ..Default::default()
-                        });
-                    let mut stream_connection = Box::pin(future);
-
-                    match stream_connection.poll_unpin(cx) {
-                        Poll::Ready(Ok(streaming)) => {
-                            self.state = BlockStreamState::Connected(streaming);
-                            self.connection_attempts = 0;
-                            info!(self.ctx.logger, "Blockstream connected");
-
-                            // Re-loop to next state
-                            continue;
-                        }
-
-                        Poll::Ready(Err(e)) => {
-                            error!(self.ctx.logger, "Unable to connect to endpoint: {}", e);
-                            self.state = BlockStreamState::Disconnected;
-
-                            return self.schedule_error_retry(cx);
-                        }
-
-                        Poll::Pending => {
-                            trace!(
-                                self.ctx.logger,
-                                "Connection is still pending when being created"
-                            );
-                            self.state = BlockStreamState::Connecting(stream_connection);
-                            return Poll::Pending;
-                        }
-                    }
-                }
-
-                BlockStreamState::Connecting(stream_connection) => {
-                    match stream_connection.poll_unpin(cx) {
-                        Poll::Ready(Ok(streaming)) => {
-                            self.state = BlockStreamState::Connected(streaming);
-                            info!(self.ctx.logger, "Blockstream connected");
-
-                            // Re-loop to next state
-                            continue;
-                        }
-
-                        Poll::Ready(Err(e)) => {
-                            error!(self.ctx.logger, "Unable to connect to endpoint: {}", e);
-                            self.state = BlockStreamState::Disconnected;
-
-                            return self.schedule_error_retry(cx);
-                        }
-
-                        Poll::Pending => {
-                            trace!(
-                                self.ctx.logger,
-                                "Connection is still pending when being wake up"
-                            );
-                            return Poll::Pending;
-                        }
-                    }
-                }
-
-                BlockStreamState::Connected(streaming) => match streaming.poll_next_unpin(cx) {
-                    Poll::Ready(Some(Ok(response))) => {
-                        match self.ctx.mapper.to_block_stream_event(
-                            &self.ctx.logger,
-                            &response,
-                            &self.ctx.adapter,
-                            &self.ctx.filter,
-                        ) {
-                            Ok(event) => {
-                                self.ctx.last_seen_cursor = Some(response.cursor);
-                                return Poll::Ready(Some(Ok(event)));
-                            }
-                            Err(e) => {
-                                error!(
-                                    self.ctx.logger,
-                                    "Mapping block to BlockStreamEvent failed {}", e
-                                );
-                                self.state = BlockStreamState::Disconnected;
-
-                                return self.schedule_error_retry(cx);
-                            }
-                        }
-                    }
-
-                    Poll::Ready(Some(Err(e))) => {
-                        error!(self.ctx.logger, "Stream disconnected from endpoint {}", e);
-                        self.state = BlockStreamState::Disconnected;
-
-                        return self.schedule_error_retry(cx);
-                    }
-
-                    Poll::Ready(None) => {
-                        error!(self.ctx.logger, "Stream has terminated blocks range, we expect never ending stream right now");
-                        self.state = BlockStreamState::Disconnected;
-
-                        return self.schedule_error_retry(cx);
-                    }
-
-                    Poll::Pending => {
-                        trace!(
-                            self.ctx.logger,
-                            "Stream is pending, no item available yet, going to be wake up later to check again"
-                        );
-
-                        return Poll::Pending;
-                    }
-                },
-            }
-        }
+        return self.stream.poll_next_unpin(cx);
     }
 }
 
-impl<C: Blockchain, F: FirehoseMapper<C>> FirehoseBlockStream<C, F> {
-    /// Schedule a delayed function that will wake us later in time. This implementation
-    /// uses an exponential backoff strategy to retry with incremental longer delays.
-    fn schedule_error_retry<T>(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        self.connection_attempts += 1;
-        let wait_duration = wait_duration(self.connection_attempts);
-
-        let waker = cx.waker().clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(wait_duration).await;
-            waker.wake();
-        });
-
-        Poll::Pending
-    }
-}
-
-fn wait_duration(attempt_number: u64) -> Duration {
-    let pow = if attempt_number > 5 {
-        5
-    } else {
-        attempt_number
-    };
-
-    Duration::from_secs(2 << pow)
-}
+impl<C: Blockchain> BlockStream<C> for FirehoseBlockStream<C> {}


### PR DESCRIPTION
The implementation of the never ending Firehose stream of blocks have been re-implemented using `async-stream` library. This will makes the implementation much more readable and maintainable in the future. This should enable re-using `TriggersAdapter::triggers_in_block` directly instead of having to defer to `firehose_triggers_in_block` (subsequent PR to come).

This also removes the `notify_block_consumed` callback on the `FirehoseBlockStream` and the latest active cursor to reconnect to is now saved inside the FirehoseBlockStream directly. This will make it easier to implement the `BufferedBlockStream` in the future.

*Caveats* Formatting of code inside `try_stream!` macro doesn't work, unclear if it's a general limitation in macros in general or this very specific macro.

