### PR TITLE
Revamp handling of earliest block

### DIFF
--- a/docs/implementation/metadata.md
+++ b/docs/implementation/metadata.md
@@ -59,30 +59,30 @@ shard alongside the deployment's data in `sgdNNN`. The table should only
 contain frequently changing data, but for historical reasons contains also
 static data.
 
-| Column                               | Type       | Use                       |
-|--------------------------------------|------------|---------------------------|
-| `id`                                 | `integer!` | primary key, same as `deployment_schemas.id`               |
-| `deployment`                         | `text!`    | IPFS hash                 |
-| `failed`                             | `boolean!` |                           |
-| `synced`                             | `boolean!` |                           |
-| `earliest_ethereum_block_hash`       | `bytea`    | start block from manifest |
-| `earliest_ethereum_block_number`     | `numeric`  |                           |
-| `latest_ethereum_block_hash`         | `bytea`    | current subgraph head     |
-| `latest_ethereum_block_number`       | `numeric`  |                           |
-| `entity_count`                       | `numeric!` | total number of entities  |
-| `graft_base`                         | `text`     | IPFS hash of graft base   |
-| `graft_block_hash`                   | `bytea`    | graft block               |
-| `graft_block_number`                 | `numeric`  |                           |
-| `reorg_count`                        | `integer!` |                           |
-| `current_reorg_depth`                | `integer!` |                           |
-| `max_reorg_depth`                    | `integer!` |                           |
-| `fatal_error`                        | `text`     |                           |
-| `non_fatal_errors`                   | `text[]`   |                           |
-| `health`                             | `health!`  |                           |
-| `last_healthy_ethereum_block_hash`   | `bytea`    |                           |
-| `last_healthy_ethereum_block_number` | `numeric`  |                           |
-| `firehose_cursor`                    | `text`     |                           |
-| `debug_fork`                         | `text`     |                           |
+| Column                               | Type       | Use                                          |
+|--------------------------------------|------------|----------------------------------------------|
+| `id`                                 | `integer!` | primary key, same as `deployment_schemas.id` |
+| `deployment`                         | `text!`    | IPFS hash                                    |
+| `failed`                             | `boolean!` |                                              |
+| `synced`                             | `boolean!` |                                              |
+| `earliest_ethereum_block_hash`       | `bytea`    | start block from manifest (to be removed)    |
+| `earliest_ethereum_block_number`     | `numeric`  |                                              |
+| `latest_ethereum_block_hash`         | `bytea`    | current subgraph head                        |
+| `latest_ethereum_block_number`       | `numeric`  |                                              |
+| `entity_count`                       | `numeric!` | total number of entities                     |
+| `graft_base`                         | `text`     | IPFS hash of graft base                      |
+| `graft_block_hash`                   | `bytea`    | graft block                                  |
+| `graft_block_number`                 | `numeric`  |                                              |
+| `reorg_count`                        | `integer!` |                                              |
+| `current_reorg_depth`                | `integer!` |                                              |
+| `max_reorg_depth`                    | `integer!` |                                              |
+| `fatal_error`                        | `text`     |                                              |
+| `non_fatal_errors`                   | `text[]`   |                                              |
+| `health`                             | `health!`  |                                              |
+| `last_healthy_ethereum_block_hash`   | `bytea`    |                                              |
+| `last_healthy_ethereum_block_number` | `numeric`  |                                              |
+| `firehose_cursor`                    | `text`     |                                              |
+| `debug_fork`                         | `text`     |                                              |
 
 The columns `reorg_count`, `current_reorg_depth`, and `max_reorg_depth` are
 set during indexing. They are used to determine whether a reorg happened
@@ -94,16 +94,18 @@ query.
 Details about a deployment that rarely change. Maintained in the
 shard alongside the deployment's data in `sgdNNN`.
 
-| Column                  | Type       | Use            |
-|-------------------------|------------|----------------|
-| `id`                    | `integer!` | primary key, same as `deployment_schemas.id`    |
-| `spec_version`          | `text!`    |                |
-| `description`           | `text`     |                |
-| `repository`            | `text`     |                |
-| `schema`                | `text!`    | GraphQL schema |
-| `features`              | `text[]!`  |                |
-| `graph_node_version_id` | `integer`  |                |
-| `use_bytea_prefix`      | `boolean!` |                |
+| Column                  | Type       | Use                                          |
+|-------------------------|------------|----------------------------------------------|
+| `id`                    | `integer!` | primary key, same as `deployment_schemas.id` |
+| `spec_version`          | `text!`    |                                              |
+| `description`           | `text`     |                                              |
+| `repository`            | `text`     |                                              |
+| `schema`                | `text!`    | GraphQL schema                               |
+| `features`              | `text[]!`  |                                              |
+| `graph_node_version_id` | `integer`  |                                              |
+| `use_bytea_prefix`      | `boolean!` |                                              |
+| `start_block_hash`      | `bytea`    | Start block from the manifest                |
+| `start_block_number`    | `int4`     |                                              |
 
 ### `subgraph_deployment_assignment`
 

--- a/docs/implementation/metadata.md
+++ b/docs/implementation/metadata.md
@@ -94,18 +94,18 @@ query.
 Details about a deployment that rarely change. Maintained in the
 shard alongside the deployment's data in `sgdNNN`.
 
-| Column                  | Type       | Use                                          |
-|-------------------------|------------|----------------------------------------------|
-| `id`                    | `integer!` | primary key, same as `deployment_schemas.id` |
-| `spec_version`          | `text!`    |                                              |
-| `description`           | `text`     |                                              |
-| `repository`            | `text`     |                                              |
-| `schema`                | `text!`    | GraphQL schema                               |
-| `features`              | `text[]!`  |                                              |
-| `graph_node_version_id` | `integer`  |                                              |
-| `use_bytea_prefix`      | `boolean!` |                                              |
-| `start_block_hash`      | `bytea`    | Start block from the manifest                |
-| `start_block_number`    | `int4`     |                                              |
+| Column                  | Type       | Use                                                  |
+|-------------------------|------------|------------------------------------------------------|
+| `id`                    | `integer!` | primary key, same as `deployment_schemas.id`         |
+| `spec_version`          | `text!`    |                                                      |
+| `description`           | `text`     |                                                      |
+| `repository`            | `text`     |                                                      |
+| `schema`                | `text!`    | GraphQL schema                                       |
+| `features`              | `text[]!`  |                                                      |
+| `graph_node_version_id` | `integer`  |                                                      |
+| `use_bytea_prefix`      | `boolean!` |                                                      |
+| `start_block_hash`      | `bytea`    | Parent of the smallest start block from the manifest |
+| `start_block_number`    | `int4`     |                                                      |
 
 ### `subgraph_deployment_assignment`
 

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -804,6 +804,13 @@ impl DeploymentState {
                 self.id, self.latest_block.number, block
             ));
         }
+        if block < self.earliest_block_number {
+            return Err(format!(
+                "subgraph {} only has data starting at block number {} \
+                            and data for block number {} is therefore not yet available",
+                self.id, self.earliest_block_number, block
+            ));
+        }
         Ok(())
     }
 }

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -792,6 +792,17 @@ impl DeploymentState {
     pub fn is_deployed(&self) -> bool {
         self.latest_ethereum_block_number > 0
     }
+
+    pub fn block_queryable(&self, block: BlockNumber) -> Result<(), String> {
+        if block > self.latest_ethereum_block_number {
+            return Err(format!(
+                "subgraph {} has only indexed up to block number {} \
+                        and data for block number {} is therefore not yet available",
+                self.id, self.latest_ethereum_block_number, block
+            ));
+        }
+        Ok(())
+    }
 }
 
 fn display_vector(input: &[impl std::fmt::Display]) -> impl std::fmt::Display {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -786,6 +786,8 @@ pub struct DeploymentState {
     pub max_reorg_depth: u32,
     /// The last block that the subgraph has processed
     pub latest_block: BlockPtr,
+    /// The earliest block that the subgraph has processed
+    pub earliest_block_number: BlockNumber,
 }
 
 impl DeploymentState {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -25,6 +25,7 @@ use thiserror::Error;
 use wasmparser;
 use web3::types::Address;
 
+use crate::blockchain::BlockPtr;
 use crate::data::store::Entity;
 use crate::data::{
     schema::{Schema, SchemaImportError, SchemaValidationError},
@@ -783,22 +784,22 @@ pub struct DeploymentState {
     /// The maximum number of blocks we ever reorged without moving a block
     /// forward in between
     pub max_reorg_depth: u32,
-    /// The number of the last block that the subgraph has processed
-    pub latest_ethereum_block_number: BlockNumber,
+    /// The last block that the subgraph has processed
+    pub latest_block: BlockPtr,
 }
 
 impl DeploymentState {
     /// Is this subgraph deployed and has it processed any blocks?
     pub fn is_deployed(&self) -> bool {
-        self.latest_ethereum_block_number > 0
+        self.latest_block.number > 0
     }
 
     pub fn block_queryable(&self, block: BlockNumber) -> Result<(), String> {
-        if block > self.latest_ethereum_block_number {
+        if block > self.latest_block.number {
             return Err(format!(
                 "subgraph {} has only indexed up to block number {} \
                         and data for block number {} is therefore not yet available",
-                self.id, self.latest_ethereum_block_number, block
+                self.id, self.latest_block.number, block
             ));
         }
         Ok(())

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -807,7 +807,7 @@ impl DeploymentState {
         if block < self.earliest_block_number {
             return Err(format!(
                 "subgraph {} only has data starting at block number {} \
-                            and data for block number {} is therefore not yet available",
+                            and data for block number {} is therefore not available",
                 self.id, self.earliest_block_number, block
             ));
         }

--- a/graph/src/data/subgraph/status.rs
+++ b/graph/src/data/subgraph/status.rs
@@ -61,8 +61,8 @@ pub struct ChainInfo {
     pub network: String,
     /// The current head block of the chain.
     pub chain_head_block: Option<EthereumBlock>,
-    /// The earliest block available for this subgraph.
-    pub earliest_block: Option<EthereumBlock>,
+    /// The earliest block available for this subgraph (only the number).
+    pub earliest_block_number: BlockNumber,
     /// The latest block that the subgraph has synced to.
     pub latest_block: Option<EthereumBlock>,
 }
@@ -72,7 +72,7 @@ impl IntoValue for ChainInfo {
         let ChainInfo {
             network,
             chain_head_block,
-            earliest_block,
+            earliest_block_number,
             latest_block,
         } = self;
         object! {
@@ -81,7 +81,11 @@ impl IntoValue for ChainInfo {
             __typename: "EthereumIndexingStatus",
             network: network,
             chainHeadBlock: chain_head_block,
-            earliestBlock: earliest_block,
+            earliestBlock: object! {
+                __typename: "EarliestBlock",
+                number: earliest_block_number,
+                hash: "0x0"
+            },
             latestBlock: latest_block,
         }
     }

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -128,7 +128,7 @@ where
             // there is only one reorg of one block, and we therefore avoid
             // flagging a lot of queries a bit behind the head
             let n_blocks = new_state.max_reorg_depth * (new_state.reorg_count - state.reorg_count);
-            if latest_block + n_blocks as u64 > state.latest_ethereum_block_number as u64 {
+            if latest_block + n_blocks as u64 > state.latest_block.number as u64 {
                 return Err(QueryExecutionError::DeploymentReverted);
             }
         }

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -192,6 +192,7 @@ where
             let resolver = StoreResolver::at_block(
                 &self.logger,
                 store.cheap_clone(),
+                &state,
                 self.subscription_manager.cheap_clone(),
                 bc,
                 error_policy,

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1420,6 +1420,12 @@ fn query_at_block_with_vars() {
 
 #[test]
 fn query_detects_reorg() {
+    async fn query_at(deployment: &DeploymentLocator, block: i32) -> QueryResult {
+        let query =
+            format!("query {{ musician(id: \"m1\", block: {{ number: {block} }}) {{ id }} }}");
+        execute_query(&deployment, &query).await
+    }
+
     run_test_sequentially(|store| async move {
         let deployment = setup(
             store.as_ref(),
@@ -1428,7 +1434,7 @@ fn query_detects_reorg() {
             IdType::String,
         )
         .await;
-        let query = "query { musician(id: \"m1\") { id } }";
+        // Initial state with latest block at block 1
         let state = deployment_state(STORE.as_ref(), &deployment.hash).await;
 
         // Inject a fake initial state; c435c25decbc4ad7bbbadf8e0ced0ff2
@@ -1437,7 +1443,7 @@ fn query_detects_reorg() {
             .unwrap() = Some(state);
 
         // When there is no revert, queries work fine
-        let result = execute_query(&deployment, query).await;
+        let result = query_at(&deployment, 1).await;
 
         assert_eq!(
             extract_data!(result),
@@ -1446,19 +1452,20 @@ fn query_detects_reorg() {
 
         // Revert one block
         revert_block(&*STORE, &deployment, &*GENESIS_PTR).await;
-        // A query is still fine since we implicitly query at block 0; we were
-        // at block 1 when we got `state`, and reorged once by one block, which
-        // can not affect block 0, and it's therefore ok to query at block 0
+
+        // A query is still fine since we query at block 0; we were at block
+        // 1 when we got `state`, and reorged once by one block, which can
+        // not affect block 0, and it's therefore ok to query at block 0
         // even with a concurrent reorg
-        let result = execute_query(&deployment, query).await;
+        let result = query_at(&deployment, 0).await;
         assert_eq!(
             extract_data!(result),
             Some(object!(musician: object!(id: "m1")))
         );
 
-        // We move the subgraph head forward, which will execute the query at block 1
-        // But the state we have is also for block 1, but with a smaller reorg count
-        // and we therefore report an error
+        // We move the subgraph head forward. The state we have is also for
+        // block 1, but with a smaller reorg count and we therefore report
+        // an error
         test_store::transact_and_wait(
             &STORE.subgraph_store(),
             &deployment,
@@ -1468,7 +1475,7 @@ fn query_detects_reorg() {
         .await
         .unwrap();
 
-        let result = execute_query(&deployment, query).await;
+        let result = query_at(&deployment, 1).await;
         match result.to_result().unwrap_err()[0] {
             QueryError::ExecutionError(QueryExecutionError::DeploymentReverted) => { /* expected */
             }

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -68,7 +68,7 @@ type SubgraphIndexingStatus {
 interface ChainIndexingStatus {
   network: String!
   chainHeadBlock: Block
-  earliestBlock: Block
+  earliestBlock: EarliestBlock
   latestBlock: Block
   lastHealthyBlock: Block
 }
@@ -76,7 +76,7 @@ interface ChainIndexingStatus {
 type EthereumIndexingStatus implements ChainIndexingStatus {
   network: String!
   chainHeadBlock: Block
-  earliestBlock: Block
+  earliestBlock: EarliestBlock
   latestBlock: Block
   lastHealthyBlock: Block
 }
@@ -98,6 +98,11 @@ type EntityTypeDeletions {
 
 type Block {
   hash: Bytes!
+  number: BigInt!
+}
+
+type EarliestBlock {
+  hash: Bytes! @deprecated(reason: "hash will always be reported as 0x0.")
   number: BigInt!
 }
 

--- a/store/postgres/migrations/2022-06-12-003442_move_earliest_to_manifest/down.sql
+++ b/store/postgres/migrations/2022-06-12-003442_move_earliest_to_manifest/down.sql
@@ -1,0 +1,6 @@
+alter table subgraphs.subgraph_deployment
+      drop column earliest_block_number;
+
+alter table subgraphs.subgraph_manifest
+      drop column start_block_number,
+      drop column start_block_hash;

--- a/store/postgres/migrations/2022-06-12-003442_move_earliest_to_manifest/up.sql
+++ b/store/postgres/migrations/2022-06-12-003442_move_earliest_to_manifest/up.sql
@@ -1,0 +1,16 @@
+alter table subgraphs.subgraph_manifest
+      add column start_block_number int4,
+      add column start_block_hash   bytea;
+
+update subgraphs.subgraph_manifest m
+   set start_block_number = d.earliest_ethereum_block_number,
+       start_block_hash = d.earliest_ethereum_block_hash
+  from subgraphs.subgraph_deployment d
+ where m.id = d.id;
+
+alter table subgraphs.subgraph_deployment
+      add column earliest_block_number int4 not null default 0;
+
+update subgraphs.subgraph_deployment
+   set earliest_block_number = earliest_ethereum_block_number
+ where earliest_ethereum_block_number is not null;

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -110,6 +110,7 @@ table! {
         schema -> Text,
         graph_node_version_id -> Nullable<Integer>,
         use_bytea_prefix -> Bool,
+        /// Parent of the smallest start block from the manifest
         start_block_number -> Nullable<Integer>,
         start_block_hash -> Nullable<Binary>,
     }
@@ -469,7 +470,7 @@ pub fn block_ptr(conn: &PgConnection, id: &DeploymentHash) -> Result<Option<Bloc
 
 /// Initialize the subgraph's block pointer. If the block pointer in
 /// `latest_ethereum_block` is set already, do nothing. If it is still
-/// `null`, set it to `earliest_ethereum_block`
+/// `null`, set it to `start_ethereum_block` from `subgraph_manifest`
 pub fn initialize_block_ptr(conn: &PgConnection, site: &Site) -> Result<(), StoreError> {
     use subgraph_deployment as d;
     use subgraph_manifest as m;

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -1,10 +1,7 @@
 //! Utilities for dealing with deployment metadata. Any connection passed
 //! into these methods must be for the shard that holds the actual
 //! deployment data and metadata
-use crate::{
-    detail::GraphNodeVersion,
-    functions::{coalesce_binary, coalesce_numeric},
-};
+use crate::detail::GraphNodeVersion;
 use diesel::{
     connection::SimpleConnection,
     dsl::{count, delete, insert_into, select, sql, update},
@@ -70,8 +67,10 @@ table! {
         synced -> Bool,
         fatal_error -> Nullable<Text>,
         non_fatal_errors -> Array<Text>,
+        // Not used anymore; only written to keep backwards compatible
         earliest_ethereum_block_hash -> Nullable<Binary>,
         earliest_ethereum_block_number -> Nullable<Numeric>,
+        earliest_block_number -> Integer,
         latest_ethereum_block_hash -> Nullable<Binary>,
         latest_ethereum_block_number -> Nullable<Numeric>,
         last_healthy_ethereum_block_hash -> Nullable<Binary>,
@@ -111,6 +110,8 @@ table! {
         schema -> Text,
         graph_node_version_id -> Nullable<Integer>,
         use_bytea_prefix -> Bool,
+        start_block_number -> Nullable<Integer>,
+        start_block_hash -> Nullable<Binary>,
     }
 }
 
@@ -126,7 +127,7 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(subgraph_deployment, subgraph_error);
+allow_tables_to_appear_in_same_query!(subgraph_deployment, subgraph_error, subgraph_manifest);
 
 /// Look up the graft point for the given subgraph in the database and
 /// return it. If `pending_only` is `true`, only return `Some(_)` if the
@@ -471,28 +472,38 @@ pub fn block_ptr(conn: &PgConnection, id: &DeploymentHash) -> Result<Option<Bloc
 /// `null`, set it to `earliest_ethereum_block`
 pub fn initialize_block_ptr(conn: &PgConnection, site: &Site) -> Result<(), StoreError> {
     use subgraph_deployment as d;
+    use subgraph_manifest as m;
 
-    let init_hash = coalesce_binary(
-        d::latest_ethereum_block_hash,
-        d::earliest_ethereum_block_hash,
-    );
-    let init_number = coalesce_numeric(
-        d::latest_ethereum_block_number,
-        d::earliest_ethereum_block_number,
-    );
-    // Avoid an unnecessary update by filtering for null block pointers
-    update(
-        d::table
-            .filter(d::id.eq(site.id))
-            .filter(d::latest_ethereum_block_hash.is_null()),
-    )
-    .set((
-        d::latest_ethereum_block_hash.eq(init_hash),
-        d::latest_ethereum_block_number.eq(init_number),
-    ))
-    .execute(conn)
-    .map(|_| ())
-    .map_err(|e| e.into())
+    let needs_init = d::table
+        .filter(d::id.eq(site.id))
+        .filter(d::latest_ethereum_block_hash.is_null())
+        .select(d::id)
+        .first::<i32>(conn)
+        .optional()?
+        .is_some();
+
+    if needs_init {
+        if let (Some(hash), Some(number)) = m::table
+            .filter(m::id.eq(site.id))
+            .select((m::start_block_hash, m::start_block_number))
+            .first::<(Option<Vec<u8>>, Option<BlockNumber>)>(conn)?
+        {
+            let number = format!("{}::numeric", number);
+
+            update(d::table.filter(d::id.eq(site.id)))
+                .set((
+                    d::latest_ethereum_block_hash.eq(&hash),
+                    d::latest_ethereum_block_number.eq(sql(&number)),
+                ))
+                .execute(conn)
+                .map(|_| ())
+                .map_err(|e| e.into())
+        } else {
+            Ok(())
+        }
+    } else {
+        Ok(())
+    }
 }
 
 fn convert_to_u32(number: Option<i32>, field: &str, subgraph: &str) -> Result<u32, StoreError> {
@@ -521,7 +532,7 @@ pub fn state(conn: &PgConnection, id: DeploymentHash) -> Result<DeploymentState,
             d::max_reorg_depth,
             d::latest_ethereum_block_number,
             d::latest_ethereum_block_hash,
-            d::earliest_ethereum_block_number,
+            d::earliest_block_number,
         ))
         .first::<(
             String,
@@ -529,7 +540,7 @@ pub fn state(conn: &PgConnection, id: DeploymentHash) -> Result<DeploymentState,
             i32,
             Option<BigDecimal>,
             Option<Vec<u8>>,
-            Option<BigDecimal>,
+            BlockNumber,
         )>(conn)
         .optional()?
     {
@@ -562,18 +573,6 @@ pub fn state(conn: &PgConnection, id: DeploymentHash) -> Result<DeploymentState,
                 ))
             })?
             .to_ptr();
-            let earliest_block_number = earliest_block_number
-                .map(|number| {
-                    number.to_i32().ok_or_else(|| {
-                        constraint_violation!(
-                            "invalid value {:?} for earliest_block_number in subgraph {}",
-                            number,
-                            id
-                        )
-                    })
-                })
-                .transpose()?
-                .unwrap_or(0);
             Ok(DeploymentState {
                 id,
                 reorg_count,
@@ -942,6 +941,7 @@ pub fn create_deployment(
         graft_block,
         debug_fork,
     } = deployment;
+    let earliest_block_number = earliest_block.as_ref().map(|ptr| ptr.number).unwrap_or(0);
 
     let deployment_values = (
         d::id.eq(site.id),
@@ -953,6 +953,7 @@ pub fn create_deployment(
         d::non_fatal_errors.eq::<Vec<String>>(vec![]),
         d::earliest_ethereum_block_hash.eq(b(&earliest_block)),
         d::earliest_ethereum_block_number.eq(n(&earliest_block)),
+        d::earliest_block_number.eq(earliest_block_number),
         d::latest_ethereum_block_hash.eq(sql("null")),
         d::latest_ethereum_block_number.eq(sql("null")),
         d::entity_count.eq(sql("0")),
@@ -975,6 +976,8 @@ pub fn create_deployment(
         // New subgraphs index only a prefix of bytea columns
         // see: attr-bytea-prefix
         m::use_bytea_prefix.eq(true),
+        m::start_block_hash.eq(b(&earliest_block)),
+        m::start_block_number.eq(earliest_block_number),
     );
 
     if exists && replace {

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -49,8 +49,11 @@ pub struct DeploymentDetail {
     pub synced: bool,
     fatal_error: Option<String>,
     non_fatal_errors: Vec<String>,
+    // Not used anymore; only written to keep backwards compatible
     earliest_ethereum_block_hash: Option<Bytes>,
     earliest_ethereum_block_number: Option<BigDecimal>,
+    // New tracker for earliest block number
+    earliest_block_number: i32,
     pub latest_ethereum_block_hash: Option<Bytes>,
     pub latest_ethereum_block_number: Option<BigDecimal>,
     last_healthy_ethereum_block_hash: Option<Bytes>,
@@ -342,6 +345,8 @@ struct StoredSubgraphManifest {
     schema: String,
     graph_node_version_id: Option<i32>,
     use_bytea_prefix: bool,
+    start_block_number: Option<i32>,
+    start_block_hash: Option<Bytes>,
 }
 
 impl From<StoredSubgraphManifest> for SubgraphManifestEntity {

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -193,8 +193,7 @@ pub(crate) fn info_from_details(
         synced,
         fatal_error: _,
         non_fatal_errors: _,
-        earliest_ethereum_block_hash,
-        earliest_ethereum_block_number,
+        earliest_block_number,
         latest_ethereum_block_hash,
         latest_ethereum_block_number,
         entity_count,
@@ -212,12 +211,6 @@ pub(crate) fn info_from_details(
     // This needs to be filled in later since it lives in a
     // different shard
     let chain_head_block = None;
-    let earliest_block = block(
-        &deployment,
-        "earliest_ethereum_block",
-        earliest_ethereum_block_hash,
-        earliest_ethereum_block_number,
-    )?;
     let latest_block = block(
         &deployment,
         "latest_ethereum_block",
@@ -228,7 +221,7 @@ pub(crate) fn info_from_details(
     let chain = status::ChainInfo {
         network: site.network.clone(),
         chain_head_block,
-        earliest_block,
+        earliest_block_number,
         latest_block,
     };
     let entity_count = entity_count.to_u64().ok_or_else(|| {

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -2015,7 +2015,7 @@ fn reorg_tracking() {
             assert_eq!($reorg_count, state.reorg_count, "reorg_count");
             assert_eq!($max_reorg_depth, state.max_reorg_depth, "max_reorg_depth");
             assert_eq!(
-                $latest_ethereum_block_number, state.latest_ethereum_block_number,
+                $latest_ethereum_block_number, state.latest_block.number,
                 "latest_ethereum_block_number"
             );
         };

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -446,12 +446,14 @@ async fn execute_subgraph_query_internal(
         .query_store(deployment.into(), false)
         .await
         .unwrap();
+    let state = store.deployment_state().await.unwrap();
     for (bc, (selection_set, error_policy)) in return_err!(query.block_constraint()) {
         let logger = logger.clone();
         let resolver = return_err!(
             StoreResolver::at_block(
                 &logger,
                 store.clone(),
+                &state,
                 SUBSCRIPTION_MANAGER.clone(),
                 bc,
                 error_policy,


### PR DESCRIPTION
This change is needed to implement subgraph pruning - for that, we do not want to track the hash of the earliest block so that we can perform a large prune operation in batches and update the earliest block after each batch. Since we don't have a reliable way to get the hash for a block number from deep inside the store, we need to not track that.

So far, the earliest block was always the start block of a subgraph; with pruning that will change. To clarify that, we now store the start block ptr in `subgraph_manifest` and only keep the earliest block number in `subgraph_deployment`. The table still has the `earliest_ethereum_block` block pointer, but that is only there to simplify rollbacks and will be removed in a future PR once this PR has been deployed and looks stable.

The PR changes the `earliestBlock` field in the `index-node` API in such a way that the `hash` field still appears in the output but will always be `0x0`