### PR TITLE
add gzip encoding to firehose GRPC stream requests (requires srv support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
  "object 0.26.0",
  "rustc-demangle",
 ]
@@ -1237,6 +1237,16 @@ name = "fixedbitset"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.5.3",
+]
 
 [[package]]
 name = "fnv"
@@ -2549,6 +2559,15 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -4476,6 +4495,7 @@ dependencies = [
  "axum",
  "base64",
  "bytes",
+ "flate2",
  "futures-core",
  "futures-util",
  "h2",

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -49,7 +49,7 @@ tokio-retry = "0.3.0"
 url = "2.2.1"
 prometheus = "0.13.1"
 priority-queue = "0.7.0"
-tonic = { version = "0.7.1", features = ["tls-roots"] }
+tonic = { version = "0.7.1", features = ["tls-roots","compression"] }
 prost = "0.10.4"
 prost-types = "0.10.1"
 
@@ -70,4 +70,4 @@ maplit = "1.0.2"
 structopt = { version = "0.3" }
 
 [build-dependencies]
-tonic-build = { version = "0.7.2", features = ["prost"] }
+tonic-build = { version = "0.7.2", features = ["prost","compression"] }

--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -119,7 +119,9 @@ impl FirehoseEndpoint {
 
                 Ok(r)
             },
-        );
+        )
+        .accept_gzip()
+        .send_gzip();
 
         debug!(
             logger,
@@ -208,7 +210,9 @@ impl FirehoseEndpoint {
 
                 Ok(r)
             },
-        );
+        )
+        .accept_gzip()
+        .send_gzip();
 
         let response_stream = client.blocks(request).await?;
         let block_stream = response_stream.into_inner();

--- a/graph/src/firehose/sf.firehose.v1.rs
+++ b/graph/src/firehose/sf.firehose.v1.rs
@@ -198,8 +198,8 @@ pub mod stream_server {
     #[derive(Debug)]
     pub struct StreamServer<T: Stream> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Stream> StreamServer<T> {
@@ -222,6 +222,18 @@ pub mod stream_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.accept_compression_encodings.enable_gzip();
+            self
+        }
+        /// Compress responses with `gzip`, if the client supports it.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.send_compression_encodings.enable_gzip();
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for StreamServer<T>

--- a/graph/src/substreams/sf.substreams.v1.rs
+++ b/graph/src/substreams/sf.substreams.v1.rs
@@ -482,8 +482,8 @@ pub mod stream_server {
     #[derive(Debug)]
     pub struct StreamServer<T: Stream> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Stream> StreamServer<T> {
@@ -506,6 +506,18 @@ pub mod stream_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.accept_compression_encodings.enable_gzip();
+            self
+        }
+        /// Compress responses with `gzip`, if the client supports it.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.send_compression_encodings.enable_gzip();
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for StreamServer<T>


### PR DESCRIPTION
* This adds `send_grpc()` and `accept_grpc()` tonic parameters to the stream calls on firehose
* Setting only `accept_grpc()` is not sufficent because of the grpc-go implementation's behavior (https://github.com/grpc/grpc-go/blob/master/Documentation/compression.md?plain=1#L20-L21)
* firehose will need to be upgraded with gzip support before this is PR is merged/deployed
