### PR TITLE
core: subgraph might continue processing to next block when an error occurred on a revert

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -545,7 +545,9 @@ where
                                     "block_hash" => format!("{}", subgraph_ptr.hash),
                                     "error" => e.to_string(),
                                 );
-                                continue;
+
+                                // Exit inner block stream consumption loop and go up to loop that restarts subgraph
+                                break;
                             }
                         }
                         None => {
@@ -575,7 +577,9 @@ where
                                     "block_hash" => format!("{}", subgraph_ptr.hash),
                                     "error" => e.to_string(),
                                 );
-                                continue;
+
+                                // Exit inner block stream consumption loop and go up to loop that restarts subgraph
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
The `continue` in the `instance_manager` run loop are actually doing a `continue` that continue to the next block in the stream.

That meant to be `break`s instead so they actually go up to the outer loop which restart the subgraph.

