### PR TITLE
Revert "Cargo.toml: Update to Rust 2021"

### DIFF
--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-chain-ethereum"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 futures = "0.1.21"

--- a/chain/near/Cargo.toml
+++ b/chain/near/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-chain-near"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [build-dependencies]
 tonic-build = "0.5.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-core"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 async-trait = "0.1.50"

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-graphql"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 crossbeam = "0.8"

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-mock"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 graph = { path = "../graph" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-node"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 default-run = "graph-node"
 
 [[bin]]

--- a/runtime/derive/Cargo.toml
+++ b/runtime/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-runtime-derive"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/runtime/derive/src/lib.rs
+++ b/runtime/derive/src/lib.rs
@@ -67,7 +67,7 @@ fn asc_type_derive_struct(item_struct: ItemStruct) -> TokenStream {
     };
 
     TokenStream::from(quote! {
-        impl #impl_generics graph::runtime::AscType for #struct_name #ty_generics #where_clause {
+        impl#impl_generics graph::runtime::AscType for #struct_name#ty_generics #where_clause {
             fn to_asc_bytes(&self) -> Result<Vec<u8>, graph::runtime::DeterministicHostError> {
                 let in_memory_byte_count = std::mem::size_of::<Self>();
                 let mut bytes = Vec::with_capacity(in_memory_byte_count);
@@ -196,7 +196,7 @@ fn asc_type_derive_enum(item_enum: ItemEnum) -> TokenStream {
     let variant_discriminant2 = variant_discriminant.clone();
 
     TokenStream::from(quote! {
-        impl #impl_generics graph::runtime::AscType for #enum_name #ty_generics #where_clause {
+        impl#impl_generics graph::runtime::AscType for #enum_name#ty_generics #where_clause {
             fn to_asc_bytes(&self) -> Result<Vec<u8>, graph::runtime::DeterministicHostError> {
                 let discriminant: u32 = match self {
                     #(#enum_name_iter::#variant_paths => #variant_discriminant,)*

--- a/runtime/test/Cargo.toml
+++ b/runtime/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-runtime-test"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 semver = "1.0"

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-runtime-wasm"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 async-trait = "0.1.50"

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-server-http"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 futures = "0.1.21"

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-server-index-node"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 futures = "0.3.4"

--- a/server/json-rpc/Cargo.toml
+++ b/server/json-rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-server-json-rpc"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 graph = { path = "../../graph" }

--- a/server/metrics/Cargo.toml
+++ b/server/metrics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-server-metrics"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 futures = "0.1.21"

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-server-websocket"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 futures = "0.1.23"

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-store-postgres"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 async-trait = "0.1.50"

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test-store"
 version = "0.25.1"
 authors = ["Leonardo Yvens <leoyvens@gmail.com>"]
-edition = "2021"
+edition = "2018"
 description = "Provides static store instance for tests."
 
 [dependencies]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graph-tests"
 version = "0.25.1"
-edition = "2021"
+edition = "2018"
 
 [dev-dependencies]
 bollard = "0.10"


### PR DESCRIPTION
This reverts https://github.com/graphprotocol/graph-node/pull/3305.

Should solve:
```
Mar 09 20:22:15.139 ERRO Failed to start subgraph, code: SubgraphStartFailure, error: no chain configured for network near-mainnet: no network near-mainnet found on chain near, sgd: 1128, subgraph_id: QmHash, component: SubgraphInstanceManager
```