### PR TITLE
store: Make cross-shard copying of priavte data sources work

### DIFF
--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1256,9 +1256,13 @@ impl DeploymentStore {
 
             let conn = self.get_conn()?;
             conn.transaction(|| -> Result<(), StoreError> {
-                // Copy dynamic data sources and adjust their ID
+                // Copy shared dynamic data sources and adjust their ID; if
+                // the subgraph uses private data sources, that is done by
+                // `copy::Connection::copy_data` since it requires access to
+                // the source schema which in sharded setups is only
+                // available while that function runs
                 let start = Instant::now();
-                let count = dynds::copy(&conn, &src.site, &dst.site, block.number)?;
+                let count = dynds::shared::copy(&conn, &src.site, &dst.site, block.number)?;
                 info!(logger, "Copied {} dynamic data sources", count;
                       "time_ms" => start.elapsed().as_millis());
 

--- a/store/postgres/src/dynds/mod.rs
+++ b/store/postgres/src/dynds/mod.rs
@@ -46,22 +46,6 @@ pub(crate) fn insert(
     }
 }
 
-pub(crate) fn copy(
-    conn: &PgConnection,
-    src: &Site,
-    dst: &Site,
-    target_block: BlockNumber,
-) -> Result<usize, StoreError> {
-    match src.schema_version.private_data_sources() {
-        true => DataSourcesTable::new(src.namespace.clone()).copy_to(
-            conn,
-            &DataSourcesTable::new(dst.namespace.clone()),
-            target_block,
-        ),
-        false => shared::copy(conn, src, dst, target_block),
-    }
-}
-
 pub(crate) fn revert(
     conn: &PgConnection,
     site: &Site,

--- a/store/postgres/src/dynds/private.rs
+++ b/store/postgres/src/dynds/private.rs
@@ -173,7 +173,7 @@ impl DataSourcesTable {
 
     /// Copy the dynamic data sources from `self` to `dst`. All data sources that
     /// were created up to and including `target_block` will be copied.
-    pub(super) fn copy_to(
+    pub(crate) fn copy_to(
         &self,
         conn: &PgConnection,
         dst: &DataSourcesTable,

--- a/store/postgres/src/dynds/shared.rs
+++ b/store/postgres/src/dynds/shared.rs
@@ -154,13 +154,19 @@ pub(super) fn insert(
 
 /// Copy the dynamic data sources for `src` to `dst`. All data sources that
 /// were created up to and including `target_block` will be copied.
-pub(super) fn copy(
+pub(crate) fn copy(
     conn: &PgConnection,
     src: &Site,
     dst: &Site,
     target_block: BlockNumber,
 ) -> Result<usize, StoreError> {
     use dynamic_ethereum_contract_data_source as decds;
+
+    // Subgraphs that use private data sources have no data in the shared
+    // table
+    if src.schema_version.private_data_sources() {
+        return Ok(0);
+    }
 
     let src_nsp = if src.shard == dst.shard {
         "subgraphs".to_string()


### PR DESCRIPTION
The existing coude tried to access the source schema when it was not mapped into the destination shard. It is only mapped while `copy_data` is running; move private ds copying into `copy_data`

