### PR TITLE
Release 0.25.2 + new update version script 🪄 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,3 +229,17 @@ jobs:
         with:
           command: check
           args: --release
+
+  version-check:
+    name: Check that all graph-node crates have the same version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Checks through all Cargo.toml files, making sure their version is unique
+        run: |
+          source 'scripts/toml-utils.sh'
+
+          ALL_TOML_FILE_NAMES=$(get_all_toml_files)
+          ALL_TOML_VERSIONS=$(get_all_toml_versions $ALL_TOML_FILE_NAMES)
+
+          ./scripts/lines-unique.sh $ALL_TOML_VERSIONS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "graph"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-ethereum"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-near"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "base64",
  "diesel",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-tendermint"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "graph",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "graph-core"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "graph-graphql"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1480,14 +1480,14 @@ dependencies = [
 
 [[package]]
 name = "graph-mock"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "graph",
 ]
 
 [[package]]
 name = "graph-node"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "assert_cli",
  "clap",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-derive"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "quote",
  "syn",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-test"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "graph",
  "graph-chain-ethereum",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-wasm"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-http"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "futures 0.1.31",
  "graph",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-index-node"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "either",
  "futures 0.3.16",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-json-rpc"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "graph",
  "jsonrpc-http-server",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-metrics"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "futures 0.1.31",
  "graph",
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-websocket"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "futures 0.1.31",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "graph-store-postgres"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "graph-tests"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "bollard",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "test-store"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "diesel",
  "graph",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,15 @@
   where whitespace characters were part of the terms.
 - Adds support for Solidity Custom Errors (issue #2577)
 
+## 0.25.2
+
+This release includes two changes:
+
+- Bug fix of blocks being skipped from processing when: a deterministic error happens **and** the `index-node` gets restarted. Issue [#3236](https://github.com/graphprotocol/graph-node/issues/3236), Pull Request: [#3316](https://github.com/graphprotocol/graph-node/pull/3316).
+- Automatic retries for non-deterministic errors. Issue [#2945](https://github.com/graphprotocol/graph-node/issues/2945), Pull Request: [#2988](https://github.com/graphprotocol/graph-node/pull/2988).
+
+This is the last patch on the `0.25` minor version, soon `0.26.0` will be released. While that we recommend updating to this version to avoid determinism issues that could be caused on `graph-node` restarts.
+
 ## 0.25.1
 
 This release only adds two fixes:

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-ethereum"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/chain/near/Cargo.toml
+++ b/chain/near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-near"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [build-dependencies]

--- a/chain/tendermint/Cargo.toml
+++ b/chain/tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-tendermint"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2018"
 
 [build-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-core"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-graphql"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-mock"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-node"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 default-run = "graph-node"
 

--- a/runtime/derive/Cargo.toml
+++ b/runtime/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-derive"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [lib]

--- a/runtime/test/Cargo.toml
+++ b/runtime/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-test"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-wasm"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,39 @@
+# scripts
+
+## update-cargo-version.sh
+
+This script helps to update the versions of all `Cargo.toml` files and the `Cargo.lock` one.
+
+### Functionality
+
+It does more than what's listed below, but this represents the main behavior of it.
+
+1. Asserts that currently all `Cargo.toml` files in the repository have the **same version**;
+2. Changes all of the crates to use the new provided version: `patch`, `minor` or `major`;
+3. Updates the `Cargo.lock` via `cargo check --tests`;
+4. Adds the changes in a `Release X.Y.Z` commit.
+
+### Usage
+
+The only argument it accepts is the type of version you want to do `(patch|minor|major)`.
+
+```bash
+./scripts/update-cargo-version.sh patch
+```
+
+Example output:
+
+```
+Current version: "0.25.1"
+New version: "0.25.2"
+Changing 18 toml files
+Toml files are still consistent in their version after the update
+Updating Cargo.lock file
+    Finished dev [unoptimized + debuginfo] target(s) in 0.58s
+Cargo.lock file updated
+Updating version of the Cargo.{lock, toml} files succeded!
+[otavio/update-news-0-25-2 2f2175bae] Release 0.25.2
+ 20 files changed, 38 insertions(+), 38 deletions(-)
+```
+
+This script contains several assertions to make sure no mistake has been made. Unfortunately for now we don't have a way to revert it, or to recover from an error when it fails in the middle of it, this can be improved in the future.

--- a/scripts/abort.sh
+++ b/scripts/abort.sh
@@ -1,0 +1,6 @@
+abort () {
+  local ERROR_MESSAGE=$1
+  echo "Release failed, error message:"
+  echo $ERROR_MESSAGE
+  exit 1
+}

--- a/scripts/lines-unique.sh
+++ b/scripts/lines-unique.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+source 'scripts/abort.sh'
+
+# Exits with code 0 if lines are unique, 1 otherwise
+LINES=$@
+
+# Validate that parameters are being sent
+[ -z "$LINES" ] && abort "No lines received"
+
+if [ $(echo $LINES | tr " " "\n" | sort | uniq | wc -l) -eq 1 ]; then
+  exit 0
+else
+  exit 1
+fi

--- a/scripts/toml-utils.sh
+++ b/scripts/toml-utils.sh
@@ -1,0 +1,19 @@
+# Get all files named 'Cargo.toml' in the `graph-node` directory, excluding the `integration-tests` folder.
+get_all_toml_files () {
+  echo "$(find . -name Cargo.toml | grep -v integration-tests)"
+}
+
+get_all_toml_versions () {
+  local FILE_NAMES=$@
+  echo $(
+    echo $FILE_NAMES | \
+    # Read all 'Cargo.toml' file contents.
+    xargs cat | \
+    # Get the 'version' key of the TOML, eg: version = "0.25.2"
+    grep '^version = ' | \
+    # Remove the '"' enclosing the version, eg: "0.25.2"
+    tr -d '"' | \
+    # Get only the version number, eg: 0.25.2
+    awk '{print $3}' \
+  )
+}

--- a/scripts/update-cargo-version.sh
+++ b/scripts/update-cargo-version.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+source 'scripts/abort.sh'
+source 'scripts/toml-utils.sh'
+
+ALL_TOML_FILE_NAMES=$(get_all_toml_files)
+ALL_TOML_VERSIONS=$(get_all_toml_versions $ALL_TOML_FILE_NAMES)
+
+# Asserts all .toml versions are currently the same, otherwise abort.
+if ./scripts/lines-unique.sh $ALL_TOML_VERSIONS; then
+  CURRENT_VERSION=$(echo $ALL_TOML_VERSIONS | awk '{print $1}')
+  echo "Current version: \"$CURRENT_VERSION\""
+else
+  abort "Some Cargo.toml files have different versions than others, make sure they're all the same before creating a new release"
+fi
+
+
+# Increment by CLI argument (major, minor, patch)
+MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
+MINOR=$(echo $CURRENT_VERSION | cut -d. -f2)
+PATCH=$(echo $CURRENT_VERSION | cut -d. -f3)
+
+case $1 in
+  "major")
+    let "MAJOR++"
+    MINOR=0
+    PATCH=0
+    ;;
+  "minor")
+    let "MINOR++"
+    PATCH=0
+    ;;
+  "patch")
+    let "PATCH++"
+    ;;
+  *)
+    abort "Version argument should be one of: major, minor or patch"
+    ;;
+esac
+
+NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+echo "New version: \"$NEW_VERSION\""
+
+
+# Replace on all .toml files
+echo "Changing $(echo $ALL_TOML_VERSIONS | tr " " "\n" | wc -l | awk '{$1=$1;print}') toml files"
+
+# MacOS/OSX unfortunately doesn't have the same API for `sed`, so we're
+# using `perl` instead since it's installed by default in all Mac machines.
+#
+# For mor info: https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    perl -i -pe"s/^version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" $ALL_TOML_FILE_NAMES
+# Default, for decent OSs (eg: GNU-Linux)
+else
+    sed -i "s/^version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" $ALL_TOML_FILE_NAMES
+fi
+
+
+# Assert all the new .toml versions are the same, otherwise abort
+UPDATED_TOML_VERSIONS=$(get_all_toml_versions $ALL_TOML_FILE_NAMES)
+if ./scripts/lines-unique.sh $UPDATED_TOML_VERSIONS; then
+  echo "Toml files are still consistent in their version after the update"
+else
+  abort "Something went wrong with the version replacement and the new version isn't the same across the Cargo.toml files"
+fi
+
+
+# Assert there was a git diff in the changed files, otherwise abort
+if [[ $(git diff $ALL_TOML_FILE_NAMES) ]]; then
+  :
+else
+  abort "Somehow the toml files didn't get changed"
+fi
+
+
+echo "Updating Cargo.lock file"
+cargo check --tests
+
+
+# Assert .lock file changed the versions, otherwise abort
+if [[ $(git diff Cargo.lock) ]]; then
+    echo "Cargo.lock file updated"
+else
+    abort "There was no change in the Cargo.lock file, something went wrong with updating the crates versions"
+fi
+
+
+echo "Updating version of the Cargo.{lock, toml} files succeded!"
+
+git add Cargo.lock $ALL_TOML_FILE_NAMES
+git commit -m "Release ${NEW_VERSION}"

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-http"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-index-node"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/server/json-rpc/Cargo.toml
+++ b/server/json-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-json-rpc"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/server/metrics/Cargo.toml
+++ b/server/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-metrics"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-websocket"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-store-postgres"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dependencies]

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-store"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Leonardo Yvens <leoyvens@gmail.com>"]
 edition = "2021"
 description = "Provides static store instance for tests."

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-tests"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 
 [dev-dependencies]


### PR DESCRIPTION
This Pull Request does a few things:

- Updates the `NEWS.md`, cherry-picked from: https://github.com/graphprotocol/graph-node/pull/3317;
- Adds a new `scripts` folder with bash commands to change the `Cargo.toml`/`Cargo.lock` versions automatically;
- Updates the `Cargo.toml`/`Cargo.lock` files (done using the new script ✨ );
- Adds a check to the CI so that no new `crate` can be added to the repo without having the correct version (aka the same as the rest).
