### PR TITLE
Fix child basis filtering on derived fields

### DIFF
--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -262,12 +262,19 @@ fn build_child_filter_from_object(
         .object_or_interface(type_name)
         .ok_or(QueryExecutionError::InvalidFilterError)?;
     let filter = build_filter_from_object(child_entity, object, schema)?;
+    let derived = field.is_derived();
 
     Ok(EntityFilter::Child(Child {
-        attr: field_name,
+        attr: match derived {
+            true => sast::get_derived_from_field(child_entity, field)
+                .ok_or(QueryExecutionError::InvalidFilterError)?
+                .name
+                .to_string(),
+            false => field_name,
+        },
         entity_type: EntityType::new(type_name.to_string()),
         filter: Box::new(filter),
-        derived: field.is_derived(),
+        derived,
     }))
 }
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -587,6 +587,27 @@ fn can_query_with_child_filter_on_list_type_field() {
 }
 
 #[test]
+fn can_query_with_child_filter_on_derived_list_type_field() {
+    const QUERY: &str = "
+    query {
+        musicians(first: 100, orderBy: id, where: { writtenSongs_: { title_contains: \"Rock\" } }) {
+            name
+        }
+    }";
+
+    run_query(QUERY, |result, _| {
+        let exp = object! {
+            musicians: vec![
+                object! { name: "Lisa" },
+            ]
+        };
+
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    })
+}
+
+#[test]
 fn can_query_with_child_filter_on_named_type_field() {
     const QUERY: &str = "
     query {
@@ -602,6 +623,28 @@ fn can_query_with_child_filter_on_named_type_field() {
         let exp = object! {
             musicians: vec![
                 object! { name: "Tom", mainBand: object! { id: "b2"} }
+            ]
+        };
+
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    })
+}
+
+#[test]
+fn can_query_with_child_filter_on_derived_named_type_field() {
+    const QUERY: &str = "
+    query {
+        songs(first: 100, orderBy: id, where: { band_: { name_contains: \"The Musicians\" } }) {
+            title
+        }
+    }";
+
+    run_query(QUERY, |result, _| {
+        let exp = object! {
+            songs: vec![
+                object! { title: "Cheesy Tune" },
+                object! { title: "Rock Tune" },
             ]
         };
 

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -924,15 +924,23 @@ impl<'a> QueryFilter<'a> {
                     ));
                 }
 
-                // Make sure that the attribute name is valid for the given table
-                table.column_for_field(child.attr.as_str())?;
+                if child.derived {
+                    let derived_table = layout.table_for_entity(&child.entity_type)?;
+                    // Make sure that the attribute name is valid for the given table
+                    derived_table.column_for_field(child.attr.as_str())?;
 
-                Self::valid_attributes(
-                    &child.filter,
-                    layout.table_for_entity(&child.entity_type)?,
-                    layout,
-                    true,
-                )?;
+                    Self::valid_attributes(&child.filter, derived_table, layout, true)?;
+                } else {
+                    // Make sure that the attribute name is valid for the given table
+                    table.column_for_field(child.attr.as_str())?;
+
+                    Self::valid_attributes(
+                        &child.filter,
+                        layout.table_for_entity(&child.entity_type)?,
+                        layout,
+                        true,
+                    )?;
+                }
             }
             // This is a special case since we want to allow passing "block" column filter, but we dont
             // want to fail/error when this is passed here, since this column is not really an entity column.


### PR DESCRIPTION
Seems like child filtering on derived fields is broken. 

This PR adds two tests to cover derived fields (see below) and of course a fix.


```
songs: [Song]!  @derivedFrom(field: "writtenBy")

band:   Band    @derivedFrom(field: "originalSongs")
```