### PR TITLE
docker: add health check dependent packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ARG TAG_NAME=unknown
 ADD . /graph-node
 
 RUN cd /graph-node \
-    && apt-get update && apt-get install -y cmake \
+    && apt-get update && apt-get install -y bc cmake curl jq \
     && rustup component add rustfmt \
     && RUSTFLAGS="-g" cargo install --locked --path node \
     && cargo clean \


### PR DESCRIPTION
# Problem / Solution / Result

Add additional packages via docker to enable verifying the graph-node `chainHeadBlock` and `latestBlock` are in sync.

# Context

Command to be used to check health with either a kubernetes livenessProbe or readinessProbe:

```
delta="$(curl -s 'http://localhost:8000' --data-raw '{"query":"{ indexingStatusForCurrentVersion(subgraphName: \"ensofinance/enso-v1\") { subgraph synced fatalError { message } nonFatalErrors {message } chains { chainHeadBlock {number} latestBlock {number} lastHealthyBlock {number} }  } }"}' | jq -C '.data.indexingStatusForCurrentVersion.chains[] | to_entries[] | select(.key | endswith("Block")) | .value.number' -r | grep -oP \d+ | tr '\n' ' ' | sed 's/ /&- /' | bc)"
test "$delta" -eq 0
```