### PR TITLE
graph, graphql, store: Use the correct parent type for type d queries

### DIFF
--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -364,7 +364,7 @@ pub enum EntityLink {
     /// The parent id is stored in this child attribute
     Direct(WindowAttribute, ChildMultiplicity),
     /// Join with the parents table to get at the parent id
-    Parent(ParentLink),
+    Parent(EntityType, ParentLink),
 }
 
 /// Window results of an `EntityQuery` query along the parent's id:

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -338,7 +338,10 @@ impl<'a> JoinCond<'a> {
                         (ids, ParentLink::List(child_ids))
                     }
                 };
-                (ids, EntityLink::Parent(parent_link))
+                (
+                    ids,
+                    EntityLink::Parent(self.parent_type.clone(), parent_link),
+                )
             }
         }
     }

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -497,10 +497,10 @@ fn query() {
         let coll = EntityCollection::Window(vec![EntityWindow {
             child_type: THING.clone(),
             ids: vec![ROOT.to_owned()],
-            link: EntityLink::Parent(ParentLink::List(vec![vec![
-                CHILD1.to_owned(),
-                CHILD2.to_owned(),
-            ]])),
+            link: EntityLink::Parent(
+                THING.clone(),
+                ParentLink::List(vec![vec![CHILD1.to_owned(), CHILD2.to_owned()]]),
+            ),
             column_names: AttributeNames::All,
         }]);
         let things = fetch(conn, layout, coll);
@@ -512,7 +512,10 @@ fn query() {
         let coll = EntityCollection::Window(vec![EntityWindow {
             child_type: THING.clone(),
             ids: vec![CHILD1.to_owned(), CHILD2.to_owned()],
-            link: EntityLink::Parent(ParentLink::Scalar(vec![ROOT.to_owned(), ROOT.to_owned()])),
+            link: EntityLink::Parent(
+                THING.clone(),
+                ParentLink::Scalar(vec![ROOT.to_owned(), ROOT.to_owned()]),
+            ),
             column_names: AttributeNames::All,
         }]);
         let things = fetch(conn, layout, coll);


### PR DESCRIPTION
When we stitch the result of a query of type d back into the parents, we need to make sure that the parent ids we pass through the query use the type of the parent's id field. Previously, the code was using the type of the child's id field but that has no relation to the correct type.

Fixes https://github.com/graphprotocol/graph-node/issues/3600

