### PR TITLE
graph,graphql,store: nested sorting

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -126,6 +126,9 @@ those.
 - `GRAPH_GRAPHQL_DISABLE_BOOL_FILTERS`: disables the ability to use AND/OR
   filters. This is useful if we want to disable filters because of
   performance reasons.
+- `GRAPH_GRAPHQL_DISABLE_CHILD_SORTING`: disables the ability to use child-based
+  sorting. This is useful if we want to disable child-based sorting because of
+  performance reasons.
 - `GRAPH_GRAPHQL_TRACE_TOKEN`: the token to use to enable query tracing for
   a GraphQL request. If this is set, requests that have a header
   `X-GraphTraceQuery` set to this value will include a trace of the SQL

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -280,6 +280,24 @@ impl EntityFilter {
     }
 }
 
+/// Holds the information needed to query a store.
+#[derive(Clone, Debug, PartialEq)]
+pub struct EntityOrderByChildInfo {
+    /// The attribute of the child entity that is used to order the results.
+    pub sort_by_attribute: Attribute,
+    /// The attribute that is used to join to the parent and child entity.
+    pub join_attribute: Attribute,
+    /// If true, the child entity is derived from the parent entity.
+    pub derived: bool,
+}
+
+/// Holds the information needed to order the results of a query based on nested entities.
+#[derive(Clone, Debug, PartialEq)]
+pub enum EntityOrderByChild {
+    Object(EntityOrderByChildInfo, EntityType),
+    Interface(EntityOrderByChildInfo, Vec<EntityType>),
+}
+
 /// The order in which entities should be restored from a store.
 #[derive(Clone, Debug, PartialEq)]
 pub enum EntityOrder {
@@ -287,6 +305,10 @@ pub enum EntityOrder {
     Ascending(String, ValueType),
     /// Order descending by the given attribute. Use `id` as a tie-breaker
     Descending(String, ValueType),
+    /// Order ascending by the given attribute of a child entity. Use `id` as a tie-breaker
+    ChildAscending(EntityOrderByChild),
+    /// Order descending by the given attribute of a child entity. Use `id` as a tie-breaker
+    ChildDescending(EntityOrderByChild),
     /// Order by the `id` of the entities
     Default,
     /// Do not order at all. This speeds up queries where we know that

--- a/graph/src/env/graphql.rs
+++ b/graph/src/env/graphql.rs
@@ -87,6 +87,9 @@ pub struct EnvVarsGraphQl {
     /// Set by the flag `GRAPH_GRAPHQL_DISABLE_BOOL_FILTERS`. Off by default.
     /// Disables AND/OR filters
     pub disable_bool_filters: bool,
+    /// Set by the flag `GRAPH_GRAPHQL_DISABLE_CHILD_SORTING`. Off by default.
+    /// Disables child-based sorting
+    pub disable_child_sorting: bool,
     /// Set by `GRAPH_GRAPHQL_TRACE_TOKEN`, the token to use to enable query
     /// tracing for a GraphQL request. If this is set, requests that have a
     /// header `X-GraphTraceQuery` set to this value will include a trace of
@@ -137,6 +140,7 @@ impl From<InnerGraphQl> for EnvVarsGraphQl {
             error_result_size: x.error_result_size.0 .0,
             max_operations_per_connection: x.max_operations_per_connection,
             disable_bool_filters: x.disable_bool_filters.0,
+            disable_child_sorting: x.disable_child_sorting.0,
             query_trace_token: x.query_trace_token,
         }
     }
@@ -185,6 +189,8 @@ pub struct InnerGraphQl {
     max_operations_per_connection: usize,
     #[envconfig(from = "GRAPH_GRAPHQL_DISABLE_BOOL_FILTERS", default = "false")]
     pub disable_bool_filters: EnvVarBoolean,
+    #[envconfig(from = "GRAPH_GRAPHQL_DISABLE_CHILD_SORTING", default = "false")]
+    pub disable_child_sorting: EnvVarBoolean,
     #[envconfig(from = "GRAPH_GRAPHQL_TRACE_TOKEN", default = "")]
     query_trace_token: String,
 }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -122,10 +122,11 @@ pub mod prelude {
     pub use crate::components::store::{
         AttributeNames, BlockNumber, CachedEthereumCall, ChainStore, Child, ChildMultiplicity,
         EntityCache, EntityChange, EntityChangeOperation, EntityCollection, EntityFilter,
-        EntityLink, EntityModification, EntityOperation, EntityOrder, EntityQuery, EntityRange,
-        EntityWindow, EthereumCallCache, ParentLink, PartialBlockPtr, PoolWaitStats, QueryStore,
-        QueryStoreManager, StoreError, StoreEvent, StoreEventStream, StoreEventStreamBox,
-        SubgraphStore, UnfailOutcome, WindowAttribute, BLOCK_NUMBER_MAX,
+        EntityLink, EntityModification, EntityOperation, EntityOrder, EntityOrderByChild,
+        EntityOrderByChildInfo, EntityQuery, EntityRange, EntityWindow, EthereumCallCache,
+        ParentLink, PartialBlockPtr, PoolWaitStats, QueryStore, QueryStoreManager, StoreError,
+        StoreEvent, StoreEventStream, StoreEventStreamBox, SubgraphStore, UnfailOutcome,
+        WindowAttribute, BLOCK_NUMBER_MAX,
     };
     pub use crate::components::subgraph::{
         BlockState, DataSourceTemplateInfo, HostMetrics, RuntimeHost, RuntimeHostBuilder,

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -190,53 +190,45 @@ fn test_schema(id: DeploymentHash, id_type: IdType) -> Schema {
         id: Bytes!
     }
 
-    interface Review {
+    interface Review @entity {
         id: ID!
         body: String!
-        author: User!
+        author: Author!
     }
 
     type SongReview implements Review @entity {
         id: ID!
         body: String!
         song: Song
-        author: User!
+        author: Author!
     }
 
     type BandReview implements Review @entity {
         id: ID!
         body: String!
         band: Band
-        author: User!
-    }
-
-    type User @entity {
-        id: ID!
-        name: String!
-        bandReviews: [BandReview!]! @derivedFrom(field: \"author\")
-        songReviews: [SongReview!]! @derivedFrom(field: \"author\")
-        reviews: [Review!]! @derivedFrom(field: \"author\")
-        latestSongReview: SongReview!
-        latestBandReview: BandReview!
-        latestReview: Review!
+        author: Author!
     }
 
     interface Media {
         id: ID!
         title: String!
         song: Song!
+        author: User!
     }
 
     type Photo implements Media @entity {
         id: ID!
         title: String!
         song: Song! @derivedFrom(field: \"media\")
+        author: User!
     }
 
     type Video implements Media @entity {
         id: ID!
         title: String!
         song: Song! @derivedFrom(field: \"media\")
+        author: User!
     }
 
     interface Release {
@@ -257,6 +249,29 @@ fn test_schema(id: DeploymentHash, id_type: IdType) -> Schema {
         id: ID!
         title: String!
         songs: [Song!]!
+    }
+
+    interface Author {
+        id: ID!
+        name: String!
+    }
+
+    type User implements Author @entity {
+        id: ID!
+        name: String!
+        reviews: [Review!]! @derivedFrom(field: \"author\")
+        bandReviews: [BandReview!]! @derivedFrom(field: \"author\")
+        songReviews: [SongReview!]! @derivedFrom(field: \"author\")
+        latestSongReview: SongReview!
+        latestBandReview: BandReview!
+        latestReview: Review!
+        medias: [Media!]! @derivedFrom(field: \"author\")
+    }
+
+    type AnonymousUser implements Author @entity {
+        id: ID!
+        name: String!
+        reviews: [Review!]! @derivedFrom(field: \"author\")
     }
     ";
 
@@ -296,21 +311,24 @@ async fn insert_test_entities(
         entity! { __typename: "Song", id: s[4], sid: "s4", title: "Folk Tune",    publisher: "0xb1", writtenBy: "m3", media: vec![md[6]] },
         entity! { __typename: "SongStat", id: s[1], played: 10 },
         entity! { __typename: "SongStat", id: s[2], played: 15 },
-        entity! { __typename: "BandReview", id: "r1", body: "Bad musicians", band: "b1", author: "u1" },
-        entity! { __typename: "BandReview", id: "r2", body: "Good amateurs", band: "b2", author: "u2" },
-        entity! { __typename: "SongReview", id: "r3", body: "Bad", song: s[2], author: "u1" },
-        entity! { __typename: "SongReview", id: "r4", body: "Good", song: s[3], author: "u2" },
-        entity! { __typename: "User", id: "u1", name: "Baden", latestSongReview: "r3", latestBandReview: "r1", latestReview: "r1" },
-        entity! { __typename: "User", id: "u2", name: "Goodwill", latestSongReview: "r4", latestBandReview: "r2", latestReview: "r2" },
-        entity! { __typename: "Photo", id: md[1], title: "Cheesy Tune Single Cover" },
-        entity! { __typename: "Video", id: md[2], title: "Cheesy Tune Music Video" },
-        entity! { __typename: "Photo", id: md[3], title: "Rock Tune Single Cover" },
-        entity! { __typename: "Video", id: md[4], title: "Rock Tune Music Video" },
-        entity! { __typename: "Photo", id: md[5], title: "Pop Tune Single Cover" },
-        entity! { __typename: "Video", id: md[6], title: "Folk Tune Music Video" },
-        entity! { __typename: "Album", id: "rl1", title: "Pop and Folk", songs: vec![s[3], s[4]] },
-        entity! { __typename: "Single", id: "rl2", title: "Rock", songs: vec![s[2]] },
-        entity! { __typename: "Single", id: "rl3", title: "Cheesy", songs: vec![s[1]] },
+        entity! { __typename: "BandReview", id: "r1", body: "Bad musicians",        band: "b1", author: "u1" },
+        entity! { __typename: "BandReview", id: "r2", body: "Good amateurs",        band: "b2", author: "u2" },
+        entity! { __typename: "BandReview", id: "r5", body: "Very Bad musicians",   band: "b1", author: "u3" },
+        entity! { __typename: "SongReview", id: "r3", body: "Bad",                  song: s[2], author: "u1" },
+        entity! { __typename: "SongReview", id: "r4", body: "Good",                 song: s[3], author: "u2" },
+        entity! { __typename: "SongReview", id: "r6", body: "Very Bad",             song: s[2], author: "u3" },
+        entity! { __typename: "User",           id: "u1", name: "Baden",        latestSongReview: "r3", latestBandReview: "r1", latestReview: "r1" },
+        entity! { __typename: "User",           id: "u2", name: "Goodwill",     latestSongReview: "r4", latestBandReview: "r2", latestReview: "r2" },
+        entity! { __typename: "AnonymousUser",  id: "u3", name: "Anonymous 3",  latestSongReview: "r6", latestBandReview: "r5", latestReview: "r5" },
+        entity! { __typename: "Photo", id: md[1],   title: "Cheesy Tune Single Cover",  author: "u1" },
+        entity! { __typename: "Video", id: md[2],   title: "Cheesy Tune Music Video",   author: "u2" },
+        entity! { __typename: "Photo", id: md[3],   title: "Rock Tune Single Cover",    author: "u1" },
+        entity! { __typename: "Video", id: md[4],   title: "Rock Tune Music Video",     author: "u2" },
+        entity! { __typename: "Photo", id: md[5],   title: "Pop Tune Single Cover",     author: "u1" },
+        entity! { __typename: "Video", id: md[6],   title: "Folk Tune Music Video",     author: "u2" },
+        entity! { __typename: "Album", id: "rl1",   title: "Pop and Folk",    songs: vec![s[3], s[4]] },
+        entity! { __typename: "Single", id: "rl2",  title: "Rock",           songs: vec![s[2]] },
+        entity! { __typename: "Single", id: "rl3",  title: "Cheesy",         songs: vec![s[1]] },
     ];
 
     let entities1 = vec![
@@ -667,6 +685,279 @@ fn can_query_many_to_many_relationship() {
         let data = extract_data!(result).unwrap();
         assert_eq!(data, exp);
     })
+}
+
+#[test]
+fn can_query_with_sorting_by_child_entity() {
+    const QUERY: &str = "
+    query {
+        desc: musicians(first: 100, orderBy: mainBand__name, orderDirection: desc) {
+            name
+            mainBand {
+                name
+            }
+        }
+        asc: musicians(first: 100, orderBy: mainBand__name, orderDirection: asc) {
+            name
+            mainBand {
+                name
+            }
+        }
+    }";
+
+    run_query(QUERY, |result, _| {
+        let exp = object! {
+            desc: vec![
+                object! { name: "Valerie", mainBand: r::Value::Null },
+                object! { name: "Lisa", mainBand: object! { name: "The Musicians" } },
+                object! { name: "John", mainBand: object! { name: "The Musicians" } },
+                object! { name: "Tom",  mainBand: object! { name: "The Amateurs"} },
+                ],
+            asc: vec![
+                object! { name: "Tom",  mainBand: object! { name: "The Amateurs"} },
+                object! { name: "John", mainBand: object! { name: "The Musicians" } },
+                object! { name: "Lisa", mainBand: object! { name: "The Musicians" } },
+                object! { name: "Valerie", mainBand: r::Value::Null },
+                ]
+        };
+
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    })
+}
+
+#[test]
+fn can_query_with_sorting_by_derived_child_entity() {
+    const QUERY: &str = "
+    query {
+        desc: songStats(first: 100, orderBy: song__title, orderDirection: desc) {
+            id
+            song {
+              id
+              title
+            }
+            played
+        }
+        asc: songStats(first: 100, orderBy: song__title, orderDirection: asc) {
+            id
+            song {
+              id
+              title
+            }
+            played
+        }
+    }";
+
+    run_query(QUERY, |result, id_type| {
+        let s = id_type.songs();
+        let exp = object! {
+            desc: vec![
+                object! {
+                    id: s[2],
+                    song: object! { id: s[2], title: "Rock Tune" },
+                    played: 15
+                },
+                object! {
+                    id: s[1],
+                    song: object! { id: s[1], title: "Cheesy Tune" },
+                    played: 10,
+                }
+            ],
+            asc: vec![
+                object! {
+                    id: s[1],
+                    song: object! { id: s[1], title: "Cheesy Tune" },
+                    played: 10,
+                },
+                object! {
+                    id: s[2],
+                    song: object! { id: s[2], title: "Rock Tune" },
+                    played: 15
+                }
+            ]
+        };
+
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    })
+}
+
+#[test]
+fn can_query_with_sorting_by_child_entity_id() {
+    const QUERY: &str = "
+    query {
+        desc: bandReviews(first: 100, orderBy: author__id, orderDirection: desc) {
+            body
+            author {
+                name
+            }
+        }
+        asc: bandReviews(first: 100, orderBy: author__id, orderDirection: asc) {
+            body
+            author {
+                name
+            }
+        }
+    }";
+
+    run_query(QUERY, |result, _| {
+        let exp = object! {
+            desc: vec![
+                object! { body: "Very Bad musicians",   author: object! { name: "Anonymous 3"  } },
+                object! { body: "Good amateurs",        author: object! { name: "Goodwill" } },
+                object! { body: "Bad musicians",        author: object! { name: "Baden" } },
+                ],
+            asc: vec![
+                object! { body: "Bad musicians",        author: object! { name: "Baden" } },
+                object! { body: "Good amateurs",        author: object! { name: "Goodwill" } },
+                object! { body: "Very Bad musicians",   author: object! { name: "Anonymous 3"  } },
+                ]
+        };
+
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    })
+}
+
+#[test]
+fn can_query_with_sorting_by_derived_child_entity_id() {
+    const QUERY: &str = "
+    query {
+        desc: songStats(first: 100, orderBy: song__id, orderDirection: desc) {
+            id
+            song {
+              id
+              title
+            }
+            played
+        }
+        asc: songStats(first: 100, orderBy: song__id, orderDirection: asc) {
+            id
+            song {
+              id
+              title
+            }
+            played
+        }
+    }";
+
+    run_query(QUERY, |result, id_type| {
+        let s = id_type.songs();
+        let exp = object! {
+            desc: vec![
+                object! {
+                    id: s[2],
+                    song: object! { id: s[2], title: "Rock Tune" },
+                    played: 15
+                },
+                object! {
+                    id: s[1],
+                    song: object! { id: s[1], title: "Cheesy Tune" },
+                    played: 10,
+                }
+            ],
+            asc: vec![
+                object! {
+                    id: s[1],
+                    song: object! { id: s[1], title: "Cheesy Tune" },
+                    played: 10,
+                },
+                object! {
+                    id: s[2],
+                    song: object! { id: s[2], title: "Rock Tune" },
+                    played: 15
+                }
+            ]
+        };
+
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    })
+}
+
+#[test]
+fn can_query_with_sorting_by_child_interface() {
+    const QUERY: &str = "
+    query {
+        desc: songReviews(first: 100, orderBy: author__name, orderDirection: desc) {
+            body
+            author {
+                name
+            }
+        }
+        asc: songReviews(first: 100, orderBy: author__name, orderDirection: asc) {
+            body
+            author {
+                name
+            }
+        }
+    }";
+
+    run_query(QUERY, |result, _| {
+        let exp = object! {
+            desc: vec![
+                object! { body: "Good", author: object! { name: "Goodwill" } },
+                object! { body: "Bad", author: object! { name: "Baden" } },
+                object! { body: "Very Bad", author: object! { name: "Anonymous 3" } },
+                ],
+            asc: vec![
+                object! { body: "Very Bad", author: object! { name: "Anonymous 3" } },
+                object! { body: "Bad", author: object! { name: "Baden" } },
+                object! { body: "Good", author: object! { name: "Goodwill" } },
+                ]
+        };
+
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    })
+}
+
+#[test]
+fn can_not_query_interface_with_sorting_by_child_entity() {
+    const QUERY: &str = "
+    query {
+        desc: medias(first: 100, orderBy: author__name, orderDirection: desc) {
+            title
+            author {
+                name
+            }
+        }
+        asc: medias(first: 100, orderBy: author__name, orderDirection: asc) {
+            title
+            author {
+                name
+            }
+        }
+    }";
+
+    run_query(QUERY, |result, _| {
+        // Sorting an interface by child-level entity (derived) is not supported
+        assert!(result.has_errors());
+    });
+}
+
+#[test]
+fn can_not_query_interface_with_sorting_by_derived_child_entity() {
+    const QUERY: &str = "
+    query {
+        desc: medias(first: 100, orderBy: song__title, orderDirection: desc) {
+            title
+            song {
+                title
+            }
+        }
+        asc: medias(first: 100, orderBy: song__title, orderDirection: asc) {
+            title
+            song {
+                title
+            }
+        }
+    }";
+
+    run_query(QUERY, |result, _| {
+        // Sorting an interface by child-level entity is not supported
+        assert!(result.has_errors());
+    });
 }
 
 #[test]

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -687,6 +687,7 @@ impl Layout {
             FilterCollection::new(self, query.collection, query.filter.as_ref(), query.block)?;
         let query = FilterQuery::new(
             &filter_collection,
+            &self,
             query.filter.as_ref(),
             query.order,
             query.range,


### PR DESCRIPTION
#3737

Given this schema:

```graphql
type Country @entity {
  id: ID!
  capital: City!
  cities: [City!]!
}

type City @entity {
  id: ID!
  name: String
  population: Int
  landmarks: [String!]!
}
```

It adds fields of child entity to `*_orderBy` enum:

```diff
enum Country_orderBy {
   id
   capital
   cities
+  capital__id
+  capital__name
+  capital__population
}
```

- [x] sort by `type Child @entity { name: String }`
- [x] sort by `type Child @entity { id: ID }` 
- [x] can't sort by `type Child @entity { names: [String] }`
- [x] can't sort by `type Child @entity { secondLevelChild: AnotherEntity }`
- [x] can't sort by `type Child @entity { secondLevelChildren: [AnotherEntity] }`
- [x] support `@derivedFrom`
- [x] sort by `interface Child { name: String }`
- [x] sort by `interface Child { id: ID }`
- [ ] sort interface by `type Child @entity { name: String }` (done in https://github.com/graphprotocol/graph-node/pull/4058)