### PR TITLE
chain/near,chain/ethereum: improved revert code and fixed NEAR on revert to pass parent_ptr

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -602,17 +602,17 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
                 ))
             }
 
-            StepUndo => Ok(BlockStreamEvent::Revert(
-                BlockPtr {
-                    hash: BlockHash::from(block.hash),
-                    number: block.number as i32,
-                },
-                FirehoseCursor::Some(response.cursor.clone()),
-                Some(BlockPtr {
-                    hash: BlockHash::from(block.header.unwrap().parent_hash),
-                    number: (block.number.checked_sub(1).unwrap() as i32), // Will never receive undo on blocknum 0
-                }),
-            )),
+            StepUndo => {
+                let parent_ptr = block
+                    .parent_ptr()
+                    .expect("A reverted block should always have a parent");
+
+                Ok(BlockStreamEvent::Revert(
+                    block.ptr(),
+                    FirehoseCursor::Some(response.cursor.clone()),
+                    Some(parent_ptr),
+                ))
+            }
 
             StepIrreversible => {
                 unreachable!("irreversible step is not handled and should not be requested in the Firehose request")

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -605,7 +605,7 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
             StepUndo => {
                 let parent_ptr = block
                     .parent_ptr()
-                    .expect("A reverted block should always have a parent");
+                    .expect("Genesis block should never be reverted");
 
                 Ok(BlockStreamEvent::Revert(
                     block.ptr(),

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -310,7 +310,7 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
                 let header = block.header();
                 let parent_ptr = header
                     .parent_ptr()
-                    .expect("A reverted block should always have a parent");
+                    .expect("Genesis block should never be reverted");
 
                 Ok(BlockStreamEvent::Revert(
                     block.ptr(),

--- a/chain/near/src/codec.rs
+++ b/chain/near/src/codec.rs
@@ -43,14 +43,12 @@ impl Block {
         self.header.as_ref().unwrap()
     }
 
+    pub fn ptr(&self) -> BlockPtr {
+        BlockPtr::from(self.header())
+    }
+
     pub fn parent_ptr(&self) -> Option<BlockPtr> {
         self.header().parent_ptr()
-    }
-}
-
-impl From<Block> for BlockPtr {
-    fn from(b: Block) -> BlockPtr {
-        (&b).into()
     }
 }
 


### PR DESCRIPTION
This PR is a continuation of #2979 adding the required support for NEAR. 

At the same time, this PRs turns some no-op silent returns into panics in NEAR, all those around the `IngestorTrait` now that it's clear it's an Ethereum specific thing. We should probably actually move it out completely to an `EthereumBlockIngestor` and refactor the `Chain` implementation to get rid of it. I did not investigate the implications and might prove hard.
