### PR TITLE
Allow using `Bytes` as well as `String`/`ID` for the `id` of entities

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1521,7 +1521,36 @@ impl EntityCache {
     /// with existing data. The entity will be validated against the
     /// subgraph schema, and any errors will result in an `Err` being
     /// returned.
-    pub fn set(&mut self, key: EntityKey, entity: Entity) -> Result<(), anyhow::Error> {
+    pub fn set(&mut self, key: EntityKey, mut entity: Entity) -> Result<(), anyhow::Error> {
+        fn check_id(key: &EntityKey, prev_id: &str) -> Result<(), anyhow::Error> {
+            if prev_id != key.entity_id {
+                return Err(anyhow!(
+                    "Value of {} attribute 'id' conflicts with ID passed to `store.set()`: \
+                {} != {}",
+                    key.entity_type,
+                    prev_id,
+                    key.entity_id,
+                ));
+            } else {
+                return Ok(());
+            }
+        }
+
+        // Set the id if there isn't one yet, and make sure that a
+        // previously set id agrees with the one in the `key`
+        match entity.get("id") {
+            Some(Value::String(s)) => check_id(&key, &s)?,
+            Some(Value::Bytes(b)) => check_id(&key, &b.to_string())?,
+            Some(_) => {
+                // The validation will catch the type mismatch
+                ()
+            }
+            None => {
+                let value = self.store.input_schema().id_value(&key)?;
+                entity.set("id", value);
+            }
+        }
+
         let is_valid = entity
             .validate(&self.store.input_schema().document, &key)
             .is_ok();

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -1551,9 +1551,7 @@ impl EntityCache {
             }
         }
 
-        let is_valid = entity
-            .validate(&self.store.input_schema().document, &key)
-            .is_ok();
+        let is_valid = entity.validate(&self.store.input_schema(), &key).is_ok();
 
         self.entity_op(key.clone(), EntityOp::Update(entity));
 
@@ -1568,7 +1566,7 @@ impl EntityCache {
                     key.entity_id
                 )
             })?;
-            entity.validate(&self.store.input_schema().document, &key)?;
+            entity.validate(&self.store.input_schema(), &key)?;
         }
 
         Ok(())

--- a/graph/src/data/graphql/ext.rs
+++ b/graph/src/data/graphql/ext.rs
@@ -4,10 +4,8 @@ use crate::prelude::s::{
     Definition, Directive, Document, EnumType, Field, InterfaceType, ObjectType, Type,
     TypeDefinition, Value,
 };
-use crate::prelude::ValueType;
 use lazy_static::lazy_static;
 use std::collections::{BTreeMap, HashMap};
-use std::str::FromStr;
 
 lazy_static! {
     static ref ALLOW_NON_DETERMINISTIC_FULLTEXT_SEARCH: bool = if cfg!(debug_assertions) {
@@ -64,8 +62,6 @@ pub trait DocumentExt {
     fn object_or_interface(&self, name: &str) -> Option<ObjectOrInterface<'_>>;
 
     fn get_named_type(&self, name: &str) -> Option<&TypeDefinition>;
-
-    fn scalar_value_type(&self, field_type: &Type) -> ValueType;
 
     /// Return `true` if the type does not allow selection of child fields.
     ///
@@ -206,25 +202,6 @@ impl DocumentExt for Document {
                 TypeDefinition::Scalar(t) => &t.name == name,
                 TypeDefinition::Union(t) => &t.name == name,
             })
-    }
-
-    fn scalar_value_type(&self, field_type: &Type) -> ValueType {
-        use TypeDefinition as t;
-        match field_type {
-            Type::NamedType(name) => {
-                ValueType::from_str(&name).unwrap_or_else(|_| match self.get_named_type(name) {
-                    Some(t::Object(_)) | Some(t::Interface(_)) | Some(t::Enum(_)) => {
-                        ValueType::String
-                    }
-                    Some(t::Scalar(_)) => unreachable!("user-defined scalars are not used"),
-                    Some(t::Union(_)) => unreachable!("unions are not used"),
-                    Some(t::InputObject(_)) => unreachable!("inputObjects are not used"),
-                    None => unreachable!("names of field types have been validated"),
-                })
-            }
-            Type::NonNullType(inner) => self.scalar_value_type(inner),
-            Type::ListType(inner) => self.scalar_value_type(inner),
-        }
     }
 
     fn is_leaf_type(&self, field_type: &Type) -> bool {

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -613,11 +613,17 @@ impl Schema {
             .get_base_type();
 
         match base_type {
-            "String" => Ok(store::Value::String(key.entity_id.clone())),
+            "ID" | "String" => Ok(store::Value::String(key.entity_id.clone())),
             "Bytes" => Ok(store::Value::Bytes(scalar::Bytes::from_str(
                 &key.entity_id,
             )?)),
-            _ => todo!(),
+            s => {
+                return Err(anyhow!(
+                    "Entity type {} uses illegal type {} for id column",
+                    key.entity_type,
+                    s
+                ))
+            }
         }
     }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     components::store::{DeploymentLocator, EntityType},
-    prelude::{anyhow::Context, q, r, s, CacheWeight, EntityKey, QueryExecutionError},
+    data::graphql::ObjectTypeExt,
+    prelude::{anyhow::Context, q, r, s, CacheWeight, EntityKey, QueryExecutionError, Schema},
     runtime::gas::{Gas, GasSizeOf},
 };
 use crate::{data::subgraph::DeploymentHash, prelude::EntityChange};
@@ -605,14 +606,58 @@ impl Entity {
     /// Validate that this entity matches the object type definition in the
     /// schema. An entity that passes these checks can be stored
     /// successfully in the subgraph's database schema
-    pub fn validate(&self, schema: &s::Document, key: &EntityKey) -> Result<(), anyhow::Error> {
+    pub fn validate(&self, schema: &Schema, key: &EntityKey) -> Result<(), anyhow::Error> {
+        fn scalar_value_type(schema: &Schema, field_type: &s::Type) -> ValueType {
+            use s::TypeDefinition as t;
+            match field_type {
+                s::Type::NamedType(name) => ValueType::from_str(&name).unwrap_or_else(|_| {
+                    match schema.document.get_named_type(name) {
+                        Some(t::Object(obj_type)) => {
+                            let id = obj_type.field("id").expect("all object types have an id");
+                            scalar_value_type(schema, &id.field_type)
+                        }
+                        Some(t::Interface(intf)) => {
+                            // Validation checks that all implementors of an
+                            // interface use the same type for `id`. It is
+                            // therefore enough to use the id type of one of
+                            // the implementors
+                            match schema
+                                .types_for_interface()
+                                .get(&EntityType::new(intf.name.clone()))
+                                .expect("interface type names are known")
+                                .first()
+                            {
+                                None => {
+                                    // Nothing is implementing this interface; we assume it's of type string
+                                    // see also: id-type-for-unimplemented-interfaces
+                                    ValueType::String
+                                }
+                                Some(obj_type) => {
+                                    let id =
+                                        obj_type.field("id").expect("all object types have an id");
+                                    scalar_value_type(schema, &id.field_type)
+                                }
+                            }
+                        }
+                        Some(t::Enum(_)) => ValueType::String,
+                        Some(t::Scalar(_)) => unreachable!("user-defined scalars are not used"),
+                        Some(t::Union(_)) => unreachable!("unions are not used"),
+                        Some(t::InputObject(_)) => unreachable!("inputObjects are not used"),
+                        None => unreachable!("names of field types have been validated"),
+                    }
+                }),
+                s::Type::NonNullType(inner) => scalar_value_type(schema, inner),
+                s::Type::ListType(inner) => scalar_value_type(schema, inner),
+            }
+        }
+
         if key.entity_type.is_poi() {
             // Users can't modify Poi entities, and therefore they do not
             // need to be validated. In addition, the schema has no object
             // type for them, and validation would therefore fail
             return Ok(());
         }
-        let object_type_definitions = schema.get_object_type_definitions();
+        let object_type_definitions = schema.document.get_object_type_definitions();
         let object_type = object_type_definitions
             .iter()
             .find(|object_type| key.entity_type.as_str() == &object_type.name)
@@ -627,7 +672,7 @@ impl Entity {
             let is_derived = field.is_derived();
             match (self.get(&field.name), is_derived) {
                 (Some(value), false) => {
-                    let scalar_type = schema.scalar_value_type(&field.field_type);
+                    let scalar_type = scalar_value_type(schema, &field.field_type);
                     if field.field_type.is_list() {
                         // Check for inhomgeneous lists to produce a better
                         // error message for them; other problems, like
@@ -815,7 +860,7 @@ fn entity_validation() {
             id.to_owned(),
         );
 
-        let err = thing.validate(&schema.document, &key);
+        let err = thing.validate(&schema, &key);
         if errmsg == "" {
             assert!(
                 err.is_ok(),

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -564,11 +564,15 @@ impl Entity {
         v
     }
 
-    /// Try to get this entity's ID
+    /// Return the ID of this entity. If the ID is a string, return the
+    /// string. If it is `Bytes`, return it as a hex string with a `0x`
+    /// prefix. If the ID is not set or anything but a `String` or `Bytes`,
+    /// return an error
     pub fn id(&self) -> Result<String, Error> {
         match self.get("id") {
             None => Err(anyhow!("Entity is missing an `id` attribute")),
             Some(Value::String(s)) => Ok(s.to_owned()),
+            Some(Value::Bytes(b)) => Ok(b.to_string()),
             _ => Err(anyhow!("Entity has non-string `id` attribute")),
         }
     }

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -425,7 +425,7 @@ fn entity_validation() {
             id.to_owned(),
         );
 
-        let err = thing.validate(&schema.document, &key);
+        let err = thing.validate(&schema, &key);
         if errmsg == "" {
             assert!(
                 err.is_ok(),

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -133,7 +133,7 @@ impl<C: Blockchain> HostExports<C> {
         proof_of_indexing: &SharedProofOfIndexing,
         entity_type: String,
         entity_id: String,
-        mut data: HashMap<String, Value>,
+        data: HashMap<String, Value>,
         stopwatch: &StopwatchMetrics,
         gas: &GasCounter,
     ) -> Result<(), anyhow::Error> {
@@ -150,22 +150,6 @@ impl<C: Blockchain> HostExports<C> {
         );
         poi_section.end();
 
-        let id_insert_section = stopwatch.start_section("host_export_store_set__insert_id");
-        // Automatically add an "id" value
-        match data.insert("id".to_string(), Value::String(entity_id.clone())) {
-            Some(ref v) if v != &Value::String(entity_id.clone()) => {
-                return Err(anyhow!(
-                    "Value of {} attribute 'id' conflicts with ID passed to `store.set()`: \
-                     {} != {}",
-                    entity_type,
-                    v,
-                    entity_id,
-                ));
-            }
-            _ => (),
-        }
-
-        id_insert_section.end();
         let validation_section = stopwatch.start_section("host_export_store_set");
         let key = EntityKey {
             subgraph_id: self.subgraph_id.clone(),

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -291,6 +291,7 @@ impl Layout {
                     } else {
                         // For interfaces that are not implemented at all, pretend
                         // they have a String `id` field
+                        // see also: id-type-for-unimplemented-interfaces
                         let id_type = types.iter().next().cloned().unwrap_or(IdType::String);
                         Ok((interface.to_owned(), id_type))
                     }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -367,8 +367,9 @@ pub trait FromColumnValue: Sized {
             (j::String(s), ColumnType::String) | (j::String(s), ColumnType::Enum(_)) => {
                 Ok(Self::from_string(s))
             }
-            (j::String(s), ColumnType::Bytes) => Self::from_bytes(s.trim_start_matches("\\x")),
-            (j::String(s), ColumnType::BytesId) => Ok(Self::from_string(bytes_as_str(&s))),
+            (j::String(s), ColumnType::Bytes) | (j::String(s), ColumnType::BytesId) => {
+                Self::from_bytes(s.trim_start_matches("\\x"))
+            }
             (j::String(s), column_type) => Err(StoreError::Unknown(anyhow!(
                 "can not convert string {} to {:?}",
                 s,

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -1,10 +1,12 @@
 //! Test relational schemas that use `Bytes` to store ids
 use diesel::connection::SimpleConnection as _;
 use diesel::pg::PgConnection;
+use graph::data::store::scalar;
 use graph_mock::MockMetricsRegistry;
 use hex_literal::hex;
 use lazy_static::lazy_static;
 use std::borrow::Cow;
+use std::str::FromStr;
 use std::{collections::BTreeMap, sync::Arc};
 
 use graph::prelude::{
@@ -63,7 +65,7 @@ lazy_static! {
         "977c084229c72a0fa377cae304eda9099b6a2cb5d83b25cdf0f0969b69874255"
     ));
     static ref BEEF_ENTITY: Entity = entity! {
-        id: "deadbeef",
+        id: scalar::Bytes::from_str("deadbeef").unwrap(),
         name: "Beef",
         __typename: "Thing"
     };
@@ -247,9 +249,9 @@ fn find() {
 #[test]
 fn find_many() {
     run_test(|conn, layout| {
-        const ID: &str = "deadbeef";
+        const ID: &str = "0xdeadbeef";
         const NAME: &str = "Beef";
-        const ID2: &str = "deadbeef02";
+        const ID2: &str = "0xdeadbeef02";
         const NAME2: &str = "Moo";
         insert_thing(&conn, &layout, ID, NAME);
         insert_thing(&conn, &layout, ID2, NAME2);
@@ -343,11 +345,11 @@ fn delete() {
 //
 // Test Layout::query to check that query generation is syntactically sound
 //
-const ROOT: &str = "dead00";
-const CHILD1: &str = "babe01";
-const CHILD2: &str = "babe02";
-const GRANDCHILD1: &str = "fafa01";
-const GRANDCHILD2: &str = "fafa02";
+const ROOT: &str = "0xdead00";
+const CHILD1: &str = "0xbabe01";
+const CHILD2: &str = "0xbabe02";
+const GRANDCHILD1: &str = "0xfafa01";
+const GRANDCHILD2: &str = "0xfafa02";
 
 /// Create a set of test data that forms a tree through the `parent` and `children` attributes.
 /// The tree has this form:


### PR DESCRIPTION
This PR makes it possible to declare entities with an `id` type of `Bytes`; building on previous support that was committed a long time ago, with this PR, the `Bytes` are not converted to a string before handing them to mappings. Instead, such entities show up in the mappings with a bytes value for their ID. Companion PR's for `graph-ts` and `graph-cli` will make that more usable.

An example of what it takes to convert a subgraph to all `Bytes` ids can be found [here](https://github.com/lutter/uniswap-v2-subgraph/tree/bytes)