### PR TITLE
Fix 'graphman copy create'

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -6,7 +6,7 @@ use graph::blockchain::Blockchain;
 use graph::blockchain::BlockchainKind;
 use graph::blockchain::BlockchainMap;
 use graph::components::store::{DeploymentId, DeploymentLocator, SubscriptionManager};
-use graph::data::subgraph::schema::SubgraphDeploymentEntity;
+use graph::data::subgraph::schema::DeploymentCreate;
 use graph::data::subgraph::MAX_SPEC_VERSION;
 use graph::prelude::{
     CreateSubgraphResult, SubgraphAssignmentProvider as SubgraphAssignmentProviderTrait,
@@ -568,7 +568,7 @@ async fn create_subgraph_version<C: Blockchain, S: SubgraphStore, L: LinkResolve
 
     // Apply the subgraph versioning and deployment operations,
     // creating a new subgraph deployment if one doesn't exist.
-    let deployment = SubgraphDeploymentEntity::new(&manifest, false, start_block)
+    let deployment = DeploymentCreate::new(&manifest, start_block)
         .graft(base_block)
         .debug(debug_fork);
     deployment_store

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -62,7 +62,7 @@ pub trait SubgraphStore: Send + Sync + 'static {
         &self,
         name: SubgraphName,
         schema: &Schema,
-        deployment: SubgraphDeploymentEntity,
+        deployment: DeploymentCreate,
         node_id: NodeId,
         network: String,
         mode: SubgraphVersionSwitchingMode,

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -99,6 +99,45 @@ impl TryFromValue for SubgraphHealth {
     }
 }
 
+/// The deployment data that is needed to create a deployment
+pub struct DeploymentCreate {
+    pub manifest: SubgraphManifestEntity,
+    pub earliest_block: Option<BlockPtr>,
+    pub graft_base: Option<DeploymentHash>,
+    pub graft_block: Option<BlockPtr>,
+    pub debug_fork: Option<DeploymentHash>,
+}
+
+impl DeploymentCreate {
+    pub fn new(
+        source_manifest: &SubgraphManifest<impl Blockchain>,
+        earliest_block: Option<BlockPtr>,
+    ) -> Self {
+        Self {
+            manifest: SubgraphManifestEntity::from(source_manifest),
+            earliest_block: earliest_block.cheap_clone(),
+            graft_base: None,
+            graft_block: None,
+            debug_fork: None,
+        }
+    }
+
+    pub fn graft(mut self, base: Option<(DeploymentHash, BlockPtr)>) -> Self {
+        if let Some((subgraph, ptr)) = base {
+            self.graft_base = Some(subgraph);
+            self.graft_block = Some(ptr);
+        }
+        self
+    }
+
+    pub fn debug(mut self, fork: Option<DeploymentHash>) -> Self {
+        self.debug_fork = fork;
+        self
+    }
+}
+
+/// The representation of a subgraph deployment when reading an existing
+/// deployment
 #[derive(Debug)]
 pub struct SubgraphDeploymentEntity {
     pub manifest: SubgraphManifestEntity,
@@ -115,47 +154,6 @@ pub struct SubgraphDeploymentEntity {
     pub reorg_count: i32,
     pub current_reorg_depth: i32,
     pub max_reorg_depth: i32,
-}
-
-impl SubgraphDeploymentEntity {
-    pub fn new(
-        source_manifest: &SubgraphManifest<impl Blockchain>,
-        synced: bool,
-        earliest_block: Option<BlockPtr>,
-    ) -> Self {
-        Self {
-            manifest: SubgraphManifestEntity::from(source_manifest),
-            failed: false,
-            health: SubgraphHealth::Healthy,
-            synced,
-            fatal_error: None,
-            non_fatal_errors: vec![],
-            earliest_block: earliest_block.cheap_clone(),
-            latest_block: earliest_block,
-            graft_base: None,
-            graft_block: None,
-            debug_fork: None,
-            reorg_count: 0,
-            current_reorg_depth: 0,
-            max_reorg_depth: 0,
-        }
-    }
-
-    pub fn graft(mut self, base: Option<(DeploymentHash, BlockPtr)>) -> Self {
-        if let Some((subgraph, ptr)) = base {
-            self.graft_base = Some(subgraph);
-            self.graft_block = Some(ptr);
-            // When we graft, the block pointer is only set after copying
-            // from the base subgraph finished successfully
-            self.latest_block = None;
-        }
-        self
-    }
-
-    pub fn debug(mut self, fork: Option<DeploymentHash>) -> Self {
-        self.debug_fork = fork;
-        self
-    }
 }
 
 #[derive(Debug)]

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate pretty_assertions;
 
+use graph::data::subgraph::schema::DeploymentCreate;
 use graph::data::value::Object;
 use graphql_parser::Pos;
 use std::iter::FromIterator;
@@ -23,8 +24,8 @@ use graph::{
         futures03::stream::StreamExt, o, q, r, serde_json, slog, BlockPtr, DeploymentHash, Entity,
         EntityKey, EntityOperation, FutureExtension, GraphQlRunner as _, Logger, NodeId, Query,
         QueryError, QueryExecutionError, QueryResult, QueryStoreManager, QueryVariables, Schema,
-        SubgraphDeploymentEntity, SubgraphManifest, SubgraphName, SubgraphStore,
-        SubgraphVersionSwitchingMode, Subscription, SubscriptionError, Value,
+        SubgraphManifest, SubgraphName, SubgraphStore, SubgraphVersionSwitchingMode, Subscription,
+        SubscriptionError, Value,
     },
     semver::Version,
 };
@@ -112,7 +113,7 @@ fn insert_test_entities(
     store: &impl SubgraphStore,
     manifest: SubgraphManifest<graph_chain_ethereum::Chain>,
 ) -> DeploymentLocator {
-    let deployment = SubgraphDeploymentEntity::new(&manifest, false, None);
+    let deployment = DeploymentCreate::new(&manifest, None);
     let name = SubgraphName::new("test/query").unwrap();
     let node_id = NodeId::new("test").unwrap();
     let deployment = store

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -27,7 +27,7 @@ use std::time::Instant;
 use graph::components::store::EntityCollection;
 use graph::components::subgraph::ProofOfIndexingFinisher;
 use graph::constraint_violation;
-use graph::data::subgraph::schema::{SubgraphError, POI_OBJECT};
+use graph::data::subgraph::schema::{DeploymentCreate, SubgraphError, POI_OBJECT};
 use graph::prelude::{
     anyhow, debug, info, lazy_static, o, warn, web3, ApiSchema, AttributeNames, BlockNumber,
     BlockPtr, CheapClone, DeploymentHash, DeploymentState, Entity, EntityKey, EntityModification,
@@ -175,7 +175,7 @@ impl DeploymentStore {
     pub(crate) fn create_deployment(
         &self,
         schema: &Schema,
-        deployment: SubgraphDeploymentEntity,
+        deployment: DeploymentCreate,
         site: Arc<Site>,
         graft_base: Option<Arc<Layout>>,
         replace: bool,

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -593,7 +593,7 @@ impl SubgraphStoreInner {
             fatal_error: None,
             non_fatal_errors: vec![],
             earliest_block: deployment.earliest_block.clone(),
-            latest_block: deployment.earliest_block,
+            latest_block: None,
             graft_base: Some(src.deployment.clone()),
             graft_block: Some(block),
             debug_fork: deployment.debug_fork,

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -19,9 +19,8 @@ use graph::{
     },
     constraint_violation,
     data::query::QueryTarget,
-    data::subgraph::status,
+    data::subgraph::{schema::DeploymentCreate, status},
     prelude::StoreEvent,
-    prelude::SubgraphDeploymentEntity,
     prelude::{
         anyhow, futures03::future::join_all, lazy_static, o, web3::types::Address, ApiSchema,
         BlockNumber, BlockPtr, DeploymentHash, EntityOperation, Logger, NodeId, Schema, StoreError,
@@ -472,7 +471,7 @@ impl SubgraphStoreInner {
         &self,
         name: SubgraphName,
         schema: &Schema,
-        deployment: SubgraphDeploymentEntity,
+        deployment: DeploymentCreate,
         node_id: NodeId,
         network_name: String,
         mode: SubgraphVersionSwitchingMode,
@@ -585,21 +584,12 @@ impl SubgraphStoreInner {
         }
 
         // Transmogrify the deployment into a new one
-        let deployment = SubgraphDeploymentEntity {
+        let deployment = DeploymentCreate {
             manifest: deployment.manifest,
-            failed: false,
-            health: deployment.health,
-            synced: false,
-            fatal_error: None,
-            non_fatal_errors: vec![],
             earliest_block: deployment.earliest_block.clone(),
-            latest_block: None,
             graft_base: Some(src.deployment.clone()),
             graft_block: Some(block),
             debug_fork: deployment.debug_fork,
-            reorg_count: 0,
-            current_reorg_depth: 0,
-            max_reorg_depth: 0,
         };
 
         let graft_base = self.layout(&src.deployment)?;
@@ -652,7 +642,7 @@ impl SubgraphStoreInner {
         &self,
         name: SubgraphName,
         schema: &Schema,
-        deployment: SubgraphDeploymentEntity,
+        deployment: DeploymentCreate,
         node_id: NodeId,
         network_name: String,
         mode: SubgraphVersionSwitchingMode,
@@ -1019,7 +1009,7 @@ impl SubgraphStoreTrait for SubgraphStore {
         &self,
         name: SubgraphName,
         schema: &Schema,
-        deployment: SubgraphDeploymentEntity,
+        deployment: DeploymentCreate,
         node_id: NodeId,
         network_name: String,
         mode: SubgraphVersionSwitchingMode,

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -138,7 +138,7 @@ fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator {
     };
 
     // Create SubgraphDeploymentEntity
-    let deployment = SubgraphDeploymentEntity::new(&manifest, false, None);
+    let deployment = DeploymentCreate::new(&manifest, None);
     let name = SubgraphName::new("test/graft").unwrap();
     let node_id = NodeId::new("test").unwrap();
     let deployment = store

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1,4 +1,5 @@
 use graph::data::graphql::ext::TypeDefinitionExt;
+use graph::data::subgraph::schema::DeploymentCreate;
 use graph_chain_ethereum::{Mapping, MappingABI};
 use graph_mock::MockMetricsRegistry;
 use hex_literal::hex;
@@ -165,7 +166,7 @@ fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator {
     };
 
     // Create SubgraphDeploymentEntity
-    let deployment = SubgraphDeploymentEntity::new(&manifest, false, None);
+    let deployment = DeploymentCreate::new(&manifest, None);
     let name = SubgraphName::new("test/store").unwrap();
     let node_id = NodeId::new("test").unwrap();
     let deployment = store
@@ -1278,9 +1279,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             chain: PhantomData,
         };
 
-        // Create SubgraphDeploymentEntity
-        let deployment_entity =
-            SubgraphDeploymentEntity::new(&manifest, false, Some(TEST_BLOCK_0_PTR.clone()));
+        let deployment = DeploymentCreate::new(&manifest, Some(TEST_BLOCK_0_PTR.clone()));
         let name = SubgraphName::new("test/entity-changes-are-fired").unwrap();
         let node_id = NodeId::new("test").unwrap();
         let deployment = store
@@ -1288,7 +1287,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             .create_subgraph_deployment(
                 name,
                 &schema,
-                deployment_entity,
+                deployment,
                 node_id,
                 NETWORK_NAME.to_string(),
                 SubgraphVersionSwitchingMode::Instant,

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -3,13 +3,12 @@ use graph::{
         server::index_node::VersionInfo,
         store::{DeploymentLocator, StatusStore},
     },
-    data::subgraph::schema::SubgraphError,
     data::subgraph::schema::SubgraphHealth,
+    data::subgraph::schema::{DeploymentCreate, SubgraphError},
     prelude::EntityChange,
     prelude::EntityChangeOperation,
     prelude::QueryStoreManager,
     prelude::Schema,
-    prelude::SubgraphDeploymentEntity,
     prelude::SubgraphManifest,
     prelude::SubgraphName,
     prelude::SubgraphVersionSwitchingMode,
@@ -137,7 +136,7 @@ fn create_subgraph() {
             templates: vec![],
             chain: PhantomData,
         };
-        let deployment = SubgraphDeploymentEntity::new(&manifest, false, None);
+        let deployment = DeploymentCreate::new(&manifest, None);
         let node_id = NodeId::new("left").unwrap();
 
         let (deployment, events) = tap_store_events(|| {

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -2,7 +2,7 @@ use diesel::{self, PgConnection};
 use graph::data::graphql::effort::LoadManager;
 use graph::data::query::QueryResults;
 use graph::data::query::QueryTarget;
-use graph::data::subgraph::schema::SubgraphError;
+use graph::data::subgraph::schema::{DeploymentCreate, SubgraphError};
 use graph::log;
 use graph::prelude::{QueryStoreManager as _, SubgraphStore as _, *};
 use graph::semver::Version;
@@ -166,7 +166,7 @@ pub fn create_subgraph(
         chain: PhantomData,
     };
 
-    let deployment = SubgraphDeploymentEntity::new(&manifest, false, None).graft(base);
+    let deployment = DeploymentCreate::new(&manifest, None).graft(base);
     let name = {
         let mut name = subgraph_id.to_string();
         name.truncate(32);


### PR DESCRIPTION
Copying a subgraph that had a start block set would fail after the fix in PR #3287; ultimately, the bug was caused because `SubgraphDeploymentEntity` allows setting things that should not be set when creating a subgraph. Improve the code by using a different struct for creating a deployment.