### PR TITLE
ethereum: promote eth_call payload log to debug

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1184,7 +1184,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
             Err(e) => return Box::new(future::err(EthereumContractCallError::EncodingError(e))),
         };
 
-        trace!(logger, "eth_call";
+        debug!(logger, "eth_call";
             "address" => hex::encode(&call.address),
             "data" => hex::encode(&call_data)
         );


### PR DESCRIPTION
Reproducing an eth_call done by graph node is a recurring problem, these logs will be worth their cost.