### PR TITLE
Release 0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "graph"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-arweave"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "base64-url",
  "diesel",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-cosmos"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "graph",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-ethereum"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-near"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "base64",
  "diesel",
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-substreams"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "graph-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "graph-graphql"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1677,14 +1677,14 @@ dependencies = [
 
 [[package]]
 name = "graph-mock"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "graph",
 ]
 
 [[package]]
 name = "graph-node"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "assert_cli",
  "clap 3.2.8",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-derive"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "quote",
  "syn",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-test"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "graph",
  "graph-chain-ethereum",
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-wasm"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-http"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "futures 0.1.31",
  "graph",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-index-node"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "blake3 1.3.1",
  "either",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-json-rpc"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "graph",
  "jsonrpc-http-server",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-metrics"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "graph",
  "http",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-websocket"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "futures 0.1.31",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "graph-store-postgres"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "graph-tests"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "test-store"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "diesel",
  "graph",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,41 @@
 
 ## Unreleased
 
-- `GRAPH_MAX_GAS_PER_HANDLER` is set to a very high value by default,
-  effectively disabling handler gas limits until the costs are better
-  benchmarked and refined.
-- Pipeline store writes #3084 #3177
+- ...
+
+## 0.27.0
+
+- Store writes are now carried out in parallel to the rest of the subgraph process, improving indexing performance for subgraphs with significant store interaction. Metrics & monitoring was updated for this new pipelined process;
+- This adds support for apiVersion 0.0.7, which makes receipts accessible in Ethereum event handlers. [Documentation link](https://thegraph.com/docs/en/developing/creating-a-subgraph/#transaction-receipts-in-event-handlers);
+- This introduces some improvements to the subgraph GraphQL API, which now supports filtering on the basis of, and filtering for entities which changed from a certain block;
+- Support was added for Arweave indexing. Tendermint was renamed to Cosmos in Graph Node. These integrations are still in "beta";
+- Callhandler block filtering for contract calls now works as intended (this was a longstanding bug);
+- Gas costing for mappings is still set at a very high default, as we continue to benchmark and refine this metric;
+- A new `graphman fix block` command was added to easily refresh a block in the block cache, or clear the cache for a given network;
+- IPFS file fetching now uses `files/stat`, as `object` was deprecated;
+- Subgraphs indexing via a Firehose can now take advantage of Firehose-side filtering;
+- NEAR subgraphs can now match accounts for receipt filtering via prefixes or suffixes.
+
+## Upgrade notes
+
+- In the case of you having custom SQL, there's a [new SQL migration](https://github.com/graphprotocol/graph-node/blob/master/store/postgres/migrations/2022-04-26-125552_alter_deployment_schemas_version/up.sql);
+- On the pipelining of the store writes, there's now a new environment variable `GRAPH_STORE_WRITE_QUEUE` (default value is `5`), that if set to `0`, the old synchronous behaviour will come in instead. The value stands for the amount of write/revert parallel operations [#3177](https://github.com/graphprotocol/graph-node/pull/3177);
+- There's now support for TLS connections in the PostgreSQL `notification_listener` [#3503](https://github.com/graphprotocol/graph-node/pull/3503);
+- GraphQL HTTP and WebSocket ports can now be set via environment variables [#2832](https://github.com/graphprotocol/graph-node/pull/2832);
+- The genesis block can be set via the `GRAPH_ETHEREUM_GENESIS_BLOCK_NUMBER` env var [#3650](https://github.com/graphprotocol/graph-node/pull/3650);
+- There's a new experimental feature to limit the number of subgraphs for a specific web3 provider. [Link for documentation](https://github.com/graphprotocol/graph-node/blob/master/docs/config.md#controlling-the-number-of-subgraphs-using-a-provider);
+- Two new GraphQL validation environment variables were included: `ENABLE_GRAPHQL_VALIDATIONS` and `SILENT_GRAPHQL_VALIDATIONS`, which are documented [here](https://github.com/graphprotocol/graph-node/blob/master/docs/environment-variables.md#graphql);
+- A bug fix for `graphman index` was landed, which fixed the behavior where if one deployment was used by multiple names would result in the command not working [#3416](https://github.com/graphprotocol/graph-node/pull/3416);
+- Another fix landed for `graphman`, the bug would allow the `unassign`/`reassign` commands to make two or more nodes index the same subgraph by mistake [#3478](https://github.com/graphprotocol/graph-node/pull/3478);
+- Error messages of eth RPC providers should be clearer during `graph-node` start up [#3422](https://github.com/graphprotocol/graph-node/pull/3422);
+- Env var `GRAPH_STORE_CONNECTION_MIN_IDLE` will no longer panic, instead it will log a warning if it exceeds the `pool_size` [#3489](https://github.com/graphprotocol/graph-node/pull/3489);
+- Failed GraphQL queries now have proper timing information in the service metrics [#3508](https://github.com/graphprotocol/graph-node/pull/3508);
+- Non-primary shards now can be disabled through setting the `pool_size` to `0` [#3513](https://github.com/graphprotocol/graph-node/pull/3513);
+- Queries with large results now have a `query_id` [#3514](https://github.com/graphprotocol/graph-node/pull/3514);
+- It's now possible to disable the LFU Cache by setting `GRAPH_QUERY_LFU_CACHE_SHARDS` to `0` [#3522](https://github.com/graphprotocol/graph-node/pull/3522);
+- `GRAPH_ACCOUNT_TABLES` env var is not supported anymore [#3525](https://github.com/graphprotocol/graph-node/pull/3525);
+- [New documentation](https://github.com/graphprotocol/graph-node/blob/master/docs/implementation/metadata.md) landed on the metadata tables;
+- `GRAPH_GRAPHQL_MAX_OPERATIONS_PER_CONNECTION` for GraphQL subscriptions now has a default of `1000` [#3735](https://github.com/graphprotocol/graph-node/pull/3735)
 
 ## 0.26.0
 

--- a/chain/arweave/Cargo.toml
+++ b/chain/arweave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-arweave"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [build-dependencies]

--- a/chain/cosmos/Cargo.toml
+++ b/chain/cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-cosmos"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2018"
 
 [build-dependencies]

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-ethereum"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/chain/near/Cargo.toml
+++ b/chain/near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-near"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [build-dependencies]

--- a/chain/substreams/Cargo.toml
+++ b/chain/substreams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-substreams"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-core"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-graphql"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-mock"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-node"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 default-run = "graph-node"
 

--- a/runtime/derive/Cargo.toml
+++ b/runtime/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-derive"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [lib]

--- a/runtime/test/Cargo.toml
+++ b/runtime/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-test"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-wasm"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-http"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-index-node"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/server/json-rpc/Cargo.toml
+++ b/server/json-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-json-rpc"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/server/metrics/Cargo.toml
+++ b/server/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-metrics"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-websocket"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-store-postgres"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-store"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Leonardo Yvens <leoyvens@gmail.com>"]
 edition = "2021"
 description = "Provides static store instance for tests."

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-tests"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
All of the release notes are in the `NEWS.md` file. They were taken from [here](https://github.com/graphprotocol/graph-node/compare/v0.26.0...4baec903d100178e7a4c30ec15788c5ad961972d) (~270ish commits).