### PR TITLE
Assume that immutable entities are actually new during indexing 

### DIFF
--- a/graph/src/data/graphql/ext.rs
+++ b/graph/src/data/graphql/ext.rs
@@ -10,6 +10,7 @@ use std::collections::{BTreeMap, HashMap};
 pub trait ObjectTypeExt {
     fn field(&self, name: &str) -> Option<&Field>;
     fn is_meta(&self) -> bool;
+    fn is_immutable(&self) -> bool;
 }
 
 impl ObjectTypeExt for ObjectType {
@@ -20,6 +21,16 @@ impl ObjectTypeExt for ObjectType {
     fn is_meta(&self) -> bool {
         self.name == META_FIELD_TYPE
     }
+
+    fn is_immutable(&self) -> bool {
+        self.find_directive("entity")
+            .and_then(|dir| dir.argument("immutable"))
+            .map(|value| match value {
+                Value::Boolean(b) => *b,
+                _ => false,
+            })
+            .unwrap_or(false)
+    }
 }
 
 impl ObjectTypeExt for InterfaceType {
@@ -28,6 +39,10 @@ impl ObjectTypeExt for InterfaceType {
     }
 
     fn is_meta(&self) -> bool {
+        false
+    }
+
+    fn is_immutable(&self) -> bool {
         false
     }
 }

--- a/graphql/src/introspection/mod.rs
+++ b/graphql/src/introspection/mod.rs
@@ -2,6 +2,4 @@ mod resolver;
 mod schema;
 
 pub use self::resolver::IntrospectionResolver;
-pub use self::schema::{
-    introspection_schema, is_introspection_field, INTROSPECTION_DOCUMENT, INTROSPECTION_QUERY_TYPE,
-};
+pub use self::schema::{is_introspection_field, INTROSPECTION_DOCUMENT, INTROSPECTION_QUERY_TYPE};

--- a/graphql/src/introspection/schema.rs
+++ b/graphql/src/introspection/schema.rs
@@ -4,8 +4,6 @@ use graphql_parser;
 
 use graph::data::graphql::ext::DocumentExt;
 use graph::data::graphql::ext::ObjectTypeExt;
-use graph::data::schema::{ApiSchema, Schema};
-use graph::data::subgraph::DeploymentHash;
 use graph::prelude::s::Document;
 
 use lazy_static::lazy_static;
@@ -127,10 +125,6 @@ lazy_static! {
             .unwrap()
             .clone()
     ));
-}
-
-pub fn introspection_schema(id: DeploymentHash) -> ApiSchema {
-    ApiSchema::from_api_schema(Schema::new(id, INTROSPECTION_DOCUMENT.clone())).unwrap()
 }
 
 pub fn is_introspection_field(name: &str) -> bool {

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -27,7 +27,7 @@ mod runner;
 /// Prelude that exports the most important traits and types.
 pub mod prelude {
     pub use super::execution::{ast as a, ExecutionContext, Query, Resolver};
-    pub use super::introspection::{introspection_schema, IntrospectionResolver};
+    pub use super::introspection::IntrospectionResolver;
     pub use super::query::{execute_query, ext::BlockConstraint, QueryExecutionOptions};
     pub use super::schema::{api_schema, APISchemaError};
     pub use super::store::StoreResolver;

--- a/server/index-node/src/schema.rs
+++ b/server/index-node/src/schema.rs
@@ -4,16 +4,10 @@ lazy_static! {
     pub static ref SCHEMA: Arc<ApiSchema> = {
         let raw_schema = include_str!("./schema.graphql");
         let document = graphql_parser::parse_schema(&raw_schema).unwrap();
-        let (interfaces_for_type, types_for_interface) =
-            Schema::collect_interfaces(&document).unwrap();
-
         Arc::new(
-            ApiSchema::from_api_schema(Schema {
-                id: DeploymentHash::new("indexnode").unwrap(),
-                document,
-                interfaces_for_type,
-                types_for_interface,
-            })
+            ApiSchema::from_api_schema(
+                Schema::new(DeploymentHash::new("indexnode").unwrap(), document).unwrap(),
+            )
             .unwrap(),
         )
     };

--- a/store/postgres/src/fork.rs
+++ b/store/postgres/src/fork.rs
@@ -267,7 +267,8 @@ mod tests {
 }"#,
             )
             .unwrap(),
-        );
+        )
+        .unwrap();
         Arc::new(schema)
     }
 

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -16,7 +16,7 @@ use diesel::{connection::SimpleConnection, Connection};
 use diesel::{debug_query, OptionalExtension, PgConnection, RunQueryDsl};
 use graph::cheap_clone::CheapClone;
 use graph::constraint_violation;
-use graph::data::graphql::{DirectiveExt, TypeExt as _};
+use graph::data::graphql::TypeExt as _;
 use graph::prelude::{q, s, StopwatchMetrics, ENV_VARS};
 use graph::slog::warn;
 use inflector::Inflector;
@@ -1208,14 +1208,7 @@ impl Table {
             .account_tables
             .contains(qualified_name.as_str());
 
-        let immutable = defn
-            .find_directive("entity")
-            .and_then(|dir| dir.argument("immutable"))
-            .map(|value| match value {
-                q::Value::Boolean(b) => *b,
-                _ => false,
-            })
-            .unwrap_or(false);
+        let immutable = defn.is_immutable();
 
         let table = Table {
             object: EntityType::from(defn),


### PR DESCRIPTION
This is a better approach to get to the same result as in PR #3449 - we already know that there shouldn't be any point in trying to look up new immutable entities from the store.

We therefore optimize the code for the common happy path, that users use immutable entities correctly to avoid store interactions that are useless in that case to improve indexing performance.