### PR TITLE
ethereum: log warning and continue on parse input failures

### DIFF
--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -614,13 +614,9 @@ impl DataSource {
                       Ok(val) => val,
                       Err(err) => {
                         warn!(logger, "Failed parsing inputs, skipping"; "error" => &err.to_string());
-                        Vec::new()
+                        return Ok(None)
                       },
                     };
-                
-                if tokens.len() == 0 {
-                  return Ok(None)
-                }
 
                 ensure!(
                     tokens.len() == function_abi.inputs.len(),

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -18,7 +18,7 @@ use graph::{
     prelude::{
         async_trait,
         ethabi::{Address, Contract, Event, Function, LogParam, ParamType, RawLog},
-        info, warn, serde_json,
+        info, serde_json, warn,
         web3::types::{Log, Transaction, H256},
         BlockNumber, CheapClone, DataSourceTemplateInfo, Deserialize, EthereumCall,
         LightEthereumBlock, LightEthereumBlockExt, LinkResolver, Logger, TryStreamExt,
@@ -602,21 +602,21 @@ impl DataSource {
                 // Take the input for the call, chop off the first 4 bytes, then call
                 // `function.decode_input` to get a vector of `Token`s. Match the `Token`s
                 // with the `Param`s in `function.inputs` to create a `Vec<LogParam>`.
-                let tokens = match function_abi
-                    .decode_input(&call.input.0[4..])
-                    .with_context(|| {
+                let tokens = match function_abi.decode_input(&call.input.0[4..]).with_context(
+                    || {
                         format!(
                             "Generating function inputs for the call {:?} failed, raw input: {}",
                             &function_abi,
                             hex::encode(&call.input.0)
                         )
-                    }) {
-                      Ok(val) => val,
-                      Err(err) => {
+                    },
+                ) {
+                    Ok(val) => val,
+                    Err(err) => {
                         warn!(logger, "Failed parsing inputs, skipping"; "error" => &err.to_string());
-                        return Ok(None)
-                      },
-                    };
+                        return Ok(None);
+                    }
+                };
 
                 ensure!(
                     tokens.len() == function_abi.inputs.len(),


### PR DESCRIPTION
Subgraph gets terminated when the graph-node fails to decode the call data with function_abi here: `function_abi.decode_input(&call.input.0[4..])`

failing transaction: https://etherscan.io/tx/0x5f0b0ea26e74c9d796209920bbae08f5ebb4ae053ef8b01c7848bd0a2b85691d

Failing on the graph studio and etherscan also fails to decode this data. This PR skips the transaction that we aren't able to parse using the abi, logs the warning, and continues instead of completely failing the subgraph.

Without this, to fix and continue, we need to do something similar to the following which is not efficient time + replicating data: 
1. new subgraph needs to be deployed with a shortened `function_abi` but this isn't an issue with subgraphs itself
2. start indexing all over for the new subgraph which would take a while
3. use `grafting`  which copies the entire data from one schema to the next which takes a few hours for 10+million records

Fixes #3314 