### PR TITLE
Add Firehose blockstream metrics

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -201,6 +201,7 @@ impl Blockchain for Chain {
         });
 
         Ok(Box::new(FirehoseBlockStream::new(
+            deployment.hash,
             firehose_endpoint,
             subgraph_current_block,
             block_cursor,
@@ -209,6 +210,7 @@ impl Blockchain for Chain {
             filter,
             start_blocks,
             logger,
+            self.registry.clone(),
         )))
     }
 

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -2,7 +2,7 @@ use graph::blockchain::BlockchainKind;
 use graph::cheap_clone::CheapClone;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints};
-use graph::prelude::TryFutureExt;
+use graph::prelude::{MetricsRegistry, TryFutureExt};
 use graph::{
     anyhow,
     blockchain::{
@@ -36,6 +36,7 @@ pub struct Chain {
     name: String,
     firehose_endpoints: Arc<FirehoseEndpoints>,
     chain_store: Arc<dyn ChainStore>,
+    metrics_registry: Arc<dyn MetricsRegistry>,
 }
 
 impl std::fmt::Debug for Chain {
@@ -50,12 +51,14 @@ impl Chain {
         name: String,
         chain_store: Arc<dyn ChainStore>,
         firehose_endpoints: FirehoseEndpoints,
+        metrics_registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
         Chain {
             logger_factory,
             name,
             firehose_endpoints: Arc::new(firehose_endpoints),
             chain_store,
+            metrics_registry,
         }
     }
 }
@@ -124,6 +127,7 @@ impl Blockchain for Chain {
         });
 
         Ok(Box::new(FirehoseBlockStream::new(
+            deployment.hash,
             firehose_endpoint,
             subgraph_current_block,
             block_cursor,
@@ -132,6 +136,7 @@ impl Blockchain for Chain {
             filter,
             start_blocks,
             logger,
+            self.metrics_registry.clone(),
         )))
     }
 

--- a/chain/tendermint/src/chain.rs
+++ b/chain/tendermint/src/chain.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use graph::cheap_clone::CheapClone;
 use graph::data::subgraph::UnifiedMappingApiVersion;
+use graph::prelude::MetricsRegistry;
 use graph::{
     anyhow::anyhow,
     blockchain::{
@@ -31,6 +32,7 @@ pub struct Chain {
     name: String,
     firehose_endpoints: Arc<FirehoseEndpoints>,
     chain_store: Arc<dyn ChainStore>,
+    metrics_registry: Arc<dyn MetricsRegistry>,
 }
 
 impl std::fmt::Debug for Chain {
@@ -45,12 +47,14 @@ impl Chain {
         name: String,
         chain_store: Arc<dyn ChainStore>,
         firehose_endpoints: FirehoseEndpoints,
+        metrics_registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
         Chain {
             logger_factory,
             name,
             firehose_endpoints: Arc::new(firehose_endpoints),
             chain_store,
+            metrics_registry,
         }
     }
 }
@@ -119,6 +123,7 @@ impl Blockchain for Chain {
         });
 
         Ok(Box::new(FirehoseBlockStream::new(
+            deployment.hash,
             firehose_endpoint,
             subgraph_current_block,
             block_cursor,
@@ -127,6 +132,7 @@ impl Blockchain for Chain {
             filter,
             start_blocks,
             logger,
+            self.metrics_registry.clone(),
         )))
     }
 

--- a/graph/src/components/metrics/mod.rs
+++ b/graph/src/components/metrics/mod.rs
@@ -285,4 +285,11 @@ pub trait MetricsRegistry: Send + Sync + 'static {
         self.register(name, histograms.clone());
         Ok(histograms)
     }
+
+    fn global_histogram_vec(
+        &self,
+        name: &str,
+        help: &str,
+        variable_labels: &[&str],
+    ) -> Result<HistogramVec, PrometheusError>;
 }

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -1,6 +1,6 @@
 use graph::components::metrics::{Collector, Counter, Gauge, Opts, PrometheusError};
 use graph::prelude::MetricsRegistry as MetricsRegistryTrait;
-use graph::prometheus::{CounterVec, GaugeVec};
+use graph::prometheus::{CounterVec, GaugeVec, HistogramOpts, HistogramVec};
 
 use std::collections::HashMap;
 
@@ -65,5 +65,16 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
         let opts = Opts::new(name, help);
         let gauges = GaugeVec::new(opts, variable_labels)?;
         Ok(gauges)
+    }
+
+    fn global_histogram_vec(
+        &self,
+        name: &str,
+        help: &str,
+        variable_labels: &[&str],
+    ) -> Result<HistogramVec, PrometheusError> {
+        let opts = HistogramOpts::new(name, help);
+        let histograms = HistogramVec::new(opts, variable_labels)?;
+        Ok(histograms)
     }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -286,6 +286,7 @@ async fn main() {
             &near_networks,
             network_store.as_ref(),
             &logger_factory,
+            metrics_registry.clone(),
         );
 
         let tendermint_chains = tendermint_networks_as_chains(
@@ -294,6 +295,7 @@ async fn main() {
             &tendermint_networks,
             network_store.as_ref(),
             &logger_factory,
+            metrics_registry.clone(),
         );
 
         let blockchain_map = Arc::new(blockchain_map);
@@ -592,6 +594,7 @@ fn tendermint_networks_as_chains(
     firehose_networks: &FirehoseNetworks,
     store: &Store,
     logger_factory: &LoggerFactory,
+    metrics_registry: Arc<MetricsRegistry>,
 ) -> HashMap<String, FirehoseChain<tendermint::Chain>> {
     let chains: Vec<_> = firehose_networks
         .networks
@@ -619,6 +622,7 @@ fn tendermint_networks_as_chains(
                         network_name.clone(),
                         chain_store,
                         firehose_endpoints.clone(),
+                        metrics_registry.clone(),
                     )),
                     firehose_endpoints: firehose_endpoints.clone(),
                 },
@@ -641,6 +645,7 @@ fn near_networks_as_chains(
     firehose_networks: &FirehoseNetworks,
     store: &Store,
     logger_factory: &LoggerFactory,
+    metrics_registry: Arc<MetricsRegistry>,
 ) -> HashMap<String, FirehoseChain<near::Chain>> {
     let chains: Vec<_> = firehose_networks
         .networks
@@ -667,6 +672,7 @@ fn near_networks_as_chains(
                         chain_id.clone(),
                         chain_store,
                         endpoints.clone(),
+                        metrics_registry.clone(),
                     )),
                     firehose_endpoints: endpoints.clone(),
                 },


### PR DESCRIPTION
This adds a few metrics for Firehose block streams, all labeled with deployment and provider. Things that these metrics are tracking:

- How often do we reconnect block streams?
- How long do connection attempts take until they succeed/fail?
- How many of these reconnection attempts are successful/fail?
- How much time do we spend receiving and processing stream events?
- What kinds of events (proceed, revert, error) are we receiving?

