### PR TITLE
graphql: add `_change_block` to entities GraphQL `input` type filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ indexing across [multiple databases](./docs/config.md).
 | Query entity collections | ✅ |
 | Pagination | ✅ |
 | Filtering | ✅ |
+| Block-based Filtering | ✅ |
 | Entity relationships | ✅ |
 | Subscriptions | ✅ |
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -177,6 +177,7 @@ pub enum EntityFilter {
     NotStartsWith(Attribute, Value),
     EndsWith(Attribute, Value),
     NotEndsWith(Attribute, Value),
+    ChangeBlockGte(BlockNumber),
 }
 
 // Define some convenience methods

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -24,8 +24,9 @@ pub enum APISchemaError {
     FulltextSearchNonDeterministic,
 }
 
+// The followoing types are defined in meta.graphql
 const BLOCK_HEIGHT: &str = "Block_height";
-
+const CHANGE_BLOCK_FILTER_NAME: &str = "BlockChangedFilter";
 const ERROR_POLICY_TYPE: &str = "_SubgraphErrorPolicy_";
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -85,7 +86,6 @@ pub fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
     add_directives(&mut schema);
     add_builtin_scalar_types(&mut schema)?;
     add_order_direction_enum(&mut schema);
-    add_block_height_type(&mut schema);
     add_meta_field_type(&mut schema);
     add_types_for_object_types(&mut schema, &object_types)?;
     add_types_for_interface_types(&mut schema, &interface_types)?;
@@ -204,45 +204,6 @@ fn add_order_direction_enum(schema: &mut Document) {
     schema.definitions.push(def);
 }
 
-/// Adds a global `Block_height` type to the schema. The `block` argument
-/// accepts values of this type
-fn add_block_height_type(schema: &mut Document) {
-    let typedef = TypeDefinition::InputObject(InputObjectType {
-        position: Pos::default(),
-        description: None,
-        name: BLOCK_HEIGHT.to_string(),
-        directives: vec![],
-        fields: vec![
-            InputValue {
-                position: Pos::default(),
-                description: None,
-                name: "hash".to_owned(),
-                value_type: Type::NamedType("Bytes".to_owned()),
-                default_value: None,
-                directives: vec![],
-            },
-            InputValue {
-                position: Pos::default(),
-                description: None,
-                name: "number".to_owned(),
-                value_type: Type::NamedType("Int".to_owned()),
-                default_value: None,
-                directives: vec![],
-            },
-            InputValue {
-                position: Pos::default(),
-                description: None,
-                name: "number_gte".to_owned(),
-                value_type: Type::NamedType("Int".to_owned()),
-                default_value: None,
-                directives: vec![],
-            },
-        ],
-    });
-    let def = Definition::TypeDefinition(typedef);
-    schema.definitions.push(def);
-}
-
 /// Adds a global `_Meta_` type to the schema. The `_meta` field
 /// accepts values of this type
 fn add_meta_field_type(schema: &mut Document) {
@@ -326,12 +287,15 @@ fn add_filter_type(
     let filter_type_name = format!("{}_filter", type_name).to_string();
     match schema.get_named_type(&filter_type_name) {
         None => {
+            let mut generated_filter_fields = field_input_values(schema, fields)?;
+            generated_filter_fields.push(block_changed_filter_argument());
+
             let typedef = TypeDefinition::InputObject(InputObjectType {
                 position: Pos::default(),
                 description: None,
                 name: filter_type_name,
                 directives: vec![],
-                fields: field_input_values(schema, fields)?,
+                fields: generated_filter_fields,
             });
             let def = Definition::TypeDefinition(typedef);
             schema.definitions.push(def);
@@ -661,6 +625,17 @@ fn block_argument() -> InputValue {
         ),
         name: "block".to_string(),
         value_type: Type::NamedType(BLOCK_HEIGHT.to_owned()),
+        default_value: None,
+        directives: vec![],
+    }
+}
+
+fn block_changed_filter_argument() -> InputValue {
+    InputValue {
+        position: Pos::default(),
+        description: Some("Filter for the block changed event.".to_owned()),
+        name: "_change_block".to_string(),
+        value_type: Type::NamedType(CHANGE_BLOCK_FILTER_NAME.to_owned()),
         default_value: None,
         directives: vec![],
     }
@@ -1038,11 +1013,30 @@ mod tests {
                 "favoritePet_not_starts_with",
                 "favoritePet_ends_with",
                 "favoritePet_not_ends_with",
+                "_change_block"
             ]
             .iter()
             .map(ToString::to_string)
             .collect::<Vec<String>>()
         );
+
+        let change_block_filter = filter_type
+            .fields
+            .iter()
+            .find(move |p| match p.name.as_str() {
+                "_change_block" => true,
+                _ => false,
+            })
+            .expect("_change_block field is missing in User_filter");
+
+        match &change_block_filter.value_type {
+            Type::NamedType(name) => assert_eq!(name.as_str(), "BlockChangedFilter"),
+            _ => panic!("_change_block field is not a named type"),
+        }
+
+        schema
+            .get_named_type("BlockChangedFilter")
+            .expect("BlockChangedFilter type is missing in derived API schema");
     }
 
     #[test]

--- a/graphql/src/schema/meta.graphql
+++ b/graphql/src/schema/meta.graphql
@@ -15,6 +15,16 @@ type _Meta_ {
   hasIndexingErrors: Boolean!
 }
 
+input BlockChangedFilter {
+  number_gte: Int!
+}
+
+input Block_height {
+  hash: Bytes
+  number: Int
+  number_gte: Int
+}
+
 type _Block_ {
   "The hash of the block"
   hash: Bytes

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -805,6 +805,10 @@ impl<'a> QueryFilter<'a> {
                 }
             }
 
+            // This is a special case since we want to allow passing "block" column filter, but we dont
+            // want to fail/error when this is passed here, since this column is not really an entity column.
+            ChangeBlockGte(..) => {}
+
             Contains(attr, _)
             | NotContains(attr, _)
             | Equal(attr, _)
@@ -1085,6 +1089,21 @@ impl<'a> QueryFilter<'a> {
         Ok(())
     }
 
+    fn filter_block_gte(
+        &self,
+        block_number_gte: &BlockNumber,
+        mut out: AstPass<Pg>,
+    ) -> QueryResult<()> {
+        // constructs a filter for lower(c.block_range) >= $block_number_gte
+        // to allow consumers to filter by a specific change block
+        out.push_sql("lower(c.");
+        out.push_sql(BLOCK_RANGE_COLUMN);
+        out.push_sql(")");
+        out.push_sql(" >= ");
+        out.push_bind_param::<Integer, _>(block_number_gte)?;
+        Ok(())
+    }
+
     fn starts_or_ends_with(
         &self,
         attribute: &Attribute,
@@ -1158,6 +1177,7 @@ impl<'a> QueryFragment<Pg> for QueryFilter<'a> {
             NotEndsWith(attr, value) => {
                 self.starts_or_ends_with(attr, value, " not like ", false, out)?
             }
+            ChangeBlockGte(block_number) => self.filter_block_gte(block_number, out)?,
         }
         Ok(())
     }


### PR DESCRIPTION
Continue from: https://github.com/graphprotocol/graph-node/pull/3014

Related: https://github.com/graphprotocol/graph-node/issues/1838 

### Background

The initial discussion started at https://github.com/graphprotocol/graph-node/issues/2958 about adding a property to every type, so users can filter by it. It brought back https://github.com/graphprotocol/graph-node/issues/1838 where a user should be able to filter by block.

### Overview of the changes

* Added `EntityFilter::ChangeBlockGet` and implemented the SQL required by it.
* Added a new `input BlockChangedFilter` to allow filtering based on `number_gte` of the block change.
* No GraphQL breaking changes.
* Added special handling for filter key `_change_block` and translate that into the SQL query. 

### TODO:
- [x] Figure out the GraphQL schema structure 
- [x] Add field filter to the GraphQL `input` named `_change_block` 
- [x] Change HEAD to be based on @lutter 's refactor PR 
- [x] Introduce new input type for filtering
- [x] Modify resolvers/SQL/prefetch execution

![image](https://user-images.githubusercontent.com/3680083/145010226-db114311-1f41-4250-9608-e60403f745e9.png)

![image](https://user-images.githubusercontent.com/3680083/145010275-abd8c803-e85c-4850-b5ec-580755eb8bc2.png)

