### PR TITLE
Pipeline store writes

### DIFF
--- a/chain/ethereum/tests/manifest.rs
+++ b/chain/ethereum/tests/manifest.rs
@@ -181,7 +181,7 @@ specVersion: 0.0.2
         thing.set("id", "datthing");
         test_store::insert_entities(&deployment, vec![(EntityType::from("Thing"), thing)])
             .await
-            .expect("Can insert a thing");
+            .unwrap();
 
         // Validation against subgraph that has not reached the graft point fails
         let unvalidated = resolve_unvalidated(YAML).await;

--- a/chain/ethereum/tests/manifest.rs
+++ b/chain/ethereum/tests/manifest.rs
@@ -180,6 +180,7 @@ specVersion: 0.0.2
         let mut thing = Entity::new();
         thing.set("id", "datthing");
         test_store::insert_entities(&deployment, vec![(EntityType::from("Thing"), thing)])
+            .await
             .expect("Can insert a thing");
 
         // Validation against subgraph that has not reached the graft point fails

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -203,6 +203,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
         let stopwatch_metrics = StopwatchMetrics::new(
             logger.clone(),
             deployment.hash.clone(),
+            "process",
             self.metrics_registry.clone(),
         );
 

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -352,6 +352,7 @@ where
                 data_sources,
                 deterministic_errors,
             )
+            .await
             .context("Failed to transact block operations")?;
 
         // For subgraphs with `nonFatalErrors` feature disabled, we consider
@@ -778,6 +779,7 @@ where
             .inputs
             .store
             .revert_block_operations(revert_to_ptr, cursor.as_deref())
+            .await
         {
             error!(&self.logger, "Could not revert block. Retrying"; "error" => %e);
 

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -32,7 +32,8 @@ async fn insert_and_query(
         &deployment,
         GENESIS_PTR.clone(),
         insert_ops.collect::<Vec<_>>(),
-    )?;
+    )
+    .await?;
 
     let document = graphql_parser::parse_query(query).unwrap().into_static();
     let target = QueryTarget::Deployment(subgraph_id);

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -10,30 +10,18 @@ use test_store::*;
 async fn insert_and_query(
     subgraph_id: &str,
     schema: &str,
-    entities: Vec<(Entity, &str)>,
+    entities: Vec<(&str, Entity)>,
     query: &str,
 ) -> Result<QueryResult, StoreError> {
     let subgraph_id = DeploymentHash::new(subgraph_id).unwrap();
     let deployment = create_test_subgraph(&subgraph_id, schema).await;
 
-    let insert_ops = entities
+    let entities = entities
         .into_iter()
-        .map(|(data, entity_type)| EntityOperation::Set {
-            key: EntityKey {
-                subgraph_id: subgraph_id.clone(),
-                entity_type: EntityType::new(entity_type.to_owned()),
-                entity_id: data.get("id").unwrap().clone().as_string().unwrap(),
-            },
-            data,
-        });
+        .map(|(entity_type, data)| (EntityType::new(entity_type.to_owned()), data))
+        .collect();
 
-    transact_entity_operations(
-        &STORE.subgraph_store(),
-        &deployment,
-        GENESIS_PTR.clone(),
-        insert_ops.collect::<Vec<_>>(),
-    )
-    .await?;
+    insert_entities(&deployment, entities).await?;
 
     let document = graphql_parser::parse_query(query).unwrap().into_static();
     let target = QueryTarget::Deployment(subgraph_id);
@@ -79,8 +67,8 @@ async fn one_interface_one_entity() {
                   type Animal implements Legged @entity { id: ID!, legs: Int }";
 
     let entity = (
-        Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]),
         "Animal",
+        Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]),
     );
 
     // Collection query.
@@ -109,8 +97,8 @@ async fn one_interface_one_entity_typename() {
                   type Animal implements Legged @entity { id: ID!, legs: Int }";
 
     let entity = (
-        Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]),
         "Animal",
+        Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]),
     );
 
     let query = "query { leggeds(first: 100) { __typename } }";
@@ -132,12 +120,12 @@ async fn one_interface_multiple_entities() {
                   ";
 
     let animal = (
-        Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]),
         "Animal",
+        Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]),
     );
     let furniture = (
-        Entity::from(vec![("id", Value::from("2")), ("legs", Value::from(4))]),
         "Furniture",
+        Entity::from(vec![("id", Value::from("2")), ("legs", Value::from(4))]),
     );
 
     let query = "query { leggeds(first: 100, orderBy: legs) { legs } }";
@@ -168,10 +156,10 @@ async fn reference_interface() {
 
     let query = "query { leggeds(first: 100) { leg { id } } }";
 
-    let leg = (Entity::from(vec![("id", Value::from("1"))]), "Leg");
+    let leg = ("Leg", Entity::from(vec![("id", Value::from("1"))]));
     let animal = (
-        Entity::from(vec![("id", Value::from("1")), ("leg", Value::from("1"))]),
         "Animal",
+        Entity::from(vec![("id", Value::from("1")), ("leg", Value::from("1"))]),
     );
 
     let res = insert_and_query(subgraph_id, schema, vec![leg, animal], query)
@@ -221,20 +209,20 @@ async fn reference_interface_derived() {
 
     let query = "query { events { id transaction { id } } }";
 
-    let buy = (Entity::from(vec![("id", "buy".into())]), "BuyEvent");
-    let sell1 = (Entity::from(vec![("id", "sell1".into())]), "SellEvent");
-    let sell2 = (Entity::from(vec![("id", "sell2".into())]), "SellEvent");
+    let buy = ("BuyEvent", Entity::from(vec![("id", "buy".into())]));
+    let sell1 = ("SellEvent", Entity::from(vec![("id", "sell1".into())]));
+    let sell2 = ("SellEvent", Entity::from(vec![("id", "sell2".into())]));
     let gift = (
-        Entity::from(vec![("id", "gift".into()), ("transaction", "txn".into())]),
         "GiftEvent",
+        Entity::from(vec![("id", "gift".into()), ("transaction", "txn".into())]),
     );
     let txn = (
+        "Transaction",
         Entity::from(vec![
             ("id", "txn".into()),
             ("buyEvent", "buy".into()),
             ("sellEvents", vec!["sell1", "sell2"].into()),
         ]),
-        "Transaction",
     );
 
     let entities = vec![buy, sell1, sell2, gift, txn];
@@ -300,20 +288,20 @@ async fn follow_interface_reference() {
     let query = "query { legged(id: \"child\") { ... on Animal { parent { id } } } }";
 
     let parent = (
+        "Animal",
         Entity::from(vec![
             ("id", Value::from("parent")),
             ("legs", Value::from(4)),
             ("parent", Value::Null),
         ]),
-        "Animal",
     );
     let child = (
+        "Animal",
         Entity::from(vec![
             ("id", Value::from("child")),
             ("legs", Value::from(3)),
             ("parent", Value::String("parent".into())),
         ]),
-        "Animal",
     );
 
     let res = insert_and_query(subgraph_id, schema, vec![parent, child], query)
@@ -336,12 +324,12 @@ async fn conflicting_implementors_id() {
                   ";
 
     let animal = (
-        Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]),
         "Animal",
+        Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]),
     );
     let furniture = (
-        Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]),
         "Furniture",
+        Entity::from(vec![("id", Value::from("1")), ("legs", Value::from(3))]),
     );
 
     let query = "query { leggeds(first: 100) { legs } }";
@@ -369,10 +357,10 @@ async fn derived_interface_relationship() {
                   type Forest @entity { id: ID!, dwellers: [ForestDweller]! @derivedFrom(field: \"forest\") }
                   ";
 
-    let forest = (Entity::from(vec![("id", Value::from("1"))]), "Forest");
+    let forest = ("Forest", Entity::from(vec![("id", Value::from("1"))]));
     let animal = (
-        Entity::from(vec![("id", Value::from("1")), ("forest", Value::from("1"))]),
         "Animal",
+        Entity::from(vec![("id", Value::from("1")), ("forest", Value::from("1"))]),
     );
 
     let query = "query { forests(first: 100) { dwellers(first: 100) { id } } }";
@@ -400,20 +388,20 @@ async fn two_interfaces() {
                   ";
 
     let a = (
-        Entity::from(vec![("id", Value::from("1")), ("foo", Value::from("bla"))]),
         "A",
+        Entity::from(vec![("id", Value::from("1")), ("foo", Value::from("bla"))]),
     );
     let b = (
-        Entity::from(vec![("id", Value::from("1")), ("bar", Value::from(100))]),
         "B",
+        Entity::from(vec![("id", Value::from("1")), ("bar", Value::from(100))]),
     );
     let ab = (
+        "AB",
         Entity::from(vec![
             ("id", Value::from("2")),
             ("foo", Value::from("ble")),
             ("bar", Value::from(200)),
         ]),
-        "AB",
     );
 
     let query = "query {
@@ -438,12 +426,12 @@ async fn interface_non_inline_fragment() {
                   type Animal implements Legged @entity { id: ID!, name: String, legs: Int }";
 
     let entity = (
+        "Animal",
         Entity::from(vec![
             ("id", Value::from("1")),
             ("name", Value::from("cow")),
             ("legs", Value::from(3)),
         ]),
-        "Animal",
     );
 
     // Query only the fragment.
@@ -473,20 +461,20 @@ async fn interface_inline_fragment() {
                   type Bird implements Legged @entity { id: ID!, airspeed: Int, legs: Int }";
 
     let animal = (
+        "Animal",
         Entity::from(vec![
             ("id", Value::from("1")),
             ("name", Value::from("cow")),
             ("legs", Value::from(4)),
         ]),
-        "Animal",
     );
     let bird = (
+        "Bird",
         Entity::from(vec![
             ("id", Value::from("2")),
             ("airspeed", Value::from(24)),
             ("legs", Value::from(2)),
         ]),
-        "Bird",
     );
 
     let query =
@@ -522,31 +510,31 @@ async fn interface_inline_fragment_with_subquery() {
     ";
 
     let mama_cow = (
-        Entity::from(vec![("id", Value::from("mama_cow"))]),
         "Parent",
+        Entity::from(vec![("id", Value::from("mama_cow"))]),
     );
     let cow = (
+        "Animal",
         Entity::from(vec![
             ("id", Value::from("1")),
             ("name", Value::from("cow")),
             ("legs", Value::from(4)),
             ("parent", Value::from("mama_cow")),
         ]),
-        "Animal",
     );
 
     let mama_bird = (
-        Entity::from(vec![("id", Value::from("mama_bird"))]),
         "Parent",
+        Entity::from(vec![("id", Value::from("mama_bird"))]),
     );
     let bird = (
+        "Bird",
         Entity::from(vec![
             ("id", Value::from("2")),
             ("airspeed", Value::from(5)),
             ("legs", Value::from(2)),
             ("parent", Value::from("mama_bird")),
         ]),
-        "Bird",
     );
 
     let query = "query { leggeds(orderBy: legs) { legs ... on Bird { airspeed parent { id } } } }";
@@ -621,20 +609,20 @@ async fn alias() {
             }";
 
     let parent = (
+        "Animal",
         Entity::from(vec![
             ("id", Value::from("parent")),
             ("legs", Value::from(4)),
             ("parent", Value::Null),
         ]),
-        "Animal",
     );
     let child = (
+        "Animal",
         Entity::from(vec![
             ("id", Value::from("child")),
             ("legs", Value::from(3)),
             ("parent", Value::String("parent".into())),
         ]),
-        "Animal",
     );
 
     let res = insert_and_query(subgraph_id, schema, vec![parent, child], query)
@@ -693,24 +681,24 @@ async fn fragments_dont_panic() {
 
     // The panic manifests if two parents exist.
     let parent = (
+        "Parent",
         entity!(
             id: "p",
             child: "c",
         ),
-        "Parent",
     );
     let parent2 = (
+        "Parent",
         entity!(
             id: "p2",
             child: Value::Null,
         ),
-        "Parent",
     );
     let child = (
+        "Child",
         entity!(
             id:"c"
         ),
-        "Child",
     );
 
     let res = insert_and_query(subgraph_id, schema, vec![parent, parent2, child], query)
@@ -769,24 +757,24 @@ async fn fragments_dont_duplicate_data() {
 
     // This bug manifests if two parents exist.
     let parent = (
+        "Parent",
         entity!(
             id: "p",
             children: vec!["c"]
         ),
-        "Parent",
     );
     let parent2 = (
+        "Parent",
         entity!(
             id: "b",
             children: Vec::<String>::new()
         ),
-        "Parent",
     );
     let child = (
+        "Child",
         entity!(
             id:"c"
         ),
-        "Child",
     );
 
     let res = insert_and_query(subgraph_id, schema, vec![parent, parent2, child], query)
@@ -833,18 +821,18 @@ async fn redundant_fields() {
             }";
 
     let parent = (
+        "Animal",
         entity!(
             id: "parent",
             parent: Value::Null,
         ),
-        "Animal",
     );
     let child = (
+        "Animal",
         entity!(
             id: "child",
             parent: "parent",
         ),
-        "Animal",
     );
 
     let res = insert_and_query(subgraph_id, schema, vec![parent, child], query)
@@ -902,18 +890,18 @@ async fn fragments_merge_selections() {
     ";
 
     let parent = (
+        "Parent",
         entity!(
             id: "p",
             children: vec!["c"]
         ),
-        "Parent",
     );
     let child = (
+        "Child",
         entity!(
             id: "c",
             foo: 1,
         ),
-        "Child",
     );
 
     let res = insert_and_query(subgraph_id, schema, vec![parent, child], query)
@@ -970,18 +958,18 @@ async fn merge_fields_not_in_interface() {
             }";
 
     let animal = (
+        "Animal",
         entity!(
             id: "cow",
             human: "fred",
         ),
-        "Animal",
     );
     let human = (
+        "Human",
         entity!(
             id: "fred",
             animal: "cow",
         ),
-        "Human",
     );
 
     let res = insert_and_query(subgraph_id, schema, vec![animal, human], query)
@@ -1055,34 +1043,34 @@ async fn nested_interface_fragments() {
             }";
 
     let foo = (
+        "Foo",
         entity!(
             id: "foo",
         ),
-        "Foo",
     );
     let one = (
+        "One",
         entity!(
             id: "1",
             foo1: "foo",
         ),
-        "One",
     );
     let two = (
+        "Two",
         entity!(
             id: "2",
             foo1: "foo",
             foo2: "foo",
         ),
-        "Two",
     );
     let three = (
+        "Three",
         entity!(
             id: "3",
             foo1: "foo",
             foo2: "foo",
             foo3: "foo"
         ),
-        "Three",
     );
 
     let res = insert_and_query(subgraph_id, schema, vec![foo, one, two, three], query)
@@ -1155,24 +1143,24 @@ async fn nested_interface_fragments_overlapping() {
             }";
 
     let foo = (
+        "Foo",
         entity!(
             id: "foo",
         ),
-        "Foo",
     );
     let one = (
+        "One",
         entity!(
             id: "1",
             foo1: "foo",
         ),
-        "One",
     );
     let two = (
+        "Two",
         entity!(
             id: "2",
             foo1: "foo",
         ),
-        "Two",
     );
     let res = insert_and_query(subgraph_id, schema, vec![foo, one, two], query)
         .await
@@ -1255,20 +1243,20 @@ async fn enums() {
 
     let entities = vec![
         (
+            "Trajectory",
             Entity::from(vec![
                 ("id", Value::from("1")),
                 ("direction", Value::from("EAST")),
                 ("meters", Value::from(10)),
             ]),
-            "Trajectory",
         ),
         (
+            "Trajectory",
             Entity::from(vec![
                 ("id", Value::from("2")),
                 ("direction", Value::from("NORTH")),
                 ("meters", Value::from(15)),
             ]),
-            "Trajectory",
         ),
     ];
     let query = "query { trajectories { id, direction, meters } }";
@@ -1315,28 +1303,28 @@ async fn enum_list_filters() {
 
     let entities = vec![
         (
+            "Trajectory",
             Entity::from(vec![
                 ("id", Value::from("1")),
                 ("direction", Value::from("EAST")),
                 ("meters", Value::from(10)),
             ]),
-            "Trajectory",
         ),
         (
+            "Trajectory",
             Entity::from(vec![
                 ("id", Value::from("2")),
                 ("direction", Value::from("NORTH")),
                 ("meters", Value::from(15)),
             ]),
-            "Trajectory",
         ),
         (
+            "Trajectory",
             Entity::from(vec![
                 ("id", Value::from("3")),
                 ("direction", Value::from("WEST")),
                 ("meters", Value::from(20)),
             ]),
-            "Trajectory",
         ),
     ];
 

--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -63,6 +63,14 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         self.global_counter(name, help, deployment_labels(subgraph))
     }
 
+    fn global_deployment_counter_vec(
+        &self,
+        name: &str,
+        help: &str,
+        subgraph: &str,
+        variable_labels: &[&str],
+    ) -> Result<CounterVec, PrometheusError>;
+
     fn global_gauge(
         &self,
         name: &str,

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -44,15 +44,17 @@ impl StopwatchMetrics {
     pub fn new(
         logger: Logger,
         subgraph_id: DeploymentHash,
+        stage: &str,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
+        let stage = stage.to_owned();
         let mut inner = StopwatchInner {
             counter: *registry
                 .new_deployment_counter_vec(
                     "deployment_sync_secs",
                     "total time spent syncing",
                     subgraph_id.as_str(),
-                    vec!["section".to_owned()],
+                    vec!["section".to_owned(), stage.clone()],
                 )
                 .unwrap_or_else(|_| {
                     panic!(
@@ -61,6 +63,7 @@ impl StopwatchMetrics {
                     )
                 }),
             logger,
+            stage,
             section_stack: Vec::new(),
             timer: Instant::now(),
         };
@@ -113,6 +116,10 @@ struct StopwatchInner {
 
     // The timer is reset whenever a section starts or ends.
     timer: Instant,
+
+    // The processing stage the metrics belong to; for pipelined uses, the
+    // pipeline stage
+    stage: String,
 }
 
 impl StopwatchInner {
@@ -121,7 +128,7 @@ impl StopwatchInner {
             // Register the current timer.
             let elapsed = self.timer.elapsed().as_secs_f64();
             self.counter
-                .get_metric_with_label_values(&[section])
+                .get_metric_with_label_values(&[section, &self.stage])
                 .map(|counter| counter.inc_by(elapsed))
                 .unwrap_or_else(|e| {
                     error!(self.logger, "failed to find counter for section";

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -49,12 +49,12 @@ impl StopwatchMetrics {
     ) -> Self {
         let stage = stage.to_owned();
         let mut inner = StopwatchInner {
-            counter: *registry
-                .new_deployment_counter_vec(
+            counter: registry
+                .global_deployment_counter_vec(
                     "deployment_sync_secs",
                     "total time spent syncing",
                     subgraph_id.as_str(),
-                    vec!["section".to_owned(), stage.clone()],
+                    &["section", "stage"],
                 )
                 .unwrap_or_else(|_| {
                     panic!(

--- a/graph/src/components/store/err.rs
+++ b/graph/src/components/store/err.rs
@@ -45,6 +45,8 @@ pub enum StoreError {
     DatabaseUnavailable,
     #[error("subgraph forking failed: {0}")]
     ForkFailure(String),
+    #[error("subgraph writer poisoned by previous error")]
+    Poisoned,
 }
 
 // Convenience to report a constraint violation

--- a/graph/src/components/store/err.rs
+++ b/graph/src/components/store/err.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Error};
 use thiserror::Error;
+use tokio::task::JoinError;
 
 use super::{BlockNumber, DeploymentHash};
 use crate::prelude::QueryExecutionError;
@@ -47,6 +48,8 @@ pub enum StoreError {
     ForkFailure(String),
     #[error("subgraph writer poisoned by previous error")]
     Poisoned,
+    #[error("panic in subgraph writer: {0}")]
+    WriterPanic(JoinError),
 }
 
 // Convenience to report a constraint violation

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -753,6 +753,7 @@ pub enum UnfailOutcome {
     Unfailed,
 }
 
+#[derive(Clone)]
 pub struct StoredDynamicDataSource {
     pub name: String,
     pub source: Source,
@@ -836,6 +837,14 @@ impl EntityModification {
         use EntityModification::*;
         match self {
             Insert { key, .. } | Overwrite { key, .. } | Remove { key } => key,
+        }
+    }
+
+    pub fn entity(&self) -> Option<&Entity> {
+        match self {
+            EntityModification::Insert { data, .. }
+            | EntityModification::Overwrite { data, .. } => Some(data),
+            EntityModification::Remove { .. } => None,
         }
     }
 

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -233,6 +233,9 @@ pub trait WritableStore: Send + Sync + 'static {
     async fn health(&self, id: &DeploymentHash) -> Result<SubgraphHealth, StoreError>;
 
     fn input_schema(&self) -> Arc<Schema>;
+
+    /// Wait for the background writer to finish processing its queue
+    async fn wait(&self) -> Result<(), StoreError>;
 }
 
 #[async_trait]

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -162,7 +162,7 @@ pub trait WritableStore: Send + Sync + 'static {
     /// subgraph block pointer to `block_ptr_to`.
     ///
     /// `block_ptr_to` must point to the parent block of the subgraph block pointer.
-    fn revert_block_operations(
+    async fn revert_block_operations(
         &self,
         block_ptr_to: BlockPtr,
         firehose_cursor: Option<&str>,
@@ -195,7 +195,7 @@ pub trait WritableStore: Send + Sync + 'static {
     /// subgraph block pointer to `block_ptr_to`, and update the firehose cursor to `firehose_cursor`
     ///
     /// `block_ptr_to` must point to a child block of the current subgraph block pointer.
-    fn transact_block_operations(
+    async fn transact_block_operations(
         &self,
         block_ptr_to: BlockPtr,
         firehose_cursor: Option<String>,

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -235,7 +235,7 @@ pub trait WritableStore: Send + Sync + 'static {
     fn input_schema(&self) -> Arc<Schema>;
 
     /// Wait for the background writer to finish processing its queue
-    async fn wait(&self) -> Result<(), StoreError>;
+    async fn flush(&self) -> Result<(), StoreError>;
 }
 
 #[async_trait]

--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -92,6 +92,12 @@ pub struct EnvVarsStore {
     /// Set by the environment variable `GRAPH_STORE_CONNECTION_IDLE_TIMEOUT`
     /// (expressed in seconds). The default value is 600s.
     pub connection_idle_timeout: Duration,
+
+    /// The size of the write queue; this many blocks can be buffered for
+    /// writing before calls to transact block operations will block.
+    /// Setting this to `0` disables pipelined writes, and writes will be
+    /// done synchronously.
+    pub write_queue_size: usize,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -132,6 +138,7 @@ impl From<InnerStore> for EnvVarsStore {
             connection_timeout: Duration::from_millis(x.connection_timeout_in_millis),
             connection_min_idle: x.connection_min_idle,
             connection_idle_timeout: Duration::from_secs(x.connection_idle_timeout_in_secs),
+            write_queue_size: x.write_queue_size,
         }
     }
 }
@@ -175,4 +182,6 @@ pub struct InnerStore {
     connection_min_idle: Option<u32>,
     #[envconfig(from = "GRAPH_STORE_CONNECTION_IDLE_TIMEOUT", default = "600")]
     connection_idle_timeout_in_secs: u64,
+    #[envconfig(from = "GRAPH_STORE_WRITE_QUEUE", default = "5")]
+    write_queue_size: usize,
 }

--- a/graph/src/util/bounded_queue.rs
+++ b/graph/src/util/bounded_queue.rs
@@ -1,0 +1,127 @@
+use std::{collections::VecDeque, sync::Mutex};
+
+use crate::prelude::tokio::sync::Semaphore;
+
+/// An async-friendly queue of bounded size. In contrast to a bounded channel,
+/// the queue makes it possible to modify and remove entries in it.
+pub struct BoundedQueue<T> {
+    /// The maximum number of entries allowed in the queue
+    capacity: usize,
+    /// The actual items in the queue. New items are appended at the back, and
+    /// popped off the front.
+    queue: Mutex<VecDeque<T>>,
+    /// This semaphore has as many permits as there are empty spots in the
+    /// `queue`, i.e., `capacity - queue.len()` many permits
+    push_semaphore: Semaphore,
+    /// This semaphore has as many permits as there are entrie in the queue,
+    /// i.e., `queue.len()` many
+    pop_semaphore: Semaphore,
+}
+
+impl<T> std::fmt::Debug for BoundedQueue<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let queue = self.queue.lock().unwrap();
+        write!(
+            f,
+            "BoundedQueue[cap: {}, queue: {}/{}, push: {}, pop: {}]",
+            self.capacity,
+            queue.len(),
+            queue.capacity(),
+            self.push_semaphore.available_permits(),
+            self.pop_semaphore.available_permits(),
+        )
+    }
+}
+
+impl<T: Clone> BoundedQueue<T> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            capacity,
+            queue: Mutex::new(VecDeque::with_capacity(capacity)),
+            push_semaphore: Semaphore::new(capacity),
+            pop_semaphore: Semaphore::new(0),
+        }
+    }
+
+    /// Get an item from the queue. If the queue is currently empty
+    /// this method blocks until an item is available.
+    pub async fn pop(&self) -> T {
+        let permit = self.pop_semaphore.acquire().await.unwrap();
+        let item = self
+            .queue
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("the queue is not empty");
+        permit.forget();
+        self.push_semaphore.add_permits(1);
+        item
+    }
+
+    /// Take an item from the front of the queue and return a copy. If the
+    /// queue is currently empty this method blocks until an item is
+    /// available.
+    pub async fn peek(&self) -> T {
+        let _permit = self.pop_semaphore.acquire().await.unwrap();
+        let queue = self.queue.lock().unwrap();
+        let item = queue.front().expect("the queue is not empty");
+        item.clone()
+    }
+
+    /// Push an item into the queue. If the queue is currently full this method
+    /// blocks until an item is available
+    pub async fn push(&self, item: T) {
+        let permit = self.push_semaphore.acquire().await.unwrap();
+        self.queue.lock().unwrap().push_back(item);
+        permit.forget();
+        self.pop_semaphore.add_permits(1);
+    }
+
+    pub async fn wait_empty(&self) -> Result<(), ()> {
+        self.push_semaphore
+            .acquire_many(self.capacity as u32)
+            .await
+            .map(|_| ())
+            .map_err(|_| ())
+    }
+
+    pub fn len(&self) -> usize {
+        self.queue.lock().unwrap().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.queue.lock().unwrap().is_empty()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Iterate over the entries in the queue from newest to oldest entry
+    /// atomically, applying `f` to each entry and returning the first
+    /// result that is not `None`.
+    ///
+    /// This method locks the queue while it is executing, and `f` should
+    /// therefore not do any slow work.
+    pub fn find_map<B, F>(&self, f: F) -> Option<B>
+    where
+        F: FnMut(&T) -> Option<B>,
+    {
+        let queue = self.queue.lock().unwrap();
+        queue.iter().rev().find_map(f)
+    }
+
+    /// Iterate over the entries in the queue from newest to oldest entry
+    /// atomically, applying `f` to each entry and returning the result of
+    /// the last invocation of `f`.
+    ///
+    /// This method locks the queue while it is executing, and `f` should
+    /// therefore not do any slow work.
+    pub fn fold<B, F>(&self, init: B, f: F) -> B
+    where
+        F: FnMut(B, &T) -> B,
+    {
+        let queue = self.queue.lock().unwrap();
+        queue.iter().rev().fold(init, f)
+    }
+}

--- a/graph/src/util/bounded_queue.rs
+++ b/graph/src/util/bounded_queue.rs
@@ -138,5 +138,6 @@ impl<T: Clone> BoundedQueue<T> {
             .acquire_many(pushed as u32)
             .await
             .expect("we never close the pop_semaphore");
+        _permits.forget();
     }
 }

--- a/graph/src/util/bounded_queue.rs
+++ b/graph/src/util/bounded_queue.rs
@@ -77,12 +77,12 @@ impl<T: Clone> BoundedQueue<T> {
         self.pop_semaphore.add_permits(1);
     }
 
-    pub async fn wait_empty(&self) -> Result<(), ()> {
+    pub async fn wait_empty(&self) {
         self.push_semaphore
             .acquire_many(self.capacity as u32)
             .await
             .map(|_| ())
-            .map_err(|_| ())
+            .expect("we never close the push_semaphore")
     }
 
     pub fn len(&self) -> usize {

--- a/graph/src/util/mod.rs
+++ b/graph/src/util/mod.rs
@@ -20,3 +20,5 @@ pub mod jobs;
 
 /// Increasingly longer sleeps to back off some repeated operation
 pub mod backoff;
+
+pub mod bounded_queue;

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -149,6 +149,10 @@ impl WritableStore for MockStore {
     fn input_schema(&self) -> Arc<Schema> {
         SCHEMA.clone()
     }
+
+    async fn wait(&self) -> Result<(), StoreError> {
+        unimplemented!()
+    }
 }
 
 fn make_band(id: &'static str, data: Vec<(&str, Value)>) -> (EntityKey, Entity) {

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -150,7 +150,7 @@ impl WritableStore for MockStore {
         SCHEMA.clone()
     }
 
-    async fn wait(&self) -> Result<(), StoreError> {
+    async fn flush(&self) -> Result<(), StoreError> {
         unimplemented!()
     }
 }

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -62,7 +62,11 @@ impl WritableStore for MockStore {
         unimplemented!()
     }
 
-    fn revert_block_operations(&self, _: BlockPtr, _: Option<&str>) -> Result<(), StoreError> {
+    async fn revert_block_operations(
+        &self,
+        _: BlockPtr,
+        _: Option<&str>,
+    ) -> Result<(), StoreError> {
         unimplemented!()
     }
 
@@ -99,7 +103,7 @@ impl WritableStore for MockStore {
         }
     }
 
-    fn transact_block_operations(
+    async fn transact_block_operations(
         &self,
         _: BlockPtr,
         _: Option<String>,

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -39,11 +39,11 @@ use test_store::{
 
 const NETWORK_NAME: &str = "fake_network";
 
-fn setup(store: &Store) -> DeploymentLocator {
-    setup_with_features(store, "graphqlTestsQuery", BTreeSet::new())
+async fn setup(store: &Store) -> DeploymentLocator {
+    setup_with_features(store, "graphqlTestsQuery", BTreeSet::new()).await
 }
 
-fn setup_with_features(
+async fn setup_with_features(
     store: &Store,
     id: &str,
     features: BTreeSet<SubgraphFeature>,
@@ -70,7 +70,7 @@ fn setup_with_features(
         chain: PhantomData,
     };
 
-    insert_test_entities(store.subgraph_store().as_ref(), manifest)
+    insert_test_entities(store.subgraph_store().as_ref(), manifest).await
 }
 
 fn test_schema(id: DeploymentHash) -> Schema {
@@ -109,7 +109,7 @@ fn test_schema(id: DeploymentHash) -> Schema {
     .expect("Test schema invalid")
 }
 
-fn insert_test_entities(
+async fn insert_test_entities(
     store: &impl SubgraphStore,
     manifest: SubgraphManifest<graph_chain_ethereum::Chain>,
 ) -> DeploymentLocator {
@@ -223,7 +223,7 @@ fn insert_test_entities(
         ]),
     ];
 
-    fn insert_at(entities: Vec<Entity>, deployment: &DeploymentLocator, block_ptr: BlockPtr) {
+    async fn insert_at(entities: Vec<Entity>, deployment: &DeploymentLocator, block_ptr: BlockPtr) {
         let insert_ops = entities.into_iter().map(|data| EntityOperation::Set {
             key: EntityKey::data(
                 deployment.hash.clone(),
@@ -239,11 +239,12 @@ fn insert_test_entities(
             block_ptr,
             insert_ops.collect::<Vec<_>>(),
         )
+        .await
         .unwrap();
     }
 
-    insert_at(entities0, &deployment, GENESIS_PTR.clone());
-    insert_at(entities1, &deployment, BLOCK_ONE.clone());
+    insert_at(entities0, &deployment, GENESIS_PTR.clone()).await;
+    insert_at(entities1, &deployment, BLOCK_ONE.clone()).await;
     deployment
 }
 
@@ -291,7 +292,7 @@ macro_rules! extract_data {
 #[test]
 fn can_query_one_to_one_relationship() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let result = execute_query_document(
             &deployment.hash,
             graphql_parser::parse_query(
@@ -396,7 +397,7 @@ fn can_query_one_to_one_relationship() {
 #[test]
 fn can_query_one_to_many_relationships_in_both_directions() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let result = execute_query_document(
             &deployment.hash,
             graphql_parser::parse_query(
@@ -495,7 +496,7 @@ fn can_query_one_to_many_relationships_in_both_directions() {
 #[test]
 fn can_query_many_to_many_relationship() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let result = execute_query_document(
             &deployment.hash,
             graphql_parser::parse_query(
@@ -577,7 +578,7 @@ fn can_query_many_to_many_relationship() {
 #[test]
 fn root_fragments_are_expanded() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let query = graphql_parser::parse_query(
             r#"
             fragment Musicians on Query {
@@ -601,7 +602,7 @@ fn root_fragments_are_expanded() {
 #[test]
 fn query_variables_are_used() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let query = graphql_parser::parse_query(
             "
         query musicians($where: Musician_filter!) {
@@ -643,7 +644,7 @@ fn query_variables_are_used() {
 #[test]
 fn skip_directive_works_with_query_variables() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let query = graphql_parser::parse_query(
             "
         query musicians($skip: Boolean!) {
@@ -722,7 +723,7 @@ fn skip_directive_works_with_query_variables() {
 #[test]
 fn include_directive_works_with_query_variables() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let query = graphql_parser::parse_query(
             "
         query musicians($include: Boolean!) {
@@ -801,7 +802,7 @@ fn include_directive_works_with_query_variables() {
 #[test]
 fn query_complexity() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let query = Query::new(
             graphql_parser::parse_query(
                 "query {
@@ -870,7 +871,7 @@ fn query_complexity() {
 #[test]
 fn query_complexity_subscriptions() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let logger = Logger::root(slog::Discard, o!());
         let store = STORE
             .clone()
@@ -973,7 +974,7 @@ fn query_complexity_subscriptions() {
 #[test]
 fn instant_timeout() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let query = Query::new(
             graphql_parser::parse_query("query { musicians(first: 100) { name } }")
                 .unwrap()
@@ -1002,7 +1003,7 @@ fn instant_timeout() {
 #[test]
 fn variable_defaults() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let query = graphql_parser::parse_query(
             "
         query musicians($orderDir: OrderDirection = desc) {
@@ -1060,7 +1061,7 @@ fn variable_defaults() {
 #[test]
 fn skip_is_nullable() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let query = graphql_parser::parse_query(
             "
         query musicians {
@@ -1093,7 +1094,7 @@ fn skip_is_nullable() {
 #[test]
 fn first_is_nullable() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let query = graphql_parser::parse_query(
             "
         query musicians {
@@ -1126,7 +1127,7 @@ fn first_is_nullable() {
 #[test]
 fn nested_variable() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let query = graphql_parser::parse_query(
             "
         query musicians($name: String) {
@@ -1164,7 +1165,7 @@ fn nested_variable() {
 #[test]
 fn ambiguous_derived_from_result() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let query = graphql_parser::parse_query(
             "
         {
@@ -1208,7 +1209,7 @@ fn ambiguous_derived_from_result() {
 #[test]
 fn can_filter_by_relationship_fields() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let result = execute_query_document(
             &deployment.hash,
             graphql_parser::parse_query(
@@ -1267,7 +1268,7 @@ fn can_filter_by_relationship_fields() {
 #[test]
 fn cannot_filter_by_derved_relationship_fields() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let result = execute_query_document(
             &deployment.hash,
             graphql_parser::parse_query(
@@ -1309,7 +1310,7 @@ fn cannot_filter_by_derved_relationship_fields() {
 #[test]
 fn subscription_gets_result_even_without_events() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let logger = Logger::root(slog::Discard, o!());
         let store = STORE
             .clone()
@@ -1370,7 +1371,7 @@ fn subscription_gets_result_even_without_events() {
 #[test]
 fn can_use_nested_filter() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let result = execute_query_document(
             &deployment.hash,
             graphql_parser::parse_query(
@@ -1430,7 +1431,7 @@ fn can_use_nested_filter() {
 #[test]
 fn ignores_invalid_field_arguments() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         // This query has to return all the musicians since `id` is not a
         // valid argument for the `musicians` field and must therefore be
         // ignored
@@ -1476,7 +1477,7 @@ fn ignores_invalid_field_arguments() {
 #[test]
 fn leaf_selection_mismatch() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let result = execute_query_document(
             &deployment.hash,
             // 'name' is a string and doesn't admit a selection
@@ -1561,7 +1562,7 @@ fn leaf_selection_mismatch() {
 #[test]
 fn missing_variable() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let result = execute_query_document(
             &deployment.hash,
             // '$first' is not defined, use its default from the schema
@@ -1631,7 +1632,7 @@ fn missing_variable() {
 #[test]
 fn invalid_field_merge() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let result = execute_query_document(
             &deployment.hash,
             graphql_parser::parse_query("query { musicians { t: id t: mainBand { id } } }")
@@ -1723,7 +1724,7 @@ fn query_at_block() {
          up to block number 1 and data for block number 7000 is therefore not yet available";
         const BLOCK_HASH_NOT_FOUND: &str = "no block with that hash found";
 
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         musicians_at(&deployment, "number: 7000", Err(BLOCK_NOT_INDEXED), "n7000").await;
         musicians_at(&deployment, "number: 0", Ok(vec!["m1", "m2"]), "n0").await;
         musicians_at(
@@ -1823,7 +1824,7 @@ fn query_at_block_with_vars() {
          up to block number 1 and data for block number 7000 is therefore not yet available";
         const BLOCK_HASH_NOT_FOUND: &str = "no block with that hash found";
 
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         musicians_at_nr(&deployment, 7000, Err(BLOCK_NOT_INDEXED), "n7000").await;
         musicians_at_nr(&deployment, 0, Ok(vec!["m1", "m2"]), "n0").await;
         musicians_at_nr(&deployment, 1, Ok(vec!["m1", "m2", "m3", "m4"]), "n1").await;
@@ -1854,7 +1855,7 @@ fn query_at_block_with_vars() {
 #[test]
 fn query_detects_reorg() {
     run_test_sequentially(|store| async move {
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let query = "query { musician(id: \"m1\") { id } }";
         let query = graphql_parser::parse_query(query)
             .expect("invalid test query")
@@ -1895,6 +1896,7 @@ fn query_detects_reorg() {
             BLOCK_ONE.clone(),
             vec![],
         )
+        .await
         .unwrap();
         let result = execute_query_document(&deployment.hash, query.clone()).await;
         match result.to_result().unwrap_err()[0] {
@@ -1919,7 +1921,7 @@ fn can_query_meta() {
             .expect("invalid test query")
             .into_static();
 
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let result = execute_query_document(&deployment.hash, query).await;
         let exp = object! {
             _meta: object! {
@@ -1992,7 +1994,8 @@ fn non_fatal_errors() {
             store.as_ref(),
             "testNonFatalErrors",
             BTreeSet::from_iter(Some(SubgraphFeature::NonFatalErrors)),
-        );
+        )
+        .await;
 
         let err = SubgraphError {
             subgraph_id: deployment.hash.clone(),
@@ -2087,7 +2090,7 @@ fn can_query_root_typename() {
         let query = graphql_parser::parse_query(query)
             .expect("invalid test query")
             .into_static();
-        let deployment = setup(store.as_ref());
+        let deployment = setup(store.as_ref()).await;
         let result = execute_query_document(&deployment.hash, query).await;
         let exp = object! {
             __typename: "Query"

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -32,9 +32,8 @@ use graph::{
 use graph_graphql::{prelude::*, subscription::execute_subscription};
 use test_store::{
     deployment_state, execute_subgraph_query_with_complexity, execute_subgraph_query_with_deadline,
-    result_size_metrics, revert_block, run_test_sequentially, transact_entity_operations,
-    transact_errors, Store, BLOCK_ONE, GENESIS_PTR, LOAD_MANAGER, LOGGER, METRICS_REGISTRY, STORE,
-    SUBSCRIPTION_MANAGER,
+    result_size_metrics, revert_block, run_test_sequentially, transact_errors, Store, BLOCK_ONE,
+    GENESIS_PTR, LOAD_MANAGER, LOGGER, METRICS_REGISTRY, STORE, SUBSCRIPTION_MANAGER,
 };
 
 const NETWORK_NAME: &str = "fake_network";
@@ -233,7 +232,7 @@ async fn insert_test_entities(
             data,
         });
 
-        transact_entity_operations(
+        test_store::transact_and_wait(
             &STORE.subgraph_store(),
             &deployment,
             block_ptr,
@@ -1890,7 +1889,7 @@ fn query_detects_reorg() {
         // We move the subgraph head forward, which will execute the query at block 1
         // But the state we have is also for block 1, but with a smaller reorg count
         // and we therefore report an error
-        transact_entity_operations(
+        test_store::transact_and_wait(
             &STORE.subgraph_store(),
             &deployment,
             BLOCK_ONE.clone(),
@@ -1898,6 +1897,7 @@ fn query_detects_reorg() {
         )
         .await
         .unwrap();
+
         let result = execute_query_document(&deployment.hash, query.clone()).await;
         match result.to_result().unwrap_err()[0] {
             QueryError::ExecutionError(QueryExecutionError::DeploymentReverted) => { /* expected */

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -56,6 +56,18 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
         Ok(counters)
     }
 
+    fn global_deployment_counter_vec(
+        &self,
+        name: &str,
+        help: &str,
+        subgraph: &str,
+        variable_labels: &[&str],
+    ) -> Result<CounterVec, PrometheusError> {
+        let opts = Opts::new(name, help).const_label("deployment", subgraph);
+        let counters = CounterVec::new(opts, variable_labels)?;
+        Ok(counters)
+    }
+
     fn global_gauge_vec(
         &self,
         name: &str,

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -144,6 +144,7 @@ impl StoreBuilder {
             Arc::new(config.deployment.clone()),
             notification_sender,
             fork_base,
+            registry,
         ));
 
         (store, pools)

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -82,6 +82,7 @@ async fn test_valid_module_and_store_with_timeout(
     let stopwatch_metrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
         deployment_id.clone(),
+        "test",
         metrics_registry.clone(),
     );
     let host_metrics = Arc::new(HostMetrics::new(

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -922,6 +922,7 @@ async fn test_entity_store(api_version: Version) {
         &deployment,
         vec![(user_type.clone(), alex), (user_type, steve)],
     )
+    .await
     .unwrap();
 
     let get_user = move |module: &mut WasmInstance<Chain>, id: &str| -> Option<Entity> {

--- a/store/postgres/src/dynds.rs
+++ b/store/postgres/src/dynds.rs
@@ -60,7 +60,11 @@ fn to_source(
     })
 }
 
-pub fn load(conn: &PgConnection, id: &str) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
+pub fn load(
+    conn: &PgConnection,
+    id: &str,
+    block: BlockNumber,
+) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
     use dynamic_ethereum_contract_data_source as decds;
 
     // Query to load the data sources. Ordering by the creation block and `vid` makes sure they are
@@ -77,6 +81,7 @@ pub fn load(conn: &PgConnection, id: &str) -> Result<Vec<StoredDynamicDataSource
             decds::start_block,
             decds::ethereum_block_number,
         ))
+        .filter(decds::ethereum_block_number.le(sql(&format!("{}::numeric", block))))
         .order_by((decds::ethereum_block_number, decds::vid))
         .load::<(
             i64,

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -48,6 +48,9 @@ pub mod layout_for_tests {
         make_dummy_site, Connection, Mirror, Namespace, EVENT_TAP, EVENT_TAP_ENABLED,
     };
     pub use crate::relational::*;
+    pub mod writable {
+        pub use crate::writable::test_support::allow_steps;
+    }
 }
 
 pub use self::block_store::BlockStore;

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -37,7 +37,7 @@ use crate::{
     primary,
     primary::{DeploymentId, Mirror as PrimaryMirror, Site},
     relational::Layout,
-    writable::WritableAgent,
+    writable::WritableStore,
     NotificationSender,
 };
 use crate::{
@@ -266,7 +266,7 @@ pub struct SubgraphStoreInner {
     sites: TimedCache<DeploymentHash, Site>,
     placer: Arc<dyn DeploymentPlacer + Send + Sync + 'static>,
     sender: Arc<NotificationSender>,
-    writables: Mutex<HashMap<DeploymentId, Arc<WritableAgent>>>,
+    writables: Mutex<HashMap<DeploymentId, Arc<WritableStore>>>,
 }
 
 impl SubgraphStoreInner {
@@ -1177,7 +1177,7 @@ impl SubgraphStoreTrait for SubgraphStore {
         .await
         .unwrap()?; // Propagate panics, there shouldn't be any.
 
-        let writable = Arc::new(WritableAgent::new(self.as_ref().clone(), logger, site).await?);
+        let writable = Arc::new(WritableStore::new(self.as_ref().clone(), logger, site).await?);
         self.writables
             .lock()
             .unwrap()

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -387,14 +387,14 @@ impl WritableStoreTrait for WritableAgent {
         Ok(())
     }
 
-    fn revert_block_operations(
+    async fn revert_block_operations(
         &self,
         block_ptr_to: BlockPtr,
         firehose_cursor: Option<&str>,
     ) -> Result<(), StoreError> {
         *self.block_ptr.lock().unwrap() = Some(block_ptr_to.clone());
-        // TODO: If we haven't written the block yet, revert in memory. If
-        // we have, revert in the database
+        *self.block_cursor.lock().unwrap() = firehose_cursor.map(|c| c.to_string());
+
         self.store
             .revert_block_operations(block_ptr_to, firehose_cursor)
     }
@@ -437,7 +437,7 @@ impl WritableStoreTrait for WritableAgent {
         self.store.get(key)
     }
 
-    fn transact_block_operations(
+    async fn transact_block_operations(
         &self,
         block_ptr_to: BlockPtr,
         firehose_cursor: Option<String>,

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -488,7 +488,7 @@ impl Queue {
                 if let Err(e) = res {
                     *queue.write_err.lock().unwrap() = Some(e);
                     queue.poisoned.store(true, Ordering::SeqCst);
-                    queue.queue.clear().await;
+                    queue.queue.clear();
                     return;
                 }
             }

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -513,7 +513,7 @@ impl Queue {
     }
 
     /// Wait for the background writer to finish processing queued entries
-    async fn wait(&self) -> Result<(), StoreError> {
+    async fn flush(&self) -> Result<(), StoreError> {
         self.queue
             .wait_empty()
             .await
@@ -760,10 +760,10 @@ impl Writer {
         }
     }
 
-    async fn wait(&self) -> Result<(), StoreError> {
+    async fn flush(&self) -> Result<(), StoreError> {
         match self {
             Writer::Sync { .. } => Ok(()),
-            Writer::Async(queue) => queue.wait().await,
+            Writer::Async(queue) => queue.flush().await,
         }
     }
 
@@ -965,7 +965,7 @@ impl WritableStoreTrait for WritableStore {
         self.store.input_schema()
     }
 
-    async fn wait(&self) -> Result<(), StoreError> {
-        self.writer.wait().await
+    async fn flush(&self) -> Result<(), StoreError> {
+        self.writer.flush().await
     }
 }

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -481,7 +481,8 @@ impl Queue {
                         .store
                         .revert_block_operations(block_ptr.clone(), firehose_cursor.as_deref()),
                 };
-                // Remove the tombstone that take_front left in place
+                // The request has been handled. It's now safe to remove it
+                // from the queue
                 queue.queue.pop().await;
 
                 if let Err(e) = res {

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -506,8 +506,12 @@ impl Queue {
         // Use a separate instance of the `StopwatchMetrics` for background
         // work since that has its own call hierarchy, and using the
         // foreground metrics will lead to incorrect nesting of sections
-        let stopwatch =
-            StopwatchMetrics::new(logger, queue.store.site.deployment.clone(), registry);
+        let stopwatch = StopwatchMetrics::new(
+            logger,
+            queue.store.site.deployment.clone(),
+            "writer",
+            registry,
+        );
         graph::spawn(start_writer(queue.cheap_clone(), stopwatch));
 
         queue

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -487,6 +487,7 @@ impl Queue {
                 if let Err(e) = res {
                     *queue.write_err.lock().unwrap() = Some(e);
                     queue.poisoned.store(true, Ordering::SeqCst);
+                    queue.queue.clear().await;
                     return;
                 }
             }

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -41,7 +41,10 @@ impl WritableSubgraphStore {
     }
 }
 
-pub(crate) struct WritableStore {
+/// Write synchronously to the actual store, i.e., once a method returns,
+/// the changes have been committed to the store and are visible to anybody
+/// else connecting to that database
+struct SyncStore {
     logger: Logger,
     store: WritableSubgraphStore,
     writable: Arc<DeploymentStore>,
@@ -49,11 +52,11 @@ pub(crate) struct WritableStore {
     input_schema: Arc<Schema>,
 }
 
-impl WritableStore {
+impl SyncStore {
     const BACKOFF_BASE: Duration = Duration::from_millis(100);
     const BACKOFF_CEIL: Duration = Duration::from_secs(10);
 
-    pub(crate) fn new(
+    fn new(
         subgraph_store: SubgraphStore,
         logger: Logger,
         site: Arc<Site>,
@@ -128,10 +131,11 @@ impl WritableStore {
 }
 
 // Methods that mirror `WritableStoreTrait`
-impl WritableStore {
+impl SyncStore {
     async fn block_ptr(&self) -> Result<Option<BlockPtr>, StoreError> {
-        self.retry_async("block_ptr", || async {
-            self.writable.block_ptr(self.site.cheap_clone()).await
+        self.retry_async("block_ptr", || {
+            let site = self.site.clone();
+            async move { self.writable.block_ptr(site).await }
         })
         .await
     }
@@ -234,6 +238,10 @@ impl WritableStore {
         data_sources: &[StoredDynamicDataSource],
         deterministic_errors: &[SubgraphError],
     ) -> Result<(), StoreError> {
+        fn same_subgraph(mods: &[EntityModification], id: &DeploymentHash) -> bool {
+            mods.iter().all(|md| &md.entity_key().subgraph_id == id)
+        }
+
         assert!(
             same_subgraph(mods, &self.site.deployment),
             "can only transact operations within one shard"
@@ -328,24 +336,19 @@ impl WritableStore {
     }
 }
 
-fn same_subgraph(mods: &[EntityModification], id: &DeploymentHash) -> bool {
-    mods.iter().all(|md| &md.entity_key().subgraph_id == id)
-}
-
-#[allow(dead_code)]
-pub struct WritableAgent {
-    store: Arc<WritableStore>,
+pub struct WritableStore {
+    store: Arc<SyncStore>,
     block_ptr: Mutex<Option<BlockPtr>>,
     block_cursor: Mutex<Option<String>>,
 }
 
-impl WritableAgent {
+impl WritableStore {
     pub(crate) async fn new(
         subgraph_store: SubgraphStore,
         logger: Logger,
         site: Arc<Site>,
     ) -> Result<Self, StoreError> {
-        let store = Arc::new(WritableStore::new(subgraph_store, logger, site)?);
+        let store = Arc::new(SyncStore::new(subgraph_store, logger, site)?);
         let block_ptr = Mutex::new(store.block_ptr().await?);
         let block_cursor = Mutex::new(store.block_cursor().await?);
         Ok(Self {
@@ -356,9 +359,8 @@ impl WritableAgent {
     }
 }
 
-#[allow(unused_variables)]
 #[async_trait::async_trait]
-impl WritableStoreTrait for WritableAgent {
+impl WritableStoreTrait for WritableStore {
     async fn block_ptr(&self) -> Option<BlockPtr> {
         self.block_ptr.lock().unwrap().clone()
     }

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -5,7 +5,9 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use graph::data::subgraph::schema;
 use graph::env::env_var;
-use graph::prelude::{BlockNumber, Entity, Schema, SubgraphStore as _, BLOCK_NUMBER_MAX};
+use graph::prelude::{
+    BlockNumber, Entity, MetricsRegistry, Schema, SubgraphStore as _, BLOCK_NUMBER_MAX,
+};
 use graph::util::bounded_queue::BoundedQueue;
 use graph::{
     cheap_clone::CheapClone,
@@ -409,7 +411,6 @@ enum Request {
         block_ptr: BlockPtr,
         firehose_cursor: Option<String>,
         mods: Vec<EntityModification>,
-        stopwatch: StopwatchMetrics,
         data_sources: Vec<StoredDynamicDataSource>,
         deterministic_errors: Vec<SubgraphError>,
     },
@@ -443,15 +444,19 @@ struct Queue {
 
 impl Queue {
     /// Create a new queue and spawn a task that processes write requests
-    fn start(store: Arc<SyncStore>, capacity: usize) -> Arc<Self> {
-        async fn start_writer(queue: Arc<Queue>) {
+    fn start(
+        logger: Logger,
+        store: Arc<SyncStore>,
+        capacity: usize,
+        registry: Arc<dyn MetricsRegistry>,
+    ) -> Arc<Self> {
+        async fn start_writer(queue: Arc<Queue>, stopwatch: StopwatchMetrics) {
             loop {
                 let res = match queue.queue.peek().await.as_ref() {
                     Request::Write {
                         block_ptr: block_ptr_to,
                         firehose_cursor,
                         mods,
-                        stopwatch,
                         data_sources,
                         deterministic_errors,
                     } => queue.store.transact_block_operations(
@@ -490,7 +495,12 @@ impl Queue {
         };
         let queue = Arc::new(queue);
 
-        graph::spawn(start_writer(queue.clone()));
+        // Use a separate instance of the `StopwatchMetrics` for background
+        // work since that has its own call hierarchy, and using the
+        // foreground metrics will lead to incorrect nesting of sections
+        let stopwatch =
+            StopwatchMetrics::new(logger, queue.store.site.deployment.clone(), registry);
+        graph::spawn(start_writer(queue.clone(), stopwatch));
 
         queue
     }
@@ -688,11 +698,16 @@ enum Writer {
 }
 
 impl Writer {
-    fn new(store: Arc<SyncStore>, capacity: usize) -> Self {
+    fn new(
+        logger: Logger,
+        store: Arc<SyncStore>,
+        capacity: usize,
+        registry: Arc<dyn MetricsRegistry>,
+    ) -> Self {
         if capacity == 0 {
             Self::Sync(store)
         } else {
-            Self::Async(Queue::start(store, capacity))
+            Self::Async(Queue::start(logger, store, capacity, registry))
         }
     }
 
@@ -719,7 +734,6 @@ impl Writer {
                     block_ptr: block_ptr_to,
                     firehose_cursor,
                     mods,
-                    stopwatch: stopwatch.cheap_clone(),
                     data_sources,
                     deterministic_errors,
                 };
@@ -790,11 +804,17 @@ impl WritableStore {
         subgraph_store: SubgraphStore,
         logger: Logger,
         site: Arc<Site>,
+        registry: Arc<dyn MetricsRegistry>,
     ) -> Result<Self, StoreError> {
-        let store = Arc::new(SyncStore::new(subgraph_store, logger, site)?);
+        let store = Arc::new(SyncStore::new(subgraph_store, logger.clone(), site)?);
         let block_ptr = Mutex::new(store.block_ptr().await?);
         let block_cursor = Mutex::new(store.block_cursor().await?);
-        let writer = Writer::new(store.clone(), ENV_VARS.store.write_queue_size);
+        let writer = Writer::new(
+            logger,
+            store.clone(),
+            ENV_VARS.store.write_queue_size,
+            registry,
+        );
 
         Ok(Self {
             store,

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -329,14 +329,14 @@ async fn check_graft(
         .revert_block_operations(BLOCKS[1].clone(), None)
         .await
         .expect("We can revert a block we just created");
-    writable.wait().await.expect("we can revert to BLOCKS[1]");
+    writable.flush().await.expect("we can revert to BLOCKS[1]");
 
     let err = {
         match writable
             .revert_block_operations(BLOCKS[0].clone(), None)
             .await
         {
-            Ok(()) => writable.wait().await,
+            Ok(()) => writable.flush().await,
             Err(e) => Err(e),
         }
     }

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -176,6 +176,7 @@ lazy_static! {
     static ref MOCK_STOPWATCH: StopwatchMetrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
         THINGS_SUBGRAPH_ID.clone(),
+        "test",
         Arc::new(MockMetricsRegistry::new()),
     );
 }

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -74,6 +74,7 @@ lazy_static! {
     static ref MOCK_STOPWATCH: StopwatchMetrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
         THINGS_SUBGRAPH_ID.clone(),
+        "test",
         Arc::new(MockMetricsRegistry::new()),
     );
 }

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -145,7 +145,7 @@ where
         // Run test and wait for the background writer to finish its work so
         // it won't conflict with the next test
         test(store, writable.clone(), deployment).await;
-        writable.wait().await.unwrap();
+        writable.flush().await.unwrap();
     });
 }
 
@@ -1569,7 +1569,7 @@ fn handle_large_string_with_index() {
             )
             .await
             .expect("Failed to insert large text");
-        writable.wait().await.unwrap();
+        writable.flush().await.unwrap();
 
         let query = user_query()
             .first(5)

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1649,6 +1649,7 @@ fn handle_large_bytea_with_index() {
         let stopwatch_metrics = StopwatchMetrics::new(
             Logger::root(slog::Discard, o!()),
             deployment.hash.clone(),
+            "test",
             metrics_registry.clone(),
         );
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -142,8 +142,10 @@ where
             .await
             .expect("we can get a writable store");
 
-        // Run test
-        test(store, writable, deployment).await
+        // Run test and wait for the background writer to finish its work so
+        // it won't conflict with the next test
+        test(store, writable.clone(), deployment).await;
+        writable.wait().await.unwrap();
     });
 }
 
@@ -238,7 +240,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
         false,
         None,
     );
-    transact_entity_operations(
+    transact_and_wait(
         &store,
         &deployment,
         TEST_BLOCK_2_PTR.clone(),
@@ -316,7 +318,7 @@ fn delete_entity() {
         writable.get(&entity_key).unwrap().unwrap();
 
         let count = get_entity_count(store.clone(), &&deployment.hash);
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             TEST_BLOCK_3_PTR.clone(),
@@ -413,7 +415,7 @@ fn insert_entity() {
             Some("green"),
         );
         let count = get_entity_count(store.clone(), &&deployment.hash);
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             TEST_BLOCK_3_PTR.clone(),
@@ -1058,7 +1060,7 @@ fn revert_block_with_delete() {
         let del_key = EntityKey::data(deployment.hash.clone(), USER.to_owned(), "2".to_owned());
 
         // Process deletion
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             TEST_BLOCK_3_PTR.clone(),
@@ -1567,6 +1569,7 @@ fn handle_large_string_with_index() {
             )
             .await
             .expect("Failed to insert large text");
+        writable.wait().await.unwrap();
 
         let query = user_query()
             .first(5)
@@ -1852,7 +1855,7 @@ fn window() {
     ];
 
     run_test(|store, _, deployment| async move {
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             TEST_BLOCK_3_PTR.clone(),
@@ -1993,7 +1996,7 @@ fn reorg_tracking() {
             false,
             None,
         );
-        transact_entity_operations(store, deployment, block.clone(), vec![test_entity_1])
+        transact_and_wait(store, deployment, block.clone(), vec![test_entity_1])
             .await
             .unwrap();
     }
@@ -2023,7 +2026,7 @@ fn reorg_tracking() {
         check_state!(store, 0, 0, 2);
 
         // Jump to block 4
-        transact_entity_operations(
+        transact_and_wait(
             &subgraph_store,
             &deployment,
             TEST_BLOCK_4_PTR.clone(),

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1552,6 +1552,7 @@ fn handle_large_string_with_index() {
         let stopwatch_metrics = StopwatchMetrics::new(
             Logger::root(slog::Discard, o!()),
             deployment.hash.clone(),
+            "test",
             metrics_registry.clone(),
         );
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1667,6 +1667,7 @@ fn handle_large_bytea_with_index() {
             )
             .await
             .expect("Failed to insert large text");
+        writable.flush().await.unwrap();
 
         let query = user_query()
             .first(5)

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -441,7 +441,7 @@ fn version_info() {
 
     run_test_sequentially(|store| async move {
         let deployment = setup().await;
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             BLOCK_ONE.clone(),
@@ -589,7 +589,7 @@ fn fail_unfail_deterministic_error() {
             .unwrap();
 
         // Process the first block.
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             BLOCKS[0].clone(),
@@ -606,7 +606,7 @@ fn fail_unfail_deterministic_error() {
         assert_eq!(Some(0), vi.latest_ethereum_block_number);
 
         // Process the second block.
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             BLOCKS[1].clone(),
@@ -682,7 +682,7 @@ fn fail_unfail_deterministic_error_noop() {
         };
 
         // Process the first block.
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             BLOCKS[0].clone(),
@@ -699,7 +699,7 @@ fn fail_unfail_deterministic_error_noop() {
         assert_eq!(Some(0), vi.latest_ethereum_block_number);
 
         // Process the second block.
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             BLOCKS[1].clone(),
@@ -815,7 +815,7 @@ fn fail_unfail_non_deterministic_error() {
         };
 
         // Process the first block.
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             BLOCKS[0].clone(),
@@ -856,7 +856,7 @@ fn fail_unfail_non_deterministic_error() {
         assert_eq!(Some(0), vi.latest_ethereum_block_number);
 
         // Process the second block.
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             BLOCKS[1].clone(),
@@ -906,7 +906,7 @@ fn fail_unfail_non_deterministic_error_noop() {
         };
 
         // Process the first block.
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             BLOCKS[0].clone(),
@@ -923,7 +923,7 @@ fn fail_unfail_non_deterministic_error_noop() {
         assert_eq!(Some(0), vi.latest_ethereum_block_number);
 
         // Process the second block.
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             BLOCKS[1].clone(),

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -447,6 +447,7 @@ fn version_info() {
             BLOCK_ONE.clone(),
             vec![],
         )
+        .await
         .unwrap();
 
         let vi = get_version_info(&store, NAME);
@@ -594,6 +595,7 @@ fn fail_unfail_deterministic_error() {
             BLOCKS[0].clone(),
             vec![],
         )
+        .await
         .unwrap();
 
         // We don't have any errors and the subgraph is healthy.
@@ -610,6 +612,7 @@ fn fail_unfail_deterministic_error() {
             BLOCKS[1].clone(),
             vec![],
         )
+        .await
         .unwrap();
 
         // Still no fatal errors.
@@ -685,6 +688,7 @@ fn fail_unfail_deterministic_error_noop() {
             BLOCKS[0].clone(),
             vec![],
         )
+        .await
         .unwrap();
 
         // We don't have any errors and the subgraph is healthy.
@@ -701,6 +705,7 @@ fn fail_unfail_deterministic_error_noop() {
             BLOCKS[1].clone(),
             vec![],
         )
+        .await
         .unwrap();
 
         // Still no fatal errors.
@@ -816,6 +821,7 @@ fn fail_unfail_non_deterministic_error() {
             BLOCKS[0].clone(),
             vec![],
         )
+        .await
         .unwrap();
 
         // We don't have any errors.
@@ -856,6 +862,7 @@ fn fail_unfail_non_deterministic_error() {
             BLOCKS[1].clone(),
             vec![],
         )
+        .await
         .unwrap();
 
         // Subgraph failed but it's deployment head pointer advanced.
@@ -905,6 +912,7 @@ fn fail_unfail_non_deterministic_error_noop() {
             BLOCKS[0].clone(),
             vec![],
         )
+        .await
         .unwrap();
 
         // We don't have any errors and the subgraph is healthy.
@@ -921,6 +929,7 @@ fn fail_unfail_non_deterministic_error_noop() {
             BLOCKS[1].clone(),
             vec![],
         )
+        .await
         .unwrap();
 
         // Still no errors.

--- a/store/postgres/tests/writable.rs
+++ b/store/postgres/tests/writable.rs
@@ -1,0 +1,167 @@
+use graph::data::subgraph::schema::DeploymentCreate;
+use lazy_static::lazy_static;
+use std::marker::PhantomData;
+use test_store::*;
+
+use graph::components::store::{DeploymentLocator, WritableStore};
+use graph::components::store::{EntityKey, EntityType};
+use graph::data::subgraph::*;
+use graph::prelude::*;
+use graph::semver::Version;
+use graph_store_postgres::layout_for_tests::writable;
+use graph_store_postgres::{Store as DieselStore, SubgraphStore as DieselSubgraphStore};
+use web3::types::H256;
+
+const SCHEMA_GQL: &str = "
+    type Counter @entity {
+        id: ID!,
+        count: Int,
+    }
+";
+
+const COUNTER: &str = "Counter";
+
+lazy_static! {
+    static ref TEST_SUBGRAPH_ID_STRING: String = String::from("writableSubgraph");
+    static ref TEST_SUBGRAPH_ID: DeploymentHash =
+        DeploymentHash::new(TEST_SUBGRAPH_ID_STRING.as_str()).unwrap();
+    static ref TEST_SUBGRAPH_SCHEMA: Schema =
+        Schema::parse(SCHEMA_GQL, TEST_SUBGRAPH_ID.clone()).expect("Failed to parse user schema");
+}
+
+/// Inserts test data into the store.
+///
+/// Create a new empty subgraph with schema `SCHEMA_GQL`
+async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator {
+    let manifest = SubgraphManifest::<graph_chain_ethereum::Chain> {
+        id: TEST_SUBGRAPH_ID.clone(),
+        spec_version: Version::new(1, 0, 0),
+        features: Default::default(),
+        description: None,
+        repository: None,
+        schema: TEST_SUBGRAPH_SCHEMA.clone(),
+        data_sources: vec![],
+        graft: None,
+        templates: vec![],
+        chain: PhantomData,
+    };
+
+    // Create SubgraphDeploymentEntity
+    let deployment = DeploymentCreate::new(&manifest, None);
+    let name = SubgraphName::new("test/writable").unwrap();
+    let node_id = NodeId::new("test").unwrap();
+    let deployment = store
+        .create_subgraph_deployment(
+            name,
+            &TEST_SUBGRAPH_SCHEMA,
+            deployment,
+            node_id,
+            NETWORK_NAME.to_string(),
+            SubgraphVersionSwitchingMode::Instant,
+        )
+        .unwrap();
+    deployment
+}
+
+/// Removes test data from the database behind the store.
+fn remove_test_data(store: Arc<DieselSubgraphStore>) {
+    store
+        .delete_all_entities_for_test_use_only()
+        .expect("deleting test entities succeeds");
+}
+
+/// Test harness for running database integration tests.
+fn run_test<R, F>(test: F)
+where
+    F: FnOnce(Arc<DieselStore>, Arc<dyn WritableStore>, DeploymentLocator) -> R + Send + 'static,
+    R: std::future::Future<Output = ()> + Send + 'static,
+{
+    run_test_sequentially(|store| async move {
+        let subgraph_store = store.subgraph_store();
+        // Reset state before starting
+        remove_test_data(subgraph_store.clone());
+
+        // Seed database with test data
+        let deployment = insert_test_data(subgraph_store.clone()).await;
+        let writable = store
+            .subgraph_store()
+            .writable(LOGGER.clone(), deployment.id)
+            .await
+            .expect("we can get a writable store");
+
+        // Run test and wait for the background writer to finish its work so
+        // it won't conflict with the next test
+        test(store, writable.clone(), deployment).await;
+        writable.flush().await.unwrap();
+    });
+}
+
+fn block_pointer(number: u8) -> BlockPtr {
+    let hash = H256::from([number; 32]);
+    BlockPtr::from((hash, number as BlockNumber))
+}
+
+fn count_key(deployment: &DeploymentLocator, id: &str) -> EntityKey {
+    EntityKey {
+        subgraph_id: deployment.hash.clone(),
+        entity_type: EntityType::from(COUNTER),
+        entity_id: id.to_owned(),
+    }
+}
+
+async fn insert_count(store: &Arc<DieselSubgraphStore>, deployment: &DeploymentLocator, count: u8) {
+    let data = entity! {
+        id: "1",
+        count: count as i32
+    };
+    let entity_op = EntityOperation::Set {
+        key: count_key(deployment, &data.get("id").unwrap().to_string()),
+        data,
+    };
+    transact_entity_operations(store, deployment, block_pointer(count), vec![entity_op])
+        .await
+        .unwrap();
+}
+
+async fn pause_writer(deployment: &DeploymentLocator) {
+    flush(&deployment).await.unwrap();
+    writable::allow_steps(0).await;
+}
+
+async fn resume_writer(deployment: &DeploymentLocator, steps: usize) {
+    writable::allow_steps(steps).await;
+    flush(&deployment).await.unwrap();
+}
+
+#[test]
+fn tracker() {
+    run_test(|store, writable, deployment| async move {
+        let subgraph_store = store.subgraph_store();
+
+        let read_count = || {
+            let counter = writable.get(&count_key(&deployment, "1")).unwrap().unwrap();
+            counter.get("count").unwrap().as_int().unwrap()
+        };
+        for count in 1..4 {
+            insert_count(&subgraph_store, &deployment, count).await;
+        }
+        pause_writer(&deployment).await;
+
+        // Test reading back with a pending write
+        insert_count(&subgraph_store, &deployment, 4).await;
+        assert_eq!(4, read_count());
+        resume_writer(&deployment, 1).await;
+        assert_eq!(4, read_count());
+
+        // Test reading back with a pending revert
+        writable
+            .revert_block_operations(block_pointer(2), None)
+            .await
+            .unwrap();
+
+        assert_eq!(2, read_count());
+
+        resume_writer(&deployment, 1).await;
+        assert_eq!(2, read_count());
+    })
+}

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -217,6 +217,7 @@ pub async fn transact_errors(
     let stopwatch_metrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
         deployment.hash.clone(),
+        "transact",
         metrics_registry.clone(),
     );
     store
@@ -283,6 +284,7 @@ pub async fn transact_entities_and_dynamic_data_sources(
     let stopwatch_metrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
         deployment.hash.clone(),
+        "transact",
         metrics_registry.clone(),
     );
     store

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -232,7 +232,7 @@ pub async fn transact_errors(
             errs,
         )
         .await?;
-    wait(deployment).await
+    flush(deployment).await
 }
 
 /// Convenience to transact EntityOperation instead of EntityModification
@@ -261,7 +261,7 @@ pub async fn transact_and_wait(
         ops,
     )
     .await?;
-    wait(deployment).await
+    flush(deployment).await
 }
 
 pub async fn transact_entities_and_dynamic_data_sources(
@@ -307,7 +307,7 @@ pub async fn revert_block(store: &Arc<Store>, deployment: &DeploymentLocator, pt
         .revert_block_operations(ptr.clone(), None)
         .await
         .unwrap();
-    wait(deployment).await.unwrap();
+    flush(deployment).await.unwrap();
 }
 
 pub fn insert_ens_name(hash: &str, name: &str) {
@@ -349,17 +349,17 @@ pub async fn insert_entities(
     )
     .await?;
 
-    wait(deployment).await
+    flush(deployment).await
 }
 
 /// Wait until all pending writes have been processed
-pub async fn wait(deployment: &DeploymentLocator) -> Result<(), StoreError> {
+pub async fn flush(deployment: &DeploymentLocator) -> Result<(), StoreError> {
     let writable = SUBGRAPH_STORE
         .cheap_clone()
         .writable(LOGGER.clone(), deployment.id)
         .await
         .expect("we can get a writable");
-    writable.wait().await
+    writable.flush().await
 }
 
 /// Tap into store events sent when running `f` and return those events. This

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -230,19 +230,21 @@ pub async fn transact_errors(
             Vec::new(),
             errs,
         )
+        .await
 }
 
 /// Convenience to transact EntityOperation instead of EntityModification
-pub fn transact_entity_operations(
+pub async fn transact_entity_operations(
     store: &Arc<DieselSubgraphStore>,
     deployment: &DeploymentLocator,
     block_ptr_to: BlockPtr,
     ops: Vec<EntityOperation>,
 ) -> Result<(), StoreError> {
     transact_entities_and_dynamic_data_sources(store, deployment.clone(), block_ptr_to, vec![], ops)
+        .await
 }
 
-pub fn transact_entities_and_dynamic_data_sources(
+pub async fn transact_entities_and_dynamic_data_sources(
     store: &Arc<DieselSubgraphStore>,
     deployment: DeploymentLocator,
     block_ptr_to: BlockPtr,
@@ -263,14 +265,16 @@ pub fn transact_entities_and_dynamic_data_sources(
         deployment.hash.clone(),
         metrics_registry.clone(),
     );
-    store.transact_block_operations(
-        block_ptr_to,
-        None,
-        mods,
-        &stopwatch_metrics,
-        data_sources,
-        Vec::new(),
-    )
+    store
+        .transact_block_operations(
+            block_ptr_to,
+            None,
+            mods,
+            &stopwatch_metrics,
+            data_sources,
+            Vec::new(),
+        )
+        .await
 }
 
 pub async fn revert_block(store: &Arc<Store>, deployment: &DeploymentLocator, ptr: &BlockPtr) {
@@ -280,6 +284,7 @@ pub async fn revert_block(store: &Arc<Store>, deployment: &DeploymentLocator, pt
         .await
         .expect("can get writable")
         .revert_block_operations(ptr.clone(), None)
+        .await
         .unwrap();
 }
 
@@ -297,7 +302,7 @@ pub fn insert_ens_name(hash: &str, name: &str) {
         .unwrap();
 }
 
-pub fn insert_entities(
+pub async fn insert_entities(
     deployment: &DeploymentLocator,
     entities: Vec<(EntityType, Entity)>,
 ) -> Result<(), StoreError> {
@@ -318,6 +323,7 @@ pub fn insert_entities(
         GENESIS_PTR.clone(),
         insert_ops.collect::<Vec<_>>(),
     )
+    .await
     .map(|_| ())
 }
 


### PR DESCRIPTION
This PR makes it possible to perform database writes in parallel with the rest of processing during indexing. The size of the write queue can be set with the environment variable `GRAPH_STORE_WRITE_QUEUE` which defaults to 5 write or revert operations. Setting this to 0 makes writing synchronously and reinstates the previous behavior, also bypassing a bunch of new code.