### PR TITLE
Feature/graphman test run (IN PROGRESS)

### DIFF
--- a/.github/workflows/sf.yml
+++ b/.github/workflows/sf.yml
@@ -1,0 +1,130 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [feature/graphman-test-run]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  GRAPH_LOG: info
+  STREAMING_FAST_API_TOKEN: ${{ secrets.STREAMING_FAST_API_TOKEN }}
+  STREAMING_FAST_ETH_MAINNET_RPC: ${{ secrets.STREAMING_FAST_ETH_MAINNET_RPC }}
+  POSTGRES_PASSWORD: let-me-in
+  POSTGRES_DB: graph-node
+  POSTGRES_USER: graph-node
+  POSTGRES_HOSTPORT: localhost:5432
+
+jobs:
+  compare-dense:
+    name: Compare firehose with RPC-only on a dense segment
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: ["stable"]
+    environment: eth-mainnet
+    runs-on: ubuntu-latest
+    services:
+      ipfs:
+        image: ipfs/go-ipfs:v0.4.23
+        ports:
+          - 5001:5001
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: let-me-in
+          POSTGRES_DB: graph-node
+          POSTGRES_USER: graph-node
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Checkout sf config dev sources
+        uses: actions/checkout@v2
+        with:
+          repository: streamingfast/graph-node-dev
+          path: graph-node-dev
+
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: test-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install lld
+        run: sudo apt-get install -y lld
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '17.2'
+
+      - run: |
+          echo "installing graph-cli"
+          npm install -g @graphprotocol/graph-cli
+          echo "building the mainnet-events subgraph"
+          set -o pipefail
+          pushd graph-node-dev
+          yarn
+          graph build  --ipfs http://localhost:5001 subgraphs/ethereum/transfer/mainnet-events.yaml |tee buildout
+          IPFS_HASH="$(awk '/Build.completed/ {print $3}' buildout)"
+          echo "exporting ipfs hash $IPFS_HASH"
+          echo "ipfs_hash=$IPFS_HASH" >> $GITHUB_ENV
+          popd
+
+      - name: Build graphman
+        env:
+          RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --bin graphman
+
+      - name: run firehose test
+        run: target/debug/graphman --config graph-node-dev/config/eth-mainnet-firehose.toml test-run eth-mainnet "${{ env.ipfs_hash }}" 11000100
+        env:
+          GRAPH_DEBUG_POI_FILE: poi_firehose.csv
+
+      - name: cleanup
+        run: |
+          target/debug/graphman --config graph-node-dev/config/eth-mainnet-firehose.toml remove sf/transfer
+          target/debug/graphman --config graph-node-dev/config/eth-mainnet-firehose.toml unused record
+          target/debug/graphman --config graph-node-dev/config/eth-mainnet-firehose.toml unused remove
+
+      - name: work around rpc existing blocks requirement
+        run: |
+          sudo apt-get install --yes --no-install-recommends postgresql-client
+          psql postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOSTPORT}/${POSTGRES_DB} -c \
+          "update public.ethereum_networks set head_block_hash='d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3',head_block_number=99999999 where name='eth-mainnet'"
+
+      - name: run rpc test
+        run: target/debug/graphman --config graph-node-dev/config/eth-mainnet-rpc.toml test-run eth-mainnet "${{ env.ipfs_hash }}" 11000100
+        env:
+          GRAPH_DEBUG_POI_FILE: poi_rpc.csv
+
+      - name: Upload result firehose
+        uses: actions/upload-artifact@v2
+        with:
+          name: poi_firehose
+          path: poi_firehose.csv
+
+      - name: Upload result RPC
+        uses: actions/upload-artifact@v2
+        with:
+          name: poi_rpc
+          path: poi_rpc.csv

--- a/chain/ethereum/src/codec.rs
+++ b/chain/ethereum/src/codec.rs
@@ -134,7 +134,7 @@ impl Into<web3::types::U64> for TransactionTraceStatus {
 impl Into<Option<web3::types::U64>> for TransactionTraceStatus {
     fn into(self) -> Option<web3::types::U64> {
         match self {
-            Self::Unknown => None,
+            Self::Unknown => panic!("Got a transaction trace with status UNKNOWN, datasource is broken"),
             Self::Succeeded => Some(web3::types::U64::from(1)),
             Self::Failed => Some(web3::types::U64::from(0)),
             Self::Reverted => Some(web3::types::U64::from(0)),

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -60,6 +60,7 @@ struct IndexingInputs<C: Blockchain> {
     deployment: DeploymentLocator,
     features: BTreeSet<SubgraphFeature>,
     start_blocks: Vec<BlockNumber>,
+    stop_block: Option<BlockNumber>,
     store: Arc<dyn WritableStore>,
     triggers_adapter: Arc<C::TriggersAdapter>,
     chain: Arc<C>,
@@ -192,6 +193,7 @@ where
         self: Arc<Self>,
         loc: DeploymentLocator,
         manifest: serde_yaml::Mapping,
+        stop_block: Option<BlockNumber>,
     ) {
         let logger = self.logger_factory.subgraph_logger(&loc);
         let err_logger = logger.clone();
@@ -201,13 +203,13 @@ where
             match BlockchainKind::from_manifest(&manifest)? {
                 BlockchainKind::Ethereum => {
                     instance_manager
-                        .start_subgraph_inner::<graph_chain_ethereum::Chain>(logger, loc, manifest)
+                        .start_subgraph_inner::<graph_chain_ethereum::Chain>(logger, loc, manifest, stop_block)
                         .await
                 }
 
                 BlockchainKind::Near => {
                     instance_manager
-                        .start_subgraph_inner::<graph_chain_near::Chain>(logger, loc, manifest)
+                        .start_subgraph_inner::<graph_chain_near::Chain>(logger, loc, manifest, stop_block)
                         .await
                 }
             }
@@ -274,6 +276,7 @@ where
         logger: Logger,
         deployment: DeploymentLocator,
         manifest: serde_yaml::Mapping,
+        stop_block: Option<BlockNumber>,
     ) -> Result<(), Error> {
         let subgraph_store = self.subgraph_store.cheap_clone();
         let registry = self.metrics_registry.cheap_clone();
@@ -412,6 +415,7 @@ where
                 deployment: deployment.clone(),
                 features,
                 start_blocks,
+                stop_block,
                 store,
                 triggers_adapter,
                 chain,
@@ -597,6 +601,17 @@ where
             };
 
             let block_ptr = block.ptr();
+
+
+            match ctx.inputs.stop_block.clone() {
+                Some(stop_block) => {
+                    if block_ptr.number > stop_block {
+                        info!(&logger, "stop block reached for subgraph");
+                        return Ok(());
+                    }
+                }
+                _ => {}
+            }
 
             if block.trigger_count() > 0 {
                 subgraph_metrics

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -40,7 +40,7 @@ where
     L: LinkResolver,
     I: SubgraphInstanceManager,
 {
-    async fn start(&self, loc: DeploymentLocator) -> Result<(), SubgraphAssignmentProviderError> {
+    async fn start(&self, loc: DeploymentLocator, stop_block: Option<BlockNumber>) -> Result<(), SubgraphAssignmentProviderError> {
         let logger = self.logger_factory.subgraph_logger(&loc);
 
         // If subgraph ID already in set
@@ -63,7 +63,7 @@ where
 
         self.instance_manager
             .cheap_clone()
-            .start_subgraph(loc, raw)
+            .start_subgraph(loc, raw, stop_block)
             .await;
 
         Ok(())

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -409,7 +409,7 @@ async fn start_subgraph(
     trace!(logger, "Start subgraph");
 
     let start_time = Instant::now();
-    let result = provider.start(deployment.clone()).await;
+    let result = provider.start(deployment.clone(), None).await;
 
     debug!(
         logger,

--- a/graph/src/components/subgraph/instance_manager.rs
+++ b/graph/src/components/subgraph/instance_manager.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use crate::prelude::BlockNumber;
 
 use crate::components::store::DeploymentLocator;
 
@@ -13,6 +14,7 @@ pub trait SubgraphInstanceManager: Send + Sync + 'static {
         self: Arc<Self>,
         deployment: DeploymentLocator,
         manifest: serde_yaml::Mapping,
+        stop_block: Option<BlockNumber>,
     );
     fn stop_subgraph(&self, deployment: DeploymentLocator);
 }

--- a/graph/src/components/subgraph/provider.rs
+++ b/graph/src/components/subgraph/provider.rs
@@ -8,6 +8,7 @@ pub trait SubgraphAssignmentProvider: Send + Sync + 'static {
     async fn start(
         &self,
         deployment: DeploymentLocator,
+        stop_block: Option<BlockNumber>,
     ) -> Result<(), SubgraphAssignmentProviderError>;
     async fn stop(
         &self,

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -614,6 +614,9 @@ async fn main() {
             let config = ctx.config();
             let registry = ctx.metrics_registry().clone();
             let node_id = ctx.node_id().clone();
+            // FIXME this must be run before store_and_primary but should be pushed further down
+            let _store_builder =
+                StoreBuilder::new(&logger, &node_id, &config, registry.clone()).await;
             let (store, primary) = ctx.store_and_primary();
 
             commands::test_run::run(

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -144,6 +144,17 @@ pub enum Command {
         /// The deployments to rewind
         names: Vec<String>,
     },
+    /// Runs a suite of tests around a specific subgraph
+    TestRun {
+        /// Network name (must fit one of the chain)
+        network_name: String,
+
+        /// Subgraph in the form `<IPFS Hash>` or `<name>:<IPFS Hash>`
+        subgraph: String,
+
+        /// Number of block to process
+        block_count: u64,
+    },
     /// Check and interrogate the configuration
     ///
     /// Print information about a configuration file without
@@ -374,6 +385,18 @@ impl Context {
         }
     }
 
+    fn metrics_registry(&self) -> Arc<MetricsRegistry> {
+        self.registry.clone()
+    }
+
+    fn config(&self) -> Cfg {
+        self.config.clone()
+    }
+
+    fn node_id(&self) -> NodeId {
+        self.node_id.clone()
+    }
+
     fn primary_pool(self) -> ConnectionPool {
         let primary = self.config.primary_store();
         let pool = StoreBuilder::main_pool(
@@ -581,6 +604,30 @@ async fn main() {
                 force,
                 sleep,
             )
+        }
+        TestRun {
+            network_name,
+            subgraph,
+            block_count,
+        } => {
+            let logger = ctx.logger.clone();
+            let config = ctx.config();
+            let registry = ctx.metrics_registry().clone();
+            let node_id = ctx.node_id().clone();
+            let (store, primary) = ctx.store_and_primary();
+
+            commands::test_run::run(
+                primary,
+                store,
+                logger,
+                network_name,
+                config,
+                registry,
+                node_id,
+                subgraph,
+                block_count,
+            )
+            .await
         }
         Listen(cmd) => {
             use ListenCommand::*;

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -153,7 +153,7 @@ pub enum Command {
         subgraph: String,
 
         /// Number of block to process
-        block_count: u64,
+        stop_block: i32,
     },
     /// Check and interrogate the configuration
     ///
@@ -608,7 +608,7 @@ async fn main() {
         TestRun {
             network_name,
             subgraph,
-            block_count,
+            stop_block,
         } => {
             let logger = ctx.logger.clone();
             let config = ctx.config();
@@ -625,7 +625,7 @@ async fn main() {
                 registry,
                 node_id,
                 subgraph,
-                block_count,
+                stop_block,
             )
             .await
         }

--- a/node/src/manager/commands/mod.rs
+++ b/node/src/manager/commands/mod.rs
@@ -9,5 +9,6 @@ pub mod query;
 pub mod remove;
 pub mod rewind;
 pub mod stats;
+pub mod test_run;
 pub mod txn_speed;
 pub mod unused_deployments;

--- a/node/src/manager/commands/test_run.rs
+++ b/node/src/manager/commands/test_run.rs
@@ -1,0 +1,565 @@
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use std::time::Duration;
+use std::{collections::HashSet, convert::TryFrom};
+use std::{env, thread};
+
+use crate::config::{Config, ProviderDetails};
+use crate::manager::deployment::Deployment;
+use crate::manager::PanicSubscriptionManager;
+use crate::store_builder::StoreBuilder;
+use ethereum::{EthereumNetworks, ProviderEthRpcMetrics};
+use futures::future::join_all;
+use futures::TryFutureExt;
+use graph::anyhow::{bail, format_err, Error};
+use graph::blockchain::{Block as BlockchainBlock, BlockchainKind, BlockchainMap, ChainIdentifier};
+use graph::cheap_clone::CheapClone;
+use graph::components::store::{BlockStore as _, ChainStore as _, DeploymentId, DeploymentLocator};
+use graph::firehose::endpoints::{FirehoseEndpoint, FirehoseNetworkEndpoints, FirehoseNetworks};
+use graph::ipfs_client::IpfsClient;
+use graph::log::logger;
+use graph::prelude::{
+    anyhow, tokio, BlockNumber, BlockPtr, DeploymentHash, LoggerFactory, NodeId,
+    SubgraphAssignmentProvider, SubgraphName, SubgraphRegistrar, SubgraphStore,
+    SubgraphVersionSwitchingMode,
+};
+use graph::prelude::{prost, MetricsRegistry as MetricsRegistryTrait};
+use graph::slog::{debug, error, info, o, Logger};
+use graph::util::security::SafeDisplay;
+use graph_chain_ethereum::{self as ethereum, network_indexer, EthereumAdapterTrait, Transport};
+use graph_core::{
+    LinkResolver, MetricsRegistry, SubgraphAssignmentProvider as IpfsSubgraphAssignmentProvider,
+    SubgraphInstanceManager, SubgraphRegistrar as IpfsSubgraphRegistrar,
+};
+use graph_store_postgres::BlockStore;
+use graph_store_postgres::{connection_pool::ConnectionPool, Store};
+use lazy_static::lazy_static;
+use std::str::FromStr;
+
+pub async fn run(
+    primary: ConnectionPool,
+    store: Arc<Store>,
+    logger: Logger,
+    network_name: String,
+    config: Config,
+    metrics_registry: Arc<MetricsRegistry>,
+    node_id: NodeId,
+    subgraph: String,
+    block_count: u64,
+) -> Result<(), anyhow::Error> {
+    println!(
+        "Test run starting subgraph => {}, block_count = {}",
+        subgraph, block_count
+    );
+
+    let logger_factory = LoggerFactory::new(logger.clone(), None);
+
+    // FIXME: Hard-coded IPFS config, take it from config file instead?
+    let ipfs_clients: Vec<_> =
+        create_ipfs_clients(&logger, &vec!["http://127.0.0.1:5001".to_string()]);
+
+    // Convert the clients into a link resolver. Since we want to get past
+    // possible temporary DNS failures, make the resolver retry
+    let link_resolver = Arc::new(LinkResolver::from(ipfs_clients));
+
+    let eth_networks = create_ethereum_networks(logger.clone(), metrics_registry.clone(), &config)
+        .await
+        .expect("Failed to parse Ethereum networks");
+    let firehose_networks_by_kind =
+        create_firehose_networks(logger.clone(), metrics_registry.clone(), &config)
+            .await
+            .expect("Failed to parse Firehose endpoints");
+    let firehose_networks = firehose_networks_by_kind.get(&BlockchainKind::Ethereum);
+    let firehose_endpoints = firehose_networks.and_then(|v| v.networks.get(&network_name));
+
+    let eth_adapters = match eth_networks.networks.get(&network_name) {
+        Some(adapters) => adapters.clone(),
+        None => {
+            return Err(format_err!(
+            "No ethereum adapters found, but required in this state of graphman test-run command"
+        ))
+        }
+    };
+
+    let store_builder =
+        StoreBuilder::new(&logger, &node_id, &config, metrics_registry.clone()).await;
+    let chain_head_update_listener = store_builder.chain_head_update_listener();
+
+    let (eth_networks, ethereum_idents) = connect_ethereum_networks(&logger, eth_networks).await;
+    // let (near_networks, near_idents) = connect_firehose_networks::<NearFirehoseHeaderOnlyBlock>(
+    //     &logger,
+    //     firehose_networks_by_kind
+    //         .remove(&BlockchainKind::Near)
+    //         .unwrap_or_else(|| FirehoseNetworks::new()),
+    // )
+    // .await;
+
+    let network_identifiers = ethereum_idents.into_iter().collect();
+    let network_store = store_builder.network_store(network_identifiers);
+
+    let subgraph_store = network_store.subgraph_store();
+    let chain_store = network_store
+        .block_store()
+        .chain_store(network_name.as_ref())
+        .expect(format!("No chain store for {}", &network_name).as_ref());
+
+    let chain = ethereum::Chain::new(
+        logger_factory.clone(),
+        network_name.clone(),
+        node_id.clone(),
+        metrics_registry.clone(),
+        chain_store.cheap_clone(),
+        chain_store,
+        subgraph_store.clone(),
+        firehose_endpoints.map_or_else(|| FirehoseNetworkEndpoints::new(), |v| v.clone()),
+        eth_adapters,
+        chain_head_update_listener,
+        *ANCESTOR_COUNT,
+        *REORG_THRESHOLD,
+        // We assume the tested chain is always ingestible for now
+        true,
+    );
+
+    let mut blockchain_map = BlockchainMap::new();
+    blockchain_map.insert(network_name.clone(), Arc::new(chain));
+
+    let blockchain_map = Arc::new(blockchain_map);
+    let subgraph_instance_manager = SubgraphInstanceManager::new(
+        &logger_factory,
+        subgraph_store.clone(),
+        blockchain_map.clone(),
+        metrics_registry.clone(),
+        link_resolver.cheap_clone(),
+    );
+
+    // Create IPFS-based subgraph provider
+    let subgraph_provider = Arc::new(IpfsSubgraphAssignmentProvider::new(
+        &logger_factory,
+        link_resolver.cheap_clone(),
+        subgraph_instance_manager,
+    ));
+
+    let panicking_subscription_manager = Arc::new(PanicSubscriptionManager {});
+
+    let subgraph_registrar = Arc::new(IpfsSubgraphRegistrar::new(
+        &logger_factory,
+        link_resolver.cheap_clone(),
+        subgraph_provider.clone(),
+        subgraph_store.clone(),
+        panicking_subscription_manager,
+        blockchain_map,
+        node_id.clone(),
+        SubgraphVersionSwitchingMode::Instant,
+    ));
+
+    let (name, hash) = if subgraph.contains(':') {
+        let mut split = subgraph.split(':');
+        (split.next().unwrap(), split.next().unwrap().to_owned())
+    } else {
+        ("cli", subgraph)
+    };
+
+    let subgraph_name = SubgraphName::new(name)
+        .expect("Subgraph name must contain only a-z, A-Z, 0-9, '-' and '_'");
+    let subgraph_hash = DeploymentHash::new(hash).expect("Subgraph hash must be a valid IPFS hash");
+
+    info!(&logger, "Creating subgraph {}", name);
+    let create_result =
+        SubgraphRegistrar::create_subgraph(subgraph_registrar.as_ref(), subgraph_name.clone())
+            .await?;
+
+    info!(
+        &logger,
+        "Looking up subgraph deployment {} (Deployment hash => {}, id => {})",
+        name,
+        subgraph_hash,
+        create_result.id,
+    );
+
+    SubgraphRegistrar::create_subgraph_version(
+        subgraph_registrar.as_ref(),
+        subgraph_name.clone(),
+        subgraph_hash.clone(),
+        node_id.clone(),
+    )
+    .await?;
+
+    // let deployment_locator = DeploymentLocator::new(DeploymentId(deployment_id), subgraph_hash);
+
+    let deployments = Deployment::lookup(&primary, name.to_string())?;
+    let deployment = deployments
+        .first()
+        .expect("At least one deployment should exist");
+
+    SubgraphAssignmentProvider::start(subgraph_provider.as_ref(), deployment.locator()).await?;
+
+    tokio::time::sleep(Duration::from_millis(30000)).await;
+
+    info!(&logger, "Removing subgraph {}", name);
+    subgraph_store.clone().remove_subgraph(subgraph_name)?;
+
+    Ok(())
+}
+
+// Stuff copied directly moslty from `main.rs`
+//
+// FIXME: Share that with `main.rs` stuff
+
+// The status of a provider that we learned from connecting to it
+#[derive(PartialEq)]
+enum ProviderNetworkStatus {
+    Broken {
+        network: String,
+        provider: String,
+    },
+    Version {
+        network: String,
+        ident: ChainIdentifier,
+    },
+}
+
+/// How long we will hold up node startup to get the net version and genesis
+/// hash from the client. If we can't get it within that time, we'll try and
+/// continue regardless.
+const NET_VERSION_WAIT_TIME: Duration = Duration::from_secs(30);
+
+lazy_static! {
+    // Default to an Ethereum reorg threshold to 50 blocks
+    static ref REORG_THRESHOLD: BlockNumber = env::var("ETHEREUM_REORG_THRESHOLD")
+        .ok()
+        .map(|s| BlockNumber::from_str(&s)
+            .unwrap_or_else(|_| panic!("failed to parse env var ETHEREUM_REORG_THRESHOLD")))
+        .unwrap_or(50);
+
+    // Default to an ancestor count of 50 blocks
+    static ref ANCESTOR_COUNT: BlockNumber = env::var("ETHEREUM_ANCESTOR_COUNT")
+        .ok()
+        .map(|s| BlockNumber::from_str(&s)
+             .unwrap_or_else(|_| panic!("failed to parse env var ETHEREUM_ANCESTOR_COUNT")))
+        .unwrap_or(50);
+}
+
+fn create_ipfs_clients(logger: &Logger, ipfs_addresses: &Vec<String>) -> Vec<IpfsClient> {
+    // Parse the IPFS URL from the `--ipfs` command line argument
+    let ipfs_addresses: Vec<_> = ipfs_addresses
+        .iter()
+        .map(|uri| {
+            if uri.starts_with("http://") || uri.starts_with("https://") {
+                String::from(uri)
+            } else {
+                format!("http://{}", uri)
+            }
+        })
+        .collect();
+
+    ipfs_addresses
+        .into_iter()
+        .map(|ipfs_address| {
+            info!(
+                logger,
+                "Trying IPFS node at: {}",
+                SafeDisplay(&ipfs_address)
+            );
+
+            let ipfs_client = match IpfsClient::new(&ipfs_address) {
+                Ok(ipfs_client) => ipfs_client,
+                Err(e) => {
+                    error!(
+                        logger,
+                        "Failed to create IPFS client for `{}`: {}",
+                        SafeDisplay(&ipfs_address),
+                        e
+                    );
+                    panic!("Could not connect to IPFS");
+                }
+            };
+
+            // Test the IPFS client by getting the version from the IPFS daemon
+            let ipfs_test = ipfs_client.cheap_clone();
+            let ipfs_ok_logger = logger.clone();
+            let ipfs_err_logger = logger.clone();
+            let ipfs_address_for_ok = ipfs_address.clone();
+            let ipfs_address_for_err = ipfs_address.clone();
+            graph::spawn(async move {
+                ipfs_test
+                    .test()
+                    .map_err(move |e| {
+                        error!(
+                            ipfs_err_logger,
+                            "Is there an IPFS node running at \"{}\"?",
+                            SafeDisplay(ipfs_address_for_err),
+                        );
+                        panic!("Failed to connect to IPFS: {}", e);
+                    })
+                    .map_ok(move |_| {
+                        info!(
+                            ipfs_ok_logger,
+                            "Successfully connected to IPFS node at: {}",
+                            SafeDisplay(ipfs_address_for_ok)
+                        );
+                    })
+                    .await
+            });
+
+            ipfs_client
+        })
+        .collect()
+}
+
+/// Parses an Ethereum connection string and returns the network name and Ethereum adapter.
+async fn create_ethereum_networks(
+    logger: Logger,
+    registry: Arc<MetricsRegistry>,
+    config: &Config,
+) -> Result<EthereumNetworks, anyhow::Error> {
+    let eth_rpc_metrics = Arc::new(ProviderEthRpcMetrics::new(registry));
+    let mut parsed_networks = EthereumNetworks::new();
+    for (name, chain) in &config.chains.chains {
+        if chain.protocol != BlockchainKind::Ethereum {
+            continue;
+        }
+
+        for provider in &chain.providers {
+            if let ProviderDetails::Web3(web3) = &provider.details {
+                let capabilities = web3.node_capabilities();
+
+                let logger = logger.new(o!("provider" => provider.label.clone()));
+                info!(
+                    logger,
+                    "Creating transport";
+                    "url" => &web3.url,
+                    "capabilities" => capabilities
+                );
+
+                use crate::config::Transport::*;
+
+                let transport = match web3.transport {
+                    Rpc => Transport::new_rpc(&web3.url, web3.headers.clone()),
+                    Ipc => Transport::new_ipc(&web3.url).await,
+                    Ws => Transport::new_ws(&web3.url).await,
+                };
+
+                let supports_eip_1898 = !web3.features.contains("no_eip1898");
+
+                parsed_networks.insert(
+                    name.to_string(),
+                    capabilities,
+                    Arc::new(
+                        graph_chain_ethereum::EthereumAdapter::new(
+                            logger,
+                            provider.label.clone(),
+                            &web3.url,
+                            transport,
+                            eth_rpc_metrics.clone(),
+                            supports_eip_1898,
+                        )
+                        .await,
+                    ),
+                );
+            }
+        }
+    }
+    parsed_networks.sort();
+    Ok(parsed_networks)
+}
+
+async fn create_firehose_networks(
+    logger: Logger,
+    _registry: Arc<dyn MetricsRegistryTrait>,
+    config: &Config,
+) -> Result<BTreeMap<BlockchainKind, FirehoseNetworks>, anyhow::Error> {
+    debug!(
+        logger,
+        "Creating firehose networks [{} chains, ingestor {}]",
+        config.chains.chains.len(),
+        config.chains.ingestor,
+    );
+
+    let mut networks_by_kind = BTreeMap::new();
+
+    for (name, chain) in &config.chains.chains {
+        for provider in &chain.providers {
+            if let ProviderDetails::Firehose(ref firehose) = provider.details {
+                let logger = logger.new(o!("provider" => provider.label.clone()));
+                info!(
+                    logger,
+                    "Creating firehose endpoint";
+                    "url" => &firehose.url,
+                );
+
+                let endpoint = FirehoseEndpoint::new(
+                    logger,
+                    &provider.label,
+                    &firehose.url,
+                    firehose.token.clone(),
+                )
+                .await?;
+
+                let parsed_networks = networks_by_kind
+                    .entry(chain.protocol)
+                    .or_insert_with(|| FirehoseNetworks::new());
+                parsed_networks.insert(name.to_string(), Arc::new(endpoint));
+            }
+        }
+    }
+
+    Ok(networks_by_kind)
+}
+
+/// Try to connect to all the providers in `eth_networks` and get their net
+/// version and genesis block. Return the same `eth_networks` and the
+/// retrieved net identifiers grouped by network name. Remove all providers
+/// for which trying to connect resulted in an error from the returned
+/// `EthereumNetworks`, since it's likely pointless to try and connect to
+/// them. If the connection attempt to a provider times out after
+/// `NET_VERSION_WAIT_TIME`, keep the provider, but don't report a
+/// version for it.
+async fn connect_ethereum_networks(
+    logger: &Logger,
+    mut eth_networks: EthereumNetworks,
+) -> (EthereumNetworks, Vec<(String, Vec<ChainIdentifier>)>) {
+    // This has one entry for each provider, and therefore multiple entries
+    // for each network
+    let statuses = join_all(
+        eth_networks
+            .flatten()
+            .into_iter()
+            .map(|(network_name, capabilities, eth_adapter)| {
+                (network_name, capabilities, eth_adapter, logger.clone())
+            })
+            .map(|(network, capabilities, eth_adapter, logger)| async move {
+                let logger = logger.new(o!("provider" => eth_adapter.provider().to_string()));
+                info!(
+                    logger, "Connecting to Ethereum to get network identifier";
+                    "capabilities" => &capabilities
+                );
+                match tokio::time::timeout(NET_VERSION_WAIT_TIME, eth_adapter.net_identifiers())
+                    .await
+                    .map_err(Error::from)
+                {
+                    // An `Err` means a timeout, an `Ok(Err)` means some other error (maybe a typo
+                    // on the URL)
+                    Ok(Err(e)) | Err(e) => {
+                        error!(logger, "Connection to provider failed. Not using this provider";
+                                       "error" =>  e.to_string());
+                        ProviderNetworkStatus::Broken {
+                            network,
+                            provider: eth_adapter.provider().to_string(),
+                        }
+                    }
+                    Ok(Ok(ident)) => {
+                        info!(
+                            logger,
+                            "Connected to Ethereum";
+                            "network_version" => &ident.net_version,
+                            "capabilities" => &capabilities
+                        );
+                        ProviderNetworkStatus::Version { network, ident }
+                    }
+                }
+            }),
+    )
+    .await;
+
+    // Group identifiers by network name
+    let idents: HashMap<String, Vec<ChainIdentifier>> =
+        statuses
+            .into_iter()
+            .fold(HashMap::new(), |mut networks, status| {
+                match status {
+                    ProviderNetworkStatus::Broken { network, provider } => {
+                        eth_networks.remove(&network, &provider)
+                    }
+                    ProviderNetworkStatus::Version { network, ident } => {
+                        networks.entry(network.to_string()).or_default().push(ident)
+                    }
+                }
+                networks
+            });
+    let idents: Vec<_> = idents.into_iter().collect();
+    (eth_networks, idents)
+}
+
+/// Try to connect to all the providers in `firehose_networks` and get their net
+/// version and genesis block. Return the same `eth_networks` and the
+/// retrieved net identifiers grouped by network name. Remove all providers
+/// for which trying to connect resulted in an error from the returned
+/// `EthereumNetworks`, since it's likely pointless to try and connect to
+/// them. If the connection attempt to a provider times out after
+/// `NET_VERSION_WAIT_TIME`, keep the provider, but don't report a
+/// version for it.
+async fn connect_firehose_networks<M>(
+    logger: &Logger,
+    mut firehose_networks: FirehoseNetworks,
+) -> (FirehoseNetworks, Vec<(String, Vec<ChainIdentifier>)>)
+where
+    M: prost::Message + BlockchainBlock + Default + 'static,
+{
+    // This has one entry for each provider, and therefore multiple entries
+    // for each network
+    let statuses = join_all(
+        firehose_networks
+            .flatten()
+            .into_iter()
+            .map(|(network_name, endpoint)| (network_name, endpoint, logger.clone()))
+            .map(|(network, endpoint, logger)| async move {
+                let logger = logger.new(o!("provider" => endpoint.provider.to_string()));
+                info!(
+                    logger, "Connecting to Firehose to get network identifier";
+                    "url" => &endpoint.uri,
+                );
+                match tokio::time::timeout(
+                    NET_VERSION_WAIT_TIME,
+                    endpoint.genesis_block_ptr::<M>(&logger),
+                )
+                .await
+                .map_err(Error::from)
+                {
+                    // An `Err` means a timeout, an `Ok(Err)` means some other error (maybe a typo
+                    // on the URL)
+                    Ok(Err(e)) | Err(e) => {
+                        error!(logger, "Connection to provider failed. Not using this provider";
+                                       "error" =>  e.to_string());
+                        ProviderNetworkStatus::Broken {
+                            network,
+                            provider: endpoint.provider.to_string(),
+                        }
+                    }
+                    Ok(Ok(ptr)) => {
+                        info!(
+                            logger,
+                            "Connected to Firehose";
+                            "uri" => &endpoint.uri,
+                            "genesis_block" => format_args!("{}", &ptr),
+                        );
+
+                        let ident = ChainIdentifier {
+                            net_version: "0".to_string(),
+                            genesis_block_hash: ptr.hash,
+                        };
+
+                        ProviderNetworkStatus::Version { network, ident }
+                    }
+                }
+            }),
+    )
+    .await;
+
+    // Group identifiers by network name
+    let idents: HashMap<String, Vec<ChainIdentifier>> =
+        statuses
+            .into_iter()
+            .fold(HashMap::new(), |mut networks, status| {
+                match status {
+                    ProviderNetworkStatus::Broken { network, provider } => {
+                        firehose_networks.remove(&network, &provider)
+                    }
+                    ProviderNetworkStatus::Version { network, ident } => {
+                        networks.entry(network.to_string()).or_default().push(ident)
+                    }
+                }
+                networks
+            });
+    let idents: Vec<_> = idents.into_iter().collect();
+    (firehose_networks, idents)
+}

--- a/node/src/manager/deployment.rs
+++ b/node/src/manager/deployment.rs
@@ -16,7 +16,7 @@ use graph_store_postgres::{command_support::catalog as store_catalog, Shard, Sub
 use crate::manager::deployment;
 use crate::manager::display::List;
 
-#[derive(Queryable, PartialEq, Eq, Hash)]
+#[derive(Queryable, PartialEq, Eq, Hash, Debug)]
 pub struct Deployment {
     pub name: String,
     pub status: String,


### PR DESCRIPTION
Work in progress -- do not merge yet

# graphman test-run
* add `graphman test-run` command (implements stop-block mechanism to stop when the subgraph's end block is reached)

# github firehose/rpc comparison workflow
* add a github workflow that runs firehose vs RPC runs
* runs in about 11 minutes
* currently only matches events, not calls or full blocks. additional runs will be added.
## requirements: 
* a github environment 'eth-mainnet' with STREAMING_FAST_API_TOKEN and STREAMING_FAST_ETH_MAINNET_RPC (ex: https://some-rpc-url-with-archive-and-trace/some-token/) 
* dependancy on example subgraph and config files in github.com/streamingfast/graph-node-dev
* action is currently configured to run on this branch only
## see it in action:
 https://github.com/streamingfast/graph-node/runs
