### PR TITLE
Make `graphman query` more usable

### DIFF
--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::blockchain::block_stream::FirehoseCursor;
 use crate::components::server::index_node::VersionInfo;
 use crate::components::transaction_receipt;
+use crate::data::query::Trace;
 use crate::data::subgraph::status;
 use crate::data::value::Word;
 use crate::data::{query::QueryTarget, subgraph::schema::*};
@@ -395,7 +396,7 @@ pub trait QueryStore: Send + Sync {
     fn find_query_values(
         &self,
         query: EntityQuery,
-    ) -> Result<Vec<BTreeMap<Word, r::Value>>, QueryExecutionError>;
+    ) -> Result<(Vec<BTreeMap<Word, r::Value>>, Trace), QueryExecutionError>;
 
     async fn is_deployment_synced(&self) -> Result<bool, Error>;
 

--- a/graph/src/data/query/mod.rs
+++ b/graph/src/data/query/mod.rs
@@ -2,8 +2,10 @@ mod cache_status;
 mod error;
 mod query;
 mod result;
+mod trace;
 
 pub use self::cache_status::CacheStatus;
 pub use self::error::{QueryError, QueryExecutionError};
 pub use self::query::{Query, QueryTarget, QueryVariables};
 pub use self::result::{QueryResult, QueryResults};
+pub use self::trace::Trace;

--- a/graph/src/data/query/trace.rs
+++ b/graph/src/data/query/trace.rs
@@ -1,0 +1,77 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use serde::Serialize;
+
+use crate::env::ENV_VARS;
+
+#[derive(Debug, Serialize)]
+pub enum Trace {
+    None,
+    Root {
+        query: Arc<String>,
+        elapsed: Mutex<Duration>,
+        children: Vec<(String, Trace)>,
+    },
+    Query {
+        query: String,
+        elapsed: Duration,
+        entity_count: usize,
+
+        children: Vec<(String, Trace)>,
+    },
+}
+
+impl Default for Trace {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl Trace {
+    pub fn root(query: Arc<String>) -> Trace {
+        if ENV_VARS.log_sql_timing() || ENV_VARS.log_gql_timing() {
+            return Trace::Root {
+                query,
+                elapsed: Mutex::new(Duration::from_millis(0)),
+                children: Vec::new(),
+            };
+        } else {
+            Trace::None
+        }
+    }
+
+    pub fn finish(&self, dur: Duration) {
+        match self {
+            Trace::None | Trace::Query { .. } => { /* nothing to do */ }
+            Trace::Root { elapsed, .. } => *elapsed.lock().unwrap() = dur,
+        }
+    }
+
+    pub fn query(query: &str, elapsed: Duration, entity_count: usize) -> Trace {
+        Trace::Query {
+            query: query.to_string(),
+            elapsed,
+            entity_count,
+            children: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, name: &str, trace: Trace) {
+        match (self, &trace) {
+            (Self::Root { children, .. }, Self::Query { .. }) => {
+                children.push((name.to_string(), trace))
+            }
+            (Self::Query { children, .. }, Self::Query { .. }) => {
+                children.push((name.to_string(), trace))
+            }
+            (Self::None, Self::None) | (Self::Root { .. }, Self::None) => { /* tracing is turned off */
+            }
+            (s, t) => {
+                unreachable!("can not add child self: {:#?} trace: {:#?}", s, t)
+            }
+        }
+    }
+}

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,4 +1,5 @@
 use graph::components::store::UnitStream;
+use graph::data::query::Trace;
 use graph::prelude::{async_trait, s, tokio, ApiSchema, Error, QueryExecutionError};
 use graph::{
     data::graphql::ObjectOrInterface,
@@ -19,7 +20,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
         &self,
         ctx: &ExecutionContext<Self>,
         selection_set: &a::SelectionSet,
-    ) -> Result<Option<r::Value>, Vec<QueryExecutionError>>;
+    ) -> Result<(Option<r::Value>, Trace), Vec<QueryExecutionError>>;
 
     /// Resolves list of objects, `prefetched_objects` is `Some` if the parent already calculated the value.
     fn resolve_objects(

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -1,4 +1,5 @@
 use graph::data::graphql::ext::{FieldExt, TypeDefinitionExt};
+use graph::data::query::Trace;
 use graphql_parser::Pos;
 use std::collections::BTreeMap;
 
@@ -366,8 +367,8 @@ impl Resolver for IntrospectionResolver {
         &self,
         _: &ExecutionContext<Self>,
         _: &a::SelectionSet,
-    ) -> Result<Option<r::Value>, Vec<QueryExecutionError>> {
-        Ok(None)
+    ) -> Result<(Option<r::Value>, Trace), Vec<QueryExecutionError>> {
+        Ok((None, Trace::None))
     }
 
     fn resolve_objects(

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -144,6 +144,7 @@ where
 
         // Note: This will always iterate at least once.
         for (bc, (selection_set, error_policy)) in by_block_constraint {
+            let query_start = Instant::now();
             let resolver = StoreResolver::at_block(
                 &self.logger,
                 store.cheap_clone(),
@@ -169,6 +170,7 @@ where
                 },
             )
             .await;
+            query_res.trace.finish(query_start.elapsed());
             result.append(query_res);
         }
 

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{anyhow, Error};
 use graph::constraint_violation;
+use graph::data::query::Trace;
 use graph::data::value::{Object, Word};
 use graph::prelude::{r, CacheWeight};
 use graph::slog::warn;
@@ -481,8 +482,8 @@ pub fn run(
     ctx: &ExecutionContext<impl Resolver>,
     selection_set: &a::SelectionSet,
     graphql_metrics: &GraphQLMetrics,
-) -> Result<r::Value, Vec<QueryExecutionError>> {
-    execute_root_selection_set(resolver, ctx, selection_set).map(|nodes| {
+) -> Result<(r::Value, Trace), Vec<QueryExecutionError>> {
+    execute_root_selection_set(resolver, ctx, selection_set).map(|(nodes, trace)| {
         graphql_metrics.observe_query_result_size(nodes.weight());
         let obj = Object::from_iter(
             nodes
@@ -494,7 +495,7 @@ pub fn run(
                 })
                 .flatten(),
         );
-        r::Value::Object(obj)
+        (r::Value::Object(obj), trace)
     })
 }
 
@@ -503,9 +504,10 @@ fn execute_root_selection_set(
     resolver: &StoreResolver,
     ctx: &ExecutionContext<impl Resolver>,
     selection_set: &a::SelectionSet,
-) -> Result<Vec<Node>, Vec<QueryExecutionError>> {
+) -> Result<(Vec<Node>, Trace), Vec<QueryExecutionError>> {
+    let trace = Trace::root(ctx.query.query_text.clone());
     // Execute the root selection set against the root query type
-    execute_selection_set(resolver, ctx, make_root_node(), selection_set)
+    execute_selection_set(resolver, ctx, make_root_node(), trace, selection_set)
 }
 
 fn check_result_size<'a>(
@@ -528,8 +530,9 @@ fn execute_selection_set<'a>(
     resolver: &StoreResolver,
     ctx: &'a ExecutionContext<impl Resolver>,
     mut parents: Vec<Node>,
+    mut parent_trace: Trace,
     selection_set: &a::SelectionSet,
-) -> Result<Vec<Node>, Vec<QueryExecutionError>> {
+) -> Result<(Vec<Node>, Trace), Vec<QueryExecutionError>> {
     let schema = &ctx.query.schema;
     let mut errors: Vec<QueryExecutionError> = Vec::new();
 
@@ -590,13 +593,20 @@ fn execute_selection_set<'a>(
                 field_type,
                 collected_columns,
             ) {
-                Ok(children) => {
-                    match execute_selection_set(resolver, ctx, children, &field.selection_set) {
-                        Ok(children) => {
+                Ok((children, trace)) => {
+                    match execute_selection_set(
+                        resolver,
+                        ctx,
+                        children,
+                        trace,
+                        &field.selection_set,
+                    ) {
+                        Ok((children, trace)) => {
                             Join::perform(&mut parents, children, field.response_key());
                             let weight =
                                 parents.iter().map(|parent| parent.weight()).sum::<usize>();
                             check_result_size(ctx, weight)?;
+                            parent_trace.push(field.response_key(), trace);
                         }
                         Err(mut e) => errors.append(&mut e),
                     }
@@ -609,7 +619,7 @@ fn execute_selection_set<'a>(
     }
 
     if errors.is_empty() {
-        Ok(parents)
+        Ok((parents, parent_trace))
     } else {
         Err(errors)
     }
@@ -624,7 +634,7 @@ fn execute_field(
     field: &a::Field,
     field_definition: &s::Field,
     selected_attrs: SelectedAttributes,
-) -> Result<Vec<Node>, Vec<QueryExecutionError>> {
+) -> Result<(Vec<Node>, Trace), Vec<QueryExecutionError>> {
     let multiplicity = if sast::is_list_or_non_null_list_field(field_definition) {
         ChildMultiplicity::Many
     } else {
@@ -666,7 +676,7 @@ fn fetch(
     max_skip: u32,
     query_id: String,
     selected_attrs: SelectedAttributes,
-) -> Result<Vec<Node>, QueryExecutionError> {
+) -> Result<(Vec<Node>, Trace), QueryExecutionError> {
     let mut query = build_query(
         join.child_type,
         block,
@@ -698,13 +708,16 @@ fn fetch(
         // by the parent list
         let windows = join.windows(parents, multiplicity, &query.collection);
         if windows.is_empty() {
-            return Ok(vec![]);
+            return Ok((vec![], Trace::None));
         }
         query.collection = EntityCollection::Window(windows);
     }
-    store
-        .find_query_values(query)
-        .map(|entities| entities.into_iter().map(|entity| entity.into()).collect())
+    store.find_query_values(query).map(|(values, trace)| {
+        (
+            values.into_iter().map(|entity| entity.into()).collect(),
+            trace,
+        )
+    })
 }
 
 #[derive(Debug, Default, Clone)]

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::result;
 use std::sync::Arc;
 
+use graph::data::query::Trace;
 use graph::data::value::Object;
 use graph::data::{
     graphql::{object, ObjectOrInterface},
@@ -230,8 +231,9 @@ impl Resolver for StoreResolver {
         &self,
         ctx: &ExecutionContext<Self>,
         selection_set: &a::SelectionSet,
-    ) -> Result<Option<r::Value>, Vec<QueryExecutionError>> {
-        super::prefetch::run(self, ctx, selection_set, &self.graphql_metrics).map(Some)
+    ) -> Result<(Option<r::Value>, Trace), Vec<QueryExecutionError>> {
+        super::prefetch::run(self, ctx, selection_set, &self.graphql_metrics)
+            .map(|(value, trace)| (Some(value), trace))
     }
 
     fn resolve_objects(

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -4,6 +4,7 @@ extern crate pretty_assertions;
 use std::sync::Arc;
 
 use graph::data::graphql::{object, object_value, ObjectOrInterface};
+use graph::data::query::Trace;
 use graph::prelude::{
     async_trait, o, r, s, slog, tokio, ApiSchema, DeploymentHash, Logger, Query,
     QueryExecutionError, QueryResult, Schema,
@@ -27,8 +28,8 @@ impl Resolver for MockResolver {
         &self,
         _: &ExecutionContext<Self>,
         _: &a::SelectionSet,
-    ) -> Result<Option<r::Value>, Vec<QueryExecutionError>> {
-        Ok(None)
+    ) -> Result<(Option<r::Value>, Trace), Vec<QueryExecutionError>> {
+        Ok((None, Trace::None))
     }
 
     fn resolve_objects<'a>(

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -186,6 +186,10 @@ pub enum Command {
     Copy(CopyCommand),
     /// Run a GraphQL query
     Query {
+        /// Save the JSON query result in this file
+        #[structopt(long, short)]
+        output: Option<String>,
+
         /// The subgraph to query
         ///
         /// Either a deployment id `Qm..` or a subgraph name
@@ -921,10 +925,11 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         Query {
+            output,
             target,
             query,
             vars,
-        } => commands::query::run(ctx.graphql_runner(), target, query, vars).await,
+        } => commands::query::run(ctx.graphql_runner(), target, query, vars, output).await,
         Chain(cmd) => {
             use ChainCommand::*;
             match cmd {

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -189,6 +189,9 @@ pub enum Command {
         /// Save the JSON query result in this file
         #[structopt(long, short)]
         output: Option<String>,
+        /// Save the query trace in this file
+        #[structopt(long, short)]
+        trace: Option<String>,
 
         /// The subgraph to query
         ///
@@ -926,10 +929,11 @@ async fn main() -> anyhow::Result<()> {
         }
         Query {
             output,
+            trace,
             target,
             query,
             vars,
-        } => commands::query::run(ctx.graphql_runner(), target, query, vars, output).await,
+        } => commands::query::run(ctx.graphql_runner(), target, query, vars, output, trace).await,
         Chain(cmd) => {
             use ChainCommand::*;
             match cmd {

--- a/node/src/manager/commands/query.rs
+++ b/node/src/manager/commands/query.rs
@@ -24,6 +24,7 @@ pub async fn run(
     query: String,
     vars: Vec<String>,
     output: Option<String>,
+    trace: Option<String>,
 ) -> Result<(), anyhow::Error> {
     let target = if target.starts_with("Qm") {
         let id =
@@ -63,6 +64,14 @@ pub async fn run(
     if let Some(output) = output {
         let mut f = File::create(output)?;
         let json = serde_json::to_string(&res)?;
+        writeln!(f, "{}", json)?;
+    }
+
+    // The format of this file is pretty awful, but good enough to fish out
+    // interesting SQL queries
+    if let Some(trace) = trace {
+        let mut f = File::create(trace)?;
+        let json = serde_json::to_string(&res.traces())?;
         writeln!(f, "{}", json)?;
     }
 

--- a/node/src/manager/commands/query.rs
+++ b/node/src/manager/commands/query.rs
@@ -1,6 +1,10 @@
+use std::fs::File;
+use std::io::Write;
 use std::iter::FromIterator;
+use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 
+use graph::data::query::Trace;
 use graph::prelude::r;
 use graph::{
     data::query::QueryTarget,
@@ -19,6 +23,7 @@ pub async fn run(
     target: String,
     query: String,
     vars: Vec<String>,
+    output: Option<String>,
 ) -> Result<(), anyhow::Error> {
     let target = if target.starts_with("Qm") {
         let id =
@@ -55,8 +60,75 @@ pub async fn run(
     );
 
     let res = runner.run_query(query, target).await;
-    let json = serde_json::to_string(&res)?;
-    println!("{}", json);
+    if let Some(output) = output {
+        let mut f = File::create(output)?;
+        let json = serde_json::to_string(&res)?;
+        writeln!(f, "{}", json)?;
+    }
+
+    for trace in res.traces() {
+        print_brief_trace("root", trace, 0)?;
+    }
+    Ok(())
+}
+
+fn print_brief_trace(name: &str, trace: &Trace, indent: usize) -> Result<(), anyhow::Error> {
+    use Trace::*;
+
+    fn query_time(trace: &Trace) -> Duration {
+        match trace {
+            None => Duration::from_millis(0),
+            Root { children, .. } => children.iter().map(|(_, trace)| query_time(trace)).sum(),
+            Query {
+                elapsed, children, ..
+            } => *elapsed + children.iter().map(|(_, trace)| query_time(trace)).sum(),
+        }
+    }
+
+    match trace {
+        None => { /* do nothing */ }
+        Root {
+            elapsed, children, ..
+        } => {
+            let elapsed = *elapsed.lock().unwrap();
+            let qt = query_time(trace);
+            let pt = elapsed - qt;
+
+            println!(
+                "{space:indent$}{name:rest$} {elapsed:7}ms",
+                space = " ",
+                indent = indent,
+                rest = 48 - indent,
+                name = name,
+                elapsed = elapsed.as_millis(),
+            );
+            for (name, trace) in children {
+                print_brief_trace(name, trace, indent + 2)?;
+            }
+            println!("\nquery:      {:7}ms", qt.as_millis());
+            println!("other:      {:7}ms", pt.as_millis());
+            println!("total:      {:7}ms", elapsed.as_millis())
+        }
+        Query {
+            elapsed,
+            entity_count,
+            children,
+            ..
+        } => {
+            println!(
+                "{space:indent$}{name:rest$} {elapsed:7}ms [{count:7} entities]",
+                space = " ",
+                indent = indent,
+                rest = 50 - indent,
+                name = name,
+                elapsed = elapsed.as_millis(),
+                count = entity_count
+            );
+            for (name, trace) in children {
+                print_brief_trace(name, trace, indent + 2)?;
+            }
+        }
+    }
 
     Ok(())
 }

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::convert::TryInto;
 
 use either::Either;
+use graph::data::query::Trace;
 use web3::types::Address;
 
 use graph::blockchain::{Blockchain, BlockchainKind, BlockchainMap};
@@ -722,8 +723,8 @@ impl<S: Store> Resolver for IndexNodeResolver<S> {
         &self,
         _: &ExecutionContext<Self>,
         _: &a::SelectionSet,
-    ) -> Result<Option<r::Value>, Vec<QueryExecutionError>> {
-        Ok(None)
+    ) -> Result<(Option<r::Value>, Trace), Vec<QueryExecutionError>> {
+        Ok((None, Trace::None))
     }
 
     /// Resolves a scalar value for a given scalar type.

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
-use graph::data::value::Word;
-
 use crate::deployment_store::{DeploymentStore, ReplicaId};
 use graph::components::store::QueryStore as QueryStoreTrait;
+use graph::data::query::Trace;
+use graph::data::value::Word;
 use graph::prelude::*;
 
 use crate::primary::Site;
@@ -36,7 +36,7 @@ impl QueryStoreTrait for QueryStore {
     fn find_query_values(
         &self,
         query: EntityQuery,
-    ) -> Result<Vec<BTreeMap<Word, r::Value>>, QueryExecutionError> {
+    ) -> Result<(Vec<BTreeMap<Word, r::Value>>, Trace), graph::prelude::QueryExecutionError> {
         assert_eq!(&self.site.deployment, &query.subgraph_id);
         let conn = self
             .store

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -729,6 +729,7 @@ fn count_scalar_entities(conn: &PgConnection, layout: &Layout) -> usize {
             BLOCK_NUMBER_MAX,
             None,
         )
+        .map(|(entities, _)| entities)
         .expect("Count query failed")
         .len()
 }
@@ -963,6 +964,7 @@ fn revert_block() {
                     BLOCK_NUMBER_MAX,
                     None,
                 )
+                .map(|(entities, _)| entities)
                 .expect("loading all marties works");
 
             let mut skipped = 0;
@@ -1044,7 +1046,8 @@ impl<'a> QueryChecker<'a> {
                 BLOCK_NUMBER_MAX,
                 None,
             )
-            .expect("layout.query failed to execute query");
+            .expect("layout.query failed to execute query")
+            .0;
 
         let mut entity_ids: Vec<_> = entities
             .into_iter()
@@ -1701,7 +1704,8 @@ impl<'a> FilterChecker<'a> {
                 BLOCK_NUMBER_MAX,
                 None,
             )
-            .expect("layout.query failed to execute query");
+            .expect("layout.query failed to execute query")
+            .0;
 
         let entity_ids: Vec<_> = entities
             .into_iter()

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -411,6 +411,7 @@ fn query() {
                 BLOCK_NUMBER_MAX,
                 None,
             )
+            .map(|(entities, _)| entities)
             .expect("the query succeeds")
             .into_iter()
             .map(|e| e.id().expect("entities have an id"))


### PR DESCRIPTION
I was using `graphman query` to look at performance for some queries and got very annoyed with the amount of log spam it produces. This PR changes the following:

* the query result now goes into a file given with `--output`
* the query trace can be saved in a file given with `--trace` (the file format is sorta janky, but good enough to fish out individual SQL queries)
* the command output is now actually readable
* you still need to turn on logging by setting `GRAPH_LOG_QUERY_TIMING=gql,sql`; untangling that is surprisingly complicated

Example of using it:
```
> GRAPH_LOG_QUERY_TIMING=gql,sql  graphman query "<deployment>" "<query>"

 root                                                2759ms
  liquidityPools                                       404ms [     50 entities]
    fees                                               202ms [    150 entities]
    inputTokens                                        609ms [    100 entities]
    rewardTokens                                       190ms [     31 entities]
      token                                            191ms [      1 entities]

query:         1598ms
other:         1160ms
total:         2759ms
```