### PR TITLE
Support TLS PostgreSQL connections in notification_listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,8 +1708,10 @@ dependencies = [
  "lazy_static",
  "lru_time_cache",
  "maybe-owned",
+ "openssl",
  "pin-utils",
  "postgres",
+ "postgres-openssl",
  "rand",
  "serde",
  "stable-hash",
@@ -2510,9 +2512,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.35"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2530,9 +2532,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.65"
+version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
 dependencies = [
  "autocfg",
  "cc",
@@ -2735,6 +2737,19 @@ dependencies = [
  "futures 0.3.16",
  "log",
  "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-openssl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de0ea6504e07ca78355a6fb88ad0f36cafe9e696cbc6717f16a207f3a60be72"
+dependencies = [
+ "futures 0.3.16",
+ "openssl",
+ "tokio",
+ "tokio-openssl",
  "tokio-postgres",
 ]
 
@@ -4012,6 +4027,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08f9ffb7809f1b20c1b398d92acf4cc719874b3b2b2d9ea2f09b4a80350878a"
+dependencies = [
+ "futures-util",
+ "openssl",
+ "openssl-sys",
  "tokio",
 ]
 

--- a/docker/start
+++ b/docker/start
@@ -63,7 +63,7 @@ run_graph_node() {
     else
         unset GRAPH_NODE_CONFIG
         postgres_port=${postgres_port:-5432}
-        postgres_url="postgresql://$postgres_user:$postgres_pass@$postgres_host:$postgres_port/$postgres_db"
+        postgres_url="postgresql://$postgres_user:$postgres_pass@$postgres_host:$postgres_port/$postgres_db?sslmode=prefer"
 
         wait_for_ipfs "$ipfs"
         wait_for "$postgres_host:$postgres_port" -t 120

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -21,6 +21,8 @@ lazy_static = "1.1"
 lru_time_cache = "0.11"
 maybe-owned = "0.3.4"
 postgres = "0.19.1"
+openssl = "0.10.38"
+postgres-openssl = "0.5.0"
 rand = "0.8.4"
 serde = "1.0"
 uuid = { version = "0.8.1", features = ["v4"] }

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -4,14 +4,14 @@ use diesel::sql_types::Text;
 use graph::prelude::tokio::sync::mpsc::error::SendTimeoutError;
 use graph::util::backoff::ExponentialBackoff;
 use lazy_static::lazy_static;
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use postgres::Notification;
 use postgres::{fallible_iterator::FallibleIterator, Client};
+use postgres_openssl::MakeTlsConnector;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
-use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
-use postgres_openssl::{MakeTlsConnector};
 use tokio::sync::mpsc::{channel, Receiver};
 
 use graph::prelude::serde_json;
@@ -123,7 +123,8 @@ impl NotificationListener {
             let mut backoff =
                 ExponentialBackoff::new(Duration::from_secs(1), Duration::from_secs(30));
             loop {
-                let mut builder = SslConnector::builder(SslMethod::tls()).expect("unable to create SslConnector builder");
+                let mut builder = SslConnector::builder(SslMethod::tls())
+                    .expect("unable to create SslConnector builder");
                 builder.set_verify(SslVerifyMode::NONE);
                 let connector = MakeTlsConnector::new(builder.build());
 


### PR DESCRIPTION
Hi, this PR implements TLS PSQL connections support for the `notification_listener`, as various managed database providers allow encrypted connections only, and it is generally a bad idea to disable encryption.

Related issue: https://github.com/graphprotocol/graph-node/issues/2097

With these changes it is possible to connect to databases with both TLS support and without. Please note that certificate verification is currently **disabled**, because it fits my use-case, and I don't have any experience with Rust whatsoever to make it configurable to support more use-cases. So I would be grateful if someone takes it over from here.

You can test it e.g. locally when running Postgres with the following command:

```yaml
version: '3'
services:
  postgres:
    image: postgres
    ports:
      - '5432:5432'
    command:
      [
        "postgres",
        "-cshared_preload_libraries=pg_stat_statements",
        "-cssl=on",
        "-cssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem",
        "-cssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key"
      ]
    environment:
      POSTGRES_USER: graph-node
      POSTGRES_PASSWORD: let-me-in
      POSTGRES_DB: graph-node
```

And monitor Postgres connections with the following command:

```sql
SELECT datname,usename,ssl,client_addr,application_name
FROM pg_stat_ssl
JOIN pg_stat_activity
ON pg_stat_ssl.pid = pg_stat_activity.pid;
```