### PR TITLE
store: Fix the logic for determining if a graft was pending (again)

### DIFF
--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -138,7 +138,7 @@ fn graft(
     // The name of the base subgraph, the hash, and block number
     let graft: (Option<String>, Option<Vec<u8>>, Option<BigDecimal>) = if pending_only {
         graft_query
-            .filter(sd::graft_block_number.gt(sql("coalesce(latest_ethereum_block_number, 0)")))
+            .filter(sd::latest_ethereum_block_number.is_null())
             .first(conn)
             .optional()?
             .unwrap_or((None, None, None))


### PR DESCRIPTION
The previous version of the code was being too clever: the signal for
whether a graft is pending is whether the subgraph's block ptr is null or
not. The check whether the block ptr had progressed beyond the graft point
was too defensive and made it impossible to graft onto block 0, as well as
breaking a test.

