### PR TITLE
Add `graphman` commands: `index list` and `index drop`

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -848,9 +848,9 @@ async fn main() {
                 }
                 Show { nsp, table } => commands::stats::show(ctx.pools(), nsp, table),
                 Analyze { id, entity } => {
-                    let store = ctx.store();
+                    let (store, primary_pool) = ctx.store_and_primary();
                     let subgraph_store = store.subgraph_store();
-                    commands::stats::analyze(subgraph_store, id, entity).await
+                    commands::stats::analyze(subgraph_store, primary_pool, id, &entity).await
                 }
             }
         }

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -400,6 +400,15 @@ pub enum IndexCommand {
         )]
         method: String,
     },
+    /// Lists existing indexes for a given Entity
+    List {
+        /// The id of the deployment
+        #[structopt(empty_values = false)]
+        id: String,
+        /// The Entity name, in camel case.
+        #[structopt(empty_values = false)]
+        entity: String,
+    },
 }
 
 impl From<Opt> for config::Opt {
@@ -821,17 +830,16 @@ async fn main() {
         }
         Index(cmd) => {
             use IndexCommand::*;
+            let store = ctx.store();
+            let subgraph_store = store.subgraph_store();
             match cmd {
                 Create {
                     id,
                     entity,
                     fields,
                     method,
-                } => {
-                    let store = ctx.store();
-                    let subgraph_store = store.subgraph_store();
-                    commands::index::create(subgraph_store, id, entity, fields, method).await
-                }
+                } => commands::index::create(subgraph_store, id, entity, fields, method).await,
+                List { id, entity } => commands::index::list(subgraph_store, id, entity).await,
             }
         }
     };

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -409,6 +409,16 @@ pub enum IndexCommand {
         #[structopt(empty_values = false)]
         entity: String,
     },
+
+    /// Drops an index for a given deployment, concurrently
+    Drop {
+        /// The id of the deployment
+        #[structopt(empty_values = false)]
+        id: String,
+        /// The name of the index to be dropped
+        #[structopt(empty_values = false)]
+        index_name: String,
+    },
 }
 
 impl From<Opt> for config::Opt {
@@ -840,6 +850,9 @@ async fn main() {
                     method,
                 } => commands::index::create(subgraph_store, id, entity, fields, method).await,
                 List { id, entity } => commands::index::list(subgraph_store, id, entity).await,
+                Drop { id, index_name } => {
+                    commands::index::drop(subgraph_store, &id, &index_name).await
+                }
             }
         }
     };

--- a/node/src/manager/commands/index.rs
+++ b/node/src/manager/commands/index.rs
@@ -58,3 +58,17 @@ pub async fn list(
     }
     Ok(())
 }
+
+pub async fn drop(
+    store: Arc<SubgraphStore>,
+    id: &str,
+    index_name: &str,
+) -> Result<(), anyhow::Error> {
+    let deployment_hash = DeploymentHash::new(id)
+        .map_err(|e| anyhow::anyhow!("Subgraph hash must be a valid IPFS hash: {}", e))?;
+    store
+        .drop_index_for_deployment(&deployment_hash, &index_name)
+        .await?;
+    println!("Dropped index {index_name}");
+    Ok(())
+}

--- a/node/src/manager/commands/index.rs
+++ b/node/src/manager/commands/index.rs
@@ -73,7 +73,7 @@ pub async fn drop(
     Ok(())
 }
 
-fn find(pool: &ConnectionPool, name: &str) -> anyhow::Result<DeploymentLocator> {
+pub(super) fn find(pool: &ConnectionPool, name: &str) -> anyhow::Result<DeploymentLocator> {
     let deployment_locator = match &Deployment::lookup(pool, name)?[..] {
         [] => anyhow::bail!("Found no deployment for the given ID"),
         [deployment_locator] => deployment_locator,

--- a/node/src/manager/commands/index.rs
+++ b/node/src/manager/commands/index.rs
@@ -41,3 +41,20 @@ pub async fn create(
         Err(other) => Err(anyhow::anyhow!(other)),
     }
 }
+
+pub async fn list(
+    store: Arc<SubgraphStore>,
+    id: String,
+    entity_name: String,
+) -> Result<(), anyhow::Error> {
+    let deployment_hash = DeploymentHash::new(id)
+        .map_err(|e| anyhow::anyhow!("Subgraph hash must be a valid IPFS hash: {}", e))?;
+    let entity_type = EntityType::new(entity_name);
+    let indexes: Vec<String> = store
+        .indexes_for_entity(&deployment_hash, entity_type)
+        .await?;
+    for index in &indexes {
+        println!("{index}")
+    }
+    Ok(())
+}

--- a/node/src/manager/commands/info.rs
+++ b/node/src/manager/commands/info.rs
@@ -7,7 +7,7 @@ use crate::manager::deployment::Deployment;
 
 fn find(
     pool: ConnectionPool,
-    name: String,
+    name: &str,
     current: bool,
     pending: bool,
     used: bool,
@@ -38,7 +38,7 @@ pub fn run(
     pending: bool,
     used: bool,
 ) -> Result<(), anyhow::Error> {
-    let deployments = find(pool, name, current, pending, used)?;
+    let deployments = find(pool, &name, current, pending, used)?;
     let ids: Vec<_> = deployments.iter().map(|d| d.locator().id).collect();
     let statuses = match store {
         Some(store) => store.status(status::Filter::DeploymentIds(ids))?,

--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -71,7 +71,7 @@ pub fn run(
 
     let deployments = names
         .iter()
-        .map(|name| Deployment::lookup(&primary, name.clone()))
+        .map(|name| Deployment::lookup(&primary, name))
         .collect::<Result<Vec<_>, _>>()?
         .into_iter()
         .flatten()

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -177,7 +177,7 @@ pub async fn run(
     )
     .await?;
 
-    let deployments = Deployment::lookup(&primary_pool, name.to_string())?;
+    let deployments = Deployment::lookup(&primary_pool, name)?;
     let deployment = deployments
         .first()
         .expect("At least one deployment should exist");

--- a/node/src/manager/commands/stats.rs
+++ b/node/src/manager/commands/stats.rs
@@ -1,16 +1,15 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use super::index::find;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::PooledConnection;
 use diesel::sql_query;
 use diesel::sql_types::{Integer, Text};
 use diesel::PgConnection;
 use diesel::RunQueryDsl;
-use graph::components::store::EntityType;
 use graph::prelude::anyhow;
 use graph::prelude::anyhow::bail;
-use graph::prelude::DeploymentHash;
 use graph_store_postgres::command_support::catalog::Site;
 use graph_store_postgres::command_support::{catalog as store_catalog, SqlName};
 use graph_store_postgres::connection_pool::ConnectionPool;
@@ -158,19 +157,14 @@ pub fn show(
 
 pub async fn analyze(
     store: Arc<SubgraphStore>,
-    hash: String,
-    entity_name: String,
+    pool: ConnectionPool,
+    deployment_id: String,
+    entity_name: &str,
 ) -> Result<(), anyhow::Error> {
     println!("Running ANALYZE for {entity_name} entity");
-    let entity_type = EntityType::new(entity_name);
-    let deployment_hash = DeploymentHash::new(hash).map_err(|malformed_hash| {
-        anyhow!(
-            "Subgraph hash must be a valid IPFS hash: {}",
-            malformed_hash
-        )
-    })?;
+    let deployment_locator = find(&pool, &deployment_id)?;
     store
-        .analyze(&deployment_hash, entity_type)
+        .analyze(&deployment_locator, entity_name)
         .await
         .map_err(|e| anyhow!(e))
 }

--- a/node/src/manager/commands/stats.rs
+++ b/node/src/manager/commands/stats.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::index::find;
+use crate::manager::deployment::find_single_deployment_locator;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::PooledConnection;
 use diesel::sql_query;
@@ -162,7 +162,7 @@ pub async fn analyze(
     entity_name: &str,
 ) -> Result<(), anyhow::Error> {
     println!("Running ANALYZE for {entity_name} entity");
-    let deployment_locator = find(&pool, &deployment_id)?;
+    let deployment_locator = find_single_deployment_locator(&pool, &deployment_id)?;
     store
         .analyze(&deployment_locator, entity_name)
         .await

--- a/node/src/manager/deployment.rs
+++ b/node/src/manager/deployment.rs
@@ -30,12 +30,12 @@ pub struct Deployment {
 }
 
 impl Deployment {
-    pub fn lookup(primary: &ConnectionPool, name: String) -> Result<Vec<Self>, anyhow::Error> {
+    pub fn lookup(primary: &ConnectionPool, name: &str) -> Result<Vec<Self>, anyhow::Error> {
         let conn = primary.get()?;
         Self::lookup_with_conn(&conn, name)
     }
 
-    pub fn lookup_with_conn(conn: &PgConnection, name: String) -> Result<Vec<Self>, anyhow::Error> {
+    pub fn lookup_with_conn(conn: &PgConnection, name: &str) -> Result<Vec<Self>, anyhow::Error> {
         use store_catalog::deployment_schemas as ds;
         use store_catalog::subgraph as s;
         use store_catalog::subgraph_deployment_assignment as a;

--- a/node/src/manager/deployment.rs
+++ b/node/src/manager/deployment.rs
@@ -173,3 +173,17 @@ pub fn locate(
 pub fn as_hash(hash: String) -> Result<DeploymentHash, Error> {
     DeploymentHash::new(hash).map_err(|s| anyhow!("illegal deployment hash `{}`", s))
 }
+
+/// Finds a single deployment locator for the given deployment identifier.
+pub fn find_single_deployment_locator(
+    pool: &ConnectionPool,
+    name: &str,
+) -> anyhow::Result<DeploymentLocator> {
+    let deployment_locator = match &Deployment::lookup(pool, name)?[..] {
+        [] => anyhow::bail!("Found no deployment for the given ID"),
+        [deployment_locator] => deployment_locator,
+        _ => anyhow::bail!("Found multiplle deployments for given identifier"),
+    }
+    .locator();
+    Ok(deployment_locator)
+}

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -444,3 +444,16 @@ pub(crate) fn indexes_for_table(
 
     Ok(results.into_iter().map(|i| i.def).collect())
 }
+pub(crate) fn drop_index(
+    conn: &PgConnection,
+    schema_name: &str,
+    index_name: &str,
+) -> Result<(), StoreError> {
+    let query = format!("drop index concurrently {schema_name}.{index_name}");
+    sql_query(&query)
+        .bind::<Text, _>(schema_name)
+        .bind::<Text, _>(index_name)
+        .execute(conn)
+        .map_err::<StoreError, _>(Into::into)?;
+    Ok(())
+}

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -414,3 +414,33 @@ pub(crate) fn check_index_is_valid(
         .map(|check| check.is_valid);
     Ok(matches!(result, Some(true)))
 }
+
+pub(crate) fn indexes_for_table(
+    conn: &PgConnection,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<Vec<String>, StoreError> {
+    #[derive(Queryable, QueryableByName)]
+    struct IndexName {
+        #[sql_type = "Text"]
+        #[column_name = "indexdef"]
+        def: String,
+    }
+
+    let query = "
+        select
+            indexdef
+        from
+            pg_indexes
+        where
+            schemaname = $1
+            and tablename = $2
+        order by indexname";
+    let results = sql_query(query)
+        .bind::<Text, _>(schema_name)
+        .bind::<Text, _>(table_name)
+        .load::<IndexName>(conn)
+        .map_err::<StoreError, _>(Into::into)?;
+
+    Ok(results.into_iter().map(|i| i.def).collect())
+}

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -40,7 +40,7 @@ use web3::types::Address;
 use crate::block_range::block_number;
 use crate::catalog;
 use crate::deployment;
-use crate::relational::{Layout, LayoutCache};
+use crate::relational::{Layout, LayoutCache, SqlName, Table};
 use crate::relational_queries::FromEntityData;
 use crate::{connection_pool::ConnectionPool, detail};
 use crate::{dynds, primary::Site};
@@ -706,26 +706,41 @@ impl DeploymentStore {
     pub(crate) async fn create_manual_index(
         &self,
         site: Arc<Site>,
-        entity_type: EntityType,
+        entity_name: &str,
         field_names: Vec<String>,
         index_method: String,
     ) -> Result<(), StoreError> {
         let store = self.clone();
-
+        let entity_name = entity_name.to_owned();
         self.with_conn(move |conn, _| {
             let schema_name = site.namespace.clone();
             let layout = store.layout(conn, site)?;
-            let table = layout.table_for_entity(&entity_type)?;
-            let table_name = &table.name;
 
-            // resolve column names
+            let table = resolve_table_name(&layout, &entity_name)?;
+
+            // Resolve column names.
+            //
+            // Since we allow our input to be either camel-case or snake-case, we must retry the
+            // search using the latter if the search for the former fails.
             let column_names = field_names
                 .iter()
-                .map(|f| table.column_for_field(f).map(|column| column.name.as_str()))
-                .collect::<Result<Vec<_>, _>>()?;
+                .map(|f| {
+                    table
+                        .column_for_field(f)
+                        .or_else(|_error| {
+                            let sql_name = SqlName::from(f.as_ref());
+                            table
+                                .column(&sql_name)
+                                .ok_or_else(|| StoreError::UnknownField(f.clone()))
+                        })
+                        .map(|column| column.name.as_str())
+                })
+                .collect::<Result<Vec<&str>, StoreError>>()?;
 
             let column_names_sep_by_underscores = column_names.join("_");
             let column_names_sep_by_commas = column_names.join(", ");
+
+            let table_name = &table.name;
             let index_name = format!("manual_{table_name}_{column_names_sep_by_underscores}");
 
             let sql = format!(
@@ -757,13 +772,14 @@ impl DeploymentStore {
     pub(crate) async fn indexes_for_entity(
         &self,
         site: Arc<Site>,
-        entity_type: EntityType,
+        entity_name: &str,
     ) -> Result<Vec<String>, StoreError> {
         let store = self.clone();
+        let entity_name = entity_name.to_owned();
         self.with_conn(move |conn, _| {
             let schema_name = site.namespace.clone();
             let layout = store.layout(conn, site)?;
-            let table = layout.table_for_entity(&entity_type)?;
+            let table = resolve_table_name(&layout, &entity_name)?;
             let table_name = &table.name;
             catalog::indexes_for_table(conn, schema_name.as_str(), table_name.as_str())
                 .map_err(Into::into)
@@ -1481,4 +1497,20 @@ impl DeploymentStore {
         self.with_conn(move |conn, _| deployment::health(&conn, &id).map_err(Into::into))
             .await
     }
+}
+
+/// Tries to fetch a [`Table`] either by its Entity name or its SQL name.
+///
+/// Since we allow our input to be either camel-case or snake-case, we must retry the
+/// search using the latter if the search for the former fails.
+fn resolve_table_name<'a>(layout: &'a Layout, name: &'_ str) -> Result<&'a Table, StoreError> {
+    layout
+        .table_for_entity(&EntityType::new(name.to_owned()))
+        .map(Deref::deref)
+        .or_else(|_error| {
+            let sql_name = SqlName::from(name);
+            layout
+                .table(&sql_name)
+                .ok_or_else(|| StoreError::UnknownTable(name.to_owned()))
+        })
 }

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -717,32 +717,11 @@ impl DeploymentStore {
             let schema_name = site.namespace.clone();
             let layout = store.layout(conn, site)?;
             let table = resolve_table_name(&layout, &entity_name)?;
-
-            // Resolve column names.
-            //
-            // Since we allow our input to be either camel-case or snake-case, we must retry the
-            // search using the latter if the search for the former fails.
-            let column_names = field_names
-                .iter()
-                .map(|f| {
-                    table
-                        .column_for_field(f)
-                        .or_else(|_error| {
-                            let sql_name = SqlName::from(f.as_ref());
-                            table
-                                .column(&sql_name)
-                                .ok_or_else(|| StoreError::UnknownField(f.clone()))
-                        })
-                        .map(|column| column.name.as_str())
-                })
-                .collect::<Result<Vec<&str>, StoreError>>()?;
-
+            let column_names = resolve_column_names(table, &field_names)?;
             let column_names_sep_by_underscores = column_names.join("_");
             let column_names_sep_by_commas = column_names.join(", ");
-
             let table_name = &table.name;
             let index_name = format!("manual_{table_name}_{column_names_sep_by_underscores}");
-
             let sql = format!(
                 "create index concurrently if not exists {index_name} \
                  on {schema_name}.{table_name} using {index_method} \
@@ -750,7 +729,6 @@ impl DeploymentStore {
             );
             // This might take a long time.
             conn.execute(&sql)?;
-
             // check if the index creation was successfull
             let index_is_valid =
                 catalog::check_index_is_valid(conn, schema_name.as_str(), &index_name)?;
@@ -1513,4 +1491,28 @@ fn resolve_table_name<'a>(layout: &'a Layout, name: &'_ str) -> Result<&'a Table
                 .table(&sql_name)
                 .ok_or_else(|| StoreError::UnknownTable(name.to_owned()))
         })
+}
+
+// Resolves column names.
+//
+// Since we allow our input to be either camel-case or snake-case, we must retry the
+// search using the latter if the search for the former fails.
+fn resolve_column_names<'a, T: AsRef<str>>(
+    table: &'a Table,
+    field_names: &[T],
+) -> Result<Vec<&'a str>, StoreError> {
+    field_names
+        .iter()
+        .map(|f| {
+            table
+                .column_for_field(f.as_ref())
+                .or_else(|_error| {
+                    let sql_name = SqlName::from(f.as_ref());
+                    table
+                        .column(&sql_name)
+                        .ok_or_else(|| StoreError::UnknownField(f.as_ref().to_string()))
+                })
+                .map(|column| column.name.as_str())
+        })
+        .collect()
 }

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -686,12 +686,13 @@ impl DeploymentStore {
     pub(crate) async fn analyze(
         &self,
         site: Arc<Site>,
-        entity_type: EntityType,
+        entity_name: &str,
     ) -> Result<(), StoreError> {
         let store = self.clone();
+        let entity_name = entity_name.to_owned();
         self.with_conn(move |conn, _| {
             let layout = store.layout(conn, site)?;
-            let table = layout.table_for_entity(&entity_type)?;
+            let table = resolve_table_name(&layout, &entity_name)?;
             let table_name = &table.qualified_name;
             let sql = format!("analyze {table_name}");
             conn.execute(&sql)?;
@@ -715,7 +716,6 @@ impl DeploymentStore {
         self.with_conn(move |conn, _| {
             let schema_name = site.namespace.clone();
             let layout = store.layout(conn, site)?;
-
             let table = resolve_table_name(&layout, &entity_name)?;
 
             // Resolve column names.

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -770,6 +770,20 @@ impl DeploymentStore {
         })
         .await
     }
+
+    /// Drops an index for a given deployment, concurrently.
+    pub(crate) async fn drop_index(
+        &self,
+        site: Arc<Site>,
+        index_name: &str,
+    ) -> Result<(), StoreError> {
+        let index_name = String::from(index_name);
+        self.with_conn(move |conn, _| {
+            let schema_name = site.namespace.clone();
+            catalog::drop_index(conn, schema_name.as_str(), &index_name).map_err(Into::into)
+        })
+        .await
+    }
 }
 
 /// Methods that back the trait `graph::components::Store`, but have small

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -752,6 +752,24 @@ impl DeploymentStore {
         })
         .await
     }
+
+    /// Returns a list of all existing indexes for the specified Entity table.
+    pub(crate) async fn indexes_for_entity(
+        &self,
+        site: Arc<Site>,
+        entity_type: EntityType,
+    ) -> Result<Vec<String>, StoreError> {
+        let store = self.clone();
+        self.with_conn(move |conn, _| {
+            let schema_name = site.namespace.clone();
+            let layout = store.layout(conn, site)?;
+            let table = layout.table_for_entity(&entity_type)?;
+            let table_name = &table.name;
+            catalog::indexes_for_table(conn, schema_name.as_str(), table_name.as_str())
+                .map_err(Into::into)
+        })
+        .await
+    }
 }
 
 /// Methods that back the trait `graph::components::Store`, but have small

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -968,32 +968,32 @@ impl SubgraphStoreInner {
 
     pub async fn create_manual_index(
         &self,
-        id: &DeploymentHash,
-        entity_type: EntityType,
+        deployment: &DeploymentLocator,
+        entity_name: &str,
         field_names: Vec<String>,
         index_method: String,
     ) -> Result<(), StoreError> {
-        let (store, site) = self.store(&id)?;
+        let (store, site) = self.store(&deployment.hash)?;
         store
-            .create_manual_index(site, entity_type, field_names, index_method)
+            .create_manual_index(site, entity_name, field_names, index_method)
             .await
     }
 
     pub async fn indexes_for_entity(
         &self,
-        id: &DeploymentHash,
-        entity_type: EntityType,
+        deployment: &DeploymentLocator,
+        entity_name: &str,
     ) -> Result<Vec<String>, StoreError> {
-        let (store, site) = self.store(&id)?;
-        store.indexes_for_entity(site, entity_type).await
+        let (store, site) = self.store(&deployment.hash)?;
+        store.indexes_for_entity(site, entity_name).await
     }
 
     pub async fn drop_index_for_deployment(
         &self,
-        id: &DeploymentHash,
+        deployment: &DeploymentLocator,
         index_name: &str,
     ) -> Result<(), StoreError> {
-        let (store, site) = self.store(&id)?;
+        let (store, site) = self.store(&deployment.hash)?;
         store.drop_index(site, index_name).await
     }
 }

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -978,6 +978,15 @@ impl SubgraphStoreInner {
             .create_manual_index(site, entity_type, field_names, index_method)
             .await
     }
+
+    pub async fn indexes_for_entity(
+        &self,
+        id: &DeploymentHash,
+        entity_type: EntityType,
+    ) -> Result<Vec<String>, StoreError> {
+        let (store, site) = self.store(&id)?;
+        store.indexes_for_entity(site, entity_type).await
+    }
 }
 
 struct EnsLookup {

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -959,11 +959,11 @@ impl SubgraphStoreInner {
 
     pub async fn analyze(
         &self,
-        id: &DeploymentHash,
-        entity_type: EntityType,
+        deployment: &DeploymentLocator,
+        entity_name: &str,
     ) -> Result<(), StoreError> {
-        let (store, site) = self.store(&id)?;
-        store.analyze(site, entity_type).await
+        let (store, site) = self.store(&deployment.hash)?;
+        store.analyze(site, entity_name).await
     }
 
     pub async fn create_manual_index(

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -16,7 +16,7 @@ use graph::{
     components::{
         server::index_node::VersionInfo,
         store::{
-            self, DeploymentLocator, EnsLookup as EnsLookupTrait, EntityType, SubgraphFork,
+            self, DeploymentLocator, EnsLookup as EnsLookupTrait, SubgraphFork,
             WritableStore as WritableStoreTrait,
         },
     },

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -987,6 +987,15 @@ impl SubgraphStoreInner {
         let (store, site) = self.store(&id)?;
         store.indexes_for_entity(site, entity_type).await
     }
+
+    pub async fn drop_index_for_deployment(
+        &self,
+        id: &DeploymentHash,
+        index_name: &str,
+    ) -> Result<(), StoreError> {
+        let (store, site) = self.store(&id)?;
+        store.drop_index(site, index_name).await
+    }
 }
 
 struct EnsLookup {


### PR DESCRIPTION
This PR adds two new `graphman** subcommands:

## `graphman index list <deployment-hash> <entity-name>`

Lists all indexes for the given Entity table.

Each index will be printed to `stdout` as its own definition command, like:

```
CREATE [UNIQUE] INDEX <index-name> ON <table-name> USING <index-method> (<columns>)
```

## `graphman index drop <deployment-hash> <index-name>`

Drops the given index, concurrently.

If the index does not exist, an error message will be displayed to the user.