### PR TITLE
Experiment with the option to pass feature flags and build GraphQL schema based on that

### DIFF
--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -568,7 +568,7 @@ impl DeploymentStore {
         // API schema have a @subgraphId directive as well
         let mut schema = input_schema.clone();
         schema.document =
-            api_schema(&schema.document).map_err(|e| StoreError::Unknown(e.into()))?;
+            api_schema(&schema.document, vec![]).map_err(|e| StoreError::Unknown(e.into()))?;
         schema.add_subgraph_id_directives(site.deployment.clone());
 
         let info = SubgraphInfo {


### PR DESCRIPTION
#### Background

A POC/experiment for introducing feature-flag-based GraphQL `schema` building (related: https://github.com/graphprotocol/graph-node/issues/3024 ).

The goal of this experiment is to try to address GraphQL schema changes through an evolving set of feature-flags, instead of semantic versioning. 

This PR assumes that GraphQL schema served to the consumer can be selected by the user itself (using headers/any other protocol), and the same `graph-node` needs to be able to support multiple schema versions at the same time. 

For example, using HTTP headers:

```
X-GraphQL-Schema-Features: genesis, relay-connection, child-block-filter
```

> for this demo, I applied it in the `graphql/examples/schema` test bin only.

#### Code Changes

This experiment adds the following:

```rust
trait GraphQLSchemaComponent {
    fn should_apply(&self, active_flags: &Vec<String>) -> bool;
    fn apply(&self, input_schema: &Document, schema: &mut Document) -> Result<(), APISchemaError>;
}
```

The schema-building process in `api.rs` can now its output based on an external list of `active_flags` specified to `api_schema` function. 

#### Topics for discussion

* The basic `trait` adds only the GraphQL schema (`api.rs`) at the moment -> how can we handle that in the execution part?
	* I guess changes to the implementation needs to be communicated through a version of `graph-node`?  	
* How can we make the schema-building process more flexible? (at the moment, we can't add `Query` multiple times, or modify it)
* Bug fixes in execution == `graphql-node` version? 
* `semver`? 
	* If we want to semver for defining the versions, maybe we can try to implement a similar mechanism? (where a SchemaComponent defines it's supported range like `>1.0.0` and the use pass the version they wish to have)

#### Try It 

can be tested with: 

```
# for default output
cargo run --package graph-graphql --example schema "tests/integration-tests/non-fatal-errors/schema.graphql" genesis

# with demo example 
cargo run --package graph-graphql --example schema "tests/integration-tests/non-fatal-errors/schema.graphql" genesis,demo
```

Should yield a different GraphQL schema:

```diff
# ...

type Query {
  foo(id: ID!, "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted." block: Block_height, "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing." subgraphError: _SubgraphErrorPolicy_! = deny): Foo
  foos(skip: Int = 0, first: Int = 100, orderBy: Foo_orderBy, orderDirection: OrderDirection, where: Foo_filter, "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted." block: Block_height, "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing." subgraphError: _SubgraphErrorPolicy_! = deny): [Foo!]!
  "Access to subgraph metadata"
  _meta(block: Block_height): _Meta_
}

type Subscription {
  foo(id: ID!, "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted." block: Block_height, "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing." subgraphError: _SubgraphErrorPolicy_! = deny): Foo
  foos(skip: Int = 0, first: Int = 100, orderBy: Foo_orderBy, orderDirection: OrderDirection, where: Foo_filter, "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted." block: Block_height, "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing." subgraphError: _SubgraphErrorPolicy_! = deny): [Foo!]!
  "Access to subgraph metadata"
  _meta(block: Block_height): _Meta_
}

+ type DemoSchemaTest {
+  test: String
+}

```


