### PR TITLE
ethereum: Fix Celo reward event

### DIFF
--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -70,7 +70,7 @@ enum LogFilterNode {
 }
 
 /// Corresponds to an `eth_getLogs` call.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EthGetLogsFilter {
     pub contracts: Vec<Address>,
     pub event_signatures: Vec<EventSignature>,

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Error};
 use anyhow::{ensure, Context};
 use graph::blockchain::TriggerWithHandler;
 use graph::components::store::StoredDynamicDataSource;
+use graph::prelude::ethabi::ethereum_types::H160;
 use graph::prelude::ethabi::StateMutability;
 use graph::prelude::futures03::future::try_join;
 use graph::prelude::futures03::stream::FuturesOrdered;
@@ -553,6 +554,7 @@ impl DataSource {
                         block_hash: block.hash,
                         block_number: block.number,
                         transaction_index: log.transaction_index,
+                        from: Some(H160::zero()),
                         ..Transaction::default()
                     }
                 };


### PR DESCRIPTION
This was a sneaky consequence of `Transaction.from` being made optional which we missed #2896. This caused a panic in the runtime here https://github.com/graphprotocol/graph-node/blob/b710b90131d3b7dddbf9021cef178cc0552b6452/chain/ethereum/src/trigger.rs#L368.