### PR TITLE
chore: specify genesis block via env

### DIFF
--- a/chain/ethereum/src/env.rs
+++ b/chain/ethereum/src/env.rs
@@ -83,6 +83,12 @@ pub struct EnvVars {
     /// `GRAPH_ETHEREUM_TARGET_TRIGGERS_PER_BLOCK_RANGE`. The default value is
     /// 100.
     pub target_triggers_per_block_range: u64,
+    /// These are some chains, the genesis block is start from 1 not 0. If this
+    /// flag is not set, the default value will be 0.
+    ///
+    /// Set by the flag `GRAPH_ETHEREUM_GENESIS_BLOCK_NUMBER`. The default value
+    /// is 0.
+    pub genesis_block_number: u64,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -124,6 +130,7 @@ impl From<Inner> for EnvVars {
                 .unwrap_or(cfg!(target_os = "macos")),
             cleanup_blocks: x.cleanup_blocks.0,
             target_triggers_per_block_range: x.target_triggers_per_block_range,
+            genesis_block_number: x.genesis_block_number,
         }
     }
 }
@@ -172,4 +179,6 @@ struct Inner {
         default = "100"
     )]
     target_triggers_per_block_range: u64,
+    #[envconfig(from = "GRAPH_ETHEREUM_GENESIS_BLOCK_NUMBER", default = "0")]
+    genesis_block_number: u64,
 }

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -847,7 +847,11 @@ impl EthereumAdapterTrait for EthereumAdapter {
         let web3 = self.web3.clone();
         let metrics = self.metrics.clone();
         let provider = self.provider().to_string();
-        let gen_block_hash_future = retry("eth_getBlockByNumber(0, false) RPC call", &logger)
+        let retry_log_message = format!(
+            "eth_getBlockByNumber({}, false) RPC call",
+            ENV_VARS.genesis_block_number
+        );
+        let gen_block_hash_future = retry(retry_log_message, &logger)
             .no_limit()
             .timeout_secs(30)
             .run(move || {
@@ -856,7 +860,9 @@ impl EthereumAdapterTrait for EthereumAdapter {
                 let provider = provider.clone();
                 async move {
                     web3.eth()
-                        .block(BlockId::Number(Web3BlockNumber::Number(0.into())))
+                        .block(BlockId::Number(Web3BlockNumber::Number(
+                            ENV_VARS.genesis_block_number.into(),
+                        )))
                         .await
                         .map_err(|e| {
                             metrics.set_status(ProviderStatus::GenesisFail, &provider);

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -51,6 +51,8 @@ happens, subgraphs might process inconsistent data. Defaults to 250.
   database. In production environments, it will cause multiple downloads of
   the same blocks and therefore slow the system down. This setting can not
   be used if the store uses more than one shard.
+- `GRAPH_ETHEREUM_GENESIS_BLOCK_NUMBER`: Specify genesis block number. If the flag
+  is not set, the default value will be `0`.
 
 ## Running mapping handlers
 


### PR DESCRIPTION
Currently, the genesis block fixed with `0`, but there are some chains, the genesis block start from `1`. 

This PR support specify the genesis block by `GRAPH_ETHEREUM_GENESIS_BLOCK_NUMBER`, default value is `0`.

Related Issue: https://github.com/graphprotocol/graph-node/issues/3648