### PR TITLE
Add publicProofOfIndexing resolver to the indexing status API

### DIFF
--- a/graph/src/blockchain/types.rs
+++ b/graph/src/blockchain/types.rs
@@ -26,6 +26,10 @@ impl BlockHash {
     pub fn hash_hex(&self) -> String {
         hex::encode(&self.0)
     }
+
+    pub fn zero() -> Self {
+        Self::from(H256::zero())
+    }
 }
 
 impl fmt::Display for BlockHash {
@@ -224,7 +228,7 @@ impl TryFromValue for BlockPtr {
     fn try_from_value(value: &r::Value) -> Result<Self, anyhow::Error> {
         match value {
             r::Value::Object(o) => {
-                let number = o.get_required::<BigInt>("number")?.to_u64() as i32;
+                let number = o.get_required::<BigInt>("number")?.to_u64() as BlockNumber;
                 let hash = o.get_required::<H256>("hash")?;
 
                 Ok(BlockPtr::from((hash, number)))

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -943,3 +943,15 @@ impl AttributeNames {
         }
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct PartialBlockPtr {
+    pub number: BlockNumber,
+    pub hash: Option<BlockHash>,
+}
+
+impl From<BlockNumber> for PartialBlockPtr {
+    fn from(number: BlockNumber) -> Self {
+        Self { number, hash: None }
+    }
+}

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -451,4 +451,13 @@ pub trait StatusStore: Send + Sync + 'static {
         indexer: &Option<Address>,
         block: BlockPtr,
     ) -> Result<Option<[u8; 32]>, StoreError>;
+
+    /// Like `get_proof_of_indexing` but returns a Proof of Indexing signed by
+    /// address `0x00...0`, which allows it to be shared in public without
+    /// revealing the indexers _real_ Proof of Indexing.
+    async fn get_public_proof_of_indexing(
+        &self,
+        subgraph_id: &DeploymentHash,
+        block_number: BlockNumber,
+    ) -> Result<Option<(PartialBlockPtr, [u8; 32])>, StoreError>;
 }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -93,7 +93,7 @@ pub mod prelude {
     pub type DynTryFuture<'a, Ok = (), Err = Error> =
         Pin<Box<dyn futures03::Future<Output = Result<Ok, Err>> + Send + 'a>>;
 
-    pub use crate::blockchain::BlockPtr;
+    pub use crate::blockchain::{BlockHash, BlockPtr};
 
     pub use crate::components::ethereum::{
         EthereumBlock, EthereumBlockWithCalls, EthereumCall, LightEthereumBlock,
@@ -117,9 +117,9 @@ pub mod prelude {
         AttributeNames, BlockNumber, CachedEthereumCall, ChainStore, ChildMultiplicity,
         EntityCache, EntityChange, EntityChangeOperation, EntityCollection, EntityFilter,
         EntityKey, EntityLink, EntityModification, EntityOperation, EntityOrder, EntityQuery,
-        EntityRange, EntityWindow, EthereumCallCache, ParentLink, PoolWaitStats, QueryStore,
-        QueryStoreManager, StoreError, StoreEvent, StoreEventStream, StoreEventStreamBox,
-        SubgraphStore, UnfailOutcome, WindowAttribute, BLOCK_NUMBER_MAX,
+        EntityRange, EntityWindow, EthereumCallCache, ParentLink, PartialBlockPtr, PoolWaitStats,
+        QueryStore, QueryStoreManager, StoreError, StoreEvent, StoreEventStream,
+        StoreEventStreamBox, SubgraphStore, UnfailOutcome, WindowAttribute, BLOCK_NUMBER_MAX,
     };
     pub use crate::components::subgraph::{
         BlockState, DataSourceTemplateInfo, HostMetrics, RuntimeHost, RuntimeHostBuilder,

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -341,6 +341,13 @@ impl<S: Store> IndexNodeResolver<S> {
             .get_required::<Vec<PublicProofOfIndexingRequest>>("requests")
             .expect("valid requests required, validation should have caught this");
 
+        // Only 10 requests are allowed at a time to avoid generating too many SQL queries;
+        // NOTE: Indexers should rate limit the status API anyway, but this adds some soft
+        // extra protection
+        if requests.len() > 10 {
+            return Err(QueryExecutionError::TooExpensive);
+        }
+
         Ok(r::Value::List(
             requests
                 .into_iter()

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -1,6 +1,7 @@
-use either::Either;
 use std::collections::BTreeMap;
 use std::convert::TryInto;
+
+use either::Either;
 use web3::types::{Address, H256};
 
 use graph::blockchain::{Blockchain, BlockchainKind, BlockchainMap};
@@ -13,6 +14,48 @@ use graph::prelude::*;
 use graph_graphql::prelude::{a, ExecutionContext, Resolver};
 
 use crate::auth::PoiProtection;
+
+#[derive(Clone, Debug)]
+struct PublicProofOfIndexingRequest {
+    pub deployment: DeploymentHash,
+    pub block_number: BlockNumber,
+}
+
+impl TryFromValue for PublicProofOfIndexingRequest {
+    fn try_from_value(value: &r::Value) -> Result<Self, Error> {
+        match value {
+            r::Value::Object(o) => Ok(Self {
+                deployment: DeploymentHash::new(o.get_required::<String>("deployment")?).unwrap(),
+                block_number: o.get_required::<BlockNumber>("blockNumber")?,
+            }),
+            _ => Err(anyhow!(
+                "Cannot parse non-object value as PublicProofOfIndexingRequest: {:?}",
+                value
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PublicProofOfIndexingResult {
+    pub deployment: DeploymentHash,
+    pub block: PartialBlockPtr,
+    pub proof_of_indexing: Option<[u8; 32]>,
+}
+
+impl IntoValue for PublicProofOfIndexingResult {
+    fn into_value(self) -> r::Value {
+        object! {
+            __typename: "ProofOfIndexingResult",
+            deployment: self.deployment.to_string(),
+            block: object! {
+                number: self.block.number,
+                hash: self.block.hash.map(|hash| hash.hash_hex()),
+            },
+            proofOfIndexing: self.proof_of_indexing.map(|poi| format!("0x{}", hex::encode(&poi))),
+        }
+    }
+}
 
 /// Resolver for the index node GraphQL API.
 pub struct IndexNodeResolver<S: Store> {
@@ -288,6 +331,54 @@ impl<S: Store> IndexNodeResolver<S> {
         };
 
         Ok(poi)
+    }
+
+    fn resolve_public_proofs_of_indexing(
+        &self,
+        field: &a::Field,
+    ) -> Result<r::Value, QueryExecutionError> {
+        let requests = field
+            .get_required::<Vec<PublicProofOfIndexingRequest>>("requests")
+            .expect("valid requests required, validation should have caught this");
+
+        Ok(r::Value::List(
+            requests
+                .into_iter()
+                .map(|request| {
+                    match futures::executor::block_on(
+                        self.store.get_public_proof_of_indexing(
+                            &request.deployment,
+                            request.block_number,
+                        ),
+                    ) {
+                        Ok(Some(poi)) => (Some(poi), request),
+                        Ok(None) => (None, request),
+                        Err(e) => {
+                            error!(
+                                self.logger,
+                                "Failed to query public proof of indexing";
+                                "subgraph" => &request.deployment,
+                                "block" => format!("{}", request.block_number),
+                                "error" => format!("{:?}", e)
+                            );
+                            (None, request)
+                        }
+                    }
+                })
+                .map(|(poi_result, request)| PublicProofOfIndexingResult {
+                    deployment: request.deployment,
+                    block: match poi_result {
+                        Some((ref block, _)) => block.clone(),
+                        None => PartialBlockPtr::from(request.block_number),
+                    },
+                    proof_of_indexing: match poi_result {
+                        Some((_, poi)) => Some(poi),
+                        None => None,
+                    },
+                })
+                .map(IntoValue::into_value)
+                .collect(),
+        ))
     }
 
     fn resolve_indexing_status_for_version(
@@ -648,6 +739,11 @@ impl<S: Store> Resolver for IndexNodeResolver<S> {
             }
             (None, "CachedEthereumCall", "cachedEthereumCalls") => {
                 self.resolve_cached_ethereum_calls(field)
+            }
+
+            // The top-level `publicProofsOfIndexing` field
+            (None, "PublicProofOfIndexingResult", "publicProofsOfIndexing") => {
+                self.resolve_public_proofs_of_indexing(field)
             }
 
             // Resolve fields of `Object` values (e.g. the `chains` field of `ChainIndexingStatus`)

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -28,6 +28,14 @@ type Query {
     blockHash: Bytes!
     indexer: Bytes
   ): Bytes
+  """
+  Proofs of indexing for several deployments and blocks that can be shared and
+  compared in public without revealing the _actual_ proof of indexing that every
+  indexer has in their database
+  """
+  publicProofsOfIndexing(
+    requests: [PublicProofOfIndexingRequest!]!
+  ): [PublicProofOfIndexingResult!]!
   subgraphFeatures(subgraphId: String!): SubgraphFeatures!
   entityChangesInBlock(subgraphId: String!, blockNumber: Int!): EntityChanges!
   blockData(network: String!, blockHash: Bytes!): JSONObject
@@ -131,4 +139,37 @@ enum Feature {
   grafting
   fullTextSearch
   ipfsOnEthereumContracts
+}
+
+input BlockInput {
+  hash: Bytes!
+  number: BigInt!
+}
+
+input ProofOfIndexingRequest {
+  deployment: String!
+  block: BlockInput!
+}
+
+input PublicProofOfIndexingRequest {
+  deployment: String!
+  blockNumber: BigInt!
+}
+
+type PartialBlock {
+  hash: Bytes
+  number: BigInt!
+}
+
+type PublicProofOfIndexingResult {
+  deployment: String!
+  block: PartialBlock!
+  proofOfIndexing: Bytes!
+}
+
+type ProofOfIndexingResult {
+  deployment: String!
+  block: Block!
+  "There may not be a proof of indexing available for the deployment and block"
+  proofOfIndexing: Bytes
 }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -11,8 +11,8 @@ use graph::{
     constraint_violation,
     data::subgraph::status,
     prelude::{
-        tokio, web3::types::Address, BlockPtr, CheapClone, DeploymentHash, QueryExecutionError,
-        StoreError,
+        tokio, web3::types::Address, BlockNumber, BlockPtr, CheapClone, DeploymentHash,
+        PartialBlockPtr, QueryExecutionError, StoreError,
     },
 };
 
@@ -141,6 +141,16 @@ impl StatusStore for Store {
     ) -> Result<Option<[u8; 32]>, StoreError> {
         self.subgraph_store
             .get_proof_of_indexing(subgraph_id, indexer, block)
+            .await
+    }
+
+    async fn get_public_proof_of_indexing(
+        &self,
+        subgraph_id: &DeploymentHash,
+        block_number: BlockNumber,
+    ) -> Result<Option<(PartialBlockPtr, [u8; 32])>, StoreError> {
+        self.subgraph_store
+            .get_public_proof_of_indexing(subgraph_id, block_number, self.block_store().clone())
             .await
     }
 

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -15,7 +15,7 @@ use graph::{
     cheap_clone::CheapClone,
     components::{
         server::index_node::VersionInfo,
-        store::{self, DeploymentLocator, EnsLookup as EnsLookupTrait, SubgraphFork},
+        store::{self, BlockStore, DeploymentLocator, EnsLookup as EnsLookupTrait, SubgraphFork},
     },
     constraint_violation,
     data::query::QueryTarget,
@@ -23,8 +23,9 @@ use graph::{
     prelude::StoreEvent,
     prelude::{
         anyhow, futures03::future::join_all, lazy_static, o, web3::types::Address, ApiSchema,
-        BlockNumber, BlockPtr, DeploymentHash, EntityOperation, Logger, NodeId, Schema, StoreError,
-        SubgraphName, SubgraphStore as SubgraphStoreTrait, SubgraphVersionSwitchingMode,
+        BlockHash, BlockNumber, BlockPtr, ChainStore, DeploymentHash, EntityOperation, Logger,
+        NodeId, PartialBlockPtr, Schema, StoreError, SubgraphName,
+        SubgraphStore as SubgraphStoreTrait, SubgraphVersionSwitchingMode,
     },
     url::Url,
     util::timed_cache::TimedCache,
@@ -227,6 +228,17 @@ impl SubgraphStore {
         block: BlockPtr,
     ) -> Result<Option<[u8; 32]>, StoreError> {
         self.inner.get_proof_of_indexing(id, indexer, block).await
+    }
+
+    pub(crate) async fn get_public_proof_of_indexing(
+        &self,
+        id: &DeploymentHash,
+        block_number: BlockNumber,
+        block_store: Arc<impl BlockStore>,
+    ) -> Result<Option<(PartialBlockPtr, [u8; 32])>, StoreError> {
+        self.inner
+            .get_public_proof_of_indexing(id, block_number, block_store)
+            .await
     }
 
     pub fn notification_sender(&self) -> Arc<NotificationSender> {
@@ -905,6 +917,44 @@ impl SubgraphStoreInner {
     ) -> Result<Option<[u8; 32]>, StoreError> {
         let (store, site) = self.store(id).unwrap();
         store.get_proof_of_indexing(site, indexer, block).await
+    }
+
+    pub(crate) async fn get_public_proof_of_indexing(
+        &self,
+        id: &DeploymentHash,
+        block_number: BlockNumber,
+        block_store: Arc<impl BlockStore>,
+    ) -> Result<Option<(PartialBlockPtr, [u8; 32])>, StoreError> {
+        let (store, site) = self.store(&id).unwrap();
+
+        let chain_store = match block_store.chain_store(&site.network) {
+            Some(chain_store) => chain_store,
+            None => return Ok(None),
+        };
+        let mut hashes = chain_store.block_hashes_by_block_number(block_number)?;
+
+        // If we don't have this block or we have multiple versions of this block
+        // and using any of them could introduce non-deterministic because we don't
+        // know which one is the right one -> return no block hash
+        let block = PartialBlockPtr {
+            number: block_number,
+            hash: if hashes.is_empty() || hashes.len() > 1 {
+                None
+            } else {
+                Some(BlockHash::from(hashes.pop().unwrap()))
+            },
+        };
+
+        let block_for_poi_query = BlockPtr::new(
+            block.hash.clone().unwrap_or(BlockHash::zero()),
+            block.number,
+        );
+        let indexer = Some(Address::zero());
+        let poi = store
+            .get_proof_of_indexing(site, &indexer, block_for_poi_query)
+            .await?;
+
+        Ok(poi.map(|poi| (block, poi)))
     }
 
     // Only used by tests

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -915,7 +915,7 @@ impl SubgraphStoreInner {
         indexer: &Option<Address>,
         block: BlockPtr,
     ) -> Result<Option<[u8; 32]>, StoreError> {
-        let (store, site) = self.store(id).unwrap();
+        let (store, site) = self.store(id)?;
         store.get_proof_of_indexing(site, indexer, block).await
     }
 
@@ -925,7 +925,7 @@ impl SubgraphStoreInner {
         block_number: BlockNumber,
         block_store: Arc<impl BlockStore>,
     ) -> Result<Option<(PartialBlockPtr, [u8; 32])>, StoreError> {
-        let (store, site) = self.store(&id).unwrap();
+        let (store, site) = self.store(&id)?;
 
         let chain_store = match block_store.chain_store(&site.network) {
             Some(chain_store) => chain_store,


### PR DESCRIPTION
This allows to retrieve comparable POIs that can be shared in public without anyone being able to submit these to get for rewards without doing any work.