### PR TITLE
fix: missing env var causing pg crash on startup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,5 +40,6 @@ services:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in
       POSTGRES_DB: graph-node
+      PGDATA: "/data/postgres"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data


### PR DESCRIPTION
Running the latest on master was giving this error:
```
docker-postgres-1    | selecting default max_connections ... 100
docker-postgres-1    | selecting default shared_buffers ... 128MB
docker-postgres-1    | selecting default time zone ... Etc/UTC
docker-postgres-1    | creating configuration files ... ok
docker-postgres-1    | running bootstrap script ... 2022-04-28 21:25:23.577 UTC [40] LOG:  could not open file "pg_wal/000000010000000000000001": No such file or directory
docker-postgres-1    | 2022-04-28 21:25:23.577 UTC [40] FATAL:  could not open file "pg_wal/000000010000000000000001": No such file or directory
docker-postgres-1    | child process exited with exit code 1
docker-postgres-1    | initdb: removing contents of data directory "/var/lib/postgresql/data"
docker-postgres-1 exited with code 1
```

Adding this variable allows pg to point to the mounted volume