### PR TITLE
Fix `graphman run` for the `PollingBlockStream`

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Error};
 use graph::blockchain::BlockchainKind;
-use graph::components::store::WritableStore;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::env::env_var;
 use graph::firehose::{FirehoseEndpoints, ForkStep};
@@ -186,7 +185,7 @@ impl Blockchain for Chain {
     async fn new_firehose_block_stream(
         &self,
         deployment: DeploymentLocator,
-        writable: Arc<dyn WritableStore>,
+        block_cursor: Option<String>,
         start_blocks: Vec<BlockNumber>,
         filter: Arc<Self::TriggerFilter>,
         metrics: Arc<BlockStreamMetrics>,
@@ -216,11 +215,10 @@ impl Blockchain for Chain {
             .new(o!("component" => "FirehoseBlockStream"));
 
         let firehose_mapper = Arc::new(FirehoseMapper {});
-        let firehose_cursor = writable.block_cursor();
 
         Ok(Box::new(FirehoseBlockStream::new(
             firehose_endpoint,
-            firehose_cursor,
+            block_cursor,
             firehose_mapper,
             adapter,
             filter,

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -1,6 +1,5 @@
 use graph::blockchain::BlockchainKind;
 use graph::cheap_clone::CheapClone;
-use graph::components::store::WritableStore;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::firehose::FirehoseEndpoints;
 use graph::prelude::StopwatchMetrics;
@@ -101,7 +100,7 @@ impl Blockchain for Chain {
     async fn new_firehose_block_stream(
         &self,
         deployment: DeploymentLocator,
-        store: Arc<dyn WritableStore>,
+        block_cursor: Option<String>,
         start_blocks: Vec<BlockNumber>,
         filter: Arc<Self::TriggerFilter>,
         metrics: Arc<BlockStreamMetrics>,
@@ -127,11 +126,10 @@ impl Blockchain for Chain {
             .new(o!("component" => "FirehoseBlockStream"));
 
         let firehose_mapper = Arc::new(FirehoseMapper {});
-        let firehose_cursor = store.block_cursor();
 
         Ok(Box::new(FirehoseBlockStream::new(
             firehose_endpoint,
-            firehose_cursor,
+            block_cursor,
             firehose_mapper,
             adapter,
             filter,

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -623,9 +623,9 @@ where
 
             let block_ptr = block.ptr();
 
-            match inputs.stop_block.clone() {
+            match &inputs.stop_block {
                 Some(stop_block) => {
-                    if block_ptr.number > stop_block {
+                    if block_ptr.number > *stop_block {
                         info!(&logger, "stop block reached for subgraph");
                         return Ok(());
                     }

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -478,7 +478,7 @@ async fn new_block_stream<C: Blockchain>(
     let block_stream = match is_firehose {
         true => chain.new_firehose_block_stream(
             inputs.deployment.clone(),
-            inputs.store.clone(),
+            inputs.store.block_cursor(),
             inputs.start_blocks.clone(),
             Arc::new(filter.clone()),
             block_stream_metrics.clone(),

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -651,7 +651,7 @@ where
             if should_try_unfail_deterministic {
                 should_try_unfail_deterministic = false;
 
-                if let Some(current_ptr) = inputs.store.block_ptr() {
+                if let Some(current_ptr) = deployment_head {
                     if let Some(parent_ptr) =
                         inputs.triggers_adapter.parent_ptr(&current_ptr).await?
                     {

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -619,6 +619,7 @@ where
                     );
                     continue;
                 }
+                // Scenario where this can happen: 1504c9d8-36e4-45bb-b4f2-71cf58789ed9
                 None => unreachable!("The block stream stopped producing blocks"),
             };
 

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -6,7 +6,7 @@ use anyhow::Error;
 use async_trait::async_trait;
 use core::fmt;
 use serde::Deserialize;
-use std::{convert::TryFrom, sync::Arc};
+use std::convert::TryFrom;
 
 use super::{block_stream, HostFn, IngestorError, TriggerWithHandler};
 
@@ -296,7 +296,7 @@ impl Blockchain for MockBlockchain {
     async fn new_firehose_block_stream(
         &self,
         _deployment: crate::components::store::DeploymentLocator,
-        _store: Arc<dyn crate::components::store::WritableStore>,
+        _block_cursor: Option<String>,
         _start_blocks: Vec<crate::components::store::BlockNumber>,
         _filter: std::sync::Arc<Self::TriggerFilter>,
         _metrics: std::sync::Arc<block_stream::BlockStreamMetrics>,

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use crate::{
     components::{
-        store::{BlockNumber, ChainStore, WritableStore},
+        store::{BlockNumber, ChainStore},
         subgraph::DataSourceTemplateInfo,
     },
     prelude::{thiserror::Error, LinkResolver},
@@ -111,7 +111,7 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
     async fn new_firehose_block_stream(
         &self,
         deployment: DeploymentLocator,
-        store: Arc<dyn WritableStore>,
+        block_cursor: Option<String>,
         start_blocks: Vec<BlockNumber>,
         filter: Arc<Self::TriggerFilter>,
         metrics: Arc<BlockStreamMetrics>,

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -147,7 +147,9 @@ pub enum Command {
         /// The deployments to rewind
         names: Vec<String>,
     },
-    /// Deploy and run an arbitrary subgraph, up to a certain block (for dev and testing purposes) -- WARNING: WILL RUN MIGRATIONS ON THE DB, DO NOT USE IN PRODUCTION
+    /// Deploy and run an arbitrary subgraph up to a certain block, although it can surpass it by a few blocks, it's not exact (use for dev and testing purposes) -- WARNING: WILL RUN MIGRATIONS ON THE DB, DO NOT USE IN PRODUCTION
+    ///
+    /// Also worth noting that the deployed subgraph will be removed at the end.
     Run {
         /// Network name (must fit one of the chain)
         network_name: String,

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -203,6 +203,12 @@ pub async fn run(
             break;
         }
     }
+
+    // FIXME: wait for instance manager to stop.
+    // If we remove the subgraph first, it will panic on:
+    // 1504c9d8-36e4-45bb-b4f2-71cf58789ed9
+    tokio::time::sleep(Duration::from_millis(4000)).await;
+
     info!(&logger, "Removing subgraph {}", name);
     subgraph_store.clone().remove_subgraph(subgraph_name)?;
 


### PR DESCRIPTION
Running `graphman run` with the `PollingBlockStream` could lead to an infinite loop.

This can happen because `graphman run` keeps an [infinite loop](https://github.com/graphprotocol/graph-node/blob/399ee444d1023a95f82404d14bb5e4534d827678/node/src/manager/commands/run.rs#L189) checking if the `deployment_head` passed the `stop_block`, however the `instance_manager` would [stop processing](https://github.com/graphprotocol/graph-node/blob/399ee444d1023a95f82404d14bb5e4534d827678/core/src/subgraph/instance_manager.rs#L622) once the `PollingBlockStream` would get to the `stop_block` and not the `deployment_head`.

I've changed so that we keep the `deployment_head` state in the `instance_manager` and compare the `stop_block` to that.

I've also took the opportunity to remove the last store dependency from the Firehose \o/ 🎉 