### PR TITLE
Fast PoI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,7 +1480,6 @@ dependencies = [
  "prost-types",
  "rand",
  "reqwest",
- "second-stack",
  "semver",
  "serde",
  "serde_derive",
@@ -1590,7 +1589,6 @@ dependencies = [
  "pretty_assertions 0.7.2",
  "prost",
  "prost-types",
- "second-stack",
  "serde",
  "test-store",
  "tonic-build",
@@ -1735,7 +1733,6 @@ dependencies = [
  "lazy_static",
  "never",
  "parity-wasm",
- "second-stack",
  "semver",
  "strum",
  "strum_macros",
@@ -3586,12 +3583,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "second-stack"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c110c6371f7ca1a06d3166b235c3237ac48a8c688196f5967091990f1e3f76"
 
 [[package]]
 name = "secp256k1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,6 +1480,7 @@ dependencies = [
  "prost-types",
  "rand",
  "reqwest",
+ "second-stack",
  "semver",
  "serde",
  "serde_derive",
@@ -3583,6 +3584,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "second-stack"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f766a31680976a8b86ca6a81e37de0047d43a5a6a3354d5fe1240955d71b18e"
 
 [[package]]
 name = "secp256k1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,8 +1491,8 @@ dependencies = [
  "slog-async",
  "slog-envlogger",
  "slog-term",
- "stable-hash 0.3.2",
- "stable-hash 0.4.1",
+ "stable-hash 0.3.3",
+ "stable-hash 0.4.2",
  "structopt",
  "strum",
  "strum_macros",
@@ -1643,8 +1643,8 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "pretty_assertions 1.2.1",
- "stable-hash 0.3.2",
- "stable-hash 0.4.1",
+ "stable-hash 0.3.3",
+ "stable-hash 0.4.2",
  "test-store",
 ]
 
@@ -1848,7 +1848,7 @@ dependencies = [
  "postgres-openssl",
  "rand",
  "serde",
- "stable-hash 0.3.2",
+ "stable-hash 0.3.3",
  "test-store",
  "uuid 1.1.2",
 ]
@@ -3922,9 +3922,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable-hash"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2dfeb73d08f4ae1f48059f31f53a3768fad3dc54622631e0a3eff1d07a4ca19"
+checksum = "10196e68950ed99c0d2db7a30ffaf4dfe0bbf2f9af2ae0457ee8ad396e0a2dd7"
 dependencies = [
  "blake3 0.3.8",
  "firestorm 0.4.6",
@@ -3936,9 +3936,9 @@ dependencies = [
 
 [[package]]
 name = "stable-hash"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442fcfd15605146b373dafa4bea8368e98d9b51350e5da5a44ab2923c5ac3ca8"
+checksum = "af75bd21beb162eab69de76abbb803d4111735ead00d5086dcc6f4ddb3b53cc9"
 dependencies = [
  "blake3 0.3.8",
  "firestorm 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,6 +1590,7 @@ dependencies = [
  "pretty_assertions 0.7.2",
  "prost",
  "prost-types",
+ "second-stack",
  "serde",
  "test-store",
  "tonic-build",
@@ -1734,6 +1735,7 @@ dependencies = [
  "lazy_static",
  "never",
  "parity-wasm",
+ "second-stack",
  "semver",
  "strum",
  "strum_macros",
@@ -3587,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "second-stack"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f766a31680976a8b86ca6a81e37de0047d43a5a6a3354d5fe1240955d71b18e"
+checksum = "f4c110c6371f7ca1a06d3166b235c3237ac48a8c688196f5967091990f1e3f76"
 
 [[package]]
 name = "secp256k1"

--- a/chain/near/Cargo.toml
+++ b/chain/near/Cargo.toml
@@ -12,7 +12,6 @@ graph = { path = "../../graph" }
 prost = "0.10.1"
 prost-types = "0.10.1"
 serde = "1.0"
-second-stack = "0.3.3"
 
 graph-runtime-wasm = { path = "../../runtime/wasm" }
 graph-runtime-derive = { path = "../../runtime/derive" }

--- a/chain/near/Cargo.toml
+++ b/chain/near/Cargo.toml
@@ -12,6 +12,7 @@ graph = { path = "../../graph" }
 prost = "0.10.1"
 prost-types = "0.10.1"
 serde = "1.0"
+second-stack = "0.3.3"
 
 graph-runtime-wasm = { path = "../../runtime/wasm" }
 graph-runtime-derive = { path = "../../runtime/derive" }

--- a/chain/near/src/trigger.rs
+++ b/chain/near/src/trigger.rs
@@ -153,7 +153,6 @@ mod tests {
         runtime::gas::GasCounter,
         util::mem::init_slice,
     };
-    use second_stack::Stack;
 
     #[test]
     fn block_trigger_to_asc_ptr() {
@@ -424,7 +423,6 @@ mod tests {
 
     struct BytesHeap {
         api_version: graph::semver::Version,
-        stack: Stack,
         memory: Vec<u8>,
     }
 
@@ -433,7 +431,6 @@ mod tests {
             Self {
                 api_version,
                 memory: vec![],
-                stack: Stack::new(),
             }
         }
     }
@@ -452,10 +449,6 @@ mod tests {
             let mut data = [std::mem::MaybeUninit::<u8>::uninit(); 4];
             let init = self.read(offset, &mut data, gas)?;
             Ok(u32::from_le_bytes(init.try_into().unwrap()))
-        }
-
-        fn stack(&self) -> &Stack {
-            &self.stack
         }
 
         fn read<'a>(

--- a/chain/near/src/trigger.rs
+++ b/chain/near/src/trigger.rs
@@ -450,7 +450,7 @@ mod tests {
 
         fn read_u32(&self, offset: u32, gas: &GasCounter) -> Result<u32, DeterministicHostError> {
             let mut data = [std::mem::MaybeUninit::<u8>::uninit(); 4];
-            let init = self.init(offset, &mut data, gas)?;
+            let init = self.read(offset, &mut data, gas)?;
             Ok(u32::from_le_bytes(init.try_into().unwrap()))
         }
 
@@ -458,8 +458,8 @@ mod tests {
             &self.stack
         }
 
-        fn init<'s, 'a>(
-            &'s self,
+        fn read<'a>(
+            &self,
             offset: u32,
             buffer: &'a mut [std::mem::MaybeUninit<u8>],
             _gas: &GasCounter,

--- a/chain/near/src/trigger.rs
+++ b/chain/near/src/trigger.rs
@@ -5,11 +5,7 @@ use graph::cheap_clone::CheapClone;
 use graph::prelude::hex;
 use graph::prelude::web3::types::H256;
 use graph::prelude::BlockNumber;
-use graph::runtime::asc_new;
-use graph::runtime::gas::GasCounter;
-use graph::runtime::AscHeap;
-use graph::runtime::AscPtr;
-use graph::runtime::DeterministicHostError;
+use graph::runtime::{asc_new, gas::GasCounter, AscHeap, AscPtr, DeterministicHostError};
 use std::{cmp::Ordering, sync::Arc};
 
 use crate::codec;
@@ -146,7 +142,7 @@ pub struct ReceiptWithOutcome {
 
 #[cfg(test)]
 mod tests {
-    use std::{convert::TryFrom, mem::MaybeUninit};
+    use std::convert::TryFrom;
 
     use super::*;
 
@@ -155,6 +151,7 @@ mod tests {
         data::subgraph::API_VERSION_0_0_5,
         prelude::{hex, BigInt},
         runtime::gas::GasCounter,
+        util::mem::init_slice,
     };
     use second_stack::Stack;
 
@@ -495,15 +492,7 @@ mod tests {
 
             let src = &self.memory[start_offset..end_offset_exclusive];
 
-            // See also 6d2f040c-9361-4cf9-8b3c-426f87cc0b21
-            unsafe {
-                let uninit_src: &[MaybeUninit<u8>] = std::mem::transmute(src);
-                buffer.copy_from_slice(uninit_src);
-                // This is copied from slice_assume_init_mut, which is
-                // currently an unstable API
-                let buffer = &mut *(buffer as *mut [MaybeUninit<u8>] as *mut [u8]);
-                Ok(buffer)
-            }
+            Ok(init_slice(src, buffer))
         }
 
         fn api_version(&self) -> graph::semver::Version {

--- a/chain/near/src/trigger.rs
+++ b/chain/near/src/trigger.rs
@@ -438,7 +438,7 @@ mod tests {
         }
     }
 
-    unsafe impl AscHeap for BytesHeap {
+    impl AscHeap for BytesHeap {
         fn raw_new(
             &mut self,
             bytes: &[u8],
@@ -446,6 +446,12 @@ mod tests {
         ) -> Result<u32, DeterministicHostError> {
             self.memory.extend_from_slice(bytes);
             Ok((self.memory.len() - bytes.len()) as u32)
+        }
+
+        fn read_u32(&self, offset: u32, gas: &GasCounter) -> Result<u32, DeterministicHostError> {
+            let mut data = [std::mem::MaybeUninit::<u8>::uninit(); 4];
+            let init = self.init(offset, &mut data, gas)?;
+            Ok(u32::from_le_bytes(init.try_into().unwrap()))
         }
 
         fn init<'s, 'a>(

--- a/chain/near/src/trigger.rs
+++ b/chain/near/src/trigger.rs
@@ -156,6 +156,7 @@ mod tests {
         prelude::{hex, BigInt},
         runtime::gas::GasCounter,
     };
+    use second_stack::Stack;
 
     #[test]
     fn block_trigger_to_asc_ptr() {
@@ -426,6 +427,7 @@ mod tests {
 
     struct BytesHeap {
         api_version: graph::semver::Version,
+        stack: Stack,
         memory: Vec<u8>,
     }
 
@@ -434,6 +436,7 @@ mod tests {
             Self {
                 api_version,
                 memory: vec![],
+                stack: Stack::new(),
             }
         }
     }
@@ -452,6 +455,10 @@ mod tests {
             let mut data = [std::mem::MaybeUninit::<u8>::uninit(); 4];
             let init = self.init(offset, &mut data, gas)?;
             Ok(u32::from_le_bytes(init.try_into().unwrap()))
+        }
+
+        fn stack(&self) -> &Stack {
+            &self.stack
         }
 
         fn init<'s, 'a>(

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -10,7 +10,10 @@ use graph::blockchain::block_stream::{BlockStreamEvent, BlockWithTriggers};
 use graph::blockchain::{Block, Blockchain, DataSource, TriggerFilter as _};
 use graph::components::{
     store::ModificationsAndCache,
-    subgraph::{CausalityRegion, MappingError, ProofOfIndexing, SharedProofOfIndexing},
+    subgraph::{
+        CausalityRegion, MappingError, ProofOfIndexing, ProofOfIndexingVersion,
+        SharedProofOfIndexing,
+    },
 };
 use graph::data::store::scalar::Bytes;
 use graph::data::subgraph::{
@@ -162,6 +165,10 @@ where
         let proof_of_indexing = if self.inputs.store.supports_proof_of_indexing().await? {
             Some(Arc::new(AtomicRefCell::new(ProofOfIndexing::new(
                 block_ptr.number,
+                // TODO: (Fast PoI) This should also support the Fast
+                // variant when indicated by the subgraph manifest.
+                // See also a0a79c0f-919f-4d97-a82 a-439a1ff78230
+                ProofOfIndexingVersion::Legacy,
             ))))
         } else {
             None

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -34,8 +34,8 @@ serde_derive = "1.0.125"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 serde_yaml = "0.8"
 slog = { version = "2.7.0", features = ["release_max_level_trace", "max_level_trace"] }
-stable-hash_legacy = { version = "0.3.2", package = "stable-hash" }
-stable-hash = { version = "0.4.1"}
+stable-hash_legacy = { version = "0.3.3", package = "stable-hash" }
+stable-hash = { version = "0.4.2"}
 strum = "0.21.0"
 strum_macros = "0.21.1"
 slog-async = "2.5.0"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -28,7 +28,6 @@ num_cpus = "1.13.1"
 num-traits = "0.2.15"
 rand = "0.8.4"
 semver = { version = "1.0.12", features = ["serde"] }
-second-stack = "0.3.3"
 serde = { version = "1.0.126", features = ["rc"] }
 serde_derive = "1.0.125"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -28,6 +28,7 @@ num_cpus = "1.13.1"
 num-traits = "0.2.15"
 rand = "0.8.4"
 semver = { version = "1.0.12", features = ["serde"] }
+second-stack = "0.3.3"
 serde = { version = "1.0.126", features = ["rc"] }
 serde_derive = "1.0.125"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/graph/src/components/subgraph/mod.rs
+++ b/graph/src/components/subgraph/mod.rs
@@ -11,8 +11,8 @@ pub use self::host::{HostMetrics, MappingError, RuntimeHost, RuntimeHostBuilder}
 pub use self::instance::{BlockState, DataSourceTemplateInfo};
 pub use self::instance_manager::SubgraphInstanceManager;
 pub use self::proof_of_indexing::{
-    BlockEventStream, CausalityRegion, ProofOfIndexing, ProofOfIndexingEvent,
-    ProofOfIndexingFinisher, SharedProofOfIndexing,
+    CausalityRegion, ProofOfIndexing, ProofOfIndexingEvent, ProofOfIndexingFinisher,
+    ProofOfIndexingVersion, SharedProofOfIndexing,
 };
 pub use self::provider::SubgraphAssignmentProvider;
 pub use self::registrar::{SubgraphRegistrar, SubgraphVersionSwitchingMode};

--- a/graph/src/components/subgraph/proof_of_indexing/mod.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/mod.rs
@@ -48,20 +48,20 @@ mod tests {
     use web3::types::{Address, H256};
 
     /// Verify that the stable hash of a reference and online implementation match
-    fn check(reference: &PoI, cache: &mut HashMap<String, &str>, name: &'static str) {
+    fn check(case: Case, cache: &mut HashMap<String, &str>) {
         let logger = Logger::root(Discard, o!());
 
         // Does a sanity check to ensure that the schema itself is correct,
         // which is separate to verifying that the online/offline version
         // return the same result.
-        check_for_child_errors(reference).expect("Found child errors");
+        check_for_child_errors(&case.data).expect("Found child errors");
 
-        let offline_fast = tiny_keccak::keccak256(&fast_stable_hash(&reference).to_le_bytes());
-        let offline_legacy = stable_hash_legacy::<SetHasher, _>(reference);
+        let offline_fast = tiny_keccak::keccak256(&fast_stable_hash(&case.data).to_le_bytes());
+        let offline_legacy = stable_hash_legacy::<SetHasher, _>(&case.data);
 
-        for (version, offline) in [
-            (ProofOfIndexingVersion::Legacy, offline_legacy),
-            (ProofOfIndexingVersion::Fast, offline_fast),
+        for (version, offline, hardcoded) in [
+            (ProofOfIndexingVersion::Legacy, offline_legacy, case.legacy),
+            (ProofOfIndexingVersion::Fast, offline_fast, case.fast),
         ] {
             // The code is meant to approximate what happens during indexing as
             // close as possible. The API for the online PoI is meant to be
@@ -71,7 +71,7 @@ mod tests {
             let mut db = HashMap::<String, Vec<u8>>::new();
 
             let mut block_count = 1;
-            for causality_region in reference.causality_regions.values() {
+            for causality_region in case.data.causality_regions.values() {
                 block_count = causality_region.blocks.len();
                 break;
             }
@@ -79,7 +79,7 @@ mod tests {
             for block_i in 0..block_count {
                 let mut stream = ProofOfIndexing::new(block_i.try_into().unwrap(), version);
 
-                for (name, region) in reference.causality_regions.iter() {
+                for (name, region) in case.data.causality_regions.iter() {
                     let block = &region.blocks[block_i];
 
                     for evt in block.events.iter() {
@@ -95,13 +95,13 @@ mod tests {
             }
 
             let block_number = (block_count - 1) as u64;
-            let block_ptr = BlockPtr::from((reference.block_hash, block_number));
+            let block_ptr = BlockPtr::from((case.data.block_hash, block_number));
 
             // This region emulates the request
             let mut finisher = ProofOfIndexingFinisher::new(
                 &block_ptr,
-                &reference.subgraph_id,
-                &reference.indexer,
+                &case.data.subgraph_id,
+                &case.data.indexer,
                 version,
             );
             for (name, region) in db.iter() {
@@ -111,11 +111,19 @@ mod tests {
             let online = hex::encode(finisher.finish());
             let offline = hex::encode(&offline);
             assert_eq!(&online, &offline);
+            assert_eq!(&online, hardcoded);
 
-            if let Some(prev) = cache.insert(offline, name) {
-                panic!("Found conflict for case: {} == {}", name, prev);
+            if let Some(prev) = cache.insert(offline, case.name) {
+                panic!("Found conflict for case: {} == {}", case.name, prev);
             }
         }
+    }
+
+    struct Case<'a> {
+        name: &'static str,
+        legacy: &'static str,
+        fast: &'static str,
+        data: PoI<'a>,
     }
 
     /// This test checks that each case resolves to a unique hash, and that
@@ -131,159 +139,180 @@ mod tests {
             "null".to_owned() => Value::Null,
         };
 
-        let mut cases = hashmap! {
+        let mut cases = vec![
             // Simple case of basically nothing
-            "genesis" => PoI {
-                subgraph_id: DeploymentHash::new("test").unwrap(),
-                block_hash: H256::repeat_byte(1),
-                causality_regions: HashMap::new(),
-                indexer: None,
+            Case {
+                name: "genesis",
+                legacy: "401e5bef572bc3a56b0ced0eb6cb4619d2ca748db6af8855828d16ff3446cfdd",
+                fast: "dced49c45eac68e8b3d8f857928e7be6c270f2db8b56b0d7f27ce725100bae01",
+                data: PoI {
+                    subgraph_id: DeploymentHash::new("test").unwrap(),
+                    block_hash: H256::repeat_byte(1),
+                    causality_regions: HashMap::new(),
+                    indexer: None,
+                },
             },
-
             // Add an event
-            "one_event" => PoI {
-                subgraph_id: DeploymentHash::new("test").unwrap(),
-                block_hash: H256::repeat_byte(1),
-                causality_regions: hashmap! {
-                    "eth".to_owned() => CausalityRegion {
-                        blocks: vec! [
-                            Block::default(),
-                            Block {
-                                events: vec![
-                                    ProofOfIndexingEvent::SetEntity {
-                                        entity_type: "t",
-                                        id: "id",
-                                        data: &data_empty,
-                                    }
-                                ]
-                            }
-                        ],
+            Case {
+                name: "one_event",
+                legacy: "9241634bfc8a9a12c796a0de6f326326a74967cd477ee7ce78fbac20a9e9c303",
+                fast: "bb3c37659d4bc799b9dcf3d17b1b1e93847f5fc0b2c50ee6a27f13b5c07f7e97",
+                data: PoI {
+                    subgraph_id: DeploymentHash::new("test").unwrap(),
+                    block_hash: H256::repeat_byte(1),
+                    causality_regions: hashmap! {
+                        "eth".to_owned() => CausalityRegion {
+                            blocks: vec! [
+                                Block::default(),
+                                Block {
+                                    events: vec![
+                                        ProofOfIndexingEvent::SetEntity {
+                                            entity_type: "t",
+                                            id: "id",
+                                            data: &data_empty,
+                                        }
+                                    ]
+                                }
+                            ],
+                        },
                     },
+                    indexer: Some(Address::repeat_byte(1)),
                 },
-                indexer: Some(Address::repeat_byte(1)),
             },
-
             // Try adding a couple more blocks, including an empty block on the end
-            "multiple_blocks" => PoI {
-                subgraph_id: DeploymentHash::new("b").unwrap(),
-                block_hash: H256::repeat_byte(3),
-                causality_regions: hashmap! {
-                    "eth".to_owned() => CausalityRegion {
-                        blocks: vec! [
-                            Block::default(),
-                            Block {
-                                events: vec![
-                                    ProofOfIndexingEvent::SetEntity {
-                                        entity_type: "type",
-                                        id: "id",
-                                        data: &data,
-                                    }
-                                ]
-                            },
-                            Block::default(),
-                            Block {
-                                events: vec![
-                                    ProofOfIndexingEvent::SetEntity {
-                                        entity_type: "type",
-                                        id: "id",
-                                        data: &data_empty,
-                                    }
-                                ]
-                            },
-                            Block::default(),
-                        ],
+            Case {
+                name: "multiple_blocks",
+                legacy: "775fa30bbaef2a8659456a317923a36f46e3715e6c9cf43203dd3486af4e361f",
+                fast: "3bb882049e8f4a11cd4a7a005c6ce3b3c779a0e90057a9556c595660e626268d",
+                data: PoI {
+                    subgraph_id: DeploymentHash::new("b").unwrap(),
+                    block_hash: H256::repeat_byte(3),
+                    causality_regions: hashmap! {
+                        "eth".to_owned() => CausalityRegion {
+                            blocks: vec! [
+                                Block::default(),
+                                Block {
+                                    events: vec![
+                                        ProofOfIndexingEvent::SetEntity {
+                                            entity_type: "type",
+                                            id: "id",
+                                            data: &data,
+                                        }
+                                    ]
+                                },
+                                Block::default(),
+                                Block {
+                                    events: vec![
+                                        ProofOfIndexingEvent::SetEntity {
+                                            entity_type: "type",
+                                            id: "id",
+                                            data: &data_empty,
+                                        }
+                                    ]
+                                },
+                                Block::default(),
+                            ],
+                        },
                     },
+                    indexer: Some(Address::repeat_byte(1)),
                 },
-                indexer: Some(Address::repeat_byte(1)),
             },
-
             // Try adding another causality region
-            "causality_regions" => PoI {
-                subgraph_id: DeploymentHash::new("b").unwrap(),
-                block_hash: H256::repeat_byte(3),
-                causality_regions: hashmap! {
-                    "eth".to_owned() => CausalityRegion {
-                        blocks: vec! [
-                            Block::default(),
-                            Block {
-                                events: vec![
-                                    ProofOfIndexingEvent::SetEntity {
-                                        entity_type: "type",
-                                        id: "id",
-                                        data: &data2,
-                                    }
-                                ]
-                            },
-                            Block::default(),
-                            Block {
-                                events: vec![
-                                    ProofOfIndexingEvent::RemoveEntity {
-                                        entity_type: "type",
-                                        id: "id",
-                                    }
-                                ]
-                            },
-                            Block::default(),
-                        ],
+            Case {
+                name: "causality_regions",
+                legacy: "13e6fd2b581911c80d935d4f098b40ef3d87cbc564b5a635c81b06091a381e54",
+                fast: "b2cb70acd4a1337a67df810fe4c5c2fb3d3a3b2b8eb137dbb592bd6014869362",
+                data: PoI {
+                    subgraph_id: DeploymentHash::new("b").unwrap(),
+                    block_hash: H256::repeat_byte(3),
+                    causality_regions: hashmap! {
+                        "eth".to_owned() => CausalityRegion {
+                            blocks: vec! [
+                                Block::default(),
+                                Block {
+                                    events: vec![
+                                        ProofOfIndexingEvent::SetEntity {
+                                            entity_type: "type",
+                                            id: "id",
+                                            data: &data2,
+                                        }
+                                    ]
+                                },
+                                Block::default(),
+                                Block {
+                                    events: vec![
+                                        ProofOfIndexingEvent::RemoveEntity {
+                                            entity_type: "type",
+                                            id: "id",
+                                        }
+                                    ]
+                                },
+                                Block::default(),
+                            ],
+                        },
+                        "ipfs".to_owned() => CausalityRegion {
+                            blocks: vec! [
+                                Block::default(),
+                                Block {
+                                    events: vec![
+                                        ProofOfIndexingEvent::SetEntity {
+                                            entity_type: "type",
+                                            id: "id",
+                                            data: &data,
+                                        }
+                                    ]
+                                },
+                                Block::default(),
+                                Block {
+                                    events: vec![
+                                        ProofOfIndexingEvent::SetEntity {
+                                            entity_type: "type",
+                                            id: "id",
+                                            data: &data,
+                                        }
+                                    ]
+                                },
+                                Block::default(),
+                            ],
+                        },
                     },
-                    "ipfs".to_owned() => CausalityRegion {
-                        blocks: vec! [
-                            Block::default(),
-                            Block {
-                                events: vec![
-                                    ProofOfIndexingEvent::SetEntity {
-                                        entity_type: "type",
-                                        id: "id",
-                                        data: &data,
-                                    }
-                                ]
-                            },
-                            Block::default(),
-                            Block {
-                                events: vec![
-                                    ProofOfIndexingEvent::SetEntity {
-                                        entity_type: "type",
-                                        id: "id",
-                                        data: &data,
-                                    }
-                                ]
-                            },
-                            Block::default(),
-                        ],
-                    },
+                    indexer: Some(Address::repeat_byte(1)),
                 },
-                indexer: Some(Address::repeat_byte(1)),
             },
-
             // Back to the one event case, but try adding some data.
-            "data" => PoI {
-                subgraph_id: DeploymentHash::new("test").unwrap(),
-                block_hash: H256::repeat_byte(1),
-                causality_regions: hashmap! {
-                    "eth".to_owned() => CausalityRegion {
-                        blocks: vec! [
-                            Block::default(),
-                            Block {
-                                events: vec![
-                                    ProofOfIndexingEvent::SetEntity {
-                                        entity_type: "type",
-                                        id: "id",
-                                        data: &data,
-                                    }
-                                ]
-                            }
-                        ],
+            Case {
+                name: "data",
+                legacy: "cd3020511cf4c88dd2be542aca4f95bb2a67b06e29f444bcdf44009933b8ff31",
+                fast: "a992ba24702615a3f591014f7351acf85a35b75e1f8646fc8d77509c4b5d31ed",
+                data: PoI {
+                    subgraph_id: DeploymentHash::new("test").unwrap(),
+                    block_hash: H256::repeat_byte(1),
+                    causality_regions: hashmap! {
+                        "eth".to_owned() => CausalityRegion {
+                            blocks: vec! [
+                                Block::default(),
+                                Block {
+                                    events: vec![
+                                        ProofOfIndexingEvent::SetEntity {
+                                            entity_type: "type",
+                                            id: "id",
+                                            data: &data,
+                                        }
+                                    ]
+                                }
+                            ],
+                        },
                     },
+                    indexer: Some(Address::repeat_byte(4)),
                 },
-                indexer: Some(Address::repeat_byte(4)),
             },
-        };
+        ];
 
         // Lots of data up there ⬆️ to test. Finally, loop over each case, comparing the reference and
         // online version, then checking that there are no conflicts for the reference versions.
         let mut results = HashMap::new();
-        for (name, data) in cases.drain() {
-            check(&data, &mut results, name);
+        for case in cases.drain(..) {
+            check(case, &mut results);
         }
     }
 }

--- a/graph/src/components/subgraph/proof_of_indexing/online.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/online.rs
@@ -2,26 +2,64 @@
 //! Any hash constructed from here should be the same as if the same data was given
 //! to the reference implementation, but this is updated incrementally
 
-use super::ProofOfIndexingEvent;
+use super::{ProofOfIndexingEvent, ProofOfIndexingVersion};
 use crate::{
     blockchain::BlockPtr,
     prelude::{debug, BlockNumber, DeploymentHash, Logger, ENV_VARS},
+    util::stable_hash_glue::AsBytes,
 };
+use stable_hash::{fast::FastStableHasher, FieldAddress, StableHash, StableHasher};
 use stable_hash_legacy::crypto::{Blake3SeqNo, SetHasher};
-use stable_hash_legacy::prelude::*;
-use stable_hash_legacy::utils::AsBytes;
+use stable_hash_legacy::prelude::{
+    StableHash as StableHashLegacy, StableHasher as StableHasherLegacy, *,
+};
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt;
 use web3::types::Address;
 
-pub enum BlockEventStream {
-    LegacyHasherStream {
-        vec_length: u64,
-        handler_start: u64,
-        seq_no: Blake3SeqNo,
-        digest: SetHasher,
-    },
+pub struct BlockEventStream {
+    vec_length: u64,
+    handler_start: u64,
+    block_index: u64,
+    hasher: Hashers,
+}
+
+enum Hashers {
+    Fast(FastStableHasher),
+    Legacy(SetHasher),
+}
+
+impl Hashers {
+    fn new(version: ProofOfIndexingVersion) -> Self {
+        match version {
+            ProofOfIndexingVersion::Legacy => Hashers::Legacy(SetHasher::new()),
+            ProofOfIndexingVersion::Fast => Hashers::Fast(FastStableHasher::new()),
+        }
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Self {
+        match bytes.try_into() {
+            Ok(bytes) => Hashers::Fast(FastStableHasher::from_bytes(bytes)),
+            Err(_) => Hashers::Legacy(SetHasher::from_bytes(bytes)),
+        }
+    }
+
+    fn write<T>(&mut self, value: &T, children: &[u64])
+    where
+        T: StableHash + StableHashLegacy,
+    {
+        match self {
+            Hashers::Fast(fast) => {
+                let addr = children.iter().fold(u128::root(), |s, i| s.child(*i));
+                StableHash::stable_hash(value, addr, fast);
+            }
+            Hashers::Legacy(legacy) => {
+                let seq_no = traverse_seq_no(children);
+                StableHashLegacy::stable_hash(value, seq_no, legacy);
+            }
+        }
+    }
 }
 
 /// Go directly to a SequenceNumber identifying a field within a struct.
@@ -54,27 +92,23 @@ pub enum BlockEventStream {
 ///    0, // Vec<Inner>[0]
 ///    1, // Inner.inner_str
 ///])
-// Performance: Could write a specialized function for this easily, avoiding a bunch of clones of Blake3SeqNo
-fn traverse_seq_no(counts: &[usize]) -> Blake3SeqNo {
+// Performance: Could write a specialized function for this, avoiding a bunch of clones of Blake3SeqNo
+fn traverse_seq_no(counts: &[u64]) -> Blake3SeqNo {
     counts.iter().fold(Blake3SeqNo::root(), |mut s, i| {
-        s.skip(*i);
+        s.skip(*i as usize);
         s.next_child()
     })
 }
 
 impl BlockEventStream {
-    fn new_legacy(block_number: BlockNumber) -> Self {
-        let events = traverse_seq_no(&[
-            1,                                // kvp -> v
-            0,                                // CausalityRegion.blocks: Vec<Block>
-            block_number.try_into().unwrap(), // Vec<Block> -> [i]
-            0,                                // Block.events -> Vec<ProofOfIndexingEvent>
-        ]);
-        Self::LegacyHasherStream {
+    fn new(block_number: BlockNumber, version: ProofOfIndexingVersion) -> Self {
+        let block_index: u64 = block_number.try_into().unwrap();
+
+        Self {
             vec_length: 0,
             handler_start: 0,
-            seq_no: events,
-            digest: SetHasher::new(),
+            block_index,
+            hasher: Hashers::new(version),
         }
     }
 
@@ -82,54 +116,51 @@ impl BlockEventStream {
     /// be resumed later. Cases in which the hash function is resumed include
     /// when asking for the final PoI, or when combining with the next modified
     /// block via the argument `prev`
-    pub fn pause(self, prev: Option<&[u8]>) -> Vec<u8> {
-        match self {
-            BlockEventStream::LegacyHasherStream {
-                vec_length,
-                handler_start: _,
-                seq_no,
-                mut digest,
-            } => {
-                vec_length.stable_hash(seq_no, &mut digest);
-                let mut state = digest;
+    pub fn pause(mut self, prev: Option<&[u8]>) -> Vec<u8> {
+        self.hasher
+            .write(&self.vec_length, &[1, 0, self.block_index, 0]);
+        match self.hasher {
+            Hashers::Legacy(mut digest) => {
                 if let Some(prev) = prev {
                     let prev = SetHasher::from_bytes(prev);
-                    state.finish_unordered(prev, SequenceNumber::root());
+                    // SequenceNumber::root() is misleading here since the parameter
+                    // is unused.
+                    digest.finish_unordered(prev, SequenceNumber::root());
                 }
-                state.to_bytes()
+                digest.to_bytes()
+            }
+            Hashers::Fast(mut digest) => {
+                if let Some(prev) = prev {
+                    let prev = prev
+                        .try_into()
+                        .expect("Expected valid fast stable hash representation");
+                    let prev = FastStableHasher::from_bytes(prev);
+                    digest.mixin(&prev);
+                }
+                digest.to_bytes().to_vec()
             }
         }
     }
 
     fn write(&mut self, event: &ProofOfIndexingEvent<'_>) {
-        match self {
-            BlockEventStream::LegacyHasherStream {
-                ref mut vec_length,
-                handler_start: _,
-                seq_no,
-                ref mut digest,
-            } => {
-                *vec_length += 1;
-                event.stable_hash(seq_no.next_child(), digest);
-            }
-        }
+        let children = &[
+            1,                // kvp -> v
+            0,                // CausalityRegion.blocks: Vec<Block>
+            self.block_index, // Vec<Block> -> [i]
+            0,                // Block.events -> Vec<ProofOfIndexingEvent>
+            self.vec_length,
+        ];
+        self.hasher.write(&event, children);
+        self.vec_length += 1;
     }
 
     fn start_handler(&mut self) {
-        match self {
-            BlockEventStream::LegacyHasherStream {
-                ref vec_length,
-                ref mut handler_start,
-                seq_no: _,
-                digest: _,
-            } => {
-                *handler_start = *vec_length;
-            }
-        }
+        self.handler_start = self.vec_length;
     }
 }
-#[derive(Default)]
+
 pub struct ProofOfIndexing {
+    version: ProofOfIndexingVersion,
     block_number: BlockNumber,
     /// The POI is updated for each data source independently. This is necessary because
     /// some data sources (eg: IPFS files) may be unreliable and therefore cannot mix
@@ -145,8 +176,9 @@ impl fmt::Debug for ProofOfIndexing {
 }
 
 impl ProofOfIndexing {
-    pub fn new(block_number: BlockNumber) -> Self {
+    pub fn new(block_number: BlockNumber, version: ProofOfIndexingVersion) -> Self {
         Self {
+            version,
             block_number,
             per_causality_region: HashMap::new(),
         }
@@ -155,13 +187,8 @@ impl ProofOfIndexing {
 
 impl ProofOfIndexing {
     pub fn write_deterministic_error(&mut self, logger: &Logger, causality_region: &str) {
-        let redacted_events = self.with_causality_region(causality_region, |entry| match entry {
-            BlockEventStream::LegacyHasherStream {
-                ref vec_length,
-                ref handler_start,
-                seq_no: _,
-                digest: _,
-            } => vec_length - handler_start,
+        let redacted_events = self.with_causality_region(causality_region, |entry| {
+            entry.vec_length - entry.handler_start
         });
 
         self.write(
@@ -195,14 +222,14 @@ impl ProofOfIndexing {
     }
 
     // This is just here because the raw_entry API is not stabilized.
-    pub fn with_causality_region<F, T>(&mut self, causality_region: &str, f: F) -> T
+    fn with_causality_region<F, T>(&mut self, causality_region: &str, f: F) -> T
     where
         F: FnOnce(&mut BlockEventStream) -> T,
     {
         if let Some(causality_region) = self.per_causality_region.get_mut(causality_region) {
             f(causality_region)
         } else {
-            let mut entry = BlockEventStream::new_legacy(self.block_number);
+            let mut entry = BlockEventStream::new(self.block_number, self.version);
             let result = f(&mut entry);
             self.per_causality_region
                 .insert(causality_region.to_owned(), entry);
@@ -217,34 +244,27 @@ impl ProofOfIndexing {
 
 pub struct ProofOfIndexingFinisher {
     block_number: BlockNumber,
-    state: SetHasher,
+    state: Hashers,
     causality_count: usize,
 }
 
 impl ProofOfIndexingFinisher {
-    pub fn new(block: &BlockPtr, subgraph_id: &DeploymentHash, indexer: &Option<Address>) -> Self {
-        let mut state = SetHasher::new();
+    pub fn new(
+        block: &BlockPtr,
+        subgraph_id: &DeploymentHash,
+        indexer: &Option<Address>,
+        version: ProofOfIndexingVersion,
+    ) -> Self {
+        let mut state = Hashers::new(version);
 
-        // Add the subgraph id
-        let subgraph_id_seq_no = traverse_seq_no(&[
-            1, // PoI.subgraph_id
-        ]);
-        subgraph_id.stable_hash(subgraph_id_seq_no, &mut state);
+        // Add PoI.subgraph_id
+        state.write(&subgraph_id, &[1]);
 
-        // Add the block hash
-        let block_hash_seq_no = traverse_seq_no(&[
-            2, // PoI.block_hash
-        ]);
-        AsBytes(block.hash_slice()).stable_hash(block_hash_seq_no, &mut state);
+        // Add PoI.block_hash
+        state.write(&AsBytes(block.hash_slice()), &[2]);
 
-        // Add the indexer
-        let indexer_seq_no = traverse_seq_no(&[
-            3, // PoI.indexer
-        ]);
-        indexer
-            .as_ref()
-            .map(|i| AsBytes(i.as_bytes()))
-            .stable_hash(indexer_seq_no, &mut state);
+        // Add PoI.indexer
+        state.write(&indexer.as_ref().map(|i| AsBytes(i.as_bytes())), &[3]);
 
         ProofOfIndexingFinisher {
             block_number: block.number,
@@ -254,48 +274,43 @@ impl ProofOfIndexingFinisher {
     }
 
     pub fn add_causality_region(&mut self, name: &str, region: &[u8]) {
-        let mut state = SetHasher::from_bytes(region);
+        let mut state = Hashers::from_bytes(region);
 
-        // Finish the blocks vec
-        let blocks_seq_no = traverse_seq_no(&[
-            1, // kvp -> v
-            0, // CausalityRegion.blocks: Vec<Block>
-        ]);
+        // Finish the blocks vec by writing kvp[v], CausalityRegion.blocks.len()
         // + 1 is to account that the length of the blocks array for the genesis block is 1, not 0.
-        (self.block_number + 1).stable_hash(blocks_seq_no, &mut state);
+        state.write(&(self.block_number + 1), &[1, 0]);
 
-        // Add the name.
-        let name_seq_no = traverse_seq_no(&[
-            0, // kvp -> k
-        ]);
-        name.stable_hash(name_seq_no, &mut state);
+        // Add the name (kvp[k]).
+        state.write(&name, &[0]);
 
-        let state = state.finish();
+        // Mixin the region into PoI.causality_regions.
+        match state {
+            Hashers::Legacy(legacy) => {
+                let state = legacy.finish();
+                self.state.write(&AsBytes(&state), &[0, 1]);
+            }
+            Hashers::Fast(fast) => {
+                let state = fast.to_bytes();
+                self.state.write(&AsBytes(&state), &[0]);
+            }
+        }
 
-        // Mixin the region with the final value
-        let causality_regions_member_seq_no = traverse_seq_no(&[
-            0, // Poi.causality_regions
-            1, // unordered collection member
-        ]);
-
-        self.state.write(causality_regions_member_seq_no, &state);
         self.causality_count += 1;
     }
 
-    pub fn finish(mut self) -> <SetHasher as StableHasher>::Out {
-        let causality_regions_count_seq_no = traverse_seq_no(&[
-            0, // Poi.causality_regions
-            2, // unordered collection count
-        ]);
+    pub fn finish(mut self) -> [u8; 32] {
+        if let Hashers::Legacy(_) = self.state {
+            // Add PoI.causality_regions.len()
+            // Note that technically to get the same sequence number one would need
+            // to call causality_regions_count_seq_no.skip(self.causality_count);
+            // but it turns out that the result happens to be the same for
+            // non-negative numbers.
+            self.state.write(&self.causality_count, &[0, 2]);
+        }
 
-        // Note that technically to get the same sequence number one would need
-        // to call causality_regions_count_seq_no.skip(self.causality_count);
-        // but it turns out that the result happens to be the same for
-        // non-negative numbers.
-
-        self.causality_count
-            .stable_hash(causality_regions_count_seq_no, &mut self.state);
-
-        self.state.finish()
+        match self.state {
+            Hashers::Legacy(legacy) => legacy.finish(),
+            Hashers::Fast(fast) => tiny_keccak::keccak256(&fast.finish().to_le_bytes()),
+        }
     }
 }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -585,9 +585,6 @@ where
     }
 }
 
-// Note: Do not modify fields without making a backward compatible change to the
-//  StableHash impl (below) An entity is represented as a map of attribute names
-//  to values.
 /// An entity is represented as a map of attribute names to values.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 pub struct Entity(HashMap<Attribute, Value>);
@@ -600,13 +597,15 @@ impl stable_hash_legacy::StableHash for Entity {
         state: &mut H,
     ) {
         use stable_hash_legacy::SequenceNumber;
-        stable_hash_legacy::StableHash::stable_hash(&self.0, sequence_number.next_child(), state);
+        let Self(inner) = self;
+        stable_hash_legacy::StableHash::stable_hash(inner, sequence_number.next_child(), state);
     }
 }
 
 impl StableHash for Entity {
     fn stable_hash<H: StableHasher>(&self, field_address: H::Addr, state: &mut H) {
-        StableHash::stable_hash(&self.0, field_address.child(0), state);
+        let Self(inner) = self;
+        StableHash::stable_hash(inner, field_address.child(0), state);
     }
 }
 

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -4,7 +4,7 @@ use diesel_derives::{AsExpression, FromSqlRow};
 use hex;
 use num_bigint;
 use serde::{self, Deserialize, Serialize};
-use stable_hash::utils::{AsBytes, AsInt};
+use stable_hash::utils::AsInt;
 use stable_hash::{FieldAddress, StableHash};
 use stable_hash_legacy::SequenceNumber;
 use thiserror::Error;
@@ -19,6 +19,7 @@ use std::str::FromStr;
 pub use num_bigint::Sign as BigIntSign;
 
 use crate::blockchain::BlockHash;
+use crate::util::stable_hash_glue::{impl_stable_hash, AsBytes};
 
 /// All operations on `BigDecimal` return a normalized value.
 // Caveat: The exponent is currently an i64 and may overflow. See
@@ -542,21 +543,7 @@ impl fmt::Debug for Bytes {
     }
 }
 
-impl stable_hash_legacy::StableHash for Bytes {
-    fn stable_hash<H: stable_hash_legacy::StableHasher>(
-        &self,
-        sequence_number: H::Seq,
-        state: &mut H,
-    ) {
-        stable_hash_legacy::utils::AsBytes(&self.0).stable_hash(sequence_number, state);
-    }
-}
-
-impl StableHash for Bytes {
-    fn stable_hash<H: stable_hash::StableHasher>(&self, field_address: H::Addr, state: &mut H) {
-        AsBytes(&self.0).stable_hash(field_address, state);
-    }
-}
+impl_stable_hash!(Bytes(transparent: AsBytes));
 
 impl Bytes {
     pub fn as_slice(&self) -> &[u8] {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -63,8 +63,6 @@ where
         .map(Some)
 }
 
-// Note: This has a StableHash impl. Do not modify fields without a backward
-// compatible change to the StableHash impl (below)
 /// The IPFS hash used to identifiy a deployment externally, i.e., the
 /// `Qm..` string that `graph-cli` prints when deploying to a subgraph
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -77,13 +75,15 @@ impl stable_hash_legacy::StableHash for DeploymentHash {
         mut sequence_number: H::Seq,
         state: &mut H,
     ) {
-        stable_hash_legacy::StableHash::stable_hash(&self.0, sequence_number.next_child(), state);
+        let Self(inner) = self;
+        stable_hash_legacy::StableHash::stable_hash(inner, sequence_number.next_child(), state);
     }
 }
 
 impl StableHash for DeploymentHash {
     fn stable_hash<H: stable_hash::StableHasher>(&self, field_address: H::Addr, state: &mut H) {
-        stable_hash::StableHash::stable_hash(&self.0, field_address.child(0), state);
+        let Self(inner) = self;
+        stable_hash::StableHash::stable_hash(inner, field_address.child(0), state);
     }
 }
 

--- a/graph/src/runtime/asc_heap.rs
+++ b/graph/src/runtime/asc_heap.rs
@@ -1,6 +1,5 @@
 use std::mem::MaybeUninit;
 
-use second_stack::Stack;
 use semver::Version;
 
 use super::{
@@ -13,8 +12,6 @@ use super::{
 pub trait AscHeap {
     /// Allocate new space and write `bytes`, return the allocated address.
     fn raw_new(&mut self, bytes: &[u8], gas: &GasCounter) -> Result<u32, DeterministicHostError>;
-
-    fn stack(&self) -> &Stack;
 
     fn read<'a>(
         &self,

--- a/graph/src/runtime/asc_heap.rs
+++ b/graph/src/runtime/asc_heap.rs
@@ -1,5 +1,6 @@
 use std::mem::MaybeUninit;
 
+use second_stack::Stack;
 use semver::Version;
 
 use super::{
@@ -12,6 +13,8 @@ use super::{
 pub trait AscHeap {
     /// Allocate new space and write `bytes`, return the allocated address.
     fn raw_new(&mut self, bytes: &[u8], gas: &GasCounter) -> Result<u32, DeterministicHostError>;
+
+    fn stack(&self) -> &Stack;
 
     fn init<'s, 'a>(
         &'s self,

--- a/graph/src/runtime/asc_heap.rs
+++ b/graph/src/runtime/asc_heap.rs
@@ -16,8 +16,8 @@ pub trait AscHeap {
 
     fn stack(&self) -> &Stack;
 
-    fn init<'s, 'a>(
-        &'s self,
+    fn read<'a>(
+        &self,
         offset: u32,
         buffer: &'a mut [MaybeUninit<u8>],
         gas: &GasCounter,

--- a/graph/src/runtime/asc_ptr.rs
+++ b/graph/src/runtime/asc_ptr.rs
@@ -65,7 +65,7 @@ impl<C: AscType> AscPtr<C> {
         }?;
 
         heap.stack().uninit_slice(len as usize, |buffer| {
-            let buffer = heap.init(self.0, buffer, gas)?;
+            let buffer = heap.read(self.0, buffer, gas)?;
             C::from_asc_bytes(buffer, &heap.api_version())
         })
     }

--- a/graph/src/runtime/asc_ptr.rs
+++ b/graph/src/runtime/asc_ptr.rs
@@ -64,7 +64,7 @@ impl<C: AscType> AscPtr<C> {
             _ => self.read_len(heap, gas),
         }?;
 
-        second_stack::uninit_slice(len as usize, |buffer| {
+        heap.stack().uninit_slice(len as usize, |buffer| {
             let buffer = heap.init(self.0, buffer, gas)?;
             C::from_asc_bytes(buffer, &heap.api_version())
         })

--- a/graph/src/runtime/asc_ptr.rs
+++ b/graph/src/runtime/asc_ptr.rs
@@ -1,7 +1,7 @@
 use super::gas::GasCounter;
 use super::{padding_to_16, DeterministicHostError};
 
-use super::{asc_get_array, AscHeap, AscIndexId, AscType, IndexForAscTypeId};
+use super::{AscHeap, AscIndexId, AscType, IndexForAscTypeId};
 use semver::Version;
 use std::fmt;
 use std::marker::PhantomData;
@@ -116,8 +116,7 @@ impl<C: AscType> AscPtr<C> {
         gas: &GasCounter,
     ) -> Result<u32, DeterministicHostError> {
         // Read the bytes pointed to by `self` as the bytes of a `u32`.
-        let u32_bytes = asc_get_array(heap, self.0, gas)?;
-        Ok(u32::from_le_bytes(u32_bytes))
+        heap.read_u32(self.0, gas)
     }
 
     /// Helper that generates an AssemblyScript header.
@@ -180,8 +179,7 @@ impl<C: AscType> AscPtr<C> {
             ))
         })?;
 
-        let u32_bytes = asc_get_array(heap, start_of_rt_size, gas)?;
-        Ok(u32::from_le_bytes(u32_bytes))
+        heap.read_u32(start_of_rt_size, gas)
     }
 
     /// Conversion to `u64` for use with `AscEnum`.

--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -8,7 +8,7 @@ pub mod gas;
 mod asc_heap;
 mod asc_ptr;
 
-pub use asc_heap::{asc_get, asc_new, try_asc_get, AscHeap, FromAscObj, ToAscObj, TryFromAscObj};
+pub use asc_heap::{asc_get, asc_get_array, asc_new, AscHeap, FromAscObj, ToAscObj};
 pub use asc_ptr::AscPtr;
 
 use anyhow::Error;

--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -8,7 +8,7 @@ pub mod gas;
 mod asc_heap;
 mod asc_ptr;
 
-pub use asc_heap::{asc_get, asc_get_array, asc_new, AscHeap, FromAscObj, ToAscObj};
+pub use asc_heap::{asc_get, asc_new, AscHeap, FromAscObj, ToAscObj};
 pub use asc_ptr::AscPtr;
 
 use anyhow::Error;

--- a/graph/src/util/mem.rs
+++ b/graph/src/util/mem.rs
@@ -1,0 +1,13 @@
+use std::mem::{transmute, MaybeUninit};
+
+/// Temporarily needed until MaybeUninit::write_slice is stabilized.
+pub fn init_slice<'a, T>(src: &[T], dst: &'a mut [MaybeUninit<T>]) -> &'a mut [T]
+where
+    T: Copy,
+{
+    unsafe {
+        let uninit_src: &[MaybeUninit<T>] = transmute(src);
+        dst.copy_from_slice(uninit_src);
+        &mut *(dst as *mut [MaybeUninit<T>] as *mut [T])
+    }
+}

--- a/graph/src/util/mod.rs
+++ b/graph/src/util/mod.rs
@@ -22,3 +22,5 @@ pub mod jobs;
 pub mod backoff;
 
 pub mod bounded_queue;
+
+pub mod stable_hash_glue;

--- a/graph/src/util/mod.rs
+++ b/graph/src/util/mod.rs
@@ -24,3 +24,5 @@ pub mod backoff;
 pub mod bounded_queue;
 
 pub mod stable_hash_glue;
+
+pub mod mem;

--- a/graph/src/util/stable_hash_glue.rs
+++ b/graph/src/util/stable_hash_glue.rs
@@ -1,0 +1,82 @@
+use stable_hash::{StableHash, StableHasher};
+use stable_hash_legacy::prelude::{
+    StableHash as StableHashLegacy, StableHasher as StableHasherLegacy,
+};
+
+/// Implements StableHash and StableHashLegacy. This macro supports two forms:
+/// Struct { field1, field2, ... } and Tuple(transparent). Each field supports
+/// an optional modifier. For example: Tuple(transparent: AsBytes)
+#[macro_export]
+macro_rules! _impl_stable_hash {
+    ($T:ident$(<$lt:lifetime>)? {$($field:ident$(:$e:path)?),*}) => {
+        // Only this first impl commented, the same comments apply throughout
+        impl stable_hash::StableHash for $T$(<$lt>)? {
+            // This suppressed warning is for the final index + 1, which is unused
+            // in the next "iteration of the loop"
+            #[allow(unused_assignments)]
+            fn stable_hash<H: stable_hash::StableHasher>(&self, field_address: H::Addr, state: &mut H) {
+                // Destructuring ensures we have all of the fields. If a field is added to the struct,
+                // it must be added to the macro or it will fail to compile.
+                let $T { $($field,)* } = self;
+                let mut index = 0;
+                $(
+                    // We might need to "massage" the value, for example, to wrap
+                    // it in AsBytes. So we provide a way to inject those.
+                    $(let $field = $e($field);)?
+                    stable_hash::StableHash::stable_hash(&$field, stable_hash::FieldAddress::child(&field_address, index), state);
+                    index += 1;
+                )*
+            }
+        }
+
+        impl stable_hash_legacy::StableHash for $T$(<$lt>)? {
+            fn stable_hash<H: stable_hash_legacy::StableHasher>(&self, mut sequence_number: H::Seq, state: &mut H) {
+                let $T { $($field,)* } = self;
+                $(
+                    $(let $field = $e($field);)*
+                    stable_hash_legacy::StableHash::stable_hash(&$field, stable_hash_legacy::SequenceNumber::next_child(&mut sequence_number), state);
+                )*
+            }
+        }
+    };
+    ($T:ident$(<$lt:lifetime>)? (transparent$(:$e:path)?)) => {
+        impl stable_hash::StableHash for $T$(<$lt>)? {
+            #[allow(unused_assignments)]
+            fn stable_hash<H: stable_hash::StableHasher>(&self, field_address: H::Addr, state: &mut H) {
+                let Self(transparent) = self;
+                $(let transparent = $e(transparent);)?
+                stable_hash::StableHash::stable_hash(&transparent, field_address, state);
+            }
+        }
+
+        impl stable_hash_legacy::StableHash for $T$(<$lt>)? {
+            fn stable_hash<H: stable_hash_legacy::StableHasher>(&self, sequence_number: H::Seq, state: &mut H,
+            ) {
+                let Self(transparent) = self;
+                $(let transparent = $e(transparent);)*
+                stable_hash_legacy::StableHash::stable_hash(&transparent, sequence_number, state);
+            }
+        }
+    };
+}
+pub use crate::_impl_stable_hash as impl_stable_hash;
+
+pub struct AsBytes<T>(pub T);
+
+impl<T> StableHashLegacy for AsBytes<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn stable_hash<H: StableHasherLegacy>(&self, sequence_number: H::Seq, state: &mut H) {
+        stable_hash_legacy::utils::AsBytes(self.0.as_ref()).stable_hash(sequence_number, state);
+    }
+}
+
+impl<T> StableHash for AsBytes<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn stable_hash<H: StableHasher>(&self, field_address: H::Addr, state: &mut H) {
+        stable_hash::utils::AsBytes(self.0.as_ref()).stable_hash(field_address, state);
+    }
+}

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -11,9 +11,9 @@ graphql-tools = "0.0.19"
 indexmap = "1.9"
 Inflector = "0.11.3"
 lazy_static = "1.2.0"
-stable-hash_legacy = { version = "0.3.2", package = "stable-hash" }
-stable-hash = { version = "0.4.1"}
 once_cell = "1.12.1"
+stable-hash_legacy = { version = "0.3.3", package = "stable-hash" }
+stable-hash = { version = "0.4.2"}
 defer = "0.1"
 parking_lot = "0.12"
 anyhow = "1.0"

--- a/runtime/test/src/lib.rs
+++ b/runtime/test/src/lib.rs
@@ -1,3 +1,3 @@
+#![cfg(test)]
 pub mod common;
-#[cfg(test)]
 mod test;

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -2,7 +2,7 @@ use graph::data::store::scalar;
 use graph::data::subgraph::*;
 use graph::prelude::web3::types::U256;
 use graph::prelude::*;
-use graph::runtime::{asc_get, asc_new, try_asc_get, AscIndexId, AscType};
+use graph::runtime::{asc_get, asc_new, AscIndexId, AscType};
 use graph::runtime::{AscPtr, ToAscObj};
 use graph::{components::store::*, ipfs_client::IpfsClient};
 use graph_chain_ethereum::{Chain, DataSource};
@@ -959,8 +959,7 @@ async fn test_entity_store(api_version: Version) {
             None
         } else {
             Some(Entity::from(
-                try_asc_get::<HashMap<String, Value>, _, _>(module, entity_ptr, &module.gas)
-                    .unwrap(),
+                asc_get::<HashMap<String, Value>, _, _>(module, entity_ptr, &module.gas).unwrap(),
             ))
         }
     };

--- a/runtime/test/src/test/abi.rs
+++ b/runtime/test/src/test/abi.rs
@@ -277,37 +277,37 @@ async fn test_abi_store_value(api_version: Version) {
     let func = module.get_func("value_null").typed().unwrap().clone();
     let ptr: u32 = func.call(()).unwrap();
     let null_value_ptr: AscPtr<AscEnum<StoreValueKind>> = ptr.into();
-    let null_value: Value = try_asc_get(&module, null_value_ptr, &module.gas).unwrap();
+    let null_value: Value = asc_get(&module, null_value_ptr, &module.gas).unwrap();
     assert_eq!(null_value, Value::Null);
 
     // Value::String
     let string = "some string";
     let new_value_ptr = module.invoke_export1("value_from_string", string);
-    let new_value: Value = try_asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
     assert_eq!(new_value, Value::from(string));
 
     // Value::Int
     let int = i32::min_value();
     let new_value_ptr = module.takes_val_returns_ptr("value_from_int", int);
-    let new_value: Value = try_asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
     assert_eq!(new_value, Value::Int(int));
 
     // Value::BigDecimal
     let big_decimal = BigDecimal::from_str("3.14159001").unwrap();
     let new_value_ptr = module.invoke_export1("value_from_big_decimal", &big_decimal);
-    let new_value: Value = try_asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
     assert_eq!(new_value, Value::BigDecimal(big_decimal));
 
     let big_decimal = BigDecimal::new(10.into(), 5);
     let new_value_ptr = module.invoke_export1("value_from_big_decimal", &big_decimal);
-    let new_value: Value = try_asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
     assert_eq!(new_value, Value::BigDecimal(1_000_000.into()));
 
     // Value::Bool
     let boolean = true;
     let new_value_ptr =
         module.takes_val_returns_ptr("value_from_bool", if boolean { 1 } else { 0 });
-    let new_value: Value = try_asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
     assert_eq!(new_value, Value::Bool(boolean));
 
     // Value::List
@@ -321,7 +321,7 @@ async fn test_abi_store_value(api_version: Version) {
         .call((asc_new(&mut module, string, &gas).unwrap().wasm_ptr(), int))
         .unwrap();
     let new_value_ptr = AscPtr::from(new_value_ptr);
-    let new_value: Value = try_asc_get(&module, new_value_ptr, &gas).unwrap();
+    let new_value: Value = asc_get(&module, new_value_ptr, &gas).unwrap();
     assert_eq!(
         new_value,
         Value::List(vec![Value::from(string), Value::Int(int)])
@@ -332,7 +332,7 @@ async fn test_abi_store_value(api_version: Version) {
         Value::String("bar".to_owned()),
     ];
     let new_value_ptr = module.invoke_export1("value_from_array", array);
-    let new_value: Value = try_asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
     assert_eq!(
         new_value,
         Value::List(vec![
@@ -344,13 +344,13 @@ async fn test_abi_store_value(api_version: Version) {
     // Value::Bytes
     let bytes: &[u8] = &[0, 2, 5];
     let new_value_ptr = module.invoke_export1("value_from_bytes", bytes);
-    let new_value: Value = try_asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
     assert_eq!(new_value, Value::Bytes(bytes.into()));
 
     // Value::BigInt
     let bytes: &[u8] = &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
     let new_value_ptr = module.invoke_export1("value_from_bigint", bytes);
-    let new_value: Value = try_asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
     assert_eq!(
         new_value,
         Value::BigInt(::graph::data::store::scalar::BigInt::from_unsigned_bytes_le(bytes))
@@ -511,7 +511,7 @@ async fn test_invalid_discriminant(api_version: Version) {
         .unwrap()
         .clone();
     let ptr: u32 = func.call(()).unwrap();
-    let _value: Value = try_asc_get(&module, ptr.into(), &module.gas).unwrap();
+    let _value: Value = asc_get(&module, ptr.into(), &module.gas).unwrap();
 }
 
 // This should panic rather than exhibiting UB. It's hard to test for UB, but

--- a/runtime/test/src/test/abi.rs
+++ b/runtime/test/src/test/abi.rs
@@ -79,7 +79,7 @@ async fn test_abi_array(api_version: Version, gas_used: u64) {
         "4".to_owned(),
     ];
     let new_vec_obj: AscPtr<Array<AscPtr<AscString>>> = module.invoke_export1("test_array", &vec);
-    let new_vec: Vec<String> = asc_get(&module, new_vec_obj, &module.gas).unwrap();
+    let new_vec: Vec<String> = module.asc_get(new_vec_obj).unwrap();
 
     assert_eq!(module.gas_used(), gas_used);
     assert_eq!(
@@ -118,7 +118,7 @@ async fn test_abi_subarray(api_version: Version) {
     let vec: Vec<u8> = vec![1, 2, 3, 4];
     let new_vec_obj: AscPtr<TypedArray<u8>> =
         module.invoke_export1("byte_array_third_quarter", vec.as_slice());
-    let new_vec: Vec<u8> = asc_get(&module, new_vec_obj, &module.gas).unwrap();
+    let new_vec: Vec<u8> = module.asc_get(new_vec_obj).unwrap();
 
     assert_eq!(new_vec, vec![3]);
 }
@@ -148,7 +148,7 @@ async fn test_abi_bytes_and_fixed_bytes(api_version: Version) {
     let new_vec_obj: AscPtr<Uint8Array> = module.invoke_export2("concat", &*bytes1, &*bytes2);
 
     // This should be bytes1 and bytes2 concatenated.
-    let new_vec: Vec<u8> = asc_get(&module, new_vec_obj, &module.gas).unwrap();
+    let new_vec: Vec<u8> = module.asc_get(new_vec_obj).unwrap();
 
     let mut concated = bytes1.clone();
     concated.extend(bytes2.clone());
@@ -175,7 +175,6 @@ async fn test_abi_ethabi_token_identity(api_version: Version) {
         api_version,
     )
     .await;
-    let gas = module.gas.cheap_clone();
 
     // Token::Address
     let address = H160([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
@@ -185,7 +184,7 @@ async fn test_abi_ethabi_token_identity(api_version: Version) {
         module.invoke_export1("token_to_address", &token_address);
 
     let new_token_ptr = module.takes_ptr_returns_ptr("token_from_address", new_address_obj);
-    let new_token = asc_get(&module, new_token_ptr, &gas).unwrap();
+    let new_token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(token_address, new_token);
 
@@ -193,7 +192,7 @@ async fn test_abi_ethabi_token_identity(api_version: Version) {
     let token_bytes = Token::Bytes(vec![42, 45, 7, 245, 45]);
     let new_bytes_obj: AscPtr<ArrayBuffer> = module.invoke_export1("token_to_bytes", &token_bytes);
     let new_token_ptr = module.takes_ptr_returns_ptr("token_from_bytes", new_bytes_obj);
-    let new_token = asc_get(&module, new_token_ptr, &gas).unwrap();
+    let new_token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(token_bytes, new_token);
 
@@ -202,7 +201,7 @@ async fn test_abi_ethabi_token_identity(api_version: Version) {
     let new_int_obj: AscPtr<ArrayBuffer> = module.invoke_export1("token_to_int", &int_token);
 
     let new_token_ptr = module.takes_ptr_returns_ptr("token_from_int", new_int_obj);
-    let new_token = asc_get(&module, new_token_ptr, &gas).unwrap();
+    let new_token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(int_token, new_token);
 
@@ -211,7 +210,7 @@ async fn test_abi_ethabi_token_identity(api_version: Version) {
 
     let new_uint_obj: AscPtr<ArrayBuffer> = module.invoke_export1("token_to_uint", &uint_token);
     let new_token_ptr = module.takes_ptr_returns_ptr("token_from_uint", new_uint_obj);
-    let new_token = asc_get(&module, new_token_ptr, &module.gas).unwrap();
+    let new_token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(uint_token, new_token);
     assert_ne!(uint_token, int_token);
@@ -219,12 +218,12 @@ async fn test_abi_ethabi_token_identity(api_version: Version) {
     // Token::Bool
     let token_bool = Token::Bool(true);
 
-    let token_bool_ptr = asc_new(&mut module, &token_bool, &gas).unwrap();
+    let token_bool_ptr = module.asc_new(&token_bool).unwrap();
     let func = module.get_func("token_to_bool").typed().unwrap().clone();
     let boolean: i32 = func.call(token_bool_ptr.wasm_ptr()).unwrap();
 
     let new_token_ptr = module.takes_val_returns_ptr("token_from_bool", boolean);
-    let new_token = asc_get(&module, new_token_ptr, &module.gas).unwrap();
+    let new_token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(token_bool, new_token);
 
@@ -232,7 +231,7 @@ async fn test_abi_ethabi_token_identity(api_version: Version) {
     let token_string = Token::String("漢字Go🇧🇷".into());
     let new_string_obj: AscPtr<AscString> = module.invoke_export1("token_to_string", &token_string);
     let new_token_ptr = module.takes_ptr_returns_ptr("token_from_string", new_string_obj);
-    let new_token = asc_get(&module, new_token_ptr, &module.gas).unwrap();
+    let new_token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(token_string, new_token);
 
@@ -243,7 +242,7 @@ async fn test_abi_ethabi_token_identity(api_version: Version) {
         module.invoke_export1("token_to_array", &token_array_nested);
 
     let new_token_ptr = module.takes_ptr_returns_ptr("token_from_array", new_array_obj);
-    let new_token: Token = asc_get(&module, new_token_ptr, &module.gas).unwrap();
+    let new_token: Token = module.asc_get(new_token_ptr).unwrap();
 
     assert_eq!(new_token, token_array_nested);
 }
@@ -277,51 +276,50 @@ async fn test_abi_store_value(api_version: Version) {
     let func = module.get_func("value_null").typed().unwrap().clone();
     let ptr: u32 = func.call(()).unwrap();
     let null_value_ptr: AscPtr<AscEnum<StoreValueKind>> = ptr.into();
-    let null_value: Value = asc_get(&module, null_value_ptr, &module.gas).unwrap();
+    let null_value: Value = module.asc_get(null_value_ptr).unwrap();
     assert_eq!(null_value, Value::Null);
 
     // Value::String
     let string = "some string";
     let new_value_ptr = module.invoke_export1("value_from_string", string);
-    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = module.asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::from(string));
 
     // Value::Int
     let int = i32::min_value();
     let new_value_ptr = module.takes_val_returns_ptr("value_from_int", int);
-    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = module.asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::Int(int));
 
     // Value::BigDecimal
     let big_decimal = BigDecimal::from_str("3.14159001").unwrap();
     let new_value_ptr = module.invoke_export1("value_from_big_decimal", &big_decimal);
-    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = module.asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::BigDecimal(big_decimal));
 
     let big_decimal = BigDecimal::new(10.into(), 5);
     let new_value_ptr = module.invoke_export1("value_from_big_decimal", &big_decimal);
-    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = module.asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::BigDecimal(1_000_000.into()));
 
     // Value::Bool
     let boolean = true;
     let new_value_ptr =
         module.takes_val_returns_ptr("value_from_bool", if boolean { 1 } else { 0 });
-    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = module.asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::Bool(boolean));
 
     // Value::List
-    let gas = module.gas.cheap_clone();
     let func = module
         .get_func("array_from_values")
         .typed()
         .unwrap()
         .clone();
     let new_value_ptr: u32 = func
-        .call((asc_new(&mut module, string, &gas).unwrap().wasm_ptr(), int))
+        .call((module.asc_new(string).unwrap().wasm_ptr(), int))
         .unwrap();
     let new_value_ptr = AscPtr::from(new_value_ptr);
-    let new_value: Value = asc_get(&module, new_value_ptr, &gas).unwrap();
+    let new_value: Value = module.asc_get(new_value_ptr).unwrap();
     assert_eq!(
         new_value,
         Value::List(vec![Value::from(string), Value::Int(int)])
@@ -332,7 +330,7 @@ async fn test_abi_store_value(api_version: Version) {
         Value::String("bar".to_owned()),
     ];
     let new_value_ptr = module.invoke_export1("value_from_array", array);
-    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = module.asc_get(new_value_ptr).unwrap();
     assert_eq!(
         new_value,
         Value::List(vec![
@@ -344,13 +342,13 @@ async fn test_abi_store_value(api_version: Version) {
     // Value::Bytes
     let bytes: &[u8] = &[0, 2, 5];
     let new_value_ptr = module.invoke_export1("value_from_bytes", bytes);
-    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = module.asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::Bytes(bytes.into()));
 
     // Value::BigInt
     let bytes: &[u8] = &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
     let new_value_ptr = module.invoke_export1("value_from_bigint", bytes);
-    let new_value: Value = asc_get(&module, new_value_ptr, &module.gas).unwrap();
+    let new_value: Value = module.asc_get(new_value_ptr).unwrap();
     assert_eq!(
         new_value,
         Value::BigInt(::graph::data::store::scalar::BigInt::from_unsigned_bytes_le(bytes))
@@ -383,7 +381,7 @@ async fn test_abi_h160(api_version: Version) {
     let new_address_obj: AscPtr<Uint8Array> = module.invoke_export1("test_address", &address);
 
     // This should have 1 added to the first and last byte.
-    let new_address: H160 = asc_get(&module, new_address_obj, &module.gas).unwrap();
+    let new_address: H160 = module.asc_get(new_address_obj).unwrap();
 
     assert_eq!(
         new_address,
@@ -413,7 +411,7 @@ async fn test_string(api_version: Version) {
     .await;
     let string = "    漢字Double_Me🇧🇷  ";
     let trimmed_string_obj: AscPtr<AscString> = module.invoke_export1("repeat_twice", string);
-    let doubled_string: String = asc_get(&module, trimmed_string_obj, &module.gas).unwrap();
+    let doubled_string: String = module.asc_get(trimmed_string_obj).unwrap();
     assert_eq!(doubled_string, string.repeat(2));
 }
 
@@ -442,7 +440,7 @@ async fn test_abi_big_int(api_version: Version) {
     let old_uint = U256::zero();
     let new_uint_obj: AscPtr<AscBigInt> =
         module.invoke_export1("test_uint", &BigInt::from_unsigned_u256(&old_uint));
-    let new_uint: BigInt = asc_get(&module, new_uint_obj, &module.gas).unwrap();
+    let new_uint: BigInt = module.asc_get(new_uint_obj).unwrap();
     assert_eq!(new_uint, BigInt::from(1 as i32));
     let new_uint = new_uint.to_unsigned_u256();
     assert_eq!(new_uint, U256([1, 0, 0, 0]));
@@ -450,7 +448,7 @@ async fn test_abi_big_int(api_version: Version) {
     // Test passing in -50 and increment it by 1
     let old_uint = BigInt::from(-50);
     let new_uint_obj: AscPtr<AscBigInt> = module.invoke_export1("test_uint", &old_uint);
-    let new_uint: BigInt = asc_get(&module, new_uint_obj, &module.gas).unwrap();
+    let new_uint: BigInt = module.asc_get(new_uint_obj).unwrap();
     assert_eq!(new_uint, BigInt::from(-49 as i32));
     let new_uint_from_u256 = BigInt::from_signed_u256(&new_uint.to_signed_u256());
     assert_eq!(new_uint, new_uint_from_u256);
@@ -480,7 +478,7 @@ async fn test_big_int_to_string(api_version: Version) {
     let big_int_str = "30145144166666665000000000000000000";
     let big_int = BigInt::from_str(big_int_str).unwrap();
     let string_obj: AscPtr<AscString> = module.invoke_export1("big_int_to_string", &big_int);
-    let string: String = asc_get(&module, string_obj, &module.gas).unwrap();
+    let string: String = module.asc_get(string_obj).unwrap();
     assert_eq!(string, big_int_str);
 }
 
@@ -511,7 +509,7 @@ async fn test_invalid_discriminant(api_version: Version) {
         .unwrap()
         .clone();
     let ptr: u32 = func.call(()).unwrap();
-    let _value: Value = asc_get(&module, ptr.into(), &module.gas).unwrap();
+    let _value: Value = module.asc_get(ptr.into()).unwrap();
 }
 
 // This should panic rather than exhibiting UB. It's hard to test for UB, but

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -22,7 +22,6 @@ anyhow = "1.0"
 wasmtime = "0.27.0"
 defer = "0.1"
 never = "0.1"
-second-stack = "0.3.3"
 
 wasm-instrument = { version = "0.2.0", features = ["std", "sign_ext"] }
 

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1.0"
 wasmtime = "0.27.0"
 defer = "0.1"
 never = "0.1"
+second-stack = "0.3.3"
 
 wasm-instrument = { version = "0.2.0", features = ["std", "sign_ext"] }
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -10,7 +10,6 @@ use std::time::Instant;
 use anyhow::anyhow;
 use anyhow::Error;
 use never::Never;
-use second_stack::Stack;
 use semver::Version;
 use wasmtime::{Memory, Trap};
 
@@ -267,8 +266,6 @@ pub struct WasmInstanceContext<C: Blockchain> {
     pub deterministic_host_trap: bool,
 
     pub(crate) experimental_features: ExperimentalFeatures,
-
-    stack: Stack,
 }
 
 impl<C: Blockchain> WasmInstance<C> {
@@ -695,10 +692,6 @@ impl<C: Blockchain> AscHeap for WasmInstanceContext<C> {
         }
     }
 
-    fn stack(&self) -> &Stack {
-        &self.stack
-    }
-
     fn api_version(&self) -> Version {
         self.ctx.host_exports.api_version.clone()
     }
@@ -769,7 +762,6 @@ impl<C: Blockchain> WasmInstanceContext<C> {
             possible_reorg: false,
             deterministic_host_trap: false,
             experimental_features,
-            stack: Stack::new(),
         })
     }
 
@@ -826,7 +818,6 @@ impl<C: Blockchain> WasmInstanceContext<C> {
             possible_reorg: false,
             deterministic_host_trap: false,
             experimental_features,
-            stack: Stack::new(),
         })
     }
 }

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -664,8 +664,8 @@ impl<C: Blockchain> AscHeap for WasmInstanceContext<C> {
         Ok(u32::from_le_bytes(bytes))
     }
 
-    fn init<'s, 'a>(
-        &'s self,
+    fn read<'a>(
+        &self,
         offset: u32,
         buffer: &'a mut [MaybeUninit<u8>],
         gas: &GasCounter,

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -1,16 +1,11 @@
 use ethabi;
 
+use graph::prelude::{BigDecimal, BigInt};
 use graph::runtime::gas::GasCounter;
-use graph::runtime::{
-    asc_get, asc_new, try_asc_get, AscIndexId, AscPtr, AscType, AscValue, ToAscObj,
-};
+use graph::runtime::{asc_get, asc_new, AscIndexId, AscPtr, AscType, AscValue, ToAscObj};
 use graph::{data::store, runtime::DeterministicHostError};
 use graph::{prelude::serde_json, runtime::FromAscObj};
 use graph::{prelude::web3::types as web3, runtime::AscHeap};
-use graph::{
-    prelude::{BigDecimal, BigInt},
-    runtime::TryFromAscObj,
-};
 
 use crate::asc_abi::class::*;
 
@@ -106,8 +101,8 @@ impl ToAscObj<AscBigDecimal> for BigDecimal {
     }
 }
 
-impl TryFromAscObj<AscBigDecimal> for BigDecimal {
-    fn try_from_asc_obj<H: AscHeap + ?Sized>(
+impl FromAscObj<AscBigDecimal> for BigDecimal {
+    fn from_asc_obj<H: AscHeap + ?Sized>(
         big_decimal: AscBigDecimal,
         heap: &H,
         gas: &GasCounter,
@@ -238,8 +233,8 @@ impl FromAscObj<AscEnum<EthereumValueKind>> for ethabi::Token {
     }
 }
 
-impl TryFromAscObj<AscEnum<StoreValueKind>> for store::Value {
-    fn try_from_asc_obj<H: AscHeap + ?Sized>(
+impl FromAscObj<AscEnum<StoreValueKind>> for store::Value {
+    fn from_asc_obj<H: AscHeap + ?Sized>(
         asc_enum: AscEnum<StoreValueKind>,
         heap: &H,
         gas: &GasCounter,
@@ -255,12 +250,12 @@ impl TryFromAscObj<AscEnum<StoreValueKind>> for store::Value {
             StoreValueKind::Int => Value::Int(i32::from(payload)),
             StoreValueKind::BigDecimal => {
                 let ptr: AscPtr<AscBigDecimal> = AscPtr::from(payload);
-                Value::BigDecimal(try_asc_get(heap, ptr, gas)?)
+                Value::BigDecimal(asc_get(heap, ptr, gas)?)
             }
             StoreValueKind::Bool => Value::Bool(bool::from(payload)),
             StoreValueKind::Array => {
                 let ptr: AscEnumArray<StoreValueKind> = AscPtr::from(payload);
-                Value::List(try_asc_get(heap, ptr, gas)?)
+                Value::List(asc_get(heap, ptr, gas)?)
             }
             StoreValueKind::Null => Value::Null,
             StoreValueKind::Bytes => {

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -26,7 +26,7 @@ postgres-openssl = "0.5.0"
 rand = "0.8.4"
 serde = "1.0"
 uuid = { version = "1.1.2", features = ["v4"] }
-stable-hash_legacy = { version = "0.3.2", package = "stable-hash" }
+stable-hash_legacy = { version = "0.3.3", package = "stable-hash" }
 diesel_derives = "1.4.1"
 anyhow = "1.0.57"
 git-testament = "0.2.0"

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -22,7 +22,7 @@ use std::sync::{atomic::AtomicUsize, Arc, Mutex};
 use std::time::Instant;
 
 use graph::components::store::EntityCollection;
-use graph::components::subgraph::ProofOfIndexingFinisher;
+use graph::components::subgraph::{ProofOfIndexingFinisher, ProofOfIndexingVersion};
 use graph::constraint_violation;
 use graph::data::subgraph::schema::{DeploymentCreate, SubgraphError, POI_OBJECT};
 use graph::prelude::{
@@ -892,7 +892,13 @@ impl DeploymentStore {
             })
             .collect::<Result<HashMap<_, _>, anyhow::Error>>()?;
 
-        let mut finisher = ProofOfIndexingFinisher::new(&block2, &site3.deployment, &indexer);
+        // TODO: (Fast PoI) This should also support the Fast
+        // variant when indicated by the subgraph manifest.
+        // See also a0a79c0f-919f-4d97-a82a-439a1ff78230
+        let version = ProofOfIndexingVersion::Legacy;
+
+        let mut finisher =
+            ProofOfIndexingFinisher::new(&block2, &site3.deployment, &indexer, version);
         for (name, region) in by_causality_region.drain() {
             finisher.add_causality_region(&name, &region);
         }


### PR DESCRIPTION
Changes:
* (Performance) Introduces Fast PoI implementation, but currently switched off (needs to be enabled through subgraph manifest)
* (Performance) Optimize WASM Heap access by avoiding unnecessary heap allocations and writes
* (Hygiene) Merge AscGet and TryAscGet
* (Hygiene) Use const generics for FromAscObj [u8; LEN] instead of duplicated code