### PR TITLE
cosmos: handle nones

### DIFF
--- a/chain/cosmos/src/codec.rs
+++ b/chain/cosmos/src/codec.rs
@@ -21,17 +21,29 @@ impl Block {
     }
 
     pub fn begin_block_events(&self) -> impl Iterator<Item = &Event> {
-        self.result_begin_block.as_ref().unwrap().events.iter()
+        self.result_begin_block
+            .as_ref()
+            .map(|b| b.events.iter())
+            .into_iter()
+            .flatten()
     }
 
     pub fn tx_events(&self) -> impl Iterator<Item = &Event> {
-        self.transactions
-            .iter()
-            .flat_map(|tx| tx.result.as_ref().unwrap().events.iter())
+        self.transactions.iter().flat_map(|tx| {
+            tx.result
+                .as_ref()
+                .map(|b| b.events.iter())
+                .into_iter()
+                .flatten()
+        })
     }
 
     pub fn end_block_events(&self) -> impl Iterator<Item = &Event> {
-        self.result_end_block.as_ref().unwrap().events.iter()
+        self.result_end_block
+            .as_ref()
+            .map(|b| b.events.iter())
+            .into_iter()
+            .flatten()
     }
 
     pub fn transactions(&self) -> impl Iterator<Item = &TxResult> {


### PR DESCRIPTION
I'm unsure of why these would be `None`, but we've seen this crash. Resolves #3621.