### PR TITLE
Improve debug forking

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -267,6 +267,7 @@ where
         hash: DeploymentHash,
         node_id: NodeId,
         debug_fork: Option<DeploymentHash>,
+        start_block: Option<BlockPtr>,
     ) -> Result<(), SubgraphRegistrarError> {
         // We don't have a location for the subgraph yet; that will be
         // assigned when we deploy for real. For logging purposes, make up a
@@ -302,6 +303,7 @@ where
                     self.chains.cheap_clone(),
                     name.clone(),
                     hash.cheap_clone(),
+                    start_block,
                     raw,
                     node_id,
                     debug_fork,
@@ -318,6 +320,7 @@ where
                     self.chains.cheap_clone(),
                     name.clone(),
                     hash.cheap_clone(),
+                    start_block,
                     raw,
                     node_id,
                     debug_fork,
@@ -334,6 +337,7 @@ where
                     self.chains.cheap_clone(),
                     name.clone(),
                     hash.cheap_clone(),
+                    start_block,
                     raw,
                     node_id,
                     debug_fork,
@@ -510,6 +514,7 @@ async fn create_subgraph_version<C: Blockchain, S: SubgraphStore, L: LinkResolve
     chains: Arc<BlockchainMap>,
     name: SubgraphName,
     deployment: DeploymentHash,
+    start_block_ptr: Option<BlockPtr>,
     raw: serde_yaml::Mapping,
     node_id: NodeId,
     debug_fork: Option<DeploymentHash>,
@@ -550,8 +555,13 @@ async fn create_subgraph_version<C: Blockchain, S: SubgraphStore, L: LinkResolve
         return Err(SubgraphRegistrarError::NameNotFound(name.to_string()));
     }
 
-    let (start_block, base_block) =
+    let (manifest_start_block, base_block) =
         resolve_subgraph_chain_blocks(&manifest, chain, &logger.clone()).await?;
+
+    let start_block = match start_block_ptr {
+        Some(block) => Some(block),
+        None => manifest_start_block,
+    };
 
     info!(
         logger,

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -32,6 +32,7 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
         hash: DeploymentHash,
         assignment_node_id: NodeId,
         debug_fork: Option<DeploymentHash>,
+        start_block: Option<BlockPtr>,
     ) -> Result<(), SubgraphRegistrarError>;
 
     async fn remove_subgraph(&self, name: SubgraphName) -> Result<(), SubgraphRegistrarError>;

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -425,13 +425,31 @@ async fn main() {
                 .debug_fork
                 .map(DeploymentHash::new)
                 .map(|h| h.expect("Debug fork hash must be a valid IPFS hash"));
+            let start_block = opt
+                .start_block
+                .map(|block| {
+                    let mut split = block.split(":");
+                    (
+                        // BlockHash
+                        split.next().unwrap().to_owned(),
+                        // BlockNumber
+                        split.next().unwrap().parse::<i64>().unwrap(),
+                    )
+                })
+                .map(|(hash, number)| BlockPtr::try_from((hash.as_str(), number)))
+                .map(Result::unwrap);
 
             graph::spawn(
                 async move {
                     subgraph_registrar.create_subgraph(name.clone()).await?;
                     subgraph_registrar
-                        // TODO: Add support for `debug_fork` parameter
-                        .create_subgraph_version(name, subgraph_id, node_id, debug_fork)
+                        .create_subgraph_version(
+                            name,
+                            subgraph_id,
+                            node_id,
+                            debug_fork,
+                            start_block,
+                        )
                         .await
                 }
                 .map_err(|e| panic!("Failed to deploy subgraph from `--subgraph` flag: {}", e)),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -421,13 +421,17 @@ async fn main() {
                 .expect("Subgraph name must contain only a-z, A-Z, 0-9, '-' and '_'");
             let subgraph_id =
                 DeploymentHash::new(hash).expect("Subgraph hash must be a valid IPFS hash");
+            let debug_fork = opt
+                .debug_fork
+                .map(DeploymentHash::new)
+                .map(|h| h.expect("Debug fork hash must be a valid IPFS hash"));
 
             graph::spawn(
                 async move {
                     subgraph_registrar.create_subgraph(name.clone()).await?;
                     subgraph_registrar
                         // TODO: Add support for `debug_fork` parameter
-                        .create_subgraph_version(name, subgraph_id, node_id, None)
+                        .create_subgraph_version(name, subgraph_id, node_id, debug_fork)
                         .await
                 }
                 .map_err(|e| panic!("Failed to deploy subgraph from `--subgraph` flag: {}", e)),

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -180,6 +180,7 @@ pub async fn run(
         subgraph_hash.clone(),
         node_id.clone(),
         None,
+        None,
     )
     .await?;
 

--- a/node/src/opt.rs
+++ b/node/src/opt.rs
@@ -34,6 +34,14 @@ pub struct Opt {
         help = "name and IPFS hash of the subgraph manifest"
     )]
     pub subgraph: Option<String>,
+
+    #[structopt(
+        long,
+        value_name = "BLOCK_HASH:BLOCK_NUMBER",
+        help = "block hash and number that the subgraph passed will start indexing at"
+    )]
+    pub start_block: Option<String>,
+
     #[structopt(
         long,
         value_name = "URL",

--- a/node/src/opt.rs
+++ b/node/src/opt.rs
@@ -196,6 +196,13 @@ pub struct Opt {
     )]
     pub unsafe_config: bool,
 
+    #[structopt(
+        long,
+        value_name = "IPFS_HASH",
+        help = "IPFS hash of the subgraph manifest that you want to fork"
+    )]
+    pub debug_fork: Option<String>,
+
     #[structopt(long, value_name = "URL", help = "Base URL for forking subgraphs")]
     pub fork_base: Option<String>,
 }

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -98,6 +98,9 @@ impl<R: SubgraphRegistrar> JsonRpcServer<R> {
                 params.ipfs_hash.clone(),
                 node_id,
                 params.debug_fork.clone(),
+                // Here it doesn't make sense to receive another
+                // startBlock, we'll use the one from the manifest.
+                None,
             )
             .await
         {


### PR DESCRIPTION
I do accept any suggestions on the CLI API, I'm not sure those parameters should be passed where I've put them (and with those names).

This PR adds:

- `--debug-fork` CLI option
- `--start-block` CLI option

With those you can basically get **any subgraph** from the Hosted Service and debug it at **any block** without having the source code to change the **start block**, which debug forking currently requires ([docs](https://thegraph.com/docs/en/developer/subgraph-debug-forking/)).

Eg (enzyme fork that I've been able to reproduce #3236) :

```
cargo run -p graph-node -- \
          --postgres-url $THEGRAPH_STORE_POSTGRES_DIESEL_URL \
          --ethereum-rpc $ETHEREUM_RPC_URL \
          --subgraph QmTBxvMF6YnbT1eYeRx9XQpH4WvxTV53vdptCCZFiZSprg \
          --ipfs $IPFS_URL \
          --debug-fork QmTBxvMF6YnbT1eYeRx9XQpH4WvxTV53vdptCCZFiZSprg \
          --start-block 0x8e28f0485a3bbcca851d502c2ca1120607b7178bf997ca8a40f4a457b8acb964:14178262 \
          --fork-base $FORK_BASE_URL
```

I know a lot of parameters, that's why I'm not sure if this is the way to go with the API design.

@VIVelev if you can give any suggestions here, thanks a lot your tool is super useful ❤️ 