### PR TITLE
GraphQL route for dumping entity changes in subgraph and block

### DIFF
--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -988,6 +988,12 @@ pub trait SubgraphStore: Send + Sync + 'static {
     /// subgraph has any deployments attached to it
     fn subgraph_exists(&self, name: &SubgraphName) -> Result<bool, StoreError>;
 
+    fn changed_entities_in_block(
+        &self,
+        subgraph_id: &DeploymentHash,
+        block_number: BlockNumber,
+    ) -> Result<BTreeMap<EntityType, Entity>, StoreError>;
+
     /// Return the GraphQL schema supplied by the user
     fn input_schema(&self, subgraph_id: &DeploymentHash) -> Result<Arc<Schema>, StoreError>;
 

--- a/graph/src/components/store.rs
+++ b/graph/src/components/store.rs
@@ -996,7 +996,7 @@ pub trait SubgraphStore: Send + Sync + 'static {
         &self,
         subgraph_id: &DeploymentHash,
         block_number: BlockNumber,
-    ) -> Result<Vec<EntityModification<EntityType>>, StoreError>;
+    ) -> Result<Vec<EntityOperation>, StoreError>;
 
     /// Return the GraphQL schema supplied by the user
     fn input_schema(&self, subgraph_id: &DeploymentHash) -> Result<Arc<Schema>, StoreError>;
@@ -1354,13 +1354,13 @@ pub trait StatusStore: Send + Sync + 'static {
 /// `EntityOperation`, we already know whether a `Set` should be an `Insert`
 /// or `Update`
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum EntityModification<K = EntityKey> {
+pub enum EntityModification {
     /// Insert the entity
-    Insert { key: K, data: Entity },
+    Insert { key: EntityKey, data: Entity },
     /// Update the entity by overwriting it
-    Overwrite { key: K, data: Entity },
+    Overwrite { key: EntityKey, data: Entity },
     /// Remove the entity
-    Remove { key: K },
+    Remove { key: EntityKey },
 }
 
 impl EntityModification {

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -215,6 +215,7 @@ impl Value {
             ("Bytes", Value::String(s)) => Ok(Value::String(s)),
             ("BigInt", Value::String(s)) => Ok(Value::String(s)),
             ("BigInt", Value::Int(n)) => Ok(Value::String(n.to_string())),
+            ("JSONObject", Value::Object(obj)) => Ok(Value::Object(obj)),
             (_, v) => Err(v),
         }
     }

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -372,22 +372,14 @@ fn entity_changes_to_graphql(entity_changes: Vec<EntityOperation>) -> r::Value {
                 let fields = data
                     .sorted()
                     .into_iter()
-                    .map(|(name, value)| {
-                        let json = serde_json::to_string(&value)
-                            .expect("Can't serialize entity data to JSON.");
-
-                        let mut map = BTreeMap::new();
-                        map.insert("field".to_string(), r::Value::String(name));
-                        map.insert("valueAsJSON".to_string(), r::Value::String(json));
-                        r::Value::object(map)
-                    })
+                    .map(|(name, value)| (name, value.into()))
                     .collect();
                 let graphql_object = r::Value::object(BTreeMap::from([
                     (
                         "entityType".to_string(),
                         r::Value::String(key.entity_type.to_string()),
                     ),
-                    ("fields".to_string(), r::Value::List(fields)),
+                    ("fields".to_string(), r::Value::Object(fields)),
                 ]));
 
                 updates.push(graphql_object);

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -384,35 +384,33 @@ fn entity_changes_to_graphql(entity_changes: Vec<EntityOperation>) -> r::Value {
 
     for (entity_type, entities) in updates {
         updates_graphql.push(object! {
-            type: r::Value::String(entity_type.to_string()),
+            type: entity_type.to_string(),
             entities:
-                r::Value::List(
-                    entities
-                        .into_iter()
-                        .map(|e| {
-                            r::Value::object(
-                                e.sorted()
-                                    .into_iter()
-                                    .map(|(name, value)| (name, value.into()))
-                                    .collect(),
-                            )
-                        })
-                        .collect(),
-                ),
+                entities
+                    .into_iter()
+                    .map(|e| {
+                        r::Value::object(
+                            e.sorted()
+                                .into_iter()
+                                .map(|(name, value)| (name, value.into()))
+                                .collect(),
+                        )
+                    })
+                    .collect::<Vec<r::Value>>(),
         });
     }
 
     for (entity_type, ids) in deletions {
         deletions_graphql.push(object! {
-            type: r::Value::String(entity_type.to_string()),
+            type: entity_type.to_string(),
             entities:
-                r::Value::List(ids.into_iter().map(r::Value::String).collect()),
+                ids.into_iter().map(r::Value::String).collect::<Vec<r::Value>>(),
         });
     }
 
     object! {
-        updates:r::Value::List(updates_graphql),
-        deletions:r::Value::List(deletions_graphql),
+        updates: updates_graphql,
+        deletions: deletions_graphql,
     }
 }
 

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -384,7 +384,7 @@ fn entity_changes_to_graphql(entity_changes: Vec<EntityModification<EntityType>>
                     })
                     .collect();
                 let graphql_object = r::Value::object(BTreeMap::from([
-                    ("name".to_string(), r::Value::String(key.to_string())),
+                    ("entityType".to_string(), r::Value::String(key.to_string())),
                     ("fields".to_string(), r::Value::List(fields)),
                 ]));
 

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -61,13 +61,18 @@ type EthereumIndexingStatus implements ChainIndexingStatus {
 }
 
 type EntityChanges {
-  updates: [EntityData!]!
-  deletes: [String!]!
+  updates: [EntityTypeUpdates!]!
+  deletions: [EntityTypeDeletions!]!
 }
 
-type EntityData {
-  entityType: String!
-  fields: JSONObject!
+type EntityTypeUpdates {
+  type: String!
+  entities: [JSONObject!]!
+}
+
+type EntityTypeDeletions {
+  type: String!
+  entities: [ID!]!
 }
 
 type Block {

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -20,7 +20,6 @@ type Query {
     indexer: Bytes
   ): Bytes
   subgraphFeatures(subgraphId: String!): SubgraphFeatures!
-  subgraph(subgraphId: String!): SubgraphFeatures!
   entityChangesInBlock(subgraphId: String!, blockNumber: Int!): EntityChanges!
 }
 

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -18,6 +18,10 @@ type Query {
     blockHash: Bytes!
     indexer: Bytes
   ): Bytes
+  entitiesChangedInBlock(
+    subgraphName: String!
+    blockNumber: Int!
+  ): [EntityData!]!
   subgraphFeatures(subgraphId: String!): SubgraphFeatures!
 }
 
@@ -57,6 +61,11 @@ type EthereumIndexingStatus implements ChainIndexingStatus {
   lastHealthyBlock: Block
 }
 
+type EntityData {
+  name: String!
+  fields: [String!]!
+}
+
 type Block {
   hash: Bytes!
   number: BigInt!
@@ -82,7 +91,6 @@ enum Health {
   failed
 }
 
-
 type SubgraphFeatures {
   features: [Feature!]!
   errors: [String!]!
@@ -90,8 +98,8 @@ type SubgraphFeatures {
 }
 
 enum Feature {
-  nonFatalErrors,
-  grafting,
-  fullTextSearch,
-  ipfsOnEthereumContracts,
+  nonFatalErrors
+  grafting
+  fullTextSearch
+  ipfsOnEthereumContracts
 }

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -65,7 +65,7 @@ type EntityChanges {
 }
 
 type EntityData {
-  name: String!
+  entityType: String!
   fields: [EntityField!]!
 }
 

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -4,6 +4,7 @@ scalar Bytes
 scalar ID
 scalar Int
 scalar String
+scalar JSONObject
 
 type Query {
   indexingStatusForCurrentVersion(subgraphName: String!): SubgraphIndexingStatus
@@ -66,12 +67,7 @@ type EntityChanges {
 
 type EntityData {
   entityType: String!
-  fields: [EntityField!]!
-}
-
-type EntityField {
-  field: String!
-  valueAsJSON: String!
+  fields: JSONObject!
 }
 
 type Block {

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -18,11 +18,9 @@ type Query {
     blockHash: Bytes!
     indexer: Bytes
   ): Bytes
-  entitiesChangedInBlock(
-    subgraphName: String!
-    blockNumber: Int!
-  ): [EntityData!]!
   subgraphFeatures(subgraphId: String!): SubgraphFeatures!
+  subgraph(subgraphId: String!): SubgraphFeatures!
+  entityChangesInBlock(subgraphId: String!, blockNumber: Int!): EntityChanges!
 }
 
 type SubgraphIndexingStatus {
@@ -61,9 +59,19 @@ type EthereumIndexingStatus implements ChainIndexingStatus {
   lastHealthyBlock: Block
 }
 
+type EntityChanges {
+  updates: [EntityData!]!
+  deletes: [String!]!
+}
+
 type EntityData {
   name: String!
-  fields: [String!]!
+  fields: [EntityField!]!
+}
+
+type EntityField {
+  field: String!
+  valueAsJSON: String!
 }
 
 type Block {

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -125,10 +125,6 @@ impl<'a> QueryFragment<Pg> for BlockRangeUpperBoundClause<'a> {
         out.push_identifier(BLOCK_RANGE_COLUMN)?;
         out.push_sql("), 2147483647) = ");
         out.push_bind_param::<Integer, _>(&self.block)?;
-        out.push_sql(" and lower(");
-        out.push_identifier(BLOCK_RANGE_COLUMN)?;
-        out.push_sql(") !=");
-        out.push_bind_param::<Integer, _>(&self.block)?;
 
         Ok(())
     }

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -93,24 +93,41 @@ impl ToSql<Range<Integer>, Pg> for BlockRange {
 }
 
 #[derive(Constructor)]
-pub struct BlockBoundsMatchClause<'a> {
-    table_prefix: &'a str,
+pub struct BlockRangeLowerBoundClause<'a> {
+    _table_prefix: &'a str,
     block: BlockNumber,
 }
 
-impl<'a> QueryFragment<Pg> for BlockBoundsMatchClause<'a> {
+impl<'a> QueryFragment<Pg> for BlockRangeLowerBoundClause<'a> {
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
 
         out.push_sql("lower(");
-        out.push_sql(self.table_prefix);
         out.push_identifier(BLOCK_RANGE_COLUMN)?;
         out.push_sql(") = ");
         out.push_bind_param::<Integer, _>(&self.block)?;
-        out.push_sql(" or upper(");
-        out.push_sql(self.table_prefix);
+
+        Ok(())
+    }
+}
+
+#[derive(Constructor)]
+pub struct BlockRangeUpperBoundClause<'a> {
+    _table_prefix: &'a str,
+    block: BlockNumber,
+}
+
+impl<'a> QueryFragment<Pg> for BlockRangeUpperBoundClause<'a> {
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+
+        out.push_sql("coalesce(upper(");
         out.push_identifier(BLOCK_RANGE_COLUMN)?;
-        out.push_sql(") = ");
+        out.push_sql("), 2147483647) = ");
+        out.push_bind_param::<Integer, _>(&self.block)?;
+        out.push_sql(" and lower(");
+        out.push_identifier(BLOCK_RANGE_COLUMN)?;
+        out.push_sql(") !=");
         out.push_bind_param::<Integer, _>(&self.block)?;
 
         Ok(())

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -7,7 +7,8 @@ use diesel::r2d2::{ConnectionManager, PooledConnection};
 use graph::components::store::{EntityType, StoredDynamicDataSource};
 use graph::data::subgraph::status;
 use graph::prelude::{
-    tokio, CancelHandle, CancelToken, CancelableError, PoolWaitStats, SubgraphDeploymentEntity,
+    tokio, CancelHandle, CancelToken, CancelableError, EntityOperation, PoolWaitStats,
+    SubgraphDeploymentEntity,
 };
 use lru_time_cache::LruCache;
 use rand::{seq::SliceRandom, thread_rng};
@@ -935,7 +936,7 @@ impl DeploymentStore {
         &self,
         site: Arc<Site>,
         block: BlockNumber,
-    ) -> Result<Vec<EntityModification<EntityType>>, StoreError> {
+    ) -> Result<Vec<EntityOperation>, StoreError> {
         let conn = self.get_conn()?;
         let layout = self.layout(&conn, site)?;
         let changes = layout.find_changes(&conn, block)?;

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -935,7 +935,7 @@ impl DeploymentStore {
         &self,
         site: Arc<Site>,
         block: BlockNumber,
-    ) -> Result<BTreeMap<EntityType, Entity>, StoreError> {
+    ) -> Result<Vec<EntityModification<EntityType>>, StoreError> {
         let conn = self.get_conn()?;
         let layout = self.layout(&conn, site)?;
         let changes = layout.find_changes(&conn, block)?;

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -931,6 +931,18 @@ impl DeploymentStore {
         layout.find_many(&conn, ids_for_type, BLOCK_NUMBER_MAX)
     }
 
+    pub(crate) fn get_changes(
+        &self,
+        site: Arc<Site>,
+        block: BlockNumber,
+    ) -> Result<BTreeMap<EntityType, Entity>, StoreError> {
+        let conn = self.get_conn()?;
+        let layout = self.layout(&conn, site)?;
+        let changes = layout.find_changes(&conn, block)?;
+
+        Ok(changes)
+    }
+
     // Only used by tests
     #[cfg(debug_assertions)]
     pub(crate) fn find(

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1275,14 +1275,19 @@ impl<'a, Conn> RunQueryDsl<Conn> for FindChangesQuery<'a> {}
 /// Builds a query over a given set of [`Table`]s in an attempt to find deleted
 /// entities; i.e. such that the block range's lower bound is equal to said
 /// block number.
+///
+/// Please note that the result set from this query is *not* definitive. This
+/// query is intented to be used together with [`FindChangesQuery`]; by
+/// combining the results it's possible to see which entities were *actually*
+/// deleted and which ones were just updated.
 #[derive(Debug, Clone, Constructor)]
-pub struct FindDeletionsQuery<'a> {
+pub struct FindPossibleDeletionsQuery<'a> {
     pub(crate) _namespace: &'a Namespace,
     pub(crate) tables: &'a [&'a Table],
     pub(crate) block: BlockNumber,
 }
 
-impl<'a> QueryFragment<Pg> for FindDeletionsQuery<'a> {
+impl<'a> QueryFragment<Pg> for FindPossibleDeletionsQuery<'a> {
     fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
 
@@ -1303,19 +1308,19 @@ impl<'a> QueryFragment<Pg> for FindDeletionsQuery<'a> {
     }
 }
 
-impl<'a> QueryId for FindDeletionsQuery<'a> {
+impl<'a> QueryId for FindPossibleDeletionsQuery<'a> {
     type QueryId = ();
 
     const HAS_STATIC_QUERY_ID: bool = false;
 }
 
-impl<'a> LoadQuery<PgConnection, EntityDeletion> for FindDeletionsQuery<'a> {
+impl<'a> LoadQuery<PgConnection, EntityDeletion> for FindPossibleDeletionsQuery<'a> {
     fn internal_load(self, conn: &PgConnection) -> QueryResult<Vec<EntityDeletion>> {
         conn.query_by_name(&self)
     }
 }
 
-impl<'a, Conn> RunQueryDsl<Conn> for FindDeletionsQuery<'a> {}
+impl<'a, Conn> RunQueryDsl<Conn> for FindPossibleDeletionsQuery<'a> {}
 
 #[derive(Debug, Clone, Constructor)]
 pub struct FindManyQuery<'a> {

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -16,7 +16,7 @@ use graph::{
     components::{
         server::index_node::VersionInfo,
         store::{
-            self, DeploymentLocator, EnsLookup as EnsLookupTrait, EntityType, SubgraphFork,
+            self, DeploymentLocator, EnsLookup as EnsLookupTrait, SubgraphFork,
             WritableStore as WritableStoreTrait,
         },
     },
@@ -27,9 +27,8 @@ use graph::{
     prelude::SubgraphDeploymentEntity,
     prelude::{
         anyhow, futures03::future::join_all, lazy_static, o, web3::types::Address, ApiSchema,
-        BlockNumber, BlockPtr, DeploymentHash, EntityModification, Logger, NodeId, Schema,
-        StoreError, SubgraphName, SubgraphStore as SubgraphStoreTrait,
-        SubgraphVersionSwitchingMode,
+        BlockNumber, BlockPtr, DeploymentHash, EntityOperation, Logger, NodeId, Schema, StoreError,
+        SubgraphName, SubgraphStore as SubgraphStoreTrait, SubgraphVersionSwitchingMode,
     },
     url::Url,
     util::timed_cache::TimedCache,
@@ -1084,7 +1083,7 @@ impl SubgraphStoreTrait for SubgraphStore {
         &self,
         subgraph_id: &DeploymentHash,
         block: BlockNumber,
-    ) -> Result<Vec<EntityModification<EntityType>>, StoreError> {
+    ) -> Result<Vec<EntityOperation>, StoreError> {
         let (store, site) = self.store(subgraph_id)?;
         let changes = store.get_changes(site, block)?;
         Ok(changes)

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -5,7 +5,7 @@ use diesel::{
     types::{FromSql, ToSql},
 };
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     sync::{Arc, Mutex},
 };
 use std::{fmt, io::Write};
@@ -23,13 +23,14 @@ use graph::{
     constraint_violation,
     data::query::QueryTarget,
     data::subgraph::status,
+    prelude::StoreEvent,
     prelude::SubgraphDeploymentEntity,
     prelude::{
         anyhow, futures03::future::join_all, lazy_static, o, web3::types::Address, ApiSchema,
-        BlockNumber, BlockPtr, DeploymentHash, Logger, NodeId, Schema, StoreError, SubgraphName,
-        SubgraphStore as SubgraphStoreTrait, SubgraphVersionSwitchingMode,
+        BlockNumber, BlockPtr, DeploymentHash, EntityModification, Logger, NodeId, Schema,
+        StoreError, SubgraphName, SubgraphStore as SubgraphStoreTrait,
+        SubgraphVersionSwitchingMode,
     },
-    prelude::{Entity, StoreEvent},
     url::Url,
     util::timed_cache::TimedCache,
 };
@@ -1079,11 +1080,11 @@ impl SubgraphStoreTrait for SubgraphStore {
         self.mirror.subgraph_exists(name)
     }
 
-    fn changed_entities_in_block(
+    fn entity_changes_in_block(
         &self,
         subgraph_id: &DeploymentHash,
         block: BlockNumber,
-    ) -> Result<BTreeMap<EntityType, Entity>, StoreError> {
+    ) -> Result<Vec<EntityModification<EntityType>>, StoreError> {
         let (store, site) = self.store(subgraph_id)?;
         let changes = store.get_changes(site, block)?;
         Ok(changes)


### PR DESCRIPTION
Closes https://github.com/graphprotocol/graph-node/issues/3274.

The GraphQL API implemented here looks like the following (a bit different from #3274's first draft; after collecting feedback):

```graphql
type Query {
  entityChangesInBlock(subgraphId: String!, blockNumber: Int!): EntityChanges!
}

type EntityChanges {
  updates: [EntityData!]!
  deletes: [String!]!
}

type EntityData {
  name: String!
  fields: [EntityField!]!
}

type EntityField {
  field: String!
  valueAsJSON: String!
}
```