### PR TITLE
Fixed build now that `sign-ext-feature-flag` branch has been merged upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,7 +3265,7 @@ dependencies = [
 [[package]]
 name = "pwasm-utils"
 version = "0.19.0"
-source = "git+https://github.com/edgeandnode/wasm-utils?branch=sign-ext-feature-flag#1b939aba3ee861338d6102ce01d6511128b7b11f"
+source = "git+https://github.com/paritytech/wasm-utils?rev=b22696aaa516212284f2d94a28d8d292afe27859#b22696aaa516212284f2d94a28d8d292afe27859"
 dependencies = [
  "byteorder",
  "log",

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -24,8 +24,7 @@ wasmtime = "0.27.0"
 defer = "0.1"
 never = "0.1"
 
-# Patch being upstreamed in https://github.com/paritytech/wasm-utils/pull/174
-pwasm-utils = { git = "https://github.com/edgeandnode/wasm-utils", branch = "sign-ext-feature-flag", features = ["sign_ext"] }
+pwasm-utils = { git = "https://github.com/paritytech/wasm-utils", rev = "b22696aaa516212284f2d94a28d8d292afe27859", features = ["sign_ext"] }
 
 # AssemblyScript uses sign extensions
 parity-wasm = { version = "0.42", features = ["std", "sign_ext"] }


### PR DESCRIPTION
The branch being now deleted, the `master` branch is failing to compile properly. This fixes it by changing the location and rev where to find the dependency.

