### PR TITLE
Feature: add env based config for forking options

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -187,3 +187,7 @@ happens, subgraphs might process inconsistent data. Defaults to 250.
   identified as unused, `graph-node` will wait at least this long before
   actually deleting the data (value is in minutes, defaults to 360, i.e. 6
   hours)
+- `START_BLOCK`: block hash:block number where the forked subgraph will start indexing at
+- `FORK_BASE`: api url for where the graph node will fork from, use `https://api.thegraph.com/subgraphs/id/`
+  for the hosted service.
+- `DEBUG_FORK`: the IPFS hash id of the subgraph to fork

--- a/node/src/opt.rs
+++ b/node/src/opt.rs
@@ -37,6 +37,7 @@ pub struct Opt {
 
     #[structopt(
         long,
+        env = "START_BLOCK",
         value_name = "BLOCK_HASH:BLOCK_NUMBER",
         help = "block hash and number that the subgraph passed will start indexing at"
     )]
@@ -207,11 +208,17 @@ pub struct Opt {
     #[structopt(
         long,
         value_name = "IPFS_HASH",
+        env = "DEBUG_FORK",
         help = "IPFS hash of the subgraph manifest that you want to fork"
     )]
     pub debug_fork: Option<String>,
 
-    #[structopt(long, value_name = "URL", help = "Base URL for forking subgraphs")]
+    #[structopt(
+        long,
+        value_name = "URL",
+        env = "FORK_BASE",
+        help = "Base URL for forking subgraphs"
+    )]
     pub fork_base: Option<String>,
 }
 


### PR DESCRIPTION
Adding ability to pass in environment variables into forking options, this makes it possible to enable forking in the docker-compose.yml file.