### PR TITLE
elasticsearch: Use connection pool

### DIFF
--- a/graph/src/log/elastic.rs
+++ b/graph/src/log/elastic.rs
@@ -27,6 +27,8 @@ pub struct ElasticLoggingConfig {
     pub username: Option<String>,
     /// The Elasticsearch password (optional).
     pub password: Option<String>,
+    /// A client to serve as a connection pool to the endpoint.
+    pub client: Client,
 }
 
 /// Serializes an slog log level using a serde Serializer.
@@ -265,14 +267,16 @@ impl ElasticDrain {
                 batch_url.set_path("_bulk");
 
                 // Send batch of logs to Elasticsearch
-                let client = Client::new();
-
                 let header = match config.general.username {
-                    Some(username) => client
+                    Some(username) => config
+                        .general
+                        .client
                         .post(batch_url)
                         .header(CONTENT_TYPE, "application/json")
                         .basic_auth(username, config.general.password.clone()),
-                    None => client
+                    None => config
+                        .general
+                        .client
                         .post(batch_url)
                         .header(CONTENT_TYPE, "application/json"),
                 };

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -177,6 +177,7 @@ async fn main() {
             endpoint: endpoint.clone(),
             username: opt.elasticsearch_user.clone(),
             password: opt.elasticsearch_password.clone(),
+            client: reqwest::Client::new(),
         });
 
     // Create a component and subgraph logger factory


### PR DESCRIPTION
This is less overhead than creating a new client for each request. Particularly we were seeing this generate excessive DNS requests.