### PR TITLE
Add a store.get_in_block host fn

### DIFF
--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -2,7 +2,7 @@ mod cache;
 mod err;
 mod traits;
 
-pub use cache::{CachedEthereumCall, EntityCache, ModificationsAndCache};
+pub use cache::{CachedEthereumCall, EntityCache, GetScope, ModificationsAndCache};
 pub use err::StoreError;
 pub use traits::*;
 

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -11,7 +11,7 @@ use web3::types::H160;
 use graph::blockchain::DataSource;
 use graph::blockchain::{Blockchain, DataSourceTemplate as _};
 use graph::components::store::EntityType;
-use graph::components::store::{EnsLookup, EntityKey};
+use graph::components::store::{EnsLookup, EntityKey, GetScope};
 use graph::components::subgraph::{CausalityRegion, ProofOfIndexingEvent, SharedProofOfIndexing};
 use graph::data::store;
 use graph::ensure;
@@ -201,6 +201,7 @@ impl<C: Blockchain> HostExports<C> {
         entity_type: String,
         entity_id: String,
         gas: &GasCounter,
+        scope: GetScope,
     ) -> Result<Option<Entity>, anyhow::Error> {
         let store_key = EntityKey {
             subgraph_id: self.subgraph_id.clone(),
@@ -208,7 +209,7 @@ impl<C: Blockchain> HostExports<C> {
             entity_id,
         };
 
-        let result = state.entity_cache.get(&store_key)?;
+        let result = state.entity_cache.get(&store_key, scope)?;
         gas.consume_host_fn(gas::STORE_GET.with_args(complexity::Linear, (&store_key, &result)))?;
 
         Ok(result)

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 
 use anyhow::anyhow;
 use anyhow::Error;
+use graph::components::store::GetScope;
 use never::Never;
 use semver::Version;
 use wasmtime::{Memory, Trap};
@@ -458,6 +459,13 @@ impl<C: Blockchain> WasmInstance<C> {
 
         link!("store.get", store_get, "host_export_store_get", entity, id);
         link!(
+            "store.get_in_block",
+            store_get,
+            "host_export_store_get_in_block",
+            entity,
+            id
+        );
+        link!(
             "store.set",
             store_set,
             "host_export_store_set",
@@ -797,6 +805,64 @@ impl<C: Blockchain> WasmInstanceContext<C> {
             experimental_features,
         })
     }
+
+    fn store_get_scoped(
+        &mut self,
+        gas: &GasCounter,
+        entity_ptr: AscPtr<AscString>,
+        id_ptr: AscPtr<AscString>,
+        scope: GetScope,
+    ) -> Result<AscPtr<AscEntity>, HostExportError> {
+        let _timer = self
+            .host_metrics
+            .cheap_clone()
+            .time_host_fn_execution_region("store_get");
+
+        let entity_type: String = asc_get(self, entity_ptr, gas)?;
+        let id: String = asc_get(self, id_ptr, gas)?;
+        let entity_option = self.ctx.host_exports.store_get(
+            &mut self.ctx.state,
+            entity_type.clone(),
+            id.clone(),
+            gas,
+            scope,
+        )?;
+
+        let ret = match entity_option {
+            Some(entity) => {
+                let _section = self
+                    .host_metrics
+                    .stopwatch
+                    .start_section("store_get_asc_new");
+                asc_new(self, &entity.sorted(), gas)?
+            }
+            None => match &self.ctx.debug_fork {
+                Some(fork) => {
+                    let entity_option = fork.fetch(entity_type, id).map_err(|e| {
+                        HostExportError::Unknown(anyhow!(
+                            "store_get: failed to fetch entity from the debug fork: {}",
+                            e
+                        ))
+                    })?;
+                    match entity_option {
+                        Some(entity) => {
+                            let _section = self
+                                .host_metrics
+                                .stopwatch
+                                .start_section("store_get_asc_new");
+                            let entity = asc_new(self, &entity.sorted(), gas)?;
+                            self.store_set(gas, entity_ptr, id_ptr, entity)?;
+                            entity
+                        }
+                        None => AscPtr::null(),
+                    }
+                }
+                None => AscPtr::null(),
+            },
+        };
+
+        Ok(ret)
+    }
 }
 
 // Implementation of externals.
@@ -888,54 +954,17 @@ impl<C: Blockchain> WasmInstanceContext<C> {
         entity_ptr: AscPtr<AscString>,
         id_ptr: AscPtr<AscString>,
     ) -> Result<AscPtr<AscEntity>, HostExportError> {
-        let _timer = self
-            .host_metrics
-            .cheap_clone()
-            .time_host_fn_execution_region("store_get");
+        self.store_get_scoped(gas, entity_ptr, id_ptr, GetScope::Store)
+    }
 
-        let entity_type: String = asc_get(self, entity_ptr, gas)?;
-        let id: String = asc_get(self, id_ptr, gas)?;
-        let entity_option = self.ctx.host_exports.store_get(
-            &mut self.ctx.state,
-            entity_type.clone(),
-            id.clone(),
-            gas,
-        )?;
-
-        let ret = match entity_option {
-            Some(entity) => {
-                let _section = self
-                    .host_metrics
-                    .stopwatch
-                    .start_section("store_get_asc_new");
-                asc_new(self, &entity.sorted(), gas)?
-            }
-            None => match &self.ctx.debug_fork {
-                Some(fork) => {
-                    let entity_option = fork.fetch(entity_type, id).map_err(|e| {
-                        HostExportError::Unknown(anyhow!(
-                            "store_get: failed to fetch entity from the debug fork: {}",
-                            e
-                        ))
-                    })?;
-                    match entity_option {
-                        Some(entity) => {
-                            let _section = self
-                                .host_metrics
-                                .stopwatch
-                                .start_section("store_get_asc_new");
-                            let entity = asc_new(self, &entity.sorted(), gas)?;
-                            self.store_set(gas, entity_ptr, id_ptr, entity)?;
-                            entity
-                        }
-                        None => AscPtr::null(),
-                    }
-                }
-                None => AscPtr::null(),
-            },
-        };
-
-        Ok(ret)
+    /// function store.get_in_block(entity: string, id: string): Entity | null
+    pub fn store_get_in_block(
+        &mut self,
+        gas: &GasCounter,
+        entity_ptr: AscPtr<AscString>,
+        id_ptr: AscPtr<AscString>,
+    ) -> Result<AscPtr<AscEntity>, HostExportError> {
+        self.store_get_scoped(gas, entity_ptr, id_ptr, GetScope::InBlock)
     }
 
     /// function typeConversion.bytesToString(bytes: Bytes): string


### PR DESCRIPTION
The new `store.get_in_block` host function lets subgraph authors indicate that they only want to look up entities that other handlers might have stored during the processing of the current block. 

The new function bypasses store lookups and can be a significant boost to performance. How much of a boost this is needs to be investigated, but there are cases where subgraphs make 20 such lookups per second which have to query the store even though the subgraph author knows that querying the store is pointless, and they just want to access a possibly previously created instance of the entity.
