### PR TITLE
integration-tests: Point to branch main of graph-{cli, ts}

### DIFF
--- a/tests/integration-tests/data-source-context/package.json
+++ b/tests/integration-tests/data-source-context/package.json
@@ -9,8 +9,8 @@
     "deploy:test": "graph deploy test/data-source-context --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
-    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#main",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#main",
     "solc": "^0.8.2"
   },
   "dependencies": {

--- a/tests/integration-tests/data-source-revert/package.json
+++ b/tests/integration-tests/data-source-revert/package.json
@@ -9,8 +9,8 @@
     "deploy:test": "graph deploy test/data-source-revert --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
-    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#main",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#main",
     "solc": "^0.8.2"
   },
   "dependencies": {

--- a/tests/integration-tests/fatal-error/package.json
+++ b/tests/integration-tests/fatal-error/package.json
@@ -9,8 +9,8 @@
     "deploy:test": "graph deploy test/fatal-error --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
-    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#main",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#main",
     "solc": "^0.8.2"
   },
   "dependencies": {

--- a/tests/integration-tests/ganache-reverts/package.json
+++ b/tests/integration-tests/ganache-reverts/package.json
@@ -9,8 +9,8 @@
     "deploy:test": "graph deploy test/ganache-reverts --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
-    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#main",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#main",
     "solc": "^0.8.2"
   },
   "dependencies": {

--- a/tests/integration-tests/host-exports/package.json
+++ b/tests/integration-tests/host-exports/package.json
@@ -9,8 +9,8 @@
     "deploy:test": "graph deploy test/host-exports --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
-    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#main",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#main",
     "solc": "^0.8.2"
   },
   "dependencies": {

--- a/tests/integration-tests/non-fatal-errors/package.json
+++ b/tests/integration-tests/non-fatal-errors/package.json
@@ -9,8 +9,8 @@
     "deploy:test": "graph deploy test/non-fatal-errors --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
-    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#main",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#main",
     "solc": "^0.8.2"
   },
   "dependencies": {

--- a/tests/integration-tests/overloaded-contract-functions/package.json
+++ b/tests/integration-tests/overloaded-contract-functions/package.json
@@ -9,8 +9,8 @@
     "deploy:test": "graph deploy test/overloaded-contract-functions --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
-    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#main",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#main",
     "solc": "^0.8.2"
   },
   "dependencies": {

--- a/tests/integration-tests/poi-for-failed-subgraph/package.json
+++ b/tests/integration-tests/poi-for-failed-subgraph/package.json
@@ -9,8 +9,8 @@
     "deploy:test": "graph deploy test/poi-for-failed-subgraph --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
-    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#main",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#main",
     "solc": "^0.8.2"
   },
   "dependencies": {

--- a/tests/integration-tests/remove-then-update/package.json
+++ b/tests/integration-tests/remove-then-update/package.json
@@ -9,8 +9,8 @@
     "deploy:test": "graph deploy test/remove-then-update --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
-    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#main",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#main",
     "solc": "^0.8.2"
   },
   "dependencies": {

--- a/tests/integration-tests/value-roundtrip/package.json
+++ b/tests/integration-tests/value-roundtrip/package.json
@@ -9,8 +9,8 @@
     "deploy:test": "graph deploy test/value-roundtrip --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#master",
-    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#master",
+    "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#main",
+    "@graphprotocol/graph-ts": "https://github.com/graphprotocol/graph-ts#main",
     "solc": "^0.8.2"
   },
   "dependencies": {


### PR DESCRIPTION
`master` 🔫 
`main` ❤️ 

Both `graph-cli` and `graph-ts` now have `main` as their default branch and I'm keeping up `master` while this doesn't get merged.