### PR TITLE
runner: fix subgraph cancelation

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -97,6 +97,14 @@ where
                 .map_err(CancelableError::Error)
                 .cancelable(&block_stream_canceler, || Err(CancelableError::Cancel));
 
+            // Keep the stream's cancel guard around to be able to shut it down when the subgraph
+            // deployment is unassigned
+            self.ctx
+                .instances
+                .write()
+                .unwrap()
+                .insert(self.inputs.deployment.id, block_stream_canceler);
+
             debug!(self.logger, "Starting block stream");
 
             // Process events from the stream as long as no restart is needed


### PR DESCRIPTION
This was accidentally in https://github.com/graphprotocol/graph-node/pull/3367