### PR TITLE
Add non-intrusive Clippy linting to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,29 @@ jobs:
           command: test
           args: --verbose --package graph-tests -- --nocapture
 
+  rustfmt:
+    name: Check rustfmt style
+    strategy:
+      matrix:
+        rust: ["stable"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt
+          override: true
+
+      - name: Check formatting
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: "-D warnings"
+        with:
+          command: fmt
+          args: --all -- --check
+
   clippy:
     name: Report Clippy warnings
     strategy:
@@ -164,29 +187,6 @@ jobs:
         continue-on-error: true
         with:
           command: clippy
-
-  rustfmt:
-    name: Check rustfmt style
-    strategy:
-      matrix:
-        rust: ["stable"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          components: rustfmt
-          override: true
-
-      - name: Check formatting
-        uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: "-D warnings"
-        with:
-          command: fmt
-          args: --all -- --check
 
   release-check:
     name: Build in release mode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,29 @@ jobs:
           command: test
           args: --verbose --package graph-tests -- --nocapture
 
+  clippy:
+    name: Report Clippy warnings
+    strategy:
+      matrix:
+        rust: ["stable"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          components: clippy
+          override: true
+
+      - name: Run Clippy
+        uses: actions-rs/cargo@v1
+        # We do *not* block builds if Clippy complains. It's just here to let us
+        # keep an eye out on the warnings it produces.
+        continue-on-error: true
+        with:
+          command: clippy
+
   rustfmt:
     name: Check rustfmt style
     strategy:
@@ -147,20 +170,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt
           override: true
-      - name: Cache cargo registry
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: rustfmt-cargo-${{ hashFiles('**/Cargo.toml') }}
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libpq-dev
-
-      - name: Check formating
+      - name: Check formatting
         uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "-D warnings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,15 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: clippy
           override: true
+      # Unlike rustfmt, Clippy actually compiles stuff so it benefits from
+      # caching.
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: check-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Run Clippy
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
See discussion in #3304. The CI will *not* break if Clippy complains; that seems way too daunting and unforgiving. We just want to keep an eye out for antipatterns.

I'm also removing caching + dependencies install for `rustfmt` since it doesn't benefit from it.