### PR TITLE
store: Mark new subgraphs to index only a prefix of bytea columns

### DIFF
--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -84,6 +84,7 @@ impl Catalog {
             // DDL generation creates a POI table
             use_poi: true,
             // DDL generation creates indexes for prefixes of bytes columns
+            // see: attr-bytea-prefix
             use_bytea_prefix: true,
         }
     }

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -956,6 +956,9 @@ pub fn create_deployment(
         m::features.eq(features),
         m::schema.eq(schema),
         m::graph_node_version_id.eq(graph_node_version_id),
+        // New subgraphs index only a prefix of bytea columns
+        // see: attr-bytea-prefix
+        m::use_bytea_prefix.eq(true),
     );
 
     if exists && replace {

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1065,6 +1065,7 @@ impl Column {
         // generation needs to match how these columns are indexed, and we
         // therefore use that remembered value from `catalog` to determine
         // if we should use queries for prefixes or for the entire value.
+        // see: attr-bytea-prefix
         let use_prefix_comparison = !is_primary_key
             && !is_reference
             && !field.field_type.is_list()

--- a/store/postgres/src/relational/ddl.rs
+++ b/store/postgres/src/relational/ddl.rs
@@ -206,6 +206,7 @@ impl Table {
                     // Postgres' limit on values that can go into a BTree.
                     // For those attributes, only index the first
                     // STRING_PREFIX_SIZE or BYTE_ARRAY_PREFIX_SIZE characters
+                    // see: attr-bytea-prefix
                     let index_expr = if column.use_prefix_comparison {
                         match column.column_type {
                             ColumnType::String => {


### PR DESCRIPTION
PR https://github.com/graphprotocol/graph-node/pull/3383 neglected to set this, so that sugraphs did not get marked properly, resulting in queries that could not use the index on the prefix of `bytea` columns.

