### PR TITLE
env vars: set high gas default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- `GRAPH_MAX_GAS_PER_HANDLER` is set to a very high value by default,
+  effectively disabling handler gas limits until the costs are better
+  benchmarked and refined.
 - Pipeline store writes #3084 #3177
 
 ## 0.26.0

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -324,7 +324,12 @@ struct Inner {
     elastic_search_max_retries: usize,
     #[envconfig(from = "GRAPH_LOCK_CONTENTION_LOG_THRESHOLD_MS", default = "100")]
     lock_contention_log_threshold_in_ms: u64,
-    #[envconfig(from = "GRAPH_MAX_GAS_PER_HANDLER", default = "")]
+
+    // For now this is set absurdly high by default because we've seen many cases of gas being
+    // overestimated and failing otherwise legit subgraphs. Once gas costs have been better
+    // benchmarked and adjusted, and out of gas has been made a deterministic error, this default
+    // should be removed and this should somehow be gated on `UNSAFE_CONFIG`.
+    #[envconfig(from = "GRAPH_MAX_GAS_PER_HANDLER", default = "1_000_000_000_000_000")]
     max_gas_per_handler:
         WithDefaultUsize<NoUnderscores<u64>, { CONST_MAX_GAS_PER_HANDLER as usize }>,
     #[envconfig(from = "GRAPH_LOG_QUERY_TIMING", default = "")]


### PR DESCRIPTION
This matches the value currently used in the hosted service.