### PR TITLE
Release 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "graph"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-ethereum"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-near"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "base64",
  "diesel",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-tendermint"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "graph",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "graph-core"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "graph-graphql"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1480,14 +1480,14 @@ dependencies = [
 
 [[package]]
 name = "graph-mock"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "graph",
 ]
 
 [[package]]
 name = "graph-node"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "assert_cli",
  "clap",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-derive"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "quote",
  "syn",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-test"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "graph",
  "graph-chain-ethereum",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-wasm"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-http"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "futures 0.1.31",
  "graph",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-index-node"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "blake3",
  "either",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-json-rpc"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "graph",
  "jsonrpc-http-server",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-metrics"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "futures 0.1.31",
  "graph",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-websocket"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "futures 0.1.31",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "graph-store-postgres"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "graph-tests"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "bollard",
@@ -3820,7 +3820,7 @@ dependencies = [
 
 [[package]]
 name = "test-store"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "diesel",
  "graph",

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
 - Pipeline store writes #3084 #3177
-- Allow using Bytes as well as String/ID for the id of entities #3271
 
 ## 0.26.0
 
@@ -11,7 +10,7 @@
 
 - Gas metering #2414
 - Adds support for Solidity Custom Errors #2577
-- Debug fork tool #2995
+- Debug fork tool #2995 #3292
 - Automatically remove unused deployments #3023
 - Fix fulltextsearch space handling #3048
 - Allow placing new deployments onto one of several shards #3049
@@ -22,6 +21,7 @@
 - Skip block updates when triggers are empty #3223 #3268
 - Use new GraphiQL version #3252
 - GraphQL prefetching #3256
+- Allow using Bytes as well as String/ID for the id of entities #3271
 - GraphQL route for dumping entity changes in subgraph and block #3275
 - Firehose filters #3323
 - NEAR filters #3372
@@ -35,15 +35,15 @@
 - Prevent subscriptions from back-pressuring the notification queue #3053
 - Avoid parsing X triggers if the filter is empty #3083
 - Pipeline `BlockStream` #3085
-- More robust proofOfIndexing GraphQL route #3348
+- More robust `proofOfIndexing` GraphQL route #3348
 
 ### `graphman`
 
-- Add `run` command #3079
-- Add `analyze` command #3170
-- Add `index create` command #3175
-- Add `index list` command #3198
-- Add `index drop` command #3198
+- Add `run` command, for running a subgraph up to a block #3079
+- Add `analyze` command, for analyzing a PostgreSQL table, which can improve performance #3170
+- Add `index create` command, for adding an index to certain attributes #3175
+- Add `index list` command, for listing indexes #3198
+- Add `index drop` command, for dropping indexes #3198
 
 ### Dependency Updates
 
@@ -72,6 +72,29 @@ These are the main ones:
 - Increase default reorg threshold to 250 for Ethereum #3308
 - Improve traces error logs #3353
 - Add warning and continue on parse input failures for Ethereum #3326
+
+### Upgrade Notes
+
+When upgrading to this version, we recommend taking a brief look into these changes:
+
+- Gas metering #2414
+  - Now there's a gas limit for subgraph mappings, if the limit is reached the subgraph will fail with a non-deterministic error, you can make them recover via the environment variable `GRAPH_MAX_GAS_PER_HANDLER`
+- Improve our `CacheWeight` estimates #2935
+  - This is relevant because a couple of releases back we've added a limit for the memory size of a query result. That limit is based of the `CacheWeight`.
+
+These are some of the features that will probably be helpful for indexers 😊
+
+- Allow placing new deployments onto one of several shards #3049
+- GraphQL route for dumping entity changes in subgraph and block #3275
+- Unused deployments are automatically removed now #3023
+  - The interval can be set via `GRAPH_REMOVE_UNUSED_INTERVAL`
+- Setup databases in parallel #3019
+- Block ingestor now fetches receipts in parallel #3030
+  - `GRAPH_ETHEREUM_FETCH_TXN_RECEIPTS_IN_BATCHES` can be set to `true` for the old fetching behavior
+- More robust `proofOfIndexing` GraphQL route #3348
+  - A token can be set via `GRAPH_POI_ACCESS_TOKEN` to limit access to the POI route
+- The new `graphman` commands 🙂
+
 
 ## 0.25.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # NEWS
 
-## Unreleased
+## 0.26.0
+
 - Gracefully handle syntax errors on fulltext search. Specifically provides information about common use case
   where whitespace characters were part of the terms.
 - Adds support for Solidity Custom Errors (issue #2577)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,70 @@
 
 - Gracefully handle syntax errors on fulltext search. Specifically provides information about common use case
   where whitespace characters were part of the terms.
-- Adds support for Solidity Custom Errors (issue #2577)
+- Adds support for Solidity Custom Errors #2577
+
+### Features
+
+- Gas metering #2414
+- Debug fork tool #2995
+- Automatically remove unused deployments #3023
+- Allow placing new deployments onto one of several shards #3049
+- Store pipelining #3084
+- Make NEAR update the sync status #3108
+- GraphQL validations #3164
+- Add special treatment for immutable entities #3201
+- Skip block updates when triggers are empty #3223 #3268
+- Use new GraphiQL version #3252
+- GraphQL prefetching #3256
+- Allow using Bytes as well as String/ID for the id of entities #3271
+- GraphQL route for dumping entity changes in subgraph and block #3275
+- Firehose filters #3323
+
+### Robustness
+
+- Improve our `CacheWeight` estimates #2935
+- Refactor GraphQL execution #3005
+- Setup databases in parallel #3019
+- Block ingestor now fetches receipts in parallel #3030
+- Prevent subscriptions from back-pressuring the notification queue #3053
+- Avoid parsing X triggers if the filter is empty #3083
+- Pipeline `BlockStream` #3085
+- Tendermint integration #3212
+
+### `graphman`
+
+- Add `run` command #3079
+- Add `analyze` command #3170
+- Add `index create` command #3175
+- Add `index list` command #3198
+- Add `index drop` command #3198
+
+### Dependency Updates
+
+These are the main ones:
+
+- Updated protobuf to latest version for NEAR #2947
+- Update `web3` crate #2916 #3120 #3338
+- Update `graphql-parser` to `v0.4.0` #3020
+- Bump `itertools` from `0.10.1` to `0.10.3` #3037
+- Bump `clap` from `2.33.3` to `2.34.0` #3039
+- Bump `serde_yaml` from `0.8.21` to `0.8.23` #3065
+- Bump `tokio` from `1.14.0` to `1.15.0` #3092
+- Bump `indexmap` from `1.7.0` to `1.8.0` #3143
+- Update `ethabi` to its latest version #3144
+- Bump `structopt` from `0.3.25` to `0.3.26` #3180
+- Bump `anyhow` from `1.0.45` to `1.0.53` #3182
+- Bump `quote` from `1.0.9` to `1.0.15` #3112 #3183
+- Bump `tokio` from `1.15.0` to `1.16.1` #3208
+- Bump `semver` from `1.0.4` to `1.0.5` #3229
+- Bump `async-stream` from `0.3.2` to `0.3.3` #3361
+- Update `jsonrpc-server` #3313
+
+### Misc
+
+- More context when logging RPC calls #3128
+- Increase default reorg threshold to 250 for Ethereum #3308
+- Improve traces error logs #3353
 
 ## 0.25.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,27 +1,30 @@
 # NEWS
 
-## 0.26.0
+## Unreleased
 
-- Gracefully handle syntax errors on fulltext search. Specifically provides information about common use case
-  where whitespace characters were part of the terms.
-- Adds support for Solidity Custom Errors #2577
+- Pipeline store writes #3084 #3177
+- Allow using Bytes as well as String/ID for the id of entities #3271
+
+## 0.26.0
 
 ### Features
 
 - Gas metering #2414
+- Adds support for Solidity Custom Errors #2577
 - Debug fork tool #2995
 - Automatically remove unused deployments #3023
+- Fix fulltextsearch space handling #3048
 - Allow placing new deployments onto one of several shards #3049
-- Store pipelining #3084
-- Make NEAR update the sync status #3108
+- Make NEAR subgraphs update their sync status #3108
 - GraphQL validations #3164
 - Add special treatment for immutable entities #3201
+- Tendermint integration #3212
 - Skip block updates when triggers are empty #3223 #3268
 - Use new GraphiQL version #3252
 - GraphQL prefetching #3256
-- Allow using Bytes as well as String/ID for the id of entities #3271
 - GraphQL route for dumping entity changes in subgraph and block #3275
 - Firehose filters #3323
+- NEAR filters #3372
 
 ### Robustness
 
@@ -32,7 +35,7 @@
 - Prevent subscriptions from back-pressuring the notification queue #3053
 - Avoid parsing X triggers if the filter is empty #3083
 - Pipeline `BlockStream` #3085
-- Tendermint integration #3212
+- More robust proofOfIndexing GraphQL route #3348
 
 ### `graphman`
 
@@ -57,7 +60,7 @@ These are the main ones:
 - Update `ethabi` to its latest version #3144
 - Bump `structopt` from `0.3.25` to `0.3.26` #3180
 - Bump `anyhow` from `1.0.45` to `1.0.53` #3182
-- Bump `quote` from `1.0.9` to `1.0.15` #3112 #3183
+- Bump `quote` from `1.0.9` to `1.0.16` #3112 #3183 #3384
 - Bump `tokio` from `1.15.0` to `1.16.1` #3208
 - Bump `semver` from `1.0.4` to `1.0.5` #3229
 - Bump `async-stream` from `0.3.2` to `0.3.3` #3361
@@ -68,6 +71,7 @@ These are the main ones:
 - More context when logging RPC calls #3128
 - Increase default reorg threshold to 250 for Ethereum #3308
 - Improve traces error logs #3353
+- Add warning and continue on parse input failures for Ethereum #3326
 
 ## 0.25.2
 

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-ethereum"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/chain/near/Cargo.toml
+++ b/chain/near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-near"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [build-dependencies]

--- a/chain/tendermint/Cargo.toml
+++ b/chain/tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-tendermint"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2018"
 
 [build-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-core"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-graphql"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-mock"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-node"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 default-run = "graph-node"
 

--- a/runtime/derive/Cargo.toml
+++ b/runtime/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-derive"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [lib]

--- a/runtime/test/Cargo.toml
+++ b/runtime/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-test"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-wasm"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-http"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-index-node"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/server/json-rpc/Cargo.toml
+++ b/server/json-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-json-rpc"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/server/metrics/Cargo.toml
+++ b/server/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-metrics"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-websocket"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-store-postgres"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-store"
-version = "0.25.2"
+version = "0.26.0"
 authors = ["Leonardo Yvens <leoyvens@gmail.com>"]
 edition = "2021"
 description = "Provides static store instance for tests."

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-tests"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2021"
 
 [dev-dependencies]


### PR DESCRIPTION
This used `./scripts/update-cargo-version.sh` to update the `Cargo` files.

The commit range we're releasing here is: https://github.com/graphprotocol/graph-node/compare/v0.25.2...ae6951328df4270e3153897220fdef1822055859 (the one that ran on the integration tests/cluster).