### PR TITLE
Replace specialized `firehose_triggers_in_block` by direct usage of TriggerAdapter::triggers_in_blocks`

### DIFF
--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -77,8 +77,9 @@ pub trait TriggersAdapter<C: Blockchain>: Send + Sync {
     async fn parent_ptr(&self, block: &BlockPtr) -> Result<Option<BlockPtr>, Error>;
 }
 
+#[async_trait]
 pub trait FirehoseMapper<C: Blockchain>: Send + Sync {
-    fn to_block_stream_event(
+    async fn to_block_stream_event(
         &self,
         logger: &Logger,
         response: &bstream::BlockResponseV2,

--- a/graph/src/blockchain/firehose_block_stream.rs
+++ b/graph/src/blockchain/firehose_block_stream.rs
@@ -94,7 +94,7 @@ fn stream_blocks<C: Blockchain, F: FirehoseMapper<C>>(
                     for await response in stream {
                         match response {
                             Ok(v) => {
-                                match mapper.to_block_stream_event(&logger, &v, &adapter, &filter) {
+                                match mapper.to_block_stream_event(&logger, &v, &adapter, &filter).await {
                                     Ok(event) => {
                                         yield event;
 


### PR DESCRIPTION
With the revamped `FirehoseBlockStream`, it's now possible to directly re-use the `TriggerAdapter::triggers_in_blocks` code instead of relying on our specialized `firehose_triggers_in_block`. This make the code more re-usable.

Eliminated at the same time a useless close in `NearChair::TriggersAdapter`. Also make some `NearChain` now panics instead of silently returning something that is not good.

Linked to #3080

### Note

Based on #3078
