### PR TITLE
metrics: Remove redundant store_set section

### DIFF
--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -150,7 +150,6 @@ impl<C: Blockchain> HostExports<C> {
         );
         poi_section.end();
 
-        let validation_section = stopwatch.start_section("host_export_store_set");
         let key = EntityKey {
             subgraph_id: self.subgraph_id.clone(),
             entity_type: EntityType::new(entity_type),
@@ -161,7 +160,6 @@ impl<C: Blockchain> HostExports<C> {
 
         let entity = Entity::from(data);
         state.entity_cache.set(key.clone(), entity)?;
-        validation_section.end();
 
         Ok(())
     }


### PR DESCRIPTION
This is redundant with https://github.com/graphprotocol/graph-node/blob/5d4006f8d9e14d08aa5ee4f91a6f44fa2cb23b9c/runtime/wasm/src/module/mod.rs#L426