### PR TITLE
minor optimization: Return early if there are no transaction hashes

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1664,6 +1664,11 @@ async fn filter_call_triggers_from_unsuccessful_transactions(
             "failed to obtain transaction hash from call triggers"
         ))?;
 
+    // Return early if there are no transaction hashes
+    if transaction_hashes.is_empty() {
+        return Ok(block);
+    }
+
     // And obtain all Transaction values for the calls in this block.
     let transactions: Vec<&Transaction> = {
         match &block.block {

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1690,11 +1690,6 @@ async fn filter_call_triggers_from_unsuccessful_transactions(
         bail!("failed to find transactions in block for the given call triggers")
     }
 
-    // Return early if there are no transactions to inspect
-    if transactions.is_empty() {
-        return Ok(block);
-    }
-
     // We'll also need the receipts for those transactions. In this step we collect all receipts
     // we have in store for the current block.
     let mut receipts = chain_store


### PR DESCRIPTION
This early return prevents an unecessary iteration over the block transactions, where each would be checked for containment against an empty vector.