### PR TITLE
chain/near: added dynamic data source support

### DIFF
--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -25,7 +25,7 @@ use graph::{
     },
 };
 
-use graph::data::subgraph::{calls_host_fn, DataSourceContext, Source};
+use graph::data::subgraph::{calls_host_fn, DataSourceContext, EthereumSource};
 
 use crate::chain::Chain;
 use crate::trigger::{EthereumBlockTriggerType, EthereumTrigger, MappingTrigger};
@@ -41,7 +41,7 @@ pub struct DataSource {
     pub kind: String,
     pub network: Option<String>,
     pub name: String,
-    pub source: Source,
+    pub source: EthereumSource,
     pub mapping: Mapping,
     pub context: Arc<Option<DataSourceContext>>,
     pub creation_block: Option<BlockNumber>,
@@ -119,7 +119,8 @@ impl blockchain::DataSource<Chain> for DataSource {
     fn as_stored_dynamic_data_source(&self) -> StoredDynamicDataSource {
         StoredDynamicDataSource {
             name: self.name.to_owned(),
-            source: self.source.clone(),
+            source: Some(self.source.clone()),
+            near_source: None,
             context: self
                 .context
                 .as_ref()
@@ -136,6 +137,7 @@ impl blockchain::DataSource<Chain> for DataSource {
         let StoredDynamicDataSource {
             name,
             source,
+            near_source: _,
             context,
             creation_block,
         } = stored;
@@ -152,7 +154,7 @@ impl blockchain::DataSource<Chain> for DataSource {
             kind: template.kind.to_string(),
             network: template.network.as_ref().map(|s| s.to_string()),
             name,
-            source,
+            source: source.expect("ethereum source must be set here"),
             mapping: template.mapping.clone(),
             context: Arc::new(context),
             creation_block,
@@ -215,7 +217,7 @@ impl DataSource {
         kind: String,
         network: Option<String>,
         name: String,
-        source: Source,
+        source: EthereumSource,
         mapping: Mapping,
         context: Option<DataSourceContext>,
     ) -> Result<Self, Error> {
@@ -684,7 +686,7 @@ pub struct UnresolvedDataSource {
     pub kind: String,
     pub network: Option<String>,
     pub name: String,
-    pub source: Source,
+    pub source: EthereumSource,
     pub mapping: UnresolvedMapping,
     pub context: Option<DataSourceContext>,
 }
@@ -751,7 +753,7 @@ impl TryFrom<DataSourceTemplateInfo<Chain>> for DataSource {
             kind: template.kind,
             network: template.network,
             name: template.name,
-            source: Source {
+            source: EthereumSource {
                 address: Some(address),
                 abi: template.source.abi,
                 start_block: 0,

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -19,8 +19,8 @@ use web3::types::{Address, H256};
 use crate::blockchain::{Block, Blockchain};
 use crate::components::server::index_node::VersionInfo;
 use crate::components::transaction_receipt;
-use crate::data::subgraph::status;
-use crate::data::{store::*, subgraph::Source};
+use crate::data::store::*;
+use crate::data::subgraph::{status, EthereumSource, NearSource};
 use crate::prelude::*;
 use crate::util::lfu_cache::LfuCache;
 use crate::{
@@ -853,7 +853,8 @@ impl From<std::fmt::Error> for StoreError {
 
 pub struct StoredDynamicDataSource {
     pub name: String,
-    pub source: Source,
+    pub source: Option<EthereumSource>,
+    pub near_source: Option<NearSource>,
     pub context: Option<String>,
     pub creation_block: Option<BlockNumber>,
 }

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -413,7 +413,14 @@ impl UnresolvedSchema {
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Deserialize)]
-pub struct Source {
+pub struct NearSource {
+    pub account: String,
+    #[serde(rename = "startBlock", default)]
+    pub start_block: BlockNumber,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Deserialize)]
+pub struct EthereumSource {
     /// The contract address for the data source. We allow data sources
     /// without an address for 'wildcard' triggers that catch all possible
     /// events with the given `abi`

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -116,7 +116,7 @@ pub fn mock_data_source(path: &str, api_version: Version) -> DataSource {
         kind: String::from("ethereum/contract"),
         name: String::from("example data source"),
         network: Some(String::from("mainnet")),
-        source: Source {
+        source: EthereumSource {
             address: Some(Address::from_str("0123123123012312312301231231230123123123").unwrap()),
             abi: String::from("123123"),
             start_block: 0,


### PR DESCRIPTION
#### WIP

This cannot be merged as-is. While doing the work, I realized that how data source are stored (via `StoredDynamicDataSource) and queried is still chain specific and tied to Ethereum.

Some thinking and discussions will be required to decide what will be the best approach to make them chain agnostic and how we are going to have this properly handle backward compatibility for existing stored dynamic data source.

Right now in this PR, I "hijack" the current format and I'm able to make NEAR dynamic data source works.

