### PR TITLE
node: make terminating slash in fork-base optional

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -615,14 +615,25 @@ async fn main() {
         Ok(node) => node,
     };
 
-    let fork_base = match opt.fork_base {
-        Some(url) => match Url::parse(&url) {
-            Err(e) => {
-                eprintln!("invalid fork base URL: {}", e);
-                std::process::exit(1);
+    let fork_base = match &opt.fork_base {
+        Some(url) => {
+            // Make sure the endpoint ends with a terminating slash.
+            let url = if !url.ends_with("/") {
+                let mut url = url.clone();
+                url.push('/');
+                Url::parse(&url)
+            } else {
+                Url::parse(url)
+            };
+
+            match url {
+                Err(e) => {
+                    eprintln!("invalid fork base URL: {}", e);
+                    std::process::exit(1);
+                }
+                Ok(url) => Some(url),
             }
-            Ok(url) => Some(url),
-        },
+        }
         None => None,
     };
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -132,7 +132,18 @@ async fn main() {
 
     // Obtain the fork base URL
     let fork_base = match &opt.fork_base {
-        Some(url) => Some(Url::parse(url).expect("Failed to parse the fork base URL")),
+        Some(url) => {
+            // Make sure the endpoint ends with a terminating slash.
+            let url = if !url.ends_with("/") {
+                let mut url = url.clone();
+                url.push('/');
+                Url::parse(&url)
+            } else {
+                Url::parse(url)
+            };
+
+            Some(url.expect("Failed to parse the fork base URL"))
+        }
         None => {
             warn!(
                 logger,

--- a/store/postgres/src/fork.rs
+++ b/store/postgres/src/fork.rs
@@ -33,7 +33,7 @@ struct Variables {
 
 /// SubgraphFork represents a simple subgraph forking mechanism
 /// which lazily fetches entities from a remote subgraph's store
-/// associated with a GraphQL endpoint at `fork_url`.
+/// associated with a GraphQL `endpoint`.
 ///
 /// Since this mechanism is used for debug forks, entities are
 /// fetched only once per id in order to avoid fetching an entity


### PR DESCRIPTION
A small PR to make the ending slash for the fork-base URL optional. (It simply adds it if it's not there.)