### PR TITLE
runtime: Improve error message for error initing AS global

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -425,7 +425,8 @@ where
                                     .unwrap()
                                     .remove(&self.inputs.deployment.id);
 
-                                error!(logger, "Subgraph failed with non-deterministic error: {}", e;
+                                let message = format!("{:#}", e).replace("\n", "\t");
+                                error!(logger, "Subgraph failed with non-deterministic error: {}", message;
                                     "attempt" => backoff.attempt,
                                     "retry_delay_s" => backoff.delay().as_secs());
 


### PR DESCRIPTION
Previously such errors in the WASM start function would generate a `"WASM runtime thread terminated abnormally"` with newlines in it, making it impossible to search for in logging tools. Now it properly bubbles up.