### PR TITLE
Removed alphanumeric enforcement for node IDs

### DIFF
--- a/docker/start
+++ b/docker/start
@@ -57,7 +57,7 @@ run_graph_node() {
         wait_for_ipfs "$ipfs"
         sleep 5
         graph-node \
-            --node-id "${node_id//-/_}" \
+            --node-id "$node_id" \
             --config "$GRAPH_NODE_CONFIG" \
             --ipfs "$ipfs" \
             ${fork_base:+ --fork-base "$fork_base"}
@@ -71,7 +71,7 @@ run_graph_node() {
         sleep 5
 
         graph-node \
-            --node-id "${node_id//-/_}" \
+            --node-id "$node_id" \
             --postgres-url "$postgres_url" \
             --ethereum-rpc $ethereum \
             --ipfs "$ipfs" \
@@ -97,6 +97,14 @@ start_index_node() {
 start_combined_node() {
     run_graph_node
 }
+
+# Allow operators to opt out of legacy character
+# restrictions on the node ID by setting enablement
+# variable to a non-zero length string:
+if [ -z "$GRAPH_NODE_ID_USE_LITERAL_VALUE" ]
+then
+	node_id="${node_id//-/_}"
+fi
 
 if [ -n "$disable_core_dumps" ]
 then

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -136,6 +136,12 @@ those.
   in parallel and deploy to specific nodes; each ID must be unique among the set
   of nodes. A single node should have the same value between consecutive restarts.
   Subgraphs get assigned to node IDs and are not reassigned to other nodes automatically.
+- `GRAPH_NODE_ID_USE_LITERAL_VALUE`: (Docker only) Use the literal `node_id`
+  provided to the docker start script instead of replacing hyphens (-) in names
+  with underscores (\_). Changing this for an existing `graph-node`
+  installation requires also changing the assigned node IDs in the
+  `subgraphs.subgraph_deployment_assignment` table in the database. This can be
+  done with GraphMan or via the PostgreSQL command line.
 - `GRAPH_LOG`: control log levels, the same way that `RUST_LOG` is described
   [here](https://docs.rs/env_logger/0.6.0/env_logger/)
 - `THEGRAPH_STORE_POSTGRES_DIESEL_URL`: postgres instance used when running

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -63,14 +63,8 @@ impl NodeId {
     pub fn new(s: impl Into<String>) -> Result<Self, ()> {
         let s = s.into();
 
-        // Enforce length limit
-        if s.len() > 63 {
-            return Err(());
-        }
-
-        // Check that the ID contains only allowed characters.
-        // Note: these restrictions are relied upon to prevent SQL injection
-        if !s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        // Enforce minimum and maximum length limit
+        if s.len() > 63 || s.len() < 1 {
             return Err(());
         }
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -133,8 +133,8 @@ async fn main() {
         std::process::exit(0);
     }
 
-    let node_id =
-        NodeId::new(opt.node_id.clone()).expect("Node ID must contain only a-z, A-Z, 0-9, and '_'");
+    let node_id = NodeId::new(opt.node_id.clone())
+        .expect("Node ID must be between 1 and 63 characters in length");
     let query_only = config.query_only(&node_id);
 
     // Obtain subgraph related command-line arguments


### PR DESCRIPTION
This removes the node ID check requiring that a node identifier be solely composed of A through Z, 0 through 0, or an underscore (_) character. My reasoning for removing this restriction is that it enables easier node provisioning by enabling the use of generated Kubernetes host names to name index and query nodes. This also removes confusion when a new indexer deploys the indexer stack.