### PR TITLE
Remove SubgraphRunner Clones 🔫 

### DIFF
--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -188,9 +188,9 @@ where
     pub(crate) fn add_dynamic_data_source(
         &mut self,
         logger: &Logger,
-        data_source: C::DataSource,
-        templates: Arc<Vec<C::DataSourceTemplate>>,
-        metrics: Arc<HostMetrics>,
+        data_source: &C::DataSource,
+        templates: &Arc<Vec<C::DataSourceTemplate>>,
+        metrics: &Arc<HostMetrics>,
     ) -> Result<Option<Arc<T::Host>>, Error> {
         // Protect against creating more than the allowed maximum number of data sources
         if let Some(max_data_sources) = ENV_VARS.subgraph_max_data_sources {
@@ -209,8 +209,12 @@ where
                 <= data_source.creation_block()
         );
 
-        let host =
-            Arc::new(self.new_host(logger.clone(), data_source, templates, metrics.clone())?);
+        let host = Arc::new(self.new_host(
+            logger.clone(),
+            data_source.clone(),
+            templates.clone(),
+            metrics.clone(),
+        )?);
 
         Ok(if self.hosts.contains(&host) {
             None

--- a/core/src/subgraph/instance.rs
+++ b/core/src/subgraph/instance.rs
@@ -188,9 +188,9 @@ where
     pub(crate) fn add_dynamic_data_source(
         &mut self,
         logger: &Logger,
-        data_source: &C::DataSource,
-        templates: &Arc<Vec<C::DataSourceTemplate>>,
-        metrics: &Arc<HostMetrics>,
+        data_source: C::DataSource,
+        templates: Arc<Vec<C::DataSourceTemplate>>,
+        metrics: Arc<HostMetrics>,
     ) -> Result<Option<Arc<T::Host>>, Error> {
         // Protect against creating more than the allowed maximum number of data sources
         if let Some(max_data_sources) = ENV_VARS.subgraph_max_data_sources {
@@ -209,12 +209,7 @@ where
                 <= data_source.creation_block()
         );
 
-        let host = Arc::new(self.new_host(
-            logger.clone(),
-            data_source.clone(),
-            templates.clone(),
-            metrics.clone(),
-        )?);
+        let host = Arc::new(self.new_host(logger.clone(), data_source, templates, metrics)?);
 
         Ok(if self.hosts.contains(&host) {
             None

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -451,9 +451,9 @@ where
             // Try to create a runtime host for the data source
             let host = self.ctx.instance.add_dynamic_data_source(
                 &self.logger,
-                &data_source,
-                &self.inputs.templates,
-                &self.metrics.host,
+                data_source.clone(),
+                self.inputs.templates.clone(),
+                self.metrics.host.clone(),
             )?;
 
             match host {

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -450,10 +450,10 @@ where
 
             // Try to create a runtime host for the data source
             let host = self.ctx.instance.add_dynamic_data_source(
-                &logger,
-                data_source.clone(),
-                self.inputs.templates.clone(),
-                host_metrics.clone(),
+                &self.logger,
+                &data_source,
+                &self.inputs.templates,
+                &self.metrics.host,
             )?;
 
             match host {

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -320,7 +320,6 @@ where
         // Transact entity operations into the store and update the
         // subgraph's block stream pointer
         let _section = self.metrics.host.stopwatch.start_section("transact_block");
-        let stopwatch = self.metrics.host.stopwatch.clone();
         let start = Instant::now();
 
         let store = &self.inputs.store;
@@ -348,7 +347,7 @@ where
             block_ptr,
             firehose_cursor,
             mods,
-            stopwatch,
+            &self.metrics.host.stopwatch,
             data_sources,
             deterministic_errors,
         ) {

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -93,9 +93,7 @@ where
             let block_stream_cancel_handle = block_stream_canceler.handle();
 
             let stream_metrics = self.metrics.stream.clone();
-            let filter = self.ctx.filter.clone();
-            let stream_inputs = self.inputs.clone();
-            let mut block_stream = new_block_stream(stream_inputs, filter)
+            let mut block_stream = new_block_stream(&self.inputs, &self.ctx.filter)
                 .await?
                 .map_err(CancelableError::Error)
                 .cancelable(&block_stream_canceler, || Err(CancelableError::Cancel));

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -151,13 +151,7 @@ where
 
         let subgraph_metrics = self.metrics.subgraph.clone();
 
-        let proof_of_indexing = if self
-            .inputs
-            .store
-            .clone()
-            .supports_proof_of_indexing()
-            .await?
-        {
+        let proof_of_indexing = if self.inputs.store.supports_proof_of_indexing().await? {
             Some(Arc::new(AtomicRefCell::new(ProofOfIndexing::new(
                 block_ptr.number,
             ))))
@@ -687,7 +681,6 @@ where
 
             // Handle unexpected stream errors by marking the subgraph as failed.
             Err(e) => {
-                let store_for_err = self.inputs.store.cheap_clone();
                 // Clear entity cache when a subgraph fails.
                 //
                 // This is done to be safe and sure that there's no state that's
@@ -716,7 +709,8 @@ where
                         // Fail subgraph:
                         // - Change status/health.
                         // - Save the error to the database.
-                        store_for_err
+                        self.inputs
+                            .store
                             .fail_subgraph(error)
                             .await
                             .context("Failed to set subgraph status to `failed`")?;
@@ -740,7 +734,8 @@ where
                             // Fail subgraph:
                             // - Change status/health.
                             // - Save the error to the database.
-                            store_for_err
+                            self.inputs
+                                .store
                                 .fail_subgraph(error)
                                 .await
                                 .context("Failed to set subgraph status to `failed`")?;

--- a/core/src/subgraph/stream.rs
+++ b/core/src/subgraph/stream.rs
@@ -1,18 +1,17 @@
 use crate::subgraph::inputs::IndexingInputs;
 use graph::blockchain::block_stream::{BlockStream, BufferedBlockStream};
 use graph::blockchain::Blockchain;
-use graph::prelude::{CheapClone, Error};
+use graph::prelude::Error;
 use std::sync::Arc;
 
 const BUFFERED_BLOCK_STREAM_SIZE: usize = 100;
 const BUFFERED_FIREHOSE_STREAM_SIZE: usize = 1;
 
 pub async fn new_block_stream<C: Blockchain>(
-    inputs: Arc<IndexingInputs<C>>,
-    filter: C::TriggerFilter,
+    inputs: &IndexingInputs<C>,
+    filter: &C::TriggerFilter,
 ) -> Result<Box<dyn BlockStream<C>>, Error> {
-    let chain = inputs.chain.cheap_clone();
-    let is_firehose = chain.is_firehose_supported();
+    let is_firehose = inputs.chain.is_firehose_supported();
 
     let buffer_size = match is_firehose {
         true => BUFFERED_FIREHOSE_STREAM_SIZE,
@@ -22,7 +21,7 @@ pub async fn new_block_stream<C: Blockchain>(
     let current_ptr = inputs.store.block_ptr().await;
 
     let block_stream = match is_firehose {
-        true => chain.new_firehose_block_stream(
+        true => inputs.chain.new_firehose_block_stream(
             inputs.deployment.clone(),
             inputs.store.block_cursor().await,
             inputs.start_blocks.clone(),
@@ -30,7 +29,7 @@ pub async fn new_block_stream<C: Blockchain>(
             Arc::new(filter.clone()),
             inputs.unified_api_version.clone(),
         ),
-        false => chain.new_polling_block_stream(
+        false => inputs.chain.new_polling_block_stream(
             inputs.deployment.clone(),
             inputs.start_blocks.clone(),
             current_ptr,

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -200,7 +200,7 @@ pub trait WritableStore: Send + Sync + 'static {
         block_ptr_to: BlockPtr,
         firehose_cursor: Option<String>,
         mods: Vec<EntityModification>,
-        stopwatch: StopwatchMetrics,
+        stopwatch: &StopwatchMetrics,
         data_sources: Vec<StoredDynamicDataSource>,
         deterministic_errors: Vec<SubgraphError>,
     ) -> Result<(), StoreError>;

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -104,7 +104,7 @@ impl WritableStore for MockStore {
         _: BlockPtr,
         _: Option<String>,
         _: Vec<EntityModification>,
-        _: StopwatchMetrics,
+        _: &StopwatchMetrics,
         _: Vec<StoredDynamicDataSource>,
         _: Vec<SubgraphError>,
     ) -> Result<(), StoreError> {

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -293,7 +293,7 @@ impl DeploymentStore {
         layout: &Layout,
         mods: &[EntityModification],
         ptr: &BlockPtr,
-        stopwatch: StopwatchMetrics,
+        stopwatch: &StopwatchMetrics,
     ) -> Result<i32, StoreError> {
         use EntityModification::*;
         let mut count = 0;
@@ -329,14 +329,14 @@ impl DeploymentStore {
         // Inserts:
         for (entity_type, mut entities) in inserts.into_iter() {
             count +=
-                self.insert_entities(&entity_type, &mut entities, conn, layout, ptr, &stopwatch)?
+                self.insert_entities(&entity_type, &mut entities, conn, layout, ptr, stopwatch)?
                     as i32
         }
 
         // Overwrites:
         for (entity_type, mut entities) in overwrites.into_iter() {
             // we do not update the count since the number of entities remains the same
-            self.overwrite_entities(&entity_type, &mut entities, conn, layout, ptr, &stopwatch)?;
+            self.overwrite_entities(&entity_type, &mut entities, conn, layout, ptr, stopwatch)?;
         }
 
         // Removals
@@ -347,7 +347,7 @@ impl DeploymentStore {
                 conn,
                 layout,
                 ptr,
-                &stopwatch,
+                stopwatch,
             )? as i32;
         }
         Ok(count)
@@ -953,7 +953,7 @@ impl DeploymentStore {
         block_ptr_to: &BlockPtr,
         firehose_cursor: Option<&str>,
         mods: &[EntityModification],
-        stopwatch: StopwatchMetrics,
+        stopwatch: &StopwatchMetrics,
         data_sources: &[StoredDynamicDataSource],
         deterministic_errors: &[SubgraphError],
     ) -> Result<StoreEvent, StoreError> {

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -230,7 +230,7 @@ impl WritableStore {
         block_ptr_to: &BlockPtr,
         firehose_cursor: Option<&str>,
         mods: &[EntityModification],
-        stopwatch: StopwatchMetrics,
+        stopwatch: &StopwatchMetrics,
         data_sources: &[StoredDynamicDataSource],
         deterministic_errors: &[SubgraphError],
     ) -> Result<(), StoreError> {
@@ -244,7 +244,7 @@ impl WritableStore {
                 block_ptr_to,
                 firehose_cursor,
                 mods,
-                stopwatch.cheap_clone(),
+                stopwatch,
                 data_sources,
                 deterministic_errors,
             )?;
@@ -442,7 +442,7 @@ impl WritableStoreTrait for WritableAgent {
         block_ptr_to: BlockPtr,
         firehose_cursor: Option<String>,
         mods: Vec<EntityModification>,
-        stopwatch: StopwatchMetrics,
+        stopwatch: &StopwatchMetrics,
         data_sources: Vec<StoredDynamicDataSource>,
         deterministic_errors: Vec<SubgraphError>,
     ) -> Result<(), StoreError> {
@@ -450,7 +450,7 @@ impl WritableStoreTrait for WritableAgent {
             &block_ptr_to,
             firehose_cursor.as_deref(),
             &mods,
-            stopwatch,
+            &stopwatch,
             &data_sources,
             &deterministic_errors,
         )?;

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1547,7 +1547,7 @@ fn handle_large_string_with_index() {
                     make_insert_op(ONE, &long_text),
                     make_insert_op(TWO, &other_text),
                 ],
-                stopwatch_metrics,
+                &stopwatch_metrics,
                 Vec::new(),
                 Vec::new(),
             )
@@ -1641,7 +1641,7 @@ fn handle_large_bytea_with_index() {
                     make_insert_op(ONE, &long_bytea),
                     make_insert_op(TWO, &other_bytea),
                 ],
-                stopwatch_metrics,
+                &stopwatch_metrics,
                 Vec::new(),
                 Vec::new(),
             )

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -226,7 +226,7 @@ pub async fn transact_errors(
             block_ptr_to,
             None,
             Vec::new(),
-            stopwatch_metrics,
+            &stopwatch_metrics,
             Vec::new(),
             errs,
         )
@@ -267,7 +267,7 @@ pub fn transact_entities_and_dynamic_data_sources(
         block_ptr_to,
         None,
         mods,
-        stopwatch_metrics,
+        &stopwatch_metrics,
         data_sources,
         Vec::new(),
     )


### PR DESCRIPTION
This is a refactor that removes unnecessary:

- Parameters/Arguments;
- Variables;
- Clones.

And chooses usage of `self.` or `&` (references) instead 😉 

Related issue #3246 