### PR TITLE
Add environment variable `GRAPH_LOG_TIME_FORMAT`

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -152,6 +152,7 @@ happens, subgraphs might process inconsistent data. Defaults to 250.
   `gql`, also logs information for each toplevel GraphQL query field
   whether that could be retrieved from cache or not. Defaults to no
   logging.
+- `GRAPH_LOG_TIME_FORMAT`: Custom log time format.Default value is `%b %d %H:%M:%S%.3f`.More information [here](https://docs.rs/chrono/latest/chrono/#formatting-and-parsing).
 - `STORE_CONNECTION_POOL_SIZE`: How many simultaneous connections to allow to the store.
   Due to implementation details, this value may not be strictly adhered to. Defaults to 10.
 - `GRAPH_LOG_POI_EVENTS`: Logs Proof of Indexing events deterministically.

--- a/graph/src/log/mod.rs
+++ b/graph/src/log/mod.rs
@@ -91,8 +91,7 @@ where
     fn format_custom(&self, record: &Record, values: &OwnedKVList) -> io::Result<()> {
         self.decorator.with_record(record, values, |mut decorator| {
             decorator.start_timestamp()?;
-            timestamp_local(&mut decorator)?;
-
+            custom_timestamp_local(&mut decorator)?;
             decorator.start_whitespace()?;
             write!(decorator, " ")?;
 
@@ -382,8 +381,21 @@ fn log_query_timing(kind: &str) -> bool {
         .any(|v| v == kind)
 }
 
+fn log_time_format() -> String {
+    env::var("GRAPH_LOG_TIME_FORMAT").unwrap_or(String::from("%b %d %H:%M:%S%.3f"))
+}
+
 lazy_static! {
     pub static ref LOG_SQL_TIMING: bool = log_query_timing("sql");
     pub static ref LOG_GQL_TIMING: bool = log_query_timing("gql");
     pub static ref LOG_GQL_CACHE_TIMING: bool = *LOG_GQL_TIMING && log_query_timing("cache");
+    static ref LOG_TIME_FORMAT: String = log_time_format();
+}
+
+pub fn custom_timestamp_local(io: &mut dyn io::Write) -> io::Result<()> {
+    write!(
+        io,
+        "{}",
+        chrono::Local::now().format(LOG_TIME_FORMAT.as_str())
+    )
 }


### PR DESCRIPTION
### Purpose

This pr to add a feature which be requested in #3349 .

### Test
This feature seems not be applicable with unit test.So I tested it in this way:
After run a node.I got those log:
```shell
Mar 21 21:35:33.589 INFO Graph Node version: 0.25.1 :: fraction+6 (9c3952d69 2022-03-15) dirty 110 modifications
Mar 21 21:35:33.590 INFO Generating configuration from command line arguments
Mar 21 21:35:33.590 WARN No fork base URL specified, subgraph forking is disabled
Mar 21 21:35:33.590 INFO Starting up
Mar 21 21:35:33.590 INFO Trying IPFS node at: http://127.0.0.1:5001/
```
Add a  environment variable:
```shell
export GRAPH_LOG_TIME_FORMAT="%Y-%m-%d %H:%M:%S"
```
Run a node again,time format be changed:
```shell
2022-03-21 21:40:34 INFO Graph Node version: 0.25.1 :: fraction+6 (9c3952d69 2022-03-15) dirty 110 modifications
2022-03-21 21:40:34 INFO Generating configuration from command line arguments
2022-03-21 21:40:34 WARN No fork base URL specified, subgraph forking is disabled
2022-03-21 21:40:34 INFO Starting up
2022-03-21 21:40:34 INFO Trying IPFS node at: http://127.0.0.1:5001/
```
### Explanation
This feature is not check the `GRAPH_LOG_TIME_FORMAT` is empty or not,legal or not.
There would be some problem If `GRAPH_LOG_TIME_FORMAT` 's value is empty(After run `export GRAPH_LOG_TIME_FORMAT=`) or mismatch with `chrono`(Such as `YYYY-MM-HH`).But I didn't check the `value` because the illegal value won't make panic and it's a oipional config,user need read doc before use it.
