### PR TITLE
node: Check that the shard for 'copy create' exists

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -828,8 +828,9 @@ async fn main() {
                     node,
                     offset,
                 } => {
+                    let shards: Vec<_> = ctx.config.stores.keys().cloned().collect();
                     let (store, primary) = ctx.store_and_primary();
-                    commands::copy::create(store, primary, src, shard, node, offset).await
+                    commands::copy::create(store, primary, src, shard, shards, node, offset).await
                 }
                 Activate { deployment, shard } => {
                     commands::copy::activate(ctx.subgraph_store(), deployment, shard)

--- a/node/src/manager/commands/copy.rs
+++ b/node/src/manager/commands/copy.rs
@@ -83,6 +83,7 @@ pub async fn create(
     primary: ConnectionPool,
     src: DeploymentSearch,
     shard: String,
+    shards: Vec<String>,
     node: String,
     block_offset: u32,
 ) -> Result<(), Error> {
@@ -118,6 +119,12 @@ pub async fn create(
     };
     let base_ptr = BlockPtr::from((hash, src_number));
 
+    if !shards.contains(&shard) {
+        bail!(
+            "unknown shard {shard}, only shards {} are configured",
+            shards.join(", ")
+        )
+    }
     let shard = Shard::new(shard)?;
     let node = NodeId::new(node.clone()).map_err(|()| anyhow!("invalid node id `{}`", node))?;
 


### PR DESCRIPTION
Otherwise, a typo can create a deployment that is hard to get rid of