### PR TITLE
Remove `mockall` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,12 +1070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
-
-[[package]]
 name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,15 +1276,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
 
 [[package]]
-name = "float-cmp"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,12 +1305,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "fragile"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "funty"
@@ -1613,7 +1592,6 @@ dependencies = [
  "graph-core",
  "graph-runtime-derive",
  "graph-runtime-wasm",
- "mockall",
  "pretty_assertions 0.7.2",
  "prost",
  "prost-types",
@@ -1641,7 +1619,6 @@ dependencies = [
  "itertools",
  "jsonrpc-core",
  "lazy_static",
- "mockall",
  "prost",
  "prost-types",
  "semver",
@@ -1688,7 +1665,6 @@ dependencies = [
  "itertools",
  "jsonrpc-core",
  "lazy_static",
- "mockall",
  "prost",
  "prost-types",
  "semver",
@@ -2614,33 +2590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d614ad23f9bb59119b8b5670a85c7ba92c5e9adf4385c81ea00c51c8be33d5"
-dependencies = [
- "cfg-if 1.0.0",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd4234635bca06fc96c7368d038061e0aae1b00a764dc817e900dc974e3deea"
-dependencies = [
- "cfg-if 1.0.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "more-asserts"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2734,12 +2683,6 @@ name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
@@ -3115,35 +3058,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
 dependencies = [
  "vcpkg",
-]
-
-[[package]]
-name = "predicates"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
-dependencies = [
- "difference",
- "float-cmp",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dd0fd014130206c9352efbdc92be592751b2b9274dff685348341082c6ea3d"
-dependencies = [
- "predicates-core",
- "treeline",
 ]
 
 [[package]]
@@ -4741,12 +4655,6 @@ dependencies = [
  "pin-project",
  "tracing",
 ]
-
-[[package]]
-name = "treeline"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "try-lock"

--- a/chain/cosmos/Cargo.toml
+++ b/chain/cosmos/Cargo.toml
@@ -8,7 +8,6 @@ tonic-build = { version = "0.7.1", features = ["prost"] }
 
 [dependencies]
 graph = { path = "../../graph" }
-mockall = "0.9.1"
 prost = "0.10.1"
 prost-types = "0.10.1"
 serde = "1.0"

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -10,7 +10,6 @@ http = "0.2.4"
 jsonrpc-core = "18.0.0"
 graph = { path = "../../graph" }
 lazy_static = "1.2.0"
-mockall = "0.9.1"
 serde = "1.0"
 prost = "0.10.4"
 prost-types = "0.10.1"

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -6,8 +6,6 @@ use graph::firehose::CallToFilter;
 use graph::firehose::CombinedFilter;
 use graph::firehose::LogFilter;
 use itertools::Itertools;
-use mockall::automock;
-use mockall::predicate::*;
 use prost::Message;
 use prost_types::Any;
 use std::cmp;
@@ -841,7 +839,6 @@ impl SubgraphEthRpcMetrics {
 ///
 /// Implementations may be implemented against an in-process Ethereum node
 /// or a remote node over RPC.
-#[automock]
 #[async_trait]
 pub trait EthereumAdapter: Send + Sync + 'static {
     fn url_hostname(&self) -> &str;

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -24,7 +24,7 @@ pub mod trigger;
 
 pub use crate::adapter::{
     EthereumAdapter as EthereumAdapterTrait, EthereumContractCall, EthereumContractCallError,
-    MockEthereumAdapter, ProviderEthRpcMetrics, SubgraphEthRpcMetrics, TriggerFilter,
+    ProviderEthRpcMetrics, SubgraphEthRpcMetrics, TriggerFilter,
 };
 pub use crate::chain::Chain;
 pub use crate::network::EthereumNetworks;

--- a/chain/substreams/Cargo.toml
+++ b/chain/substreams/Cargo.toml
@@ -10,7 +10,6 @@ http = "0.2.4"
 jsonrpc-core = "18.0.0"
 graph = { path = "../../graph" }
 lazy_static = "1.2.0"
-mockall = "0.9.1"
 serde = "1.0"
 prost = "0.10.4"
 prost-types = "0.10.1"

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -44,7 +44,6 @@ impl MockStore {
     }
 }
 
-// The store trait must be implemented manually because mockall does not support async_trait, nor borrowing from arguments.
 #[async_trait]
 impl WritableStore for MockStore {
     async fn block_ptr(&self) -> Option<BlockPtr> {


### PR DESCRIPTION
Turns out we are not using it.

