### PR TITLE
feat(graph, graphql): allow to run GraphQL validations silently

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -11,7 +11,7 @@ those.
 ## JSON-RPC configuration for EVM chains
 
 - `ETHEREUM_REORG_THRESHOLD`: Maximum expected reorg size, if a larger reorg
-happens, subgraphs might process inconsistent data. Defaults to 250.
+  happens, subgraphs might process inconsistent data. Defaults to 250.
 - `ETHEREUM_POLLING_INTERVAL`: how often to poll Ethereum for new blocks (in ms,
   defaults to 500ms)
 - `GRAPH_ETHEREUM_TARGET_TRIGGERS_PER_BLOCK_RANGE`: The ideal amount of triggers
@@ -37,9 +37,9 @@ happens, subgraphs might process inconsistent data. Defaults to 250.
   so it can be low. This limit guards against scenarios such as requesting a
   block hash that has been reorged. Defaults to 10.
 - `GRAPH_ETHEREUM_BLOCK_INGESTOR_MAX_CONCURRENT_JSON_RPC_CALLS_FOR_TXN_RECEIPTS`:
-   The maximum number of concurrent requests made against Ethereum for
-   requesting transaction receipts during block ingestion.
-   Defaults to 1,000.
+  The maximum number of concurrent requests made against Ethereum for
+  requesting transaction receipts during block ingestion.
+  Defaults to 1,000.
 - `GRAPH_ETHEREUM_FETCH_TXN_RECEIPTS_IN_BATCHES`: Set to `true` to
   disable fetching receipts from the Ethereum node concurrently during
   block ingestion. This will use fewer, batched requests. This is always set to `true`
@@ -116,12 +116,17 @@ happens, subgraphs might process inconsistent data. Defaults to 250.
   mechanism that is used to trigger updates on GraphQL subscriptions. When
   this variable is set to any value, `graph-node` will still accept GraphQL
   subscriptions, but they won't receive any updates.
+- `ENABLE_GRAPHQL_VALIDATIONS`: enables GraphQL validations, based on the GraphQL specification.
+  This will validate and ensure every query executes follows the execution rules.
+- `SILENT_GRAPHQL_VALIDATIONS`: If `ENABLE_GRAPHQL_VALIDATIONS` is enabled, you are also able to just
+  silently print the GraphQL validation errors, without failing the actual query. Note: queries
+  might still fail as part of the later stage validations running, during GraphQL engine execution.
 
 ### GraphQL caching
 
 - `GRAPH_CACHED_SUBGRAPH_IDS`: when set to `*`, cache all subgraphs (default behavior). Otherwise, a comma-separated list of subgraphs for which to cache queries.
 - `GRAPH_QUERY_CACHE_BLOCKS`: How many recent blocks per network should be kept in the query cache. This should be kept small since the lookup time and the cache memory usage are proportional to this value. Set to 0 to disable the cache. Defaults to 1.
-- `GRAPH_QUERY_CACHE_MAX_MEM`: Maximum total memory to be used by the query cache, in MB. The total amount of memory used for caching will be twice this value - once for recent blocks, divided evenly among the `GRAPH_QUERY_CACHE_BLOCKS`, and once for frequent queries against older blocks.  The default is plenty for most loads, particularly if `GRAPH_QUERY_CACHE_BLOCKS` is kept small. Defaults to 1000, which corresponds to 1GB.
+- `GRAPH_QUERY_CACHE_MAX_MEM`: Maximum total memory to be used by the query cache, in MB. The total amount of memory used for caching will be twice this value - once for recent blocks, divided evenly among the `GRAPH_QUERY_CACHE_BLOCKS`, and once for frequent queries against older blocks. The default is plenty for most loads, particularly if `GRAPH_QUERY_CACHE_BLOCKS` is kept small. Defaults to 1000, which corresponds to 1GB.
 - `GRAPH_QUERY_CACHE_STALE_PERIOD`: Number of queries after which a cache entry can be considered stale. Defaults to 100.
 
 ## Miscellaneous
@@ -178,8 +183,8 @@ happens, subgraphs might process inconsistent data. Defaults to 250.
   decisions. Set to `true` to turn simulation on, defaults to `false`
 - `GRAPH_STORE_CONNECTION_TIMEOUT`: How long to wait to connect to a
   database before assuming the database is down in ms. Defaults to 5000ms.
-- `EXPERIMENTAL_SUBGRAPH_VERSION_SWITCHING_MODE`: default is `instant`, set 
-  to `synced` to only switch a named subgraph to a new deployment once it 
+- `EXPERIMENTAL_SUBGRAPH_VERSION_SWITCHING_MODE`: default is `instant`, set
+  to `synced` to only switch a named subgraph to a new deployment once it
   has synced, making the new deployment the "Pending" version.
 - `GRAPH_REMOVE_UNUSED_INTERVAL`: How long to wait before removing an
   unused deployment. The system periodically checks and marks deployments

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -143,7 +143,9 @@ impl Query {
     pub fn new(document: q::Document, variables: Option<QueryVariables>) -> Self {
         let shape_hash = shape_hash(&document);
 
-        let (query_text, variables_text) = if ENV_VARS.log_gql_timing() {
+        let (query_text, variables_text) = if ENV_VARS.log_gql_timing()
+            || (ENV_VARS.graphql.enable_validations && ENV_VARS.graphql.silent_graphql_validations)
+        {
             (
                 document
                     .format(graphql_parser::Style::default().indent(0))

--- a/graph/src/env/graphql.rs
+++ b/graph/src/env/graphql.rs
@@ -4,8 +4,10 @@ use super::*;
 
 #[derive(Clone)]
 pub struct EnvVarsGraphQl {
-    /// Set by the flag `ENABLE_GRAPHQL_VALIDATIONS`. Off by default.
+    /// Set by the flag `ENABLE_GRAPHQL_VALIDATIONS`. On by default.
     pub enable_validations: bool,
+    /// Set by the flag `SILENT_GRAPHQL_VALIDATIONS`. On by default.
+    pub silent_graphql_validations: bool,
     pub subscription_throttle_interval: Duration,
     /// This is the timeout duration for SQL queries.
     ///
@@ -95,6 +97,7 @@ impl From<InnerGraphQl> for EnvVarsGraphQl {
     fn from(x: InnerGraphQl) -> Self {
         Self {
             enable_validations: x.enable_validations.0,
+            silent_graphql_validations: x.silent_graphql_validations.0,
             subscription_throttle_interval: Duration::from_millis(
                 x.subscription_throttle_interval_in_ms,
             ),
@@ -131,8 +134,10 @@ impl From<InnerGraphQl> for EnvVarsGraphQl {
 
 #[derive(Clone, Debug, Envconfig)]
 pub struct InnerGraphQl {
-    #[envconfig(from = "ENABLE_GRAPHQL_VALIDATIONS", default = "false")]
+    #[envconfig(from = "ENABLE_GRAPHQL_VALIDATIONS", default = "true")]
     enable_validations: EnvVarBoolean,
+    #[envconfig(from = "SILENT_GRAPHQL_VALIDATIONS", default = "true")]
+    silent_graphql_validations: EnvVarBoolean,
     #[envconfig(from = "SUBSCRIPTION_THROTTLE_INTERVAL", default = "1000")]
     subscription_throttle_interval_in_ms: u64,
     #[envconfig(from = "GRAPH_SQL_STATEMENT_TIMEOUT")]

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -15,7 +15,9 @@ use graph::data::graphql::{ext::TypeExt, ObjectOrInterface};
 use graph::data::query::QueryExecutionError;
 use graph::data::query::{Query as GraphDataQuery, QueryVariables};
 use graph::data::schema::ApiSchema;
-use graph::prelude::{info, o, q, r, s, BlockNumber, CheapClone, Logger, TryFromValue, ENV_VARS};
+use graph::prelude::{
+    info, o, q, r, s, warn, BlockNumber, CheapClone, Logger, TryFromValue, ENV_VARS,
+};
 
 use crate::execution::ast as a;
 use crate::query::{ast as qast, ext::BlockConstraint};
@@ -152,12 +154,25 @@ impl Query {
             validate(schema.document(), &query.document, &GRAPHQL_VALIDATION_PLAN);
 
         if !validation_errors.is_empty() {
-            return Err(validation_errors
-                .into_iter()
-                .map(|e| {
-                    QueryExecutionError::ValidationError(e.locations.first().cloned(), e.message)
-                })
-                .collect());
+            if !ENV_VARS.graphql.silent_graphql_validations {
+                return Err(validation_errors
+                    .into_iter()
+                    .map(|e| {
+                        QueryExecutionError::ValidationError(
+                            e.locations.first().cloned(),
+                            e.message,
+                        )
+                    })
+                    .collect());
+            } else {
+                warn!(
+                  &logger,
+                  "GraphQL Validation failure";
+                  "query" => &query.query_text,
+                  "variables" => &query.variables_text,
+                  "errors" => format!("[{:?}]", validation_errors.iter().map(|e| e.message.clone()).collect::<Vec<_>>().join(", "))
+                );
+            }
         }
 
         let mut operation = None;


### PR DESCRIPTION
Closes https://github.com/graphprotocol/graph-node/issues/3715 

## Changes in this PR 

- Change `ENABLE_GRAPHQL_VALIDATIONS` to be enabled by default.
- Added `SILENT_GRAPHQL_VALIDATIONS` env var that is (enabled by default)
- Document environment variables related to GraphQL validations 

## Behavior changes 

- No breaking changes are expected by this PR. 
- For every given incoming query, the GraphQL validations will run now, but will report the results silently to the log in case of an error. 