### PR TITLE
Modify error string to remove Ethereum

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -260,7 +260,7 @@ pub enum SubgraphRegistrarError {
     NameExists(String),
     #[error("subgraph name not found: {0}")]
     NameNotFound(String),
-    #[error("Ethereum network not supported by registrar: {0}")]
+    #[error("network not supported by registrar: {0}")]
     NetworkNotSupported(Error),
     #[error("deployment not found: {0}")]
     DeploymentNotFound(String),


### PR DESCRIPTION
With the addition of additional protocols, deploying a subgraph with an invalid upstream provider would return an error String that incorrectly states Ethereum network not supported. This just removes the Ethereum part of the string to allow it to make more sense

<img width="851" alt="error_string" src="https://user-images.githubusercontent.com/7063963/167211236-e8d709ae-9c08-45cc-af69-5757ca89ac3c.png">
