### PR TITLE
Expose expensive queries file as an option

### DIFF
--- a/node/src/opt.rs
+++ b/node/src/opt.rs
@@ -152,6 +152,14 @@ pub struct Opt {
         help = "a unique identifier for this node. Should have the same value between consecutive node restarts"
     )]
     pub node_id: String,
+    #[structopt(
+        long,
+        value_name = "FILE",
+        env = "GRAPH_NODE_EXPENSIVE_QUERIES_FILE",
+        default_value = "/etc/graph-node/expensive-queries.txt",
+        help = "a file with a list of expensive queries, one query per line. Attempts to run these queries will return a QueryExecutionError::TooExpensive to clients"
+    )]
+    pub expensive_queries_filename: String,
     #[structopt(long, help = "Enable debug logging")]
     pub debug: bool,
 


### PR DESCRIPTION
This pull request replaces the defined constant with EXPENSIVE_QUERIES with a parameter of a similar name. It also adds documentation in the testament describing the functionality exposed with the expensive queries file. Logs into the information log which file is used.