### PR TITLE
firehose: Add timeout to `stream_blocks` request

### DIFF
--- a/graph/src/blockchain/firehose_block_stream.rs
+++ b/graph/src/blockchain/firehose_block_stream.rs
@@ -241,7 +241,8 @@ fn stream_blocks<C: Blockchain, F: FirehoseMapper<C>>(
             }
 
             let mut connect_start = Instant::now();
-            let result = endpoint.clone().stream_blocks(request).await;
+            let req = endpoint.clone().stream_blocks(request);
+            let result = tokio::time::timeout(Duration::from_secs(30), req).await.map_err(|x| x.into()).and_then(|x| x);
 
             match result {
                 Ok(stream) => {


### PR DESCRIPTION
We have a timeout configured on the tonic endpoint which is catching most but somehow not all hangs.