### PR TITLE
firehose: fix request for v2

### DIFF
--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -140,7 +140,7 @@ impl FirehoseEndpoint {
             .blocks(firehose::Request {
                 start_block_num: number as i64,
                 stop_block_num: number as u64,
-                fork_steps: vec![ForkStep::StepNew as i32, ForkStep::StepIrreversible as i32],
+                fork_steps: vec![ForkStep::StepNew as i32, ForkStep::StepUndo as i32],
                 ..Default::default()
             })
             .await?;


### PR DESCRIPTION
Firehose v2 does not allow the `[new, irreversible]` combination.