### PR TITLE
chain/ethereum,graph,node: start backfill BlockIngestor process for unprocessed blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,6 +1744,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "blake3",
+ "chrono",
  "clap",
  "derive_more",
  "diesel",

--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -142,18 +142,8 @@ where
             ExponentialBackoff::new(Duration::from_millis(250), Duration::from_secs(30));
         loop {
             match self.chain_store.clone().chain_backfill_is_completed() {
-                Ok(opt) => {
-                    return match opt {
-                        Some(t) => t,
-                        None => {
-                            info!(
-                                self.logger,
-                                "Fetching chain backfill completion returned None. Sleeping."
-                            );
-                            backoff.sleep_async().await;
-                            continue;
-                        }
-                    }
+                Ok(b) => {
+                    return b;
                 }
                 Err(e) => {
                     error!(

--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -92,7 +92,7 @@ where
 
         let mut backfill_target_block_number = self.fetch_backfill_target_block_num().await;
         if backfill_target_block_number.is_none() {
-                backfill_target_block_number =  Some(self.initialize_backfill_target_block_num().await);
+            backfill_target_block_number = Some(self.initialize_backfill_target_block_num().await);
         }
 
         loop {
@@ -218,7 +218,7 @@ where
                         .set_chain_backfill_target_block_num(block_num)
                         .await
                     {
-                        Ok(_) => {},
+                        Ok(_) => {}
                         Err(e) => {
                             error!(self.logger, "Setting chain backfill target failed: {:?}", e);
                             backoff.sleep_async().await;

--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -89,6 +89,7 @@ where
             ExponentialBackoff::new(Duration::from_millis(250), Duration::from_secs(30));
 
         let mut backfill_cursor = self.fetch_backfill_cursor().await;
+        let backfill_target_block_number = self.fetch_backfill_target_block_num().await;
 
         loop {
             let backfill_completed = self.fetch_backfill_is_completed().await;
@@ -97,7 +98,6 @@ where
                 break;
             }
 
-            let backfill_target_block_number = self.fetch_backfill_target_block_num().await;
             let result = self
                 .endpoint
                 .clone()
@@ -333,7 +333,7 @@ where
 
         self.chain_store
             .clone()
-            .set_chain_head(block.clone(), response.cursor.clone())
+            .set_chain_head(block, response.cursor.clone())
             .await
             .context("Updating chain head")?;
 

--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -411,7 +411,7 @@ where
                 .clone()
                 .set_chain_backfill_as_completed()
                 .await
-                .context("setting backfill completion")?;
+                .context("Setting backfill completion")?;
         }
 
         Ok(())

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1339,6 +1339,33 @@ pub trait ChainStore: Send + Sync + 'static {
         cursor: String,
     ) -> Result<(), Error>;
 
+    /// Get the current backfill block cursor for this chain.
+    ///
+    /// The backfill block cursor will be None on initial set up.
+    fn chain_backfill_cursor(&self) -> Result<Option<String>, Error>;
+
+    /// Set the current backfill cursor for this chain.
+    async fn set_chain_backfill_cursor(self: Arc<Self>, cursor: String) -> Result<(), Error>;
+
+    /// Get the backfill target block number from the ethereum_networks table.
+    ///
+    /// If this value is not yet set, will return None
+    fn chain_backfill_target_block_num(&self) -> Result<Option<BlockNumber>, Error>;
+
+    /// Set the backfill target block number in the ethereum_networks table
+    async fn set_chain_backfill_target_block_num(self: Arc<Self>, block_num: BlockNumber) -> Result<(), Error>;
+
+    /// Determine the initial backfill target block number from the raw blocks storage table
+    ///
+    /// Should only be called once
+    fn chain_initial_backfill_target_block_num(&self) -> Result<Option<BlockNumber>, Error>;
+
+    /// Returns whether or not the backfill process is complete
+    fn chain_backfill_is_completed(&self) -> Result<Option<bool>, Error>;
+
+    /// This method sets the backfill process as completed
+    async fn set_chain_backfill_as_completed(self: Arc<Self>) -> Result<(), Error>;
+
     /// Returns the blocks present in the store.
     fn blocks(&self, hashes: &[H256]) -> Result<Vec<serde_json::Value>, Error>;
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1353,7 +1353,10 @@ pub trait ChainStore: Send + Sync + 'static {
     fn chain_backfill_target_block_num(&self) -> Result<Option<BlockNumber>, Error>;
 
     /// Set the backfill target block number in the ethereum_networks table
-    async fn set_chain_backfill_target_block_num(self: Arc<Self>, block_num: BlockNumber) -> Result<(), Error>;
+    async fn set_chain_backfill_target_block_num(
+        self: Arc<Self>,
+        block_num: BlockNumber,
+    ) -> Result<(), Error>;
 
     /// Determine the initial backfill target block number from the raw blocks storage table
     ///

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1364,7 +1364,7 @@ pub trait ChainStore: Send + Sync + 'static {
     fn chain_initial_backfill_target_block_num(&self) -> Result<Option<BlockNumber>, Error>;
 
     /// Returns whether or not the backfill process is complete
-    fn chain_backfill_is_completed(&self) -> Result<Option<bool>, Error>;
+    fn chain_backfill_is_completed(&self) -> Result<bool, Error>;
 
     /// This method sets the backfill process as completed
     async fn set_chain_backfill_as_completed(self: Arc<Self>) -> Result<(), Error>;

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 async-trait = "0.1.50"
 blake3 = "0.3.8"
 derive_more = { version = "0.99.17" }
-diesel = { version = "1.4.8", features = ["postgres", "serde_json", "numeric", "r2d2"] }
+chrono = "0.4.0"
+diesel = { version = "1.4.8", features = ["chrono", "postgres", "serde_json", "numeric", "r2d2"] }
 # We use diesel-dynamic-schema straight from git as the project has not
 # made a release as a crate yet
 diesel-dynamic-schema = { git = "https://github.com/diesel-rs/diesel-dynamic-schema", rev="a8ec4fb1" }

--- a/store/postgres/migrations/2021-12-10-154628_firehose_backfill/down.sql
+++ b/store/postgres/migrations/2021-12-10-154628_firehose_backfill/down.sql
@@ -1,0 +1,5 @@
+alter table public.ethereum_networks
+    drop column backfill_block_cursor,
+    drop column backfill_completed,
+    drop column backfill_completed_date,
+    drop column backfill_target_block_number;

--- a/store/postgres/migrations/2021-12-10-154628_firehose_backfill/up.sql
+++ b/store/postgres/migrations/2021-12-10-154628_firehose_backfill/up.sql
@@ -1,0 +1,5 @@
+alter table public.ethereum_networks
+    add column backfill_block_cursor text default null,
+    add column backfill_completed boolean default false,
+    add column backfill_completed_date timestamp default null,
+    add column backfill_target_block_number bigint default null;

--- a/store/postgres/migrations/2021-12-10-154628_firehose_backfill/up.sql
+++ b/store/postgres/migrations/2021-12-10-154628_firehose_backfill/up.sql
@@ -1,5 +1,5 @@
 alter table public.ethereum_networks
     add column backfill_block_cursor text default null,
-    add column backfill_completed boolean default false,
+    add column backfill_completed boolean not null default false,
     add column backfill_completed_date timestamp default null,
     add column backfill_target_block_number bigint default null;


### PR DESCRIPTION
Since the Firehose Block Ingestor starts at the current HEAD block of the chain, the purpose of this change is to spawn a process which will backfill the blocks from the start of the chain all the way to the block where the ingestor first started processing its blocks.