### PR TITLE
core: add missing word in MetricsRegistry initialization error msg

### DIFF
--- a/core/src/metrics/registry.rs
+++ b/core/src/metrics/registry.rs
@@ -127,7 +127,7 @@ impl MetricsRegistryTrait for MetricsRegistry {
             PrometheusError::AlreadyReg => {
                 error!(
                     self.logger,
-                    "registering metric [{}] because it was already registered", name,
+                    "registering metric [{}] failed because it was already registered", name,
                 );
             }
             PrometheusError::InconsistentCardinality { expect, got } => {


### PR DESCRIPTION
-------

Small fix for a missing word in an error message.