### PR TITLE
graph, graphql: Represent map keys in GraphQL query results as Box<str>

### DIFF
--- a/graph/examples/stress.rs
+++ b/graph/examples/stress.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::iter::FromIterator;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 
+use graph::data::value::Word;
 use graph::prelude::{lazy_static, q};
 use rand::SeedableRng;
 use rand::{rngs::SmallRng, Rng};
@@ -206,6 +207,23 @@ impl Template<String> for String {
         }
         s
     }
+    fn sample(&self, size: usize, _rng: Option<&mut SmallRng>) -> Box<Self::Item> {
+        Box::new(self[0..size].into())
+    }
+}
+
+/// Template for testing caching of `String`
+impl Template<Word> for Word {
+    type Item = Word;
+
+    fn create(size: usize, _rng: Option<&mut SmallRng>) -> Self {
+        let mut s = String::with_capacity(size);
+        for _ in 0..size {
+            s.push('x');
+        }
+        Word::from(s)
+    }
+
     fn sample(&self, size: usize, _rng: Option<&mut SmallRng>) -> Box<Self::Item> {
         Box::new(self[0..size].into())
     }
@@ -529,6 +547,8 @@ pub fn main() {
         stress::<ValueMap>(&opt);
     } else if opt.template == "string" {
         stress::<String>(&opt);
+    } else if opt.template == "word" {
+        stress::<Word>(&opt);
     } else if opt.template == "usizemap" {
         stress::<UsizeMap>(&opt)
     } else {

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::components::server::index_node::VersionInfo;
 use crate::components::transaction_receipt;
 use crate::data::subgraph::status;
+use crate::data::value::Word;
 use crate::data::{query::QueryTarget, subgraph::schema::*};
 
 pub trait SubscriptionManager: Send + Sync + 'static {
@@ -390,7 +391,7 @@ pub trait QueryStore: Send + Sync {
     fn find_query_values(
         &self,
         query: EntityQuery,
-    ) -> Result<Vec<BTreeMap<String, r::Value>>, QueryExecutionError>;
+    ) -> Result<Vec<BTreeMap<Word, r::Value>>, QueryExecutionError>;
 
     async fn is_deployment_synced(&self) -> Result<bool, Error>;
 

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -1,5 +1,6 @@
 use crate::{
     components::store::EntityType,
+    data::value::Word,
     prelude::{q, BigDecimal, BigInt, EntityKey, Value},
 };
 use std::{
@@ -57,6 +58,12 @@ impl<T: CacheWeight, U: CacheWeight> CacheWeight for HashMap<T, U> {
 impl CacheWeight for String {
     fn indirect_weight(&self) -> usize {
         self.capacity()
+    }
+}
+
+impl CacheWeight for Word {
+    fn indirect_weight(&self) -> usize {
+        self.len()
     }
 }
 

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -749,7 +749,7 @@ impl Transform {
                 let mut rmap = BTreeMap::new();
                 for (key, value) in map.into_iter() {
                     let value = self.interpolate_value(value, pos);
-                    rmap.insert(key, value);
+                    rmap.insert(key.into(), value);
                 }
                 r::Value::object(rmap)
             }

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{anyhow, Error};
 use graph::constraint_violation;
-use graph::data::value::Object;
+use graph::data::value::{Object, Word};
 use graph::prelude::{r, CacheWeight};
 use graph::slog::warn;
 use graph::util::cache_weight;
@@ -45,7 +45,7 @@ struct Node {
     /// the keys and values of the `children` map, but not of the map itself
     children_weight: usize,
 
-    entity: BTreeMap<String, r::Value>,
+    entity: BTreeMap<Word, r::Value>,
     /// We are using an `Rc` here for two reasons: it allows us to defer
     /// copying objects until the end, when converting to `q::Value` forces
     /// us to copy any child that is referenced by multiple parents. It also
@@ -86,11 +86,11 @@ struct Node {
     /// copies to the point where we need to convert to `q::Value`, and it
     /// would be desirable to base the data structure that GraphQL execution
     /// uses on a DAG rather than a tree, but that's a good amount of work
-    children: BTreeMap<String, Vec<Rc<Node>>>,
+    children: BTreeMap<Word, Vec<Rc<Node>>>,
 }
 
-impl From<BTreeMap<String, r::Value>> for Node {
-    fn from(entity: BTreeMap<String, r::Value>) -> Self {
+impl From<BTreeMap<Word, r::Value>> for Node {
+    fn from(entity: BTreeMap<Word, r::Value>) -> Self {
         Node {
             children_weight: entity.weight(),
             entity,
@@ -151,7 +151,10 @@ impl From<Node> for r::Value {
     fn from(node: Node) -> Self {
         let mut map = node.entity;
         for (key, nodes) in node.children.into_iter() {
-            map.insert(format!("prefetch:{}", key), node_list_as_value(nodes));
+            map.insert(
+                format!("prefetch:{}", key).into(),
+                node_list_as_value(nodes),
+            );
         }
         r::Value::object(map)
     }
@@ -180,7 +183,7 @@ impl Node {
     }
 
     fn get(&self, key: &str) -> Option<&r::Value> {
-        self.entity.get(key)
+        self.entity.get(&key.into())
     }
 
     fn typename(&self) -> &str {
@@ -200,7 +203,7 @@ impl Node {
         let key_weight = response_key.weight();
 
         self.children_weight += nodes_weight(&nodes) + key_weight;
-        let old = self.children.insert(response_key, nodes);
+        let old = self.children.insert(response_key.into(), nodes);
         if let Some(old) = old {
             self.children_weight -= nodes_weight(&old) + key_weight;
         }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -131,7 +131,7 @@ fn build_fulltext_filter_from_object(
         |(key, value)| {
             if let r::Value::String(s) = value {
                 Ok(Some(EntityFilter::Equal(
-                    key.clone(),
+                    key.to_string(),
                     Value::String(s.clone()),
                 )))
             } else {
@@ -276,7 +276,7 @@ fn build_fulltext_order_by_from_object(
         Err(QueryExecutionError::FulltextQueryRequiresFilter),
         |(key, value)| {
             if let r::Value::String(_) = value {
-                Ok(Some((key.clone(), ValueType::String)))
+                Ok(Some((key.to_string(), ValueType::String)))
             } else {
                 Err(QueryExecutionError::FulltextQueryRequiresFilter)
             }

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -202,17 +202,17 @@ impl StoreResolver {
                 number: number,
                 __typename: BLOCK_FIELD_TYPE
             };
-            map.insert("prefetch:block".to_string(), r::Value::List(vec![block]));
+            map.insert("prefetch:block".into(), r::Value::List(vec![block]));
             map.insert(
-                "deployment".to_string(),
+                "deployment".into(),
                 r::Value::String(self.deployment.to_string()),
             );
             map.insert(
-                "hasIndexingErrors".to_string(),
+                "hasIndexingErrors".into(),
                 r::Value::Boolean(self.has_non_fatal_errors),
             );
             map.insert(
-                "__typename".to_string(),
+                "__typename".into(),
                 r::Value::String(META_FIELD_TYPE.to_string()),
             );
             return Ok((None, Some(r::Value::object(map))));

--- a/graphql/src/values/coercion.rs
+++ b/graphql/src/values/coercion.rs
@@ -79,7 +79,7 @@ fn coerce_to_definition<'a>(
                     let def = t
                         .fields
                         .iter()
-                        .find(|f| f.name == name)
+                        .find(|f| f.name == &*name)
                         .ok_or_else(|| object_for_error.clone())?;
                     coerced_object.insert(
                         name.clone(),

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -654,7 +654,7 @@ fn entity_changes_to_graphql(entity_changes: Vec<EntityOperation>) -> r::Value {
                         r::Value::object(
                             e.sorted()
                                 .into_iter()
-                                .map(|(name, value)| (name, value.into()))
+                                .map(|(name, value)| (name.into(), value.into()))
                                 .collect(),
                         )
                     })

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use graph::data::value::Word;
 use web3::types::H256;
 
 use crate::deployment_store::{DeploymentStore, ReplicaId};
@@ -36,7 +37,7 @@ impl QueryStoreTrait for QueryStore {
     fn find_query_values(
         &self,
         query: EntityQuery,
-    ) -> Result<Vec<BTreeMap<String, r::Value>>, QueryExecutionError> {
+    ) -> Result<Vec<BTreeMap<Word, r::Value>>, QueryExecutionError> {
         assert_eq!(&self.site.deployment, &query.subgraph_id);
         let conn = self
             .store

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -12,6 +12,7 @@ use diesel::result::{Error as DieselError, QueryResult};
 use diesel::sql_types::{Array, BigInt, Binary, Bool, Integer, Jsonb, Text};
 use diesel::Connection;
 
+use graph::data::value::Word;
 use graph::prelude::{
     anyhow, r, serde_json, Attribute, BlockNumber, ChildMultiplicity, Entity, EntityCollection,
     EntityFilter, EntityKey, EntityLink, EntityOrder, EntityRange, EntityWindow, ParentLink,
@@ -244,17 +245,17 @@ impl FromEntityData for Entity {
     }
 }
 
-impl FromEntityData for BTreeMap<String, r::Value> {
+impl FromEntityData for BTreeMap<Word, r::Value> {
     type Value = r::Value;
 
     fn new_entity(typename: String) -> Self {
         let mut map = BTreeMap::new();
-        map.insert("__typename".to_string(), Self::Value::from_string(typename));
+        map.insert("__typename".into(), Self::Value::from_string(typename));
         map
     }
 
     fn insert_entity_data(&mut self, key: String, v: Self::Value) {
-        self.insert(key, v);
+        self.insert(Word::from(key), v);
     }
 }
 


### PR DESCRIPTION
I've been looking for ways to reduce the size of the internal representation of query results since that often takes up much more space then the resulting JSON. I suspect that a big driver of that is that `String` is very memory-inefficient for short strings - the string `id` as a `String` takes 24+2 bytes.

One way to reduce the amount of space taken by short strings, and there are a lot of them in query results, would be string interning, where we could get away with as little as 2 or 4 bytes of storage per string, depending on how we intern strings. But interning the map keys that we use in `r::Value::Object` is a bit of an undertaking: we'd want to build a string pool for the API schema, and then put a string pool derived from additional keys (field aliases) introduced by the GraphQL query 'on top' of that.

Rather than doing that, we can switch from `String` for these keys to `Box<str>` which reduces the memory overhead for each string by 8 bytes, so that the string `id` takes 16+2 bytes. The difference between the two is that `Box<str>` doesn't support mutating the string, but we don't need that for the keys in query results.

If this fairly simple change turns out to be worthwhile, it points the way to (a) that interning strings would also be worthwhile and (b) that it would be worth using `Box<str>` in more places where we deal with immutable strings (e.g., the GraphQL AST or `Entity`)

I am using a newtype for `Box<str>` in this PR and, because naming is hard, called it `Word`.