### PR TITLE
Add initial support for offchain data sources in manifest

### DIFF
--- a/graph/src/data/subgraph/api_version.rs
+++ b/graph/src/data/subgraph/api_version.rs
@@ -31,6 +31,9 @@ pub const SPEC_VERSION_0_0_5: Version = Version::new(0, 0, 5);
 /// Enables the Fast POI calculation variant.
 pub const SPEC_VERSION_0_0_6: Version = Version::new(0, 0, 6);
 
+/// Enables offchain data sources.
+pub const SPEC_VERSION_0_0_7: Version = Version::new(0, 0, 7);
+
 pub const MIN_SPEC_VERSION: Version = Version::new(0, 0, 2);
 
 #[derive(Clone, PartialEq, Debug)]

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -12,7 +12,11 @@ pub use features::{SubgraphFeature, SubgraphFeatureValidationError};
 
 use anyhow::ensure;
 use anyhow::{anyhow, Error};
-use futures03::{future::try_join3, stream::FuturesOrdered, TryStreamExt as _};
+use futures03::{
+    future::try_join4,
+    stream::{FuturesOrdered, FuturesUnordered},
+    TryStreamExt as _,
+};
 use semver::Version;
 use serde::de;
 use serde::ser;
@@ -20,7 +24,7 @@ use serde_yaml;
 use slog::{debug, info, Logger};
 use stable_hash::{FieldAddress, StableHash};
 use stable_hash_legacy::SequenceNumber;
-use std::{collections::BTreeSet, marker::PhantomData};
+use std::{collections::BTreeSet, marker::PhantomData, mem::take};
 use thiserror::Error;
 use wasmparser;
 use web3::types::Address;
@@ -31,6 +35,7 @@ use crate::data::{
     schema::{Schema, SchemaImportError, SchemaValidationError},
     subgraph::features::validate_subgraph_features,
 };
+use crate::offchain;
 use crate::prelude::{r, CheapClone, ENV_VARS};
 use crate::{blockchain::DataSource, data::graphql::TryFromValue};
 use crate::{blockchain::DataSourceTemplate as _, data::query::QueryExecutionError};
@@ -499,7 +504,7 @@ impl Graft {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BaseSubgraphManifest<C, S, D, T> {
+pub struct BaseSubgraphManifest<C, S, D, T, O> {
     pub id: DeploymentHash,
     pub spec_version: Version,
     #[serde(default)]
@@ -511,6 +516,8 @@ pub struct BaseSubgraphManifest<C, S, D, T> {
     pub graft: Option<Graft>,
     #[serde(default)]
     pub templates: Vec<T>,
+    #[serde(default)]
+    pub offchain_data_sources: Vec<O>,
     #[serde(skip_serializing, default)]
     pub chain: PhantomData<C>,
 }
@@ -521,6 +528,7 @@ type UnresolvedSubgraphManifest<C> = BaseSubgraphManifest<
     UnresolvedSchema,
     <C as Blockchain>::UnresolvedDataSource,
     <C as Blockchain>::UnresolvedDataSourceTemplate,
+    offchain::UnresolvedDataSource,
 >;
 
 /// SubgraphManifest validated with IPFS links resolved
@@ -529,6 +537,7 @@ pub type SubgraphManifest<C> = BaseSubgraphManifest<
     Schema,
     <C as Blockchain>::DataSource,
     <C as Blockchain>::DataSourceTemplate,
+    offchain::DataSource,
 >;
 
 /// Unvalidated SubgraphManifest
@@ -644,10 +653,28 @@ impl<C: Blockchain> SubgraphManifest<C> {
         max_spec_version: semver::Version,
     ) -> Result<Self, SubgraphManifestResolveError> {
         // Inject the IPFS hash as the ID of the subgraph into the definition.
-        raw.insert(
-            serde_yaml::Value::from("id"),
-            serde_yaml::Value::from(id.to_string()),
-        );
+        raw.insert("id".into(), id.to_string().into());
+
+        // Separate offchain data sources (where `kind` starts with "file").
+        let data_sources: Vec<serde_yaml::Value> = raw
+            .remove(&serde_yaml::Value::from("dataSources"))
+            .and_then(|mut v| v.as_sequence_mut().map(take))
+            .unwrap_or_default();
+        let mut onchain_data_sources = Vec::new();
+        let mut offchain_data_sources = Vec::new();
+        for data_source in data_sources {
+            let kind = data_source
+                .get(&serde_yaml::Value::from("kind"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if kind.starts_with("file") {
+                offchain_data_sources.push(data_source);
+            } else {
+                onchain_data_sources.push(data_source);
+            }
+        }
+        raw.insert("dataSources".into(), onchain_data_sources.into());
+        raw.insert("offchainDataSources".into(), offchain_data_sources.into());
 
         // Parse the YAML data into an UnresolvedSubgraphManifest
         let unresolved: UnresolvedSubgraphManifest<C> = serde_yaml::from_value(raw.into())?;
@@ -714,6 +741,7 @@ impl<C: Blockchain> UnresolvedSubgraphManifest<C> {
             data_sources,
             graft,
             templates,
+            offchain_data_sources,
             chain,
         } = self;
 
@@ -727,7 +755,7 @@ impl<C: Blockchain> UnresolvedSubgraphManifest<C> {
             ));
         }
 
-        let (schema, data_sources, templates) = try_join3(
+        let (schema, data_sources, templates, offchain_data_sources) = try_join4(
             schema.resolve(id.clone(), &resolver, logger),
             data_sources
                 .into_iter()
@@ -738,6 +766,11 @@ impl<C: Blockchain> UnresolvedSubgraphManifest<C> {
                 .into_iter()
                 .map(|template| template.resolve(&resolver, logger))
                 .collect::<FuturesOrdered<_>>()
+                .try_collect::<Vec<_>>(),
+            offchain_data_sources
+                .into_iter()
+                .map(|ds| ds.resolve(&resolver, logger))
+                .collect::<FuturesUnordered<_>>()
                 .try_collect::<Vec<_>>(),
         )
         .await?;
@@ -763,6 +796,7 @@ impl<C: Blockchain> UnresolvedSubgraphManifest<C> {
             data_sources,
             graft,
             templates,
+            offchain_data_sources,
             chain,
         })
     }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -20,6 +20,8 @@ pub mod ipfs_client;
 
 pub mod blockchain;
 
+pub mod offchain;
+
 pub mod runtime;
 
 pub mod firehose;

--- a/graph/src/offchain/mod.rs
+++ b/graph/src/offchain/mod.rs
@@ -1,0 +1,97 @@
+use crate::{components::link_resolver::LinkResolver, prelude::Link};
+
+use anyhow::anyhow;
+use serde::Deserialize;
+use slog::{info, Logger};
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct DataSource {
+    pub name: String,
+    pub source: Option<Source>,
+    pub mapping: Mapping,
+}
+
+#[derive(Debug)]
+pub enum Source {
+    Ipfs(Link),
+}
+
+#[derive(Clone, Debug)]
+pub struct Mapping {
+    pub language: String,
+    pub api_version: semver::Version,
+    pub entities: Vec<String>,
+    pub handler: String,
+    pub runtime: Arc<Vec<u8>>,
+    pub link: Link,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
+pub struct UnresolvedDataSource {
+    pub kind: String,
+    pub name: String,
+    pub source: Option<UnresolvedSource>,
+    pub mapping: UnresolvedMapping,
+}
+
+#[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Deserialize)]
+pub struct UnresolvedSource {
+    file: Link,
+}
+
+#[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnresolvedMapping {
+    pub api_version: String,
+    pub language: String,
+    pub file: Link,
+    pub handler: String,
+    pub entities: Vec<String>,
+}
+
+impl UnresolvedDataSource {
+    pub async fn resolve(
+        self,
+        resolver: &Arc<dyn LinkResolver>,
+        logger: &Logger,
+    ) -> Result<DataSource, anyhow::Error> {
+        info!(logger, "Resolve offchain data source";
+            "name" => &self.name,
+            "kind" => &self.kind,
+            "source" => format_args!("{:?}", &self.source),
+        );
+        let source = match self.kind.as_str() {
+            "file/ipfs" => self.source.map(|src| Source::Ipfs(src.file)),
+            _ => {
+                return Err(anyhow!(
+                    "offchain data source has invalid `kind`, expected `file/ipfs` but found {}",
+                    self.kind
+                ))
+            }
+        };
+        Ok(DataSource {
+            name: self.name,
+            source,
+            mapping: self.mapping.resolve(&*resolver, logger).await?,
+        })
+    }
+}
+
+impl UnresolvedMapping {
+    pub async fn resolve(
+        self,
+        resolver: &Arc<dyn LinkResolver>,
+        logger: &Logger,
+    ) -> Result<Mapping, anyhow::Error> {
+        info!(logger, "Resolve offchain mapping"; "link" => &self.file.link);
+        Ok(Mapping {
+            language: self.language,
+            api_version: semver::Version::parse(&self.api_version)?,
+            entities: self.entities,
+            handler: self.handler,
+            runtime: Arc::new(resolver.cat(logger, &self.file).await?),
+            link: self.file,
+        })
+    }
+}

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -120,6 +120,7 @@ async fn setup(
             data_sources: vec![],
             graft: None,
             templates: vec![],
+            offchain_data_sources: vec![],
             chain: PhantomData,
         };
 

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -134,6 +134,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
         data_sources: vec![],
         graft: None,
         templates: vec![],
+        offchain_data_sources: vec![],
         chain: PhantomData,
     };
 

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -164,6 +164,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
         data_sources: vec![],
         graft: None,
         templates: vec![],
+        offchain_data_sources: vec![],
         chain: PhantomData,
     };
 
@@ -1288,6 +1289,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             data_sources: vec![],
             graft: None,
             templates: vec![],
+            offchain_data_sources: vec![],
             chain: PhantomData,
         };
 

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -134,6 +134,7 @@ fn create_subgraph() {
             data_sources: vec![],
             graft: None,
             templates: vec![],
+            offchain_data_sources: vec![],
             chain: PhantomData,
         };
         let deployment = DeploymentCreate::new(&manifest, None);

--- a/store/postgres/tests/writable.rs
+++ b/store/postgres/tests/writable.rs
@@ -43,6 +43,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
         data_sources: vec![],
         graft: None,
         templates: vec![],
+        offchain_data_sources: vec![],
         chain: PhantomData,
     };
 

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -163,6 +163,7 @@ pub async fn create_subgraph(
         data_sources: vec![],
         graft: None,
         templates: vec![],
+        offchain_data_sources: vec![],
         chain: PhantomData,
     };
 


### PR DESCRIPTION
This adds offchain data source definitions to the subgraph manifest as part of #3072.

