### PR TITLE
graph, store: Remove H256 dependency for status API

### DIFF
--- a/graph/src/data/subgraph/status.rs
+++ b/graph/src/data/subgraph/status.rs
@@ -1,9 +1,10 @@
 //! Support for the indexing status API
 
 use super::schema::{SubgraphError, SubgraphHealth};
-use crate::components::store::DeploymentId;
+use crate::blockchain::BlockHash;
+use crate::components::store::{BlockNumber, DeploymentId};
 use crate::data::graphql::{object, IntoValue};
-use crate::prelude::{r, web3::types::H256, BlockPtr, Value};
+use crate::prelude::{r, BlockPtr, Value};
 
 pub enum Filter {
     /// Get all versions for the named subgraph
@@ -22,8 +23,8 @@ pub enum Filter {
 pub struct EthereumBlock(BlockPtr);
 
 impl EthereumBlock {
-    pub fn new(hash: H256, number: u64) -> Self {
-        EthereumBlock(BlockPtr::from((hash, number)))
+    pub fn new(hash: BlockHash, number: BlockNumber) -> Self {
+        EthereumBlock(BlockPtr::new(hash, number))
     }
 
     pub fn to_ptr(self) -> BlockPtr {

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -9,6 +9,7 @@ use diesel::prelude::{
 };
 use diesel_derives::Associations;
 use git_testament::{git_testament, git_testament_macros};
+use graph::blockchain::BlockHash;
 use graph::data::subgraph::schema::{SubgraphError, SubgraphManifestEntity};
 use graph::prelude::{
     bigdecimal::ToPrimitive, BigDecimal, BlockPtr, DeploymentHash, StoreError,
@@ -147,21 +148,23 @@ pub(crate) fn block(
     hash: Option<Vec<u8>>,
     number: Option<BigDecimal>,
 ) -> Result<Option<status::EthereumBlock>, StoreError> {
-    match (&hash, &number) {
+    match (hash, number) {
         (Some(hash), Some(number)) => {
-            let hash = H256::from_slice(&hash.as_slice()[0..32]);
-            let number = number.to_u64().ok_or_else(|| {
+            let number = number.to_i32().ok_or_else(|| {
                 constraint_violation!(
-                    "the block number {} for {} in {} is not representable as a u64",
+                    "the block number {} for {} in {} is not representable as an i32",
                     number,
                     name,
                     id
                 )
             })?;
-            Ok(Some(status::EthereumBlock::new(hash, number)))
+            Ok(Some(status::EthereumBlock::new(
+                BlockHash(hash.into_boxed_slice()),
+                number,
+            )))
         }
         (None, None) => Ok(None),
-        _ => Err(constraint_violation!(
+        (hash, number) => Err(constraint_violation!(
             "the hash and number \
         of a block pointer must either both be null or both have a \
         value, but for `{}` the hash of {} is `{:?}` and the number is `{:?}`",


### PR DESCRIPTION
This is missing a test, but setting up a test is fairly involved and I wanted to get this hopeful fix out first