### PR TITLE
Added local hardhat to dev setup

### DIFF
--- a/store/test-store/devel/docker-compose.yml
+++ b/store/test-store/devel/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     ports:
       - '8545:8545'
     volumes:
+      - ./data/hardhat/contracts:/hardhat/contracts
       - ./data/hardhat/cache:/hardhat/cache
       - ./data/hardhat/artifacts:/hardhat/artifacts
     build:

--- a/store/test-store/devel/docker-compose.yml
+++ b/store/test-store/devel/docker-compose.yml
@@ -1,5 +1,14 @@
 version: '3'
 services:
+  local_chain:
+    ports:
+      - '8545:8545'
+    volumes:
+      - ./data/hardhat/cache:/hardhat/cache
+      - ./data/hardhat/artifacts:/hardhat/artifacts
+    build:
+      context: ./local-chain/
+      dockerfile: Dockerfile
   ipfs:
     image: ipfs/go-ipfs:v0.4.23
     ports:

--- a/store/test-store/devel/local-chain/Dockerfile
+++ b/store/test-store/devel/local-chain/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:16.13.1-alpine3.14
+
+WORKDIR /hardhat
+
+ADD package.json hardhat.config.js .
+RUN npm install
+
+EXPOSE 8545
+
+CMD npm run chain

--- a/store/test-store/devel/local-chain/hardhat.config.js
+++ b/store/test-store/devel/local-chain/hardhat.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/store/test-store/devel/local-chain/package.json
+++ b/store/test-store/devel/local-chain/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "chain": "hardhat node --network hardhat"
+  },
+  "dependencies": {
+    "hardhat": "2.8.0"
+  }
+}

--- a/store/test-store/devel/up.sh
+++ b/store/test-store/devel/up.sh
@@ -26,7 +26,7 @@ main() {
   prepare
 
   # Pass execution to docker compose
-  exec docker-compose up
+  exec docker-compose up --force-recreate
 }
 
 prepare() {

--- a/store/test-store/devel/up.sh
+++ b/store/test-store/devel/up.sh
@@ -26,7 +26,7 @@ main() {
   prepare
 
   # Pass execution to docker compose
-  exec docker-compose up --force-recreate
+  exec docker-compose up
 }
 
 prepare() {


### PR DESCRIPTION
This PR adds a clean `hardhat` to the Docker Compose setup.

With this setup, we can easily run `graph-node` for development purposes with the following:

```
# Terminal 1
./store/test-store/devel/up.sh

# Terminal 2
cargo run -p graph-node --release -- --postgres-url postgresql://localhost:5432/graph-node --ethereum-rpc localhost:http://localhost:8545/ --ipfs 127.0.0.1:5001
```

If this is being merged, I think the next step could be to simplify some of the scripts/commands (for example: running in watch mode in a single command, running in release mode and so on) and we can also create a script for seed (that deploys a contract to the local chain and deploys a subgraph to the local `graph-node`) 
