### PR TITLE
Fix Firehose chains not starting properly

### DIFF
--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -332,7 +332,7 @@ where
                     // on the URL)
                     Ok(Err(e)) | Err(e) => {
                         error!(logger, "Connection to provider failed. Not using this provider";
-                                       "error" =>  e.to_string());
+                                       "error" =>  format!("{:#}", e));
                         ProviderNetworkStatus::Broken {
                             chain_id,
                             provider: endpoint.provider.to_string(),


### PR DESCRIPTION
It appears that requesting `start_block_num: 0, stop_block_num: 0` does not stop the stream after receiving the genesis block as I expected. Instead, the stream continue to send blocks forever.

This caused the `block_ptr_for_number` to never return properly, causing the `NET_WAIT` timeout to kick which was ultimately leading to the network not being added to the blockchain map and hence, no subgraph could run for this network.

To prevent looping infinitely, we stop as soon as a new received block's number is higher than the latest received block's number, in which case it means it's an event for a block we are not interested in.

