### PR TITLE
chain/ethereum,graph,node: moved BlockIngestor to chain/ethereum and removed IngestorAdapter

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -14,17 +14,15 @@ use graph::{
         },
         firehose_block_stream::FirehoseBlockStream,
         polling_block_stream::PollingBlockStream,
-        Block, BlockHash, BlockPtr, Blockchain, ChainHeadUpdateListener,
-        IngestorAdapter as IngestorAdapterTrait, IngestorError, TriggerFilter as _,
+        Block, BlockPtr, Blockchain, ChainHeadUpdateListener, IngestorError, TriggerFilter as _,
     },
     cheap_clone::CheapClone,
     components::store::DeploymentLocator,
     firehose,
-    log::factory::{ComponentLoggerConfig, ElasticComponentLoggerConfig},
     prelude::{
-        async_trait, error, lazy_static, o, serde_json as json, web3::types::H256, BlockNumber,
-        ChainStore, EthereumBlockWithCalls, Future01CompatExt, Logger, LoggerFactory,
-        MetricsRegistry, NodeId, SubgraphStore,
+        async_trait, lazy_static, o, serde_json as json, BlockNumber, ChainStore,
+        EthereumBlockWithCalls, Future01CompatExt, Logger, LoggerFactory, MetricsRegistry, NodeId,
+        SubgraphStore,
     },
 };
 use prost::Message;
@@ -72,7 +70,6 @@ pub struct Chain {
     registry: Arc<dyn MetricsRegistry>,
     firehose_endpoints: Arc<FirehoseEndpoints>,
     eth_adapters: Arc<EthereumNetworkAdapters>,
-    ancestor_count: BlockNumber,
     chain_store: Arc<dyn ChainStore>,
     call_cache: Arc<dyn EthereumCallCache>,
     subgraph_store: Arc<dyn SubgraphStore>,
@@ -99,7 +96,6 @@ impl Chain {
         firehose_endpoints: FirehoseEndpoints,
         eth_adapters: EthereumNetworkAdapters,
         chain_head_update_listener: Arc<dyn ChainHeadUpdateListener>,
-        ancestor_count: BlockNumber,
         reorg_threshold: BlockNumber,
         is_ingestible: bool,
     ) -> Self {
@@ -110,7 +106,6 @@ impl Chain {
             registry,
             firehose_endpoints: Arc::new(firehose_endpoints),
             eth_adapters: Arc::new(eth_adapters),
-            ancestor_count,
             chain_store,
             call_cache,
             subgraph_store,
@@ -118,6 +113,12 @@ impl Chain {
             reorg_threshold,
             is_ingestible,
         }
+    }
+}
+
+impl Chain {
+    pub fn cheapest_adapter(&self) -> Arc<EthereumAdapter> {
+        self.eth_adapters.cheapest().unwrap().clone()
     }
 }
 
@@ -144,8 +145,6 @@ impl Blockchain for Chain {
     type TriggerFilter = crate::adapter::TriggerFilter;
 
     type NodeCapabilities = crate::capabilities::NodeCapabilities;
-
-    type IngestorAdapter = IngestorAdapter;
 
     type RuntimeAdapter = RuntimeAdapter;
 
@@ -297,29 +296,6 @@ impl Blockchain for Chain {
             unified_api_version,
             subgraph_start_block,
         )))
-    }
-
-    fn ingestor_adapter(&self) -> Arc<Self::IngestorAdapter> {
-        let eth_adapter = self.eth_adapters.cheapest().unwrap().clone();
-        let logger = self
-            .logger_factory
-            .component_logger(
-                "BlockIngestor",
-                Some(ComponentLoggerConfig {
-                    elastic: Some(ElasticComponentLoggerConfig {
-                        index: String::from("block-ingestor-logs"),
-                    }),
-                }),
-            )
-            .new(o!("provider" => eth_adapter.provider().to_string()));
-
-        let adapter = IngestorAdapter {
-            eth_adapter,
-            logger,
-            ancestor_count: self.ancestor_count,
-            chain_store: self.chain_store.clone(),
-        };
-        Arc::new(adapter)
     }
 
     fn chain_store(&self) -> Arc<dyn ChainStore> {
@@ -622,81 +598,5 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
                 unreachable!("unknown step should not happen in the Firehose response")
             }
         }
-    }
-}
-
-pub struct IngestorAdapter {
-    logger: Logger,
-    ancestor_count: i32,
-    eth_adapter: Arc<EthereumAdapter>,
-    chain_store: Arc<dyn ChainStore>,
-}
-
-#[async_trait]
-impl IngestorAdapterTrait<Chain> for IngestorAdapter {
-    fn logger(&self) -> &Logger {
-        &self.logger
-    }
-
-    fn ancestor_count(&self) -> BlockNumber {
-        self.ancestor_count
-    }
-
-    async fn latest_block(&self) -> Result<BlockPtr, IngestorError> {
-        self.eth_adapter
-            .latest_block_header(&self.logger)
-            .compat()
-            .await
-            .map(|block| block.into())
-    }
-
-    async fn ingest_block(
-        &self,
-        block_hash: &BlockHash,
-    ) -> Result<Option<BlockHash>, IngestorError> {
-        // TODO: H256::from_slice can panic
-        let block_hash = H256::from_slice(block_hash.as_slice());
-
-        // Get the fully populated block
-        let block = self
-            .eth_adapter
-            .block_by_hash(&self.logger, block_hash)
-            .compat()
-            .await?
-            .ok_or_else(|| IngestorError::BlockUnavailable(block_hash))?;
-        let ethereum_block = self
-            .eth_adapter
-            .load_full_block(&self.logger, block)
-            .await?;
-
-        // We need something that implements `Block` to store the block; the
-        // store does not care whether the block is final or not
-        let ethereum_block = BlockFinality::NonFinal(EthereumBlockWithCalls {
-            ethereum_block,
-            calls: None,
-        });
-
-        // Store it in the database and try to advance the chain head pointer
-        self.chain_store
-            .upsert_block(Arc::new(ethereum_block))
-            .await?;
-
-        self.chain_store
-            .cheap_clone()
-            .attempt_chain_head_update(self.ancestor_count)
-            .await
-            .map(|missing| missing.map(|h256| h256.into()))
-            .map_err(|e| {
-                error!(self.logger, "failed to update chain head");
-                IngestorError::Unknown(e)
-            })
-    }
-
-    fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error> {
-        self.chain_store.chain_head_ptr()
-    }
-
-    fn cleanup_cached_blocks(&self) -> Result<Option<(i32, usize)>, Error> {
-        self.chain_store.cleanup_cached_blocks(self.ancestor_count)
     }
 }

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -3,6 +3,7 @@ mod capabilities;
 pub mod codec;
 mod data_source;
 mod ethereum_adapter;
+mod ingestor;
 pub mod runtime;
 mod transport;
 
@@ -26,6 +27,7 @@ pub use crate::adapter::{
 };
 pub use crate::chain::Chain;
 pub use crate::network::EthereumNetworks;
+pub use ingestor::{BlockIngestor, CLEANUP_BLOCKS};
 
 #[cfg(test)]
 mod tests;

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -11,7 +11,7 @@ use graph::{
             FirehoseMapper as FirehoseMapperTrait, TriggersAdapter as TriggersAdapterTrait,
         },
         firehose_block_stream::FirehoseBlockStream,
-        BlockHash, BlockPtr, Blockchain, IngestorAdapter as IngestorAdapterTrait, IngestorError,
+        BlockHash, BlockPtr, Blockchain, IngestorError,
     },
     components::store::DeploymentLocator,
     firehose::{self as firehose, ForkStep},
@@ -84,8 +84,6 @@ impl Blockchain for Chain {
 
     type NodeCapabilities = crate::capabilities::NodeCapabilities;
 
-    type IngestorAdapter = IngestorAdapter;
-
     type RuntimeAdapter = RuntimeAdapter;
 
     fn triggers_adapter(
@@ -150,10 +148,6 @@ impl Blockchain for Chain {
         _unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Box<dyn BlockStream<Self>>, Error> {
         panic!("NEAR does not support polling block stream")
-    }
-
-    fn ingestor_adapter(&self) -> Arc<Self::IngestorAdapter> {
-        Arc::new(IngestorAdapter {})
     }
 
     fn chain_store(&self) -> Arc<dyn ChainStore> {
@@ -327,37 +321,5 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
                 panic!("unknown step should not happen in the Firehose response")
             }
         }
-    }
-}
-
-pub struct IngestorAdapter {}
-
-#[async_trait]
-impl IngestorAdapterTrait<Chain> for IngestorAdapter {
-    fn logger(&self) -> &Logger {
-        panic!("Should never be called, FirehoseBlockIngestor must be used instead")
-    }
-
-    fn ancestor_count(&self) -> BlockNumber {
-        panic!("Should never be called, FirehoseBlockIngestor must be used instead")
-    }
-
-    async fn latest_block(&self) -> Result<BlockPtr, IngestorError> {
-        panic!("Should never be called, FirehoseBlockIngestor must be used instead")
-    }
-
-    async fn ingest_block(
-        &self,
-        _block_hash: &BlockHash,
-    ) -> Result<Option<BlockHash>, IngestorError> {
-        panic!("Should never be called, FirehoseBlockIngestor must be used instead")
-    }
-
-    fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error> {
-        panic!("Should never be called, FirehoseBlockIngestor must be used instead")
-    }
-
-    fn cleanup_cached_blocks(&self) -> Result<Option<(i32, usize)>, Error> {
-        panic!("Should never be called, FirehoseBlockIngestor must be used instead")
     }
 }

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -2,7 +2,6 @@
 //! blockchain into Graph Node. A blockchain is represented by an implementation of the `Blockchain`
 //! trait which is the centerpiece of this module.
 
-pub mod block_ingestor;
 pub mod block_stream;
 pub mod firehose_block_ingestor;
 pub mod firehose_block_stream;
@@ -98,8 +97,6 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
 
     type NodeCapabilities: NodeCapabilities<Self> + std::fmt::Display;
 
-    type IngestorAdapter: IngestorAdapter<Self>;
-
     type RuntimeAdapter: RuntimeAdapter<Self>;
 
     fn triggers_adapter(
@@ -129,8 +126,6 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
         metrics: Arc<BlockStreamMetrics>,
         unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Box<dyn BlockStream<Self>>, Error>;
-
-    fn ingestor_adapter(&self) -> Arc<Self::IngestorAdapter>;
 
     fn chain_store(&self) -> Arc<dyn ChainStore>;
 
@@ -171,39 +166,6 @@ impl From<Error> for IngestorError {
 impl From<web3::Error> for IngestorError {
     fn from(e: web3::Error) -> Self {
         IngestorError::Unknown(anyhow::anyhow!(e))
-    }
-}
-
-#[async_trait]
-pub trait IngestorAdapter<C: Blockchain> {
-    fn logger(&self) -> &Logger;
-
-    /// How many ancestors of the current chain head to ingest. For chains
-    /// that can experience reorgs, this should be large enough to cover all
-    /// blocks that could be subject to reorgs to ensure that `graph-node`
-    /// has enough blocks in its local cache to traverse a sidechain back to
-    /// the main chain even if those blocks get removed from the network
-    /// client.
-    fn ancestor_count(&self) -> BlockNumber;
-
-    /// Get the latest block from the chain
-    async fn latest_block(&self) -> Result<BlockPtr, IngestorError>;
-
-    /// Retrieve all necessary data for the block  `hash` from the chain and
-    /// store it in the database
-    async fn ingest_block(&self, hash: &BlockHash) -> Result<Option<BlockHash>, IngestorError>;
-
-    /// Return the chain head that is stored locally, and therefore visible
-    /// to the block streams of subgraphs
-    fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error>;
-
-    /// Remove old blocks from the database cache and return a pair
-    /// containing the number of the oldest block retained and the number of
-    /// blocks deleted if anything was removed. This is generally only used
-    /// in small test installations, and can remain a noop without
-    /// influencing correctness.
-    fn cleanup_cached_blocks(&self) -> Result<Option<(i32, usize)>, Error> {
-        Ok(None)
     }
 }
 

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1,6 +1,6 @@
 use graph::{
     anyhow::Error,
-    blockchain::{block_ingestor::CLEANUP_BLOCKS, BlockchainKind},
+    blockchain::BlockchainKind,
     prelude::{
         anyhow::{anyhow, bail, Context, Result},
         info,
@@ -11,7 +11,7 @@ use graph::{
         serde_json, Logger, NodeId, StoreError,
     },
 };
-use graph_chain_ethereum::NodeCapabilities;
+use graph_chain_ethereum::{NodeCapabilities, CLEANUP_BLOCKS};
 use graph_store_postgres::{DeploymentPlacer, Shard as ShardName, PRIMARY_SHARD};
 
 use http::{HeaderMap, Uri};


### PR DESCRIPTION
The `IngestorAdapter` was actually protocol specific and having the abstraction in the Blockchain trait was not used expect for Ethereum chain.

Removed `IngestorAdapter` from block chain and moved the chain agnostic `BlockIngestor` to `graph-chain-ethereum` crate.

