### PR TITLE
Firehose connection pool

### DIFF
--- a/chain/ethereum/examples/firehose.rs
+++ b/chain/ethereum/examples/firehose.rs
@@ -1,7 +1,6 @@
 use anyhow::Error;
 use graph::{
     env::env_var,
-    log::logger,
     prelude::{prost, tokio, tonic},
     {firehose, firehose::FirehoseEndpoint, firehose::ForkStep},
 };
@@ -20,17 +19,13 @@ async fn main() -> Result<(), Error> {
         token = Some(token_env);
     }
 
-    let logger = logger(true);
-    let firehose = Arc::new(
-        FirehoseEndpoint::new(
-            logger,
-            "firehose",
-            "https://api.streamingfast.io:443",
-            token,
-            false,
-        )
-        .await?,
-    );
+    let firehose = Arc::new(FirehoseEndpoint::new(
+        "firehose",
+        "https://api.streamingfast.io:443",
+        token,
+        false,
+        1,
+    ));
 
     loop {
         println!("Connecting to the stream!");

--- a/chain/substreams/examples/substreams.rs
+++ b/chain/substreams/examples/substreams.rs
@@ -45,9 +45,13 @@ async fn main() -> Result<(), Error> {
         prometheus_registry.clone(),
     ));
 
-    let firehose = Arc::new(
-        FirehoseEndpoint::new(logger.clone(), "substreams", &endpoint, token, false).await?,
-    );
+    let firehose = Arc::new(FirehoseEndpoint::new(
+        "substreams",
+        &endpoint,
+        token,
+        false,
+        1,
+    ));
 
     let mut stream: SubstreamsBlockStream<graph_chain_substreams::Chain> =
         SubstreamsBlockStream::new(

--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -11,7 +11,7 @@ use futures03::StreamExt;
 use http::uri::{Scheme, Uri};
 use rand::prelude::IteratorRandom;
 use slog::Logger;
-use std::{collections::BTreeMap, fmt::Display, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, fmt::Display, iter, sync::Arc, time::Duration};
 use tonic::{
     metadata::MetadataValue,
     transport::{Channel, ClientTlsConfig},
@@ -26,7 +26,6 @@ pub struct FirehoseEndpoint {
     pub token: Option<String>,
     pub filters_enabled: bool,
     channel: Channel,
-    _logger: Logger,
 }
 
 impl Display for FirehoseEndpoint {
@@ -36,13 +35,13 @@ impl Display for FirehoseEndpoint {
 }
 
 impl FirehoseEndpoint {
-    pub async fn new<S: AsRef<str>>(
-        logger: Logger,
+    pub fn new<S: AsRef<str>>(
         provider: S,
         url: S,
         token: Option<String>,
         filters_enabled: bool,
-    ) -> Result<Self, anyhow::Error> {
+        conn_pool_size: u16,
+    ) -> Self {
         let uri = url
             .as_ref()
             .parse::<Uri>()
@@ -72,17 +71,15 @@ impl FirehoseEndpoint {
             .connect_timeout(Duration::from_secs(10))
             .tcp_keepalive(Some(Duration::from_secs(15)));
 
-        //connect_lazy() used to return Result, but not anymore, that makes sence since Channel is not used immediatelly
-        //FirehoseEndpoint has all the info to report error - provider & uri
-        let channel = endpoint.connect_lazy();
+        // Load balancing on a same endpoint is useful because it creates a connection pool.
+        let channel = Channel::balance_list(iter::repeat(endpoint).take(conn_pool_size as usize));
 
-        Ok(FirehoseEndpoint {
+        FirehoseEndpoint {
             provider: provider.as_ref().to_string(),
             channel,
             token,
-            _logger: logger,
             filters_enabled,
-        })
+        }
     }
 
     pub async fn genesis_block_ptr<M>(&self, logger: &Logger) -> Result<BlockPtr, anyhow::Error>

--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -23,7 +23,6 @@ use super::codec as firehose;
 #[derive(Clone, Debug)]
 pub struct FirehoseEndpoint {
     pub provider: String,
-    pub uri: String,
     pub token: Option<String>,
     pub filters_enabled: bool,
     channel: Channel,
@@ -73,14 +72,12 @@ impl FirehoseEndpoint {
             .connect_timeout(Duration::from_secs(10))
             .tcp_keepalive(Some(Duration::from_secs(15)));
 
-        let uri = endpoint.uri().to_string();
         //connect_lazy() used to return Result, but not anymore, that makes sence since Channel is not used immediatelly
         //FirehoseEndpoint has all the info to report error - provider & uri
         let channel = endpoint.connect_lazy();
 
         Ok(FirehoseEndpoint {
             provider: provider.as_ref().to_string(),
-            uri,
             channel,
             token,
             _logger: logger,

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -160,11 +160,10 @@ pub async fn create_ethereum_networks(
     Ok(parsed_networks)
 }
 
-pub async fn create_firehose_networks(
+pub fn create_firehose_networks(
     logger: Logger,
-    _registry: Arc<dyn MetricsRegistryTrait>,
     config: &Config,
-) -> Result<BTreeMap<BlockchainKind, FirehoseNetworks>, anyhow::Error> {
+) -> BTreeMap<BlockchainKind, FirehoseNetworks> {
     debug!(
         logger,
         "Creating firehose networks [{} chains, ingestor {}]",
@@ -177,21 +176,19 @@ pub async fn create_firehose_networks(
     for (name, chain) in &config.chains.chains {
         for provider in &chain.providers {
             if let ProviderDetails::Firehose(ref firehose) = provider.details {
-                let logger = logger.new(o!("provider" => provider.label.clone()));
                 info!(
                     logger,
-                    "Creating firehose endpoint";
+                    "Configuring firehose endpoint";
                     "provider" => &provider.label,
                 );
 
                 let endpoint = FirehoseEndpoint::new(
-                    logger,
                     &provider.label,
                     &firehose.url,
                     firehose.token.clone(),
                     firehose.filters_enabled(),
-                )
-                .await?;
+                    firehose.conn_pool_size,
+                );
 
                 let parsed_networks = networks_by_kind
                     .entry(chain.protocol)
@@ -201,7 +198,7 @@ pub async fn create_firehose_networks(
         }
     }
 
-    Ok(networks_by_kind)
+    networks_by_kind
 }
 
 /// Try to connect to all the providers in `eth_networks` and get their net

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -181,7 +181,7 @@ pub async fn create_firehose_networks(
                 info!(
                     logger,
                     "Creating firehose endpoint";
-                    "url" => &firehose.url,
+                    "provider" => &provider.label,
                 );
 
                 let endpoint = FirehoseEndpoint::new(
@@ -309,7 +309,7 @@ where
                 let logger = logger.new(o!("provider" => endpoint.provider.to_string()));
                 info!(
                     logger, "Connecting to Firehose to get chain identifier";
-                    "url" => &endpoint.uri,
+                    "provider" => &endpoint.provider,
                 );
                 match tokio::time::timeout(
                     NET_VERSION_WAIT_TIME,
@@ -332,7 +332,7 @@ where
                         info!(
                             logger,
                             "Connected to Firehose";
-                            "uri" => &endpoint.uri,
+                            "provider" => &endpoint.provider,
                             "genesis_block" => format_args!("{}", &ptr),
                         );
 

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -548,10 +548,17 @@ pub enum ProviderDetails {
 
 const FIREHOSE_FILTER_FEATURE: &str = "filters";
 const FIREHOSE_PROVIDER_FEATURES: [&str; 1] = [FIREHOSE_FILTER_FEATURE];
+
+fn ten() -> u16 {
+    10
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct FirehoseProvider {
     pub url: String,
     pub token: Option<String>,
+    #[serde(default = "ten")]
+    pub conn_pool_size: u16,
     #[serde(default)]
     pub features: BTreeSet<String>,
 }
@@ -1323,6 +1330,7 @@ mod tests {
                     url: "http://localhost:9000".to_owned(),
                     token: None,
                     features: BTreeSet::new(),
+                    conn_pool_size: 10,
                 }),
             },
             actual
@@ -1346,6 +1354,7 @@ mod tests {
                     url: "http://localhost:9000".to_owned(),
                     token: None,
                     features: BTreeSet::new(),
+                    conn_pool_size: 10,
                 }),
             },
             actual

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -222,9 +222,7 @@ async fn main() {
     let mut firehose_networks_by_kind = if query_only {
         BTreeMap::new()
     } else {
-        create_firehose_networks(logger.clone(), metrics_registry.clone(), &config)
-            .await
-            .expect("Failed to parse Firehose networks")
+        create_firehose_networks(logger.clone(), &config)
     };
 
     let graphql_metrics_registry = metrics_registry.clone();

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -1,7 +1,8 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::chain::create_firehose_networks;
 use crate::config::{Config, ProviderDetails};
 use crate::manager::PanicSubscriptionManager;
 use crate::store_builder::StoreBuilder;
@@ -15,9 +16,8 @@ use graph::blockchain::{BlockchainKind, BlockchainMap, ChainIdentifier};
 use graph::cheap_clone::CheapClone;
 use graph::components::store::{BlockStore as _, DeploymentLocator};
 use graph::env::EnvVars;
-use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints, FirehoseNetworks};
+use graph::firehose::FirehoseEndpoints;
 use graph::ipfs_client::IpfsClient;
-use graph::prelude::MetricsRegistry as MetricsRegistryTrait;
 use graph::prelude::{
     anyhow, tokio, BlockNumber, DeploymentHash, LoggerFactory, NodeId, SubgraphAssignmentProvider,
     SubgraphName, SubgraphRegistrar, SubgraphStore, SubgraphVersionSwitchingMode, ENV_VARS,
@@ -72,10 +72,7 @@ pub async fn run(
     let eth_networks = create_ethereum_networks(logger.clone(), metrics_registry.clone(), &config)
         .await
         .expect("Failed to parse Ethereum networks");
-    let firehose_networks_by_kind =
-        create_firehose_networks(logger.clone(), metrics_registry.clone(), &config)
-            .await
-            .expect("Failed to parse Firehose endpoints");
+    let firehose_networks_by_kind = create_firehose_networks(logger.clone(), &config);
     let firehose_networks = firehose_networks_by_kind.get(&BlockchainKind::Ethereum);
     let firehose_endpoints = firehose_networks
         .and_then(|v| v.networks.get(&network_name))
@@ -398,50 +395,6 @@ async fn create_ethereum_networks(
     }
     parsed_networks.sort();
     Ok(parsed_networks)
-}
-
-async fn create_firehose_networks(
-    logger: Logger,
-    _registry: Arc<dyn MetricsRegistryTrait>,
-    config: &Config,
-) -> Result<BTreeMap<BlockchainKind, FirehoseNetworks>, anyhow::Error> {
-    debug!(
-        logger,
-        "Creating firehose networks [{} chains, ingestor {}]",
-        config.chains.chains.len(),
-        config.chains.ingestor,
-    );
-
-    let mut networks_by_kind = BTreeMap::new();
-
-    for (name, chain) in &config.chains.chains {
-        for provider in &chain.providers {
-            if let ProviderDetails::Firehose(ref firehose) = provider.details {
-                let logger = logger.new(o!("provider" => provider.label.clone()));
-                info!(
-                    logger,
-                    "Creating firehose endpoint";
-                    "url" => &firehose.url,
-                );
-
-                let endpoint = FirehoseEndpoint::new(
-                    logger,
-                    &provider.label,
-                    &firehose.url,
-                    firehose.token.clone(),
-                    firehose.filters_enabled(),
-                )
-                .await?;
-
-                let parsed_networks = networks_by_kind
-                    .entry(chain.protocol)
-                    .or_insert_with(|| FirehoseNetworks::new());
-                parsed_networks.insert(name.to_string(), Arc::new(endpoint));
-            }
-        }
-    }
-
-    Ok(networks_by_kind)
 }
 
 /// Try to connect to all the providers in `eth_networks` and get their net

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -28,11 +28,13 @@ pub async fn chain(blocks: Vec<BlockWithTriggers<Chain>>, stores: &Stores) -> Ch
 
     // This is needed bacause the stream builder only works for firehose and this will only be called if there
     // are > 1 firehose endpoints. The endpoint itself is never used because it's mocked.
-    let firehose_endpoints: FirehoseEndpoints = vec![Arc::new(
-        FirehoseEndpoint::new(logger.clone(), "", "https://example.com", None, true)
-            .await
-            .expect("unable to create endpoint"),
-    )]
+    let firehose_endpoints: FirehoseEndpoints = vec![Arc::new(FirehoseEndpoint::new(
+        "",
+        "https://example.com",
+        None,
+        true,
+        0,
+    ))]
     .into();
 
     Chain::new(


### PR DESCRIPTION
This adds a `conn_pool_size` field to the toml configuration of firehose providers, which enables load balancing across multiple connections to the provider's endpoint. It defaults to 10.

Also does some refactoring around `FirehoseEndpoint::new`.