### PR TITLE
runner: More subgraph ptr logs

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -464,7 +464,7 @@ where
 
         if triggers.len() == 1 {
             debug!(&logger, "1 candidate trigger in this block");
-        } else if triggers.len() > 1 {
+        } else {
             debug!(
                 &logger,
                 "{} candidate triggers in this block",


### PR DESCRIPTION
Right now it can be hard to reconstruct how the subgraph pointer is moving from the logs, because we don't log anything when moving forward if the block had zero relevant triggers.