### PR TITLE
store: alter deployment_schemas.version column to int

### DIFF
--- a/graph/src/components/store/err.rs
+++ b/graph/src/components/store/err.rs
@@ -1,9 +1,8 @@
+use super::{BlockNumber, DeploymentHash, DeploymentSchemaVersion};
+use crate::prelude::QueryExecutionError;
 use anyhow::{anyhow, Error};
 use thiserror::Error;
 use tokio::task::JoinError;
-
-use super::{BlockNumber, DeploymentHash};
-use crate::prelude::QueryExecutionError;
 
 #[derive(Error, Debug)]
 pub enum StoreError {
@@ -51,7 +50,9 @@ pub enum StoreError {
     #[error("panic in subgraph writer: {0}")]
     WriterPanic(JoinError),
     #[error(
-        "found deployment schema version {0} which is not supported. Did you downgrade Graph Node?"
+        "found schema version {0} but this graph node only supports versions up to {}. \
+         Did you downgrade Graph Node?",
+        DeploymentSchemaVersion::LATEST
     )]
     UnsupportedDeploymentSchemaVersion(i32),
 }

--- a/graph/src/components/store/err.rs
+++ b/graph/src/components/store/err.rs
@@ -50,6 +50,10 @@ pub enum StoreError {
     Poisoned,
     #[error("panic in subgraph writer: {0}")]
     WriterPanic(JoinError),
+    #[error(
+        "found deployment schema version {0} which is not supported. Did you downgrade Graph Node?"
+    )]
+    UnsupportedDeploymentSchemaVersion(i32),
 }
 
 // Convenience to report a constraint violation

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -964,3 +964,34 @@ impl From<BlockNumber> for PartialBlockPtr {
         Self { number, hash: None }
     }
 }
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DeploymentSchemaVersion {
+    /// Baseline version, in which:
+    /// - A relational schema is used.
+    /// - Each deployment has its own namespace for entity tables.
+    /// - Dynamic data sources are stored in `subgraphs.dynamic_ethereum_contract_data_source`.
+    V0 = 0,
+}
+
+impl DeploymentSchemaVersion {
+    // Latest schema version supported by this version of graph node.
+    pub const LATEST: Self = Self::V0;
+}
+
+impl TryFrom<i32> for DeploymentSchemaVersion {
+    type Error = StoreError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::V0),
+            _ => Err(StoreError::UnsupportedDeploymentSchemaVersion(value)),
+        }
+    }
+}
+
+impl fmt::Display for DeploymentSchemaVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&(*self as i32), f)
+    }
+}

--- a/store/postgres/migrations/2022-04-26-125552_alter_deployment_schemas_version/down.sql
+++ b/store/postgres/migrations/2022-04-26-125552_alter_deployment_schemas_version/down.sql
@@ -1,0 +1,61 @@
+-- This file should undo anything in `up.sql`
+
+-- This is dropped and left for the fdw logic which runs after migrations to recreate.
+drop schema if exists primary_public cascade;
+
+drop view if exists info.subgraph_info;
+drop view if exists info.all_sizes;
+drop materialized view if exists info.subgraph_sizes;
+
+create type deployment_schema_version as enum('split', 'relational');
+alter table if exists deployment_schemas alter version type deployment_schema_version using 'relational';
+
+create view info.subgraph_info as
+SELECT ds.id AS schema_id,
+    ds.name AS schema_name,
+    ds.subgraph,
+    ds.version,
+    s.name,
+        CASE
+            WHEN s.pending_version = v.id THEN 'pending'::text
+            WHEN s.current_version = v.id THEN 'current'::text
+            ELSE 'unused'::text
+        END AS status,
+    d.failed,
+    d.synced
+   FROM deployment_schemas ds,
+    subgraphs.subgraph_deployment d,
+    subgraphs.subgraph_version v,
+    subgraphs.subgraph s
+  WHERE d.deployment = ds.subgraph::text AND v.deployment = d.deployment AND v.subgraph = s.id;
+
+create materialized view info.subgraph_sizes as
+select *,
+       pg_size_pretty(total_bytes) as total,
+       pg_size_pretty(index_bytes) as index,
+       pg_size_pretty(toast_bytes) as toast,
+       pg_size_pretty(table_bytes) as table
+  from (
+    select *,
+           total_bytes-index_bytes-coalesce(toast_bytes,0) AS table_bytes
+      from (
+        select nspname as name,
+               ds.subgraph as subgraph,
+               ds.version::text as version,
+               sum(c.reltuples) as row_estimate,
+               sum(pg_total_relation_size(c.oid)) as total_bytes,
+               sum(pg_indexes_size(c.oid)) as index_bytes,
+               sum(pg_total_relation_size(reltoastrelid)) as toast_bytes
+          from pg_class c
+               join pg_namespace n on n.oid = c.relnamespace
+               join deployment_schemas ds on ds."name" = n.nspname
+          where relkind = 'r'
+            and nspname like 'sgd%'
+          group by nspname, subgraph, version
+  ) a
+) a with no data;
+
+create view info.all_sizes as
+select * from info.subgraph_sizes
+union all
+select * from info.table_sizes;

--- a/store/postgres/migrations/2022-04-26-125552_alter_deployment_schemas_version/up.sql
+++ b/store/postgres/migrations/2022-04-26-125552_alter_deployment_schemas_version/up.sql
@@ -8,7 +8,7 @@ drop view if exists info.subgraph_info;
 drop view if exists info.all_sizes;
 drop materialized view if exists info.subgraph_sizes;
 
-alter table if exists deployment_schemas alter version type integer using 0;
+alter table deployment_schemas alter version type integer using 0;
 drop type if exists deployment_schema_version;
 
 create view info.subgraph_info as

--- a/store/postgres/migrations/2022-04-26-125552_alter_deployment_schemas_version/up.sql
+++ b/store/postgres/migrations/2022-04-26-125552_alter_deployment_schemas_version/up.sql
@@ -1,0 +1,62 @@
+--  Alter `deployment_schemas.version` from enum to integer.
+--  Some views are recreated because they depend on the altered column.
+
+-- This is left for the fdw logic which runs after migrations to recreate.
+drop schema if exists primary_public cascade;
+
+drop view if exists info.subgraph_info;
+drop view if exists info.all_sizes;
+drop materialized view if exists info.subgraph_sizes;
+
+alter table if exists deployment_schemas alter version type integer using 0;
+drop type if exists deployment_schema_version;
+
+create view info.subgraph_info as
+SELECT ds.id AS schema_id,
+    ds.name AS schema_name,
+    ds.subgraph,
+    ds.version,
+    s.name,
+        CASE
+            WHEN s.pending_version = v.id THEN 'pending'::text
+            WHEN s.current_version = v.id THEN 'current'::text
+            ELSE 'unused'::text
+        END AS status,
+    d.failed,
+    d.synced
+   FROM deployment_schemas ds,
+    subgraphs.subgraph_deployment d,
+    subgraphs.subgraph_version v,
+    subgraphs.subgraph s
+  WHERE d.deployment = ds.subgraph::text AND v.deployment = d.deployment AND v.subgraph = s.id;
+
+create materialized view info.subgraph_sizes as
+select *,
+       pg_size_pretty(total_bytes) as total,
+       pg_size_pretty(index_bytes) as index,
+       pg_size_pretty(toast_bytes) as toast,
+       pg_size_pretty(table_bytes) as table
+  from (
+    select *,
+           total_bytes-index_bytes-coalesce(toast_bytes,0) AS table_bytes
+      from (
+        select nspname as name,
+               ds.subgraph as subgraph,
+               ds.version::text as version,
+               sum(c.reltuples) as row_estimate,
+               sum(pg_total_relation_size(c.oid)) as total_bytes,
+               sum(pg_indexes_size(c.oid)) as index_bytes,
+               sum(pg_total_relation_size(reltoastrelid)) as toast_bytes
+          from pg_class c
+               join pg_namespace n on n.oid = c.relnamespace
+               join deployment_schemas ds on ds."name" = n.nspname
+          where relkind = 'r'
+            and nspname like 'sgd%'
+          group by nspname, subgraph, version
+  ) a
+) a with no data;
+
+create view info.all_sizes as
+select * from info.subgraph_sizes
+union all
+select * from info.table_sizes;

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -23,10 +23,6 @@ use diesel::{
     Connection as _,
 };
 use graph::{
-    components::store::DeploymentId as GraphDeploymentId,
-    prelude::{chrono, CancelHandle, CancelToken},
-};
-use graph::{
     components::store::DeploymentLocator,
     constraint_violation,
     data::subgraph::status,
@@ -34,6 +30,10 @@ use graph::{
         anyhow, bigdecimal::ToPrimitive, serde_json, DeploymentHash, EntityChange,
         EntityChangeOperation, NodeId, StoreError, SubgraphName, SubgraphVersionSwitchingMode,
     },
+};
+use graph::{
+    components::store::{DeploymentId as GraphDeploymentId, DeploymentSchemaVersion},
+    prelude::{chrono, CancelHandle, CancelToken},
 };
 use graph::{data::subgraph::schema::generate_entity_id, prelude::StoreEvent};
 use itertools::Itertools;
@@ -111,31 +111,6 @@ table! {
     public.ens_names(hash) {
         hash -> Varchar,
         name -> Varchar,
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum DeploymentSchemaVersion {
-    /// Baseline version, in which:
-    /// - A relational schema is used.
-    /// - Each deployment has its own namespace for entity tables.
-    /// - Dynamic data sources are stored in `subgraphs.dynamic_ethereum_contract_data_source`.
-    V0 = 0,
-}
-
-impl DeploymentSchemaVersion {
-    // Latest schema version supported by this version of graph node.
-    const LATEST: Self = Self::V0;
-}
-
-impl TryFrom<i32> for DeploymentSchemaVersion {
-    type Error = StoreError;
-
-    fn try_from(value: i32) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Self::V0),
-            _ => Err(StoreError::UnsupportedDeploymentSchemaVersion(value)),
-        }
     }
 }
 

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -168,16 +168,15 @@ impl SyncStore {
 
     fn start_subgraph_deployment(&self, logger: &Logger) -> Result<(), StoreError> {
         self.retry("start_subgraph_deployment", || {
-            let store = &self.writable;
-
-            let graft_base = match store.graft_pending(&self.site.deployment)? {
+            let graft_base = match self.writable.graft_pending(&self.site.deployment)? {
                 Some((base_id, base_ptr)) => {
                     let src = self.store.layout(&base_id)?;
                     Some((src, base_ptr))
                 }
                 None => None,
             };
-            store.start_subgraph(logger, self.site.clone(), graft_base)?;
+            self.writable
+                .start_subgraph(logger, self.site.clone(), graft_base)?;
             self.store.primary_conn()?.copy_finished(self.site.as_ref())
         })
     }


### PR DESCRIPTION
The plan is to use this column to control migrations such as the one to a dedicated data source table described in #3405.

This changes that column to be an integer rather than an enum, so we don't need to add a DB enum variant on each new version.