### PR TITLE
Added an environment to control if Firehoe is preferred or not when present

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -62,7 +62,8 @@ lazy_static! {
     /// Controls if firehose should be preferred over RPC if Firehose endpoints are present, if not set, the default behavior is
     /// is kept which is to automatically favor Firehose.
     static ref IS_FIREHOSE_PREFERRED: Option<bool> = std::env::var("GRAPH_ETHEREUM_IS_FIREHOSE_PREFERRED")
-        .map_or_else(|_| None, |input| Some(input.parse::<bool>().expect("invalid GRAPH_ETHEREUM_IS_FIREHOSE_PREFERRED")));
+        .ok()
+        .map(|input| input.parse::<bool>().expect("invalid GRAPH_ETHEREUM_IS_FIREHOSE_PREFERRED"));
 }
 
 /// Celo Mainnet: 42220, Testnet Alfajores: 44787, Testnet Baklava: 62320


### PR DESCRIPTION
If the environment is **not** set, the current behavior and Firehose is automatically picked up if there is endpoints configured with it.

If the environment set, firehose is preferred only if the variable is true and there is endpoints configured with it.

