### PR TITLE
Prefetching: don't collect introspection fields

### DIFF
--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -718,7 +718,13 @@ impl SelectedAttributes {
                         .map(|field_type| !field_type.is_derived())
                         .unwrap_or(false)
                 })
-                .map(|field| field.name.clone())
+                .filter_map(|field| {
+                    if field.name.starts_with("__") {
+                        None
+                    } else {
+                        Some(field.name.clone())
+                    }
+                })
                 .collect();
             map.insert(
                 object_type.name().to_string(),


### PR DESCRIPTION
This fixes the current query errors when `GRAPH_ENABLE_SELECT_BY_SPECIFIC_ATTRIBUTES` is turned on.

Currently, introspection fields are included in the `SelectedAttributes` value and would later be inadequately selected as columns in SQL queries.
 
This PR prevents such fields from being collected by filtering out field names that start with double underscores.

Fixes #2938.