### PR TITLE
Add transaction hash to trigger logs

### DIFF
--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -562,6 +562,7 @@ impl DataSource {
                 let logging_extras = Arc::new(o! {
                     "signature" => event_handler.event.to_string(),
                     "address" => format!("{}", &log.address),
+                    "transaction" => format!("{}", &transaction.hash),
                 });
                 Ok(Some(TriggerWithHandler::new_with_logging_extras(
                     MappingTrigger::Log {
@@ -662,6 +663,7 @@ impl DataSource {
                 let logging_extras = Arc::new(o! {
                     "function" => handler.function.to_string(),
                     "to" => format!("{}", &call.to),
+                    "transaction" => format!("{}", &transaction.hash),
                 });
                 Ok(Some(TriggerWithHandler::new_with_logging_extras(
                     MappingTrigger::Call {


### PR DESCRIPTION
Adds transaction hash information in log messages when processing triggers.