### PR TITLE
Include missing arguments to format string

### DIFF
--- a/graph/src/blockchain/types.rs
+++ b/graph/src/blockchain/types.rs
@@ -186,7 +186,10 @@ impl TryFrom<(&[u8], i64)> for BlockPtr {
             H256::from_slice(bytes)
         } else {
             return Err(anyhow!(
-                "invalid H256 value `{}` has {} bytes instead of {}"
+                "invalid H256 value `{:?}` has {} bytes instead of {}",
+                bytes,
+                bytes.len(),
+                H256::len_bytes()
             ));
         };
         Ok(BlockPtr::from((hash, number)))


### PR DESCRIPTION
Run into this when trying out an updated version of the `anyhow` crate. 