### PR TITLE
core,graph,store: on block revert, Firehose should save the cursor to the database

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -576,8 +576,8 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
 
                 Ok(BlockStreamEvent::Revert(
                     block.ptr(),
+                    parent_ptr,
                     FirehoseCursor::Some(response.cursor.clone()),
-                    Some(parent_ptr),
                 ))
             }
 

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -304,15 +304,15 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
             )),
 
             StepUndo => {
-                let header = block.header();
-                let parent_ptr = header
+                let parent_ptr = block
+                    .header()
                     .parent_ptr()
                     .expect("Genesis block should never be reverted");
 
                 Ok(BlockStreamEvent::Revert(
                     block.ptr(),
+                    parent_ptr,
                     Some(response.cursor.clone()),
-                    Some(parent_ptr),
                 ))
             }
 

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -553,7 +553,7 @@ where
 
             let (block, cursor) = match event {
                 Some(Ok(BlockStreamEvent::ProcessBlock(block, cursor))) => (block, cursor),
-                Some(Ok(BlockStreamEvent::Revert(subgraph_ptr, _, optional_parent_ptr))) => {
+                Some(Ok(BlockStreamEvent::Revert(subgraph_ptr, parent_ptr, cursor))) => {
                     info!(
                         logger,
                         "Reverting block to get back to main chain";
@@ -561,53 +561,20 @@ where
                         "block_hash" => format!("{}", subgraph_ptr.hash)
                     );
 
-                    // We would like to revert the DB state to the parent of the current block.
-                    match optional_parent_ptr {
-                        Some(parent_ptr) => {
-                            if let Err(e) = inputs.store.revert_block_operations(parent_ptr) {
-                                error!(
-                                    &logger,
-                                    "Could not revert block. Retrying";
-                                    "block_number" => format!("{}", subgraph_ptr.number),
-                                    "block_hash" => format!("{}", subgraph_ptr.hash),
-                                    "error" => e.to_string(),
-                                );
+                    if let Err(e) = inputs
+                        .store
+                        .revert_block_operations(parent_ptr, cursor.as_deref())
+                    {
+                        error!(
+                            &logger,
+                            "Could not revert block. Retrying";
+                            "block_number" => format!("{}", subgraph_ptr.number),
+                            "block_hash" => format!("{}", subgraph_ptr.hash),
+                            "error" => e.to_string(),
+                        );
 
-                                // Exit inner block stream consumption loop and go up to loop that restarts subgraph
-                                break;
-                            }
-                        }
-                        None => {
-                            // First, load the block in order to get the parent hash.
-                            if let Err(e) = inputs
-                                .triggers_adapter
-                                .parent_ptr(&subgraph_ptr)
-                                .await
-                                .map(|parent_ptr| {
-                                    parent_ptr.expect("genesis block cannot be reverted")
-                                })
-                                .and_then(|parent_ptr| {
-                                    // Revert entity changes from this block, and update subgraph ptr.
-                                    inputs
-                                        .store
-                                        .revert_block_operations(parent_ptr)
-                                        .map_err(Into::into)
-                                })
-                            {
-                                error!(
-                                    &logger,
-                                    "Could not revert block. \
-                                    The likely cause is the block not being found due to a deep reorg. \
-                                    Retrying";
-                                    "block_number" => format!("{}", subgraph_ptr.number),
-                                    "block_hash" => format!("{}", subgraph_ptr.hash),
-                                    "error" => e.to_string(),
-                                );
-
-                                // Exit inner block stream consumption loop and go up to loop that restarts subgraph
-                                break;
-                            }
-                        }
+                        // Exit inner block stream consumption loop and go up to loop that restarts subgraph
+                        break;
                     }
 
                     ctx.block_stream_metrics
@@ -626,6 +593,7 @@ where
                     ctx.state.entity_lfu_cache = LfuCache::new();
                     continue;
                 }
+
                 // Log and drop the errors from the block_stream
                 // The block stream will continue attempting to produce blocks
                 Some(Err(e)) => {

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -177,7 +177,7 @@ pub enum BlockStreamEvent<C: Blockchain> {
     // The payload is the current subgraph head pointer, which should be reverted, such that the
     // parent of the current subgraph head becomes the new subgraph head.
     // An optional pointer to the parent block will save a round trip operation when reverting.
-    Revert(BlockPtr, FirehoseCursor, Option<BlockPtr>),
+    Revert(BlockPtr, BlockPtr, FirehoseCursor),
 
     ProcessBlock(BlockWithTriggers<C>, FirehoseCursor),
 }

--- a/graph/src/blockchain/polling_block_stream.rs
+++ b/graph/src/blockchain/polling_block_stream.rs
@@ -142,7 +142,7 @@ where
     /// Blocks and range size
     Blocks(VecDeque<BlockWithTriggers<C>>, BlockNumber),
 
-    // The payload is the current subgraph head pointer, which should be reverted and it's parent, such that the
+    // The payload is the current subgraph head pointer, which should be reverted and its parent, such that the
     // parent of the current subgraph head becomes the new subgraph head.
     Revert(BlockPtr, BlockPtr),
     Done,
@@ -220,7 +220,9 @@ where
 
                     return Ok(NextBlocks::Done);
                 }
-                ReconciliationStep::Revert(from, to) => return Ok(NextBlocks::Revert(from, to)),
+                ReconciliationStep::Revert(from, parent_ptr) => {
+                    return Ok(NextBlocks::Revert(from, parent_ptr))
+                }
             }
         }
     }
@@ -565,14 +567,14 @@ impl<C: Blockchain> Stream for PollingBlockStream<C> {
                                 // Poll for chain head update
                                 continue;
                             }
-                            NextBlocks::Revert(from, to) => {
-                                self.ctx.current_block = to.into();
+                            NextBlocks::Revert(from, parent_ptr) => {
+                                self.ctx.current_block = Some(parent_ptr.clone());
 
                                 self.state = BlockStreamState::BeginReconciliation;
                                 break Poll::Ready(Some(Ok(BlockStreamEvent::Revert(
                                     from,
+                                    parent_ptr,
                                     FirehoseCursor::None,
-                                    self.ctx.current_block.clone(),
                                 ))));
                             }
                         },

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1037,7 +1037,11 @@ pub trait WritableStore: Send + Sync + 'static {
     /// subgraph block pointer to `block_ptr_to`.
     ///
     /// `block_ptr_to` must point to the parent block of the subgraph block pointer.
-    fn revert_block_operations(&self, block_ptr_to: BlockPtr) -> Result<(), StoreError>;
+    fn revert_block_operations(
+        &self,
+        block_ptr_to: BlockPtr,
+        firehose_cursor: Option<&str>,
+    ) -> Result<(), StoreError>;
 
     /// If a deterministic error happened, this function reverts the block operations from the
     /// current block to the previous block.

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -58,7 +58,7 @@ impl WritableStore for MockStore {
         unimplemented!()
     }
 
-    fn revert_block_operations(&self, _: BlockPtr) -> Result<(), StoreError> {
+    fn revert_block_operations(&self, _: BlockPtr, _: Option<&str>) -> Result<(), StoreError> {
         unimplemented!()
     }
 

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -301,13 +301,13 @@ async fn check_graft(
         .cheap_clone()
         .writable(LOGGER.clone(), deployment.id)
         .await?
-        .revert_block_operations(BLOCKS[1].clone())
+        .revert_block_operations(BLOCKS[1].clone(), None)
         .expect("We can revert a block we just created");
 
     let err = store
         .writable(LOGGER.clone(), deployment.id)
         .await?
-        .revert_block_operations(BLOCKS[0].clone())
+        .revert_block_operations(BLOCKS[0].clone(), None)
         .expect_err("Reverting past graft point is not allowed");
 
     assert!(err.to_string().contains("Can not revert subgraph"));

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -278,7 +278,7 @@ pub async fn revert_block(store: &Arc<Store>, deployment: &DeploymentLocator, pt
         .writable(LOGGER.clone(), deployment.id)
         .await
         .expect("can get writable")
-        .revert_block_operations(ptr.clone())
+        .revert_block_operations(ptr.clone(), None)
         .unwrap();
 }
 


### PR DESCRIPTION
This PR ensures that the Firehose cursor is saved properly even on revert operations.