### PR TITLE
Improve memory efficiency of `EntityCache`

### DIFF
--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -4,7 +4,7 @@ use anyhow::Error;
 use graph::{
     blockchain::{self, block_stream::BlockWithTriggers, BlockPtr},
     components::{
-        store::{DeploymentLocator, EntityRef, SubgraphFork},
+        store::{DeploymentLocator, EntityKey, SubgraphFork},
         subgraph::{MappingError, ProofOfIndexingEvent, SharedProofOfIndexing},
     },
     data::store::scalar::Bytes,
@@ -188,7 +188,7 @@ where
                     };
                     let entity_id: String = String::from_utf8(entity_change.id.clone())
                         .map_err(|e| MappingError::Unknown(anyhow::Error::from(e)))?;
-                    let key = EntityRef::data(entity_type.to_string(), entity_id.clone());
+                    let key = EntityKey::data(entity_type.to_string(), entity_id.clone());
 
                     let mut data: HashMap<String, Value> = HashMap::from_iter(vec![]);
                     for field in entity_change.fields.iter() {
@@ -249,7 +249,7 @@ where
                     let entity_type: &str = &entity_change.entity;
                     let entity_id: String = String::from_utf8(entity_change.id.clone())
                         .map_err(|e| MappingError::Unknown(anyhow::Error::from(e)))?;
-                    let key = EntityRef::data(entity_type.to_string(), entity_id.clone());
+                    let key = EntityKey::data(entity_type.to_string(), entity_id.clone());
 
                     state.entity_cache.remove(key);
 

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -4,13 +4,13 @@ use anyhow::Error;
 use graph::{
     blockchain::{self, block_stream::BlockWithTriggers, BlockPtr},
     components::{
-        store::{DeploymentLocator, EntityType, SubgraphFork},
+        store::{DeploymentLocator, EntityRef, SubgraphFork},
         subgraph::{MappingError, ProofOfIndexingEvent, SharedProofOfIndexing},
     },
     data::store::scalar::Bytes,
     prelude::{
         anyhow, async_trait, BigDecimal, BigInt, BlockHash, BlockNumber, BlockState, Entity,
-        EntityKey, RuntimeHostBuilder, Value,
+        RuntimeHostBuilder, Value,
     },
     slog::Logger,
     substreams::Modules,
@@ -188,11 +188,7 @@ where
                     };
                     let entity_id: String = String::from_utf8(entity_change.id.clone())
                         .map_err(|e| MappingError::Unknown(anyhow::Error::from(e)))?;
-                    let key = EntityKey {
-                        subgraph_id: self.locator.hash.clone(),
-                        entity_type: EntityType::new(entity_type.into()),
-                        entity_id: entity_id.clone(),
-                    };
+                    let key = EntityRef::data(entity_type.to_string(), entity_id.clone());
 
                     let mut data: HashMap<String, Value> = HashMap::from_iter(vec![]);
                     for field in entity_change.fields.iter() {
@@ -253,11 +249,7 @@ where
                     let entity_type: &str = &entity_change.entity;
                     let entity_id: String = String::from_utf8(entity_change.id.clone())
                         .map_err(|e| MappingError::Unknown(anyhow::Error::from(e)))?;
-                    let key = EntityKey {
-                        subgraph_id: self.locator.hash.clone(),
-                        entity_type: EntityType::new(entity_type.into()),
-                        entity_id: entity_id.clone(),
-                    };
+                    let key = EntityRef::data(entity_type.to_string(), entity_id.clone());
 
                     state.entity_cache.remove(key);
 

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -6,7 +6,7 @@ use crate::subgraph::stream::new_block_stream;
 use atomic_refcell::AtomicRefCell;
 use graph::blockchain::block_stream::{BlockStreamEvent, BlockWithTriggers, FirehoseCursor};
 use graph::blockchain::{Block, Blockchain, DataSource, TriggerFilter as _};
-use graph::components::store::EntityRef;
+use graph::components::store::EntityKey;
 use graph::components::{
     store::ModificationsAndCache,
     subgraph::{CausalityRegion, MappingError, ProofOfIndexing, SharedProofOfIndexing},
@@ -868,7 +868,7 @@ async fn update_proof_of_indexing(
 
     for (causality_region, stream) in proof_of_indexing.drain() {
         // Create the special POI entity key specific to this causality_region
-        let entity_key = EntityRef {
+        let entity_key = EntityKey {
             entity_type: POI_OBJECT.to_owned(),
             entity_id: causality_region.into(),
         };

--- a/core/src/subgraph/state.rs
+++ b/core/src/subgraph/state.rs
@@ -1,5 +1,5 @@
 use graph::{
-    components::store::EntityRef,
+    components::store::EntityKey,
     prelude::Entity,
     util::{backoff::ExponentialBackoff, lfu_cache::LfuCache},
 };
@@ -18,5 +18,5 @@ pub struct IndexingState {
     /// - The time THRESHOLD is passed
     /// - Or the subgraph has triggers for the block
     pub skip_ptr_updates_timer: Instant,
-    pub entity_lfu_cache: LfuCache<EntityRef, Option<Entity>>,
+    pub entity_lfu_cache: LfuCache<EntityKey, Option<Entity>>,
 }

--- a/core/src/subgraph/state.rs
+++ b/core/src/subgraph/state.rs
@@ -1,5 +1,6 @@
 use graph::{
-    prelude::{Entity, EntityKey},
+    components::store::EntityRef,
+    prelude::Entity,
     util::{backoff::ExponentialBackoff, lfu_cache::LfuCache},
 };
 use std::time::Instant;
@@ -17,5 +18,5 @@ pub struct IndexingState {
     /// - The time THRESHOLD is passed
     /// - Or the subgraph has triggers for the block
     pub skip_ptr_updates_timer: Instant,
-    pub entity_lfu_cache: LfuCache<EntityKey, Option<Entity>>,
+    pub entity_lfu_cache: LfuCache<EntityRef, Option<Entity>>,
 }

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -5,10 +5,7 @@ use web3::types::{
     U64,
 };
 
-use crate::{
-    blockchain::BlockPtr,
-    prelude::{BlockNumber, DeploymentHash, EntityKey, ToEntityKey},
-};
+use crate::{blockchain::BlockPtr, prelude::BlockNumber};
 
 pub type LightEthereumBlock = Block<Transaction>;
 
@@ -171,11 +168,5 @@ impl<'a> From<&'a EthereumBlock> for BlockPtr {
 impl<'a> From<&'a EthereumCall> for BlockPtr {
     fn from(call: &'a EthereumCall) -> BlockPtr {
         BlockPtr::from((call.block_hash, call.block_number))
-    }
-}
-
-impl ToEntityKey for BlockPtr {
-    fn to_entity_key(&self, subgraph: DeploymentHash) -> EntityKey {
-        EntityKey::data(subgraph, "Block".into(), self.hash_hex())
     }
 }

--- a/graph/src/components/store/cache.rs
+++ b/graph/src/components/store/cache.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use crate::blockchain::BlockPtr;
 use crate::blockchain::DataSource;
 use crate::components::store::{
-    self as s, Entity, EntityOp, EntityOperation, EntityRef, EntityType,
+    self as s, Entity, EntityKey, EntityOp, EntityOperation, EntityType,
 };
 use crate::prelude::ENV_VARS;
 use crate::util::lfu_cache::LfuCache;
@@ -21,13 +21,13 @@ use crate::util::lfu_cache::LfuCache;
 pub struct EntityCache {
     /// The state of entities in the store. An entry of `None`
     /// means that the entity is not present in the store
-    current: LfuCache<EntityRef, Option<Entity>>,
+    current: LfuCache<EntityKey, Option<Entity>>,
 
     /// The accumulated changes to an entity.
-    updates: HashMap<EntityRef, EntityOp>,
+    updates: HashMap<EntityKey, EntityOp>,
 
     // Updates for a currently executing handler.
-    handler_updates: HashMap<EntityRef, EntityOp>,
+    handler_updates: HashMap<EntityKey, EntityOp>,
 
     // Marks whether updates should go in `handler_updates`.
     in_handler: bool,
@@ -50,7 +50,7 @@ impl Debug for EntityCache {
 pub struct ModificationsAndCache {
     pub modifications: Vec<s::EntityModification>,
     pub data_sources: Vec<s::StoredDynamicDataSource>,
-    pub entity_lfu_cache: LfuCache<EntityRef, Option<Entity>>,
+    pub entity_lfu_cache: LfuCache<EntityKey, Option<Entity>>,
 }
 
 impl EntityCache {
@@ -67,7 +67,7 @@ impl EntityCache {
 
     pub fn with_current(
         store: Arc<dyn s::WritableStore>,
-        current: LfuCache<EntityRef, Option<Entity>>,
+        current: LfuCache<EntityKey, Option<Entity>>,
     ) -> EntityCache {
         EntityCache {
             current,
@@ -101,7 +101,7 @@ impl EntityCache {
         self.handler_updates.clear();
     }
 
-    pub fn get(&mut self, eref: &EntityRef) -> Result<Option<Entity>, s::QueryExecutionError> {
+    pub fn get(&mut self, eref: &EntityKey) -> Result<Option<Entity>, s::QueryExecutionError> {
         // Get the current entity, apply any updates from `updates`, then
         // from `handler_updates`.
         let mut entity = self.current.get_entity(&*self.store, eref)?;
@@ -114,7 +114,7 @@ impl EntityCache {
         Ok(entity)
     }
 
-    pub fn remove(&mut self, key: EntityRef) {
+    pub fn remove(&mut self, key: EntityKey) {
         self.entity_op(key, EntityOp::Remove);
     }
 
@@ -123,8 +123,8 @@ impl EntityCache {
     /// with existing data. The entity will be validated against the
     /// subgraph schema, and any errors will result in an `Err` being
     /// returned.
-    pub fn set(&mut self, key: EntityRef, mut entity: Entity) -> Result<(), anyhow::Error> {
-        fn check_id(key: &EntityRef, prev_id: &str) -> Result<(), anyhow::Error> {
+    pub fn set(&mut self, key: EntityKey, mut entity: Entity) -> Result<(), anyhow::Error> {
+        fn check_id(key: &EntityKey, prev_id: &str) -> Result<(), anyhow::Error> {
             if prev_id != key.entity_id.as_str() {
                 return Err(anyhow!(
                     "Value of {} attribute 'id' conflicts with ID passed to `store.set()`: \
@@ -194,7 +194,7 @@ impl EntityCache {
             .push(data_source.as_stored_dynamic_data_source());
     }
 
-    fn entity_op(&mut self, key: EntityRef, op: EntityOp) {
+    fn entity_op(&mut self, key: EntityKey, op: EntityOp) {
         use std::collections::hash_map::Entry;
         let updates = match self.in_handler {
             true => &mut self.handler_updates,
@@ -253,7 +253,7 @@ impl EntityCache {
 
         for (entity_type, entities) in self.store.get_many(missing_by_type)? {
             for entity in entities {
-                let key = EntityRef {
+                let key = EntityKey {
                     entity_type: entity_type.clone(),
                     entity_id: entity.id().unwrap().into(),
                 };
@@ -317,12 +317,12 @@ impl EntityCache {
     }
 }
 
-impl LfuCache<EntityRef, Option<Entity>> {
+impl LfuCache<EntityKey, Option<Entity>> {
     // Helper for cached lookup of an entity.
     fn get_entity(
         &mut self,
         store: &(impl s::WritableStore + ?Sized),
-        key: &EntityRef,
+        key: &EntityKey,
     ) -> Result<Option<Entity>, s::QueryExecutionError> {
         match self.get(key) {
             None => {

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -96,7 +96,7 @@ impl EntityFilterDerivative {
 /// Key by which an individual entity in the store can be accessed. Stores
 /// only the entity type and id. The deployment must be known from context.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EntityRef {
+pub struct EntityKey {
     /// Name of the entity type.
     pub entity_type: EntityType,
 
@@ -104,7 +104,7 @@ pub struct EntityRef {
     pub entity_id: Word,
 }
 
-impl EntityRef {
+impl EntityKey {
     pub fn data(entity_type: String, entity_id: String) -> Self {
         Self {
             entity_type: EntityType::new(entity_type),
@@ -536,7 +536,7 @@ pub enum EntityChange {
 }
 
 impl EntityChange {
-    pub fn for_data(subgraph_id: DeploymentHash, key: EntityRef) -> Self {
+    pub fn for_data(subgraph_id: DeploymentHash, key: EntityKey) -> Self {
         Self::Data {
             subgraph_id: subgraph_id,
             entity_type: key.entity_type,
@@ -781,10 +781,10 @@ where
 pub enum EntityOperation {
     /// Locates the entity specified by `key` and sets its attributes according to the contents of
     /// `data`.  If no entity exists with this key, creates a new entity.
-    Set { key: EntityRef, data: Entity },
+    Set { key: EntityKey, data: Entity },
 
     /// Removes an entity with the specified key, if one exists.
-    Remove { key: EntityRef },
+    Remove { key: EntityKey },
 }
 
 #[derive(Debug, PartialEq)]
@@ -865,15 +865,15 @@ pub type PoolWaitStats = Arc<RwLock<MovingStats>>;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EntityModification {
     /// Insert the entity
-    Insert { key: EntityRef, data: Entity },
+    Insert { key: EntityKey, data: Entity },
     /// Update the entity by overwriting it
-    Overwrite { key: EntityRef, data: Entity },
+    Overwrite { key: EntityKey, data: Entity },
     /// Remove the entity
-    Remove { key: EntityRef },
+    Remove { key: EntityKey },
 }
 
 impl EntityModification {
-    pub fn entity_ref(&self) -> &EntityRef {
+    pub fn entity_ref(&self) -> &EntityKey {
         use EntityModification::*;
         match self {
             Insert { key, .. } | Overwrite { key, .. } | Remove { key } => key,

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -24,7 +24,6 @@ use crate::data::store::scalar::Bytes;
 use crate::data::store::*;
 use crate::data::value::Word;
 use crate::prelude::*;
-use crate::util::stable_hash_glue::impl_stable_hash;
 
 /// The type name of an entity. This is the string that is used in the
 /// subgraph's GraphQL schema as `type NAME @entity { .. }`
@@ -94,8 +93,6 @@ impl EntityFilterDerivative {
     }
 }
 
-// Note: Do not modify fields without making a backward compatible change to
-// the StableHash impl (below)
 /// Key by which an individual entity in the store can be accessed.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EntityKey {
@@ -108,12 +105,6 @@ pub struct EntityKey {
     /// ID of the individual entity.
     pub entity_id: String,
 }
-
-impl_stable_hash!(EntityKey {
-    subgraph_id,
-    entity_type: EntityType::as_str,
-    entity_id
-});
 
 impl EntityKey {
     pub fn data(subgraph_id: DeploymentHash, entity_type: String, entity_id: String) -> Self {
@@ -146,24 +137,6 @@ impl EntityRef {
     }
 }
 
-#[test]
-fn key_stable_hash() {
-    use stable_hash_legacy::crypto::SetHasher;
-    use stable_hash_legacy::utils::stable_hash;
-
-    #[track_caller]
-    fn hashes_to(key: &EntityKey, exp: &str) {
-        let hash = hex::encode(stable_hash::<SetHasher, _>(&key));
-        assert_eq!(exp, hash.as_str());
-    }
-
-    let id = DeploymentHash::new("QmP9MRvVzwHxr3sGvujihbvJzcTz2LYLMfi5DyihBg6VUd").unwrap();
-    let key = EntityKey::data(id.clone(), "Account".to_string(), "0xdeadbeef".to_string());
-    hashes_to(
-        &key,
-        "905b57035d6f98cff8281e7b055e10570a2bd31190507341c6716af2d3c1ad98",
-    );
-}
 #[derive(Clone, Debug, PartialEq)]
 pub struct Child {
     pub attr: Attribute,

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -93,32 +93,8 @@ impl EntityFilterDerivative {
     }
 }
 
-/// Key by which an individual entity in the store can be accessed.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EntityKey {
-    /// ID of the subgraph.
-    pub subgraph_id: DeploymentHash,
-
-    /// Name of the entity type.
-    pub entity_type: EntityType,
-
-    /// ID of the individual entity.
-    pub entity_id: String,
-}
-
-impl EntityKey {
-    pub fn data(subgraph_id: DeploymentHash, entity_type: String, entity_id: String) -> Self {
-        Self {
-            subgraph_id,
-            entity_type: EntityType::new(entity_type),
-            entity_id,
-        }
-    }
-}
-
-/// Same as an `EntityKey`, but the deployment is known from context. That
-/// makes an `EntityRef` quite a bit more memory-efficient than an
-/// `EntityKey`
+/// Key by which an individual entity in the store can be accessed. Stores
+/// only the entity type and id. The deployment must be known from context.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EntityRef {
     /// Name of the entity type.

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -22,32 +22,33 @@ use std::time::Duration;
 use crate::blockchain::{Block, Blockchain};
 use crate::data::store::scalar::Bytes;
 use crate::data::store::*;
+use crate::data::value::Word;
 use crate::prelude::*;
 use crate::util::stable_hash_glue::impl_stable_hash;
 
 /// The type name of an entity. This is the string that is used in the
 /// subgraph's GraphQL schema as `type NAME @entity { .. }`
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EntityType(String);
+pub struct EntityType(Word);
 
 impl EntityType {
     /// Construct a new entity type. Ideally, this is only called when
     /// `entity_type` either comes from the GraphQL schema, or from
     /// the database from fields that are known to contain a valid entity type
     pub fn new(entity_type: String) -> Self {
-        Self(entity_type)
+        Self(entity_type.into())
     }
 
     pub fn as_str(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 
     pub fn into_string(self) -> String {
-        self.0
+        self.0.to_string()
     }
 
     pub fn is_poi(&self) -> bool {
-        &self.0 == "Poi$"
+        self.0.as_str() == "Poi$"
     }
 }
 

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -196,7 +196,7 @@ pub trait WritableStore: Send + Sync + 'static {
     async fn supports_proof_of_indexing(&self) -> Result<bool, StoreError>;
 
     /// Looks up an entity using the given store key at the latest block.
-    fn get(&self, key: &EntityKey) -> Result<Option<Entity>, StoreError>;
+    fn get(&self, key: &EntityRef) -> Result<Option<Entity>, StoreError>;
 
     /// Transact the entity changes from a single block atomically into the store, and update the
     /// subgraph block pointer to `block_ptr_to`, and update the firehose cursor to `firehose_cursor`

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -196,7 +196,7 @@ pub trait WritableStore: Send + Sync + 'static {
     async fn supports_proof_of_indexing(&self) -> Result<bool, StoreError>;
 
     /// Looks up an entity using the given store key at the latest block.
-    fn get(&self, key: &EntityRef) -> Result<Option<Entity>, StoreError>;
+    fn get(&self, key: &EntityKey) -> Result<Option<Entity>, StoreError>;
 
     /// Transact the entity changes from a single block atomically into the store, and update the
     /// subgraph block pointer to `block_ptr_to`, and update the firehose cursor to `firehose_cursor`

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -1,5 +1,5 @@
 use crate::blockchain::Blockchain;
-use crate::components::store::EntityRef;
+use crate::components::store::EntityKey;
 use crate::prelude::*;
 use crate::util::lfu_cache::LfuCache;
 use crate::{components::store::WritableStore, data::subgraph::schema::SubgraphError};
@@ -28,7 +28,7 @@ pub struct BlockState<C: Blockchain> {
 impl<C: Blockchain> BlockState<C> {
     pub fn new(
         store: Arc<dyn WritableStore>,
-        lfu_cache: LfuCache<EntityRef, Option<Entity>>,
+        lfu_cache: LfuCache<EntityKey, Option<Entity>>,
     ) -> Self {
         BlockState {
             entity_cache: EntityCache::with_current(store, lfu_cache),

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -1,4 +1,5 @@
 use crate::blockchain::Blockchain;
+use crate::components::store::EntityRef;
 use crate::prelude::*;
 use crate::util::lfu_cache::LfuCache;
 use crate::{components::store::WritableStore, data::subgraph::schema::SubgraphError};
@@ -27,7 +28,7 @@ pub struct BlockState<C: Blockchain> {
 impl<C: Blockchain> BlockState<C> {
     pub fn new(
         store: Arc<dyn WritableStore>,
-        lfu_cache: LfuCache<EntityKey, Option<Entity>>,
+        lfu_cache: LfuCache<EntityRef, Option<Entity>>,
     ) -> Self {
         BlockState {
             entity_cache: EntityCache::with_current(store, lfu_cache),

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -1,5 +1,5 @@
 use crate::cheap_clone::CheapClone;
-use crate::components::store::{EntityRef, EntityType, SubgraphStore};
+use crate::components::store::{EntityKey, EntityType, SubgraphStore};
 use crate::data::graphql::ext::{DirectiveExt, DirectiveFinder, DocumentExt, TypeExt, ValueExt};
 use crate::data::graphql::ObjectTypeExt;
 use crate::data::store::{self, ValueType};
@@ -608,7 +608,7 @@ impl Schema {
     }
 
     /// Construct a value for the entity type's id attribute
-    pub fn id_value(&self, key: &EntityRef) -> Result<store::Value, Error> {
+    pub fn id_value(&self, key: &EntityKey) -> Result<store::Value, Error> {
         let base_type = self
             .document
             .get_object_type_definition(key.entity_type.as_str())

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -1,5 +1,5 @@
 use crate::cheap_clone::CheapClone;
-use crate::components::store::{EntityKey, EntityType, SubgraphStore};
+use crate::components::store::{EntityRef, EntityType, SubgraphStore};
 use crate::data::graphql::ext::{DirectiveExt, DirectiveFinder, DocumentExt, TypeExt, ValueExt};
 use crate::data::graphql::ObjectTypeExt;
 use crate::data::store::{self, ValueType};
@@ -608,7 +608,7 @@ impl Schema {
     }
 
     /// Construct a value for the entity type's id attribute
-    pub fn id_value(&self, key: &EntityKey) -> Result<store::Value, Error> {
+    pub fn id_value(&self, key: &EntityRef) -> Result<store::Value, Error> {
         let base_type = self
             .document
             .get_object_type_definition(key.entity_type.as_str())
@@ -626,7 +626,7 @@ impl Schema {
             .get_base_type();
 
         match base_type {
-            "ID" | "String" => Ok(store::Value::String(key.entity_id.clone())),
+            "ID" | "String" => Ok(store::Value::String(key.entity_id.to_string())),
             "Bytes" => Ok(store::Value::Bytes(scalar::Bytes::from_str(
                 &key.entity_id,
             )?)),

--- a/graph/src/data/store/ethereum.rs
+++ b/graph/src/data/store/ethereum.rs
@@ -1,6 +1,6 @@
 use super::scalar;
 use crate::prelude::*;
-use web3::types::{Address, Bytes, H160, H2048, H256, H64, U128, U256, U64};
+use web3::types::{Address, Bytes, H2048, H256, H64, U128, U256, U64};
 
 impl From<U128> for Value {
     fn from(n: U128) -> Value {
@@ -47,17 +47,5 @@ impl From<U64> for Value {
 impl From<U256> for Value {
     fn from(n: U256) -> Value {
         Value::BigInt(BigInt::from_unsigned_u256(&n))
-    }
-}
-
-impl ToEntityId for H160 {
-    fn to_entity_id(&self) -> String {
-        format!("{:x}", self)
-    }
-}
-
-impl ToEntityId for H256 {
-    fn to_entity_id(&self) -> String {
-        format!("{:x}", self)
     }
 }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::store::{DeploymentLocator, EntityType},
+    components::store::{DeploymentLocator, EntityRef, EntityType},
     data::graphql::ObjectTypeExt,
     prelude::{anyhow::Context, q, r, s, CacheWeight, EntityKey, QueryExecutionError, Schema},
     runtime::gas::{Gas, GasSizeOf},
@@ -700,7 +700,7 @@ impl Entity {
     /// Validate that this entity matches the object type definition in the
     /// schema. An entity that passes these checks can be stored
     /// successfully in the subgraph's database schema
-    pub fn validate(&self, schema: &Schema, key: &EntityKey) -> Result<(), anyhow::Error> {
+    pub fn validate(&self, schema: &Schema, key: &EntityRef) -> Result<(), anyhow::Error> {
         fn scalar_value_type(schema: &Schema, field_type: &s::Type) -> ValueType {
             use s::TypeDefinition as t;
             match field_type {
@@ -948,11 +948,7 @@ fn entity_validation() {
         let schema =
             crate::prelude::Schema::parse(DOCUMENT, subgraph).expect("Failed to parse test schema");
         let id = thing.id().unwrap_or("none".to_owned());
-        let key = EntityKey::data(
-            DeploymentHash::new("doesntmatter").unwrap(),
-            "Thing".to_owned(),
-            id.to_owned(),
-        );
+        let key = EntityRef::data("Thing".to_owned(), id.clone());
 
         let err = thing.validate(&schema, &key);
         if errmsg == "" {

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     components::store::{DeploymentLocator, EntityRef, EntityType},
     data::graphql::ObjectTypeExt,
-    prelude::{anyhow::Context, q, r, s, CacheWeight, EntityKey, QueryExecutionError, Schema},
+    prelude::{anyhow::Context, q, r, s, CacheWeight, QueryExecutionError, Schema},
     runtime::gas::{Gas, GasSizeOf},
 };
 use crate::{data::subgraph::DeploymentHash, prelude::EntityChange};
@@ -880,11 +880,6 @@ pub trait TryIntoEntity {
 /// A value that can be converted to an `Entity` ID.
 pub trait ToEntityId {
     fn to_entity_id(&self) -> String;
-}
-
-/// A value that can be converted to an `Entity` key.
-pub trait ToEntityKey {
-    fn to_entity_key(&self, subgraph: DeploymentHash) -> EntityKey;
 }
 
 #[test]

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::store::{DeploymentLocator, EntityRef, EntityType},
+    components::store::{DeploymentLocator, EntityKey, EntityType},
     data::graphql::ObjectTypeExt,
     prelude::{anyhow::Context, q, r, s, CacheWeight, QueryExecutionError, Schema},
     runtime::gas::{Gas, GasSizeOf},
@@ -700,7 +700,7 @@ impl Entity {
     /// Validate that this entity matches the object type definition in the
     /// schema. An entity that passes these checks can be stored
     /// successfully in the subgraph's database schema
-    pub fn validate(&self, schema: &Schema, key: &EntityRef) -> Result<(), anyhow::Error> {
+    pub fn validate(&self, schema: &Schema, key: &EntityKey) -> Result<(), anyhow::Error> {
         fn scalar_value_type(schema: &Schema, field_type: &s::Type) -> ValueType {
             use s::TypeDefinition as t;
             match field_type {
@@ -938,7 +938,7 @@ fn entity_validation() {
         let schema =
             crate::prelude::Schema::parse(DOCUMENT, subgraph).expect("Failed to parse test schema");
         let id = thing.id().unwrap_or("none".to_owned());
-        let key = EntityRef::data("Thing".to_owned(), id.clone());
+        let key = EntityKey::data("Thing".to_owned(), id.clone());
 
         let err = thing.validate(&schema, &key);
         if errmsg == "" {

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -877,11 +877,6 @@ pub trait TryIntoEntity {
     fn try_into_entity(self) -> Result<Entity, Error>;
 }
 
-/// A value that can be converted to an `Entity` ID.
-pub trait ToEntityId {
-    fn to_entity_id(&self) -> String;
-}
-
 #[test]
 fn value_bytes() {
     let graphql_value = r::Value::String("0x8f494c66afc1d3f8ac1b45df21f02a46".to_owned());

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -8,7 +8,7 @@ use std::iter::FromIterator;
 /// An immutable string that is more memory-efficient since it only has an
 /// overhead of 16 bytes for storing a string vs the 24 bytes that `String`
 /// requires
-#[derive(Clone, Default, Debug, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Word(Box<str>);
 
 impl Word {
@@ -40,6 +40,24 @@ impl From<&str> for Word {
 impl From<String> for Word {
     fn from(s: String) -> Self {
         Word(s.into_boxed_str())
+    }
+}
+
+impl Serialize for Word {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Word {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(Into::into)
     }
 }
 

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -148,8 +148,8 @@ pub mod prelude {
     pub use crate::data::store::ethereum::*;
     pub use crate::data::store::scalar::{BigDecimal, BigInt, BigIntSign};
     pub use crate::data::store::{
-        AssignmentEvent, Attribute, Entity, NodeId, SubscriptionFilter, ToEntityId, ToEntityKey,
-        TryIntoEntity, Value, ValueType,
+        AssignmentEvent, Attribute, Entity, NodeId, SubscriptionFilter, ToEntityId, TryIntoEntity,
+        Value, ValueType,
     };
     pub use crate::data::subgraph::schema::SubgraphDeploymentEntity;
     pub use crate::data::subgraph::{

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -148,8 +148,8 @@ pub mod prelude {
     pub use crate::data::store::ethereum::*;
     pub use crate::data::store::scalar::{BigDecimal, BigInt, BigIntSign};
     pub use crate::data::store::{
-        AssignmentEvent, Attribute, Entity, NodeId, SubscriptionFilter, ToEntityId, TryIntoEntity,
-        Value, ValueType,
+        AssignmentEvent, Attribute, Entity, NodeId, SubscriptionFilter, TryIntoEntity, Value,
+        ValueType,
     };
     pub use crate::data::subgraph::schema::SubgraphDeploymentEntity;
     pub use crate::data::subgraph::{

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -122,10 +122,10 @@ pub mod prelude {
     pub use crate::components::store::{
         AttributeNames, BlockNumber, CachedEthereumCall, ChainStore, Child, ChildMultiplicity,
         EntityCache, EntityChange, EntityChangeOperation, EntityCollection, EntityFilter,
-        EntityKey, EntityLink, EntityModification, EntityOperation, EntityOrder, EntityQuery,
-        EntityRange, EntityWindow, EthereumCallCache, ParentLink, PartialBlockPtr, PoolWaitStats,
-        QueryStore, QueryStoreManager, StoreError, StoreEvent, StoreEventStream,
-        StoreEventStreamBox, SubgraphStore, UnfailOutcome, WindowAttribute, BLOCK_NUMBER_MAX,
+        EntityLink, EntityModification, EntityOperation, EntityOrder, EntityQuery, EntityRange,
+        EntityWindow, EthereumCallCache, ParentLink, PartialBlockPtr, PoolWaitStats, QueryStore,
+        QueryStoreManager, StoreError, StoreEvent, StoreEventStream, StoreEventStreamBox,
+        SubgraphStore, UnfailOutcome, WindowAttribute, BLOCK_NUMBER_MAX,
     };
     pub use crate::components::subgraph::{
         BlockState, DataSourceTemplateInfo, HostMetrics, RuntimeHost, RuntimeHostBuilder,

--- a/graph/src/runtime/gas/size_of.rs
+++ b/graph/src/runtime/gas/size_of.rs
@@ -1,7 +1,7 @@
 //! Various implementations of GasSizeOf;
 
 use crate::{
-    components::store::EntityType,
+    components::store::{EntityRef, EntityType},
     data::store::{scalar::Bytes, Value},
     prelude::{BigDecimal, BigInt, EntityKey},
 };
@@ -167,6 +167,12 @@ impl GasSizeOf for EntityKey {
         self.subgraph_id.gas_size_of()
             + self.entity_type.gas_size_of()
             + self.entity_id.gas_size_of()
+    }
+}
+
+impl GasSizeOf for EntityRef {
+    fn gas_size_of(&self) -> Gas {
+        self.entity_type.gas_size_of() + self.entity_id.gas_size_of()
     }
 }
 

--- a/graph/src/runtime/gas/size_of.rs
+++ b/graph/src/runtime/gas/size_of.rs
@@ -1,7 +1,7 @@
 //! Various implementations of GasSizeOf;
 
 use crate::{
-    components::store::{EntityRef, EntityType},
+    components::store::{EntityKey, EntityType},
     data::store::{scalar::Bytes, Value},
     prelude::{BigDecimal, BigInt},
 };
@@ -162,7 +162,7 @@ impl GasSizeOf for usize {
     }
 }
 
-impl GasSizeOf for EntityRef {
+impl GasSizeOf for EntityKey {
     fn gas_size_of(&self) -> Gas {
         self.entity_type.gas_size_of() + self.entity_id.gas_size_of()
     }

--- a/graph/src/runtime/gas/size_of.rs
+++ b/graph/src/runtime/gas/size_of.rs
@@ -3,7 +3,7 @@
 use crate::{
     components::store::{EntityRef, EntityType},
     data::store::{scalar::Bytes, Value},
-    prelude::{BigDecimal, BigInt, EntityKey},
+    prelude::{BigDecimal, BigInt},
 };
 
 use super::{Gas, GasSizeOf, SaturatingInto as _};
@@ -159,14 +159,6 @@ impl GasSizeOf for usize {
     fn const_gas_size_of() -> Option<Gas> {
         // Must be the same regardless of platform.
         u64::const_gas_size_of()
-    }
-}
-
-impl GasSizeOf for EntityKey {
-    fn gas_size_of(&self) -> Gas {
-        self.subgraph_id.gas_size_of()
-            + self.entity_type.gas_size_of()
-            + self.entity_id.gas_size_of()
     }
 }
 

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::store::{EntityRef, EntityType},
+    components::store::{EntityKey, EntityType},
     data::value::Word,
     prelude::{q, BigDecimal, BigInt, Value},
 };
@@ -121,7 +121,7 @@ impl CacheWeight for EntityType {
     }
 }
 
-impl CacheWeight for EntityRef {
+impl CacheWeight for EntityKey {
     fn indirect_weight(&self) -> usize {
         self.entity_id.indirect_weight() + self.entity_type.indirect_weight()
     }

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -1,7 +1,7 @@
 use crate::{
-    components::store::EntityType,
+    components::store::{EntityRef, EntityType},
     data::value::Word,
-    prelude::{q, BigDecimal, BigInt, EntityKey, Value},
+    prelude::{q, BigDecimal, BigInt, Value},
 };
 use std::{
     collections::{BTreeMap, HashMap},
@@ -121,11 +121,9 @@ impl CacheWeight for EntityType {
     }
 }
 
-impl CacheWeight for EntityKey {
+impl CacheWeight for EntityRef {
     fn indirect_weight(&self) -> usize {
-        self.subgraph_id.indirect_weight()
-            + self.entity_id.indirect_weight()
-            + self.entity_type.indirect_weight()
+        self.entity_id.indirect_weight() + self.entity_type.indirect_weight()
     }
 }
 

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -8,7 +8,7 @@ use slog::Logger;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use graph::components::store::{EntityRef, EntityType, StoredDynamicDataSource, WritableStore};
+use graph::components::store::{EntityKey, EntityType, StoredDynamicDataSource, WritableStore};
 use graph::{
     components::store::{DeploymentId, DeploymentLocator},
     prelude::{anyhow, DeploymentHash, Entity, EntityCache, EntityModification, Value},
@@ -86,7 +86,7 @@ impl WritableStore for MockStore {
         unimplemented!()
     }
 
-    fn get(&self, key: &EntityRef) -> Result<Option<Entity>, StoreError> {
+    fn get(&self, key: &EntityKey) -> Result<Option<Entity>, StoreError> {
         match self.get_many_res.get(&key.entity_type) {
             Some(entities) => Ok(entities
                 .iter()
@@ -155,9 +155,9 @@ impl WritableStore for MockStore {
     }
 }
 
-fn make_band(id: &'static str, data: Vec<(&str, Value)>) -> (EntityRef, Entity) {
+fn make_band(id: &'static str, data: Vec<(&str, Value)>) -> (EntityKey, Entity) {
     (
-        EntityRef {
+        EntityKey {
             entity_type: EntityType::new("Band".to_string()),
             entity_id: id.into(),
         },

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -399,8 +399,9 @@ pub fn is_list(field_type: &s::Type) -> bool {
 
 #[test]
 fn entity_validation() {
+    use graph::components::store::EntityRef;
     use graph::data::store;
-    use graph::prelude::{DeploymentHash, Entity, EntityKey};
+    use graph::prelude::{DeploymentHash, Entity};
 
     fn make_thing(name: &str) -> Entity {
         let mut thing = Entity::new();
@@ -434,11 +435,7 @@ fn entity_validation() {
         let schema =
             graph::prelude::Schema::parse(DOCUMENT, subgraph).expect("Failed to parse test schema");
         let id = thing.id().unwrap_or("none".to_owned());
-        let key = EntityKey::data(
-            DeploymentHash::new("doesntmatter").unwrap(),
-            "Thing".to_owned(),
-            id.to_owned(),
-        );
+        let key = EntityRef::data("Thing".to_owned(), id.clone());
 
         let err = thing.validate(&schema, &key);
         if errmsg == "" {

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -399,7 +399,7 @@ pub fn is_list(field_type: &s::Type) -> bool {
 
 #[test]
 fn entity_validation() {
-    use graph::components::store::EntityRef;
+    use graph::components::store::EntityKey;
     use graph::data::store;
     use graph::prelude::{DeploymentHash, Entity};
 
@@ -435,7 +435,7 @@ fn entity_validation() {
         let schema =
             graph::prelude::Schema::parse(DOCUMENT, subgraph).expect("Failed to parse test schema");
         let id = thing.id().unwrap_or("none".to_owned());
-        let key = EntityRef::data("Thing".to_owned(), id.clone());
+        let key = EntityKey::data("Thing".to_owned(), id.clone());
 
         let err = thing.validate(&schema, &key);
         if errmsg == "" {

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate pretty_assertions;
 
+use graph::components::store::{EntityRef, EntityType};
 use graph::data::subgraph::schema::DeploymentCreate;
 use graph::entity;
 use graph::prelude::SubscriptionResult;
@@ -24,8 +25,8 @@ use graph::{
     },
     prelude::{
         futures03::stream::StreamExt, lazy_static, o, q, r, serde_json, slog, BlockPtr,
-        DeploymentHash, Entity, EntityKey, EntityOperation, FutureExtension, GraphQlRunner as _,
-        Logger, NodeId, Query, QueryError, QueryExecutionError, QueryResult, QueryStoreManager,
+        DeploymentHash, Entity, EntityOperation, FutureExtension, GraphQlRunner as _, Logger,
+        NodeId, Query, QueryError, QueryExecutionError, QueryResult, QueryStoreManager,
         QueryVariables, Schema, SubgraphManifest, SubgraphName, SubgraphStore,
         SubgraphVersionSwitchingMode, Subscription, SubscriptionError,
     },
@@ -221,11 +222,12 @@ async fn insert_test_entities(
 
     async fn insert_at(entities: Vec<Entity>, deployment: &DeploymentLocator, block_ptr: BlockPtr) {
         let insert_ops = entities.into_iter().map(|data| EntityOperation::Set {
-            key: EntityKey::data(
-                deployment.hash.clone(),
-                data.get("__typename").unwrap().clone().as_string().unwrap(),
-                data.get("id").unwrap().clone().as_string().unwrap(),
-            ),
+            key: EntityRef {
+                entity_type: EntityType::new(
+                    data.get("__typename").unwrap().clone().as_string().unwrap(),
+                ),
+                entity_id: data.get("id").unwrap().clone().as_string().unwrap().into(),
+            },
             data,
         });
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate pretty_assertions;
 
-use graph::components::store::{EntityRef, EntityType};
+use graph::components::store::{EntityKey, EntityType};
 use graph::data::subgraph::schema::DeploymentCreate;
 use graph::entity;
 use graph::prelude::SubscriptionResult;
@@ -222,7 +222,7 @@ async fn insert_test_entities(
 
     async fn insert_at(entities: Vec<Entity>, deployment: &DeploymentLocator, block_ptr: BlockPtr) {
         let insert_ops = entities.into_iter().map(|data| EntityOperation::Set {
-            key: EntityRef {
+            key: EntityKey {
                 entity_type: EntityType::new(
                     data.get("__typename").unwrap().clone().as_string().unwrap(),
                 ),

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -423,7 +423,7 @@ fn make_thing(id: &str, value: &str) -> (String, EntityModification) {
     data.set("id", id);
     data.set("value", value);
     data.set("extra", USER_DATA);
-    let key = EntityRef {
+    let key = EntityKey {
         entity_type: EntityType::new("Thing".to_string()),
         entity_id: id.into(),
     };

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -10,8 +10,8 @@ use web3::types::H160;
 
 use graph::blockchain::DataSource;
 use graph::blockchain::{Blockchain, DataSourceTemplate as _};
-use graph::components::store::EntityType;
-use graph::components::store::{EnsLookup, EntityKey};
+use graph::components::store::EnsLookup;
+use graph::components::store::{EntityRef, EntityType};
 use graph::components::subgraph::{CausalityRegion, ProofOfIndexingEvent, SharedProofOfIndexing};
 use graph::data::store;
 use graph::ensure;
@@ -150,10 +150,9 @@ impl<C: Blockchain> HostExports<C> {
         );
         poi_section.end();
 
-        let key = EntityKey {
-            subgraph_id: self.subgraph_id.clone(),
+        let key = EntityRef {
             entity_type: EntityType::new(entity_type),
-            entity_id,
+            entity_id: entity_id.into(),
         };
 
         gas.consume_host_fn(gas::STORE_SET.with_args(complexity::Linear, (&key, &data)))?;
@@ -182,10 +181,9 @@ impl<C: Blockchain> HostExports<C> {
             &self.causality_region,
             logger,
         );
-        let key = EntityKey {
-            subgraph_id: self.subgraph_id.clone(),
+        let key = EntityRef {
             entity_type: EntityType::new(entity_type),
-            entity_id,
+            entity_id: entity_id.into(),
         };
 
         gas.consume_host_fn(gas::STORE_REMOVE.with_args(complexity::Size, &key))?;
@@ -202,10 +200,9 @@ impl<C: Blockchain> HostExports<C> {
         entity_id: String,
         gas: &GasCounter,
     ) -> Result<Option<Entity>, anyhow::Error> {
-        let store_key = EntityKey {
-            subgraph_id: self.subgraph_id.clone(),
+        let store_key = EntityRef {
             entity_type: EntityType::new(entity_type),
-            entity_id,
+            entity_id: entity_id.into(),
         };
 
         let result = state.entity_cache.get(&store_key)?;

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -11,7 +11,7 @@ use web3::types::H160;
 use graph::blockchain::DataSource;
 use graph::blockchain::{Blockchain, DataSourceTemplate as _};
 use graph::components::store::EnsLookup;
-use graph::components::store::{EntityRef, EntityType};
+use graph::components::store::{EntityKey, EntityType};
 use graph::components::subgraph::{CausalityRegion, ProofOfIndexingEvent, SharedProofOfIndexing};
 use graph::data::store;
 use graph::ensure;
@@ -150,7 +150,7 @@ impl<C: Blockchain> HostExports<C> {
         );
         poi_section.end();
 
-        let key = EntityRef {
+        let key = EntityKey {
             entity_type: EntityType::new(entity_type),
             entity_id: entity_id.into(),
         };
@@ -181,7 +181,7 @@ impl<C: Blockchain> HostExports<C> {
             &self.causality_region,
             logger,
         );
-        let key = EntityRef {
+        let key = EntityKey {
             entity_type: EntityType::new(entity_type),
             entity_id: entity_id.into(),
         };
@@ -200,7 +200,7 @@ impl<C: Blockchain> HostExports<C> {
         entity_id: String,
         gas: &GasCounter,
     ) -> Result<Option<Entity>, anyhow::Error> {
-        let store_key = EntityRef {
+        let store_key = EntityKey {
             entity_type: EntityType::new(entity_type),
             entity_id: entity_id.into(),
         };

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -11,7 +11,7 @@ use graph::components::versions::VERSIONS;
 use graph::data::graphql::{object, IntoValue, ObjectOrInterface, ValueMap};
 use graph::data::subgraph::features::detect_features;
 use graph::data::subgraph::status;
-use graph::data::value::Object;
+use graph::data::value::{Object, Word};
 use graph::prelude::*;
 use graph_graphql::prelude::{a, ExecutionContext, Resolver};
 
@@ -661,7 +661,7 @@ fn entity_changes_to_graphql(entity_changes: Vec<EntityOperation>) -> r::Value {
 
     // First, we isolate updates and deletions with the same entity type.
     let mut updates: BTreeMap<EntityType, Vec<Entity>> = BTreeMap::new();
-    let mut deletions: BTreeMap<EntityType, Vec<String>> = BTreeMap::new();
+    let mut deletions: BTreeMap<EntityType, Vec<Word>> = BTreeMap::new();
 
     for change in entity_changes {
         match change {
@@ -705,7 +705,7 @@ fn entity_changes_to_graphql(entity_changes: Vec<EntityOperation>) -> r::Value {
         deletions_graphql.push(object! {
             type: entity_type.to_string(),
             entities:
-                ids.into_iter().map(r::Value::String).collect::<Vec<r::Value>>(),
+                ids.into_iter().map(|s| s.to_string()).map(r::Value::String).collect::<Vec<r::Value>>(),
         });
     }
 

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1012,7 +1012,7 @@ impl DeploymentStore {
             // wait with sending it until we have done all our other work
             // so that we do not hold a lock on the notification queue
             // for longer than we have to
-            let event: StoreEvent = mods.iter().collect();
+            let event: StoreEvent = StoreEvent::from_mods(&site.deployment, mods);
 
             // Make the changes
             let layout = self.layout(&conn, site.clone())?;

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -4,7 +4,7 @@ use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use graph::blockchain::block_stream::FirehoseCursor;
-use graph::components::store::{EntityRef, EntityType, StoredDynamicDataSource};
+use graph::components::store::{EntityKey, EntityType, StoredDynamicDataSource};
 use graph::components::versions::VERSIONS;
 use graph::data::query::Trace;
 use graph::data::subgraph::{status, SPEC_VERSION_0_0_6};
@@ -252,7 +252,7 @@ impl DeploymentStore {
         &self,
         conn: &PgConnection,
         layout: &Layout,
-        key: &EntityRef,
+        key: &EntityKey,
     ) -> Result<(), StoreError> {
         // Collect all types that share an interface implementation with this
         // entity type, and make sure there are no conflicting IDs.
@@ -366,7 +366,7 @@ impl DeploymentStore {
     fn insert_entities<'a>(
         &'a self,
         entity_type: &'a EntityType,
-        data: &'a mut [(&'a EntityRef, Cow<'a, Entity>)],
+        data: &'a mut [(&'a EntityKey, Cow<'a, Entity>)],
         conn: &PgConnection,
         layout: &'a Layout,
         ptr: &BlockPtr,
@@ -386,7 +386,7 @@ impl DeploymentStore {
     fn overwrite_entities<'a>(
         &'a self,
         entity_type: &'a EntityType,
-        data: &'a mut [(&'a EntityRef, Cow<'a, Entity>)],
+        data: &'a mut [(&'a EntityKey, Cow<'a, Entity>)],
         conn: &PgConnection,
         layout: &'a Layout,
         ptr: &BlockPtr,
@@ -928,7 +928,7 @@ impl DeploymentStore {
     pub(crate) fn get(
         &self,
         site: Arc<Site>,
-        key: &EntityRef,
+        key: &EntityKey,
         block: BlockNumber,
     ) -> Result<Option<Entity>, StoreError> {
         let conn = self.get_conn()?;

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -41,7 +41,7 @@ use crate::{
         FilterQuery, FindManyQuery, FindQuery, InsertQuery, RevertClampQuery, RevertRemoveQuery,
     },
 };
-use graph::components::store::{EntityRef, EntityType};
+use graph::components::store::{EntityKey, EntityType};
 use graph::data::graphql::ext::{DirectiveFinder, DocumentExt, ObjectTypeExt};
 use graph::data::schema::{FulltextConfig, FulltextDefinition, Schema, SCHEMA_TYPE_NAME};
 use graph::data::store::BYTES_SCALAR;
@@ -555,7 +555,7 @@ impl Layout {
                 .expect("__typename expected; this is a bug");
 
             changes.push(EntityOperation::Set {
-                key: EntityRef {
+                key: EntityKey {
                     entity_type,
                     entity_id,
                 },
@@ -571,7 +571,7 @@ impl Layout {
             // about why this check is necessary.
             if !processed_entities.contains(&(entity_type.clone(), entity_id.clone())) {
                 changes.push(EntityOperation::Remove {
-                    key: EntityRef {
+                    key: EntityKey {
                         entity_type,
                         entity_id,
                     },
@@ -586,7 +586,7 @@ impl Layout {
         &'a self,
         conn: &PgConnection,
         entity_type: &'a EntityType,
-        entities: &'a mut [(&'a EntityRef, Cow<'a, Entity>)],
+        entities: &'a mut [(&'a EntityKey, Cow<'a, Entity>)],
         block: BlockNumber,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
@@ -726,7 +726,7 @@ impl Layout {
         &'a self,
         conn: &PgConnection,
         entity_type: &'a EntityType,
-        entities: &'a mut [(&'a EntityRef, Cow<'a, Entity>)],
+        entities: &'a mut [(&'a EntityKey, Cow<'a, Entity>)],
         block: BlockNumber,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -12,7 +12,7 @@ use diesel::result::{Error as DieselError, QueryResult};
 use diesel::sql_types::{Array, BigInt, Binary, Bool, Integer, Jsonb, Text};
 use diesel::Connection;
 
-use graph::components::store::EntityRef;
+use graph::components::store::EntityKey;
 use graph::data::value::Word;
 use graph::prelude::{
     anyhow, r, serde_json, Attribute, BlockNumber, ChildMultiplicity, Entity, EntityCollection,
@@ -1646,7 +1646,7 @@ impl<'a, Conn> RunQueryDsl<Conn> for FindManyQuery<'a> {}
 #[derive(Debug)]
 pub struct InsertQuery<'a> {
     table: &'a Table,
-    entities: &'a [(&'a EntityRef, Cow<'a, Entity>)],
+    entities: &'a [(&'a EntityKey, Cow<'a, Entity>)],
     unique_columns: Vec<&'a Column>,
     br_column: BlockRangeColumn<'a>,
 }
@@ -1654,7 +1654,7 @@ pub struct InsertQuery<'a> {
 impl<'a> InsertQuery<'a> {
     pub fn new(
         table: &'a Table,
-        entities: &'a mut [(&'a EntityRef, Cow<Entity>)],
+        entities: &'a mut [(&'a EntityKey, Cow<Entity>)],
         block: BlockNumber,
     ) -> Result<InsertQuery<'a>, StoreError> {
         for (entity_key, entity) in entities.iter_mut() {
@@ -1695,7 +1695,7 @@ impl<'a> InsertQuery<'a> {
     /// Build the column name list using the subset of all keys among present entities.
     fn unique_columns(
         table: &'a Table,
-        entities: &'a [(&'a EntityRef, Cow<'a, Entity>)],
+        entities: &'a [(&'a EntityKey, Cow<'a, Entity>)],
     ) -> Vec<&'a Column> {
         let mut hashmap = HashMap::new();
         for (_key, entity) in entities.iter() {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -12,10 +12,11 @@ use diesel::result::{Error as DieselError, QueryResult};
 use diesel::sql_types::{Array, BigInt, Binary, Bool, Integer, Jsonb, Text};
 use diesel::Connection;
 
+use graph::components::store::EntityRef;
 use graph::data::value::Word;
 use graph::prelude::{
     anyhow, r, serde_json, Attribute, BlockNumber, ChildMultiplicity, Entity, EntityCollection,
-    EntityFilter, EntityKey, EntityLink, EntityOrder, EntityRange, EntityWindow, ParentLink,
+    EntityFilter, EntityLink, EntityOrder, EntityRange, EntityWindow, ParentLink,
     QueryExecutionError, StoreError, Value, ENV_VARS,
 };
 use graph::{
@@ -1645,7 +1646,7 @@ impl<'a, Conn> RunQueryDsl<Conn> for FindManyQuery<'a> {}
 #[derive(Debug)]
 pub struct InsertQuery<'a> {
     table: &'a Table,
-    entities: &'a [(&'a EntityKey, Cow<'a, Entity>)],
+    entities: &'a [(&'a EntityRef, Cow<'a, Entity>)],
     unique_columns: Vec<&'a Column>,
     br_column: BlockRangeColumn<'a>,
 }
@@ -1653,7 +1654,7 @@ pub struct InsertQuery<'a> {
 impl<'a> InsertQuery<'a> {
     pub fn new(
         table: &'a Table,
-        entities: &'a mut [(&'a EntityKey, Cow<Entity>)],
+        entities: &'a mut [(&'a EntityRef, Cow<Entity>)],
         block: BlockNumber,
     ) -> Result<InsertQuery<'a>, StoreError> {
         for (entity_key, entity) in entities.iter_mut() {
@@ -1694,7 +1695,7 @@ impl<'a> InsertQuery<'a> {
     /// Build the column name list using the subset of all keys among present entities.
     fn unique_columns(
         table: &'a Table,
-        entities: &'a [(&'a EntityKey, Cow<'a, Entity>)],
+        entities: &'a [(&'a EntityRef, Cow<'a, Entity>)],
     ) -> Vec<&'a Column> {
         let mut hashmap = HashMap::new();
         for (_key, entity) in entities.iter() {

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use std::{collections::BTreeMap, sync::Arc};
 
 use graph::blockchain::block_stream::FirehoseCursor;
-use graph::components::store::EntityRef;
+use graph::components::store::EntityKey;
 use graph::data::subgraph::schema;
 use graph::env::env_var;
 use graph::prelude::{
@@ -239,7 +239,7 @@ impl SyncStore {
         .await
     }
 
-    fn get(&self, key: &EntityRef, block: BlockNumber) -> Result<Option<Entity>, StoreError> {
+    fn get(&self, key: &EntityKey, block: BlockNumber) -> Result<Option<Entity>, StoreError> {
         self.retry("get", || {
             self.writable.get(self.site.cheap_clone(), key, block)
         })
@@ -624,7 +624,7 @@ impl Queue {
 
     /// Get the entity for `key` if it exists by looking at both the queue
     /// and the store
-    fn get(&self, key: &EntityRef) -> Result<Option<Entity>, StoreError> {
+    fn get(&self, key: &EntityKey) -> Result<Option<Entity>, StoreError> {
         enum Op {
             Write(Entity),
             Remove,
@@ -864,7 +864,7 @@ impl Writer {
         }
     }
 
-    fn get(&self, key: &EntityRef) -> Result<Option<Entity>, StoreError> {
+    fn get(&self, key: &EntityKey) -> Result<Option<Entity>, StoreError> {
         match self {
             Writer::Sync(store) => store.get(key, BLOCK_NUMBER_MAX),
             Writer::Async(queue) => queue.get(key),
@@ -999,7 +999,7 @@ impl WritableStoreTrait for WritableStore {
         self.store.supports_proof_of_indexing().await
     }
 
-    fn get(&self, key: &EntityRef) -> Result<Option<Entity>, StoreError> {
+    fn get(&self, key: &EntityKey) -> Result<Option<Entity>, StoreError> {
         self.writer.get(key)
     }
 

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -5,7 +5,7 @@ use std::{marker::PhantomData, str::FromStr};
 use test_store::*;
 
 use graph::components::store::{
-    DeploymentLocator, EntityOrder, EntityQuery, EntityRef, EntityType,
+    DeploymentLocator, EntityKey, EntityOrder, EntityQuery, EntityType,
 };
 use graph::data::store::scalar;
 use graph::data::subgraph::schema::*;
@@ -263,7 +263,7 @@ fn create_test_entity(
     );
 
     EntityOperation::Set {
-        key: EntityRef {
+        key: EntityKey {
             entity_type: EntityType::new(entity_type.to_string()),
             entity_id: id.into(),
         },
@@ -329,7 +329,7 @@ async fn check_graft(
     // Make our own entries for block 2
     shaq.set("email", "shaq@gmail.com");
     let op = EntityOperation::Set {
-        key: EntityRef {
+        key: EntityKey {
             entity_type: EntityType::new(USER.to_owned()),
             entity_id: "3".into(),
         },

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -5,7 +5,7 @@ use std::{marker::PhantomData, str::FromStr};
 use test_store::*;
 
 use graph::components::store::{
-    DeploymentLocator, EntityKey, EntityOrder, EntityQuery, EntityType,
+    DeploymentLocator, EntityOrder, EntityQuery, EntityRef, EntityType,
 };
 use graph::data::store::scalar;
 use graph::data::subgraph::schema::*;
@@ -263,11 +263,10 @@ fn create_test_entity(
     );
 
     EntityOperation::Set {
-        key: EntityKey::data(
-            TEST_SUBGRAPH_ID.clone(),
-            entity_type.to_owned(),
-            id.to_owned(),
-        ),
+        key: EntityRef {
+            entity_type: EntityType::new(entity_type.to_string()),
+            entity_id: id.into(),
+        },
         data: test_entity,
     }
 }
@@ -330,7 +329,10 @@ async fn check_graft(
     // Make our own entries for block 2
     shaq.set("email", "shaq@gmail.com");
     let op = EntityOperation::Set {
-        key: EntityKey::data(deployment.hash.clone(), USER.to_owned(), "3".to_owned()),
+        key: EntityRef {
+            entity_type: EntityType::new(USER.to_owned()),
+            entity_id: "3".into(),
+        },
         data: shaq,
     };
     transact_and_wait(&store, &deployment, BLOCKS[2].clone(), vec![op])

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -1,7 +1,7 @@
 //! Test mapping of GraphQL schema to a relational schema
 use diesel::connection::SimpleConnection as _;
 use diesel::pg::PgConnection;
-use graph::components::store::EntityRef;
+use graph::components::store::EntityKey;
 use graph::data::store::scalar;
 use graph::entity;
 use graph::prelude::BlockNumber;
@@ -218,10 +218,10 @@ fn insert_entity_at(
     let entities_with_keys_owned = entities
         .drain(..)
         .map(|entity| {
-            let key = EntityRef::data(entity_type.to_owned(), entity.id().unwrap());
+            let key = EntityKey::data(entity_type.to_owned(), entity.id().unwrap());
             (key, entity)
         })
-        .collect::<Vec<(EntityRef, Entity)>>();
+        .collect::<Vec<(EntityKey, Entity)>>();
     let mut entities_with_keys: Vec<_> = entities_with_keys_owned
         .iter()
         .map(|(key, entity)| (key, Cow::from(entity)))
@@ -254,10 +254,10 @@ fn update_entity_at(
     mut entities: Vec<Entity>,
     block: BlockNumber,
 ) {
-    let entities_with_keys_owned: Vec<(EntityRef, Entity)> = entities
+    let entities_with_keys_owned: Vec<(EntityKey, Entity)> = entities
         .drain(..)
         .map(|entity| {
-            let key = EntityRef::data(entity_type.to_owned(), entity.id().unwrap());
+            let key = EntityKey::data(entity_type.to_owned(), entity.id().unwrap());
             (key, entity)
         })
         .collect();
@@ -547,7 +547,7 @@ fn update() {
         entity.set("string", "updated");
         entity.remove("strings");
         entity.set("bool", Value::Null);
-        let key = EntityRef::data("Scalar".to_owned(), entity.id().unwrap().clone());
+        let key = EntityKey::data("Scalar".to_owned(), entity.id().unwrap().clone());
 
         let entity_type = EntityType::from("Scalar");
         let mut entities = vec![(&key, Cow::from(&entity))];
@@ -594,13 +594,13 @@ fn update_many() {
 
         // generate keys
         let entity_type = EntityType::from("Scalar");
-        let keys: Vec<EntityRef> = ["one", "two", "three"]
+        let keys: Vec<EntityKey> = ["one", "two", "three"]
             .iter()
-            .map(|id| EntityRef::data("Scalar".to_owned(), String::from(*id)))
+            .map(|id| EntityKey::data("Scalar".to_owned(), String::from(*id)))
             .collect();
 
         let entities_vec = vec![one, two, three];
-        let mut entities: Vec<(&EntityRef, Cow<'_, Entity>)> = keys
+        let mut entities: Vec<(&EntityKey, Cow<'_, Entity>)> = keys
             .iter()
             .zip(entities_vec.iter().map(|e| Cow::Borrowed(e)))
             .collect();
@@ -666,7 +666,7 @@ fn serialize_bigdecimal() {
             let d = BigDecimal::from_str(d).unwrap();
             entity.set("bigDecimal", d);
 
-            let key = EntityRef::data("Scalar".to_owned(), entity.id().unwrap().clone());
+            let key = EntityKey::data("Scalar".to_owned(), entity.id().unwrap().clone());
             let entity_type = EntityType::from("Scalar");
             let mut entities = vec![(&key, Cow::Borrowed(&entity))];
             layout
@@ -722,7 +722,7 @@ fn delete() {
         insert_entity(&conn, &layout, "Scalar", vec![two]);
 
         // Delete where nothing is getting deleted
-        let key = EntityRef::data("Scalar".to_owned(), "no such entity".to_owned());
+        let key = EntityKey::data("Scalar".to_owned(), "no such entity".to_owned());
         let entity_type = EntityType::from("Scalar");
         let mut entity_keys = vec![key.entity_id.as_str()];
         let count = layout

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -1,7 +1,7 @@
 //! Test relational schemas that use `Bytes` to store ids
 use diesel::connection::SimpleConnection as _;
 use diesel::pg::PgConnection;
-use graph::components::store::EntityRef;
+use graph::components::store::EntityKey;
 use graph::data::store::scalar;
 use graph_mock::MockMetricsRegistry;
 use hex_literal::hex;
@@ -87,7 +87,7 @@ fn remove_test_data(conn: &PgConnection) {
 }
 
 fn insert_entity(conn: &PgConnection, layout: &Layout, entity_type: &str, entity: Entity) {
-    let key = EntityRef::data(entity_type.to_owned(), entity.id().unwrap());
+    let key = EntityKey::data(entity_type.to_owned(), entity.id().unwrap());
 
     let entity_type = EntityType::from(entity_type);
     let mut entities = vec![(&key, Cow::from(&entity))];
@@ -282,7 +282,7 @@ fn update() {
         // Update the entity
         let mut entity = BEEF_ENTITY.clone();
         entity.set("name", "Moo");
-        let key = EntityRef::data("Thing".to_owned(), entity.id().unwrap().clone());
+        let key = EntityKey::data("Thing".to_owned(), entity.id().unwrap().clone());
 
         let entity_id = entity.id().unwrap().clone();
         let entity_type = key.entity_type.clone();
@@ -311,7 +311,7 @@ fn delete() {
         insert_entity(&conn, &layout, "Thing", two);
 
         // Delete where nothing is getting deleted
-        let key = EntityRef::data("Thing".to_owned(), "ffff".to_owned());
+        let key = EntityKey::data("Thing".to_owned(), "ffff".to_owned());
         let entity_type = key.entity_type.clone();
         let mut entity_keys = vec![key.entity_id.as_str()];
         let count = layout

--- a/store/postgres/tests/writable.rs
+++ b/store/postgres/tests/writable.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use std::marker::PhantomData;
 use test_store::*;
 
-use graph::components::store::{DeploymentLocator, EntityRef, WritableStore};
+use graph::components::store::{DeploymentLocator, EntityKey, WritableStore};
 use graph::data::subgraph::*;
 use graph::prelude::*;
 use graph::semver::Version;
@@ -102,8 +102,8 @@ fn block_pointer(number: u8) -> BlockPtr {
     BlockPtr::from((hash, number as BlockNumber))
 }
 
-fn count_key(id: &str) -> EntityRef {
-    EntityRef::data(COUNTER.to_owned(), id.to_owned())
+fn count_key(id: &str) -> EntityKey {
+    EntityKey::data(COUNTER.to_owned(), id.to_owned())
 }
 
 async fn insert_count(store: &Arc<DieselSubgraphStore>, deployment: &DeploymentLocator, count: u8) {

--- a/store/postgres/tests/writable.rs
+++ b/store/postgres/tests/writable.rs
@@ -4,8 +4,7 @@ use lazy_static::lazy_static;
 use std::marker::PhantomData;
 use test_store::*;
 
-use graph::components::store::{DeploymentLocator, WritableStore};
-use graph::components::store::{EntityKey, EntityType};
+use graph::components::store::{DeploymentLocator, EntityRef, WritableStore};
 use graph::data::subgraph::*;
 use graph::prelude::*;
 use graph::semver::Version;
@@ -103,12 +102,8 @@ fn block_pointer(number: u8) -> BlockPtr {
     BlockPtr::from((hash, number as BlockNumber))
 }
 
-fn count_key(deployment: &DeploymentLocator, id: &str) -> EntityKey {
-    EntityKey {
-        subgraph_id: deployment.hash.clone(),
-        entity_type: EntityType::from(COUNTER),
-        entity_id: id.to_owned(),
-    }
+fn count_key(id: &str) -> EntityRef {
+    EntityRef::data(COUNTER.to_owned(), id.to_owned())
 }
 
 async fn insert_count(store: &Arc<DieselSubgraphStore>, deployment: &DeploymentLocator, count: u8) {
@@ -117,7 +112,7 @@ async fn insert_count(store: &Arc<DieselSubgraphStore>, deployment: &DeploymentL
         count: count as i32
     };
     let entity_op = EntityOperation::Set {
-        key: count_key(deployment, &data.get("id").unwrap().to_string()),
+        key: count_key(&data.get("id").unwrap().to_string()),
         data,
     };
     transact_entity_operations(store, deployment, block_pointer(count), vec![entity_op])
@@ -141,7 +136,7 @@ fn tracker() {
         let subgraph_store = store.subgraph_store();
 
         let read_count = || {
-            let counter = writable.get(&count_key(&deployment, "1")).unwrap().unwrap();
+            let counter = writable.get(&count_key("1")).unwrap().unwrap();
             counter.get("count").unwrap().as_int().unwrap()
         };
         for count in 1..4 {

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -8,7 +8,7 @@ use graph::prelude::{QueryStoreManager as _, SubgraphStore as _, *};
 use graph::semver::Version;
 use graph::{
     blockchain::block_stream::FirehoseCursor, blockchain::ChainIdentifier,
-    components::store::DeploymentLocator, components::store::EntityRef,
+    components::store::DeploymentLocator, components::store::EntityKey,
     components::store::EntityType, components::store::StatusStore,
     components::store::StoredDynamicDataSource, data::subgraph::status, prelude::NodeId,
 };
@@ -348,7 +348,7 @@ pub async fn insert_entities(
     let insert_ops = entities
         .into_iter()
         .map(|(entity_type, data)| EntityOperation::Set {
-            key: EntityRef {
+            key: EntityKey {
                 entity_type: entity_type.to_owned(),
                 entity_id: data.get("id").unwrap().clone().as_string().unwrap().into(),
             },

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -8,9 +8,9 @@ use graph::prelude::{QueryStoreManager as _, SubgraphStore as _, *};
 use graph::semver::Version;
 use graph::{
     blockchain::block_stream::FirehoseCursor, blockchain::ChainIdentifier,
-    components::store::DeploymentLocator, components::store::EntityType,
-    components::store::StatusStore, components::store::StoredDynamicDataSource,
-    data::subgraph::status, prelude::NodeId,
+    components::store::DeploymentLocator, components::store::EntityRef,
+    components::store::EntityType, components::store::StatusStore,
+    components::store::StoredDynamicDataSource, data::subgraph::status, prelude::NodeId,
 };
 use graph_graphql::prelude::{
     execute_query, Query as PreparedQuery, QueryExecutionOptions, StoreResolver,
@@ -348,10 +348,9 @@ pub async fn insert_entities(
     let insert_ops = entities
         .into_iter()
         .map(|(entity_type, data)| EntityOperation::Set {
-            key: EntityKey {
-                subgraph_id: deployment.hash.clone(),
+            key: EntityRef {
                 entity_type: entity_type.to_owned(),
-                entity_id: data.get("id").unwrap().clone().as_string().unwrap(),
+                entity_id: data.get("id").unwrap().clone().as_string().unwrap().into(),
             },
             data,
         });


### PR DESCRIPTION
This PR makes the `EntityCache` more memory efficient, meaning the same amount of memory will be able to store more entities with two changes:

* Use `Word` (`Box<str>`) for entity types and ids
* Remove the subgraph id from `EntityKey` since that adds an overhead of 70 bytes _for every cache entry_