### PR TITLE
Add special treatment for immutable entities

### DIFF
--- a/docs/implementation/time-travel.md
+++ b/docs/implementation/time-travel.md
@@ -45,6 +45,19 @@ For background on ranges in Postgres, see the
 [range operators](https://www.postgresql.org/docs/9.6/functions-range.html)
 chapters in the documentation.
 
+### Immutable entities
+
+For entity types declared with `@entity(immutable: true)`, the table has a
+`block$ int not null` column instead of a `block_range` column, where the
+`block$` column stores the value that would be stored in
+`lower(block_range)`. Since the upper bound of the block range for an
+immutable entity is always infinite, a test like `block_range @> $B`, which
+is equivalent to `lower(block_range) <= $B and upper(block_range) > $B`,
+can be simplified to `block$ <= $B`.
+
+The operations in the next section are adjusted accordingly for immutable
+entities.
+
 ## Operations
 
 For all operations, we assume that we perform them for block number `B`;
@@ -85,10 +98,14 @@ deleting it consists of clamping the block range at `B`:
      where id = $ID and block_range @> $INTMAX;
 ```
 
+Note that this operation is not allowed for immutable entities.
+
 ### Update entity
 
 Only the current version of an entity can be updated. An update is performed
 as a deletion followed by an insertion.
+
+Note that this operation is not allowed for immutable entities.
 
 ### Rolling back
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -278,9 +278,9 @@ impl Value {
         matches!(self, Value::String(_))
     }
 
-    pub fn as_int(self) -> Option<i32> {
+    pub fn as_int(&self) -> Option<i32> {
         if let Value::Int(i) = self {
-            Some(i)
+            Some(*i)
         } else {
             None
         }

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -183,7 +183,7 @@ impl<'a> BlockRangeColumn<'a> {
 
     /// Output the literal value of the block range `[block,..)`, mostly for
     /// generating an insert statement containing the block range column
-    pub fn literal_value(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+    pub fn literal_range_current(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
         match self {
             BlockRangeColumn::Mutable { block, .. } => {
                 let block_range: BlockRange = (*block..).into();

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -92,9 +92,9 @@ impl ToSql<Range<Integer>, Pg> for BlockRange {
     }
 }
 
-/// Generate the clause that checks whether `block` is in the block range
-/// of an entity
-#[derive(Debug, Clone)]
+/// Helper for generating various SQL fragments for handling the block range
+/// of entity versions
+#[derive(Debug, Clone, Copy)]
 pub enum BlockRangeColumn<'a> {
     Mutable {
         table: &'a Table,
@@ -181,8 +181,9 @@ impl<'a> BlockRangeColumn<'a> {
         }
     }
 
-    /// Output the literal value of the block range `[block,..)`
-    pub fn value(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
+    /// Output the literal value of the block range `[block,..)`, mostly for
+    /// generating an insert statement containing the block range column
+    pub fn literal_value(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
         match self {
             BlockRangeColumn::Mutable { block, .. } => {
                 let block_range: BlockRange = (*block..).into();

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1062,7 +1062,7 @@ impl DeploymentStore {
             // The revert functions want the number of the first block that we need to get rid of
             let block = block + 1;
 
-            let (event, count) = layout.revert_block(&conn, &site.deployment, block)?;
+            let (event, count) = layout.revert_block(&conn, block)?;
 
             // Revert the meta data changes that correspond to this subgraph.
             // Only certain meta data changes need to be reverted, most
@@ -1273,7 +1273,7 @@ impl DeploymentStore {
                 let block_to_revert: BlockNumber = (block.number + 1)
                     .try_into()
                     .expect("block numbers fit into an i32");
-                dst.revert_block(&conn, &dst.site.deployment, block_to_revert)?;
+                dst.revert_block(&conn, block_to_revert)?;
                 info!(logger, "Rewound subgraph to block {}", block.number;
                       "time_ms" => start.elapsed().as_millis());
 

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -732,10 +732,13 @@ impl Layout {
         Ok(count)
     }
 
+    /// Revert the block with number `block` and all blocks with higher
+    /// numbers. After this operation, only entity versions inserted or
+    /// updated at blocks with numbers strictly lower than `block` will
+    /// remain
     pub fn revert_block(
         &self,
         conn: &PgConnection,
-        subgraph_id: &DeploymentHash,
         block: BlockNumber,
     ) -> Result<(StoreEvent, i32), StoreError> {
         let mut changes: Vec<EntityChange> = Vec::new();
@@ -770,13 +773,13 @@ impl Layout {
                 .into_iter()
                 .filter(|id| !unclamped.contains(id))
                 .map(|_| EntityChange::Data {
-                    subgraph_id: subgraph_id.clone(),
+                    subgraph_id: self.site.deployment.clone(),
                     entity_type: table.object.clone(),
                 });
             changes.extend(deleted);
             // EntityChange for versions that we just updated or inserted
             let set = unclamped.into_iter().map(|_| EntityChange::Data {
-                subgraph_id: subgraph_id.clone(),
+                subgraph_id: self.site.deployment.clone(),
                 entity_type: table.object.clone(),
             });
             changes.extend(set);

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1488,6 +1488,8 @@ impl LayoutCache {
 
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
+
     use super::*;
 
     use crate::layout_for_tests::make_dummy_site;
@@ -1531,25 +1533,37 @@ mod tests {
 
     #[test]
     fn generate_ddl() {
+        // Check that the two strings are the same after replacing runs of
+        // whitespace with a single space
+        #[track_caller]
+        fn check_eqv(left: &str, right: &str) {
+            let left_s = left.split_whitespace().join(" ");
+            let right_s = right.split_whitespace().join(" ");
+            if left_s != right_s {
+                // Make sure the original strings show up in the error message
+                assert_eq!(left, right);
+            }
+        }
+
         let layout = test_layout(THING_GQL);
         let sql = layout.as_ddl().expect("Failed to generate DDL");
-        assert_eq!(THING_DDL, sql);
+        check_eqv(THING_DDL, &sql);
 
         let layout = test_layout(MUSIC_GQL);
         let sql = layout.as_ddl().expect("Failed to generate DDL");
-        assert_eq!(MUSIC_DDL, sql);
+        check_eqv(MUSIC_DDL, &sql);
 
         let layout = test_layout(FOREST_GQL);
         let sql = layout.as_ddl().expect("Failed to generate DDL");
-        assert_eq!(FOREST_DDL, sql);
+        check_eqv(FOREST_DDL, &sql);
 
         let layout = test_layout(FULLTEXT_GQL);
         let sql = layout.as_ddl().expect("Failed to generate DDL");
-        assert_eq!(FULLTEXT_DDL, sql);
+        check_eqv(FULLTEXT_DDL, &sql);
 
         let layout = test_layout(FORWARD_ENUM_GQL);
         let sql = layout.as_ddl().expect("Failed to generate DDL");
-        assert_eq!(FORWARD_ENUM_SQL, sql);
+        check_eqv(FORWARD_ENUM_SQL, &sql);
     }
 
     #[test]

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -698,7 +698,7 @@ impl Layout {
             .collect();
 
         let section = stopwatch.start_section("update_modification_clamp_range_query");
-        ClampRangeQuery::new(table, &entity_type, &entity_keys, block).execute(conn)?;
+        ClampRangeQuery::new(table, &entity_keys, block).execute(conn)?;
         section.end();
 
         let _section = stopwatch.start_section("update_modification_insert_query");
@@ -727,7 +727,7 @@ impl Layout {
         let _section = stopwatch.start_section("delete_modification_clamp_range_query");
         let mut count = 0;
         for chunk in entity_ids.chunks(DELETE_OPERATION_CHUNK_SIZE) {
-            count += ClampRangeQuery::new(table, &entity_type, chunk, block).execute(conn)?
+            count += ClampRangeQuery::new(table, chunk, block).execute(conn)?
         }
         Ok(count)
     }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1370,7 +1370,7 @@ impl<'a> QueryFragment<Pg> for InsertQuery<'a> {
                 }
                 out.push_sql(", ");
             }
-            self.br_column.value(&mut out)?;
+            self.br_column.literal_value(&mut out)?;
             out.push_sql(")");
 
             // finalize line according to remaining entities to insert
@@ -2009,7 +2009,7 @@ impl<'a> FilterCollection<'a> {
 
 /// Convenience to pass the name of the column to order by around. If `name`
 /// is `None`, the sort key should be ignored
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum SortKey<'a> {
     None,
     /// Order by `id asc`

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1370,7 +1370,7 @@ impl<'a> QueryFragment<Pg> for InsertQuery<'a> {
                 }
                 out.push_sql(", ");
             }
-            self.br_column.literal_value(&mut out)?;
+            self.br_column.literal_range_current(&mut out)?;
             out.push_sql(")");
 
             // finalize line according to remaining entities to insert

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -175,7 +175,7 @@ lazy_static! {
 }
 
 /// Removes test data from the database behind the store.
-fn remove_test_data(conn: &PgConnection) {
+fn remove_schema(conn: &PgConnection) {
     let query = format!("drop schema if exists {} cascade", NAMESPACE.as_str());
     conn.batch_execute(&query)
         .expect("Failed to drop test schema");
@@ -380,7 +380,7 @@ fn insert_pets(conn: &PgConnection, layout: &Layout) {
     insert_pet(conn, layout, "Cat", "garfield", "Garfield");
 }
 
-fn insert_test_data(conn: &PgConnection) -> Layout {
+fn create_schema(conn: &PgConnection) -> Layout {
     let schema = Schema::parse(THINGS_GQL, THINGS_SUBGRAPH_ID.clone()).unwrap();
     let site = make_dummy_site(
         THINGS_SUBGRAPH_ID.clone(),
@@ -441,10 +441,10 @@ where
 {
     run_test_with_conn(|conn| {
         // Reset state before starting
-        remove_test_data(conn);
+        remove_schema(conn);
 
-        // Seed database with test data
-        let layout = insert_test_data(conn);
+        // Create the database schema
+        let layout = create_schema(conn);
 
         // Run test
         test(conn, &layout);


### PR DESCRIPTION
A lot of entities are immutable, e.g., data that is copied directly from chain data into the subgraph such as transfers, but our store architecture assumed it was mutable, and subgraph authors had no way to indicate that a certain type is immutable.

With this PR, it is now possible to do that by declaring the type with `type Thing @entity(immutable: true) { .. }`. That is the only change needed to take advantage of this feature.

The storage for such types is much simpler and faster than the storage for mutable types since it avoids using GiST indexes which are expensive to maintain and slower to query than the BTree indexes we can use with immutable entities. The real-life impact of this improvement still needs to be measured in a controlled environment, but subgraph authors should be encouraged to take advantage of this feature whenever possible.