### PR TITLE
GraphQL route to expose call cache contents by block

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -80,6 +80,7 @@ impl std::fmt::Debug for Chain {
 }
 
 impl Chain {
+    /// Creates a new Ethereum [`Chain`].
     pub fn new(
         logger_factory: LoggerFactory,
         name: String,
@@ -107,9 +108,12 @@ impl Chain {
             is_ingestible,
         }
     }
-}
 
-impl Chain {
+    /// Returns a handler to this chain's [`EthereumCallCache`].
+    pub fn call_cache(&self) -> Arc<dyn EthereumCallCache> {
+        self.call_cache.clone()
+    }
+
     pub fn cheapest_adapter(&self) -> Arc<EthereumAdapter> {
         self.eth_adapters.cheapest().unwrap().clone()
     }

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -362,7 +362,7 @@ impl BlockchainKind {
 }
 
 /// A collection of blockchains, keyed by `BlockchainKind` and network.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct BlockchainMap(HashMap<(BlockchainKind, String), Arc<dyn Any + Send + Sync>>);
 
 impl BlockchainMap {

--- a/graph/src/components/store/cache.rs
+++ b/graph/src/components/store/cache.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self, Debug};
 use std::sync::Arc;
 
+use crate::blockchain::BlockPtr;
 use crate::components::store::{
     self as s, Entity, EntityKey, EntityOp, EntityOperation, EntityType,
 };
@@ -340,4 +341,21 @@ impl LfuCache<EntityKey, Option<Entity>> {
             Some(data) => Ok(data.to_owned()),
         }
     }
+}
+
+/// Represents an item retrieved from an
+/// [`EthereumCallCache`](super::EthereumCallCache) implementor.
+pub struct CachedEthereumCall {
+    /// The BLAKE3 hash that uniquely represents this cache item. The way this
+    /// hash is constructed is an implementation detail.
+    pub blake3_id: Vec<u8>,
+
+    /// Block details related to this Ethereum call.
+    pub block_ptr: BlockPtr,
+
+    /// The address to the called contract.
+    pub contract_address: ethabi::Address,
+
+    /// The encoded return value of this call.
+    pub return_value: Vec<u8>,
 }

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -2,7 +2,7 @@ mod cache;
 mod err;
 mod traits;
 
-pub use cache::{EntityCache, ModificationsAndCache};
+pub use cache::{CachedEthereumCall, EntityCache, ModificationsAndCache};
 pub use err::StoreError;
 pub use traits::*;
 

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -358,7 +358,8 @@ pub trait ChainStore: Send + Sync + 'static {
 }
 
 pub trait EthereumCallCache: Send + Sync + 'static {
-    /// Cached return value.
+    /// Returns the return value of the provided Ethereum call, if present in
+    /// the cache.
     fn get_call(
         &self,
         contract_address: ethabi::Address,
@@ -366,7 +367,11 @@ pub trait EthereumCallCache: Send + Sync + 'static {
         block: BlockPtr,
     ) -> Result<Option<Vec<u8>>, Error>;
 
-    // Add entry to the cache.
+    /// Returns all cached calls for a given `block`. This method does *not*
+    /// update the last access time of the returned cached calls.
+    fn get_calls_in_block(&self, block: BlockPtr) -> Result<Vec<CachedEthereumCall>, Error>;
+
+    /// Stores the provided Ethereum call in the cache.
     fn set_call(
         &self,
         contract_address: ethabi::Address,

--- a/graph/src/data/graphql/object_macro.rs
+++ b/graph/src/data/graphql/object_macro.rs
@@ -68,6 +68,20 @@ impl<T: IntoValue> IntoValue for Vec<T> {
     }
 }
 
+impl IntoValue for &[u8] {
+    #[inline]
+    fn into_value(self) -> r::Value {
+        r::Value::String(format!("0x{}", hex::encode(self)))
+    }
+}
+
+impl IntoValue for chrono::NaiveDate {
+    #[inline]
+    fn into_value(self) -> r::Value {
+        r::Value::String(self.format("%Y-%m-%d").to_string())
+    }
+}
+
 macro_rules! impl_into_values {
     ($(($T:ty, $V:ident)),*) => {
         $(

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -210,6 +210,7 @@ impl Value {
             ("BigInt", Value::String(s)) => Ok(Value::String(s)),
             ("BigInt", Value::Int(n)) => Ok(Value::String(n.to_string())),
             ("JSONObject", Value::Object(obj)) => Ok(Value::Object(obj)),
+            ("Date", Value::String(obj)) => Ok(Value::String(obj)),
             (_, v) => Err(v),
         }
     }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -113,12 +113,13 @@ pub mod prelude {
     pub use crate::components::server::query::GraphQLServer;
     pub use crate::components::server::subscription::SubscriptionServer;
     pub use crate::components::store::{
-        AttributeNames, BlockNumber, ChainStore, ChildMultiplicity, EntityCache, EntityChange,
-        EntityChangeOperation, EntityCollection, EntityFilter, EntityKey, EntityLink,
-        EntityModification, EntityOperation, EntityOrder, EntityQuery, EntityRange, EntityWindow,
-        EthereumCallCache, ParentLink, PoolWaitStats, QueryStore, QueryStoreManager, StoreError,
-        StoreEvent, StoreEventStream, StoreEventStreamBox, SubgraphStore, UnfailOutcome,
-        WindowAttribute, BLOCK_NUMBER_MAX, SUBSCRIPTION_THROTTLE_INTERVAL,
+        AttributeNames, BlockNumber, CachedEthereumCall, ChainStore, ChildMultiplicity,
+        EntityCache, EntityChange, EntityChangeOperation, EntityCollection, EntityFilter,
+        EntityKey, EntityLink, EntityModification, EntityOperation, EntityOrder, EntityQuery,
+        EntityRange, EntityWindow, EthereumCallCache, ParentLink, PoolWaitStats, QueryStore,
+        QueryStoreManager, StoreError, StoreEvent, StoreEventStream, StoreEventStreamBox,
+        SubgraphStore, UnfailOutcome, WindowAttribute, BLOCK_NUMBER_MAX,
+        SUBSCRIPTION_THROTTLE_INTERVAL,
     };
     pub use crate::components::subgraph::{
         BlockState, DataSourceTemplateInfo, HostMetrics, RuntimeHost, RuntimeHostBuilder,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -317,6 +317,7 @@ async fn main() {
 
         let mut index_node_server = IndexNodeServer::new(
             &logger_factory,
+            blockchain_map.clone(),
             graphql_runner.clone(),
             network_store.clone(),
             link_resolver.clone(),

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -3,15 +3,13 @@ use std::collections::BTreeMap;
 use std::convert::TryInto;
 use web3::types::{Address, H256};
 
-use graph::blockchain::{Blockchain, BlockchainKind};
+use graph::blockchain::{Blockchain, BlockchainKind, BlockchainMap};
+use graph::components::store::{BlockStore, EntityType, Store};
+use graph::data::graphql::{object, IntoValue, ObjectOrInterface, ValueMap};
 use graph::data::subgraph::features::detect_features;
 use graph::data::subgraph::{status, MAX_SPEC_VERSION};
 use graph::data::value::Object;
 use graph::prelude::*;
-use graph::{
-    components::store::{BlockStore, EntityType, Store},
-    data::graphql::{object, IntoValue, ObjectOrInterface, ValueMap},
-};
 use graph_graphql::prelude::{a, ExecutionContext, Resolver};
 
 use crate::auth::POI_PROTECTION;
@@ -19,6 +17,7 @@ use crate::auth::POI_PROTECTION;
 /// Resolver for the index node GraphQL API.
 pub struct IndexNodeResolver<S, R> {
     logger: Logger,
+    blockchain_map: Arc<BlockchainMap>,
     store: Arc<S>,
     link_resolver: Arc<R>,
     bearer_token: Option<String>,
@@ -34,10 +33,12 @@ where
         store: Arc<S>,
         link_resolver: Arc<R>,
         bearer_token: Option<String>,
+        blockchain_map: Arc<BlockchainMap>,
     ) -> Self {
         let logger = logger.new(o!("component" => "IndexNodeResolver"));
         Self {
             logger,
+            blockchain_map,
             store,
             link_resolver,
             bearer_token,
@@ -503,6 +504,7 @@ where
     fn clone(&self) -> Self {
         Self {
             logger: self.logger.clone(),
+            blockchain_map: self.blockchain_map.clone(),
             store: self.store.clone(),
             link_resolver: self.link_resolver.clone(),
             bearer_token: self.bearer_token.clone(),

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -124,7 +124,7 @@ where
         } else {
             error!(
                 self.logger,
-                "Failed to fetch block data; nonexistant network";
+                "Failed to fetch block data; nonexistent network";
                 "network" => network,
                 "block_hash" => format!("{}", block_hash),
             );

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -4,7 +4,16 @@ scalar Bytes
 scalar ID
 scalar Int
 scalar String
+
+# An opaque object type. Note that this is equivalent to a JSON object, rather
+# than a generic JSON value; as such it cannot be e.g. a string or an integer.
 scalar JSONObject
+# A string in the format of `YYYY-MM-DD`. This is the standard adopted by
+# RFC3339, which is equivalent to the "ISO 8601 extended format".
+# See also:
+# - https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+# - https://en.wikipedia.org/wiki/ISO_8601#Calendar_dates
+scalar Date
 
 type Query {
   indexingStatusForCurrentVersion(subgraphName: String!): SubgraphIndexingStatus
@@ -22,6 +31,10 @@ type Query {
   subgraphFeatures(subgraphId: String!): SubgraphFeatures!
   entityChangesInBlock(subgraphId: String!, blockNumber: Int!): EntityChanges!
   blockData(network: String!, blockHash: Bytes!): JSONObject
+  cachedEthereumCalls(
+    network: String!
+    blockHash: Bytes!
+  ): [CachedEthereumCall!]
 }
 
 type SubgraphIndexingStatus {
@@ -98,6 +111,13 @@ enum Health {
   unhealthy
   "Subgraph halted due to errors"
   failed
+}
+
+type CachedEthereumCall {
+  idHash: Bytes!
+  block: Block!
+  contractAddress: Bytes!
+  returnValue: Bytes!
 }
 
 type SubgraphFeatures {

--- a/server/index-node/src/server.rs
+++ b/server/index-node/src/server.rs
@@ -4,6 +4,7 @@ use hyper::Server;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
 use graph::{
+    blockchain::BlockchainMap,
     components::store::Store,
     prelude::{IndexNodeServer as IndexNodeServerTrait, *},
 };
@@ -27,6 +28,7 @@ impl From<hyper::Error> for IndexNodeServeError {
 /// A GraphQL server based on Hyper.
 pub struct IndexNodeServer<Q, S, R> {
     logger: Logger,
+    blockchain_map: Arc<BlockchainMap>,
     graphql_runner: Arc<Q>,
     store: Arc<S>,
     link_resolver: Arc<R>,
@@ -36,6 +38,7 @@ impl<Q, S, R> IndexNodeServer<Q, S, R> {
     /// Creates a new GraphQL server.
     pub fn new(
         logger_factory: &LoggerFactory,
+        blockchain_map: Arc<BlockchainMap>,
         graphql_runner: Arc<Q>,
         store: Arc<S>,
         link_resolver: Arc<R>,
@@ -51,6 +54,7 @@ impl<Q, S, R> IndexNodeServer<Q, S, R> {
 
         IndexNodeServer {
             logger,
+            blockchain_map,
             graphql_runner,
             store,
             link_resolver,
@@ -86,6 +90,7 @@ where
         let store = self.store.clone();
         let service = IndexNodeService::new(
             logger_for_service.clone(),
+            self.blockchain_map.clone(),
             graphql_runner.clone(),
             store.clone(),
             self.link_resolver.clone(),

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -1,3 +1,4 @@
+use graph::blockchain::BlockchainMap;
 use http::header::{
     self, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
     CONTENT_TYPE, LOCATION,
@@ -28,6 +29,7 @@ pub type IndexNodeServiceResponse = DynTryFuture<'static, Response<Body>, GraphQ
 #[derive(Debug)]
 pub struct IndexNodeService<Q, S, R> {
     logger: Logger,
+    blockchain_map: Arc<BlockchainMap>,
     graphql_runner: Arc<Q>,
     store: Arc<S>,
     explorer: Arc<Explorer<S>>,
@@ -38,6 +40,7 @@ impl<Q, S, R> Clone for IndexNodeService<Q, S, R> {
     fn clone(&self) -> Self {
         Self {
             logger: self.logger.clone(),
+            blockchain_map: self.blockchain_map.clone(),
             graphql_runner: self.graphql_runner.clone(),
             store: self.store.clone(),
             explorer: self.explorer.clone(),
@@ -57,6 +60,7 @@ where
     /// Creates a new GraphQL service.
     pub fn new(
         logger: Logger,
+        blockchain_map: Arc<BlockchainMap>,
         graphql_runner: Arc<Q>,
         store: Arc<S>,
         link_resolver: Arc<R>,
@@ -65,6 +69,7 @@ where
 
         IndexNodeService {
             logger,
+            blockchain_map,
             graphql_runner,
             store,
             explorer,
@@ -132,6 +137,7 @@ where
                 store,
                 self.link_resolver.clone(),
                 validated.bearer_token,
+                self.blockchain_map.clone(),
             );
             let options = QueryExecutionOptions {
                 resolver,

--- a/store/postgres/migrations/2022-03-09-07000_call_cache_block_number_idx/down.sql
+++ b/store/postgres/migrations/2022-03-09-07000_call_cache_block_number_idx/down.sql
@@ -1,0 +1,15 @@
+drop index eth_call_cache_block_number_idx;
+
+do $$
+declare
+	tables cursor for select namespace from ethereum_networks;
+begin
+	for table_record in tables loop
+		execute
+			'drop index '
+			|| table_record.namespace
+			|| '.'
+			|| 'call_cache_block_number_idx';
+	end loop;
+end;
+$$;

--- a/store/postgres/migrations/2022-03-09-07000_call_cache_block_number_idx/up.sql
+++ b/store/postgres/migrations/2022-03-09-07000_call_cache_block_number_idx/up.sql
@@ -1,0 +1,18 @@
+create index if not exists
+	eth_call_cache_block_number_idx
+on
+	eth_call_cache(block_number);
+
+do $$
+declare
+	tables cursor for select namespace from ethereum_networks;
+begin
+	for table_record in tables loop
+		execute
+			'create index if not exists call_cache_block_number_idx on '
+			|| table_record.namespace
+			|| '.'
+			|| 'call_cache(block_number)';
+	end loop;
+end;
+$$;

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -348,6 +348,7 @@ mod data {
 	              contract_address bytea not null,
 	              block_number     int4 not null
                 );
+                create index call_cache_block_number_idx ON {nsp}.call_cache(block_number);
 
                 create table {nsp}.call_meta (
                     contract_address bytea not null primary key,

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -3,19 +3,7 @@ use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use diesel::sql_types::Text;
 use diesel::{insert_into, update};
-use graph::blockchain::{Block, ChainIdentifier};
-use graph::cheap_clone::CheapClone;
-use graph::prelude::web3::types::H256;
-use graph::util::timed_cache::TimedCache;
-use graph::{
-    constraint_violation,
-    prelude::{
-        async_trait, ethabi, CancelableError, ChainStore as ChainStoreTrait, EthereumCallCache,
-        StoreError,
-    },
-};
 
-use graph::ensure;
 use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
@@ -24,9 +12,16 @@ use std::{
     time::Duration,
 };
 
+use graph::blockchain::{Block, ChainIdentifier};
+use graph::cheap_clone::CheapClone;
+use graph::prelude::web3::types::H256;
 use graph::prelude::{
-    serde_json as json, transaction_receipt::LightTransactionReceipt, BlockNumber, BlockPtr, Error,
+    async_trait, ethabi, serde_json as json, transaction_receipt::LightTransactionReceipt,
+    BlockNumber, BlockPtr, CachedEthereumCall, CancelableError, ChainStore as ChainStoreTrait,
+    Error, EthereumCallCache, StoreError,
 };
+use graph::util::timed_cache::TimedCache;
+use graph::{constraint_violation, ensure};
 
 use crate::{
     block_store::ChainStatus, chain_head_listener::ChainHeadUpdateSender,
@@ -52,33 +47,26 @@ pub use data::Storage;
 
 /// Encapuslate access to the blocks table for a chain.
 mod data {
-
-    use diesel::sql_types::Binary;
-    use diesel::{connection::SimpleConnection, insert_into};
-    use diesel::{delete, prelude::*, sql_query};
-    use diesel::{dsl::sql, pg::PgConnection};
-    use diesel::{
-        pg::Pg,
-        serialize::Output,
-        sql_types::Text,
-        types::{FromSql, ToSql},
-    };
-    use diesel::{
-        sql_types::{BigInt, Bytea, Integer, Jsonb},
-        update,
-    };
+    use diesel::connection::SimpleConnection;
+    use diesel::dsl::sql;
+    use diesel::pg::{Pg, PgConnection};
+    use diesel::serialize::Output;
+    use diesel::sql_types::{BigInt, Binary, Bytea, Integer, Jsonb, Text};
+    use diesel::types::{FromSql, ToSql};
+    use diesel::{delete, insert_into, prelude::*, sql_query, update};
     use diesel_dynamic_schema as dds;
     use graph::blockchain::{Block, BlockHash};
-    use graph::{
-        constraint_violation,
-        prelude::{transaction_receipt::LightTransactionReceipt, StoreError},
+    use graph::constraint_violation;
+    use graph::prelude::ethabi::ethereum_types::H160;
+    use graph::prelude::transaction_receipt::LightTransactionReceipt;
+    use graph::prelude::web3::types::H256;
+    use graph::prelude::{
+        serde_json as json, BlockNumber, BlockPtr, CachedEthereumCall, Error, StoreError,
     };
 
     use std::fmt;
     use std::iter::FromIterator;
     use std::{convert::TryFrom, io::Write};
-
-    use graph::prelude::{serde_json as json, web3::types::H256, BlockNumber, BlockPtr, Error};
 
     use crate::transaction_receipt::RawTransactionReceipt;
 
@@ -237,6 +225,10 @@ mod data {
 
         fn id(&self) -> DynColumn<Bytea> {
             self.table.column::<Bytea, _>("id")
+        }
+
+        fn block_number(&self) -> DynColumn<BigInt> {
+            self.table.column::<BigInt, _>("block_number")
         }
 
         fn return_value(&self) -> DynColumn<Bytea> {
@@ -939,6 +931,46 @@ mod data {
                     .optional()
                     .map_err(Error::from),
             }
+        }
+
+        pub(super) fn get_calls_in_block(
+            &self,
+            conn: &PgConnection,
+            block_ptr: BlockPtr,
+        ) -> Result<Vec<CachedEthereumCall>, Error> {
+            let block_num = block_ptr.block_number();
+
+            let rows = match self {
+                Storage::Shared => {
+                    use public::eth_call_cache as cache;
+
+                    cache::table
+                        .select((cache::id, cache::return_value, cache::contract_address))
+                        .filter(cache::block_number.eq(block_num))
+                        .order(cache::contract_address)
+                        .get_results::<(Vec<u8>, Vec<u8>, Vec<u8>)>(conn)?
+                }
+                Storage::Private(Schema { call_cache, .. }) => call_cache
+                    .table()
+                    .select((
+                        call_cache.id(),
+                        call_cache.return_value(),
+                        call_cache.contract_address(),
+                    ))
+                    .filter(call_cache.block_number().eq(block_num as i64))
+                    .order(call_cache.contract_address())
+                    .get_results::<(Vec<u8>, Vec<u8>, Vec<u8>)>(conn)?,
+            };
+
+            Ok(rows
+                .into_iter()
+                .map(|row| CachedEthereumCall {
+                    blake3_id: row.0,
+                    block_ptr: block_ptr.clone(),
+                    contract_address: H160::from_slice(&row.2[..]),
+                    return_value: row.1,
+                })
+                .collect())
         }
 
         pub(super) fn update_accessed_at(
@@ -1645,6 +1677,11 @@ impl EthereumCallCache for ChainStore {
         } else {
             Ok(None)
         }
+    }
+
+    fn get_calls_in_block(&self, block: BlockPtr) -> Result<Vec<CachedEthereumCall>, Error> {
+        let conn = &*self.get_conn()?;
+        conn.transaction::<_, Error, _>(|| Ok(self.storage.get_calls_in_block(conn, block)?))
     }
 
     fn set_call(


### PR DESCRIPTION
Closes #3312.

Initially, I tried to retrace all contract calls in the given block using the logic inside `EthereumAdapter`, then query the cache to see which of those calls were present in the cache, if any. This operates under the assumption that the data coming from the `EthereumAdapter` at the time of cache insertion and cache lookup are identical, which is not necessarily true, as we wouldn't need this debugging API in the first place if that was the case.

After some back and forth, I realized there was no way I could guarantee total consistency of the results obtained this way with the actual contents of the cache and I landed on the original, simpler design - an additional index to the `call_cache` tables.