### PR TITLE
Filipe/arweave filter sha256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cranelift-bforest"
 version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,6 +1535,7 @@ dependencies = [
  "prost",
  "prost-types",
  "serde",
+ "sha2 0.10.2",
  "test-store",
  "tonic-build",
 ]
@@ -2942,7 +2952,7 @@ dependencies = [
  "md-5",
  "memchr",
  "rand",
- "sha2",
+ "sha2 0.9.5",
  "stringprep",
 ]
 
@@ -3743,7 +3753,7 @@ checksum = "1a0c8611594e2ab4ebbf06ec7cbbf0a99450b8570e96cbf5188b5d5f6ef18d81"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -3756,9 +3766,20 @@ checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures 0.2.2",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -4863,7 +4884,7 @@ dependencies = [
  "libc",
  "log",
  "serde",
- "sha2",
+ "sha2 0.9.5",
  "toml",
  "winapi",
  "zstd",

--- a/chain/arweave/Cargo.toml
+++ b/chain/arweave/Cargo.toml
@@ -12,6 +12,7 @@ graph = { path = "../../graph" }
 prost = "0.10.1"
 prost-types = "0.10.1"
 serde = "1.0"
+sha2 = "0.10.2"
 
 graph-runtime-wasm = { path = "../../runtime/wasm" }
 graph-runtime-derive = { path = "../../runtime/derive" }


### PR DESCRIPTION
Fixes https://github.com/graphprotocol/graph-node/issues/3609

Changes:
1. Transaction filter now uses both public keys and sha256 of those public keys
2. Filtering will try the long form (as is used right now for blocks from firehose) and then try the sha256
3. When parsing the data sources, we'll calculate the "short version" of the pubkey and store it alongside any sources that defined those keys. 

Arweave uses base64url(sha256(pubkey)) in their explorer and that is much easier for users to retrieve than the pubkey, so the goal of this PR is to enable filtering by either. Currently firehose only supports pubkey format on the protobuf. With these changes we can just switch from checking the owner to checking sha256 as soon as it is available and possibly remove the pubkey matching completing since we can calculate the checksum version when creating the filters. 
