### PR TITLE
Default to fetching receipts concurrently

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -115,8 +115,10 @@ lazy_static! {
         .parse::<usize>()
         .expect("invalid GRAPH_ETHEREUM_BLOCK_INGESTOR_MAX_CONCURRENT_JSON_RPC_CALLS_FOR_TXN_RECEIPTS env var");
 
-    static ref FETCH_RECEIPTS_CONCURRENTLY: bool = std::env::var("GRAPH_EXPERIMENTAL_FETCH_TXN_RECEIPTS_CONCURRENTLY")
-            .is_ok();
+    static ref FETCH_RECEIPTS_IN_BATCHES: bool = std::env::var("GRAPH_ETHEREUM_FETCH_TXN_RECEIPTS_IN_BATCHES")
+        .map_or(false, |var| var.parse::<bool>().unwrap_or_default());
+
+
 
 
 }
@@ -1081,7 +1083,10 @@ impl EthereumAdapterTrait for EthereumAdapter {
             })));
         }
         let hashes: Vec<_> = block.transactions.iter().map(|txn| txn.hash).collect();
-        let receipts_future = if *FETCH_RECEIPTS_CONCURRENTLY {
+        let receipts_future = if *FETCH_RECEIPTS_IN_BATCHES {
+            // Deprecated batching retrieval of transaction receipts.
+            fetch_transaction_receipts_in_batch_with_retry(web3, hashes, block_hash, logger).boxed()
+        } else {
             let hash_stream = graph::tokio_stream::iter(hashes);
             let receipt_stream = graph::tokio_stream::StreamExt::map(hash_stream, move |tx_hash| {
                 fetch_transaction_receipt_with_retry(
@@ -1095,9 +1100,6 @@ impl EthereumAdapterTrait for EthereumAdapter {
             graph::tokio_stream::StreamExt::collect::<Result<Vec<TransactionReceipt>, IngestorError>>(
                 receipt_stream,
             ).boxed()
-        } else {
-            // Deprecated batching retrieval of transaction receipts.
-            fetch_transaction_receipts_in_batch_with_retry(web3, hashes, block_hash, logger).boxed()
         };
 
         let block_future =

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -115,12 +115,8 @@ lazy_static! {
         .parse::<usize>()
         .expect("invalid GRAPH_ETHEREUM_BLOCK_INGESTOR_MAX_CONCURRENT_JSON_RPC_CALLS_FOR_TXN_RECEIPTS env var");
 
-    static ref FETCH_RECEIPTS_IN_BATCHES: bool = std::env::var("GRAPH_ETHEREUM_FETCH_TXN_RECEIPTS_IN_BATCHES")
-        .map_or(false, |var| var.parse::<bool>().unwrap_or_default());
-
-
-
-
+    static ref FETCH_RECEIPTS_IN_BATCHES: bool =
+        matches!(std::env::var("GRAPH_ETHEREUM_FETCH_TXN_RECEIPTS_IN_BATCHES").as_deref(), Ok("true"));
 }
 
 /// Gas limit for `eth_call`. The value of 50_000_000 is a protocol-wide parameter so this

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -38,6 +38,9 @@ those.
    The maximum number of concurrent requests made against Ethereum for
    requesting transaction receipts during block ingestion.
    Defaults to 1,000.
+- `GRAPH_ETHEREUM_FETCH_TXN_RECEIPTS_IN_BATCHES`: Set to `true` to
+  disable fetching receipts from the Ethereum node concurrently during
+  block ingestion. This will use fewer, batched requests.
 - `GRAPH_ETHEREUM_CLEANUP_BLOCKS` : Set to `true` to clean up unneeded
   blocks from the cache in the database. When this is `false` or unset (the
   default), blocks will never be removed from the block cache. This setting


### PR DESCRIPTION
- Inverts the logic in `ethereum_adapter` module to make fetching receipts concurrently the default behaviour.
- An environment variable `GRAPH_ETHEREUM_FETCH_TXN_RECEIPTS_IN_BATCHES` is provided for reverting to the previous, batching strategy.