### PR TITLE
docker: Install cmake which is required by prost

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ ARG TAG_NAME=unknown
 ADD . /graph-node
 
 RUN cd /graph-node \
+    && apt-get update && apt-get install -y cmake \
     && rustup component add rustfmt \
     && RUSTFLAGS="-g" cargo install --locked --path node \
     && cargo clean \


### PR DESCRIPTION
Requirement was added in this PR:
https://github.com/graphprotocol/graph-node/pull/3531

