### PR TITLE
Make traversing derived relationships work when using `Bytes` ids

### DIFF
--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -98,6 +98,11 @@ pub struct EnvVarsStore {
     /// Setting this to `0` disables pipelined writes, and writes will be
     /// done synchronously.
     pub write_queue_size: usize,
+
+    /// This is just in case new behavior causes issues. This can be removed
+    /// once the new behavior has run in the hosted service for a few days
+    /// without issues.
+    pub disable_error_for_toplevel_parents: bool,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -139,6 +144,7 @@ impl From<InnerStore> for EnvVarsStore {
             connection_min_idle: x.connection_min_idle,
             connection_idle_timeout: Duration::from_secs(x.connection_idle_timeout_in_secs),
             write_queue_size: x.write_queue_size,
+            disable_error_for_toplevel_parents: x.disable_error_for_toplevel_parents.0,
         }
     }
 }
@@ -184,4 +190,6 @@ pub struct InnerStore {
     connection_idle_timeout_in_secs: u64,
     #[envconfig(from = "GRAPH_STORE_WRITE_QUEUE", default = "5")]
     write_queue_size: usize,
+    #[envconfig(from = "GRAPH_DISABLE_ERROR_FOR_TOPLEVEL_PARENTS", default = "false")]
+    disable_error_for_toplevel_parents: EnvVarBoolean,
 }

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -472,7 +472,7 @@ impl Layout {
         FindQuery::new(table.as_ref(), id, block)
             .get_result::<EntityData>(conn)
             .optional()?
-            .map(|entity_data| entity_data.deserialize_with_layout(self))
+            .map(|entity_data| entity_data.deserialize_with_layout(self, None))
             .transpose()
     }
 
@@ -501,7 +501,7 @@ impl Layout {
             entities_for_type
                 .entry(data.entity_type())
                 .or_default()
-                .push(data.deserialize_with_layout(self)?);
+                .push(data.deserialize_with_layout(self, None)?);
         }
         Ok(entities_for_type)
     }
@@ -530,7 +530,7 @@ impl Layout {
 
         for entity_data in inserts_or_updates.into_iter() {
             let entity_type = entity_data.entity_type();
-            let mut data: Entity = entity_data.deserialize_with_layout(self)?;
+            let mut data: Entity = entity_data.deserialize_with_layout(self, None)?;
             let entity_id = data.id().expect("Invalid ID for entity.");
             processed_entities.insert((entity_type.clone(), entity_id.clone()));
 
@@ -682,11 +682,13 @@ impl Layout {
                 )),
             })?;
         log_query_timing(logger, &query_clone, start.elapsed(), values.len());
+
+        let parent_type = filter_collection.parent_type()?.map(ColumnType::from);
         values
             .into_iter()
             .map(|entity_data| {
                 entity_data
-                    .deserialize_with_layout(self)
+                    .deserialize_with_layout(self, parent_type.as_ref())
                     .map_err(|e| e.into())
             })
             .collect()

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -476,12 +476,22 @@ impl EntityData {
                     if key == "g$parent_id" {
                         match &parent_type {
                             None => {
-                                // A query that does not have parents
-                                // somehow returned parent ids. We have no
-                                // idea how to deserialize that
-                                return Err(graph::constraint_violation!(
-                                    "query unexpectedly produces parent ids"
-                                ));
+                                if ENV_VARS.store.disable_error_for_toplevel_parents {
+                                    // Only temporarily in case reporting an
+                                    // error causes unexpected trouble. Can
+                                    // be removed once it's been working for
+                                    // a few days
+                                    let value =
+                                        T::Value::from_column_value(&ColumnType::String, json)?;
+                                    out.insert_entity_data("g$parent_id".to_owned(), value);
+                                } else {
+                                    // A query that does not have parents
+                                    // somehow returned parent ids. We have no
+                                    // idea how to deserialize that
+                                    return Err(graph::constraint_violation!(
+                                        "query unexpectedly produces parent ids"
+                                    ));
+                                }
                             }
                             Some(parent_type) => {
                                 let value = T::Value::from_column_value(parent_type, json)?;

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -443,7 +443,7 @@ impl EntityDeletion {
 /// at compile time. Because of that, we retrieve the actual data for an
 /// entity as Jsonb by converting the row containing the entity using the
 /// `to_jsonb` function.
-#[derive(QueryableByName)]
+#[derive(QueryableByName, Debug)]
 pub struct EntityData {
     #[sql_type = "Text"]
     entity: String,
@@ -460,6 +460,7 @@ impl EntityData {
     pub fn deserialize_with_layout<T: FromEntityData>(
         self,
         layout: &Layout,
+        parent_type: Option<&ColumnType>,
     ) -> Result<T, StoreError> {
         let entity_type = EntityType::new(self.entity);
         let table = layout.table_for_entity(&entity_type)?;
@@ -473,8 +474,20 @@ impl EntityData {
                     // column; those will be things like the block_range that
                     // is used internally for versioning
                     if key == "g$parent_id" {
-                        let value = T::Value::from_column_value(&ColumnType::String, json)?;
-                        out.insert_entity_data("g$parent_id".to_owned(), value);
+                        match &parent_type {
+                            None => {
+                                // A query that does not have parents
+                                // somehow returned parent ids. We have no
+                                // idea how to deserialize that
+                                return Err(graph::constraint_violation!(
+                                    "query unexpectedly produces parent ids"
+                                ));
+                            }
+                            Some(parent_type) => {
+                                let value = T::Value::from_column_value(parent_type, json)?;
+                                out.insert_entity_data("g$parent_id".to_owned(), value);
+                            }
+                        }
                     } else if let Some(column) = table.column(&SqlName::verbatim(key)) {
                         let value = T::Value::from_column_value(&column.column_type, json)?;
                         if !value.is_null() {
@@ -1803,6 +1816,13 @@ impl<'a> FilterWindow<'a> {
         })
     }
 
+    fn parent_type(&self) -> IdType {
+        match &self.link {
+            TableLink::Direct(column, _) => column.column_type.id_type(),
+            TableLink::Parent(_) => self.table.primary_key().column_type.id_type(),
+        }
+    }
+
     fn and_filter(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
         if let Some(filter) = &self.query_filter {
             out.push_sql("\n   and ");
@@ -2169,6 +2189,25 @@ impl<'a> FilterCollection<'a> {
             FilterCollection::All(entities) => entities.is_empty(),
             FilterCollection::SingleWindow(_) => false,
             FilterCollection::MultiWindow(windows, _) => windows.is_empty(),
+        }
+    }
+
+    /// Return the id type of the fields in the parents for which the query
+    /// produces children. This is `None` if there are no parents, i.e., for
+    /// a toplevel query.
+    pub(crate) fn parent_type(&self) -> Result<Option<IdType>, StoreError> {
+        match self {
+            FilterCollection::All(_) => Ok(None),
+            FilterCollection::SingleWindow(window) => Ok(Some(window.parent_type())),
+            FilterCollection::MultiWindow(windows, _) => {
+                if windows.iter().map(FilterWindow::parent_type).all_equal() {
+                    Ok(Some(windows[0].parent_type().to_owned()))
+                } else {
+                    Err(graph::constraint_violation!(
+                        "all implementors of an interface must use the same type for their `id`"
+                    ))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
There will also be tests that expose this issue, and make sure it stays fixed. But since that involves an extensive rewrite of `graphql/tests/query.rs`, it will happen in a separate PR so we can at least roll out this fix first.