### PR TITLE
Add an alias for the `ipfsOnEthereumContracts` feature

### DIFF
--- a/graph/src/data/subgraph/features.rs
+++ b/graph/src/data/subgraph/features.rs
@@ -23,7 +23,6 @@ use super::calls_host_fn;
 /// This array must contain all IPFS-related functions that are exported by the host WASM runtime.
 ///
 /// For reference, search this codebase for: ff652476-e6ad-40e4-85b8-e815d6c6e5e2
-
 const IPFS_ON_ETHEREUM_CONTRACTS_FUNCTION_NAMES: [&'static str; 2] = ["ipfs.cat", "ipfs.map"];
 
 #[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -32,6 +31,7 @@ pub enum SubgraphFeature {
     NonFatalErrors,
     Grafting,
     FullTextSearch,
+    #[serde(alias = "nonDeterministicIpfs")]
     IpfsOnEthereumContracts,
 }
 


### PR DESCRIPTION
This PR adds an alias for the `ipfsOnEthereumContracts` feature named `nonDeterministicIpfs`.

Related to https://github.com/graphprotocol/graph-cli/pull/889