### PR TITLE
add totalDifficulity from firehose block ver.2

### DIFF
--- a/chain/ethereum/src/codec.rs
+++ b/chain/ethereum/src/codec.rs
@@ -260,8 +260,12 @@ impl TryInto<EthereumBlockWithCalls> for &Block {
                         .difficulty
                         .as_ref()
                         .map_or_else(|| U256::default(), |v| v.into()),
-                    // FIXME (SF): Not sure we have such equivalent stuff in Firehose, need to double-check (is this important?)
-                    total_difficulty: None,
+                    total_difficulty: Some(
+                        header
+                            .total_difficulty
+                            .as_ref()
+                            .map_or_else(|| U256::default(), |v| v.into()),
+                    ),
                     // FIXME (SF): Firehose does not have seal fields, are they really used? Might be required for POA chains only also, I've seen that stuff on xDai (is this important?)
                     seal_fields: vec![],
                     uncles: self


### PR DESCRIPTION
fixes POI discrepancies seen during comparison, ex: subgraph `QmcskbugoHafPJC4EcFzkPNc2ExNPY8L32QagCn5qrtQU5`