### PR TITLE
ethereum: Detect xdai eth_call revert

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -474,6 +474,7 @@ impl EthereumAdapter {
 
                     const PARITY_VM_EXECUTION_ERROR: i64 = -32015;
                     const PARITY_REVERT_PREFIX: &str = "Reverted 0x";
+                    const XDAI_REVERT: &str = "revert";
 
                     // Deterministic Geth execution errors. We might need to expand this as
                     // subgraphs come across other errors. See
@@ -534,7 +535,8 @@ impl EthereumAdapter {
                                         || data.starts_with(PARITY_STACK_LIMIT_PREFIX)
                                         || data == PARITY_BAD_INSTRUCTION_FE
                                         || data == PARITY_BAD_INSTRUCTION_FD
-                                        || data == PARITY_OUT_OF_GAS =>
+                                        || data == PARITY_OUT_OF_GAS
+                                        || data == XDAI_REVERT =>
                                 {
                                     let reason = if data == PARITY_BAD_INSTRUCTION_FE {
                                         PARITY_BAD_INSTRUCTION_FE.to_owned()


### PR DESCRIPTION
We've seen [this subgraph](https://thegraph.com/hosted-service/subgraph/superfluid-finance/protocol-dev-xdai?selected=logs) get stuck on this. The RPC response is:
```
Error { code: ServerError(-32015), message: "VM execution error.", data: Some(String("revert")) }
```