### PR TITLE
Cosmos: return results

### DIFF
--- a/chain/cosmos/src/chain.rs
+++ b/chain/cosmos/src/chain.rs
@@ -197,7 +197,7 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
         let header_only_block = codec::HeaderOnlyBlock::from(&block);
 
         let mut triggers: Vec<_> = shared_block
-            .begin_block_events()
+            .begin_block_events()?
             .cloned()
             // FIXME (Cosmos): Optimize. Should use an Arc instead of cloning the
             // block. This is not currently possible because EventData is automatically
@@ -205,12 +205,12 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             .filter_map(|event| {
                 filter_event_trigger(filter, event, &header_only_block, EventOrigin::BeginBlock)
             })
-            .chain(shared_block.tx_events().cloned().filter_map(|event| {
+            .chain(shared_block.tx_events()?.cloned().filter_map(|event| {
                 filter_event_trigger(filter, event, &header_only_block, EventOrigin::DeliverTx)
             }))
             .chain(
                 shared_block
-                    .end_block_events()
+                    .end_block_events()?
                     .cloned()
                     .filter_map(|event| {
                         filter_event_trigger(
@@ -316,6 +316,7 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
             ForkStep::StepUndo => {
                 let parent_ptr = sp
                     .parent_ptr()
+                    .map_err(FirehoseError::from)?
                     .expect("Genesis block should never be reverted");
 
                 Ok(BlockStreamEvent::Revert(

--- a/chain/cosmos/src/data_source.rs
+++ b/chain/cosmos/src/data_source.rs
@@ -62,7 +62,7 @@ impl blockchain::DataSource<Chain> for DataSource {
             },
 
             CosmosTrigger::Event { event_data, origin } => {
-                match self.handler_for_event(event_data.event(), *origin) {
+                match self.handler_for_event(event_data.event()?, *origin) {
                     Some(handler) => handler.handler,
                     None => return Ok(None),
                 }


### PR DESCRIPTION
Related to https://github.com/graphprotocol/graph-node/issues/3621

Wherever possible, instead of unwrapping Option fields turn them into Results with "missing field" errors.

The only places still unwrapping are implementations of `graph::blockchain::Block` because its methods don't return Results.

