### PR TITLE
Put receipts into `Arc`s to prevent excessive cloning.

### DIFF
--- a/chain/ethereum/src/codec.rs
+++ b/chain/ethereum/src/codec.rs
@@ -284,6 +284,9 @@ impl Into<EthereumBlockWithCalls> for &Block {
                             effective_gas_price: None,
                         })
                     })
+                    // Transaction receipts will be shared along the code, so we put them into an
+                    // Arc here to avoid excessive cloning.
+                    .map(Arc::new)
                     .collect(),
             },
             // Comment (437a9f17-67cc-478f-80a3-804fe554b227): This Some() will avoid calls in the triggers_in_block

--- a/chain/ethereum/src/runtime/abi.rs
+++ b/chain/ethereum/src/runtime/abi.rs
@@ -578,7 +578,7 @@ where
 }
 
 impl<T, B> ToAscObj<AscEthereumEvent_0_0_7<T, B>>
-    for (EthereumEventData, Option<TransactionReceipt>)
+    for (EthereumEventData, Option<&TransactionReceipt>)
 where
     T: AscType + AscIndexId,
     B: AscType + AscIndexId,
@@ -665,7 +665,7 @@ impl ToAscObj<AscEthereumLog> for Log {
     }
 }
 
-impl ToAscObj<AscEthereumTransactionReceipt> for TransactionReceipt {
+impl ToAscObj<AscEthereumTransactionReceipt> for &TransactionReceipt {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,

--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -47,7 +47,7 @@ pub enum MappingTrigger {
         transaction: Arc<Transaction>,
         log: Arc<Log>,
         params: Vec<LogParam>,
-        receipt: Option<TransactionReceipt>,
+        receipt: Option<Arc<TransactionReceipt>>,
     },
     Call {
         block: Arc<LightEthereumBlock>,
@@ -143,7 +143,7 @@ impl blockchain::MappingTrigger for MappingTrigger {
                         >,
                         _,
                         _,
-                    >(heap, &(ethereum_event_data, receipt), gas)?
+                    >(heap, &(ethereum_event_data, receipt.as_deref()), gas)?
                     .erase()
                 } else if api_version >= API_VERSION_0_0_6 {
                     asc_new::<
@@ -217,7 +217,7 @@ impl blockchain::MappingTrigger for MappingTrigger {
 pub enum EthereumTrigger {
     Block(BlockPtr, EthereumBlockTriggerType),
     Call(Arc<EthereumCall>),
-    Log(Arc<Log>, Option<TransactionReceipt>),
+    Log(Arc<Log>, Option<Arc<TransactionReceipt>>),
 }
 
 impl PartialEq for EthereumTrigger {

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -101,7 +101,7 @@ pub fn evaluate_transaction_status(receipt_status: Option<U64>) -> bool {
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct EthereumBlock {
     pub block: Arc<LightEthereumBlock>,
-    pub transaction_receipts: Vec<TransactionReceipt>,
+    pub transaction_receipts: Vec<Arc<TransactionReceipt>>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq)]


### PR DESCRIPTION
This PR aims to improve performance issues introduced in #3373.

It envelops `TransactionReceipt`s in `Arcs`s to share them without cloning inside the `parse_log_triggers` function.

