### PR TITLE
Update docker readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -83,6 +83,7 @@ deploy your subgraph to the running Graph Node.
   
 We do not currently build native images for Macbook M1, which can lead to processes being killed due to out-of-memory errors (code 137). Based on the example `docker-compose.yml` is possible to rebuild the image for your M1 by running the following, then running `docker-compose up` as normal:
  
+It is important to increase memory limits for the docker engine running on your machine. Otherwise docker build command will fail due to out of memory error. To do that, open docker-desktop and go to Resources/advanced/memory
 ```
 # Remove the original image
 docker rmi graphprotocol/graph-node:latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -83,7 +83,7 @@ deploy your subgraph to the running Graph Node.
   
 We do not currently build native images for Macbook M1, which can lead to processes being killed due to out-of-memory errors (code 137). Based on the example `docker-compose.yml` is possible to rebuild the image for your M1 by running the following, then running `docker-compose up` as normal:
  
-> **Important** Increase memory limits for the docker engine running on your machine. Otherwise docker build command will fail due to out of memory error. To do that, open docker-desktop and go to Resources/advanced/memory
+> **Important** Increase memory limits for the docker engine running on your machine. Otherwise docker build command will fail due to out of memory error. To do that, open docker-desktop and go to Resources/advanced/memory.
 ```
 # Remove the original image
 docker rmi graphprotocol/graph-node:latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -83,7 +83,7 @@ deploy your subgraph to the running Graph Node.
   
 We do not currently build native images for Macbook M1, which can lead to processes being killed due to out-of-memory errors (code 137). Based on the example `docker-compose.yml` is possible to rebuild the image for your M1 by running the following, then running `docker-compose up` as normal:
  
-It is important to increase memory limits for the docker engine running on your machine. Otherwise docker build command will fail due to out of memory error. To do that, open docker-desktop and go to Resources/advanced/memory
+> **Important** Increase memory limits for the docker engine running on your machine. Otherwise docker build command will fail due to out of memory error. To do that, open docker-desktop and go to Resources/advanced/memory
 ```
 # Remove the original image
 docker rmi graphprotocol/graph-node:latest


### PR DESCRIPTION
When running on m1 macbook pro, I followed instructions to rebuild the image. It was failing due to out of memory errors. To fix that users should increase their memory limits in docker-desktop application.

