### PR TITLE
store: Fix detection of whether a graft is still pending or not

### DIFF
--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -138,7 +138,7 @@ fn graft(
     // The name of the base subgraph, the hash, and block number
     let graft: (Option<String>, Option<Vec<u8>>, Option<BigDecimal>) = if pending_only {
         graft_query
-            .filter(sd::graft_block_number.ge(sql("coalesce(latest_ethereum_block_number, 0)")))
+            .filter(sd::graft_block_number.gt(sql("coalesce(latest_ethereum_block_number, 0)")))
             .first(conn)
             .optional()?
             .unwrap_or((None, None, None))


### PR DESCRIPTION
When we start a subgraph, we determine whether we need to do a graft based
on the subgraph's block pointer: if that is behind the graft point, or not
set at all, we do all the steps needed for grafting. When the graft
finishes successfully, we set the block pointer to the graft point.

The method deployment::graft_pending checked whether the graft point was >=
the block pointer so that we erroneously believed we still had to graft
when we finished grafting, but the subgraph did not progress beyond that
block for some other reason (e.g., because it immediately failed)

We now check whether the graft point is > the block pointer to avoid that
situation.

