### PR TITLE
Fix documented defaults for environment variables: Api & Spec versions

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -84,7 +84,9 @@ happens, subgraphs might process inconsistent data. Defaults to 250.
 - `GRAPH_QUERY_CACHE_STALE_PERIOD`: Number of queries after which a cache
   entry can be considered stale. Defaults to 100.
 - `GRAPH_MAX_API_VERSION`: Maximum `apiVersion` supported, if a developer tries to create a subgraph
-  with a higher `apiVersion` than this in their mappings, they'll receive an error. Defaults to `0.0.6`.
+  with a higher `apiVersion` than this in their mappings, they'll receive an error. Defaults to `0.0.7`.
+- `GRAPH_MAX_SPEC_VERSION`: Maximum `specVersion` supported. if a developer tries to create a subgraph
+  with a higher `apiVersion` than this, the'll receive an error. Defaults to `0.0.5`.
 - `GRAPH_RUNTIME_MAX_STACK_SIZE`: Maximum stack size for the WASM runtime, if exceeded the execution
   stops and an error is thrown. Defaults to 512KiB.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -86,7 +86,7 @@ happens, subgraphs might process inconsistent data. Defaults to 250.
 - `GRAPH_MAX_API_VERSION`: Maximum `apiVersion` supported, if a developer tries to create a subgraph
   with a higher `apiVersion` than this in their mappings, they'll receive an error. Defaults to `0.0.7`.
 - `GRAPH_MAX_SPEC_VERSION`: Maximum `specVersion` supported. if a developer tries to create a subgraph
-  with a higher `apiVersion` than this, the'll receive an error. Defaults to `0.0.5`.
+  with a higher `apiVersion` than this, they'll receive an error. Defaults to `0.0.5`.
 - `GRAPH_RUNTIME_MAX_STACK_SIZE`: Maximum stack size for the WASM runtime, if exceeded the execution
   stops and an error is thrown. Defaults to 512KiB.
 

--- a/graph/src/env/mappings.rs
+++ b/graph/src/env/mappings.rs
@@ -10,7 +10,7 @@ pub struct EnvVarsMapping {
     /// kilobytes). The default value is 10 megabytes.
     pub entity_cache_size: usize,
     /// Set by the environment variable `GRAPH_MAX_API_VERSION`. The default
-    /// value is `0.0.6`.
+    /// value is `0.0.7`.
     pub max_api_version: Version,
     /// Set by the environment variable `GRAPH_MAPPING_HANDLER_TIMEOUT`
     /// (expressed in seconds). No default is provided.

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -110,7 +110,7 @@ pub struct EnvVars {
     /// are enabled.
     pub allow_non_deterministic_fulltext_search: bool,
     /// Set by the environment variable `GRAPH_MAX_SPEC_VERSION`. The default
-    /// value is `0.0.4`.
+    /// value is `0.0.5`.
     pub max_spec_version: Version,
     /// Set by the flag `GRAPH_DISABLE_GRAFTS`.
     pub disable_grafts: bool,


### PR DESCRIPTION
This PR adds an entry for the `GRAPH_MAX_SPEC_VERSION` in the environment variables markdown file.

It also updates docs and comments for the latest default versions of:
- `GRAPH_MAX_SPEC_VERSION`
- `GRAPH_MAX_API_VERSION`