### PR TITLE
core, metrics: observe processing time only for processed triggers

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -331,10 +331,10 @@ pub enum BlockFinality {
 }
 
 impl BlockFinality {
-    pub(crate) fn light_block(&self) -> Arc<LightEthereumBlock> {
+    pub(crate) fn light_block(&self) -> &Arc<LightEthereumBlock> {
         match self {
-            BlockFinality::Final(block) => block.cheap_clone(),
-            BlockFinality::NonFinal(block) => block.ethereum_block.block.cheap_clone(),
+            BlockFinality::Final(block) => block,
+            BlockFinality::NonFinal(block) => &block.ethereum_block.block,
         }
     }
 }

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -60,7 +60,7 @@ impl blockchain::DataSource<Chain> for DataSource {
     fn match_and_decode(
         &self,
         trigger: &<Chain as Blockchain>::TriggerData,
-        block: Arc<<Chain as Blockchain>::Block>,
+        block: &Arc<<Chain as Blockchain>::Block>,
         logger: &Logger,
     ) -> Result<Option<TriggerWithHandler<Chain>>, Error> {
         let block = block.light_block();
@@ -447,7 +447,7 @@ impl DataSource {
     fn match_and_decode(
         &self,
         trigger: &EthereumTrigger,
-        block: Arc<LightEthereumBlock>,
+        block: &Arc<LightEthereumBlock>,
         logger: &Logger,
     ) -> Result<Option<TriggerWithHandler<Chain>>, Error> {
         if !self.matches_trigger_address(&trigger) {
@@ -465,7 +465,9 @@ impl DataSource {
                     None => return Ok(None),
                 };
                 Ok(Some(TriggerWithHandler::new(
-                    MappingTrigger::Block { block },
+                    MappingTrigger::Block {
+                        block: block.cheap_clone(),
+                    },
                     handler.handler,
                 )))
             }
@@ -566,7 +568,7 @@ impl DataSource {
                 });
                 Ok(Some(TriggerWithHandler::new_with_logging_extras(
                     MappingTrigger::Log {
-                        block,
+                        block: block.cheap_clone(),
                         transaction: Arc::new(transaction),
                         log: log.cheap_clone(),
                         params,
@@ -667,7 +669,7 @@ impl DataSource {
                 });
                 Ok(Some(TriggerWithHandler::new_with_logging_extras(
                     MappingTrigger::Call {
-                        block,
+                        block: block.cheap_clone(),
                         transaction,
                         call: call.cheap_clone(),
                         inputs,

--- a/chain/near/src/data_source.rs
+++ b/chain/near/src/data_source.rs
@@ -43,7 +43,7 @@ impl blockchain::DataSource<Chain> for DataSource {
     fn match_and_decode(
         &self,
         trigger: &<Chain as Blockchain>::TriggerData,
-        block: Arc<<Chain as Blockchain>::Block>,
+        block: &Arc<<Chain as Blockchain>::Block>,
         _logger: &Logger,
     ) -> Result<Option<TriggerWithHandler<Chain>>, Error> {
         if self.source.start_block > block.number() {

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -91,7 +91,7 @@ impl<C: Blockchain> DataSource<C> for MockDataSource {
     fn match_and_decode(
         &self,
         _trigger: &C::TriggerData,
-        _block: std::sync::Arc<C::Block>,
+        _block: &std::sync::Arc<C::Block>,
         _logger: &slog::Logger,
     ) -> Result<Option<TriggerWithHandler<C>>, anyhow::Error> {
         todo!()

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -199,10 +199,19 @@ pub trait DataSource<C: Blockchain>:
 
     /// Checks if `trigger` matches this data source, and if so decodes it into a `MappingTrigger`.
     /// A return of `Ok(None)` mean the trigger does not match.
+    ///
+    /// Performance note: This is very hot code, because in the worst case it could be called a
+    /// quadratic T*D times where T is the total number of triggers in the chain and D is the number
+    /// of data sources in the subgraph. So it could be called billions, or even trillions, of times
+    /// in the sync time of a subgraph.
+    ///
+    /// This is typicaly reduced by the triggers being pre-filtered in the block stream. But with
+    /// dynamic data sources the block stream does not filter on the dynamic parameters, so the
+    /// matching should efficently discard false positives.
     fn match_and_decode(
         &self,
         trigger: &C::TriggerData,
-        block: Arc<C::Block>,
+        block: &Arc<C::Block>,
         logger: &Logger,
     ) -> Result<Option<TriggerWithHandler<C>>, Error>;
 

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -47,7 +47,7 @@ pub trait RuntimeHost<C: Blockchain>: Send + Sync + 'static {
     fn match_and_decode(
         &self,
         trigger: &C::TriggerData,
-        block: Arc<C::Block>,
+        block: &Arc<C::Block>,
         logger: &Logger,
     ) -> Result<Option<TriggerWithHandler<C>>, Error>;
 

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -222,7 +222,7 @@ impl<C: Blockchain> RuntimeHostTrait<C> for RuntimeHost<C> {
     fn match_and_decode(
         &self,
         trigger: &C::TriggerData,
-        block: Arc<C::Block>,
+        block: &Arc<C::Block>,
         logger: &Logger,
     ) -> Result<Option<TriggerWithHandler<C>>, Error> {
         self.data_source.match_and_decode(trigger, block, logger)


### PR DESCRIPTION
Previously the `deployment_trigger_processing_duration` metric would count triggers that do not match, so it wasn't very useful.

This also adds a note about `match_and_decode` being hot code, and optimizes so we don't have to clone an `Arc` when checking if a trigger matches a data source address. After https://github.com/graphprotocol/graph-node/issues/3257 this will be called much more often when templates are present, so it's good to keep it as efficient as possible by avoiding atomic instructions.