### PR TITLE
Small change to memory accounting in `LfuCache` and various changes to the cache stress testing tool

### DIFF
--- a/graph/examples/stress.rs
+++ b/graph/examples/stress.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::sync::Arc;
 
 use graph::data::value::{Object, Word};
+use graph::object;
 use graph::prelude::{lazy_static, q, r, BigDecimal, BigInt, QueryResult};
 use rand::SeedableRng;
 use rand::{rngs::SmallRng, Rng};
@@ -337,6 +338,18 @@ fn make_object(size: usize, mut rng: Option<&mut SmallRng>) -> Object {
     obj
 }
 
+fn make_domains(size: usize, _rng: Option<&mut SmallRng>) -> Object {
+    let owner = object! {
+        owner: object! {
+            id: "0xe8d391ef649a6652b9047735f6c0d48b6ae751df",
+            name: "36190.eth"
+        }
+    };
+
+    let domains: Vec<_> = (0..size).map(|_| owner.clone()).collect();
+    Object::from_iter([("domains".to_string(), r::Value::List(domains))])
+}
+
 /// Template for testing caching of `Object`
 impl Template for Object {
     fn create(size: usize, rng: Option<&mut SmallRng>) -> Self {
@@ -361,7 +374,7 @@ impl Template for Object {
 /// Template for testing caching of `QueryResult`
 impl Template for QueryResult {
     fn create(size: usize, rng: Option<&mut SmallRng>) -> Self {
-        QueryResult::new(make_object(size, rng))
+        QueryResult::new(make_domains(size, rng))
     }
 
     fn sample(&self, size: usize, rng: Option<&mut SmallRng>) -> Box<Self> {
@@ -376,7 +389,7 @@ impl Template for QueryResult {
                     .map(|(k, v)| (k.to_owned(), v.to_owned())),
             )))
         } else {
-            Box::new(QueryResult::new(make_object(size, rng)))
+            Box::new(QueryResult::new(make_domains(size, rng)))
         }
     }
 }

--- a/graph/examples/stress.rs
+++ b/graph/examples/stress.rs
@@ -593,47 +593,16 @@ pub fn main() {
     unsafe { PRINT_SAMPLES = opt.samples }
 
     // Use different Cacheables to see how the cache manages memory with
-    // different types of cache entries. Uncomment one of the 'let mut cacheable'
-    // lines
-    if opt.template == "vec" {
-        // The weight of Vec<usize> is precise. The additional memory that
-        // the cache uses must be solely due to the memory for the cache
-        // itself
-        //
-        // obj_size  |  heap factor
-        //   10      |     2.5
-        //   20      |     1.9
-        //   30      |     1.8
-        //   50      |     1.3
-        //  100      |     1.3
-        // 1000      |     1.1
-        stress::<Vec<usize>>(&opt);
-    } else if opt.template == "hashmap" {
-        // The heap factor ranges between 1.9 (size 3) and 1.06 (size 100)
-        stress::<HashMap<String, String>>(&opt);
-    } else if opt.template == "valuemap" {
-        // Cache BTreeMap<String, Value>
-        // obj_size  |  heap factor
-        //    3      |      1.3
-        //    5      |      1.5
-        //   10      |      1.5
-        //   50      |      1.2
-        //  100      |      0.9
-        //
-        // For small maps (say, up to about 20 entries), the weight is an
-        // accurate estimation of the map's allocation
-        stress::<ValueMap>(&opt);
-    } else if opt.template == "string" {
-        stress::<String>(&opt);
-    } else if opt.template == "word" {
-        stress::<Word>(&opt);
-    } else if opt.template == "usizemap" {
-        stress::<UsizeMap>(&opt)
-    } else if opt.template == "object" {
-        stress::<Object>(&opt)
-    } else if opt.template == "result" {
-        stress::<QueryResult>(&opt)
-    } else {
-        println!("unknown value for --template")
+    // different types of cache entries.
+    match opt.template.as_str() {
+        "hashmap" => stress::<HashMap<String, String>>(&opt),
+        "object" => stress::<Object>(&opt),
+        "result" => stress::<QueryResult>(&opt),
+        "string" => stress::<String>(&opt),
+        "usizemap" => stress::<UsizeMap>(&opt),
+        "valuemap" => stress::<ValueMap>(&opt),
+        "vec" => stress::<Vec<usize>>(&opt),
+        "word" => stress::<Word>(&opt),
+        _ => println!("unknown value `{}` for --template", opt.template),
     }
 }

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -184,7 +184,7 @@ impl QueryResults {
 }
 
 /// The result of running a query, if successful.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 pub struct QueryResult {
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -248,6 +248,10 @@ impl QueryResult {
 
     pub fn errors_mut(&mut self) -> &mut Vec<QueryError> {
         &mut self.errors
+    }
+
+    pub fn data(&self) -> Option<&Data> {
+        self.data.as_ref()
     }
 }
 

--- a/graph/src/util/lfu_cache.rs
+++ b/graph/src/util/lfu_cache.rs
@@ -43,9 +43,12 @@ impl<K, V: Default + CacheWeight> CacheEntry<K, V> {
 }
 
 impl<K: CacheWeight, V: Default + CacheWeight> CacheEntry<K, V> {
-    /// Estimate the size of a `CacheEntry` with the given key and value
+    /// Estimate the size of a `CacheEntry` with the given key and value. Do
+    /// not count the size of `Self` since that is memory that is not freed
+    /// when the cache entry is dropped as its storage is embedded in the
+    /// `PriorityQueue`
     fn weight(key: &K, value: &V) -> usize {
-        value.indirect_weight() + key.indirect_weight() + std::mem::size_of::<Self>()
+        value.indirect_weight() + key.indirect_weight()
     }
 }
 

--- a/graph/src/util/lfu_cache.rs
+++ b/graph/src/util/lfu_cache.rs
@@ -181,6 +181,13 @@ impl<K: Clone + Ord + Eq + Hash + Debug + CacheWeight, V: CacheWeight + Default>
         max_weight: usize,
         stale_period: u64,
     ) -> Option<(usize, usize, usize)> {
+        use crate::prelude::lazy_static;
+        lazy_static! {
+            // Setting `DEAD_WEIGHT` is dangerous since it can lead to a
+            // situation where an empty cache is bigger than the max_weight
+            // which leads to a panic
+            static ref DEAD_WEIGHT: bool = std::env::var("DEAD_WEIGHT").ok().is_some();
+        }
         if self.total_weight <= max_weight {
             return None;
         }
@@ -201,7 +208,12 @@ impl<K: Clone + Ord + Eq + Hash + Debug + CacheWeight, V: CacheWeight + Default>
 
         let mut evicted = 0;
         let old_weight = self.total_weight;
-        while self.total_weight > max_weight {
+        let dead_weight = if *DEAD_WEIGHT {
+            self.len() * (std::mem::size_of::<CacheEntry<K, V>>() + 40)
+        } else {
+            0
+        };
+        while self.total_weight + dead_weight > max_weight {
             let entry = self
                 .queue
                 .pop()


### PR DESCRIPTION
The only commit with an impact on production code is the last commit in this PR which tries to account for the fact that we cannot free the `CacheEntry` itself from the `LfuCache`

The rest of the changes expand what can be tested with the cache stress testing tool, and try to get it closer to how we actually use the `LfuCache`