### PR TITLE
Fix skip block pointer update

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -233,6 +233,7 @@ where
 
                 if block.trigger_count() == 0
                     && skip_ptr_updates_timer.elapsed() <= SKIP_PTR_UPDATES_THRESHOLD
+                    && !synced
                 {
                     continue;
                 } else {

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -540,7 +540,7 @@ impl EntityChange {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 /// The store emits `StoreEvents` to indicate that some entities have changed.
 /// For block-related data, at most one `StoreEvent` is emitted for each block
 /// that is processed. The `changes` vector contains the details of what changes

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -540,7 +540,7 @@ impl EntityChange {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 /// The store emits `StoreEvents` to indicate that some entities have changed.
 /// For block-related data, at most one `StoreEvent` is emitted for each block
 /// that is processed. The `changes` vector contains the details of what changes

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -169,12 +169,14 @@ impl WritableStore {
         firehose_cursor: Option<&str>,
     ) -> Result<(), StoreError> {
         self.retry("revert_block_operations", || {
-            let event = self.writable.revert_block_operations(
+            match self.writable.revert_block_operations(
                 self.site.clone(),
                 block_ptr_to.clone(),
                 firehose_cursor.clone(),
-            )?;
-            self.try_send_store_event(event)
+            )? {
+                Some(event) => self.try_send_store_event(event),
+                None => Ok(()),
+            }
         })
     }
 


### PR DESCRIPTION
This PR does two things:

1. Stop skipping blocks if the subgraph is synced
2. Ignore a revert of a block that wasn't processed

It's necessary because of a bug introduced in #3223 

**Edit**: I'm still testing this locally with a subgraph that's close to chain head. (probably with the [debug forking tool](https://thegraph.com/docs/en/developer/subgraph-debug-forking/))