### PR TITLE
Stepd/fix poi cursor on deterministic error

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -81,7 +81,8 @@ where
                 let _outcome = self
                     .inputs
                     .store
-                    .unfail_deterministic_error(&current_ptr, &parent_ptr).await?;
+                    .unfail_deterministic_error(&current_ptr, &parent_ptr)
+                    .await?;
             }
         }
 

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -81,7 +81,7 @@ where
                 let _outcome = self
                     .inputs
                     .store
-                    .unfail_deterministic_error(&current_ptr, &parent_ptr)?;
+                    .unfail_deterministic_error(&current_ptr, &parent_ptr).await?;
             }
         }
 

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -173,7 +173,7 @@ pub trait WritableStore: Send + Sync + 'static {
 
     /// If a deterministic error happened, this function reverts the block operations from the
     /// current block to the previous block.
-    fn unfail_deterministic_error(
+    async fn unfail_deterministic_error(
         &self,
         current_ptr: &BlockPtr,
         parent_ptr: &BlockPtr,

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -70,7 +70,7 @@ impl WritableStore for MockStore {
         unimplemented!()
     }
 
-    fn unfail_deterministic_error(
+    async fn unfail_deterministic_error(
         &self,
         _: &BlockPtr,
         _: &BlockPtr,

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -957,7 +957,7 @@ impl WritableStoreTrait for WritableStore {
         self.writer.revert(block_ptr_to, firehose_cursor).await
     }
 
-    fn unfail_deterministic_error(
+    async fn unfail_deterministic_error(
         &self,
         current_ptr: &BlockPtr,
         parent_ptr: &BlockPtr,
@@ -967,7 +967,8 @@ impl WritableStoreTrait for WritableStore {
             .unfail_deterministic_error(current_ptr, parent_ptr)?;
 
         if let UnfailOutcome::Unfailed = outcome {
-            *self.block_ptr.lock().unwrap() = Some(parent_ptr.clone());
+            *self.block_ptr.lock().unwrap() = self.store.block_ptr().await?;
+            *self.block_cursor.lock().unwrap() = self.store.block_cursor().await?;
         }
 
         Ok(outcome)

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -650,6 +650,7 @@ fn fail_unfail_deterministic_error() {
         // Unfail the subgraph.
         let outcome = writable
             .unfail_deterministic_error(&BLOCKS[1], &BLOCKS[0])
+            .await
             .unwrap();
 
         // We don't have fatal errors anymore and the block got reverted.
@@ -725,6 +726,7 @@ fn fail_unfail_deterministic_error_noop() {
         // Run unfail with no errors results in NOOP.
         let outcome = writable
             .unfail_deterministic_error(&BLOCKS[1], &BLOCKS[0])
+            .await
             .unwrap();
 
         // Nothing to unfail, state continues the same.
@@ -756,6 +758,7 @@ fn fail_unfail_deterministic_error_noop() {
         // Running unfail_deterministic_error against a NON-deterministic error will do nothing.
         let outcome = writable
             .unfail_deterministic_error(&BLOCKS[1], &BLOCKS[0])
+            .await
             .unwrap();
 
         // State continues the same, nothing happened.
@@ -782,6 +785,7 @@ fn fail_unfail_deterministic_error_noop() {
         // the hashes won't match and there's nothing to revert.
         let outcome = writable
             .unfail_deterministic_error(&BLOCKS[1], &BLOCKS[0])
+            .await
             .unwrap();
 
         // State continues the same.


### PR DESCRIPTION
(depends on https://github.com/graphprotocol/graph-node/pull/3748) 

Fixes the following scenario:
* A deterministic error happens at block 15
* The store updates its current head to be block=15, cursor={15}
* The deployment stops with "Subgraph Error"

When we restart the graph-node instance, it will try again:
* it detects that current head block 15 has errors
* It reverts the block 15 (down to 14...)
* It starts the stream again with start_block=15 (but also, with cursor={15})
* firehose skips the block 15 because that's how firehose cursors work (exclusive...)
* firehose sends block 16... the subgraph_deployment now has invalid data !

This patch prevents updating the cursor in the store when a deterministic error happened, so that it keeps the previous cursor. It relies on the fact that the next time that this subgraph is started, the problematic block will be reverted, so the cursor will be valid at that moment.

@leoyvens do you agree with this approach ? 
(ping @maoueh)