### PR TITLE
Allow limiting the number of subgraphs using a web3 provider

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -113,6 +113,11 @@ chain. For each provider, the following information must be given:
 * `features`: an array of features that the provider supports, either empty
   or any combination of `traces` and `archive`
 * `headers`: HTTP headers to be added on every request. Defaults to none.
+* `limit`: the maximum number of subgraphs that can use this provider.
+  Defaults to unlimited. At least one provider should be unlimited,
+  otherwise `graph-node` might not be able to handle all subgraphs. The
+  tracking for this is approximate, and a small amount of deviation from
+  this value should be expected. The deviation will be less than 10.
 
 The following example configures two chains, `mainnet` and `kovan`, where
 blocks for `mainnet` are stored in the `vip` shard and blocks for `kovan`

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,7 +1,5 @@
 # Advanced Graph Node configuration
 
-**This feature is considered experimental. In particular, the format of the configuration file might still change in backwards-incompatible ways**
-
 A TOML configuration file can be used to set more complex configurations than those exposed in the
 CLI. The location of the file is passed with the `--config` command line switch. When using a
 configuration file, it is not possible to use the options `--postgres-url`,
@@ -137,6 +135,37 @@ provider = [
 shard = "primary"
 provider = [ { label = "kovan", url = "http://..", features = [] } ]
 ```
+
+### Controlling the number of subgraphs using a provider
+
+**This feature is experimental and might be removed in a future release**
+
+Each provider can set a limit for the number of subgraphs that can use this
+provider. The measurement of the number of subgraphs using a provider is
+approximate and can differ from the true number by a small amount
+(generally less than 10)
+
+The limit is set through rules that match on the node name. If a node's
+name does not match any rule, the corresponding provider can be used for an
+unlimited number of subgraphs. It is recommended that at least one provider
+is generally unlimited. The limit is set in the following way:
+
+```toml
+[chains.mainnet]
+shard = "vip"
+provider = [
+  { label = "mainnet-0", url = "http://..", features = [] },
+  { label = "mainnet-1", url = "http://..", features = [],
+    match = [
+      { name = "some_node_.*", limit = 10 },
+      { name = "other_node_.*", limit = 0 } ] } ]
+```
+
+Nodes named `some_node_.*` will use `mainnet-1` for at most 10 subgraphs,
+and `mainnet-0` for everything else, nodes named `other_node_.*` will never
+use `mainnet-1` and always `mainnet-0`. Any node whose name does not match
+one of these patterns will use `mainnet-0` and `mainnet-1` for an unlimited
+number of subgraphs.
 
 ## Controlling Deployment
 

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -151,6 +151,7 @@ pub async fn create_ethereum_networks(
                         )
                         .await,
                     ),
+                    web3.limit_for(&config.node),
                 );
             }
         }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -64,6 +64,8 @@ impl Default for Opt {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Config {
+    #[serde(skip, default = "default_node_id")]
+    pub node: NodeId,
     pub general: Option<GeneralSection>,
     #[serde(rename = "store")]
     pub stores: BTreeMap<String, Shard>,
@@ -173,8 +175,11 @@ impl Config {
         let deployment = Deployment::from_opt(opt);
         let mut stores = BTreeMap::new();
         let chains = ChainSection::from_opt(opt)?;
+        let node = NodeId::new(opt.node_id.to_string())
+            .map_err(|()| anyhow!("invalid node id {}", opt.node_id))?;
         stores.insert(PRIMARY_SHARD.to_string(), Shard::from_opt(true, opt)?);
         Ok(Config {
+            node,
             general: None,
             stores,
             chains,

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -390,6 +390,7 @@ async fn create_ethereum_networks(
                         )
                         .await,
                     ),
+                    web3.limit_for(&config.node),
                 );
             }
         }


### PR DESCRIPTION
Introduce a `limit` for the configuration of web3 providers. The limit is enforced through an approximation, but will be usable to roughly shield a provider from getting too much traffic. There needs to be an unlimited provider for each chain, otherwise `graph-node` may not be able to handle all subgraphs for that chain.