### PR TITLE
graphql: refactor and prefer static GraphQL where possible

### DIFF
--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -25,7 +25,6 @@ pub enum APISchemaError {
 }
 
 const BLOCK_HEIGHT: &str = "Block_height";
-
 const ERROR_POLICY_TYPE: &str = "_SubgraphErrorPolicy_";
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -82,10 +81,6 @@ pub fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
 
     // Refactor: Don't clone the schema.
     let mut schema = input_schema.clone();
-    add_directives(&mut schema);
-    add_builtin_scalar_types(&mut schema)?;
-    add_order_direction_enum(&mut schema);
-    add_block_height_type(&mut schema);
     add_meta_field_type(&mut schema);
     add_types_for_object_types(&mut schema, &object_types)?;
     add_types_for_interface_types(&mut schema, &interface_types)?;
@@ -103,144 +98,6 @@ pub fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
     });
 
     Ok(schema)
-}
-
-/// Adds built-in GraphQL scalar types (`Int`, `String` etc.) to the schema.
-fn add_builtin_scalar_types(schema: &mut Document) -> Result<(), APISchemaError> {
-    for name in [
-        "Boolean",
-        "ID",
-        "Int",
-        "BigDecimal",
-        "String",
-        "Bytes",
-        "BigInt",
-    ]
-    .iter()
-    {
-        match schema.get_named_type(name) {
-            None => {
-                let typedef = TypeDefinition::Scalar(ScalarType {
-                    position: Pos::default(),
-                    description: None,
-                    name: name.to_string(),
-                    directives: vec![],
-                });
-                let def = Definition::TypeDefinition(typedef);
-                schema.definitions.push(def);
-            }
-            Some(_) => return Err(APISchemaError::TypeExists(name.to_string())),
-        }
-    }
-    Ok(())
-}
-
-/// Add directive definitions for our custom directives
-fn add_directives(schema: &mut Document) {
-    let entity = Definition::DirectiveDefinition(DirectiveDefinition {
-        position: Pos::default(),
-        description: None,
-        name: "entity".to_owned(),
-        arguments: vec![],
-        locations: vec![DirectiveLocation::Object],
-        repeatable: false,
-    });
-
-    let derived_from = Definition::DirectiveDefinition(DirectiveDefinition {
-        position: Pos::default(),
-        description: None,
-        name: "derivedFrom".to_owned(),
-        arguments: vec![InputValue {
-            position: Pos::default(),
-            description: None,
-            name: "field".to_owned(),
-            value_type: Type::NamedType("String".to_owned()),
-            default_value: None,
-            directives: vec![],
-        }],
-        locations: vec![DirectiveLocation::FieldDefinition],
-        repeatable: false,
-    });
-
-    let subgraph_id = Definition::DirectiveDefinition(DirectiveDefinition {
-        position: Pos::default(),
-        description: None,
-        name: "subgraphId".to_owned(),
-        arguments: vec![InputValue {
-            position: Pos::default(),
-            description: None,
-            name: "id".to_owned(),
-            value_type: Type::NamedType("String".to_owned()),
-            default_value: None,
-            directives: vec![],
-        }],
-        locations: vec![DirectiveLocation::Object],
-        repeatable: false,
-    });
-
-    schema.definitions.push(entity);
-    schema.definitions.push(derived_from);
-    schema.definitions.push(subgraph_id);
-}
-
-/// Adds a global `OrderDirection` type to the schema.
-fn add_order_direction_enum(schema: &mut Document) {
-    let typedef = TypeDefinition::Enum(EnumType {
-        position: Pos::default(),
-        description: None,
-        name: "OrderDirection".to_string(),
-        directives: vec![],
-        values: ["asc", "desc"]
-            .iter()
-            .map(|name| EnumValue {
-                position: Pos::default(),
-                description: None,
-                name: name.to_string(),
-                directives: vec![],
-            })
-            .collect(),
-    });
-    let def = Definition::TypeDefinition(typedef);
-    schema.definitions.push(def);
-}
-
-/// Adds a global `Block_height` type to the schema. The `block` argument
-/// accepts values of this type
-fn add_block_height_type(schema: &mut Document) {
-    let typedef = TypeDefinition::InputObject(InputObjectType {
-        position: Pos::default(),
-        description: None,
-        name: BLOCK_HEIGHT.to_string(),
-        directives: vec![],
-        fields: vec![
-            InputValue {
-                position: Pos::default(),
-                description: None,
-                name: "hash".to_owned(),
-                value_type: Type::NamedType("Bytes".to_owned()),
-                default_value: None,
-                directives: vec![],
-            },
-            InputValue {
-                position: Pos::default(),
-                description: None,
-                name: "number".to_owned(),
-                value_type: Type::NamedType("Int".to_owned()),
-                default_value: None,
-                directives: vec![],
-            },
-            InputValue {
-                position: Pos::default(),
-                description: None,
-                name: "number_gte".to_owned(),
-                value_type: Type::NamedType("Int".to_owned()),
-                default_value: None,
-                directives: vec![],
-            },
-        ],
-    });
-    let def = Definition::TypeDefinition(typedef);
-    schema.definitions.push(def);
 }
 
 /// Adds a global `_Meta_` type to the schema. The `_meta` field

--- a/graphql/src/schema/meta.graphql
+++ b/graphql/src/schema/meta.graphql
@@ -1,5 +1,27 @@
+# GraphQL core functionality
+scalar Boolean
+scalar ID
+scalar Int
+scalar Float
+scalar String
+
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+# The Graph extensions
+
+"Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive."
+directive @entity on OBJECT
+
+"Defined a Subgraph ID for an object type"
+directive @subgraphId(id: String!) on OBJECT
+
+"creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API."
+directive @derivedFrom(field: String!) on FIELD_DEFINITION
+
+scalar BigDecimal
+scalar Bytes
+scalar BigInt
 
 # The type names are purposely awkward to minimize the risk of them
 # colliding with user-supplied types
@@ -31,4 +53,25 @@ enum _SubgraphErrorPolicy_ {
 
   "If the subgraph has indexing errors, data will be omitted. The default."
   deny
+}
+
+"The block at which the query should be executed."
+input Block_height {
+  "Value containing a block hash"
+  hash: Bytes
+  "Value containing a block number"
+  number: Int
+  """
+  Value containing the minimum block number. 
+  In the case of `number_gte`, the query will be executed on the latest block only if
+  the subgraph has progressed to or past the minimum block number.
+  Defaults to the latest block when omitted.
+  """
+  number_gte: Int
+}
+
+"Defines the order direction, either ascending or descending"
+enum OrderDirection {
+  asc
+  desc
 }


### PR DESCRIPTION
Closes https://github.com/graphprotocol/graph-node/issues/3203 

- [x] Move static GraphQL to be in `meta.graphql`
- [x] Added missing `@skip` and `@include` direcrives to the type definitions. 
- [x] Added descriptions to all static type defs. 