### PR TITLE
Asyncify various methods in `WritableStore` abd `SubgraphStore`

### DIFF
--- a/chain/ethereum/tests/manifest.rs
+++ b/chain/ethereum/tests/manifest.rs
@@ -167,6 +167,7 @@ specVersion: 0.0.2
         // graft-related checks work
         let msg = unvalidated
             .validate(store.clone(), true)
+            .await
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| matches!(e, SubgraphManifestValidationError::GraftBaseInvalid(_)))
@@ -187,6 +188,7 @@ specVersion: 0.0.2
         let unvalidated = resolve_unvalidated(YAML).await;
         let msg = unvalidated
             .validate(store, true)
+            .await
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| matches!(e, SubgraphManifestValidationError::GraftBaseInvalid(_)))
@@ -255,6 +257,7 @@ graft:
         let unvalidated = resolve_unvalidated(YAML).await;
         let error_msg = unvalidated
             .validate(store.clone(), true)
+            .await
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -291,6 +294,7 @@ graft:
         let unvalidated = resolve_unvalidated(YAML).await;
         assert!(unvalidated
             .validate(store.clone(), true)
+            .await
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -321,6 +325,7 @@ schema:
         let unvalidated = resolve_unvalidated(YAML).await;
         assert!(unvalidated
             .validate(store.clone(), true)
+            .await
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -371,6 +376,7 @@ schema:
 
         assert!(unvalidated
             .validate(store.clone(), true)
+            .await
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -420,6 +426,7 @@ schema:
 
         let error_msg = unvalidated
             .validate(store.clone(), true)
+            .await
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -493,6 +500,7 @@ dataSources:
 
         let error_msg = unvalidated
             .validate(store.clone(), true)
+            .await
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -568,6 +576,7 @@ dataSources:
 
         assert!(unvalidated
             .validate(store.clone(), true)
+            .await
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {
@@ -596,6 +605,7 @@ schema:
         let unvalidated = resolve_unvalidated(YAML).await;
         assert!(unvalidated
             .validate(store.clone(), true)
+            .await
             .expect_err("Validation must fail")
             .into_iter()
             .find(|e| {

--- a/chain/ethereum/tests/manifest.rs
+++ b/chain/ethereum/tests/manifest.rs
@@ -160,7 +160,7 @@ specVersion: 0.0.2
         //
         // Validation against subgraph that hasn't synced anything fails
         //
-        let deployment = test_store::create_test_subgraph(&subgraph, GQL_SCHEMA);
+        let deployment = test_store::create_test_subgraph(&subgraph, GQL_SCHEMA).await;
         // This check is awkward since the test manifest has other problems
         // that the validation complains about as setting up a valid manifest
         // would be a bit more work; we just want to make sure that

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -152,11 +152,15 @@ where
             let store = store.clone();
             let logger = logger.clone();
 
-            store
-                .start_subgraph_deployment(&logger)
-                .map_err(Error::from)
-                .await
-                .map_err(Error::from)?
+            // `start_subgraph_deployment` is blocking.
+            task::spawn_blocking(move || {
+                store
+                    .start_subgraph_deployment(&logger)
+                    .map_err(Error::from)
+            })
+            .await
+            .map_err(Error::from)
+            .and_then(|x| x)?;
         }
 
         let manifest: SubgraphManifest<C> = {

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -152,15 +152,11 @@ where
             let store = store.clone();
             let logger = logger.clone();
 
-            // `start_subgraph_deployment` is blocking.
-            task::spawn_blocking(move || {
-                store
-                    .start_subgraph_deployment(&logger)
-                    .map_err(Error::from)
-            })
-            .await
-            .map_err(Error::from)
-            .and_then(|x| x)?;
+            store
+                .start_subgraph_deployment(&logger)
+                .map_err(Error::from)
+                .await
+                .map_err(Error::from)?
         }
 
         let manifest: SubgraphManifest<C> = {
@@ -259,7 +255,7 @@ where
 
         // Initialize deployment_head with current deployment head. Any sort of trouble in
         // getting the deployment head ptr leads to initializing with 0
-        let deployment_head = store.block_ptr().map(|ptr| ptr.number).unwrap_or(0) as f64;
+        let deployment_head = store.block_ptr().await.map(|ptr| ptr.number).unwrap_or(0) as f64;
         block_stream_metrics.deployment_head.set(deployment_head);
 
         let host_builder = graph_runtime_wasm::RuntimeHostBuilder::new(

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -148,20 +148,7 @@ where
         // sources; if the subgraph is a graft or a copy, starting it will
         // do the copying and dynamic data sources won't show up until after
         // that is done
-        {
-            let store = store.clone();
-            let logger = logger.clone();
-
-            // `start_subgraph_deployment` is blocking.
-            task::spawn_blocking(move || {
-                store
-                    .start_subgraph_deployment(&logger)
-                    .map_err(Error::from)
-            })
-            .await
-            .map_err(Error::from)
-            .and_then(|x| x)?;
-        }
+        store.start_subgraph_deployment(&logger).await?;
 
         let manifest: SubgraphManifest<C> = {
             info!(logger, "Resolve subgraph files using IPFS");

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -528,6 +528,7 @@ async fn create_subgraph_version<C: Blockchain, S: SubgraphStore, L: LinkResolve
 
     let manifest = unvalidated
         .validate(store.cheap_clone(), true)
+        .await
         .map_err(SubgraphRegistrarError::ManifestValidationError)?;
 
     let network_name = manifest.network_name();

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -58,12 +58,12 @@ async fn new_block_stream<C: Blockchain>(
         false => BUFFERED_BLOCK_STREAM_SIZE,
     };
 
-    let current_ptr = inputs.store.block_ptr();
+    let current_ptr = inputs.store.block_ptr().await;
 
     let block_stream = match is_firehose {
         true => chain.new_firehose_block_stream(
             inputs.deployment.clone(),
-            inputs.store.block_cursor(),
+            inputs.store.block_cursor().await,
             inputs.start_blocks.clone(),
             current_ptr,
             Arc::new(filter.clone()),
@@ -116,7 +116,7 @@ where
         // If a subgraph failed for deterministic reasons, before start indexing, we first
         // revert the deployment head. It should lead to the same result since the error was
         // deterministic.
-        if let Some(current_ptr) = self.inputs.store.block_ptr() {
+        if let Some(current_ptr) = self.inputs.store.block_ptr().await {
             if let Some(parent_ptr) = self
                 .inputs
                 .triggers_adapter
@@ -182,7 +182,7 @@ where
                         //
                         // Safe unwrap because in a Revert event we're sure the subgraph has
                         // advanced at least once.
-                        let subgraph_ptr = self.inputs.store.block_ptr().unwrap();
+                        let subgraph_ptr = self.inputs.store.block_ptr().await.unwrap();
                         if revert_to_ptr.number >= subgraph_ptr.number {
                             info!(&logger, "Block to revert is higher than subgraph pointer, nothing to do"; "subgraph_ptr" => &subgraph_ptr, "revert_to_ptr" => &revert_to_ptr);
                             continue;

--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -14,7 +14,7 @@ async fn insert_and_query(
     query: &str,
 ) -> Result<QueryResult, StoreError> {
     let subgraph_id = DeploymentHash::new(subgraph_id).unwrap();
-    let deployment = create_test_subgraph(&subgraph_id, schema);
+    let deployment = create_test_subgraph(&subgraph_id, schema).await;
 
     let insert_ops = entities
         .into_iter()

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -156,7 +156,7 @@ pub trait WritableStore: Send + Sync + 'static {
     async fn delete_block_cursor(&self) -> Result<(), StoreError>;
 
     /// Start an existing subgraph deployment.
-    async fn start_subgraph_deployment(&self, logger: &Logger) -> Result<(), StoreError>;
+    fn start_subgraph_deployment(&self, logger: &Logger) -> Result<(), StoreError>;
 
     /// Revert the entity changes from a single block atomically in the store, and update the
     /// subgraph block pointer to `block_ptr_to`.

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -133,7 +133,7 @@ pub trait SubgraphStore: Send + Sync + 'static {
     /// that we would use to query or copy from; in particular, this will
     /// ignore any instances of this deployment that are in the process of
     /// being set up
-    fn least_block_ptr(&self, id: &DeploymentHash) -> Result<Option<BlockPtr>, StoreError>;
+    async fn least_block_ptr(&self, id: &DeploymentHash) -> Result<Option<BlockPtr>, StoreError>;
 
     /// Find the deployment locators for the subgraph with the given hash
     fn locators(&self, hash: &str) -> Result<Vec<DeploymentLocator>, StoreError>;
@@ -146,17 +146,17 @@ pub trait SubgraphStore: Send + Sync + 'static {
 #[async_trait]
 pub trait WritableStore: Send + Sync + 'static {
     /// Get a pointer to the most recently processed block in the subgraph.
-    fn block_ptr(&self) -> Option<BlockPtr>;
+    async fn block_ptr(&self) -> Option<BlockPtr>;
 
     /// Returns the Firehose `cursor` this deployment is currently at in the block stream of events. This
     /// is used when re-connecting a Firehose stream to start back exactly where we left off.
-    fn block_cursor(&self) -> Option<String>;
+    async fn block_cursor(&self) -> Option<String>;
 
     /// Deletes the current Firehose `cursor` this deployment is currently at.
-    fn delete_block_cursor(&self) -> Result<(), StoreError>;
+    async fn delete_block_cursor(&self) -> Result<(), StoreError>;
 
     /// Start an existing subgraph deployment.
-    fn start_subgraph_deployment(&self, logger: &Logger) -> Result<(), StoreError>;
+    async fn start_subgraph_deployment(&self, logger: &Logger) -> Result<(), StoreError>;
 
     /// Revert the entity changes from a single block atomically in the store, and update the
     /// subgraph block pointer to `block_ptr_to`.
@@ -386,7 +386,7 @@ pub trait QueryStore: Send + Sync {
 
     async fn is_deployment_synced(&self) -> Result<bool, Error>;
 
-    fn block_ptr(&self) -> Result<Option<BlockPtr>, StoreError>;
+    async fn block_ptr(&self) -> Result<Option<BlockPtr>, StoreError>;
 
     fn block_number(&self, block_hash: H256) -> Result<Option<BlockNumber>, StoreError>;
 

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -156,7 +156,7 @@ pub trait WritableStore: Send + Sync + 'static {
     async fn delete_block_cursor(&self) -> Result<(), StoreError>;
 
     /// Start an existing subgraph deployment.
-    fn start_subgraph_deployment(&self, logger: &Logger) -> Result<(), StoreError>;
+    async fn start_subgraph_deployment(&self, logger: &Logger) -> Result<(), StoreError>;
 
     /// Revert the entity changes from a single block atomically in the store, and update the
     /// subgraph block pointer to `block_ptr_to`.

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -46,19 +46,19 @@ impl MockStore {
 // The store trait must be implemented manually because mockall does not support async_trait, nor borrowing from arguments.
 #[async_trait]
 impl WritableStore for MockStore {
-    fn block_ptr(&self) -> Option<BlockPtr> {
+    async fn block_ptr(&self) -> Option<BlockPtr> {
         unimplemented!()
     }
 
-    fn block_cursor(&self) -> Option<String> {
+    async fn block_cursor(&self) -> Option<String> {
         unimplemented!()
     }
 
-    fn delete_block_cursor(&self) -> Result<(), StoreError> {
+    async fn delete_block_cursor(&self) -> Result<(), StoreError> {
         unimplemented!()
     }
 
-    fn start_subgraph_deployment(&self, _: &Logger) -> Result<(), StoreError> {
+    async fn start_subgraph_deployment(&self, _: &Logger) -> Result<(), StoreError> {
         unimplemented!()
     }
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -76,9 +76,7 @@ impl StoreResolver {
     ) -> Result<Self, QueryExecutionError> {
         let store_clone = store.cheap_clone();
         let deployment2 = deployment.clone();
-        let block_ptr = Self::locate_block(store_clone.as_ref(), bc, deployment2.clone())
-            .await
-            .map_err(|e| QueryExecutionError::Panic(e.to_string()))?;
+        let block_ptr = Self::locate_block(store_clone.as_ref(), bc, deployment2.clone()).await?;
 
         let has_non_fatal_errors = store
             .has_non_fatal_errors(Some(block_ptr.block_number()))

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -76,12 +76,9 @@ impl StoreResolver {
     ) -> Result<Self, QueryExecutionError> {
         let store_clone = store.cheap_clone();
         let deployment2 = deployment.clone();
-        let block_ptr = graph::spawn_blocking_allow_panic(move || {
-            Self::locate_block(store_clone.as_ref(), bc, deployment2.clone())
-        })
-        .await
-        .map_err(|e| QueryExecutionError::Panic(e.to_string()))
-        .and_then(|x| x)?; // Propagate panics.
+        let block_ptr = Self::locate_block(store_clone.as_ref(), bc, deployment2.clone())
+            .await
+            .map_err(|e| QueryExecutionError::Panic(e.to_string()))?;
 
         let has_non_fatal_errors = store
             .has_non_fatal_errors(Some(block_ptr.block_number()))
@@ -107,7 +104,7 @@ impl StoreResolver {
             .unwrap_or(BLOCK_NUMBER_MAX)
     }
 
-    fn locate_block(
+    async fn locate_block(
         store: &dyn QueryStore,
         bc: BlockConstraint,
         subgraph: DeploymentHash,
@@ -147,7 +144,7 @@ impl StoreResolver {
                     })
             }
             BlockConstraint::Number(number) => {
-                store.block_ptr().map_err(Into::into).and_then(|ptr| {
+                store.block_ptr().await.map_err(Into::into).and_then(|ptr| {
                     check_ptr(subgraph, ptr, number)?;
                     // We don't have a way here to look the block hash up from
                     // the database, and even if we did, there is no guarantee
@@ -160,12 +157,14 @@ impl StoreResolver {
             }
             BlockConstraint::Min(number) => store
                 .block_ptr()
+                .await
                 .map_err(Into::into)
                 .and_then(|ptr| check_ptr(subgraph, ptr, number)),
-            BlockConstraint::Latest => store
-                .block_ptr()
-                .map_err(Into::into)
-                .map(|ptr| ptr.expect("we should have already checked that the subgraph exists")),
+            BlockConstraint::Latest => {
+                store.block_ptr().await.map_err(Into::into).map(|ptr| {
+                    ptr.expect("we should have already checked that the subgraph exists")
+                })
+            }
         }
     }
 

--- a/node/src/manager/commands/copy.rs
+++ b/node/src/manager/commands/copy.rs
@@ -92,7 +92,7 @@ pub async fn create(
     let query_store = store.query_store(src.hash.clone().into(), true).await?;
     let network = query_store.network_name();
 
-    let src_ptr = query_store.block_ptr()?.ok_or_else(|| anyhow!("subgraph {} has not indexed any blocks yet and can not be used as the source of a copy", src))?;
+    let src_ptr = query_store.block_ptr().await?.ok_or_else(|| anyhow!("subgraph {} has not indexed any blocks yet and can not be used as the source of a copy", src))?;
     let src_number = if src_ptr.number <= block_offset {
         bail!("subgraph {} has only indexed up to block {}, but we need at least block {} before we can copy from it", src, src_ptr.number, block_offset);
     } else {

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -200,6 +200,7 @@ pub async fn run(
 
         let block_ptr = subgraph_store
             .least_block_ptr(&subgraph_hash)
+            .await
             .unwrap()
             .unwrap();
 

--- a/runtime/test/src/test/abi.rs
+++ b/runtime/test/src/test/abi.rs
@@ -9,7 +9,7 @@ use graph_runtime_wasm::{
 
 use super::*;
 
-fn test_unbounded_loop(api_version: Version) {
+async fn test_unbounded_loop(api_version: Version) {
     // Set handler timeout to 3 seconds.
     let module = test_valid_module_and_store_with_timeout(
         "unboundedLoop",
@@ -20,6 +20,7 @@ fn test_unbounded_loop(api_version: Version) {
         api_version,
         Some(Duration::from_secs(3)),
     )
+    .await
     .0;
     let res: Result<(), _> = module.get_func("loop").typed().unwrap().call(());
     assert!(res.unwrap_err().to_string().contains(TRAP_TIMEOUT));
@@ -27,15 +28,15 @@ fn test_unbounded_loop(api_version: Version) {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn unbounded_loop_v0_0_4() {
-    test_unbounded_loop(API_VERSION_0_0_4);
+    test_unbounded_loop(API_VERSION_0_0_4).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn unbounded_loop_v0_0_5() {
-    test_unbounded_loop(API_VERSION_0_0_5);
+    test_unbounded_loop(API_VERSION_0_0_5).await;
 }
 
-fn test_unbounded_recursion(api_version: Version) {
+async fn test_unbounded_recursion(api_version: Version) {
     let module = test_module(
         "unboundedRecursion",
         mock_data_source(
@@ -43,7 +44,8 @@ fn test_unbounded_recursion(api_version: Version) {
             api_version.clone(),
         ),
         api_version,
-    );
+    )
+    .await;
     let res: Result<(), _> = module.get_func("rabbit_hole").typed().unwrap().call(());
     let err_msg = res.unwrap_err().to_string();
     assert!(err_msg.contains("call stack exhausted"), "{:#?}", err_msg);
@@ -51,15 +53,15 @@ fn test_unbounded_recursion(api_version: Version) {
 
 #[tokio::test]
 async fn unbounded_recursion_v0_0_4() {
-    test_unbounded_recursion(API_VERSION_0_0_4);
+    test_unbounded_recursion(API_VERSION_0_0_4).await;
 }
 
 #[tokio::test]
 async fn unbounded_recursion_v0_0_5() {
-    test_unbounded_recursion(API_VERSION_0_0_5);
+    test_unbounded_recursion(API_VERSION_0_0_5).await;
 }
 
-fn test_abi_array(api_version: Version, gas_used: u64) {
+async fn test_abi_array(api_version: Version, gas_used: u64) {
     let mut module = test_module(
         "abiArray",
         mock_data_source(
@@ -67,7 +69,8 @@ fn test_abi_array(api_version: Version, gas_used: u64) {
             api_version.clone(),
         ),
         api_version,
-    );
+    )
+    .await;
 
     let vec = vec![
         "1".to_owned(),
@@ -93,15 +96,15 @@ fn test_abi_array(api_version: Version, gas_used: u64) {
 
 #[tokio::test]
 async fn abi_array_v0_0_4() {
-    test_abi_array(API_VERSION_0_0_4, 695935);
+    test_abi_array(API_VERSION_0_0_4, 695935).await;
 }
 
 #[tokio::test]
 async fn abi_array_v0_0_5() {
-    test_abi_array(API_VERSION_0_0_5, 1636130);
+    test_abi_array(API_VERSION_0_0_5, 1636130).await;
 }
 
-fn test_abi_subarray(api_version: Version) {
+async fn test_abi_subarray(api_version: Version) {
     let mut module = test_module(
         "abiSubarray",
         mock_data_source(
@@ -109,7 +112,8 @@ fn test_abi_subarray(api_version: Version) {
             api_version.clone(),
         ),
         api_version,
-    );
+    )
+    .await;
 
     let vec: Vec<u8> = vec![1, 2, 3, 4];
     let new_vec_obj: AscPtr<TypedArray<u8>> =
@@ -121,15 +125,15 @@ fn test_abi_subarray(api_version: Version) {
 
 #[tokio::test]
 async fn abi_subarray_v0_0_4() {
-    test_abi_subarray(API_VERSION_0_0_4);
+    test_abi_subarray(API_VERSION_0_0_4).await;
 }
 
 #[tokio::test]
 async fn abi_subarray_v0_0_5() {
-    test_abi_subarray(API_VERSION_0_0_5);
+    test_abi_subarray(API_VERSION_0_0_5).await;
 }
 
-fn test_abi_bytes_and_fixed_bytes(api_version: Version) {
+async fn test_abi_bytes_and_fixed_bytes(api_version: Version) {
     let mut module = test_module(
         "abiBytesAndFixedBytes",
         mock_data_source(
@@ -137,7 +141,8 @@ fn test_abi_bytes_and_fixed_bytes(api_version: Version) {
             api_version.clone(),
         ),
         api_version,
-    );
+    )
+    .await;
     let bytes1: Vec<u8> = vec![42, 45, 7, 245, 45];
     let bytes2: Vec<u8> = vec![3, 12, 0, 1, 255];
     let new_vec_obj: AscPtr<Uint8Array> = module.invoke_export2("concat", &*bytes1, &*bytes2);
@@ -152,15 +157,15 @@ fn test_abi_bytes_and_fixed_bytes(api_version: Version) {
 
 #[tokio::test]
 async fn abi_bytes_and_fixed_bytes_v0_0_4() {
-    test_abi_bytes_and_fixed_bytes(API_VERSION_0_0_4);
+    test_abi_bytes_and_fixed_bytes(API_VERSION_0_0_4).await;
 }
 
 #[tokio::test]
 async fn abi_bytes_and_fixed_bytes_v0_0_5() {
-    test_abi_bytes_and_fixed_bytes(API_VERSION_0_0_5);
+    test_abi_bytes_and_fixed_bytes(API_VERSION_0_0_5).await;
 }
 
-fn test_abi_ethabi_token_identity(api_version: Version) {
+async fn test_abi_ethabi_token_identity(api_version: Version) {
     let mut module = test_module(
         "abiEthabiTokenIdentity",
         mock_data_source(
@@ -168,7 +173,8 @@ fn test_abi_ethabi_token_identity(api_version: Version) {
             api_version.clone(),
         ),
         api_version,
-    );
+    )
+    .await;
     let gas = module.gas.cheap_clone();
 
     // Token::Address
@@ -246,17 +252,17 @@ fn test_abi_ethabi_token_identity(api_version: Version) {
 /// and assert the final token is the same as the starting one.
 #[tokio::test]
 async fn abi_ethabi_token_identity_v0_0_4() {
-    test_abi_ethabi_token_identity(API_VERSION_0_0_4);
+    test_abi_ethabi_token_identity(API_VERSION_0_0_4).await;
 }
 
 /// Test a roundtrip Token -> Payload -> Token identity conversion through asc,
 /// and assert the final token is the same as the starting one.
 #[tokio::test]
 async fn abi_ethabi_token_identity_v0_0_5() {
-    test_abi_ethabi_token_identity(API_VERSION_0_0_5);
+    test_abi_ethabi_token_identity(API_VERSION_0_0_5).await;
 }
 
-fn test_abi_store_value(api_version: Version) {
+async fn test_abi_store_value(api_version: Version) {
     let mut module = test_module(
         "abiStoreValue",
         mock_data_source(
@@ -264,7 +270,8 @@ fn test_abi_store_value(api_version: Version) {
             api_version.clone(),
         ),
         api_version,
-    );
+    )
+    .await;
 
     // Value::Null
     let func = module.get_func("value_null").typed().unwrap().clone();
@@ -352,15 +359,15 @@ fn test_abi_store_value(api_version: Version) {
 
 #[tokio::test]
 async fn abi_store_value_v0_0_4() {
-    test_abi_store_value(API_VERSION_0_0_4);
+    test_abi_store_value(API_VERSION_0_0_4).await;
 }
 
 #[tokio::test]
 async fn abi_store_value_v0_0_5() {
-    test_abi_store_value(API_VERSION_0_0_5);
+    test_abi_store_value(API_VERSION_0_0_5).await;
 }
 
-fn test_abi_h160(api_version: Version) {
+async fn test_abi_h160(api_version: Version) {
     let mut module = test_module(
         "abiH160",
         mock_data_source(
@@ -368,7 +375,8 @@ fn test_abi_h160(api_version: Version) {
             api_version.clone(),
         ),
         api_version,
-    );
+    )
+    .await;
     let address = H160::zero();
 
     // As an `Uint8Array`
@@ -385,15 +393,15 @@ fn test_abi_h160(api_version: Version) {
 
 #[tokio::test]
 async fn abi_h160_v0_0_4() {
-    test_abi_h160(API_VERSION_0_0_4);
+    test_abi_h160(API_VERSION_0_0_4).await;
 }
 
 #[tokio::test]
 async fn abi_h160_v0_0_5() {
-    test_abi_h160(API_VERSION_0_0_5);
+    test_abi_h160(API_VERSION_0_0_5).await;
 }
 
-fn test_string(api_version: Version) {
+async fn test_string(api_version: Version) {
     let mut module = test_module(
         "string",
         mock_data_source(
@@ -401,7 +409,8 @@ fn test_string(api_version: Version) {
             api_version.clone(),
         ),
         api_version,
-    );
+    )
+    .await;
     let string = "    漢字Double_Me🇧🇷  ";
     let trimmed_string_obj: AscPtr<AscString> = module.invoke_export1("repeat_twice", string);
     let doubled_string: String = asc_get(&module, trimmed_string_obj, &module.gas).unwrap();
@@ -410,15 +419,15 @@ fn test_string(api_version: Version) {
 
 #[tokio::test]
 async fn string_v0_0_4() {
-    test_string(API_VERSION_0_0_4);
+    test_string(API_VERSION_0_0_4).await;
 }
 
 #[tokio::test]
 async fn string_v0_0_5() {
-    test_string(API_VERSION_0_0_5);
+    test_string(API_VERSION_0_0_5).await;
 }
 
-fn test_abi_big_int(api_version: Version) {
+async fn test_abi_big_int(api_version: Version) {
     let mut module = test_module(
         "abiBigInt",
         mock_data_source(
@@ -426,7 +435,8 @@ fn test_abi_big_int(api_version: Version) {
             api_version.clone(),
         ),
         api_version,
-    );
+    )
+    .await;
 
     // Test passing in 0 and increment it by 1
     let old_uint = U256::zero();
@@ -448,15 +458,15 @@ fn test_abi_big_int(api_version: Version) {
 
 #[tokio::test]
 async fn abi_big_int_v0_0_4() {
-    test_abi_big_int(API_VERSION_0_0_4);
+    test_abi_big_int(API_VERSION_0_0_4).await;
 }
 
 #[tokio::test]
 async fn abi_big_int_v0_0_5() {
-    test_abi_big_int(API_VERSION_0_0_5);
+    test_abi_big_int(API_VERSION_0_0_5).await;
 }
 
-fn test_big_int_to_string(api_version: Version) {
+async fn test_big_int_to_string(api_version: Version) {
     let mut module = test_module(
         "bigIntToString",
         mock_data_source(
@@ -464,7 +474,8 @@ fn test_big_int_to_string(api_version: Version) {
             api_version.clone(),
         ),
         api_version,
-    );
+    )
+    .await;
 
     let big_int_str = "30145144166666665000000000000000000";
     let big_int = BigInt::from_str(big_int_str).unwrap();
@@ -475,15 +486,15 @@ fn test_big_int_to_string(api_version: Version) {
 
 #[tokio::test]
 async fn big_int_to_string_v0_0_4() {
-    test_big_int_to_string(API_VERSION_0_0_4);
+    test_big_int_to_string(API_VERSION_0_0_4).await;
 }
 
 #[tokio::test]
 async fn big_int_to_string_v0_0_5() {
-    test_big_int_to_string(API_VERSION_0_0_5);
+    test_big_int_to_string(API_VERSION_0_0_5).await;
 }
 
-fn test_invalid_discriminant(api_version: Version) {
+async fn test_invalid_discriminant(api_version: Version) {
     let module = test_module(
         "invalidDiscriminant",
         mock_data_source(
@@ -491,7 +502,8 @@ fn test_invalid_discriminant(api_version: Version) {
             api_version.clone(),
         ),
         api_version,
-    );
+    )
+    .await;
 
     let func = module
         .get_func("invalid_discriminant")
@@ -507,7 +519,7 @@ fn test_invalid_discriminant(api_version: Version) {
 #[tokio::test]
 #[should_panic]
 async fn invalid_discriminant_v0_0_4() {
-    test_invalid_discriminant(API_VERSION_0_0_4);
+    test_invalid_discriminant(API_VERSION_0_0_4).await;
 }
 
 // This should panic rather than exhibiting UB. It's hard to test for UB, but
@@ -515,5 +527,5 @@ async fn invalid_discriminant_v0_0_4() {
 #[tokio::test]
 #[should_panic]
 async fn invalid_discriminant_v0_0_5() {
-    test_invalid_discriminant(API_VERSION_0_0_5);
+    test_invalid_discriminant(API_VERSION_0_0_5).await;
 }

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -241,7 +241,7 @@ impl<C: Blockchain> HostExports<C> {
         // Does not consume gas because this is not a part of the deterministic feature set.
         // Ideally this would first consume gas for fetching the file stats, and then again
         // for the bytes of the file.
-        block_on03(self.link_resolver.cat(logger, &Link { link }))
+        graph::block_on(self.link_resolver.cat(logger, &Link { link }))
     }
 
     // Read the IPFS file `link`, split it into JSON objects, and invoke the
@@ -285,9 +285,9 @@ impl<C: Blockchain> HostExports<C> {
 
         let result = {
             let mut stream: JsonValueStream =
-                block_on03(link_resolver.json_stream(&logger, &Link { link }))?;
+                graph::block_on(link_resolver.json_stream(&logger, &Link { link }))?;
             let mut v = Vec::new();
-            while let Some(sv) = block_on03(stream.next()) {
+            while let Some(sv) = graph::block_on(stream.next()) {
                 let sv = sv?;
                 let module = WasmInstance::from_valid_module_with_ctx(
                     valid_module.clone(),
@@ -755,10 +755,6 @@ impl<C: Blockchain> HostExports<C> {
             .map(|mut tokens| tokens.pop().unwrap())
             .context("Failed to decode")
     }
-}
-
-fn block_on03<T>(future: impl futures03::Future<Output = T> + Send) -> T {
-    graph::block_on(future)
 }
 
 fn string_to_h160(string: &str) -> Result<H160, DeterministicHostError> {

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -54,8 +54,8 @@ impl QueryStoreTrait for QueryStore {
             .await?)
     }
 
-    fn block_ptr(&self) -> Result<Option<BlockPtr>, StoreError> {
-        self.store.block_ptr(&self.site)
+    async fn block_ptr(&self) -> Result<Option<BlockPtr>, StoreError> {
+        self.store.block_ptr(self.site.cheap_clone()).await
     }
 
     fn block_number(&self, block_hash: H256) -> Result<Option<BlockNumber>, StoreError> {

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1130,7 +1130,7 @@ impl SubgraphStoreTrait for SubgraphStore {
         .await
         .unwrap()?; // Propagate panics, there shouldn't be any.
 
-        let writable = Arc::new(WritableAgent::new(self.as_ref().clone(), logger, site)?);
+        let writable = Arc::new(WritableAgent::new(self.as_ref().clone(), logger, site).await?);
         self.writables
             .lock()
             .unwrap()
@@ -1146,9 +1146,9 @@ impl SubgraphStoreTrait for SubgraphStore {
         }
     }
 
-    fn least_block_ptr(&self, id: &DeploymentHash) -> Result<Option<BlockPtr>, StoreError> {
+    async fn least_block_ptr(&self, id: &DeploymentHash) -> Result<Option<BlockPtr>, StoreError> {
         let (store, site) = self.store(id)?;
-        store.block_ptr(site.as_ref())
+        store.block_ptr(site.cheap_clone()).await
     }
 
     /// Find the deployment locators for the subgraph with the given hash

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -387,7 +387,7 @@ impl WritableStoreTrait for WritableAgent {
         self.store.start_subgraph_deployment(logger)?;
 
         // Refresh all in memory state in case this instance was used before
-        futures03::executor::block_on(async {
+        graph::block_on(async {
             *self.block_ptr.lock().unwrap() = self.store.block_ptr().await?;
             *self.block_cursor.lock().unwrap() = self.store.block_cursor().await?;
 

--- a/store/postgres/tests/chain_head.rs
+++ b/store/postgres/tests/chain_head.rs
@@ -172,7 +172,7 @@ fn block_number() {
     run_test_async(chain, move |_, subgraph_store| {
         let subgraph = subgraph.cheap_clone();
         async move {
-            create_test_subgraph(&subgraph, "type Dummy @entity { id: ID! }");
+            create_test_subgraph(&subgraph, "type Dummy @entity { id: ID! }").await;
 
             let query_store = subgraph_store
                 .query_store(subgraph.cheap_clone().into(), false)

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -414,7 +414,8 @@ fn copy() {
             .cheap_clone()
             .writable(LOGGER.clone(), deployment.id)
             .await?
-            .start_subgraph_deployment(&*LOGGER)?;
+            .start_subgraph_deployment(&*LOGGER)
+            .await?;
 
         store.activate(&deployment)?;
 

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -263,14 +263,14 @@ fn remove_test_data(store: Arc<DieselSubgraphStore>) {
         .expect("deleting test entities succeeds");
 }
 
-fn create_grafted_subgraph(
+async fn create_grafted_subgraph(
     subgraph_id: &DeploymentHash,
     schema: &str,
     base_id: &str,
     base_block: BlockPtr,
 ) -> Result<DeploymentLocator, StoreError> {
     let base = Some((DeploymentHash::new(base_id).unwrap(), base_block));
-    test_store::create_subgraph(subgraph_id, schema, base)
+    test_store::create_subgraph(subgraph_id, schema, base).await
 }
 
 fn find_entities(
@@ -352,6 +352,7 @@ fn graft() {
             TEST_SUBGRAPH_ID.as_str(),
             BLOCKS[1].clone(),
         )
+        .await
         .expect("can create grafted subgraph");
 
         check_graft(store.clone(), deployment).await.unwrap();
@@ -368,6 +369,7 @@ fn graft() {
             TEST_SUBGRAPH_ID.as_str(),
             BLOCKS[1].clone(),
         )
+        .await
         .expect_err("grafting onto block 1 fails");
         assert!(err.to_string().contains("can not be made immutable"));
 
@@ -378,6 +380,7 @@ fn graft() {
             TEST_SUBGRAPH_ID.as_str(),
             BLOCKS[0].clone(),
         )
+        .await
         .expect("grafting onto block 0 works");
 
         let (entities, ids) = find_entities(store.as_ref(), &deployment);
@@ -414,7 +417,8 @@ fn copy() {
             .cheap_clone()
             .writable(LOGGER.clone(), deployment.id)
             .await?
-            .start_subgraph_deployment(&*LOGGER)?;
+            .start_subgraph_deployment(&*LOGGER)
+            .await?;
 
         store.activate(&deployment)?;
 

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -414,8 +414,7 @@ fn copy() {
             .cheap_clone()
             .writable(LOGGER.clone(), deployment.id)
             .await?
-            .start_subgraph_deployment(&*LOGGER)
-            .await?;
+            .start_subgraph_deployment(&*LOGGER)?;
 
         store.activate(&deployment)?;
 

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -53,10 +53,10 @@ fn get_version_info(store: &Store, subgraph_name: &str) -> VersionInfo {
 
 #[test]
 fn reassign_subgraph() {
-    fn setup() -> DeploymentLocator {
+    async fn setup() -> DeploymentLocator {
         let id = DeploymentHash::new("reassignSubgraph").unwrap();
         remove_subgraphs();
-        create_test_subgraph(&id, SUBGRAPH_GQL)
+        create_test_subgraph(&id, SUBGRAPH_GQL).await
     }
 
     fn find_assignment(store: &SubgraphStore, deployment: &DeploymentLocator) -> Option<String> {
@@ -67,7 +67,7 @@ fn reassign_subgraph() {
     }
 
     run_test_sequentially(|store| async move {
-        let id = setup();
+        let id = setup().await;
         let store = store.subgraph_store();
 
         // Check our setup
@@ -323,18 +323,18 @@ fn status() {
     const NAME: &str = "infoSubgraph";
     const OTHER: &str = "otherInfoSubgraph";
 
-    fn setup() -> DeploymentLocator {
+    async fn setup() -> DeploymentLocator {
         let id = DeploymentHash::new(NAME).unwrap();
         remove_subgraphs();
-        let deployment = create_test_subgraph(&id, SUBGRAPH_GQL);
-        create_test_subgraph(&DeploymentHash::new(OTHER).unwrap(), SUBGRAPH_GQL);
+        let deployment = create_test_subgraph(&id, SUBGRAPH_GQL).await;
+        create_test_subgraph(&DeploymentHash::new(OTHER).unwrap(), SUBGRAPH_GQL).await;
         deployment
     }
 
     run_test_sequentially(|store| async move {
         use graph::data::subgraph::status;
 
-        let deployment = setup();
+        let deployment = setup().await;
         let infos = store
             .status(status::Filter::Deployments(vec![
                 deployment.hash.to_string(),
@@ -432,15 +432,15 @@ fn status() {
 fn version_info() {
     const NAME: &str = "versionInfoSubgraph";
 
-    fn setup() -> DeploymentLocator {
+    async fn setup() -> DeploymentLocator {
         let id = DeploymentHash::new(NAME).unwrap();
         remove_subgraphs();
         block_store::set_chain(vec![], NETWORK_NAME);
-        create_test_subgraph(&id, SUBGRAPH_GQL)
+        create_test_subgraph(&id, SUBGRAPH_GQL).await
     }
 
     run_test_sequentially(|store| async move {
-        let deployment = setup();
+        let deployment = setup().await;
         transact_entity_operations(
             &store.subgraph_store(),
             &deployment,
@@ -473,7 +473,8 @@ fn version_info() {
 fn subgraph_error() {
     test_store::run_test_sequentially(|store| async move {
         let subgraph_id = DeploymentHash::new("testSubgraph").unwrap();
-        let deployment = test_store::create_test_subgraph(&subgraph_id, "type Foo { id: ID! }");
+        let deployment =
+            test_store::create_test_subgraph(&subgraph_id, "type Foo { id: ID! }").await;
 
         let count = || -> usize {
             let store = store.subgraph_store();
@@ -528,14 +529,14 @@ fn subgraph_error() {
 
 #[test]
 fn fatal_vs_non_fatal() {
-    fn setup() -> DeploymentLocator {
+    async fn setup() -> DeploymentLocator {
         let id = DeploymentHash::new("failUnfail").unwrap();
         remove_subgraphs();
-        create_test_subgraph(&id, SUBGRAPH_GQL)
+        create_test_subgraph(&id, SUBGRAPH_GQL).await
     }
 
     run_test_sequentially(|store| async move {
-        let deployment = setup();
+        let deployment = setup().await;
         let query_store = store
             .query_store(deployment.hash.clone().into(), false)
             .await
@@ -572,14 +573,14 @@ fn fatal_vs_non_fatal() {
 fn fail_unfail_deterministic_error() {
     const NAME: &str = "failUnfailDeterministic";
 
-    fn setup() -> DeploymentLocator {
+    async fn setup() -> DeploymentLocator {
         let id = DeploymentHash::new(NAME).unwrap();
         remove_subgraphs();
-        create_test_subgraph(&id, SUBGRAPH_GQL)
+        create_test_subgraph(&id, SUBGRAPH_GQL).await
     }
 
     run_test_sequentially(|store| async move {
-        let deployment = setup();
+        let deployment = setup().await;
 
         let query_store = store
             .query_store(deployment.hash.cheap_clone().into(), false)
@@ -663,14 +664,14 @@ fn fail_unfail_deterministic_error() {
 fn fail_unfail_deterministic_error_noop() {
     const NAME: &str = "failUnfailDeterministicNoop";
 
-    fn setup() -> DeploymentLocator {
+    async fn setup() -> DeploymentLocator {
         let id = DeploymentHash::new(NAME).unwrap();
         remove_subgraphs();
-        create_test_subgraph(&id, SUBGRAPH_GQL)
+        create_test_subgraph(&id, SUBGRAPH_GQL).await
     }
 
     run_test_sequentially(|store| async move {
-        let deployment = setup();
+        let deployment = setup().await;
 
         let count = || -> usize {
             let store = store.subgraph_store();
@@ -794,14 +795,14 @@ fn fail_unfail_deterministic_error_noop() {
 fn fail_unfail_non_deterministic_error() {
     const NAME: &str = "failUnfailNonDeterministic";
 
-    fn setup() -> DeploymentLocator {
+    async fn setup() -> DeploymentLocator {
         let id = DeploymentHash::new(NAME).unwrap();
         remove_subgraphs();
-        create_test_subgraph(&id, SUBGRAPH_GQL)
+        create_test_subgraph(&id, SUBGRAPH_GQL).await
     }
 
     run_test_sequentially(|store| async move {
-        let deployment = setup();
+        let deployment = setup().await;
 
         let count = || -> usize {
             let store = store.subgraph_store();
@@ -883,14 +884,14 @@ fn fail_unfail_non_deterministic_error() {
 fn fail_unfail_non_deterministic_error_noop() {
     const NAME: &str = "failUnfailNonDeterministicNoop";
 
-    fn setup() -> DeploymentLocator {
+    async fn setup() -> DeploymentLocator {
         let id = DeploymentHash::new(NAME).unwrap();
         remove_subgraphs();
-        create_test_subgraph(&id, SUBGRAPH_GQL)
+        create_test_subgraph(&id, SUBGRAPH_GQL).await
     }
 
     run_test_sequentially(|store| async move {
-        let deployment = setup();
+        let deployment = setup().await;
 
         let count = || -> usize {
             let store = store.subgraph_store();

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -180,12 +180,12 @@ pub fn create_subgraph(
         NETWORK_NAME.to_string(),
         SubgraphVersionSwitchingMode::Instant,
     )?;
-    futures03::executor::block_on(
+    let writable = futures03::executor::block_on(
         SUBGRAPH_STORE
             .cheap_clone()
             .writable(LOGGER.clone(), deployment.id),
-    )?
-    .start_subgraph_deployment(&*LOGGER)?;
+    )?;
+    futures03::executor::block_on(writable.start_subgraph_deployment(&*LOGGER))?;
     Ok(deployment)
 }
 

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -185,7 +185,7 @@ pub fn create_subgraph(
             .cheap_clone()
             .writable(LOGGER.clone(), deployment.id),
     )?;
-    futures03::executor::block_on(writable.start_subgraph_deployment(&*LOGGER))?;
+    writable.start_subgraph_deployment(&*LOGGER)?;
     Ok(deployment)
 }
 

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -146,7 +146,7 @@ pub fn place(name: &str) -> Result<Option<(Vec<Shard>, Vec<NodeId>)>, String> {
     CONFIG.deployment.place(name, NETWORK_NAME)
 }
 
-pub fn create_subgraph(
+pub async fn create_subgraph(
     subgraph_id: &DeploymentHash,
     schema: &str,
     base: Option<(DeploymentHash, BlockPtr)>,
@@ -180,17 +180,18 @@ pub fn create_subgraph(
         NETWORK_NAME.to_string(),
         SubgraphVersionSwitchingMode::Instant,
     )?;
-    let writable = futures03::executor::block_on(
-        SUBGRAPH_STORE
-            .cheap_clone()
-            .writable(LOGGER.clone(), deployment.id),
-    )?;
-    writable.start_subgraph_deployment(&*LOGGER)?;
+
+    SUBGRAPH_STORE
+        .cheap_clone()
+        .writable(LOGGER.clone(), deployment.id)
+        .await?
+        .start_subgraph_deployment(&*LOGGER)
+        .await?;
     Ok(deployment)
 }
 
-pub fn create_test_subgraph(subgraph_id: &DeploymentHash, schema: &str) -> DeploymentLocator {
-    create_subgraph(subgraph_id, schema, None).unwrap()
+pub async fn create_test_subgraph(subgraph_id: &DeploymentHash, schema: &str) -> DeploymentLocator {
+    create_subgraph(subgraph_id, schema, None).await.unwrap()
 }
 
 pub fn remove_subgraph(id: &DeploymentHash) {


### PR DESCRIPTION
Also asyncify a bunch of dependencies transitively that were using those.

#### `WritableStore`

- `block_ptr`
- `block_cursor`
- `delete_block_cursor`
- `start_subgraph_deployment`

#### `QueryStore`

- `block_ptr`

#### `SubgraphStore`

- `writable_for_network_indexer`
- `least_block_ptr`

