### PR TITLE
chain/ethereum: Fix broken deployment_eth_rpc_* metrics registration

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -23,9 +23,9 @@ use graph::{
     },
 };
 use prost::Message;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use crate::data_source::DataSourceTemplate;
 use crate::data_source::UnresolvedDataSourceTemplate;
@@ -58,6 +58,7 @@ pub struct Chain {
     chain_head_update_listener: Arc<dyn ChainHeadUpdateListener>,
     reorg_threshold: BlockNumber,
     pub is_ingestible: bool,
+    deployment_rpc_metrics: Arc<Mutex<HashMap<String, Arc<SubgraphEthRpcMetrics>>>>,
 }
 
 impl std::fmt::Debug for Chain {
@@ -93,6 +94,7 @@ impl Chain {
             chain_head_update_listener,
             reorg_threshold,
             is_ingestible,
+            deployment_rpc_metrics: Default::default(),
         }
     }
 
@@ -157,7 +159,15 @@ impl Blockchain for Chain {
             self.eth_adapters.cheapest_with(capabilities)?.clone()
         };
 
-        let ethrpc_metrics = Arc::new(SubgraphEthRpcMetrics::new(self.registry.clone(), &loc.hash));
+        let ethrpc_metrics = self
+            .deployment_rpc_metrics
+            .lock()
+            .unwrap()
+            .entry(String::from(loc.hash.as_str()))
+            .or_insert_with(|| {
+                Arc::new(SubgraphEthRpcMetrics::new(self.registry.clone(), &loc.hash))
+            })
+            .cheap_clone();
 
         let adapter = TriggersAdapter {
             logger,

--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -70,6 +70,13 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         const_labels: HashMap<String, String>,
     ) -> Result<Gauge, PrometheusError>;
 
+    fn global_gauge_vec(
+        &self,
+        name: &str,
+        help: &str,
+        variable_labels: &[&str],
+    ) -> Result<GaugeVec, PrometheusError>;
+
     fn new_gauge(
         &self,
         name: &str,

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -1,6 +1,6 @@
 use graph::components::metrics::{Collector, Counter, Gauge, Opts, PrometheusError};
 use graph::prelude::MetricsRegistry as MetricsRegistryTrait;
-use graph::prometheus::CounterVec;
+use graph::prometheus::{CounterVec, GaugeVec};
 
 use std::collections::HashMap;
 
@@ -54,5 +54,16 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
         let opts = Opts::new(name, help);
         let counters = CounterVec::new(opts, variable_labels)?;
         Ok(counters)
+    }
+
+    fn global_gauge_vec(
+        &self,
+        name: &str,
+        help: &str,
+        variable_labels: &[&str],
+    ) -> Result<GaugeVec, PrometheusError> {
+        let opts = Opts::new(name, help);
+        let gauges = GaugeVec::new(opts, variable_labels)?;
+        Ok(gauges)
     }
 }


### PR DESCRIPTION
I noticed the following errors being logged frequently:

    ERRO registering metric [deployment_eth_rpc_request_duration] because it was already registered, component: MetricsRegistry
    ERRO registering metric [deployment_eth_rpc_errors] because it was already registered, component: MetricsRegistry

I also noticed that graph-node wouldn't correctly observe these metrics because of this. The reason for the errors was that the metrics were recreated each time a new block stream for a deployment was created.

This commit changes it so we remember the `SubgraphEthRpcMetric` associated with each deployment instead of trying to recreate them each time.

