### PR TITLE
Fix provider selection when limit is set

### DIFF
--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -39,6 +39,7 @@ pub use task_spawn::{
 
 pub use anyhow;
 pub use bytes;
+pub use itertools;
 pub use parking_lot;
 pub use petgraph;
 pub use prometheus;

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -263,6 +263,16 @@ pub enum ConfigCommand {
         #[structopt(short, long)]
         shard: bool,
     },
+    /// Show eligible providers
+    ///
+    /// Prints the providers that can be used for a deployment on a given
+    /// network with the given features. Set the name of the node for which
+    /// to simulate placement with the toplevel `--node-id` option
+    Provider {
+        #[structopt(short, long, default_value = "")]
+        features: String,
+        network: String,
+    },
 }
 
 #[derive(Clone, Debug, StructOpt)]
@@ -481,6 +491,7 @@ impl From<Opt> for config::Opt {
         let mut config_opt = config::Opt::default();
         config_opt.config = Some(opt.config);
         config_opt.store_connection_pool_size = 5;
+        config_opt.node_id = opt.node_id;
         config_opt
     }
 }
@@ -807,6 +818,12 @@ async fn main() -> anyhow::Result<()> {
                 }
                 Check { print } => commands::config::check(&ctx.config, print),
                 Pools { nodes, shard } => commands::config::pools(&ctx.config, nodes, shard),
+                Provider { features, network } => {
+                    let logger = ctx.logger.clone();
+                    let registry = ctx.registry.clone();
+                    commands::config::provider(logger, &ctx.config, registry, features, network)
+                        .await
+                }
             }
         }
         Remove { name } => commands::remove::run(ctx.subgraph_store(), name),

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -150,7 +150,7 @@ impl Config {
     /// a config from the command line arguments in `opt`
     pub fn load(logger: &Logger, opt: &Opt) -> Result<Config> {
         if let Some(config) = &opt.config {
-            Self::from_file(logger, config)
+            Self::from_file(logger, config, &opt.node_id)
         } else {
             info!(
                 logger,
@@ -160,13 +160,15 @@ impl Config {
         }
     }
 
-    pub fn from_file(logger: &Logger, path: &str) -> Result<Config> {
+    pub fn from_file(logger: &Logger, path: &str, node: &str) -> Result<Config> {
         info!(logger, "Reading configuration file `{}`", path);
-        Self::from_str(&read_to_string(path)?)
+        Self::from_str(&read_to_string(path)?, node)
     }
 
-    pub fn from_str(config: &str) -> Result<Config> {
+    pub fn from_str(config: &str, node: &str) -> Result<Config> {
         let mut config: Config = toml::from_str(&config)?;
+        config.node =
+            NodeId::new(node.clone()).map_err(|()| anyhow!("invalid node id {}", node))?;
         config.validate()?;
         Ok(config)
     }

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -26,7 +26,7 @@ use graph::slog::{debug, error, info, o, Logger};
 use graph::util::security::SafeDisplay;
 use graph_chain_ethereum::{self as ethereum, EthereumAdapterTrait, Transport};
 use graph_core::{
-    LinkResolver, MetricsRegistry, SubgraphAssignmentProvider as IpfsSubgraphAssignmentProvider,
+    LinkResolver, SubgraphAssignmentProvider as IpfsSubgraphAssignmentProvider,
     SubgraphInstanceManager, SubgraphRegistrar as IpfsSubgraphRegistrar,
 };
 use url::Url;
@@ -342,7 +342,7 @@ fn create_ipfs_clients(logger: &Logger, ipfs_addresses: &Vec<String>) -> Vec<Ipf
 /// Parses an Ethereum connection string and returns the network name and Ethereum adapter.
 async fn create_ethereum_networks(
     logger: Logger,
-    registry: Arc<MetricsRegistry>,
+    registry: Arc<dyn MetricsRegistryTrait>,
     config: &Config,
 ) -> Result<EthereumNetworks, anyhow::Error> {
     let eth_rpc_metrics = Arc::new(ProviderEthRpcMetrics::new(registry));

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -346,7 +346,7 @@ fn create_ipfs_clients(logger: &Logger, ipfs_addresses: &Vec<String>) -> Vec<Ipf
 }
 
 /// Parses an Ethereum connection string and returns the network name and Ethereum adapter.
-async fn create_ethereum_networks(
+pub async fn create_ethereum_networks(
     logger: Logger,
     registry: Arc<dyn MetricsRegistryTrait>,
     config: &Config,

--- a/tests/src/fixture.rs
+++ b/tests/src/fixture.rs
@@ -145,7 +145,7 @@ pub async fn stores(store_config_path: &str) -> Stores {
             Err(e) => panic!("{}", e.to_string()),
         };
         let config = config.replace("$THEGRAPH_STORE_POSTGRES_DIESEL_URL", &db_url);
-        Config::from_str(&config).expect("failed to create configuration")
+        Config::from_str(&config, "default").expect("failed to create configuration")
     };
 
     let logger = graph::log::logger(true);


### PR DESCRIPTION
Provider selection with a limit did not work as intended because the node name was not passed around correctly, so that rules to set the limit were always evaluated for the node `default` (commit 209786c9 fixes that)

To make configuring limits easier and provide more insight into provider selection, this PR also adds a command `graphman config provider` that makes it possible to see which providers are eligible. Use it as `graphman --node-id index_node_0 --config /some/where/graph-node.toml config provider mainnet`