### PR TITLE
instance_manager: Add env var for chain head subgraph sync status buffer

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -685,8 +685,17 @@ where
 
             match res {
                 Ok(needs_restart) => {
+                    debug!(
+                        logger,
+                        "Sync status before if";
+                        "synced" => format!("{}", synced),
+                        "block_ptr" => format!("{}", block_ptr),
+                    );
                     // Once synced, no need to try to update the status again.
-                    if !synced && is_deployment_synced(&block_ptr, chain_store.cached_head_ptr()?) {
+                    if !synced
+                        && is_deployment_synced(&block_ptr, chain_store.cached_head_ptr(&logger)?)
+                    {
+                        debug!(logger, "Sync status inside if",);
                         // Updating the sync status is an one way operation.
                         // This state change exists: not synced -> synced
                         // This state change does NOT: synced -> not synced
@@ -698,6 +707,7 @@ where
                         // Stop recording time-to-sync metrics.
                         ctx.block_stream_metrics.stopwatch.disable();
                     }
+                    debug!(logger, "Sync status after if",);
 
                     // Keep trying to unfail subgraph for everytime it advances block(s) until it's
                     // health is not Failed anymore.

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1175,7 +1175,7 @@ pub trait ChainStore: Send + Sync + 'static {
     fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error>;
 
     /// In-memory time cached version of `chain_head_ptr`.
-    fn cached_head_ptr(&self) -> Result<Option<BlockPtr>, Error>;
+    fn cached_head_ptr(&self, logger: &Logger) -> Result<Option<BlockPtr>, Error>;
 
     /// Get the current head block cursor for this chain.
     ///

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -5,6 +5,7 @@ use diesel::sql_types::Text;
 use diesel::{insert_into, update};
 use graph::blockchain::{Block, ChainIdentifier};
 use graph::prelude::web3::types::H256;
+use graph::prelude::{debug, Logger};
 use graph::util::timed_cache::TimedCache;
 use graph::{
     constraint_violation,
@@ -1421,10 +1422,24 @@ impl ChainStoreTrait for ChainStore {
             .map_err(Error::from)
     }
 
-    fn cached_head_ptr(&self) -> Result<Option<BlockPtr>, Error> {
-        match self.block_cache.get("head") {
+    fn cached_head_ptr(&self, logger: &Logger) -> Result<Option<BlockPtr>, Error> {
+        let cached_head = self.block_cache.get("head");
+        debug!(
+            logger,
+            "Sync status cached head";
+            "cached_head" => format!("{:?}", cached_head),
+        );
+        match cached_head {
             Some(head) => Ok(Some(head.as_ref().clone())),
-            None => self.chain_head_ptr(),
+            None => {
+                let head = self.chain_head_ptr();
+                debug!(
+                    logger,
+                    "Sync status head";
+                    "head" => format!("{:?}", head),
+                );
+                head
+            }
         }
     }
 


### PR DESCRIPTION
This buffer is being added because the chain head can advance
when we're checking if a subgraph is synced or not.

