### PR TITLE
ipfs: Replace dag/stat with files/stat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ipfs:
-        image: ipfs/go-ipfs:v0.12.2
+        image: ipfs/go-ipfs:v0.10.0
         ports:
           - 5001:5001
       postgres:
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ipfs:
-        image: ipfs/go-ipfs:v0.12.2
+        image: ipfs/go-ipfs:v0.10.0
         ports:
           - 5001:5001
       postgres:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   # Install Node.js 11.x
   - nvm install 11 && nvm use 11
   # Install IPFS
-  - wget "https://dist.ipfs.io/go-ipfs/v0.12.2/go-ipfs_v0.12.2_linux-amd64.tar.gz" -O /tmp/ipfs.tar.gz
+  - wget "https://dist.ipfs.io/go-ipfs/v0.10.0/go-ipfs_v0.10.0_linux-amd64.tar.gz" -O /tmp/ipfs.tar.gz
   - pushd . && cd $HOME/bin && tar -xzvf /tmp/ipfs.tar.gz && popd
   - export PATH="$HOME/bin/go-ipfs:$PATH"
   - ipfs init

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       ethereum: 'mainnet:http://host.docker.internal:8545'
       GRAPH_LOG: info
   ipfs:
-    image: ipfs/go-ipfs:v0.12.2
+    image: ipfs/go-ipfs:v0.10.0
     ports:
       - '5001:5001'
     volumes:

--- a/store/test-store/devel/docker-compose.yml
+++ b/store/test-store/devel/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   ipfs:
-    image: ipfs/go-ipfs:v0.12.2
+    image: ipfs/go-ipfs:v0.10.0
     ports:
       - '5001:5001'
     volumes:

--- a/tests/tests/common/docker.rs
+++ b/tests/tests/common/docker.rs
@@ -7,7 +7,7 @@ use tokio::time::{sleep, Duration};
 use tokio_stream::StreamExt;
 
 const POSTGRES_IMAGE: &'static str = "postgres:latest";
-const IPFS_IMAGE: &'static str = "ipfs/go-ipfs:v0.12.2";
+const IPFS_IMAGE: &'static str = "ipfs/go-ipfs:v0.10.0";
 const GANACHE_IMAGE: &'static str = "trufflesuite/ganache-cli:latest";
 type DockerError = bollard::errors::Error;
 


### PR DESCRIPTION
This fixes a couple issues in #3570.

`dag/stat` turns out to be unreliable, even with the `progress=false` argument to get a consistent response format, the IPFS node seemed to struggle with it. So we use `files/stat` which is less expensive as it just reads the file metadata, and is probably closer to the deprecated `object/stat`.

The IPFS version in docker and CI is downgraded to 0.10.0, to workaround a startup issue affecting Mac M1s.