### PR TITLE
Add GraphQL route for fetching block data

### DIFF
--- a/graph/src/components/server/index_node.rs
+++ b/graph/src/components/server/index_node.rs
@@ -4,8 +4,8 @@ use futures::prelude::*;
 
 use crate::prelude::{BlockNumber, Schema};
 
+/// This is only needed to support the explorer API.
 #[derive(Debug)]
-/// This is only needed to support the explorer API
 pub struct VersionInfo {
     pub created_at: String,
     pub deployment_id: String,

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -30,6 +30,20 @@ pub trait EnsLookup: Send + Sync + 'static {
     fn find_name(&self, hash: &str) -> Result<Option<String>, StoreError>;
 }
 
+/// An entry point for all operations that require access to the node's storage
+/// layer. It provides access to a [`BlockStore`] and a [`SubgraphStore`].
+pub trait Store: Clone + StatusStore + Send + Sync + 'static {
+    /// The [`BlockStore`] implementor used by this [`Store`].
+    type BlockStore: BlockStore;
+
+    /// The [`SubgraphStore`] implementor used by this [`Store`].
+    type SubgraphStore: SubgraphStore;
+
+    fn block_store(&self) -> Arc<Self::BlockStore>;
+
+    fn subgraph_store(&self) -> Arc<Self::SubgraphStore>;
+}
+
 /// Common trait for store implementations.
 #[async_trait]
 pub trait SubgraphStore: Send + Sync + 'static {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -289,7 +289,8 @@ async fn main() {
             graphql_runner.clone(),
             network_store.clone(),
             link_resolver.clone(),
-            network_store.subgraph_store().clone(),
+            network_store.block_store(),
+            network_store.subgraph_store(),
         );
 
         if !opt.disable_block_ingestor {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -289,8 +289,6 @@ async fn main() {
             graphql_runner.clone(),
             network_store.clone(),
             link_resolver.clone(),
-            network_store.block_store(),
-            network_store.subgraph_store(),
         );
 
         if !opt.disable_block_ingestor {

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -21,6 +21,7 @@ type Query {
   ): Bytes
   subgraphFeatures(subgraphId: String!): SubgraphFeatures!
   entityChangesInBlock(subgraphId: String!, blockNumber: Int!): EntityChanges!
+  blockData(network: String!, blockHash: Bytes!): JSONObject
 }
 
 type SubgraphIndexingStatus {

--- a/server/index-node/src/server.rs
+++ b/server/index-node/src/server.rs
@@ -4,7 +4,7 @@ use hyper::Server;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
 use graph::{
-    components::store::{BlockStore, StatusStore},
+    components::store::Store,
     prelude::{IndexNodeServer as IndexNodeServerTrait, *},
 };
 
@@ -25,24 +25,20 @@ impl From<hyper::Error> for IndexNodeServeError {
 }
 
 /// A GraphQL server based on Hyper.
-pub struct IndexNodeServer<Q, S, R, Bt, St> {
+pub struct IndexNodeServer<Q, S, R> {
     logger: Logger,
     graphql_runner: Arc<Q>,
     store: Arc<S>,
     link_resolver: Arc<R>,
-    block_store: Arc<Bt>,
-    subgraph_store: Arc<St>,
 }
 
-impl<Q, S, R, Bt, St> IndexNodeServer<Q, S, R, Bt, St> {
+impl<Q, S, R> IndexNodeServer<Q, S, R> {
     /// Creates a new GraphQL server.
     pub fn new(
         logger_factory: &LoggerFactory,
         graphql_runner: Arc<Q>,
         store: Arc<S>,
         link_resolver: Arc<R>,
-        block_store: Arc<Bt>,
-        subgraph_store: Arc<St>,
     ) -> Self {
         let logger = logger_factory.component_logger(
             "IndexNodeServer",
@@ -58,19 +54,15 @@ impl<Q, S, R, Bt, St> IndexNodeServer<Q, S, R, Bt, St> {
             graphql_runner,
             store,
             link_resolver,
-            block_store,
-            subgraph_store,
         }
     }
 }
 
-impl<Q, S, R, Bt, St> IndexNodeServerTrait for IndexNodeServer<Q, S, R, Bt, St>
+impl<Q, S, R> IndexNodeServerTrait for IndexNodeServer<Q, S, R>
 where
     Q: GraphQlRunner,
-    S: StatusStore,
+    S: Store,
     R: LinkResolver,
-    Bt: BlockStore,
-    St: SubgraphStore,
 {
     type ServeError = IndexNodeServeError;
 
@@ -97,8 +89,6 @@ where
             graphql_runner.clone(),
             store.clone(),
             self.link_resolver.clone(),
-            self.block_store.clone(),
-            self.subgraph_store.clone(),
         );
         let new_service =
             make_service_fn(move |_| futures03::future::ok::<_, Error>(service.clone()));

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -8,7 +8,10 @@ use std::task::Context;
 use std::task::Poll;
 
 use graph::{components::server::query::GraphQLServerError, data::query::QueryResults};
-use graph::{components::store::StatusStore, prelude::*};
+use graph::{
+    components::store::{BlockStore, StatusStore},
+    prelude::*,
+};
 use graph_graphql::prelude::{execute_query, Query as PreparedQuery, QueryExecutionOptions};
 
 use crate::explorer::Explorer;
@@ -21,16 +24,17 @@ pub type IndexNodeServiceResponse = DynTryFuture<'static, Response<Body>, GraphQ
 
 /// A Hyper Service that serves GraphQL over a POST / endpoint.
 #[derive(Debug)]
-pub struct IndexNodeService<Q, S, R, St> {
+pub struct IndexNodeService<Q, S, R, Bt, St> {
     logger: Logger,
     graphql_runner: Arc<Q>,
     store: Arc<S>,
     explorer: Arc<Explorer<S>>,
     link_resolver: Arc<R>,
+    block_store: Arc<Bt>,
     subgraph_store: Arc<St>,
 }
 
-impl<Q, S, R, St> Clone for IndexNodeService<Q, S, R, St> {
+impl<Q, S, R, Bt, St> Clone for IndexNodeService<Q, S, R, Bt, St> {
     fn clone(&self) -> Self {
         Self {
             logger: self.logger.clone(),
@@ -38,18 +42,20 @@ impl<Q, S, R, St> Clone for IndexNodeService<Q, S, R, St> {
             store: self.store.clone(),
             explorer: self.explorer.clone(),
             link_resolver: self.link_resolver.clone(),
+            block_store: self.block_store.clone(),
             subgraph_store: self.subgraph_store.clone(),
         }
     }
 }
 
-impl<Q, S, R, St> CheapClone for IndexNodeService<Q, S, R, St> {}
+impl<Q, S, R, Bt, St> CheapClone for IndexNodeService<Q, S, R, Bt, St> {}
 
-impl<Q, S, R, St> IndexNodeService<Q, S, R, St>
+impl<Q, S, R, Bt, St> IndexNodeService<Q, S, R, Bt, St>
 where
     Q: GraphQlRunner,
     S: StatusStore,
     R: LinkResolver,
+    Bt: BlockStore,
     St: SubgraphStore,
 {
     /// Creates a new GraphQL service.
@@ -58,6 +64,7 @@ where
         graphql_runner: Arc<Q>,
         store: Arc<S>,
         link_resolver: Arc<R>,
+        block_store: Arc<Bt>,
         subgraph_store: Arc<St>,
     ) -> Self {
         let explorer = Arc::new(Explorer::new(store.clone()));
@@ -68,6 +75,7 @@ where
             store,
             explorer,
             link_resolver,
+            block_store,
             subgraph_store,
         }
     }
@@ -129,6 +137,7 @@ where
                     &logger,
                     store,
                     self.link_resolver.clone(),
+                    self.block_store.clone(),
                     self.subgraph_store.clone(),
                 ),
                 deadline: None,
@@ -226,11 +235,12 @@ where
     }
 }
 
-impl<Q, S, R, St> Service<Request<Body>> for IndexNodeService<Q, S, R, St>
+impl<Q, S, R, Bt, St> Service<Request<Body>> for IndexNodeService<Q, S, R, Bt, St>
 where
     Q: GraphQlRunner,
     S: StatusStore,
     R: LinkResolver,
+    Bt: BlockStore,
     St: SubgraphStore,
 {
     type Response = Response<Body>;

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use graph::{
     components::{
         server::index_node::VersionInfo,
-        store::{BlockStore as BlockStoreTrait, QueryStoreManager, StatusStore},
+        store::{
+            BlockStore as BlockStoreTrait, QueryStoreManager, StatusStore, Store as StoreTrait,
+        },
     },
     constraint_violation,
     data::subgraph::status,
@@ -26,6 +28,7 @@ use crate::{block_store::BlockStore, query_store::QueryStore, SubgraphStore};
 /// Code that needs to access the store should use the traits from
 /// [`graph::components::store`] and only require the smallest traits that are
 /// suitable for their purpose.
+#[derive(Clone)]
 pub struct Store {
     subgraph_store: Arc<SubgraphStore>,
     block_store: Arc<BlockStore>,
@@ -44,6 +47,19 @@ impl Store {
     }
 
     pub fn block_store(&self) -> Arc<BlockStore> {
+        self.block_store.cheap_clone()
+    }
+}
+
+impl StoreTrait for Store {
+    type BlockStore = BlockStore;
+    type SubgraphStore = SubgraphStore;
+
+    fn subgraph_store(&self) -> Arc<Self::SubgraphStore> {
+        self.subgraph_store.cheap_clone()
+    }
+
+    fn block_store(&self) -> Arc<Self::BlockStore> {
         self.block_store.cheap_clone()
     }
 }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -16,15 +16,16 @@ use graph::{
 
 use crate::{block_store::BlockStore, query_store::QueryStore, SubgraphStore};
 
-/// The overall store of the system, consisting of a [SubgraphStore] and a
-/// [BlockStore], each of which multiplex across multiple database shards.
+/// The overall store of the system, consisting of a [`SubgraphStore`] and a
+/// [`BlockStore`], each of which multiplex across multiple database shards.
 /// The `SubgraphStore` is responsible for storing all data and metadata related
 /// to individual subgraphs, and the `BlockStore` does the same for data belonging
 /// to the chains that are being processed.
 ///
 /// This struct should only be used during configuration and setup of `graph-node`.
-/// Code that needs to access the store should use the traits from [graph::components::store]
-/// and only require the smallest traits that are suitable for their purpose
+/// Code that needs to access the store should use the traits from
+/// [`graph::components::store`] and only require the smallest traits that are
+/// suitable for their purpose.
 pub struct Store {
     subgraph_store: Arc<SubgraphStore>,
     block_store: Arc<BlockStore>,


### PR DESCRIPTION
Closes #3311. This is the type signature of the GraphQL route:

```graphql
type Query {
  blockData(network: String!, blockHash: Bytes!): JSONObject
}
```

I'm also introducing a new `Store` trait which maintains separation of concerns between `BlockStore` and `SubgraphStore` while replacing some clutter of generics with associated types within `index-node`.