### PR TITLE
all: GraphQL API Versioning

### DIFF
--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -24,7 +24,7 @@ async fn insert_and_query(
     insert_entities(&deployment, entities).await?;
 
     let document = graphql_parser::parse_query(query).unwrap().into_static();
-    let target = QueryTarget::Deployment(subgraph_id);
+    let target = QueryTarget::Deployment(subgraph_id, Default::default());
     let query = Query::new(document, None);
     Ok(execute_subgraph_query(query, target)
         .await

--- a/graph/src/components/mod.rs
+++ b/graph/src/components/mod.rs
@@ -57,6 +57,9 @@ pub mod trigger_processor;
 /// Components dealing with collecting metrics
 pub mod metrics;
 
+/// Components dealing with versioning
+pub mod versions;
+
 /// A component that receives events of type `T`.
 pub trait EventConsumer<E> {
     /// Get the event sink.

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::blockchain::block_stream::FirehoseCursor;
 use crate::components::server::index_node::VersionInfo;
 use crate::components::transaction_receipt;
+use crate::components::versions::ApiVersion;
 use crate::data::query::Trace;
 use crate::data::subgraph::status;
 use crate::data::value::Word;
@@ -112,7 +113,11 @@ pub trait SubgraphStore: Send + Sync + 'static {
 
     /// Return the GraphQL schema that was derived from the user's schema by
     /// adding a root query type etc. to it
-    fn api_schema(&self, subgraph_id: &DeploymentHash) -> Result<Arc<ApiSchema>, StoreError>;
+    fn api_schema(
+        &self,
+        subgraph_id: &DeploymentHash,
+        api_version: &ApiVersion,
+    ) -> Result<Arc<ApiSchema>, StoreError>;
 
     /// Return a `SubgraphFork`, derived from the user's `debug-fork` deployment argument,
     /// that is used for debugging purposes only.

--- a/graph/src/components/versions/features.rs
+++ b/graph/src/components/versions/features.rs
@@ -1,0 +1,2 @@
+#[derive(Clone, PartialEq, Eq, Debug, Ord, PartialOrd, Hash)]
+pub enum FeatureFlag {}

--- a/graph/src/components/versions/mod.rs
+++ b/graph/src/components/versions/mod.rs
@@ -1,0 +1,5 @@
+mod features;
+mod registry;
+
+pub use features::FeatureFlag;
+pub use registry::{ApiVersion, VERSIONS};

--- a/graph/src/components/versions/registry.rs
+++ b/graph/src/components/versions/registry.rs
@@ -1,0 +1,71 @@
+use crate::prelude::FeatureFlag;
+use itertools::Itertools;
+use lazy_static::lazy_static;
+use semver::{Version, VersionReq};
+use std::collections::HashMap;
+
+lazy_static! {
+    static ref VERSION_COLLECTION: HashMap<Version, Vec<FeatureFlag>> = {
+        vec![
+            // baseline version
+            (Version::new(1, 0, 0), vec![]),
+        ].into_iter().collect()
+    };
+
+    // Sorted vector of versions. From higher to lower.
+    pub static ref VERSIONS: Vec<&'static Version> = {
+        let mut versions = VERSION_COLLECTION.keys().collect_vec().clone();
+        versions.sort_by(|a, b| b.partial_cmp(a).unwrap());
+        versions
+    };
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ApiVersion {
+    pub version: Version,
+    features: Vec<FeatureFlag>,
+}
+
+impl ApiVersion {
+    pub fn new(version_requirement: &VersionReq) -> Result<Self, String> {
+        let version = Self::resolve(&version_requirement)?;
+
+        Ok(Self {
+            version: version.clone(),
+            features: VERSION_COLLECTION
+                .get(&version)
+                .expect(format!("Version {:?} is not supported", version).as_str())
+                .to_vec(),
+        })
+    }
+
+    pub fn from_version(version: &Version) -> Result<ApiVersion, String> {
+        ApiVersion::new(
+            &VersionReq::parse(version.to_string().as_str())
+                .map_err(|error| format!("Invalid version requirement: {}", error))?,
+        )
+    }
+
+    pub fn supports(&self, feature: FeatureFlag) -> bool {
+        self.features.contains(&feature)
+    }
+
+    fn resolve(version_requirement: &VersionReq) -> Result<&Version, String> {
+        for version in VERSIONS.iter() {
+            if version_requirement.matches(version) {
+                return Ok(version.clone());
+            }
+        }
+
+        Err("Could not resolve the version".to_string())
+    }
+}
+
+impl Default for ApiVersion {
+    fn default() -> Self {
+        // Default to the latest version.
+        // The `VersionReq::default()` returns `*` which means "any version".
+        // The first matching version is the latest version.
+        ApiVersion::new(&VersionReq::default()).unwrap()
+    }
+}

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::{
     data::graphql::shape_hash::shape_hash,
-    prelude::{q, r, DeploymentHash, SubgraphName, ENV_VARS},
+    prelude::{q, r, ApiVersion, DeploymentHash, SubgraphName, ENV_VARS},
 };
 
 fn deserialize_number<'de, D>(deserializer: D) -> Result<q::Number, D::Error>
@@ -112,19 +112,15 @@ impl serde::ser::Serialize for QueryVariables {
 
 #[derive(Clone, Debug)]
 pub enum QueryTarget {
-    Name(SubgraphName),
-    Deployment(DeploymentHash),
+    Name(SubgraphName, ApiVersion),
+    Deployment(DeploymentHash, ApiVersion),
 }
 
-impl From<DeploymentHash> for QueryTarget {
-    fn from(id: DeploymentHash) -> Self {
-        Self::Deployment(id)
-    }
-}
-
-impl From<SubgraphName> for QueryTarget {
-    fn from(name: SubgraphName) -> Self {
-        QueryTarget::Name(name)
+impl QueryTarget {
+    pub fn get_version(&self) -> &ApiVersion {
+        match self {
+            Self::Deployment(_, version) | Self::Name(_, version) => version,
+        }
     }
 }
 

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -133,6 +133,7 @@ pub mod prelude {
         SubgraphVersionSwitchingMode,
     };
     pub use crate::components::trigger_processor::TriggerProcessor;
+    pub use crate::components::versions::{ApiVersion, FeatureFlag};
     pub use crate::components::{transaction_receipt, EventConsumer, EventProducer};
     pub use crate::env::ENV_VARS;
 
@@ -141,7 +142,7 @@ pub mod prelude {
         shape_hash::shape_hash, SerializableValue, TryFromValue, ValueMap,
     };
     pub use crate::data::query::{
-        Query, QueryError, QueryExecutionError, QueryResult, QueryVariables,
+        Query, QueryError, QueryExecutionError, QueryResult, QueryTarget, QueryVariables,
     };
     pub use crate::data::schema::{ApiSchema, Schema};
     pub use crate::data::store::ethereum::*;

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -108,7 +108,8 @@ where
         // while the query is running. `self.store` can not be used after this
         // point, and everything needs to go through the `store` we are
         // setting up here
-        let store = self.store.query_store(target, false).await?;
+
+        let store = self.store.query_store(target.clone(), false).await?;
         let state = store.deployment_state().await?;
         let network = Some(store.network_name().to_string());
         let schema = store.api_schema()?;
@@ -227,7 +228,7 @@ where
         subscription: Subscription,
         target: QueryTarget,
     ) -> Result<SubscriptionResult, SubscriptionError> {
-        let store = self.store.query_store(target, true).await?;
+        let store = self.store.query_store(target.clone(), true).await?;
         let schema = store.api_schema()?;
         let network = store.network_name().to_string();
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -263,7 +263,7 @@ async fn execute_query_document_with_variables(
         LOAD_MANAGER.clone(),
         METRICS_REGISTRY.clone(),
     ));
-    let target = QueryTarget::Deployment(id.clone());
+    let target = QueryTarget::Deployment(id.clone(), Default::default());
     let query = Query::new(query, variables);
 
     runner
@@ -364,7 +364,7 @@ where
                     LOAD_MANAGER.clone(),
                     METRICS_REGISTRY.clone(),
                 ));
-                let target = QueryTarget::Deployment(id.clone());
+                let target = QueryTarget::Deployment(id.clone(), Default::default());
                 let query = Query::new(query, variables);
 
                 runner
@@ -388,7 +388,10 @@ async fn run_subscription(
     let deployment = setup_readonly(store.as_ref()).await;
     let logger = Logger::root(slog::Discard, o!());
     let query_store = store
-        .query_store(deployment.hash.clone().into(), true)
+        .query_store(
+            QueryTarget::Deployment(deployment.hash.clone(), Default::default()),
+            true,
+        )
         .await
         .unwrap();
 
@@ -407,7 +410,10 @@ async fn run_subscription(
         max_skip: std::u32::MAX,
         graphql_metrics: graphql_metrics(),
     };
-    let schema = STORE.subgraph_store().api_schema(&deployment.hash).unwrap();
+    let schema = STORE
+        .subgraph_store()
+        .api_schema(&deployment.hash, &Default::default())
+        .unwrap();
 
     execute_subscription(Subscription { query }, schema.clone(), options)
 }
@@ -931,7 +937,7 @@ fn instant_timeout() {
         match first_result(
             execute_subgraph_query_with_deadline(
                 query,
-                deployment.hash.into(),
+                QueryTarget::Deployment(deployment.hash.into(), Default::default()),
                 Some(Instant::now()),
             )
             .await,

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -189,7 +189,7 @@ impl Config {
         })
     }
 
-    /// Genrate a JSON representation of the config.
+    /// Generate a JSON representation of the config.
     pub fn to_json(&self) -> Result<String> {
         // It would be nice to produce a TOML representation, but that runs
         // into this error: https://github.com/alexcrichton/toml-rs/issues/142

--- a/node/src/manager/commands/copy.rs
+++ b/node/src/manager/commands/copy.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, sync::Arc, time::SystemTime};
 
 use graph::{
     components::store::BlockStore as _,
+    data::query::QueryTarget,
     prelude::{
         anyhow::{anyhow, bail, Error},
         chrono::{DateTime, Duration, SecondsFormat, Utc},
@@ -90,7 +91,12 @@ pub async fn create(
     let block_offset = block_offset as i32;
     let subgraph_store = store.subgraph_store();
     let src = src.locate_unique(&primary)?;
-    let query_store = store.query_store(src.hash.clone().into(), true).await?;
+    let query_store = store
+        .query_store(
+            QueryTarget::Deployment(src.hash.clone(), Default::default()),
+            true,
+        )
+        .await?;
     let network = query_store.network_name();
 
     let src_ptr = query_store.block_ptr().await?.ok_or_else(|| anyhow!("subgraph {} has not indexed any blocks yet and can not be used as the source of a copy", src))?;

--- a/node/src/manager/commands/query.rs
+++ b/node/src/manager/commands/query.rs
@@ -29,11 +29,11 @@ pub async fn run(
     let target = if target.starts_with("Qm") {
         let id =
             DeploymentHash::new(target).map_err(|id| anyhow!("illegal deployment id `{}`", id))?;
-        QueryTarget::Deployment(id)
+        QueryTarget::Deployment(id, Default::default())
     } else {
         let name = SubgraphName::new(target.clone())
             .map_err(|()| anyhow!("illegal subgraph name `{}`", target))?;
-        QueryTarget::Name(name)
+        QueryTarget::Name(name, Default::default())
     };
 
     let document = graphql_parser::parse_query(&query)?.into_static();

--- a/server/http/src/request.rs
+++ b/server/http/src/request.rs
@@ -59,8 +59,10 @@ mod tests {
     use super::parse_graphql_request;
 
     lazy_static! {
-        static ref TARGET: QueryTarget =
-            QueryTarget::Name(SubgraphName::new("test/request").unwrap());
+        static ref TARGET: QueryTarget = QueryTarget::Name(
+            SubgraphName::new("test/request").unwrap(),
+            Default::default()
+        );
     }
 
     #[test]

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -43,6 +43,7 @@ type Query {
     network: String!
     blockHash: Bytes!
   ): [CachedEthereumCall!]
+  apiVersions(subgraphId: String!): [SubgraphVersion!]!
 }
 
 type SubgraphIndexingStatus {
@@ -177,4 +178,11 @@ type ProofOfIndexingResult {
   block: Block!
   "There may not be a proof of indexing available for the deployment and block"
   proofOfIndexing: Bytes
+}
+
+type ApiVersion {
+  """
+  Version number in SemVer format
+  """
+  version: String!
 }

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -297,7 +297,7 @@ where
                     };
 
                     // Construct a subscription
-                    let target = QueryTarget::Deployment(deployment.clone());
+                    let target = QueryTarget::Deployment(deployment.clone(), Default::default());
                     let subscription = Subscription {
                         // Subscriptions currently do not benefit from the generational cache
                         // anyways, so don't bother passing a network.

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -5,10 +5,11 @@ use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use graph::blockchain::block_stream::FirehoseCursor;
 use graph::components::store::{EntityType, StoredDynamicDataSource};
+use graph::components::versions::VERSIONS;
 use graph::data::query::Trace;
 use graph::data::subgraph::{status, SPEC_VERSION_0_0_6};
 use graph::prelude::{
-    tokio, CancelHandle, CancelToken, CancelableError, EntityOperation, PoolWaitStats,
+    tokio, ApiVersion, CancelHandle, CancelToken, CancelableError, EntityOperation, PoolWaitStats,
     SubgraphDeploymentEntity,
 };
 use graph::semver::Version;
@@ -65,7 +66,7 @@ pub(crate) struct SubgraphInfo {
     /// The schema as supplied by the user
     pub(crate) input: Arc<Schema>,
     /// The schema we derive from `input` with `graphql::schema::api::api_schema`
-    pub(crate) api: Arc<ApiSchema>,
+    pub(crate) api: HashMap<ApiVersion, Arc<ApiSchema>>,
     /// The block number at which this subgraph was grafted onto
     /// another one. We do not allow reverting past this block
     pub(crate) graft_block: Option<BlockNumber>,
@@ -265,7 +266,12 @@ impl DeploymentStore {
         // if that's Fred the Dog, Fred the Cat or both.
         //
         // This assumes that there are no concurrent writes to a subgraph.
-        let schema = self.subgraph_info_with_conn(conn, &layout.site)?.api;
+        let schema = self
+            .subgraph_info_with_conn(conn, &layout.site)?
+            .api
+            .get(&Default::default())
+            .expect("API schema should be present")
+            .clone();
         let types_for_interface = schema.types_for_interface();
         let entity_type = key.entity_type.to_string();
         let types_with_shared_interface = Vec::from_iter(
@@ -553,10 +559,16 @@ impl DeploymentStore {
 
         // Generate an API schema for the subgraph and make sure all types in the
         // API schema have a @subgraphId directive as well
-        let mut schema = input_schema.clone();
-        schema.document =
-            api_schema(&schema.document).map_err(|e| StoreError::Unknown(e.into()))?;
-        schema.add_subgraph_id_directives(site.deployment.clone());
+        let mut api: HashMap<ApiVersion, Arc<ApiSchema>> = HashMap::new();
+
+        for version in VERSIONS.iter() {
+            let api_version = ApiVersion::from_version(version).expect("Invalid API version");
+            let mut schema = input_schema.clone();
+            schema.document =
+                api_schema(&schema.document).map_err(|e| StoreError::Unknown(e.into()))?;
+            schema.add_subgraph_id_directives(site.deployment.clone());
+            api.insert(api_version, Arc::new(ApiSchema::from_api_schema(schema)?));
+        }
 
         let spec_version = Version::from_str(&spec_version).map_err(anyhow::Error::from)?;
         let poi_version = if spec_version.ge(&SPEC_VERSION_0_0_6) {
@@ -567,7 +579,7 @@ impl DeploymentStore {
 
         let info = SubgraphInfo {
             input: Arc::new(input_schema),
-            api: Arc::new(ApiSchema::from_api_schema(schema)?),
+            api,
             graft_block,
             debug_fork,
             description,

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -13,6 +13,7 @@ pub(crate) struct QueryStore {
     replica_id: ReplicaId,
     store: Arc<DeploymentStore>,
     chain_store: Arc<crate::ChainStore>,
+    api_version: Arc<ApiVersion>,
 }
 
 impl QueryStore {
@@ -21,12 +22,14 @@ impl QueryStore {
         chain_store: Arc<crate::ChainStore>,
         site: Arc<Site>,
         replica_id: ReplicaId,
+        api_version: Arc<ApiVersion>,
     ) -> Self {
         QueryStore {
             site,
             replica_id,
             store,
             chain_store,
+            api_version,
         }
     }
 }
@@ -103,7 +106,7 @@ impl QueryStoreTrait for QueryStore {
 
     fn api_schema(&self) -> Result<Arc<ApiSchema>, QueryExecutionError> {
         let info = self.store.subgraph_info(&self.site)?;
-        Ok(info.api)
+        Ok(info.api.get(&self.api_version).unwrap().clone())
     }
 
     fn network_name(&self) -> &str {

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -75,9 +75,11 @@ impl QueryStoreManager for Store {
         graph::prelude::QueryExecutionError,
     > {
         let store = self.subgraph_store.cheap_clone();
+        let api_version = target.get_version();
+        let target = target.clone();
         let (store, site, replica) = graph::spawn_blocking_allow_panic(move || {
             store
-                .replica_for_query(target, for_subscription)
+                .replica_for_query(target.clone(), for_subscription)
                 .map_err(|e| e.into())
         })
         .await
@@ -92,7 +94,13 @@ impl QueryStoreManager for Store {
             )
         })?;
 
-        Ok(Arc::new(QueryStore::new(store, chain_store, site, replica)))
+        Ok(Arc::new(QueryStore::new(
+            store,
+            chain_store,
+            site,
+            replica,
+            Arc::new(api_version.clone()),
+        )))
     }
 }
 

--- a/store/postgres/tests/chain_head.rs
+++ b/store/postgres/tests/chain_head.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use graph::prelude::web3::types::H256;
 use graph::prelude::{anyhow::anyhow, anyhow::Error};
 use graph::prelude::{serde_json as json, EthereumBlock};
-use graph::prelude::{BlockNumber, QueryStoreManager};
+use graph::prelude::{BlockNumber, QueryStoreManager, QueryTarget};
 use graph::{cheap_clone::CheapClone, prelude::web3::types::H160};
 use graph::{components::store::BlockStore as _, prelude::DeploymentHash};
 use graph::{components::store::ChainStore as _, prelude::EthereumCallCache as _};
@@ -177,7 +177,10 @@ fn block_number() {
             create_test_subgraph(&subgraph, "type Dummy @entity { id: ID! }").await;
 
             let query_store = subgraph_store
-                .query_store(subgraph.cheap_clone().into(), false)
+                .query_store(
+                    QueryTarget::Deployment(subgraph.cheap_clone().into(), Default::default()),
+                    false,
+                )
                 .await
                 .unwrap();
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1,5 +1,6 @@
 use graph::blockchain::block_stream::FirehoseCursor;
 use graph::data::graphql::ext::TypeDefinitionExt;
+use graph::data::query::QueryTarget;
 use graph::data::subgraph::schema::DeploymentCreate;
 use graph_chain_ethereum::{Mapping, MappingABI};
 use graph_mock::MockMetricsRegistry;
@@ -1412,7 +1413,10 @@ fn throttle_subscription_delivers() {
                 &*LOGGER,
                 store
                     .clone()
-                    .query_store(deployment.hash.clone().into(), true)
+                    .query_store(
+                        QueryTarget::Deployment(deployment.hash.clone().into(), Default::default()),
+                        true,
+                    )
                     .await
                     .unwrap(),
                 Duration::from_millis(500),
@@ -1454,7 +1458,10 @@ fn throttle_subscription_throttles() {
                 &*LOGGER,
                 store
                     .clone()
-                    .query_store(deployment.hash.clone().into(), true)
+                    .query_store(
+                        QueryTarget::Deployment(deployment.hash.clone(), Default::default()),
+                        true,
+                    )
                     .await
                     .unwrap(),
                 Duration::from_secs(30),
@@ -1497,7 +1504,7 @@ fn subgraph_schema_types_have_subgraph_id_directive() {
     run_test(|store, _, deployment| async move {
         let schema = store
             .subgraph_store()
-            .api_schema(&deployment.hash)
+            .api_schema(&deployment.hash, &Default::default())
             .expect("test subgraph should have a schema");
         for typedef in schema
             .definitions()

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -3,6 +3,7 @@ use graph::{
         server::index_node::VersionInfo,
         store::{DeploymentId, DeploymentLocator, StatusStore},
     },
+    data::query::QueryTarget,
     data::subgraph::schema::SubgraphHealth,
     data::subgraph::schema::{DeploymentCreate, SubgraphError},
     prelude::BlockPtr,
@@ -551,7 +552,10 @@ fn fatal_vs_non_fatal() {
     run_test_sequentially(|store| async move {
         let deployment = setup().await;
         let query_store = store
-            .query_store(deployment.hash.clone().into(), false)
+            .query_store(
+                QueryTarget::Deployment(deployment.hash.clone(), Default::default()),
+                false,
+            )
             .await
             .unwrap();
 
@@ -612,7 +616,10 @@ fn fail_unfail_deterministic_error() {
         let deployment = setup().await;
 
         let query_store = store
-            .query_store(deployment.hash.cheap_clone().into(), false)
+            .query_store(
+                QueryTarget::Deployment(deployment.hash.clone(), Default::default()),
+                false,
+            )
             .await
             .unwrap();
 


### PR DESCRIPTION
This is the initial implementation of versioning.

- [x] remove the example implementation of a feature flag

I left few comments on the interesting parts of the code to make it easier to review.
- [Where do we manage versions](https://github.com/graphprotocol/graph-node/pull/3185#discussion_r791502259)
- [How do we define "latest" version](https://github.com/graphprotocol/graph-node/pull/3185#discussion_r791502627)
- [How does the Gateway fetch a list of supported versions?](https://github.com/graphprotocol/graph-node/pull/3185#discussion_r791504128)
- [How do we define feature flags?](https://github.com/graphprotocol/graph-node/pull/3185#discussion_r791501883)
- [How do we validate the version number provided by the user?](https://github.com/graphprotocol/graph-node/pull/3185#discussion_r791503067)

Continues #3155