### PR TITLE
Reenable prefixing of `bytea` columns and avoid performance regression

### DIFF
--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -147,11 +147,11 @@ pub fn main() {
     );
     let site = Arc::new(make_dummy_site(subgraph, namespace, "anet".to_string()));
     let catalog = ensure(
-        Catalog::make_empty(site.clone()),
+        Catalog::for_tests(site.clone()),
         "Failed to construct catalog",
     );
     let layout = ensure(
-        Layout::new(site, &schema, catalog, false),
+        Layout::new(site, &schema, catalog),
         "Failed to construct Mapping",
     );
     match kind {

--- a/store/postgres/migrations/2022-03-21-172028_add_use_bytea_prefix/down.sql
+++ b/store/postgres/migrations/2022-03-21-172028_add_use_bytea_prefix/down.sql
@@ -1,0 +1,2 @@
+alter table subgraphs.subgraph_manifest
+      drop column use_bytea_prefix;

--- a/store/postgres/migrations/2022-03-21-172028_add_use_bytea_prefix/up.sql
+++ b/store/postgres/migrations/2022-03-21-172028_add_use_bytea_prefix/up.sql
@@ -1,0 +1,2 @@
+alter table subgraphs.subgraph_manifest
+      add column use_bytea_prefix bool not null default 'f';

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -52,21 +52,39 @@ table! {
 pub struct Catalog {
     pub site: Arc<Site>,
     text_columns: HashMap<String, HashSet<String>>,
+    pub use_poi: bool,
 }
 
 impl Catalog {
-    pub fn new(conn: &PgConnection, site: Arc<Site>) -> Result<Self, StoreError> {
+    /// Load the catalog for an existing subgraph
+    pub fn load(conn: &PgConnection, site: Arc<Site>) -> Result<Self, StoreError> {
         let text_columns = get_text_columns(conn, &site.namespace)?;
-        Ok(Catalog { site, text_columns })
+        let use_poi = supports_proof_of_indexing(conn, &site.namespace)?;
+        Ok(Catalog {
+            site,
+            text_columns,
+            use_poi,
+        })
+    }
+
+    /// Return a new catalog suitable for creating a new subgraph
+    pub fn for_creation(site: Arc<Site>) -> Self {
+        Catalog {
+            site,
+            text_columns: HashMap::default(),
+            // DDL generation creates a POI table
+            use_poi: true,
+        }
     }
 
     /// Make a catalog as if the given `schema` did not exist in the database
     /// yet. This function should only be used in situations where a database
     /// connection is definitely not available, such as in unit tests
-    pub fn make_empty(site: Arc<Site>) -> Result<Self, StoreError> {
+    pub fn for_tests(site: Arc<Site>) -> Result<Self, StoreError> {
         Ok(Catalog {
             site,
             text_columns: HashMap::default(),
+            use_poi: false,
         })
     }
 

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -335,6 +335,7 @@ struct StoredSubgraphManifest {
     features: Vec<String>,
     schema: String,
     graph_node_version_id: Option<i32>,
+    use_bytea_prefix: bool,
 }
 
 impl From<StoredSubgraphManifest> for SubgraphManifestEntity {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1047,7 +1047,7 @@ impl<'a> QueryFilter<'a> {
                 Comparison::NotEqual => out.push_sql(" is not null"),
                 _ => unreachable!("we only call equals with '=' or '!='"),
             }
-        } else if column.has_arbitrary_size() {
+        } else if column.use_prefix_comparison {
             PrefixComparison::new(op, column, value)?.walk_ast(out.reborrow())?;
         } else if column.is_fulltext() {
             out.push_identifier(column.name.as_str())?;
@@ -1070,7 +1070,7 @@ impl<'a> QueryFilter<'a> {
     ) -> QueryResult<()> {
         let column = self.column(attribute);
 
-        if column.has_arbitrary_size() {
+        if column.use_prefix_comparison {
             PrefixComparison::new(op, column, value)?.walk_ast(out.reborrow())?;
         } else {
             out.push_identifier(column.name.as_str())?;
@@ -1141,7 +1141,7 @@ impl<'a> QueryFilter<'a> {
         }
 
         if have_non_nulls {
-            if column.has_arbitrary_size()
+            if column.use_prefix_comparison
                 && values.iter().all(|v| match v {
                     Value::String(s) => s.len() <= STRING_PREFIX_SIZE - 1,
                     _ => false,

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1594,10 +1594,7 @@ fn handle_large_string_with_index() {
     })
 }
 
-// remove 'ignore' when reenabling bytes prefix indexing
-// see also: bytes-prefix-ignored-test
 #[test]
-#[ignore]
 fn handle_large_bytea_with_index() {
     const NAME: &str = "bin_name";
     const ONE: &str = "large_string_one";


### PR DESCRIPTION
We now remember for each subgraph whether it was created with indexes on the entire value of `bytea` columns or just a prefix, and generate queries accordingly.