### PR TITLE
block stream: Cleanup block stream metrics

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -3,14 +3,12 @@ use graph::blockchain::BlockchainKind;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::env::env_var;
 use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints, ForkStep};
-use graph::prelude::{
-    EthereumBlock, EthereumCallCache, LightEthereumBlock, LightEthereumBlockExt, StopwatchMetrics,
-};
+use graph::prelude::{EthereumBlock, EthereumCallCache, LightEthereumBlock, LightEthereumBlockExt};
 use graph::slog::debug;
 use graph::{
     blockchain::{
         block_stream::{
-            BlockStreamEvent, BlockStreamMetrics, BlockWithTriggers, FirehoseError,
+            BlockStreamEvent, BlockWithTriggers, FirehoseError,
             FirehoseMapper as FirehoseMapperTrait, TriggersAdapter as TriggersAdapterTrait,
         },
         firehose_block_stream::FirehoseBlockStream,
@@ -148,7 +146,6 @@ impl Blockchain for Chain {
         loc: &DeploymentLocator,
         capabilities: &Self::NodeCapabilities,
         unified_api_version: UnifiedMappingApiVersion,
-        stopwatch_metrics: StopwatchMetrics,
     ) -> Result<Arc<Self::TriggersAdapter>, Error> {
         let logger = self
             .logger_factory
@@ -175,7 +172,6 @@ impl Blockchain for Chain {
             logger,
             ethrpc_metrics,
             eth_adapter,
-            stopwatch_metrics,
             chain_store: self.chain_store.cheap_clone(),
             unified_api_version,
         };
@@ -189,17 +185,11 @@ impl Blockchain for Chain {
         start_blocks: Vec<BlockNumber>,
         subgraph_current_block: Option<BlockPtr>,
         filter: Arc<Self::TriggerFilter>,
-        metrics: Arc<BlockStreamMetrics>,
         unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Box<dyn BlockStream<Self>>, Error> {
         let requirements = filter.node_capabilities();
         let adapter = self
-            .triggers_adapter(
-                &deployment,
-                &requirements,
-                unified_api_version.clone(),
-                metrics.stopwatch.clone(),
-            )
+            .triggers_adapter(&deployment, &requirements, unified_api_version)
             .expect(&format!(
                 "no adapter for network {} with capabilities {}",
                 self.name, requirements
@@ -237,17 +227,11 @@ impl Blockchain for Chain {
         start_blocks: Vec<BlockNumber>,
         subgraph_current_block: Option<BlockPtr>,
         filter: Arc<Self::TriggerFilter>,
-        metrics: Arc<BlockStreamMetrics>,
         unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Box<dyn BlockStream<Self>>, Error> {
         let requirements = filter.node_capabilities();
         let adapter = self
-            .triggers_adapter(
-                &deployment,
-                &requirements,
-                unified_api_version.clone(),
-                metrics.stopwatch.clone(),
-            )
+            .triggers_adapter(&deployment, &requirements, unified_api_version.clone())
             .expect(&format!(
                 "no adapter for network {} with capabilities {}",
                 self.name, requirements
@@ -282,7 +266,6 @@ impl Blockchain for Chain {
             start_blocks,
             reorg_threshold,
             logger,
-            metrics,
             *MAX_BLOCK_RANGE_SIZE,
             *TARGET_TRIGGERS_PER_BLOCK_RANGE,
             unified_api_version,
@@ -405,7 +388,6 @@ pub struct DummyDataSourceTemplate;
 pub struct TriggersAdapter {
     logger: Logger,
     ethrpc_metrics: Arc<SubgraphEthRpcMetrics>,
-    stopwatch_metrics: StopwatchMetrics,
     chain_store: Arc<dyn ChainStore>,
     eth_adapter: Arc<EthereumAdapter>,
     unified_api_version: UnifiedMappingApiVersion,
@@ -424,7 +406,6 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             self.logger.clone(),
             self.chain_store.clone(),
             self.ethrpc_metrics.clone(),
-            self.stopwatch_metrics.clone(),
             from,
             to,
             filter,
@@ -456,7 +437,6 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
                     logger.clone(),
                     self.chain_store.clone(),
                     self.ethrpc_metrics.clone(),
-                    self.stopwatch_metrics.clone(),
                     block_number,
                     block_number,
                     filter,

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -2,12 +2,12 @@ use graph::blockchain::BlockchainKind;
 use graph::cheap_clone::CheapClone;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints};
-use graph::prelude::{StopwatchMetrics, TryFutureExt};
+use graph::prelude::TryFutureExt;
 use graph::{
     anyhow,
     blockchain::{
         block_stream::{
-            BlockStreamEvent, BlockStreamMetrics, BlockWithTriggers, FirehoseError,
+            BlockStreamEvent, BlockWithTriggers, FirehoseError,
             FirehoseMapper as FirehoseMapperTrait, TriggersAdapter as TriggersAdapterTrait,
         },
         firehose_block_stream::FirehoseBlockStream,
@@ -91,7 +91,6 @@ impl Blockchain for Chain {
         _loc: &DeploymentLocator,
         _capabilities: &Self::NodeCapabilities,
         _unified_api_version: UnifiedMappingApiVersion,
-        _stopwatch_metrics: StopwatchMetrics,
     ) -> Result<Arc<Self::TriggersAdapter>, Error> {
         let adapter = TriggersAdapter {};
         Ok(Arc::new(adapter))
@@ -104,16 +103,10 @@ impl Blockchain for Chain {
         start_blocks: Vec<BlockNumber>,
         subgraph_current_block: Option<BlockPtr>,
         filter: Arc<Self::TriggerFilter>,
-        metrics: Arc<BlockStreamMetrics>,
         unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Box<dyn BlockStream<Self>>, Error> {
         let adapter = self
-            .triggers_adapter(
-                &deployment,
-                &NodeCapabilities {},
-                unified_api_version.clone(),
-                metrics.stopwatch.clone(),
-            )
+            .triggers_adapter(&deployment, &NodeCapabilities {}, unified_api_version)
             .expect(&format!("no adapter for network {}", self.name,));
 
         let firehose_endpoint = match self.firehose_endpoints.random() {
@@ -148,7 +141,6 @@ impl Blockchain for Chain {
         _start_blocks: Vec<BlockNumber>,
         _subgraph_current_block: Option<BlockPtr>,
         _filter: Arc<Self::TriggerFilter>,
-        _metrics: Arc<BlockStreamMetrics>,
         _unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Box<dyn BlockStream<Self>>, Error> {
         panic!("NEAR does not support polling block stream")

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -216,7 +216,7 @@ where
         );
 
         let unified_mapping_api_version = manifest.unified_mapping_api_version()?;
-        let triggers_adapter = chain.triggers_adapter(&deployment, &required_capabilities, unified_mapping_api_version ,stopwatch_metrics.clone()).map_err(|e|
+        let triggers_adapter = chain.triggers_adapter(&deployment, &required_capabilities, unified_mapping_api_version).map_err(|e|
                 anyhow!(
                 "expected triggers adapter that matches deployment {} with required capabilities: {}: {}",
                 &deployment,

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -6,7 +6,7 @@ use crate::subgraph::SubgraphInstance;
 use atomic_refcell::AtomicRefCell;
 use fail::fail_point;
 use graph::blockchain::block_stream::{
-    BlockStream, BlockStreamEvent, BlockStreamMetrics, BlockWithTriggers, BufferedBlockStream,
+    BlockStream, BlockStreamEvent, BlockWithTriggers, BufferedBlockStream,
 };
 use graph::blockchain::{Block, Blockchain, DataSource, TriggerFilter as _, TriggersAdapter};
 use graph::components::store::WritableStore;
@@ -51,7 +51,6 @@ lazy_static! {
 async fn new_block_stream<C: Blockchain>(
     inputs: Arc<IndexingInputs<C>>,
     filter: C::TriggerFilter,
-    block_stream_metrics: Arc<BlockStreamMetrics>,
 ) -> Result<Box<dyn BlockStream<C>>, Error> {
     let chain = inputs.chain.cheap_clone();
     let is_firehose = chain.is_firehose_supported();
@@ -70,7 +69,6 @@ async fn new_block_stream<C: Blockchain>(
             inputs.start_blocks.clone(),
             current_ptr,
             Arc::new(filter.clone()),
-            block_stream_metrics.clone(),
             inputs.unified_api_version.clone(),
         ),
         false => chain.new_polling_block_stream(
@@ -78,7 +76,6 @@ async fn new_block_stream<C: Blockchain>(
             inputs.start_blocks.clone(),
             current_ptr,
             Arc::new(filter.clone()),
-            block_stream_metrics.clone(),
             inputs.unified_api_version.clone(),
         ),
     }
@@ -138,7 +135,7 @@ where
             let metrics = self.ctx.block_stream_metrics.clone();
             let filter = self.ctx.state.filter.clone();
             let stream_inputs = self.inputs.clone();
-            let mut block_stream = new_block_stream(stream_inputs, filter, metrics.cheap_clone())
+            let mut block_stream = new_block_stream(stream_inputs, filter)
                 .await?
                 .map_err(CancelableError::Error)
                 .cancelable(&block_stream_canceler, || Err(CancelableError::Cancel));
@@ -184,6 +181,7 @@ where
                             .block_stream_metrics
                             .reverted_blocks
                             .set(subgraph_ptr.number as f64);
+                        metrics.deployment_head.set(subgraph_ptr.number as f64);
 
                         // Revert the in-memory state:
                         // - Remove hosts for reverted dynamic data sources.
@@ -221,6 +219,7 @@ where
                 };
 
                 let block_ptr = block.ptr();
+                metrics.deployment_head.set(block_ptr.number as f64);
 
                 if block.trigger_count() > 0 {
                     subgraph_metrics

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -290,7 +290,6 @@ impl Blockchain for MockBlockchain {
         _loc: &crate::components::store::DeploymentLocator,
         _capabilities: &Self::NodeCapabilities,
         _unified_api_version: crate::data::subgraph::UnifiedMappingApiVersion,
-        _stopwatch_metrics: crate::components::metrics::stopwatch::StopwatchMetrics,
     ) -> Result<std::sync::Arc<Self::TriggersAdapter>, anyhow::Error> {
         todo!()
     }
@@ -302,7 +301,6 @@ impl Blockchain for MockBlockchain {
         _start_blocks: Vec<crate::components::store::BlockNumber>,
         _subgraph_current_block: Option<BlockPtr>,
         _filter: std::sync::Arc<Self::TriggerFilter>,
-        _metrics: std::sync::Arc<block_stream::BlockStreamMetrics>,
         _unified_api_version: crate::data::subgraph::UnifiedMappingApiVersion,
     ) -> Result<Box<dyn block_stream::BlockStream<Self>>, anyhow::Error> {
         todo!()
@@ -314,7 +312,6 @@ impl Blockchain for MockBlockchain {
         _start_blocks: Vec<crate::components::store::BlockNumber>,
         _subgraph_current_block: Option<BlockPtr>,
         _filter: std::sync::Arc<Self::TriggerFilter>,
-        _metrics: std::sync::Arc<block_stream::BlockStreamMetrics>,
         _unified_api_version: crate::data::subgraph::UnifiedMappingApiVersion,
     ) -> Result<Box<dyn block_stream::BlockStream<Self>>, anyhow::Error> {
         todo!()

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -12,10 +12,7 @@ mod types;
 // Try to reexport most of the necessary types
 use crate::{
     cheap_clone::CheapClone,
-    components::{
-        metrics::stopwatch::StopwatchMetrics,
-        store::{DeploymentLocator, StoredDynamicDataSource},
-    },
+    components::store::{DeploymentLocator, StoredDynamicDataSource},
     data::subgraph::UnifiedMappingApiVersion,
     prelude::DataSourceContext,
     runtime::{gas::GasCounter, AscHeap, AscPtr, DeterministicHostError, HostExportError},
@@ -46,7 +43,7 @@ use web3::types::H256;
 pub use block_stream::{ChainHeadUpdateListener, ChainHeadUpdateStream, TriggersAdapter};
 pub use types::{BlockHash, BlockPtr, ChainIdentifier};
 
-use self::block_stream::{BlockStream, BlockStreamMetrics};
+use self::block_stream::BlockStream;
 
 pub trait Block: Send + Sync {
     fn ptr(&self) -> BlockPtr;
@@ -105,7 +102,6 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
         loc: &DeploymentLocator,
         capabilities: &Self::NodeCapabilities,
         unified_api_version: UnifiedMappingApiVersion,
-        stopwatch_metrics: StopwatchMetrics,
     ) -> Result<Arc<Self::TriggersAdapter>, Error>;
 
     async fn new_firehose_block_stream(
@@ -115,7 +111,6 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
         start_blocks: Vec<BlockNumber>,
         subgraph_current_block: Option<BlockPtr>,
         filter: Arc<Self::TriggerFilter>,
-        metrics: Arc<BlockStreamMetrics>,
         unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Box<dyn BlockStream<Self>>, Error>;
 
@@ -125,7 +120,6 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
         start_blocks: Vec<BlockNumber>,
         subgraph_current_block: Option<BlockPtr>,
         filter: Arc<Self::TriggerFilter>,
-        metrics: Arc<BlockStreamMetrics>,
         unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Box<dyn BlockStream<Self>>, Error>;
 

--- a/graph/src/blockchain/polling_block_stream.rs
+++ b/graph/src/blockchain/polling_block_stream.rs
@@ -8,8 +8,8 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use super::block_stream::{
-    BlockStream, BlockStreamEvent, BlockStreamMetrics, BlockWithTriggers, ChainHeadUpdateStream,
-    FirehoseCursor, TriggersAdapter,
+    BlockStream, BlockStreamEvent, BlockWithTriggers, ChainHeadUpdateStream, FirehoseCursor,
+    TriggersAdapter,
 };
 use super::{Block, BlockPtr, Blockchain};
 
@@ -91,7 +91,6 @@ where
     filter: Arc<C::TriggerFilter>,
     start_blocks: Vec<BlockNumber>,
     logger: Logger,
-    metrics: Arc<BlockStreamMetrics>,
     previous_triggers_per_block: f64,
     // Not a BlockNumber, but the difference between two block numbers
     previous_block_range_size: BlockNumber,
@@ -113,7 +112,6 @@ impl<C: Blockchain> Clone for PollingBlockStreamContext<C> {
             filter: self.filter.clone(),
             start_blocks: self.start_blocks.clone(),
             logger: self.logger.clone(),
-            metrics: self.metrics.clone(),
             previous_triggers_per_block: self.previous_triggers_per_block,
             previous_block_range_size: self.previous_block_range_size,
             max_block_range_size: self.max_block_range_size,
@@ -159,7 +157,6 @@ where
         start_blocks: Vec<BlockNumber>,
         reorg_threshold: BlockNumber,
         logger: Logger,
-        metrics: Arc<BlockStreamMetrics>,
         max_block_range_size: BlockNumber,
         target_triggers_per_block_range: u64,
         unified_api_version: UnifiedMappingApiVersion,
@@ -179,7 +176,6 @@ where
                 logger,
                 filter,
                 start_blocks,
-                metrics,
                 previous_triggers_per_block: STARTING_PREVIOUS_TRIGGERS_PER_BLOCK,
                 previous_block_range_size: 1,
                 max_block_range_size,
@@ -259,8 +255,6 @@ where
             if ptr.number >= head_ptr.number {
                 return Ok(ReconciliationStep::Done);
             }
-
-            self.metrics.deployment_head.set(ptr.number as f64);
         }
 
         // Subgraph ptr is behind head ptr.


### PR DESCRIPTION
Now that the block stream is pipelined, it should not be starting sections concurrently with the runner. This removes the `"filter_call_triggers_from_unsuccessful_transactions"` which was the only one within the block stream. The `deployment_head` metric is moved from the block stream to the runner. This made the metrics dead parameters in many places.

It's likely that we'll want to reintroduce stopwatch metrics in the blockstream, separating the metrics for each stage as done in #3177, but it seems best to remove them now and start from a clean slate when reintroducing them with pipelining and firehose in mind.