### PR TITLE
graphql: Use the correct setting for number of LfuCache shards

### DIFF
--- a/graph/src/env/graphql.rs
+++ b/graph/src/env/graphql.rs
@@ -31,7 +31,7 @@ pub struct EnvVarsGraphQl {
     pub query_block_cache_shards: u8,
     /// Set by the environment variable `GRAPH_QUERY_LFU_CACHE_SHARDS`. The
     /// default value is set to whatever `GRAPH_QUERY_BLOCK_CACHE_SHARDS` is set
-    /// to.
+    /// to. Set to 0 to disable this cache.
     pub query_lfu_cache_shards: u8,
     /// How many blocks per network should be kept in the query cache. When the
     /// limit is reached, older blocks are evicted. This should be kept small


### PR DESCRIPTION
This also makes it possible to turn the LfuCache off by setting GRAPH_QUERY_LFU_CACHE_SHARDS to 0

