### PR TITLE
Private data sources table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
-- ...
+### New DB table for dynamic data sources
+
+For new subgraph deployments, dynamic data sources will be recorded under the `sgd*.data_sources$`
+table, rather than `subgraphs.ethereum_contract_data_source`. As a consequence
+new deployments will not work correctly on earlier graph node versions, so
+_downgrading to an earlier graph node version is not supported_.
+See issue #3405 for other details.
 
 ## 0.27.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 ### New DB table for dynamic data sources
 
 For new subgraph deployments, dynamic data sources will be recorded under the `sgd*.data_sources$`
-table, rather than `subgraphs.ethereum_contract_data_source`. As a consequence
+table, rather than `subgraphs.dynamic_ethereum_contract_data_source`. As a consequence
 new deployments will not work correctly on earlier graph node versions, so
 _downgrading to an earlier graph node version is not supported_.
 See issue #3405 for other details.

--- a/chain/arweave/src/data_source.rs
+++ b/chain/arweave/src/data_source.rs
@@ -215,6 +215,7 @@ impl blockchain::UnresolvedDataSource<Chain> for UnresolvedDataSource {
         self,
         resolver: &Arc<dyn LinkResolver>,
         logger: &Logger,
+        _manifest_idx: u32,
     ) -> Result<DataSource, Error> {
         let UnresolvedDataSource {
             kind,
@@ -261,6 +262,7 @@ impl blockchain::UnresolvedDataSourceTemplate<Chain> for UnresolvedDataSourceTem
         self,
         resolver: &Arc<dyn LinkResolver>,
         logger: &Logger,
+        _manifest_idx: u32,
     ) -> Result<DataSourceTemplate, Error> {
         let UnresolvedDataSourceTemplate {
             kind,
@@ -291,6 +293,10 @@ impl blockchain::DataSourceTemplate<Chain> for DataSourceTemplate {
 
     fn runtime(&self) -> Option<Arc<Vec<u8>>> {
         Some(self.mapping.runtime.cheap_clone())
+    }
+
+    fn manifest_idx(&self) -> u32 {
+        unreachable!("arweave does not support dynamic data sources")
     }
 }
 

--- a/chain/cosmos/src/data_source.rs
+++ b/chain/cosmos/src/data_source.rs
@@ -282,6 +282,7 @@ impl blockchain::UnresolvedDataSource<Chain> for UnresolvedDataSource {
         self,
         resolver: &Arc<dyn LinkResolver>,
         logger: &Logger,
+        _manifest_idx: u32,
     ) -> Result<DataSource> {
         let UnresolvedDataSource {
             kind,
@@ -325,6 +326,7 @@ impl blockchain::UnresolvedDataSourceTemplate<Chain> for UnresolvedDataSourceTem
         self,
         _resolver: &Arc<dyn LinkResolver>,
         _logger: &Logger,
+        _manifest_idx: u32,
     ) -> Result<DataSourceTemplate> {
         Err(anyhow!(TEMPLATE_ERROR))
     }
@@ -340,6 +342,10 @@ impl blockchain::DataSourceTemplate<Chain> for DataSourceTemplate {
     }
 
     fn runtime(&self) -> Option<Arc<Vec<u8>>> {
+        unimplemented!("{}", TEMPLATE_ERROR);
+    }
+
+    fn manifest_idx(&self) -> u32 {
         unimplemented!("{}", TEMPLATE_ERROR);
     }
 }

--- a/chain/near/src/data_source.rs
+++ b/chain/near/src/data_source.rs
@@ -272,6 +272,7 @@ impl blockchain::UnresolvedDataSource<Chain> for UnresolvedDataSource {
         self,
         resolver: &Arc<dyn LinkResolver>,
         logger: &Logger,
+        _manifest_idx: u32,
     ) -> Result<DataSource, Error> {
         let UnresolvedDataSource {
             kind,
@@ -346,6 +347,7 @@ impl blockchain::UnresolvedDataSourceTemplate<Chain> for UnresolvedDataSourceTem
         self,
         resolver: &Arc<dyn LinkResolver>,
         logger: &Logger,
+        _manifest_idx: u32,
     ) -> Result<DataSourceTemplate, Error> {
         let UnresolvedDataSourceTemplate {
             kind,
@@ -376,6 +378,10 @@ impl blockchain::DataSourceTemplate<Chain> for DataSourceTemplate {
 
     fn runtime(&self) -> Option<Arc<Vec<u8>>> {
         Some(self.mapping.runtime.cheap_clone())
+    }
+
+    fn manifest_idx(&self) -> u32 {
+        unreachable!("near does not support dynamic data sources")
     }
 }
 

--- a/chain/substreams/src/data_source.rs
+++ b/chain/substreams/src/data_source.rs
@@ -162,6 +162,7 @@ impl blockchain::UnresolvedDataSource<Chain> for UnresolvedDataSource {
         self,
         _resolver: &Arc<dyn LinkResolver>,
         _logger: &Logger,
+        _manifest_idx: u32,
     ) -> Result<DataSource, Error> {
         Ok(DataSource {
             kind: SUBSTREAMS_KIND.into(),
@@ -205,6 +206,10 @@ impl blockchain::DataSourceTemplate<Chain> for NoopDataSourceTemplate {
     fn runtime(&self) -> Option<Arc<Vec<u8>>> {
         unimplemented!("{}", TEMPLATE_ERROR);
     }
+
+    fn manifest_idx(&self) -> u32 {
+        todo!()
+    }
 }
 
 #[async_trait]
@@ -213,6 +218,7 @@ impl blockchain::UnresolvedDataSourceTemplate<Chain> for NoopDataSourceTemplate 
         self,
         _resolver: &Arc<dyn LinkResolver>,
         _logger: &Logger,
+        _manifest_idx: u32,
     ) -> Result<NoopDataSourceTemplate, anyhow::Error> {
         unimplemented!("{}", TEMPLATE_ERROR)
     }
@@ -260,7 +266,7 @@ mod test {
         let ds: UnresolvedDataSource = serde_yaml::from_str(TEMPLATE_DATA_SOURCE).unwrap();
         let link_resolver: Arc<dyn LinkResolver> = Arc::new(NoopLinkResolver {});
         let logger = Logger::root(Discard, o!());
-        let ds: DataSource = ds.resolve(&link_resolver, &logger).await.unwrap();
+        let ds: DataSource = ds.resolve(&link_resolver, &logger, 0).await.unwrap();
         let expected = DataSource {
             kind: SUBSTREAMS_KIND.into(),
             network: Some("mainnet".into()),

--- a/core/src/subgraph/inputs.rs
+++ b/core/src/subgraph/inputs.rs
@@ -21,4 +21,7 @@ pub struct IndexingInputs<C: Blockchain> {
     pub templates: Arc<Vec<C::DataSourceTemplate>>,
     pub unified_api_version: UnifiedMappingApiVersion,
     pub static_filters: bool,
+
+    // Correspondence between data source or template position in the manifest and name.
+    pub manifest_idx_and_name: Vec<(u32, String)>,
 }

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -260,7 +260,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
 
         // Initialize deployment_head with current deployment head. Any sort of trouble in
         // getting the deployment head ptr leads to initializing with 0
-        let deployment_head = store.block_ptr().await.map(|ptr| ptr.number).unwrap_or(0) as f64;
+        let deployment_head = store.block_ptr().map(|ptr| ptr.number).unwrap_or(0) as f64;
         block_stream_metrics.deployment_head.set(deployment_head);
 
         let host_builder = graph_runtime_wasm::RuntimeHostBuilder::new(

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -7,8 +7,9 @@ use crate::subgraph::metrics::{
 use crate::subgraph::runner::SubgraphRunner;
 use crate::subgraph::SubgraphInstance;
 use graph::blockchain::block_stream::BlockStreamMetrics;
-use graph::blockchain::Blockchain;
+use graph::blockchain::DataSource;
 use graph::blockchain::NodeCapabilities;
+use graph::blockchain::{Blockchain, DataSourceTemplate};
 use graph::blockchain::{BlockchainKind, TriggerFilter};
 use graph::prelude::{SubgraphInstanceManager as SubgraphInstanceManagerTrait, *};
 use graph::{blockchain::BlockchainMap, components::store::DeploymentLocator};
@@ -147,7 +148,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
         // that is done
         store.start_subgraph_deployment(&logger).await?;
 
-        let manifest: SubgraphManifest<C> = {
+        let (manifest, manifest_idx_and_name) = {
             info!(logger, "Resolve subgraph files using IPFS");
 
             let mut manifest = SubgraphManifest::resolve_from_raw(
@@ -161,9 +162,28 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             .await
             .context("Failed to resolve subgraph from IPFS")?;
 
-            let data_sources = load_dynamic_data_sources(store.clone(), logger.clone(), &manifest)
-                .await
-                .context("Failed to load dynamic data sources")?;
+            let manifest_idx_and_name: Vec<(u32, String)> = manifest
+                .data_sources
+                .iter()
+                .map(|ds: &C::DataSource| ds.name().to_owned())
+                .chain(
+                    manifest
+                        .templates
+                        .iter()
+                        .map(|t: &C::DataSourceTemplate| t.name().to_owned()),
+                )
+                .enumerate()
+                .map(|(idx, name)| (idx as u32, name))
+                .collect();
+
+            let data_sources = load_dynamic_data_sources(
+                store.clone(),
+                logger.clone(),
+                &manifest,
+                manifest_idx_and_name.clone(),
+            )
+            .await
+            .context("Failed to load dynamic data sources")?;
 
             info!(logger, "Successfully resolved subgraph files using IPFS");
 
@@ -176,7 +196,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
                 manifest.data_sources.len()
             );
 
-            manifest
+            (manifest, manifest_idx_and_name)
         };
 
         let required_capabilities = C::NodeCapabilities::from_data_sources(&manifest.data_sources);
@@ -273,6 +293,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             templates,
             unified_api_version,
             static_filters: self.static_filters,
+            manifest_idx_and_name,
         };
 
         // The subgraph state tracks the state of the subgraph instance over time

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -8,17 +8,21 @@ pub async fn load_dynamic_data_sources<C: Blockchain>(
     store: Arc<dyn WritableStore>,
     logger: Logger,
     manifest: &SubgraphManifest<C>,
+    manifest_idx_and_name: Vec<(u32, String)>,
 ) -> Result<Vec<C::DataSource>, Error> {
     let start_time = Instant::now();
 
     let mut data_sources: Vec<C::DataSource> = vec![];
 
-    for stored in store.load_dynamic_data_sources().await? {
+    for stored in store
+        .load_dynamic_data_sources(manifest_idx_and_name)
+        .await?
+    {
         let template = manifest
             .templates
             .iter()
-            .find(|template| template.name() == stored.name.as_str())
-            .ok_or_else(|| anyhow!("no template named `{}` was found", stored.name))?;
+            .find(|template| template.manifest_idx() == stored.manifest_idx)
+            .ok_or_else(|| anyhow!("no template with idx `{}` was found", stored.manifest_idx))?;
 
         let ds = C::DataSource::from_stored_dynamic_data_source(&template, stored)?;
 

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -72,7 +72,7 @@ where
         // If a subgraph failed for deterministic reasons, before start indexing, we first
         // revert the deployment head. It should lead to the same result since the error was
         // deterministic.
-        if let Some(current_ptr) = self.inputs.store.block_ptr().await {
+        if let Some(current_ptr) = self.inputs.store.block_ptr() {
             if let Some(parent_ptr) = self
                 .inputs
                 .triggers_adapter
@@ -798,7 +798,7 @@ where
         //
         // Safe unwrap because in a Revert event we're sure the subgraph has
         // advanced at least once.
-        let subgraph_ptr = self.inputs.store.block_ptr().await.unwrap();
+        let subgraph_ptr = self.inputs.store.block_ptr().unwrap();
         if revert_to_ptr.number >= subgraph_ptr.number {
             info!(&self.logger, "Block to revert is higher than subgraph pointer, nothing to do"; "subgraph_ptr" => &subgraph_ptr, "revert_to_ptr" => &revert_to_ptr);
             return Ok(Action::Continue);

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -375,6 +375,7 @@ where
                 &self.metrics.host.stopwatch,
                 data_sources,
                 deterministic_errors,
+                self.inputs.manifest_idx_and_name.clone(),
             )
             .await
             .context("Failed to transact block operations")?;

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -678,6 +678,13 @@ where
                     }
                 }
 
+                if let Some(stop_block) = &self.inputs.stop_block {
+                    if block_ptr.number >= *stop_block {
+                        info!(self.logger, "stop block reached for subgraph");
+                        return Ok(Action::Stop);
+                    }
+                }
+
                 if matches!(action, Action::Restart) {
                     // Cancel the stream for real
                     self.ctx
@@ -688,13 +695,6 @@ where
 
                     // And restart the subgraph
                     return Ok(Action::Restart);
-                }
-
-                if let Some(stop_block) = &self.inputs.stop_block {
-                    if block_ptr.number >= *stop_block {
-                        info!(self.logger, "stop block reached for subgraph");
-                        return Ok(Action::Stop);
-                    }
                 }
 
                 return Ok(Action::Continue);

--- a/core/src/subgraph/stream.rs
+++ b/core/src/subgraph/stream.rs
@@ -18,12 +18,12 @@ pub async fn new_block_stream<C: Blockchain>(
         false => BUFFERED_BLOCK_STREAM_SIZE,
     };
 
-    let current_ptr = inputs.store.block_ptr().await;
+    let current_ptr = inputs.store.block_ptr();
 
     let block_stream = match is_firehose {
         true => inputs.chain.new_firehose_block_stream(
             inputs.deployment.clone(),
-            inputs.store.block_cursor().await,
+            inputs.store.block_cursor(),
             inputs.start_blocks.clone(),
             current_ptr,
             Arc::new(filter.clone()),

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -129,6 +129,7 @@ impl<C: Blockchain> UnresolvedDataSource<C> for MockUnresolvedDataSource {
         self,
         _resolver: &Arc<dyn LinkResolver>,
         _logger: &slog::Logger,
+        _manifest_idx: u32,
     ) -> Result<C::DataSource, anyhow::Error> {
         todo!()
     }
@@ -149,6 +150,10 @@ impl<C: Blockchain> DataSourceTemplate<C> for MockDataSourceTemplate {
     fn name(&self) -> &str {
         todo!()
     }
+
+    fn manifest_idx(&self) -> u32 {
+        todo!()
+    }
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -160,6 +165,7 @@ impl<C: Blockchain> UnresolvedDataSourceTemplate<C> for MockUnresolvedDataSource
         self,
         _resolver: &Arc<dyn LinkResolver>,
         _logger: &slog::Logger,
+        _manifest_idx: u32,
     ) -> Result<C::DataSourceTemplate, anyhow::Error> {
         todo!()
     }

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -241,6 +241,7 @@ pub trait UnresolvedDataSourceTemplate<C: Blockchain>:
         self,
         resolver: &Arc<dyn LinkResolver>,
         logger: &Logger,
+        manifest_idx: u32,
     ) -> Result<C::DataSourceTemplate, anyhow::Error>;
 }
 
@@ -248,6 +249,7 @@ pub trait DataSourceTemplate<C: Blockchain>: Send + Sync + Debug {
     fn api_version(&self) -> semver::Version;
     fn runtime(&self) -> Option<Arc<Vec<u8>>>;
     fn name(&self) -> &str;
+    fn manifest_idx(&self) -> u32;
 }
 
 #[async_trait]
@@ -258,6 +260,7 @@ pub trait UnresolvedDataSource<C: Blockchain>:
         self,
         resolver: &Arc<dyn LinkResolver>,
         logger: &Logger,
+        manifest_idx: u32,
     ) -> Result<C::DataSource, anyhow::Error>;
 }
 

--- a/graph/src/components/store/cache.rs
+++ b/graph/src/components/store/cache.rs
@@ -4,6 +4,7 @@ use std::fmt::{self, Debug};
 use std::sync::Arc;
 
 use crate::blockchain::BlockPtr;
+use crate::blockchain::DataSource;
 use crate::components::store::{
     self as s, Entity, EntityKey, EntityOp, EntityOperation, EntityType,
 };
@@ -188,7 +189,7 @@ impl EntityCache {
     }
 
     /// Add a dynamic data source
-    pub fn add_data_source<C: s::Blockchain>(&mut self, data_source: &impl s::DataSource<C>) {
+    pub fn add_data_source<C: s::Blockchain>(&mut self, data_source: &impl DataSource<C>) {
         self.data_sources
             .push(data_source.as_stored_dynamic_data_source());
     }

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1047,7 +1047,7 @@ pub enum DeploymentSchemaVersion {
 
 impl DeploymentSchemaVersion {
     // Latest schema version supported by this version of graph node.
-    pub const LATEST: Self = Self::V0;
+    pub const LATEST: Self = Self::V1;
 
     pub fn private_data_sources(self) -> bool {
         use DeploymentSchemaVersion::*;

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -19,7 +19,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-use crate::blockchain::DataSource;
 use crate::blockchain::{Block, Blockchain};
 use crate::data::store::scalar::Bytes;
 use crate::data::store::*;
@@ -822,9 +821,9 @@ pub enum UnfailOutcome {
     Unfailed,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StoredDynamicDataSource {
-    pub name: String,
+    pub manifest_idx: u32,
     pub param: Option<Bytes>,
     pub context: Option<serde_json::Value>,
     pub creation_block: Option<BlockNumber>,

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -204,6 +204,7 @@ pub trait WritableStore: Send + Sync + 'static {
         stopwatch: &StopwatchMetrics,
         data_sources: Vec<StoredDynamicDataSource>,
         deterministic_errors: Vec<SubgraphError>,
+        manifest_idx_and_name: Vec<(u32, String)>,
     ) -> Result<(), StoreError>;
 
     /// Look up multiple entities as of the latest block. Returns a map of
@@ -225,7 +226,10 @@ pub trait WritableStore: Send + Sync + 'static {
     fn unassign_subgraph(&self) -> Result<(), StoreError>;
 
     /// Load the dynamic data sources for the given deployment
-    async fn load_dynamic_data_sources(&self) -> Result<Vec<StoredDynamicDataSource>, StoreError>;
+    async fn load_dynamic_data_sources(
+        &self,
+        manifest_idx_and_name: Vec<(u32, String)>,
+    ) -> Result<Vec<StoredDynamicDataSource>, StoreError>;
 
     /// Report the name of the shard in which the subgraph is stored. This
     /// should only be used for reporting and monitoring

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -150,11 +150,11 @@ pub trait SubgraphStore: Send + Sync + 'static {
 #[async_trait]
 pub trait WritableStore: Send + Sync + 'static {
     /// Get a pointer to the most recently processed block in the subgraph.
-    async fn block_ptr(&self) -> Option<BlockPtr>;
+    fn block_ptr(&self) -> Option<BlockPtr>;
 
     /// Returns the Firehose `cursor` this deployment is currently at in the block stream of events. This
     /// is used when re-connecting a Firehose stream to start back exactly where we left off.
-    async fn block_cursor(&self) -> FirehoseCursor;
+    fn block_cursor(&self) -> FirehoseCursor;
 
     /// Start an existing subgraph deployment.
     async fn start_subgraph_deployment(&self, logger: &Logger) -> Result<(), StoreError>;

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -42,7 +42,8 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
         hash: DeploymentHash,
         assignment_node_id: NodeId,
         debug_fork: Option<DeploymentHash>,
-        start_block: Option<BlockPtr>,
+        start_block_block: Option<BlockPtr>,
+        graft_block_override: Option<BlockPtr>,
     ) -> Result<DeploymentLocator, SubgraphRegistrarError>;
 
     async fn remove_subgraph(&self, name: SubgraphName) -> Result<(), SubgraphRegistrarError>;

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -46,11 +46,11 @@ impl MockStore {
 
 #[async_trait]
 impl WritableStore for MockStore {
-    async fn block_ptr(&self) -> Option<BlockPtr> {
+    fn block_ptr(&self) -> Option<BlockPtr> {
         unimplemented!()
     }
 
-    async fn block_cursor(&self) -> FirehoseCursor {
+    fn block_cursor(&self) -> FirehoseCursor {
         unimplemented!()
     }
 

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -107,6 +107,7 @@ impl WritableStore for MockStore {
         _: &StopwatchMetrics,
         _: Vec<StoredDynamicDataSource>,
         _: Vec<SubgraphError>,
+        _: Vec<(u32, String)>,
     ) -> Result<(), StoreError> {
         unimplemented!()
     }
@@ -126,7 +127,10 @@ impl WritableStore for MockStore {
         unimplemented!()
     }
 
-    async fn load_dynamic_data_sources(&self) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
+    async fn load_dynamic_data_sources(
+        &self,
+        _manifest_idx_and_name: Vec<(u32, String)>,
+    ) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
         unimplemented!()
     }
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -490,6 +490,7 @@ async fn main() {
                             node_id,
                             debug_fork,
                             start_block,
+                            None,
                         )
                         .await
                 }

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -205,6 +205,7 @@ pub async fn run(
         node_id.clone(),
         None,
         None,
+        None,
     )
     .await?;
 

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -30,6 +30,7 @@ fn mock_host_exports(
     let templates = vec![DataSourceTemplate {
         kind: String::from("ethereum/contract"),
         name: String::from("example template"),
+        manifest_idx: 0,
         network: Some(String::from("mainnet")),
         source: TemplateSource {
             abi: String::from("foo"),
@@ -120,6 +121,7 @@ pub fn mock_data_source(path: &str, api_version: Version) -> DataSource {
     DataSource {
         kind: String::from("ethereum/contract"),
         name: String::from("example data source"),
+        manifest_idx: 0,
         network: Some(String::from("mainnet")),
         address: Some(Address::from_str("0123123123012312312301231231230123123123").unwrap()),
         start_block: 0,

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -92,6 +92,7 @@ impl<R: SubgraphRegistrar> JsonRpcServer<R> {
                 // Here it doesn't make sense to receive another
                 // startBlock, we'll use the one from the manifest.
                 None,
+                None,
             )
             .await
         {

--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -599,6 +599,15 @@ impl Connection {
         target_block: BlockPtr,
     ) -> Result<Self, StoreError> {
         let logger = logger.new(o!("dst" => dst.site.namespace.to_string()));
+
+        if src.site.schema_version != dst.site.schema_version {
+            return Err(StoreError::ConstraintViolation(format!(
+                "attempted to copy between different schema versions, \
+                 source version is {} but destination version is {}",
+                src.site.schema_version, dst.site.schema_version
+            )));
+        }
+
         let mut last_log = Instant::now();
         let conn = pool.get_fdw(&logger, || {
             if last_log.elapsed() > LOG_INTERVAL {

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -973,6 +973,7 @@ impl DeploymentStore {
         stopwatch: &StopwatchMetrics,
         data_sources: &[StoredDynamicDataSource],
         deterministic_errors: &[SubgraphError],
+        manifest_idx_and_name: &[(u32, String)],
     ) -> Result<StoreEvent, StoreError> {
         // All operations should apply only to data or metadata for this subgraph
         if mods
@@ -1010,7 +1011,13 @@ impl DeploymentStore {
             )?;
             section.end();
 
-            dynds::insert(&conn, &site, data_sources, block_ptr_to)?;
+            dynds::insert(
+                &conn,
+                &site,
+                data_sources,
+                block_ptr_to,
+                manifest_idx_and_name,
+            )?;
 
             if !deterministic_errors.is_empty() {
                 deployment::insert_subgraph_errors(
@@ -1178,9 +1185,10 @@ impl DeploymentStore {
         &self,
         site: Arc<Site>,
         block: BlockNumber,
+        manifest_idx_and_name: Vec<(u32, String)>,
     ) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
         self.with_conn(move |conn, _| {
-            conn.transaction(|| crate::dynds::load(&conn, &site, block))
+            conn.transaction(|| crate::dynds::load(&conn, &site, block, manifest_idx_and_name))
                 .map_err(Into::into)
         })
         .await

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1250,7 +1250,7 @@ impl DeploymentStore {
             conn.transaction(|| -> Result<(), StoreError> {
                 // Copy dynamic data sources and adjust their ID
                 let start = Instant::now();
-                let count = dynds::copy(&conn, &src.site, &dst.site, &block)?;
+                let count = dynds::copy(&conn, &src.site, &dst.site, block.number)?;
                 info!(logger, "Copied {} dynamic data sources", count;
                       "time_ms" => start.elapsed().as_millis());
 

--- a/store/postgres/src/dynds/mod.rs
+++ b/store/postgres/src/dynds/mod.rs
@@ -15,10 +15,11 @@ pub fn load(
     conn: &PgConnection,
     site: &Site,
     block: BlockNumber,
+    manifest_idx_and_name: Vec<(u32, String)>,
 ) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
     match site.schema_version.private_data_sources() {
         true => DataSourcesTable::new(site.namespace.clone()).load(conn, block),
-        false => shared::load(conn, site.deployment.as_str(), block),
+        false => shared::load(conn, site.deployment.as_str(), block, manifest_idx_and_name),
     }
 }
 
@@ -27,6 +28,7 @@ pub(crate) fn insert(
     site: &Site,
     data_sources: &[StoredDynamicDataSource],
     block_ptr: &BlockPtr,
+    manifest_idx_and_name: &[(u32, String)],
 ) -> Result<usize, StoreError> {
     match site.schema_version.private_data_sources() {
         true => DataSourcesTable::new(site.namespace.clone()).insert(
@@ -34,7 +36,13 @@ pub(crate) fn insert(
             data_sources,
             block_ptr.number,
         ),
-        false => shared::insert(conn, &site.deployment, data_sources, block_ptr),
+        false => shared::insert(
+            conn,
+            &site.deployment,
+            data_sources,
+            block_ptr,
+            manifest_idx_and_name,
+        ),
     }
 }
 
@@ -52,7 +60,11 @@ pub(crate) fn copy(
         )));
     }
     match src.schema_version.private_data_sources() {
-        true => todo!(),
+        true => DataSourcesTable::new(src.namespace.clone()).copy_to(
+            conn,
+            &DataSourcesTable::new(dst.namespace.clone()),
+            target_block,
+        ),
         false => shared::copy(conn, src, dst, target_block),
     }
 }

--- a/store/postgres/src/dynds/mod.rs
+++ b/store/postgres/src/dynds/mod.rs
@@ -52,13 +52,6 @@ pub(crate) fn copy(
     dst: &Site,
     target_block: BlockNumber,
 ) -> Result<usize, StoreError> {
-    if src.schema_version != dst.schema_version {
-        return Err(StoreError::ConstraintViolation(format!(
-            "attempted to copy between different schema versions, \
-             source version is {} but destination version is {}",
-            src.schema_version, dst.schema_version
-        )));
-    }
     match src.schema_version.private_data_sources() {
         true => DataSourcesTable::new(src.namespace.clone()).copy_to(
             conn,

--- a/store/postgres/src/dynds/mod.rs
+++ b/store/postgres/src/dynds/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn copy(
     conn: &PgConnection,
     src: &Site,
     dst: &Site,
-    target_block: &BlockPtr,
+    target_block: BlockNumber,
 ) -> Result<usize, StoreError> {
     if src.schema_version != dst.schema_version {
         return Err(StoreError::ConstraintViolation(format!(

--- a/store/postgres/src/dynds/private.rs
+++ b/store/postgres/src/dynds/private.rs
@@ -2,18 +2,22 @@
 #![allow(unused_variables)]
 #![allow(unused_imports)]
 
+use std::ops::Bound;
+
 use diesel::{
     pg::types::sql_types,
+    sql_query,
     sql_types::{Binary, Integer, Jsonb, Nullable},
-    types::Bytea,
-    PgConnection, QueryDsl, RunQueryDsl,
+    ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl,
 };
+
 use graph::{
     components::store::StoredDynamicDataSource,
+    constraint_violation,
     prelude::{serde_json, BlockNumber, StoreError},
 };
 
-use crate::primary::Namespace;
+use crate::{layout_for_tests::BlockRange, primary::Namespace};
 
 type DynTable = diesel_dynamic_schema::Table<String, Namespace>;
 type DynColumn<ST> = diesel_dynamic_schema::Column<DynTable, &'static str, ST>;
@@ -78,16 +82,40 @@ impl DataSourcesTable {
         conn: &PgConnection,
         block: BlockNumber,
     ) -> Result<Vec<StoredDynamicDataSource>, StoreError> {
-        // self.table
-        //     .select((
-        //         self.block_range,
-        //         self.manifest_idx,
-        //         self.param,
-        //         self.context,
-        //     ))
-        //     .load(conn)?;
+        type Tuple = (
+            (Bound<i32>, Bound<i32>),
+            i32,
+            Option<Vec<u8>>,
+            Option<serde_json::Value>,
+        );
+        let tuples = self
+            .table
+            .clone()
+            .select((
+                &self.block_range,
+                &self.manifest_idx,
+                &self.param,
+                &self.context,
+            ))
+            .load::<Tuple>(conn)?;
 
-        todo!()
+        Ok(tuples
+            .into_iter()
+            .map(|(block_range, manifest_idx, param, context)| {
+                let creation_block = match block_range.0 {
+                    Bound::Included(block) => Some(block),
+
+                    // Should never happen.
+                    Bound::Excluded(_) | Bound::Unbounded => None,
+                };
+                StoredDynamicDataSource {
+                    manifest_idx: manifest_idx as u32,
+                    param: param.map(|p| p.into()),
+                    context,
+                    creation_block,
+                }
+            })
+            .collect())
     }
 
     pub(crate) fn insert(
@@ -96,10 +124,93 @@ impl DataSourcesTable {
         data_sources: &[StoredDynamicDataSource],
         block: BlockNumber,
     ) -> Result<usize, StoreError> {
-        todo!()
+        // Currently all data sources share the same causality region.
+        let causality_region = 0;
+
+        let mut inserted_total = 0;
+
+        for ds in data_sources {
+            let StoredDynamicDataSource {
+                manifest_idx,
+                param,
+                context,
+                creation_block,
+            } = ds;
+
+            if creation_block != &Some(block) {
+                return Err(constraint_violation!(
+                    "mismatching creation blocks `{:?}` and `{}`",
+                    creation_block,
+                    block
+                ));
+            }
+
+            let query = format!(
+                "insert into {}(block_range, manifest_idx, causality_region, param, context) \
+                 values (int4range($1, null), $2, $3, $4, $5)",
+                self.qname
+            );
+
+            inserted_total += sql_query(query)
+                .bind::<Nullable<Integer>, _>(creation_block)
+                .bind::<Integer, _>(*manifest_idx as i32)
+                .bind::<Integer, _>(causality_region)
+                .bind::<Nullable<Binary>, _>(param.as_ref().map(|p| &**p))
+                .bind::<Nullable<Jsonb>, _>(context)
+                .execute(conn)?;
+        }
+
+        Ok(inserted_total)
     }
 
     pub(crate) fn revert(&self, conn: &PgConnection, block: BlockNumber) -> Result<(), StoreError> {
-        todo!()
+        // Use `@>` to leverage the gist index.
+        // This assumes all ranges are of the form [x, +inf).
+        let query = format!(
+            "delete from {} where block_range @> $1 and lower(block_range) = $1",
+            self.qname
+        );
+        sql_query(query).bind::<Integer, _>(block).execute(conn)?;
+        Ok(())
+    }
+
+    /// Copy the dynamic data sources from `self` to `dst`. All data sources that
+    /// were created up to and including `target_block` will be copied.
+    pub(super) fn copy_to(
+        &self,
+        conn: &PgConnection,
+        dst: &DataSourcesTable,
+        target_block: BlockNumber,
+    ) -> Result<usize, StoreError> {
+        // Check if there are any data sources for dst which indicates we already copied
+        let count = dst.table.clone().count().get_result::<i64>(conn)?;
+        if count > 0 {
+            return Ok(count as usize);
+        }
+
+        // Assumes all ranges are of the form `[n, +inf)`.
+        let query = format!(
+            "\
+            insert into {dst}(block_range, causality_region, manifest_idx, parent, id, param, context)
+            select int4range(lower(e.block_range), null), e.causality_region, e.manifest_idx,
+                    e.parent, e.id, e.param, e.context
+            from {src} e
+            where lower(e.block_range) <= $1
+            ",
+            src = self.qname,
+            dst = dst.qname
+        );
+
+        let count = sql_query(&query)
+            .bind::<Integer, _>(target_block)
+            .execute(conn)?;
+
+        // Test that both tables have the same contents.
+        debug_assert!(
+            self.load(conn, target_block).map_err(|e| e.to_string())
+                == dst.load(conn, target_block).map_err(|e| e.to_string())
+        );
+
+        Ok(count)
     }
 }

--- a/store/postgres/src/dynds/private.rs
+++ b/store/postgres/src/dynds/private.rs
@@ -185,12 +185,14 @@ impl DataSourcesTable {
             return Ok(count as usize);
         }
 
-        // Assumes all ranges are of the form `[n, +inf)`.
         let query = format!(
             "\
             insert into {dst}(block_range, causality_region, manifest_idx, parent, id, param, context)
-            select int4range(lower(e.block_range), null), e.causality_region, e.manifest_idx,
-                    e.parent, e.id, e.param, e.context
+            select case
+                when upper(e.block_range) <= $1 then e.block_range
+                else int4range(lower(e.block_range), null)
+            end,
+            e.causality_region, e.manifest_idx, e.parent, e.id, e.param, e.context
             from {src} e
             where lower(e.block_range) <= $1
             ",

--- a/store/postgres/src/dynds/private.rs
+++ b/store/postgres/src/dynds/private.rs
@@ -103,7 +103,7 @@ impl DataSourcesTable {
                     Bound::Included(block) => Some(block),
 
                     // Should never happen.
-                    Bound::Excluded(_) | Bound::Unbounded => None,
+                    Bound::Excluded(_) | Bound::Unbounded => unreachable!("dds with open creation"),
                 };
                 StoredDynamicDataSource {
                     manifest_idx: manifest_idx as u32,

--- a/store/postgres/src/dynds/shared.rs
+++ b/store/postgres/src/dynds/shared.rs
@@ -146,7 +146,7 @@ pub(super) fn copy(
     conn: &PgConnection,
     src: &Site,
     dst: &Site,
-    target_block: &BlockPtr,
+    target_block: BlockNumber,
 ) -> Result<usize, StoreError> {
     use dynamic_ethereum_contract_data_source as decds;
 
@@ -183,7 +183,7 @@ pub(super) fn copy(
     Ok(sql_query(&query)
         .bind::<Text, _>(src.deployment.as_str())
         .bind::<Text, _>(dst.deployment.as_str())
-        .bind::<Integer, _>(target_block.number)
+        .bind::<Integer, _>(target_block)
         .execute(conn)?)
 }
 

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1087,12 +1087,12 @@ impl<'a> Connection<'a> {
         shard: Shard,
         subgraph: &DeploymentHash,
         network: String,
+        schema_version: DeploymentSchemaVersion,
     ) -> Result<Site, StoreError> {
         if let Some(site) = queries::find_active_site(self.conn.as_ref(), subgraph)? {
             return Ok(site);
         }
 
-        let schema_version = DeploymentSchemaVersion::LATEST;
         self.create_site(shard, subgraph.clone(), network, schema_version, true)
     }
 

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1110,14 +1110,6 @@ impl<'a> Connection<'a> {
             return Ok(site);
         }
 
-        if src.schema_version != DeploymentSchemaVersion::LATEST {
-            return Err(StoreError::Unknown(anyhow!(
-                "Attempted to copy from deployment {} which is on an old schema version.
-                This means a schema migration is ongoing, please try again later.",
-                src.id
-            )));
-        }
-
         self.create_site(
             shard,
             src.deployment.clone(),

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -15,7 +15,10 @@ use graph::{
     cheap_clone::CheapClone,
     components::{
         server::index_node::VersionInfo,
-        store::{self, BlockStore, DeploymentLocator, EnsLookup as EnsLookupTrait, SubgraphFork},
+        store::{
+            self, BlockStore, DeploymentLocator, DeploymentSchemaVersion,
+            EnsLookup as EnsLookupTrait, SubgraphFork,
+        },
     },
     constraint_violation,
     data::query::QueryTarget,
@@ -495,6 +498,12 @@ impl SubgraphStoreInner {
         #[cfg(not(debug_assertions))]
         assert!(!replace);
 
+        let graft_base = deployment
+            .graft_base
+            .as_ref()
+            .map(|base| self.layout(base))
+            .transpose()?;
+
         let (site, node_id) = {
             // We need to deal with two situations:
             //   (1) We are really creating a new subgraph; it therefore needs
@@ -507,18 +516,16 @@ impl SubgraphStoreInner {
             //       assignment that we used last time to avoid creating
             //       the same deployment in another shard
             let (shard, node_id) = self.place(&name, &network_name, node_id)?;
+            let schema_version = match &graft_base {
+                None => DeploymentSchemaVersion::LATEST,
+                Some(src_layout) => src_layout.site.schema_version,
+            };
             let conn = self.primary_conn()?;
-            let site = conn.allocate_site(shard, &schema.id, network_name)?;
+            let site = conn.allocate_site(shard, &schema.id, network_name, schema_version)?;
             let node_id = conn.assigned_node(&site)?.unwrap_or(node_id);
             (site, node_id)
         };
         let site = Arc::new(site);
-
-        let graft_base = deployment
-            .graft_base
-            .as_ref()
-            .map(|base| self.layout(base))
-            .transpose()?;
 
         if let Some(graft_base) = &graft_base {
             self.primary_conn()?

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -938,11 +938,11 @@ impl WritableStore {
 
 #[async_trait::async_trait]
 impl WritableStoreTrait for WritableStore {
-    async fn block_ptr(&self) -> Option<BlockPtr> {
+    fn block_ptr(&self) -> Option<BlockPtr> {
         self.block_ptr.lock().unwrap().clone()
     }
 
-    async fn block_cursor(&self) -> FirehoseCursor {
+    fn block_cursor(&self) -> FirehoseCursor {
         self.block_cursor.lock().unwrap().clone()
     }
 

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -59,7 +59,6 @@ async fn latest_block(store: &Store, deployment_id: DeploymentId) -> BlockPtr {
         .await
         .expect("can get writable")
         .block_ptr()
-        .await
         .unwrap()
 }
 

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -233,6 +233,7 @@ pub async fn transact_errors(
             &stopwatch_metrics,
             Vec::new(),
             errs,
+            Vec::new(),
         )
         .await?;
     flush(deployment).await
@@ -245,8 +246,15 @@ pub async fn transact_entity_operations(
     block_ptr_to: BlockPtr,
     ops: Vec<EntityOperation>,
 ) -> Result<(), StoreError> {
-    transact_entities_and_dynamic_data_sources(store, deployment.clone(), block_ptr_to, vec![], ops)
-        .await
+    transact_entities_and_dynamic_data_sources(
+        store,
+        deployment.clone(),
+        block_ptr_to,
+        vec![],
+        ops,
+        vec![],
+    )
+    .await
 }
 
 /// Convenience to transact EntityOperation instead of EntityModification and wait for the store to process the operations
@@ -262,6 +270,7 @@ pub async fn transact_and_wait(
         block_ptr_to,
         vec![],
         ops,
+        vec![],
     )
     .await?;
     flush(deployment).await
@@ -273,6 +282,7 @@ pub async fn transact_entities_and_dynamic_data_sources(
     block_ptr_to: BlockPtr,
     data_sources: Vec<StoredDynamicDataSource>,
     ops: Vec<EntityOperation>,
+    manifest_idx_and_name: Vec<(u32, String)>,
 ) -> Result<(), StoreError> {
     let store =
         futures03::executor::block_on(store.cheap_clone().writable(LOGGER.clone(), deployment.id))?;
@@ -297,6 +307,7 @@ pub async fn transact_entities_and_dynamic_data_sources(
             &stopwatch_metrics,
             data_sources,
             Vec::new(),
+            manifest_idx_and_name,
         )
         .await
 }

--- a/tests/integration-tests/data-source-revert/grafted.yaml
+++ b/tests/integration-tests/data-source-revert/grafted.yaml
@@ -1,6 +1,12 @@
 specVersion: 0.0.4
+features:
+  - grafting
 schema:
   file: ./schema.graphql
+graft:
+  # Must match the id from building `subgraph.yaml`
+  base: QmRhW72iAE6AEY6fiL9nPt5ZVffzbq9XswKDbH9LC3JPUh
+  block: 3
 dataSources:
   - kind: ethereum/contract
     name: Contract

--- a/tests/integration-tests/data-source-revert/package.json
+++ b/tests/integration-tests/data-source-revert/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "scripts": {
     "codegen": "graph codegen",
-    "create:test": "graph create test/data-source-revert --node $GRAPH_NODE_ADMIN_URI",
-    "deploy:test": "graph deploy test/data-source-revert --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
+    "deploy:test": "graph deploy test/data-source-revert --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI",
+    "deploy:test-grafted": "graph deploy test/data-source-revert-grafted grafted.yaml --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "https://github.com/graphprotocol/graph-cli#main",


### PR DESCRIPTION
This fills in the sql implementation in `dynds/private.rs`, and sets V1 as the deployment schema version for new deployments.

This maintains compatibility with the deployment schema V0, which uses the shared table. This does not implement migrations from V0 to V1, so copies are enabled for all versions.

The new stores template references by manifest index, but the shared table stores them by name and the runtime creates the by name, so a map between template name and index had to be plumbed into various places.

This was tested manually with uniswap-v3, and the `data_source_revert` end-to-end test was modified to additionally test restarting a subgraph with dynamic data sources.

Part of #3405, the only remaining work being migrations which we'll want to do eventually.