### PR TITLE
Fix revert and unfailure

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -185,8 +185,20 @@ where
 
                 let (block, cursor) = match event {
                     Some(Ok(BlockStreamEvent::ProcessBlock(block, cursor))) => (block, cursor),
-                    Some(Ok(BlockStreamEvent::Revert(subgraph_ptr, revert_to_ptr, cursor))) => {
-                        info!(&logger, "Reverting block to get back to main chain"; "current" => &subgraph_ptr, "revert_to" => &revert_to_ptr);
+                    // In the case of the PollingBlockStream, the stream_ptr can be ahead of the
+                    // subgraph's deployment head (database), because this component is pipelined.
+                    Some(Ok(BlockStreamEvent::Revert(stream_ptr, revert_to_ptr, cursor))) => {
+                        // Current deployment head in the database / WritableAgent Mutex cache.
+                        //
+                        // Safe unwrap because in a Revert event we're sure the subgraph has
+                        // advanced at least once.
+                        let subgraph_ptr = self.inputs.store.block_ptr().unwrap();
+                        if revert_to_ptr.number >= subgraph_ptr.number {
+                            info!(&logger, "Block to revert is higher than subgraph pointer, nothing to do"; "subgraph_ptr" => &subgraph_ptr, "stream_ptr" => &stream_ptr, "revert_to_ptr" => &revert_to_ptr);
+                            continue;
+                        }
+
+                        info!(&logger, "Reverting block to get back to main chain"; "subgraph_ptr" => &subgraph_ptr, "stream_ptr" => &stream_ptr, "revert_to_ptr" => &revert_to_ptr);
 
                         if let Err(e) = self
                             .inputs

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1135,25 +1135,17 @@ impl DeploymentStore {
         site: Arc<Site>,
         block_ptr_to: BlockPtr,
         firehose_cursor: Option<&str>,
-    ) -> Result<Option<StoreEvent>, StoreError> {
+    ) -> Result<StoreEvent, StoreError> {
         let conn = self.get_conn()?;
         // Unwrap: If we are reverting then the block ptr is not `None`.
         let deployment_head = Self::block_ptr_with_conn(&site.deployment, &conn)?.unwrap();
 
-        // Early return to cover scenario where the BlockStream advanced more than
-        // the deployment head (database). In this case, revert_block_operations shouldn't
-        // do anything, there's nothing to be reverted.
-        if block_ptr_to.number >= deployment_head.number {
-            return Ok(None);
-        }
-
-        // Sanity check on revert to ensure we go backward only
+        // Confidence check on revert to ensure we go backward only
         if block_ptr_to.number >= deployment_head.number {
             panic!("revert_block_operations must revert only backward, you are trying to revert forward going from subgraph block {} to new block {}", deployment_head, block_ptr_to);
         }
 
         self.rewind_with_conn(&conn, site, block_ptr_to, firehose_cursor)
-            .map(|event| Some(event))
     }
 
     pub(crate) async fn deployment_state_from_id(

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -173,14 +173,13 @@ impl WritableStore {
         firehose_cursor: Option<&str>,
     ) -> Result<(), StoreError> {
         self.retry("revert_block_operations", || {
-            match self.writable.revert_block_operations(
+            let event = self.writable.revert_block_operations(
                 self.site.clone(),
                 block_ptr_to.clone(),
                 firehose_cursor.clone(),
-            )? {
-                Some(event) => self.try_send_store_event(event),
-                None => Ok(()),
-            }
+            )?;
+
+            self.try_send_store_event(event)
         })
     }
 


### PR DESCRIPTION
This PR fixes:

- Refactors `BlockStream` revert events to be handled by the `SubgraphRunner` instead of the `Store`;
- Deterministic unfailure, where we would end up erroring in `graph-node` restarts with error `DuplicateBlockProcessing`, that outputs `subgraph `QmHash` has already processed block 11310909; there are most likely two (or more) nodes indexing this subgraph`.