### PR TITLE
Avoid parsing X triggers if the filter is empty

### DIFF
--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -400,12 +400,6 @@ impl FromIterator<(BlockNumber, Address, FunctionSelector)> for EthereumCallFilt
     }
 }
 
-impl From<EthereumBlockFilter> for EthereumCallFilter {
-    fn from(ethereum_block_filter: EthereumBlockFilter) -> Self {
-        EthereumCallFilter::from(&ethereum_block_filter)
-    }
-}
-
 impl From<&EthereumBlockFilter> for EthereumCallFilter {
     fn from(ethereum_block_filter: &EthereumBlockFilter) -> Self {
         Self {

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -483,6 +483,16 @@ impl EthereumBlockFilter {
     fn requires_traces(&self) -> bool {
         !self.contract_addresses.is_empty()
     }
+
+    /// An empty filter is one that never matches.
+    pub fn is_empty(&self) -> bool {
+        // If we are triggering every block, we are of course not empty
+        if self.trigger_every_block {
+            return false;
+        }
+
+        self.contract_addresses.is_empty()
+    }
 }
 
 #[derive(Clone)]

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -402,11 +402,19 @@ impl FromIterator<(BlockNumber, Address, FunctionSelector)> for EthereumCallFilt
 
 impl From<EthereumBlockFilter> for EthereumCallFilter {
     fn from(ethereum_block_filter: EthereumBlockFilter) -> Self {
+        EthereumCallFilter::from(&ethereum_block_filter)
+    }
+}
+
+impl From<&EthereumBlockFilter> for EthereumCallFilter {
+    fn from(ethereum_block_filter: &EthereumBlockFilter) -> Self {
         Self {
             contract_addresses_function_signatures: ethereum_block_filter
                 .contract_addresses
-                .into_iter()
-                .map(|(start_block_opt, address)| (address, (start_block_opt, HashSet::default())))
+                .iter()
+                .map(|(start_block_opt, address)| {
+                    (address.clone(), (*start_block_opt, HashSet::default()))
+                })
                 .collect::<HashMap<Address, (BlockNumber, HashSet<FunctionSelector>)>>(),
         }
     }

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -513,22 +513,12 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             }
             BlockFinality::NonFinal(full_block) => {
                 let mut triggers = Vec::new();
-
-                if !filter.log.is_empty() {
-                    triggers.append(&mut parse_log_triggers(
-                        &filter.log,
-                        &full_block.ethereum_block,
-                    ));
-                }
-
-                if !filter.call.is_empty() {
-                    triggers.append(&mut parse_call_triggers(&filter.call, &full_block)?);
-                }
-
-                if !filter.block.is_empty() {
-                    triggers.append(&mut parse_block_triggers(filter.block.clone(), &full_block));
-                }
-
+                triggers.append(&mut parse_log_triggers(
+                    &filter.log,
+                    &full_block.ethereum_block,
+                ));
+                triggers.append(&mut parse_call_triggers(&filter.call, &full_block)?);
+                triggers.append(&mut parse_block_triggers(&filter.block, &full_block));
                 Ok(BlockWithTriggers::new(block, triggers))
             }
         }

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -513,12 +513,22 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             }
             BlockFinality::NonFinal(full_block) => {
                 let mut triggers = Vec::new();
-                triggers.append(&mut parse_log_triggers(
-                    &filter.log,
-                    &full_block.ethereum_block,
-                ));
-                triggers.append(&mut parse_call_triggers(&filter.call, &full_block)?);
-                triggers.append(&mut parse_block_triggers(filter.block.clone(), &full_block));
+
+                if !filter.log.is_empty() {
+                    triggers.append(&mut parse_log_triggers(
+                        &filter.log,
+                        &full_block.ethereum_block,
+                    ));
+                }
+
+                if !filter.call.is_empty() {
+                    triggers.append(&mut parse_call_triggers(&filter.call, &full_block)?);
+                }
+
+                if !filter.block.is_empty() {
+                    triggers.append(&mut parse_block_triggers(filter.block.clone(), &full_block));
+                }
+
                 Ok(BlockWithTriggers::new(block, triggers))
             }
         }

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1590,6 +1590,10 @@ pub(crate) fn parse_log_triggers(
     log_filter: &EthereumLogFilter,
     block: &EthereumBlock,
 ) -> Vec<EthereumTrigger> {
+    if log_filter.is_empty() {
+        return vec![];
+    }
+
     block
         .transaction_receipts
         .iter()
@@ -1607,6 +1611,10 @@ pub(crate) fn parse_call_triggers(
     call_filter: &EthereumCallFilter,
     block: &EthereumBlockWithCalls,
 ) -> anyhow::Result<Vec<EthereumTrigger>> {
+    if call_filter.is_empty() {
+        return Ok(vec![]);
+    }
+
     match &block.calls {
         Some(calls) => calls
             .iter()
@@ -1625,9 +1633,13 @@ pub(crate) fn parse_call_triggers(
 }
 
 pub(crate) fn parse_block_triggers(
-    block_filter: EthereumBlockFilter,
+    block_filter: &EthereumBlockFilter,
     block: &EthereumBlockWithCalls,
 ) -> Vec<EthereumTrigger> {
+    if block_filter.is_empty() {
+        return vec![];
+    }
+
     let block_ptr = BlockPtr::from(&block.ethereum_block);
     let trigger_every_block = block_filter.trigger_every_block;
     let call_filter = EthereumCallFilter::from(block_filter);

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1388,7 +1388,7 @@ pub(crate) async fn blocks_with_triggers(
     // and the blocks yielded need to be deduped. If any error occurs
     // while searching for a trigger type, the entire operation fails.
     let eth = adapter.clone();
-    let call_filter = EthereumCallFilter::from(filter.block.clone());
+    let call_filter = EthereumCallFilter::from(&filter.block);
 
     let mut trigger_futs: futures::stream::FuturesUnordered<
         Box<dyn Future<Item = Vec<EthereumTrigger>, Error = Error> + Send>,


### PR DESCRIPTION
When a filter is empty, it means it cannot match anything. By guarding the parsing of the triggers upfront, we avoid looping through lot's of element in the blocks, this is especially true for full blocks that contain all the transactions.

Fixes #3080

