### PR TITLE
Fix some graphman bugs and improve usability

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -133,19 +133,15 @@ pub enum Command {
     },
     /// Assign or reassign a deployment
     Reassign {
-        /// The id of the deployment to reassign
-        id: String,
+        /// The deployment (see `help info`)
+        deployment: DeploymentSearch,
         /// The name of the node that should index the deployment
         node: String,
-        /// The shard of the deployment if `id` itself is ambiguous
-        shard: Option<String>,
     },
     /// Unassign a deployment
     Unassign {
-        /// The id of the deployment to unassign
-        id: String,
-        /// The shard of the deployment if `id` itself is ambiguous
-        shard: Option<String>,
+        /// The deployment (see `help info`)
+        deployment: DeploymentSearch,
     },
     /// Rewind a subgraph to a specific block
     Rewind {
@@ -755,11 +751,11 @@ async fn main() {
         }
         Remove { name } => commands::remove::run(ctx.subgraph_store(), name),
         Create { name } => commands::create::run(ctx.subgraph_store(), name),
-        Unassign { id, shard } => {
-            commands::assign::unassign(logger.clone(), ctx.subgraph_store(), id, shard).await
+        Unassign { deployment } => {
+            commands::assign::unassign(ctx.primary_pool(), &deployment).await
         }
-        Reassign { id, node, shard } => {
-            commands::assign::reassign(ctx.subgraph_store(), id, node, shard)
+        Reassign { deployment, node } => {
+            commands::assign::reassign(ctx.primary_pool(), &deployment, node)
         }
         Rewind {
             force,

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -165,8 +165,8 @@ pub enum Command {
         block_hash: String,
         /// The block number of the target block
         block_number: i32,
-        /// The deployments to rewind
-        names: Vec<String>,
+        /// The deployments to rewind (see `help info`)
+        deployments: Vec<DeploymentSearch>,
     },
     /// Deploy and run an arbitrary subgraph up to a certain block, although it can surpass it by a few blocks, it's not exact (use for dev and testing purposes) -- WARNING: WILL RUN MIGRATIONS ON THE DB, DO NOT USE IN PRODUCTION
     ///
@@ -761,13 +761,13 @@ async fn main() {
             sleep,
             block_hash,
             block_number,
-            names,
+            deployments,
         } => {
             let (store, primary) = ctx.store_and_primary();
             commands::rewind::run(
                 primary,
                 store,
-                names,
+                deployments,
                 block_hash,
                 block_number,
                 force,

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -402,11 +402,9 @@ pub enum IndexCommand {
     ///
     /// This command may be time-consuming.
     Create {
-        /// The id of the deployment.
-        ///
-        /// Can be expressed either as its Qm-hash form or as its SQL schema identifier.
+        /// The deployment (see `help info`).
         #[structopt(empty_values = false)]
-        id: String,
+        deployment: DeploymentSearch,
         /// The Entity name.
         ///
         /// Can be expressed either in upper camel case (as its GraphQL definition) or in snake case
@@ -428,11 +426,9 @@ pub enum IndexCommand {
     },
     /// Lists existing indexes for a given Entity
     List {
-        /// The id of the deployment.
-        ///
-        /// Can be expressed either as its Qm-hash form or as its SQL schema identifier.
+        /// The deployment (see `help info`).
         #[structopt(empty_values = false)]
-        id: String,
+        deployment: DeploymentSearch,
         /// The Entity name.
         ///
         /// Can be expressed either in upper camel case (as its GraphQL definition) or in snake case
@@ -443,11 +439,9 @@ pub enum IndexCommand {
 
     /// Drops an index for a given deployment, concurrently
     Drop {
-        /// The id of the deployment.
-        ///
-        /// Can be expressed either as its Qm-hash form or as its SQL schema identifier.
+        /// The deployment (see `help info`).
         #[structopt(empty_values = false)]
-        id: String,
+        deployment: DeploymentSearch,
         /// The name of the index to be dropped
         #[structopt(empty_values = false)]
         index_name: String,
@@ -883,7 +877,7 @@ async fn main() {
             let subgraph_store = store.subgraph_store();
             match cmd {
                 Create {
-                    id,
+                    deployment,
                     entity,
                     fields,
                     method,
@@ -891,18 +885,22 @@ async fn main() {
                     commands::index::create(
                         subgraph_store,
                         primary_pool,
-                        &id,
+                        deployment,
                         &entity,
                         fields,
                         method,
                     )
                     .await
                 }
-                List { id, entity } => {
-                    commands::index::list(subgraph_store, primary_pool, id, &entity).await
+                List { deployment, entity } => {
+                    commands::index::list(subgraph_store, primary_pool, deployment, &entity).await
                 }
-                Drop { id, index_name } => {
-                    commands::index::drop(subgraph_store, primary_pool, &id, &index_name).await
+                Drop {
+                    deployment,
+                    index_name,
+                } => {
+                    commands::index::drop(subgraph_store, primary_pool, deployment, &index_name)
+                        .await
                 }
             }
         }

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -1,41 +1,52 @@
-use std::sync::Arc;
+use graph::prelude::{anyhow::anyhow, Error, NodeId};
+use graph_store_postgres::{command_support::catalog, connection_pool::ConnectionPool};
 
-use graph::{
-    prelude::{anyhow::anyhow, Error, NodeId, SubgraphStore as _},
-    slog::Logger,
-};
-use graph_store_postgres::SubgraphStore;
+use crate::manager::deployment::DeploymentSearch;
 
-use crate::manager::deployment::locate;
+pub async fn unassign(primary: ConnectionPool, search: &DeploymentSearch) -> Result<(), Error> {
+    let locator = search.locate_unique(&primary)?;
 
-pub async fn unassign(
-    logger: Logger,
-    store: Arc<SubgraphStore>,
-    hash: String,
-    shard: Option<String>,
-) -> Result<(), Error> {
-    let deployment = locate(store.as_ref(), hash, shard)?;
+    let conn = primary.get()?;
+    let conn = catalog::Connection::new(conn);
 
-    println!("unassigning {}", deployment);
-    store
-        .writable(logger, deployment.id)
-        .await?
-        .unassign_subgraph()?;
+    let site = conn
+        .locate_site(locator.clone())?
+        .ok_or_else(|| anyhow!("failed to locate site for {locator}"))?;
+
+    println!("unassigning {locator}");
+    conn.unassign_subgraph(&site)?;
 
     Ok(())
 }
 
 pub fn reassign(
-    store: Arc<SubgraphStore>,
-    hash: String,
+    primary: ConnectionPool,
+    search: &DeploymentSearch,
     node: String,
-    shard: Option<String>,
 ) -> Result<(), Error> {
     let node = NodeId::new(node.clone()).map_err(|()| anyhow!("illegal node id `{}`", node))?;
-    let deployment = locate(store.as_ref(), hash, shard)?;
+    let locator = search.locate_unique(&primary)?;
 
-    println!("reassigning {} to {}", deployment, node.as_str());
-    store.reassign_subgraph(&deployment, &node)?;
+    let conn = primary.get()?;
+    let conn = catalog::Connection::new(conn);
+
+    let site = conn
+        .locate_site(locator.clone())?
+        .ok_or_else(|| anyhow!("failed to locate site for {locator}"))?;
+    match conn.assigned_node(&site)? {
+        Some(cur) => {
+            if cur == node {
+                println!("deployment {locator} is already assigned to {cur}");
+            } else {
+                println!("reassigning {locator} to {node} (was {cur})");
+                conn.reassign_subgraph(&site, &node)?;
+            }
+        }
+        None => {
+            println!("assigning {locator} to {node}");
+            conn.assign_subgraph(&site, &node)?;
+        }
+    }
 
     Ok(())
 }

--- a/node/src/manager/commands/stats.rs
+++ b/node/src/manager/commands/stats.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::manager::deployment::find_single_deployment_locator;
+use crate::manager::deployment::DeploymentSearch;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::PooledConnection;
 use diesel::sql_query;
@@ -17,32 +17,19 @@ use graph_store_postgres::Shard;
 use graph_store_postgres::SubgraphStore;
 use graph_store_postgres::PRIMARY_SHARD;
 
-fn parse_table_name(table: &str) -> Result<(&str, SqlName), anyhow::Error> {
-    let mut parts = table.split('.');
-    let nsp = parts
-        .next()
-        .ok_or_else(|| anyhow!("the table must be in the form 'sgdNNN.table'"))?;
-    let table = parts
-        .next()
-        .ok_or_else(|| anyhow!("the table must be in the form 'sgdNNN.table'"))?;
-    let table = SqlName::from(table);
-
-    if !parts.next().is_none() {
-        return Err(anyhow!("the table must be in the form 'sgdNNN.table'"));
-    }
-    Ok((nsp, table))
-}
-
 fn site_and_conn(
     pools: HashMap<Shard, ConnectionPool>,
-    nsp: &str,
+    search: &DeploymentSearch,
 ) -> Result<(Site, PooledConnection<ConnectionManager<PgConnection>>), anyhow::Error> {
-    let conn = pools.get(&*PRIMARY_SHARD).unwrap().get()?;
+    let primary_pool = pools.get(&*PRIMARY_SHARD).unwrap();
+    let locator = search.locate_unique(primary_pool)?;
+
+    let conn = primary_pool.get()?;
     let conn = store_catalog::Connection::new(conn);
 
     let site = conn
-        .find_site_by_name(nsp)?
-        .ok_or_else(|| anyhow!("deployment `{}` does not exist", nsp))?;
+        .locate_site(locator)?
+        .ok_or_else(|| anyhow!("deployment `{}` does not exist", search))?;
 
     let conn = pools.get(&site.shard).unwrap().get()?;
 
@@ -52,12 +39,13 @@ fn site_and_conn(
 pub fn account_like(
     pools: HashMap<Shard, ConnectionPool>,
     clear: bool,
+    search: &DeploymentSearch,
     table: String,
 ) -> Result<(), anyhow::Error> {
-    let (nsp, table_name) = parse_table_name(&table)?;
-    let (site, conn) = site_and_conn(pools, nsp)?;
+    let table = SqlName::from(table);
+    let (site, conn) = site_and_conn(pools, search)?;
 
-    store_catalog::set_account_like(&conn, &site, &table_name, !clear)?;
+    store_catalog::set_account_like(&conn, &site, &table, !clear)?;
     let clear_text = if clear { "cleared" } else { "set" };
     println!("{}: account-like flag {}", table, clear_text);
 
@@ -66,10 +54,10 @@ pub fn account_like(
 
 pub fn show(
     pools: HashMap<Shard, ConnectionPool>,
-    nsp: String,
+    search: &DeploymentSearch,
     table: Option<String>,
 ) -> Result<(), anyhow::Error> {
-    let (site, conn) = site_and_conn(pools, &nsp)?;
+    let (site, conn) = site_and_conn(pools, search)?;
 
     #[derive(Queryable, QueryableByName)]
     struct VersionStats {
@@ -158,13 +146,13 @@ pub fn show(
 pub async fn analyze(
     store: Arc<SubgraphStore>,
     pool: ConnectionPool,
-    deployment_id: String,
+    search: DeploymentSearch,
     entity_name: &str,
 ) -> Result<(), anyhow::Error> {
-    println!("Running ANALYZE for {entity_name} entity");
-    let deployment_locator = find_single_deployment_locator(&pool, &deployment_id)?;
+    let locator = search.locate_unique(&pool)?;
+    println!("Analyzing table sgd{}.{entity_name}", locator.id);
     store
-        .analyze(&deployment_locator, entity_name)
+        .analyze(&locator, entity_name)
         .await
         .map_err(|e| anyhow!(e))
 }

--- a/node/src/manager/deployment.rs
+++ b/node/src/manager/deployment.rs
@@ -1,7 +1,10 @@
 use std::collections::HashSet;
+use std::fmt;
+use std::str::FromStr;
 
 use diesel::{dsl::sql, prelude::*};
 use diesel::{sql_types::Text, PgConnection};
+use regex::Regex;
 
 use graph::components::store::DeploymentId;
 use graph::{
@@ -9,7 +12,7 @@ use graph::{
     data::subgraph::status,
     prelude::{
         anyhow::{self, anyhow, bail},
-        DeploymentHash, Error, SubgraphStore as _,
+        lazy_static, DeploymentHash, Error, SubgraphStore as _,
     },
 };
 use graph_store_postgres::connection_pool::ConnectionPool;
@@ -17,6 +20,127 @@ use graph_store_postgres::{command_support::catalog as store_catalog, Shard, Sub
 
 use crate::manager::deployment;
 use crate::manager::display::List;
+
+lazy_static! {
+    // `Qm...` optionally follow by `:$shard`
+    static ref HASH_RE: Regex = Regex::new("\\A(?P<hash>Qm[^:]+)(:(?P<shard>[a-z0-9_]+))?\\z").unwrap();
+    // `sgdNNN`
+    static ref DEPLOYMENT_RE: Regex = Regex::new("\\A(?P<nsp>sgd[0-9]+)\\z").unwrap();
+}
+
+/// A search for one or multiple deployments to make it possible to search
+/// by subgraph name, IPFS hash, or namespace. Since there can be multiple
+/// deployments for the same IPFS hash, the search term for a hash can
+/// optionally specify a shard.
+#[derive(Clone, Debug)]
+pub enum DeploymentSearch {
+    Name { name: String },
+    Hash { hash: String, shard: Option<String> },
+    Deployment { namespace: String },
+}
+
+impl fmt::Display for DeploymentSearch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DeploymentSearch::Name { name } => write!(f, "{}", name),
+            DeploymentSearch::Hash {
+                hash,
+                shard: Some(shard),
+            } => write!(f, "{}:{}", hash, shard),
+            DeploymentSearch::Hash { hash, shard: None } => write!(f, "{}", hash),
+            DeploymentSearch::Deployment { namespace } => write!(f, "{}", namespace),
+        }
+    }
+}
+
+impl FromStr for DeploymentSearch {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(caps) = HASH_RE.captures(s) {
+            let hash = caps.name("hash").unwrap().as_str().to_string();
+            let shard = caps.name("shard").map(|shard| shard.as_str().to_string());
+            Ok(DeploymentSearch::Hash { hash, shard })
+        } else if let Some(caps) = DEPLOYMENT_RE.captures(s) {
+            let namespace = caps.name("nsp").unwrap().as_str().to_string();
+            Ok(DeploymentSearch::Deployment { namespace })
+        } else {
+            Ok(DeploymentSearch::Name {
+                name: s.to_string(),
+            })
+        }
+    }
+}
+
+impl DeploymentSearch {
+    pub fn lookup(&self, primary: &ConnectionPool) -> Result<Vec<Deployment>, anyhow::Error> {
+        let conn = primary.get()?;
+        self.lookup_with_conn(&conn)
+    }
+
+    pub fn lookup_with_conn(&self, conn: &PgConnection) -> Result<Vec<Deployment>, anyhow::Error> {
+        use store_catalog::deployment_schemas as ds;
+        use store_catalog::subgraph as s;
+        use store_catalog::subgraph_deployment_assignment as a;
+        use store_catalog::subgraph_version as v;
+
+        let query = ds::table
+            .inner_join(v::table.on(v::deployment.eq(ds::subgraph)))
+            .inner_join(s::table.on(v::subgraph.eq(s::id)))
+            .left_outer_join(a::table.on(a::id.eq(ds::id)))
+            .select((
+                s::name,
+                sql::<Text>(
+                    "(case
+                    when subgraphs.subgraph.pending_version = subgraphs.subgraph_version.id then 'pending'
+                    when subgraphs.subgraph.current_version = subgraphs.subgraph_version.id then 'current'
+                    else 'unused' end) status",
+                ),
+                v::deployment,
+                ds::name,
+                ds::id,
+                a::node_id.nullable(),
+                ds::shard,
+                ds::network,
+                ds::active,
+            ));
+
+        let deployments: Vec<Deployment> = match self {
+            DeploymentSearch::Name { name } => {
+                let pattern = format!("%{}%", name);
+                query.filter(s::name.ilike(&pattern)).load(conn)?
+            }
+            DeploymentSearch::Hash { hash, shard } => {
+                let query = query.filter(ds::subgraph.eq(&hash));
+                match shard {
+                    Some(shard) => query.filter(ds::shard.eq(shard)).load(conn)?,
+                    None => query.load(conn)?,
+                }
+            }
+            DeploymentSearch::Deployment { namespace } => {
+                query.filter(ds::name.eq(&namespace)).load(conn)?
+            }
+        };
+        Ok(deployments)
+    }
+
+    /// Finds a single deployment locator for the given deployment identifier.
+    pub fn locate_unique(&self, pool: &ConnectionPool) -> anyhow::Result<DeploymentLocator> {
+        let mut locators: Vec<DeploymentLocator> = HashSet::<DeploymentLocator>::from_iter(
+            self.lookup(pool)?
+                .into_iter()
+                .map(|deployment| deployment.locator()),
+        )
+        .into_iter()
+        .collect();
+        let deployment_locator = match locators.len() {
+            0 => anyhow::bail!("Found no deployment for `{}`", self),
+            1 => locators.pop().unwrap(),
+            n => anyhow::bail!("Found {} deployments for `{}`", n, self),
+        };
+        Ok(deployment_locator)
+    }
+}
 
 #[derive(Queryable, PartialEq, Eq, Hash, Debug)]
 pub struct Deployment {


### PR DESCRIPTION
The `graphman index` commands wouldn't work if the same deployment is used by multiple names.

This PR also overhauls the logic for how deployments are looked up to make the lookup uniform across various commands