### PR TITLE
ipfs: Switch from object stat to dag stat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ipfs:
-        image: ipfs/go-ipfs:v0.4.23
+        image: ipfs/go-ipfs:v0.12.2
         ports:
           - 5001:5001
       postgres:
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ipfs:
-        image: ipfs/go-ipfs:v0.4.23
+        image: ipfs/go-ipfs:v0.12.2
         ports:
           - 5001:5001
       postgres:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   # Install Node.js 11.x
   - nvm install 11 && nvm use 11
   # Install IPFS
-  - wget "https://dist.ipfs.io/go-ipfs/v0.4.17/go-ipfs_v0.4.17_linux-amd64.tar.gz" -O /tmp/ipfs.tar.gz
+  - wget "https://dist.ipfs.io/go-ipfs/v0.12.2/go-ipfs_v0.12.2_linux-amd64.tar.gz" -O /tmp/ipfs.tar.gz
   - pushd . && cd $HOME/bin && tar -xzvf /tmp/ipfs.tar.gz && popd
   - export PATH="$HOME/bin/go-ipfs:$PATH"
   - ipfs init

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       ethereum: 'mainnet:http://host.docker.internal:8545'
       GRAPH_LOG: info
   ipfs:
-    image: ipfs/go-ipfs:v0.4.23
+    image: ipfs/go-ipfs:v0.12.2
     ports:
       - '5001:5001'
     volumes:

--- a/graph/src/ipfs_client.rs
+++ b/graph/src/ipfs_client.rs
@@ -11,13 +11,9 @@ use std::{str::FromStr, sync::Arc};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct ObjectStatResponse {
-    pub hash: String,
-    pub num_links: u64,
-    pub block_size: u64,
-    pub links_size: u64,
-    pub data_size: u64,
-    pub cumulative_size: u64,
+pub struct DagStatResponse {
+    pub num_blocks: u64,
+    pub size: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -58,13 +54,13 @@ impl IpfsClient {
         }
     }
 
-    /// Calls `object stat`.
-    pub async fn object_stat(
+    /// Calls `dag stat`.
+    pub async fn dag_stat(
         &self,
         path: String,
         timeout: Duration,
-    ) -> Result<ObjectStatResponse, reqwest::Error> {
-        self.call(self.url("object/stat", path), None, Some(timeout))
+    ) -> Result<DagStatResponse, reqwest::Error> {
+        self.call(self.url("dag/stat", path), None, Some(timeout))
             .await?
             .json()
             .await

--- a/store/test-store/devel/docker-compose.yml
+++ b/store/test-store/devel/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   ipfs:
-    image: ipfs/go-ipfs:v0.4.23
+    image: ipfs/go-ipfs:v0.12.2
     ports:
       - '5001:5001'
     volumes:

--- a/tests/tests/common/docker.rs
+++ b/tests/tests/common/docker.rs
@@ -7,7 +7,7 @@ use tokio::time::{sleep, Duration};
 use tokio_stream::StreamExt;
 
 const POSTGRES_IMAGE: &'static str = "postgres:latest";
-const IPFS_IMAGE: &'static str = "ipfs/go-ipfs:v0.4.23";
+const IPFS_IMAGE: &'static str = "ipfs/go-ipfs:v0.12.2";
 const GANACHE_IMAGE: &'static str = "trufflesuite/ganache-cli:latest";
 type DockerError = bollard::errors::Error;
 


### PR DESCRIPTION
It turns out the `object` API has been deprecated for a while. Resolves #3565.