### PR TITLE
ethereum: avoid large trace filter requests

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -697,7 +697,7 @@ impl EthereumAdapter {
     ) -> Box<dyn Stream<Item = EthereumCall, Error = Error> + Send + 'a> {
         let eth = self.clone();
 
-        let addresses: Vec<H160> = call_filter
+        let mut addresses: Vec<H160> = call_filter
             .contract_addresses_function_signatures
             .iter()
             .filter(|(_addr, (start_block, _fsigs))| start_block <= &to)
@@ -710,6 +710,12 @@ impl EthereumAdapter {
             // The filter has no started data sources in the requested range, nothing to do.
             // This prevents an expensive call to `trace_filter` with empty `addresses`.
             return Box::new(stream::empty());
+        }
+
+        if addresses.len() > 100 {
+            // If the address list is large, request all traces, this avoids generating huge
+            // requests and potentially getting 413 errors.
+            addresses = vec![];
         }
 
         Box::new(


### PR DESCRIPTION
We're getting 413s on subgraphs with lots of templates with call handlers.