### PR TITLE
ethereum: Lower mapping gas cost of ethereum call

### DIFF
--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -24,14 +24,15 @@ use graph_runtime_wasm::asc_abi::class::{AscEnumArray, EthereumValueKind};
 
 use super::abi::{AscUnresolvedContractCall, AscUnresolvedContractCall_0_0_4};
 
-// Allow up to 1,000 ethereum calls. The justification is that we don't know how much Ethereum gas a
-// call takes, but we limit the maximum to 25 million. One unit of Ethereum gas is at least 100ns
-// according to these benchmarks [1], so 1000 of our gas. Assuming the worst case, an Ethereum call
-// should therefore consume 25 billion gas. This allows for 400 calls per handler with the current
+// When making an ethereum call, the maximum ethereum gas is ETH_CALL_GAS which is 50 million. One
+// unit of Ethereum gas is at least 100ns according to these benchmarks [1], so 1000 of our gas. In
+// the worst case an Ethereum call could therefore consume 50 billion of our gas. However the
+// averarge call a subgraph makes is much cheaper or even cached in the call cache. So this cost is
+// set to 5 billion gas as a compromise. This allows for 2000 calls per handler with the current
 // limits.
 //
 // [1] - https://www.sciencedirect.com/science/article/abs/pii/S0166531620300900
-pub const ETHEREUM_CALL: Gas = Gas::new(25_000_000_000);
+pub const ETHEREUM_CALL: Gas = Gas::new(5_000_000_000);
 
 pub struct RuntimeAdapter {
     pub(crate) eth_adapters: Arc<EthereumNetworkAdapters>,


### PR DESCRIPTION
This lowers the mapping gas cost of an eth call from 25 to 5 billion.

By benchmarking a uniswap-like subgraph, I've observed that the eth call gas cost causes the overall gas cost to be way overestimated. And 400 calls per mapping might just not be enough for some real world subgraphs.