### PR TITLE
graphql: resolve __typename if not exists in the resolved object

### DIFF
--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1980,3 +1980,19 @@ fn non_fatal_errors() {
         assert_eq!(expected, serde_json::to_value(&result).unwrap());
     })
 }
+
+#[test]
+fn can_query_root_typename() {
+    run_test_sequentially(|store| async move {
+        let query = "query { __typename }";
+        let query = graphql_parser::parse_query(query)
+            .expect("invalid test query")
+            .into_static();
+        let deployment = setup(store.as_ref());
+        let result = execute_query_document(&deployment.hash, query).await;
+        let exp = object! {
+            __typename: "Query"
+        };
+        assert_eq!(extract_data!(result), Some(exp));
+    })
+}


### PR DESCRIPTION
Fixes https://github.com/graphprotocol/graph-node/issues/3114

Given the following query: 

```graphql
{
  __typename # this one is the problematic one
  purposes {
    __typename
  }
}
```

Should return: 

```json
{
   "__typename": "Query",
   "purposes": [
      {
         "__typename": "Purpose"
      }
   ]
}
```

But it fails to resolve `"__typename": "Query",`, because we don't handle `__typename` not only for root types but all other types.

It works for `Purpose` for example because `__typename` is added by resolvers level(prefetch) for other object types.