### PR TITLE
Use reserved discriminant segments for `IndexForAscTypeId`

### DIFF
--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -139,12 +139,23 @@ macro_rules! impl_asc_type {
 
 impl_asc_type!(u8, u16, u32, u64, i8, i32, i64, f32, f64);
 
-// The numbers on each variant could just be comments hence the
-// `#[repr(u32)]`, however having them in code enforces each value
-// to be the same as the docs.
+/// Contains type IDs and their discriminants for every blockchain supported by Graph-Node.
+///
+/// Each variant corresponds to the unique ID of an AssemblyScript concrete class used in the
+/// [`runtime`].
+///
+/// # Rules for updating this enum
+///
+/// 1 .The discriminants must have the same value as their counterparts in `TypeId` enum from
+///    graph-ts' `global` module. If not, the runtime will fail to determine the correct class
+///    during allocation.
+/// 2. Each supported blockchain has a reserved space of 500 contiguous variants.
+/// 3. Once defined, items and their discriminants cannot be changed, as this would break running
+///    subgraphs compiled in previous versions of this representation.
 #[repr(u32)]
 #[derive(Copy, Clone, Debug)]
 pub enum IndexForAscTypeId {
+    // Ethereum type IDs
     String = 0,
     ArrayBuffer = 1,
     Int8Array = 2,
@@ -199,15 +210,6 @@ pub enum IndexForAscTypeId {
     ArrayBigDecimal = 51,
 
     // Near Type IDs
-    //
-    // Generated with the following shell script:
-    //
-    // ```
-    // cat chain/near/src/runtime/generated.rs | grep IndexForAscTypeId::Near | grep -Eo "Near[a-zA-Z0-9]+" | awk '{for(x=1;x<=NF;x++)sub(/$/,"="++i+51",")}1' | sed 's/=/ = /'
-    // ```
-    //
-    // The `51` literal at the end in the `awk` should be replaced with the last element
-    // value in the list above.
     NearArrayDataReceiver = 52,
     NearArrayCryptoHash = 53,
     NearArrayActionEnum = 54,
@@ -243,70 +245,93 @@ pub enum IndexForAscTypeId {
     NearChunkHeader = 84,
     NearBlock = 85,
     NearReceiptWithOutcome = 86,
+    // Reserved discriminant space for more Near type IDs: [87, 499]:
+    // Continue to add more Near type IDs here.
+    // e.g.:
+    // NextNearType = 87,
+    // AnotherNearType = 88,
+    // ...
+    // LastNearType = 499,
 
-    // Tendermint Type IDs
+    // Reserved discriminant space for more Ethereum type IDs: [500, 999]
+    TransactionReceipt = 500,
+    Log = 501,
+    ArrayH256 = 502,
+    ArrayLog = 503,
+    // Continue to add more Ethereum type IDs here.
+    // e.g.:
+    // NextEthereumType = 504,
+    // AnotherEthereumType = 505,
+    // ...
+    // LastEthereumType = 999,
+
+    // Reserved discriminant space for Tendermint type IDs: [1,500, 1,999]
+    TendermintArrayBytes = 1500,
+    TendermintArrayCommitSig = 1501,
+    TendermintArrayEvent = 1502,
+    TendermintArrayEventAttribute = 1503,
+    TendermintArrayEventTx = 1504,
+    TendermintArrayEvidence = 1505,
+    TendermintArrayValidator = 1506,
+    TendermintArrayValidatorUpdate = 1507,
+    TendermintBlock = 1508,
+    TendermintBlockID = 1509,
+    TendermintBlockIDFlagEnum = 1510,
+    TendermintBlockParams = 1511,
+    TendermintCommit = 1512,
+    TendermintCommitSig = 1513,
+    TendermintConsensus = 1514,
+    TendermintConsensusParams = 1515,
+    TendermintData = 1516,
+    TendermintDuplicateVoteEvidence = 1517,
+    TendermintDuration = 1518,
+    TendermintEvent = 1519,
+    TendermintEventAttribute = 1520,
+    TendermintEventBlock = 1521,
+    TendermintEventData = 1522,
+    TendermintEventList = 1523,
+    TendermintEventTx = 1524,
+    TendermintEventValidatorSetUpdates = 1525,
+    TendermintEventVote = 1526,
+    TendermintEvidence = 1527,
+    TendermintEvidenceList = 1528,
+    TendermintEvidenceParams = 1529,
+    TendermintHeader = 1530,
+    TendermintLightBlock = 1531,
+    TendermintLightClientAttackEvidence = 1532,
+    TendermintPartSetHeader = 1533,
+    TendermintPublicKey = 1534,
+    TendermintResponseBeginBlock = 1535,
+    TendermintResponseDeliverTx = 1536,
+    TendermintResponseEndBlock = 1537,
+    TendermintSignedHeader = 1538,
+    TendermintSignedMsgTypeEnum = 1539,
+    TendermintTimestamp = 1540,
+    TendermintTxResult = 1541,
+    TendermintValidator = 1542,
+    TendermintValidatorParams = 1543,
+    TendermintValidatorSet = 1544,
+    TendermintValidatorUpdate = 1545,
+    TendermintVersionParams = 1546,
+    // Continue to add more Tendermint type IDs here.
+    // e.g.:
+    // NextTendermintType = 1547,
+    // AnotherTendermintType = 1547,
+    // ...
+    // LastTendermintType = 1999,
+
+    // Reserved discriminant space for a future blockchain type IDs: [2,000, 2,500]
     //
     // Generated with the following shell script:
     //
     // ```
-    // cat chain/tendermint/src/runtime/generated.rs | grep IndexForAscTypeId::Tendermint | grep -Eo "Tendermint[a-zA-Z0-9]+" | awk '{for(x=1;x<=NF;x++)sub(/$/,"="++i+86",")}1' | sed 's/=/ = /'
+    // grep -Po "(?<=IndexForAscTypeId::)IDENDIFIER_PREFIX.*\b" SRC_FILE | sort |uniq | awk 'BEGIN{count=2000} {sub("$", " = "count",", $1); count++} 1'
     // ```
     //
-    // The `86` literal at the end in the `awk` should be replaced with the last element
-    // value in the list above.
-    TendermintArrayEventTx = 87,
-    TendermintArrayEvent = 88,
-    TendermintArrayCommitSig = 89,
-    TendermintArrayBytes = 90,
-    TendermintArrayEvidence = 91,
-    TendermintArrayEventAttribute = 92,
-    TendermintBlockIDFlagEnum = 93,
-    TendermintSignedMsgTypeEnum = 94,
-    TendermintEventList = 95,
-    TendermintEventBlock = 96,
-    TendermintResponseBeginBlock = 97,
-    TendermintResponseEndBlock = 98,
-    TendermintValidatorUpdate = 99,
-    TendermintArrayValidatorUpdate = 100,
-    TendermintConsensusParams = 101,
-    TendermintBlockParams = 102,
-    TendermintEvidenceParams = 103,
-    TendermintValidatorParams = 104,
-    TendermintVersionParams = 105,
-    TendermintBlock = 106,
-    TendermintCommit = 107,
-    TendermintCommitSig = 108,
-    TendermintHeader = 109,
-    TendermintConsensus = 110,
-    TendermintBlockID = 111,
-    TendermintPartSetHeader = 112,
-    TendermintData = 113,
-    TendermintEvidence = 114,
-    TendermintDuplicateVoteEvidence = 115,
-    TendermintEventTx = 116,
-    TendermintEventVote = 117,
-    TendermintLightClientAttackEvidence = 118,
-    TendermintLightBlock = 119,
-    TendermintValidatorSet = 120,
-    TendermintSignedHeader = 121,
-    TendermintEvidenceList = 122,
-    TendermintValidator = 123,
-    TendermintArrayValidator = 124,
-    TendermintPublicKey = 125,
-    TendermintTxResult = 126,
-    TendermintResponseDeliverTx = 127,
-    TendermintEvent = 128,
-    TendermintEventAttribute = 129,
-    TendermintEventValidatorSetUpdates = 130,
-    TendermintDuration = 131,
-    TendermintTimestamp = 132,
-    TendermintEventData = 133,
-
-    // More Ethereum tyes
-    TransactionReceipt = 134,
-    Log = 135,
-    ArrayH256 = 136,
-    ArrayLog = 137,
+    // INSTRUCTIONS:
+    // 1. Replace the IDENTIFIER_PREFIX and the SRC_FILE placeholders according to the blockchain
+    //    name and implementation before running this script.
+    // 2. Insert the output right before the end of this block.
 }
 
 impl ToAscObj<u32> for IndexForAscTypeId {


### PR DESCRIPTION
This PR changes the organization of  `IndexForAscTypeId` variants for future blockchain implementations.

**Motivation**:
The incentive for this change is the expected (and desired) growth of supported blockchains in Graph-Node. Each new blockchain implementation also comes with a myriad of new *AssemblyScript* types defined in [Graph-TS](github.com/graphprotocol/graph-ts) that need to be represented in the runtime. Currently, we have been appending new type IDs to the end of `IndexForAscTypeId` enum, but the addition of new types proved to be convoluted and hard to reason about. We aim to improve the developer experience by removing this kind of friction.

**Rationale**:
We propose that each blockchain implementation will have a fixed and contiguous discriminant space of 500 items, starting to be enforced after our latest released implementations: **Ethereum** and **Near**.

Our goal is that every new supported blockchain, for instance, **Tendermint**, will have room to include new AssemblyScript class IDs without interweaving its discriminants with other blockchains.

**TODO**:
- We need to reorganize the variants in graph-ts' [`TypeId`](https://github.com/graphprotocol/graph-ts/blob/main/global/global.ts#L15) enum to exactly match the variants and their discriminants rearranged by this PR.
