### PR TITLE
instance_manager: Clear entity cache when subgraph errors/starts

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -523,6 +523,12 @@ where
     loop {
         debug!(logger, "Starting or restarting subgraph");
 
+        // Clear entity cache when subgraph starts.
+        //
+        // This is done to be safe and sure that there's no state that's
+        // out of sync from the database.
+        ctx.state.entity_lfu_cache = LfuCache::new();
+
         let block_stream_canceler = CancelGuard::new();
         let block_stream_cancel_handle = block_stream_canceler.handle();
 
@@ -732,6 +738,12 @@ where
 
                 // Handle unexpected stream errors by marking the subgraph as failed.
                 Err(e) => {
+                    // Clear entity cache when a subgraph fails.
+                    //
+                    // This is done to be safe and sure that there's no state that's
+                    // out of sync from the database.
+                    ctx.state.entity_lfu_cache = LfuCache::new();
+
                     deployment_failed.set(1.0);
 
                     let message = format!("{:#}", e).replace("\n", "\t");


### PR DESCRIPTION
When [POI for failed subgraphs](https://github.com/graphprotocol/graph-node/pull/2748) got introduced, [it added a condition](https://github.com/graphprotocol/graph-node/commit/5ede5efa1309e4b7c7126e0e8637370dd3bddb42#diff-8fa50af0e3a188e9a051db274063ed209f669b71c01bc7ae47f1e40f290cff08R914) in the instance manager that filters entity changes that will be transacted to the database.

Because of this (and other changes that might get introduced in the future), we should clear the entity cache so that it's safe to assume it's on sync with the database.