### PR TITLE
Chunk size patch

### DIFF
--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -648,7 +648,7 @@ impl Layout {
         // so we need to act in chunks whose size is defined by the number of entities times the
         // number of attributes each entity type has.
         // We add 1 to account for the `block_range` bind parameter
-        let chunk_size = POSTGRES_MAX_PARAMETERS / (table.columns.len() + 1);
+        let chunk_size = POSTGRES_MAX_PARAMETERS / (table.columns.len() + 2);
         for chunk in entities.chunks_mut(chunk_size) {
             count += InsertQuery::new(table, chunk, block)?
                 .get_results(conn)
@@ -795,7 +795,7 @@ impl Layout {
         // so we need to act in chunks whose size is defined by the number of entities times the
         // number of attributes each entity type has.
         // We add 1 to account for the `block_range` bind parameter
-        let chunk_size = POSTGRES_MAX_PARAMETERS / (table.columns.len() + 1);
+        let chunk_size = POSTGRES_MAX_PARAMETERS / (table.columns.len() + 2);
         for chunk in entities.chunks_mut(chunk_size) {
             count += InsertQuery::new(table, chunk, block)?.execute(conn)?;
         }

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -647,7 +647,7 @@ impl Layout {
         // Each operation must respect the maximum number of bindings allowed in PostgreSQL queries,
         // so we need to act in chunks whose size is defined by the number of entities times the
         // number of attributes each entity type has.
-        // We add 1 to account for the `block_range` bind parameter
+        // We add 2 to account for the `block_range` and 'vid' bind parameters
         let chunk_size = POSTGRES_MAX_PARAMETERS / (table.columns.len() + 2);
         for chunk in entities.chunks_mut(chunk_size) {
             count += InsertQuery::new(table, chunk, block)?
@@ -794,7 +794,7 @@ impl Layout {
         // Each operation must respect the maximum number of bindings allowed in PostgreSQL queries,
         // so we need to act in chunks whose size is defined by the number of entities times the
         // number of attributes each entity type has.
-        // We add 1 to account for the `block_range` bind parameter
+        // We add 2 to account for the `block_range` and 'vid' bind parameters
         let chunk_size = POSTGRES_MAX_PARAMETERS / (table.columns.len() + 2);
         for chunk in entities.chunks_mut(chunk_size) {
             count += InsertQuery::new(table, chunk, block)?.execute(conn)?;


### PR DESCRIPTION
Closes #2330.
I added +2 to chunk size calculation denominator, as @tilacog advises and our subgraph continued indexing.
I don't know internals of `table.columns.len()` - does it counts full-text search columns for example. But with this PR I want to push progress on this issue somehow.
Also I created this PR to 0.26.0 release branch because I tested only that change over 0.26.0 version and I don't know right process.