### PR TITLE
fix firehose eth CallHandler triggering on reverted calls

### DIFF
--- a/chain/ethereum/src/codec.rs
+++ b/chain/ethereum/src/codec.rs
@@ -364,6 +364,7 @@ impl TryInto<EthereumBlockWithCalls> for &Block {
                         trace
                             .calls
                             .iter()
+                            .filter(|call| !call.status_reverted)
                             .map(|call| CallAt::new(call, self, trace).try_into())
                             .collect::<Vec<Result<EthereumCall, Error>>>()
                     })

--- a/chain/ethereum/src/codec.rs
+++ b/chain/ethereum/src/codec.rs
@@ -364,7 +364,7 @@ impl TryInto<EthereumBlockWithCalls> for &Block {
                         trace
                             .calls
                             .iter()
-                            .filter(|call| !call.state_reverted)
+                            .filter(|call| !call.status_reverted && !call.status_failed)
                             .map(|call| CallAt::new(call, self, trace).try_into())
                             .collect::<Vec<Result<EthereumCall, Error>>>()
                     })

--- a/chain/ethereum/src/codec.rs
+++ b/chain/ethereum/src/codec.rs
@@ -364,7 +364,7 @@ impl TryInto<EthereumBlockWithCalls> for &Block {
                         trace
                             .calls
                             .iter()
-                            .filter(|call| !call.status_reverted)
+                            .filter(|call| !call.state_reverted)
                             .map(|call| CallAt::new(call, self, trace).try_into())
                             .collect::<Vec<Result<EthereumCall, Error>>>()
                     })


### PR DESCRIPTION
firehose exposes calls that are "failed" or "reverted". current behavior is to only filter out the transactions that are completely reverted (from the status in the Receipt).

This fixes POI inconsistencies seen in QmPDp878JK2RcvXNhWX1UQHYbhF8iEcWPTdnP9bJvy6L6P (and hopefully QmUrfWjK7rdXzbr3q6D2DVDapCw4yWBU88qjrNvZUewoNy too)

# Additional notes
* Current filtering from RPC `traces` is done on the existence of the `error` field. This field does not exist in firehose calls, so we must use another firehose-specific field.

- UPDATE -
* issue #3701 shows us that we shouldn't only skip calls that are failed, but any call that is reverted too (calls are reverted if their parent is reverted).
* In firehose, this means that we must use `state_reverted` field to correctly skip calls that had no effect on the chain.
* In RPC, it is more complex to fix.

We need to be able to compare existing POIs from RPCs with POIs from firehose to ensure that the transition is successful, so *this PR will make firehose mimic the RPC behavior* (and not fix #3701 for the moment). 