### PR TITLE
Pruning of subgraphs

### DIFF
--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1077,12 +1077,25 @@ impl ReadStore for EmptyStore {
     }
 }
 
+/// An estimate of the number of entities and the number of entity versions
+/// in a database table
+#[derive(Clone, Debug)]
+pub struct VersionStats {
+    pub entities: i32,
+    pub versions: i32,
+    pub tablename: String,
+    /// The ratio `entities / versions`
+    pub ratio: f64,
+}
+
 /// Callbacks for `SubgraphStore.prune` so that callers can report progress
 /// of the pruning procedure to users
 #[allow(unused_variables)]
 pub trait PruneReporter: Send + 'static {
-    fn start_analyze(&mut self, table: &str) {}
-    fn finish_analyze(&mut self, table: &str) {}
+    fn start_analyze(&mut self) {}
+    fn start_analyze_table(&mut self, table: &str) {}
+    fn finish_analyze_table(&mut self, table: &str) {}
+    fn finish_analyze(&mut self, stats: &[VersionStats]) {}
 
     fn copy_final_start(&mut self, earliest_block: BlockNumber, final_block: BlockNumber) {}
     fn copy_final_batch(&mut self, table: &str, rows: usize, total_rows: usize, finished: bool) {}

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1076,3 +1076,22 @@ impl ReadStore for EmptyStore {
         self.schema.cheap_clone()
     }
 }
+
+/// Callbacks for `SubgraphStore.prune` so that callers can report progress
+/// of the pruning procedure to users
+#[allow(unused_variables)]
+pub trait PruneReporter: Send + 'static {
+    fn start_analyze(&mut self, table: &str) {}
+    fn finish_analyze(&mut self, table: &str) {}
+
+    fn copy_final_start(&mut self, earliest_block: BlockNumber, final_block: BlockNumber) {}
+    fn copy_final_batch(&mut self, table: &str, rows: usize, total_rows: usize, finished: bool) {}
+    fn copy_final_finish(&mut self) {}
+
+    fn start_switch(&mut self) {}
+    fn copy_nonfinal_start(&mut self, table: &str) {}
+    fn copy_nonfinal_finish(&mut self, table: &str, rows: usize) {}
+    fn finish_switch(&mut self) {}
+
+    fn finish_prune(&mut self) {}
+}

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -399,16 +399,10 @@ pub enum StatsCommand {
     ///
     /// Show how many distinct entities and how many versions the tables of
     /// each subgraph have. The data is based on the statistics that
-    /// Postgres keeps, and only refreshed when a table is analyzed. If a
-    /// table name is passed, perform a full count of entities and versions
-    /// in that table, which can be very slow, but is needed since the
-    /// statistics based data can be off by an order of magnitude.
+    /// Postgres keeps, and only refreshed when a table is analyzed.
     Show {
         /// The deployment (see `help info`).
         deployment: DeploymentSearch,
-        /// The name of a table to fully count which can be very slow
-        #[structopt(long, short)]
-        table: Option<String>,
     },
     /// Perform a SQL ANALYZE in a Entity table
     Analyze {
@@ -989,8 +983,9 @@ async fn main() -> anyhow::Result<()> {
                     table,
                 } => {
                     let (store, primary_pool) = ctx.store_and_primary();
+                    let subgraph_store = store.subgraph_store();
                     commands::stats::account_like(
-                        store.subgraph_store(),
+                        subgraph_store,
                         primary_pool,
                         clear,
                         &deployment,
@@ -998,9 +993,7 @@ async fn main() -> anyhow::Result<()> {
                     )
                     .await
                 }
-                Show { deployment, table } => {
-                    commands::stats::show(ctx.pools(), &deployment, table)
-                }
+                Show { deployment } => commands::stats::show(ctx.pools(), &deployment),
                 Analyze { deployment, entity } => {
                     let (store, primary_pool) = ctx.store_and_primary();
                     let subgraph_store = store.subgraph_store();

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -209,6 +209,18 @@ pub enum Command {
 
     /// Manage database indexes
     Index(IndexCommand),
+
+    /// Prune deployments
+    Prune {
+        /// The deployment to prune (see `help info`)
+        deployment: DeploymentSearch,
+        /// Prune tables with a ratio of entities to entity versions lower than this
+        #[structopt(long, short, default_value = "0.20")]
+        prune_ratio: f64,
+        /// How much history to keep in blocks
+        #[structopt(long, short, default_value = "10000")]
+        history: usize,
+    },
 }
 
 impl Command {
@@ -1033,6 +1045,14 @@ async fn main() -> anyhow::Result<()> {
                         .await
                 }
             }
+        }
+        Prune {
+            deployment,
+            history,
+            prune_ratio,
+        } => {
+            let (store, primary_pool) = ctx.store_and_primary();
+            commands::prune::run(store, primary_pool, deployment, history, prune_ratio).await
         }
     }
 }

--- a/node/src/manager/commands/mod.rs
+++ b/node/src/manager/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod create;
 pub mod index;
 pub mod info;
 pub mod listen;
+pub mod prune;
 pub mod query;
 pub mod remove;
 pub mod rewind;

--- a/node/src/manager/commands/prune.rs
+++ b/node/src/manager/commands/prune.rs
@@ -1,0 +1,160 @@
+use std::{io::Write, sync::Arc, time::Instant};
+
+use graph::{
+    components::store::{PruneReporter, StatusStore},
+    data::subgraph::status,
+    prelude::{anyhow, BlockNumber},
+};
+use graph_chain_ethereum::ENV_VARS as ETH_ENV;
+use graph_store_postgres::{connection_pool::ConnectionPool, Store};
+
+use crate::manager::deployment::DeploymentSearch;
+
+struct Progress {
+    start: Instant,
+    analyze_start: Instant,
+    switch_start: Instant,
+    final_start: Instant,
+    final_table_start: Instant,
+    nonfinal_start: Instant,
+}
+
+impl Progress {
+    fn new() -> Self {
+        Self {
+            start: Instant::now(),
+            analyze_start: Instant::now(),
+            switch_start: Instant::now(),
+            final_start: Instant::now(),
+            final_table_start: Instant::now(),
+            nonfinal_start: Instant::now(),
+        }
+    }
+}
+
+impl PruneReporter for Progress {
+    fn start_analyze(&mut self, table: &str) {
+        print!("analyze {table:48} ");
+        std::io::stdout().flush().ok();
+        self.analyze_start = Instant::now();
+    }
+
+    fn finish_analyze(&mut self, table: &str) {
+        println!(
+            "\ranalyze {table:48} (done in {}s)",
+            self.analyze_start.elapsed().as_secs()
+        );
+        std::io::stdout().flush().ok();
+    }
+
+    fn copy_final_start(&mut self, earliest_block: BlockNumber, final_block: BlockNumber) {
+        println!("copy final entities (versions live between {earliest_block} and {final_block})");
+        self.final_start = Instant::now();
+        self.final_table_start = self.final_start;
+    }
+
+    fn copy_final_batch(&mut self, table: &str, _rows: usize, total_rows: usize, finished: bool) {
+        if finished {
+            println!(
+                "\r  copy final {table:43} ({total_rows} rows in {}s)",
+                self.final_table_start.elapsed().as_secs()
+            );
+            self.final_table_start = Instant::now();
+        } else {
+            print!(
+                "\r  copy final {table:43} ({total_rows} rows in {}s)",
+                self.final_table_start.elapsed().as_secs()
+            );
+        }
+        std::io::stdout().flush().ok();
+    }
+
+    fn copy_final_finish(&mut self) {
+        println!(
+            "finished copying final entity versions in {}s",
+            self.final_start.elapsed().as_secs()
+        );
+    }
+
+    fn start_switch(&mut self) {
+        println!("blocking writes and switching tables");
+        self.switch_start = Instant::now();
+    }
+
+    fn finish_switch(&mut self) {
+        println!(
+            "enabling writes. Switching took {}s",
+            self.switch_start.elapsed().as_secs()
+        );
+    }
+
+    fn copy_nonfinal_start(&mut self, table: &str) {
+        print!("  copy nonfinal {table:40}");
+        std::io::stdout().flush().ok();
+        self.nonfinal_start = Instant::now();
+    }
+
+    fn copy_nonfinal_finish(&mut self, table: &str, rows: usize) {
+        println!(
+            "\r  copy nonfinal {table:40} ({rows} rows in {}s)",
+            self.nonfinal_start.elapsed().as_secs()
+        );
+        std::io::stdout().flush().ok();
+    }
+
+    fn finish_prune(&mut self) {
+        println!("finished pruning in {}s", self.start.elapsed().as_secs());
+    }
+}
+
+pub async fn run(
+    store: Arc<Store>,
+    primary_pool: ConnectionPool,
+    search: DeploymentSearch,
+    history: usize,
+    prune_ratio: f64,
+) -> Result<(), anyhow::Error> {
+    let history = history as BlockNumber;
+    let deployment = search.locate_unique(&primary_pool)?;
+    let mut info = store
+        .status(status::Filter::DeploymentIds(vec![deployment.id]))?
+        .pop()
+        .ok_or_else(|| anyhow!("deployment {deployment} not found"))?;
+    if info.chains.len() > 1 {
+        return Err(anyhow!(
+            "deployment {deployment} indexes {} chains, not sure how to deal with more than one chain",
+            info.chains.len()
+        ));
+    }
+    let status = info
+        .chains
+        .pop()
+        .ok_or_else(|| anyhow!("deployment {} does not index any chain", deployment))?;
+    let latest = status.latest_block.map(|ptr| ptr.number()).unwrap_or(0);
+    if latest <= history {
+        return Err(anyhow!("deployment {deployment} has only indexed up to block {latest} and we can't preserve {history} blocks of history"));
+    }
+
+    println!("prune {deployment}");
+    println!("    latest: {latest}");
+    println!("     final: {}", latest - ETH_ENV.reorg_threshold);
+    println!("  earliest: {}", latest - history);
+
+    let reporter = Box::new(Progress::new());
+    store
+        .subgraph_store()
+        .prune(
+            reporter,
+            &deployment,
+            latest - history,
+            // Using the setting for eth chains is a bit lazy; the value
+            // should really depend on the chain, but we don't have a
+            // convenient way to figure out how each chain deals with
+            // finality
+            ETH_ENV.reorg_threshold,
+            prune_ratio,
+        )
+        .await?;
+
+    Ok(())
+}

--- a/node/src/manager/commands/stats.rs
+++ b/node/src/manager/commands/stats.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::manager::deployment::DeploymentSearch;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::PooledConnection;
 use diesel::PgConnection;
+use graph::components::store::VersionStats;
 use graph::prelude::anyhow;
 use graph_store_postgres::command_support::catalog as store_catalog;
 use graph_store_postgres::command_support::catalog::Site;
@@ -48,12 +50,23 @@ pub async fn account_like(
     Ok(())
 }
 
-pub fn show(
-    pools: HashMap<Shard, ConnectionPool>,
-    search: &DeploymentSearch,
-) -> Result<(), anyhow::Error> {
-    let (site, conn) = site_and_conn(pools, search)?;
+pub fn abbreviate_table_name(table: &str, size: usize) -> String {
+    if table.len() > size {
+        let fragment = size / 2 - 2;
+        let last = table.len() - fragment;
+        let mut table = table.to_string();
+        table.replace_range(fragment..last, "..");
+        let table = table.trim().to_string();
+        table
+    } else {
+        table.to_string()
+    }
+}
 
+pub fn show_stats(
+    stats: &[VersionStats],
+    account_like: HashSet<String>,
+) -> Result<(), anyhow::Error> {
     fn header() {
         println!(
             "{:^30} | {:^10} | {:^10} | {:^7}",
@@ -66,10 +79,10 @@ pub fn show(
         println!("  (a): account-like flag set");
     }
 
-    fn print_stats(s: &store_catalog::VersionStats, account_like: bool) {
+    fn print_stats(s: &VersionStats, account_like: bool) {
         println!(
             "{:<26} {:3} | {:>10} | {:>10} | {:>5.1}%",
-            s.tablename,
+            abbreviate_table_name(&s.tablename, 26),
             if account_like { "(a)" } else { "   " },
             s.entities,
             s.versions,
@@ -77,17 +90,28 @@ pub fn show(
         );
     }
 
+    header();
+    for s in stats {
+        print_stats(s, account_like.contains(&s.tablename));
+    }
+    if !account_like.is_empty() {
+        footer();
+    }
+
+    Ok(())
+}
+
+pub fn show(
+    pools: HashMap<Shard, ConnectionPool>,
+    search: &DeploymentSearch,
+) -> Result<(), anyhow::Error> {
+    let (site, conn) = site_and_conn(pools, search)?;
+
     let stats = store_catalog::stats(&conn, &site.namespace)?;
 
     let account_like = store_catalog::account_like(&conn, &site)?;
 
-    header();
-    for s in &stats {
-        print_stats(s, account_like.contains(&s.tablename));
-    }
-    footer();
-
-    Ok(())
+    show_stats(stats.as_slice(), account_like)
 }
 
 pub fn analyze(

--- a/node/src/manager/commands/stats.rs
+++ b/node/src/manager/commands/stats.rs
@@ -73,7 +73,7 @@ pub fn show(
             if account_like { "(a)" } else { "   " },
             s.entities,
             s.versions,
-            s.entities as f32 * 100.0 / s.versions as f32
+            s.ratio * 100.0
         );
     }
 

--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -296,8 +296,10 @@ impl AdaptiveBatchSize {
     // get close to TARGET_DURATION for the time it takes to copy one
     // batch, but don't step up batch_size by more than 2x at once
     pub fn adapt(&mut self, duration: Duration) {
+        // Avoid division by zero
+        let duration = duration.as_millis().max(1);
         let new_batch_size =
-            self.size as f64 * TARGET_DURATION.as_millis() as f64 / duration.as_millis() as f64;
+            self.size as f64 * TARGET_DURATION.as_millis() as f64 / duration as f64;
         self.size = (2 * self.size).min(new_batch_size.round() as i64);
     }
 }

--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -202,17 +202,17 @@ impl CopyState {
                     })
             })
             .collect::<Result<_, _>>()?;
-        tables.sort_by_key(|table| table.dst.object.to_string());
+        tables.sort_by_key(|table| table.batch.dst.object.to_string());
 
         let values = tables
             .iter()
             .map(|table| {
                 (
-                    cts::entity_type.eq(table.dst.object.as_str()),
+                    cts::entity_type.eq(table.batch.dst.object.as_str()),
                     cts::dst.eq(dst.site.id),
-                    cts::next_vid.eq(table.next_vid),
-                    cts::target_vid.eq(table.target_vid),
-                    cts::batch_size.eq(table.batch_size),
+                    cts::next_vid.eq(table.batch.next_vid),
+                    cts::target_vid.eq(table.batch.target_vid),
+                    cts::batch_size.eq(table.batch.batch_size),
                 )
             })
             .collect::<Vec<_>>();
@@ -268,14 +268,73 @@ impl CopyState {
     }
 }
 
-struct TableState {
-    dst_site: Arc<Site>,
+/// A helper to copy entities from one table to another in batches that are
+/// small enough to not interfere with the rest of the operations happening
+/// in the database. The `src` and `dst` table must have the same structure
+/// so that we can copy rows from one to the other with very little
+/// transformation. See `CopyEntityBatchQuery` for the details of what
+/// exactly that means
+pub(crate) struct BatchCopy {
     src: Arc<Table>,
     dst: Arc<Table>,
     /// The `vid` of the next entity version that we will copy
     next_vid: i64,
+    /// The last `vid` that should be copied
     target_vid: i64,
     batch_size: i64,
+}
+
+impl BatchCopy {
+    pub fn new(src: Arc<Table>, dst: Arc<Table>, first_vid: i64, last_vid: i64) -> Self {
+        let batch_size = if dst.columns.iter().any(|col| col.is_list()) {
+            INITIAL_BATCH_SIZE_LIST
+        } else {
+            INITIAL_BATCH_SIZE
+        };
+
+        Self {
+            src,
+            dst,
+            next_vid: first_vid,
+            target_vid: last_vid,
+            batch_size,
+        }
+    }
+
+    /// Copy one batch of entities and update internal state so that the
+    /// next call to `run` will copy the next batch
+    pub fn run(&mut self, conn: &PgConnection) -> Result<Duration, StoreError> {
+        let start = Instant::now();
+
+        // Copy all versions with next_vid <= vid <= next_vid + batch_size - 1,
+        // but do not go over target_vid
+        let last_vid = (self.next_vid + self.batch_size - 1).min(self.target_vid);
+        rq::CopyEntityBatchQuery::new(self.dst.as_ref(), &self.src, self.next_vid, last_vid)?
+            .execute(conn)?;
+
+        let duration = start.elapsed();
+
+        // remember how far we got
+        self.next_vid = last_vid + 1;
+
+        // adjust batch size by trying to extrapolate in such a way that we
+        // get close to TARGET_DURATION for the time it takes to copy one
+        // batch, but don't step up batch_size by more than 2x at once
+        let new_batch_size = self.batch_size as f64 * TARGET_DURATION.as_millis() as f64
+            / duration.as_millis() as f64;
+        self.batch_size = (2 * self.batch_size).min(new_batch_size.round() as i64);
+
+        Ok(duration)
+    }
+
+    pub fn finished(&self) -> bool {
+        self.next_vid > self.target_vid
+    }
+}
+
+struct TableState {
+    batch: BatchCopy,
+    dst_site: Arc<Site>,
     duration_ms: i64,
 }
 
@@ -309,25 +368,15 @@ impl TableState {
         .map(|v| v.max_vid)
         .unwrap_or(-1);
 
-        let batch_size = if dst.columns.iter().any(|col| col.is_list()) {
-            INITIAL_BATCH_SIZE_LIST
-        } else {
-            INITIAL_BATCH_SIZE
-        };
-
         Ok(Self {
+            batch: BatchCopy::new(src, dst, 0, target_vid),
             dst_site,
-            src,
-            dst,
-            next_vid: 0,
-            target_vid,
-            batch_size,
             duration_ms: 0,
         })
     }
 
     fn finished(&self) -> bool {
-        self.next_vid > self.target_vid
+        self.batch.finished()
     }
 
     fn load(
@@ -385,15 +434,16 @@ impl TableState {
                         id,
                     );
                     match (src, dst) {
-                        (Ok(src), Ok(dst)) => Ok(TableState {
-                            dst_site: dst_layout.site.clone(),
-                            src,
-                            dst,
-                            next_vid: current_vid,
-                            target_vid,
-                            batch_size,
-                            duration_ms,
-                        }),
+                        (Ok(src), Ok(dst)) => {
+                            let mut batch = BatchCopy::new(src, dst, current_vid, target_vid);
+                            batch.batch_size = batch_size;
+
+                            Ok(TableState {
+                                batch,
+                                dst_site: dst_layout.site.clone(),
+                                duration_ms,
+                            })
+                        }
                         (Err(e), _) => Err(e),
                         (_, Err(e)) => Err(e),
                     }
@@ -420,20 +470,20 @@ impl TableState {
             update(
                 cts::table
                     .filter(cts::dst.eq(self.dst_site.id))
-                    .filter(cts::entity_type.eq(self.dst.object.as_str())),
+                    .filter(cts::entity_type.eq(self.batch.dst.object.as_str())),
             )
             .set(cts::started_at.eq(sql("now()")))
             .execute(conn)?;
         }
         let values = (
-            cts::next_vid.eq(self.next_vid),
-            cts::batch_size.eq(self.batch_size),
+            cts::next_vid.eq(self.batch.next_vid),
+            cts::batch_size.eq(self.batch.batch_size),
             cts::duration_ms.eq(self.duration_ms),
         );
         update(
             cts::table
                 .filter(cts::dst.eq(self.dst_site.id))
-                .filter(cts::entity_type.eq(self.dst.object.as_str())),
+                .filter(cts::entity_type.eq(self.batch.dst.object.as_str())),
         )
         .set(values)
         .execute(conn)?;
@@ -446,7 +496,7 @@ impl TableState {
         update(
             cts::table
                 .filter(cts::dst.eq(self.dst_site.id))
-                .filter(cts::entity_type.eq(self.dst.object.as_str())),
+                .filter(cts::entity_type.eq(self.batch.dst.object.as_str())),
         )
         .set(cts::finished_at.eq(sql("now()")))
         .execute(conn)?;
@@ -472,26 +522,9 @@ impl TableState {
     }
 
     fn copy_batch(&mut self, conn: &PgConnection) -> Result<Status, StoreError> {
-        let start = Instant::now();
+        let first_batch = self.batch.next_vid == 0;
 
-        // Copy all versions with next_vid <= vid <= next_vid + batch_size - 1,
-        // but do not go over target_vid
-        let first_batch = self.next_vid == 0;
-        let last_vid = (self.next_vid + self.batch_size - 1).min(self.target_vid);
-        rq::CopyEntityBatchQuery::new(self.dst.as_ref(), &self.src, self.next_vid, last_vid)?
-            .execute(conn)?;
-
-        let duration = start.elapsed();
-
-        // remember how far we got
-        self.next_vid = last_vid + 1;
-
-        // adjust batch size by trying to extrapolate in such a way that we
-        // get close to TARGET_DURATION for the time it takes to copy one
-        // batch, but don't step up batch_size by more than 2x at once
-        let new_batch_size = self.batch_size as f64 * TARGET_DURATION.as_millis() as f64
-            / duration.as_millis() as f64;
-        self.batch_size = (2 * self.batch_size).min(new_batch_size.round() as i64);
+        let duration = self.batch.run(conn)?;
 
         self.record_progress(conn, duration, first_batch)?;
 
@@ -515,7 +548,11 @@ struct CopyProgress<'a> {
 
 impl<'a> CopyProgress<'a> {
     fn new(logger: &'a Logger, state: &CopyState) -> Self {
-        let target_vid: i64 = state.tables.iter().map(|table| table.target_vid).sum();
+        let target_vid: i64 = state
+            .tables
+            .iter()
+            .map(|table| table.batch.target_vid)
+            .sum();
         Self {
             logger,
             last_log: Instant::now(),
@@ -547,23 +584,23 @@ impl<'a> CopyProgress<'a> {
         }
     }
 
-    fn update(&mut self, table: &TableState) {
+    fn update(&mut self, batch: &BatchCopy) {
         if self.last_log.elapsed() > LOG_INTERVAL {
             info!(
                 self.logger,
                 "Copied {:.2}% of `{}` entities ({}/{} entity versions), {:.2}% of overall data",
-                Self::progress_pct(table.next_vid, table.target_vid),
-                table.dst.object,
-                table.next_vid,
-                table.target_vid,
-                Self::progress_pct(self.current_vid + table.next_vid, self.target_vid)
+                Self::progress_pct(batch.next_vid, batch.target_vid),
+                batch.dst.object,
+                batch.next_vid,
+                batch.target_vid,
+                Self::progress_pct(self.current_vid + batch.next_vid, self.target_vid)
             );
             self.last_log = Instant::now();
         }
     }
 
-    fn table_finished(&mut self, table: &TableState) {
-        self.current_vid += table.next_vid;
+    fn table_finished(&mut self, batch: &BatchCopy) {
+        self.current_vid += batch.next_vid;
     }
 
     fn finished(&self) {
@@ -669,9 +706,9 @@ impl Connection {
                 if status == Status::Cancelled {
                     return Ok(status);
                 }
-                progress.update(table);
+                progress.update(&table.batch);
             }
-            progress.table_finished(table);
+            progress.table_finished(&table.batch);
         }
 
         self.copy_private_data_sources(&state)?;

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -1010,3 +1010,31 @@ pub fn set_entity_count(
         .execute(conn)?;
     Ok(())
 }
+
+pub fn set_earliest_block(
+    conn: &PgConnection,
+    site: &Site,
+    earliest_block: BlockNumber,
+) -> Result<(), StoreError> {
+    use subgraph_deployment as d;
+
+    update(d::table.filter(d::id.eq(site.id)))
+        .set(d::earliest_block_number.eq(earliest_block))
+        .execute(conn)?;
+    Ok(())
+}
+
+/// Lock the row for `site` in `subgraph_deployment` for update. This lock
+/// is used to coordinate the changes that the subgraph writer makes with
+/// changes that other parts of the system, in particular, pruning make
+//  see also: deployment-lock-for-update
+pub fn lock(conn: &PgConnection, site: &Site) -> Result<(), StoreError> {
+    use subgraph_deployment as d;
+
+    d::table
+        .select(d::id)
+        .filter(d::id.eq(site.id))
+        .for_update()
+        .get_result::<DeploymentId>(conn)?;
+    Ok(())
+}

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -1024,9 +1024,10 @@ pub fn set_earliest_block(
     Ok(())
 }
 
-/// Lock the row for `site` in `subgraph_deployment` for update. This lock
-/// is used to coordinate the changes that the subgraph writer makes with
-/// changes that other parts of the system, in particular, pruning make
+/// Lock the row for `site` in `subgraph_deployment` for update for the
+/// remainder of the current transaction. This lock is used to coordinate
+/// the changes that the subgraph writer makes with changes that other parts
+/// of the system, in particular, pruning make
 //  see also: deployment-lock-for-update
 pub fn lock(conn: &PgConnection, site: &Site) -> Result<(), StoreError> {
     use subgraph_deployment as d;

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -698,10 +698,7 @@ impl DeploymentStore {
         let entity_name = entity_name.to_owned();
         let layout = store.layout(&conn, site)?;
         let table = resolve_table_name(&layout, &entity_name)?;
-        let table_name = &table.qualified_name;
-        let sql = format!("analyze {table_name}");
-        conn.execute(&sql)?;
-        Ok(())
+        table.analyze(conn)
     }
 
     /// Creates a new index in the specified Entity table if it doesn't already exist.

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -4,7 +4,7 @@ use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use graph::blockchain::block_stream::FirehoseCursor;
-use graph::components::store::{EntityKey, EntityType, StoredDynamicDataSource};
+use graph::components::store::{EntityKey, EntityType, PruneReporter, StoredDynamicDataSource};
 use graph::components::versions::VERSIONS;
 use graph::data::query::Trace;
 use graph::data::subgraph::{status, SPEC_VERSION_0_0_6};
@@ -794,6 +794,61 @@ impl DeploymentStore {
         })
         .await
     }
+
+    pub(crate) async fn prune(
+        self: &Arc<Self>,
+        mut reporter: Box<dyn PruneReporter>,
+        site: Arc<Site>,
+        earliest_block: BlockNumber,
+        reorg_threshold: BlockNumber,
+        prune_ratio: f64,
+    ) -> Result<Box<dyn PruneReporter>, StoreError> {
+        let store = self.clone();
+        self.with_conn(move |conn, cancel| {
+            let layout = store.layout(conn, site.clone())?;
+            cancel.check_cancel()?;
+            let state = deployment::state(&conn, site.deployment.clone())?;
+
+            if state.latest_block.number <= reorg_threshold {
+                return Ok(reporter);
+            }
+
+            if state.earliest_block_number > earliest_block {
+                return Err(constraint_violation!("earliest block can not move back from {} to {}", state.earliest_block_number, earliest_block).into());
+            }
+
+            let final_block = state.latest_block.number - reorg_threshold;
+            if final_block <= earliest_block {
+                return Err(constraint_violation!("the earliest block {} must be at least {} blocks before the current latest block {}", earliest_block, reorg_threshold, state.latest_block.number).into());
+            }
+
+            if let Some((_, graft)) = deployment::graft_point(conn, &site.deployment)? {
+                if graft.block_number() >= earliest_block {
+                    return Err(constraint_violation!("the earliest block {} must be after the graft point {}", earliest_block, graft.block_number()).into());
+                }
+            }
+
+            cancel.check_cancel()?;
+
+            conn.transaction(|| {
+                deployment::set_earliest_block(conn, site.as_ref(), earliest_block)
+            })?;
+
+            cancel.check_cancel()?;
+
+            layout.prune_by_copying(
+                &store.logger,
+                reporter.as_mut(),
+                conn,
+                earliest_block,
+                final_block,
+                prune_ratio,
+                cancel,
+            )?;
+            Ok(reporter)
+        })
+        .await
+    }
 }
 
 /// Methods that back the trait `graph::components::Store`, but have small
@@ -1016,6 +1071,10 @@ impl DeploymentStore {
 
             // Make the changes
             let layout = self.layout(&conn, site.clone())?;
+
+            //  see also: deployment-lock-for-update
+            deployment::lock(&conn, &site)?;
+
             let section = stopwatch.start_section("apply_entity_modifications");
             let count = self.apply_entity_modifications(
                 &conn,
@@ -1068,6 +1127,9 @@ impl DeploymentStore {
         firehose_cursor: &FirehoseCursor,
     ) -> Result<StoreEvent, StoreError> {
         let event = conn.transaction(|| -> Result<_, StoreError> {
+            //  see also: deployment-lock-for-update
+            deployment::lock(conn, &site)?;
+
             // Don't revert past a graft point
             let info = self.subgraph_info_with_conn(conn, site.as_ref())?;
             if let Some(graft_block) = info.graft_block {

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -69,7 +69,7 @@ pub use self::subgraph_store::{unused, DeploymentPlacer, Shard, SubgraphStore, P
 pub mod command_support {
     pub mod catalog {
         pub use crate::block_store::primary as block_store;
-        pub use crate::catalog::account_like;
+        pub use crate::catalog::{account_like, stats, VersionStats};
         pub use crate::copy::{copy_state, copy_table_state};
         pub use crate::primary::Connection;
         pub use crate::primary::{

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -69,7 +69,7 @@ pub use self::subgraph_store::{unused, DeploymentPlacer, Shard, SubgraphStore, P
 pub mod command_support {
     pub mod catalog {
         pub use crate::block_store::primary as block_store;
-        pub use crate::catalog::{account_like, stats, VersionStats};
+        pub use crate::catalog::{account_like, stats};
         pub use crate::copy::{copy_state, copy_table_state};
         pub use crate::primary::Connection;
         pub use crate::primary::{

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -14,6 +14,8 @@ mod ddl_tests;
 #[cfg(test)]
 mod query_tests;
 
+mod prune;
+
 use diesel::{connection::SimpleConnection, Connection};
 use diesel::{debug_query, OptionalExtension, PgConnection, RunQueryDsl};
 use graph::cheap_clone::CheapClone;
@@ -1241,6 +1243,22 @@ impl Table {
             immutable,
         };
         Ok(table)
+    }
+
+    /// Create a table that is like `self` except that its name in the
+    /// database is based on `namespace` and `name`
+    pub fn new_like(&self, namespace: &Namespace, name: &SqlName) -> Arc<Table> {
+        let other = Table {
+            object: self.object.clone(),
+            name: name.clone(),
+            qualified_name: SqlName::qualified_name(namespace, &name),
+            columns: self.columns.clone(),
+            is_account_like: self.is_account_like,
+            position: self.position,
+            immutable: self.immutable,
+        };
+
+        Arc::new(other)
     }
 
     /// Find the column `name` in this table. The name must be in snake case,

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1290,6 +1290,13 @@ impl Table {
             .find(|column| column.is_primary_key())
             .expect("every table has a primary key")
     }
+
+    pub(crate) fn analyze(&self, conn: &PgConnection) -> Result<(), StoreError> {
+        let table_name = &self.qualified_name;
+        let sql = format!("analyze {table_name}");
+        conn.execute(&sql)?;
+        Ok(())
+    }
 }
 
 /// Return the enclosed named type for a field type, i.e., the type after

--- a/store/postgres/src/relational/ddl.rs
+++ b/store/postgres/src/relational/ddl.rs
@@ -54,12 +54,7 @@ impl Layout {
 }
 
 impl Table {
-    /// Generate the DDL for one table, i.e. one `create table` statement
-    /// and all `create index` statements for the table's columns
-    ///
-    /// See the unit tests at the end of this file for the actual DDL that
-    /// gets generated
-    fn as_ddl(&self, out: &mut String, layout: &Layout) -> fmt::Result {
+    fn create_table(&self, out: &mut String, layout: &Layout) -> fmt::Result {
         fn columns_ddl(table: &Table) -> Result<String, fmt::Error> {
             let mut cols = String::new();
             let mut first = true;
@@ -76,190 +71,186 @@ impl Table {
             Ok(cols)
         }
 
-        fn create_table(table: &Table, out: &mut String, layout: &Layout) -> fmt::Result {
-            if table.immutable {
-                writeln!(
-                    out,
-                    r#"
-                create table {nsp}.{name} (
-                    {vid}                  bigserial primary key,
-                    {block}                int not null,
-                    {cols},
-                    unique({id})
-                );
-                "#,
-                    nsp = layout.catalog.site.namespace,
-                    name = table.name.quoted(),
-                    cols = columns_ddl(table)?,
-                    vid = VID_COLUMN,
-                    block = BLOCK_COLUMN,
-                    id = table.primary_key().name
-                )
-            } else {
-                writeln!(
-                    out,
-                    r#"
-                create table {nsp}.{name} (
-                    {vid}                  bigserial primary key,
-                    {block_range}          int4range not null,
-                    {cols}
-                );
-                "#,
-                    nsp = layout.catalog.site.namespace,
-                    name = table.name.quoted(),
-                    cols = columns_ddl(table)?,
-                    vid = VID_COLUMN,
-                    block_range = BLOCK_RANGE_COLUMN
-                )?;
+        if self.immutable {
+            writeln!(
+                out,
+                r#"
+            create table {nsp}.{name} (
+                {vid}                  bigserial primary key,
+                {block}                int not null,
+                {cols},
+                unique({id})
+            );
+            "#,
+                nsp = layout.catalog.site.namespace,
+                name = self.name.quoted(),
+                cols = columns_ddl(self)?,
+                vid = VID_COLUMN,
+                block = BLOCK_COLUMN,
+                id = self.primary_key().name
+            )
+        } else {
+            writeln!(
+                out,
+                r#"
+            create table {nsp}.{name} (
+                {vid}                  bigserial primary key,
+                {block_range}          int4range not null,
+                {cols}
+            );
+            "#,
+                nsp = layout.catalog.site.namespace,
+                name = self.name.quoted(),
+                cols = columns_ddl(self)?,
+                vid = VID_COLUMN,
+                block_range = BLOCK_RANGE_COLUMN
+            )?;
 
-                table.exclusion_ddl(
-                    out,
-                    layout.catalog.site.namespace.as_str(),
-                    layout.catalog.create_exclusion_constraint(),
-                )
-            }
+            self.exclusion_ddl(
+                out,
+                layout.catalog.site.namespace.as_str(),
+                layout.catalog.create_exclusion_constraint(),
+            )
         }
+    }
 
-        fn create_time_travel_indexes(
-            table: &Table,
-            out: &mut String,
-            layout: &Layout,
-        ) -> fmt::Result {
-            if table.immutable {
-                write!(
-                    out,
-                    "create index brin_{table_name}\n    \
-                    on {schema_name}.{table_name}\n \
-                       using brin({block}, vid);\n",
-                    table_name = table.name,
-                    schema_name = layout.catalog.site.namespace,
-                    block = BLOCK_COLUMN
-                )
-            } else {
-                // Add a BRIN index on the block_range bounds to exploit the fact
-                // that block ranges closely correlate with where in a table an
-                // entity appears physically. This index is incredibly efficient for
-                // reverts where we look for very recent blocks, so that this index
-                // is highly selective. See https://github.com/graphprotocol/graph-node/issues/1415#issuecomment-630520713
-                // for details on one experiment.
-                //
-                // We do not index the `block_range` as a whole, but rather the lower
-                // and upper bound separately, since experimentation has shown that
-                // Postgres will not use the index on `block_range` for clauses like
-                // `block_range @> $block` but rather falls back to a full table scan.
-                //
-                // We also make sure that we do not put `NULL` in the index for
-                // the upper bound since nulls can not be compared to anything and
-                // will make the index less effective.
-                //
-                // To make the index usable, queries need to have clauses using
-                // `lower(block_range)` and `coalesce(..)` verbatim.
-                //
-                // We also index `vid` as that correlates with the order in which
-                // entities are stored.
-                write!(out,"create index brin_{table_name}\n    \
-                    on {schema_name}.{table_name}\n \
-                       using brin(lower(block_range), coalesce(upper(block_range), {block_max}), vid);\n",
-                    table_name = table.name,
-                    schema_name = layout.catalog.site.namespace,
-                    block_max = BLOCK_NUMBER_MAX)?;
+    fn create_time_travel_indexes(&self, out: &mut String, layout: &Layout) -> fmt::Result {
+        if self.immutable {
+            write!(
+                out,
+                "create index brin_{table_name}\n    \
+                on {schema_name}.{table_name}\n \
+                   using brin({block}, vid);\n",
+                table_name = self.name,
+                schema_name = layout.catalog.site.namespace,
+                block = BLOCK_COLUMN
+            )
+        } else {
+            // Add a BRIN index on the block_range bounds to exploit the fact
+            // that block ranges closely correlate with where in a table an
+            // entity appears physically. This index is incredibly efficient for
+            // reverts where we look for very recent blocks, so that this index
+            // is highly selective. See https://github.com/graphprotocol/graph-node/issues/1415#issuecomment-630520713
+            // for details on one experiment.
+            //
+            // We do not index the `block_range` as a whole, but rather the lower
+            // and upper bound separately, since experimentation has shown that
+            // Postgres will not use the index on `block_range` for clauses like
+            // `block_range @> $block` but rather falls back to a full table scan.
+            //
+            // We also make sure that we do not put `NULL` in the index for
+            // the upper bound since nulls can not be compared to anything and
+            // will make the index less effective.
+            //
+            // To make the index usable, queries need to have clauses using
+            // `lower(block_range)` and `coalesce(..)` verbatim.
+            //
+            // We also index `vid` as that correlates with the order in which
+            // entities are stored.
+            write!(out,"create index brin_{table_name}\n    \
+                on {schema_name}.{table_name}\n \
+                   using brin(lower(block_range), coalesce(upper(block_range), {block_max}), vid);\n",
+                table_name = self.name,
+                schema_name = layout.catalog.site.namespace,
+                block_max = BLOCK_NUMBER_MAX)?;
 
-                // Add a BTree index that helps with the `RevertClampQuery` by making
-                // it faster to find entity versions that have been modified
-                write!(
-                    out,
-                    "create index {table_name}_block_range_closed\n    \
-                     on {schema_name}.{table_name}(coalesce(upper(block_range), {block_max}))\n \
-                     where coalesce(upper(block_range), {block_max}) < {block_max};\n",
-                    table_name = table.name,
-                    schema_name = layout.catalog.site.namespace,
-                    block_max = BLOCK_NUMBER_MAX
-                )
-            }
+            // Add a BTree index that helps with the `RevertClampQuery` by making
+            // it faster to find entity versions that have been modified
+            write!(
+                out,
+                "create index {table_name}_block_range_closed\n    \
+                 on {schema_name}.{table_name}(coalesce(upper(block_range), {block_max}))\n \
+                 where coalesce(upper(block_range), {block_max}) < {block_max};\n",
+                table_name = self.name,
+                schema_name = layout.catalog.site.namespace,
+                block_max = BLOCK_NUMBER_MAX
+            )
         }
+    }
 
-        fn create_attribute_indexes(
-            table: &Table,
-            out: &mut String,
-            layout: &Layout,
-        ) -> fmt::Result {
-            // Create indexes. Skip columns whose type is an array of enum,
-            // since there is no good way to index them with Postgres 9.6.
-            // Once we move to Postgres 11, we can enable that
-            // (tracked in graph-node issue #1330)
-            for (i, column) in table
-                .columns
-                .iter()
-                .filter(|col| !(col.is_list() && col.is_enum()))
-                .enumerate()
-            {
-                if table.immutable && column.is_primary_key() {
-                    // We create a unique index on `id` in `create_table`
-                    // and don't need an explicit attribute index
-                    continue;
+    fn create_attribute_indexes(&self, out: &mut String, layout: &Layout) -> fmt::Result {
+        // Create indexes. Skip columns whose type is an array of enum,
+        // since there is no good way to index them with Postgres 9.6.
+        // Once we move to Postgres 11, we can enable that
+        // (tracked in graph-node issue #1330)
+        for (i, column) in self
+            .columns
+            .iter()
+            .filter(|col| !(col.is_list() && col.is_enum()))
+            .enumerate()
+        {
+            if self.immutable && column.is_primary_key() {
+                // We create a unique index on `id` in `create_table`
+                // and don't need an explicit attribute index
+                continue;
+            }
+
+            let (method, index_expr) = if column.is_reference() && !column.is_list() {
+                // For foreign keys, index the key together with the block range
+                // since we almost always also have a block_range clause in
+                // queries that look for specific foreign keys
+                if self.immutable {
+                    let index_expr = format!("{}, {}", column.name.quoted(), BLOCK_COLUMN);
+                    ("btree", index_expr)
+                } else {
+                    let index_expr = format!("{}, {}", column.name.quoted(), BLOCK_RANGE_COLUMN);
+                    ("gist", index_expr)
                 }
-
-                let (method, index_expr) = if column.is_reference() && !column.is_list() {
-                    // For foreign keys, index the key together with the block range
-                    // since we almost always also have a block_range clause in
-                    // queries that look for specific foreign keys
-                    if table.immutable {
-                        let index_expr = format!("{}, {}", column.name.quoted(), BLOCK_COLUMN);
-                        ("btree", index_expr)
-                    } else {
-                        let index_expr =
-                            format!("{}, {}", column.name.quoted(), BLOCK_RANGE_COLUMN);
-                        ("gist", index_expr)
+            } else {
+                // Attributes that are plain strings or bytes are
+                // indexed with a BTree; but they can be too large for
+                // Postgres' limit on values that can go into a BTree.
+                // For those attributes, only index the first
+                // STRING_PREFIX_SIZE or BYTE_ARRAY_PREFIX_SIZE characters
+                // see: attr-bytea-prefix
+                let index_expr = if column.use_prefix_comparison {
+                    match column.column_type {
+                        ColumnType::String => {
+                            format!("left({}, {})", column.name.quoted(), STRING_PREFIX_SIZE)
+                        }
+                        ColumnType::Bytes => format!(
+                            "substring({}, 1, {})",
+                            column.name.quoted(),
+                            BYTE_ARRAY_PREFIX_SIZE
+                        ),
+                        _ => unreachable!("only String and Bytes can have arbitrary size"),
                     }
                 } else {
-                    // Attributes that are plain strings or bytes are
-                    // indexed with a BTree; but they can be too large for
-                    // Postgres' limit on values that can go into a BTree.
-                    // For those attributes, only index the first
-                    // STRING_PREFIX_SIZE or BYTE_ARRAY_PREFIX_SIZE characters
-                    // see: attr-bytea-prefix
-                    let index_expr = if column.use_prefix_comparison {
-                        match column.column_type {
-                            ColumnType::String => {
-                                format!("left({}, {})", column.name.quoted(), STRING_PREFIX_SIZE)
-                            }
-                            ColumnType::Bytes => format!(
-                                "substring({}, 1, {})",
-                                column.name.quoted(),
-                                BYTE_ARRAY_PREFIX_SIZE
-                            ),
-                            _ => unreachable!("only String and Bytes can have arbitrary size"),
-                        }
-                    } else {
-                        column.name.quoted()
-                    };
-
-                    let method = if column.is_list() || column.is_fulltext() {
-                        "gin"
-                    } else {
-                        "btree"
-                    };
-
-                    (method, index_expr)
+                    column.name.quoted()
                 };
-                write!(
-                out,
-                "create index attr_{table_index}_{column_index}_{table_name}_{column_name}\n    on {schema_name}.\"{table_name}\" using {method}({index_expr});\n",
-                table_index = table.position,
-                table_name = table.name,
-                column_index = i,
-                column_name = column.name,
-                schema_name = layout.catalog.site.namespace,
-                method = method,
-                index_expr = index_expr,
-            )?;
-            }
-            writeln!(out)
-        }
 
-        create_table(self, out, layout)?;
-        create_time_travel_indexes(self, out, layout)?;
-        create_attribute_indexes(self, out, layout)
+                let method = if column.is_list() || column.is_fulltext() {
+                    "gin"
+                } else {
+                    "btree"
+                };
+
+                (method, index_expr)
+            };
+            write!(
+            out,
+            "create index attr_{table_index}_{column_index}_{table_name}_{column_name}\n    on {schema_name}.\"{table_name}\" using {method}({index_expr});\n",
+            table_index = self.position,
+            table_name = self.name,
+            column_index = i,
+            column_name = column.name,
+            schema_name = layout.catalog.site.namespace,
+            method = method,
+            index_expr = index_expr,
+        )?;
+        }
+        writeln!(out)
+    }
+
+    /// Generate the DDL for one table, i.e. one `create table` statement
+    /// and all `create index` statements for the table's columns
+    ///
+    /// See the unit tests at the end of this file for the actual DDL that
+    /// gets generated
+    fn as_ddl(&self, out: &mut String, layout: &Layout) -> fmt::Result {
+        self.create_table(out, layout)?;
+        self.create_time_travel_indexes(out, layout)?;
+        self.create_attribute_indexes(out, layout)
     }
 
     pub fn exclusion_ddl(&self, out: &mut String, nsp: &str, as_constraint: bool) -> fmt::Result {

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -1,0 +1,318 @@
+use std::{fmt::Write, sync::Arc, time::Instant};
+
+use diesel::{
+    connection::SimpleConnection,
+    sql_query,
+    sql_types::{BigInt, Integer, Nullable},
+    Connection, PgConnection, RunQueryDsl,
+};
+use graph::{
+    components::store::PruneReporter,
+    prelude::{BlockNumber, CancelHandle, CancelToken, CancelableError, CheapClone, StoreError},
+    slog::Logger,
+};
+use itertools::Itertools;
+
+use crate::{
+    catalog,
+    copy::AdaptiveBatchSize,
+    deployment,
+    relational::{Table, VID_COLUMN},
+};
+
+use super::{Layout, SqlName};
+
+/// Utility to copy relevant data out of a source table and into a new
+/// destination table and replace the source table with the destination
+/// table
+struct TablePair {
+    src: Arc<Table>,
+    dst: Arc<Table>,
+}
+
+impl TablePair {
+    /// Create a `TablePair` for `src`. This creates a new table `dst` with
+    /// the same structure as the `src` table in the database, but without
+    /// various indexes. Those are created with `switch`
+    fn create(conn: &PgConnection, layout: &Layout, src: Arc<Table>) -> Result<Self, StoreError> {
+        let new_name = SqlName::verbatim(format!("{}_n$", src.name));
+        let nsp = &layout.site.namespace;
+
+        let dst = src.new_like(&layout.site.namespace, &new_name);
+
+        let mut query = String::new();
+        if catalog::table_exists(conn, &layout.site.namespace, &dst.name)? {
+            writeln!(query, "truncate table {nsp}.{new_name};")?;
+        } else {
+            dst.create_table(&mut query, layout)?;
+
+            // Have the new table use the same vid sequence as the source
+            // table
+            writeln!(
+                query,
+                "\
+      alter table {nsp}.{new_name} \
+        alter column {VID_COLUMN} \
+          set default nextval('{nsp}.{src_name}_vid_seq'::regclass);",
+                src_name = src.name
+            )?;
+            writeln!(query, "drop sequence {nsp}.{new_name}_vid_seq;")?;
+            writeln!(
+                query,
+                "alter sequence {nsp}.{src_name}_vid_seq owned by {nsp}.{new_name}.vid",
+                src_name = src.name
+            )?;
+        }
+        conn.batch_execute(&query)?;
+
+        Ok(TablePair { src, dst })
+    }
+
+    fn copy_final_entities(
+        &self,
+        conn: &PgConnection,
+        reporter: &mut dyn PruneReporter,
+        earliest_block: BlockNumber,
+        final_block: BlockNumber,
+        cancel: &CancelHandle,
+    ) -> Result<usize, CancelableError<StoreError>> {
+        #[derive(QueryableByName)]
+        struct VidRange {
+            #[sql_type = "Nullable<BigInt>"]
+            min_vid: Option<i64>,
+            #[sql_type = "Nullable<BigInt>"]
+            max_vid: Option<i64>,
+        }
+
+        #[derive(QueryableByName)]
+        struct LastVid {
+            #[sql_type = "BigInt"]
+            rows: i64,
+            #[sql_type = "BigInt"]
+            last_vid: i64,
+        }
+
+        let (min_vid, max_vid) = match sql_query(&format!(
+            "select min(vid) as min_vid, max(vid) as max_vid from {src} \
+              where coalesce(upper(block_range), 2147483647) > $1 \
+                and coalesce(upper(block_range), 2147483647) <= $2",
+            src = self.src.qualified_name
+        ))
+        .bind::<Integer, _>(earliest_block)
+        .bind::<Integer, _>(final_block)
+        .get_result::<VidRange>(conn)?
+        {
+            VidRange {
+                min_vid: None,
+                max_vid: None,
+            } => {
+                return Ok(0);
+            }
+            VidRange {
+                min_vid: Some(min),
+                max_vid: Some(max),
+            } => (min, max),
+            _ => unreachable!("min and max are Some or None at the same time"),
+        };
+        cancel.check_cancel()?;
+
+        let column_list = self.column_list();
+
+        let mut batch_size = AdaptiveBatchSize::new(&self.src);
+        let mut next_vid = min_vid;
+        let mut total_rows: usize = 0;
+        loop {
+            let start = Instant::now();
+            let LastVid { last_vid, rows } = conn.transaction(|| {
+                sql_query(&format!(
+                    "with cp as (insert into {dst}({column_list}) \
+                         select {column_list} from {src} \
+                          where lower(block_range) <= $2 \
+                            and coalesce(upper(block_range), 2147483647) > $1 \
+                            and coalesce(upper(block_range), 2147483647) <= $2 \
+                            and vid >= $3 \
+                            and vid <= $4 \
+                          order by vid \
+                          limit $5 \
+                          returning vid) \
+                         select max(cp.vid) as last_vid, count(*) as rows from cp",
+                    src = self.src.qualified_name,
+                    dst = self.dst.qualified_name
+                ))
+                .bind::<Integer, _>(earliest_block)
+                .bind::<Integer, _>(final_block)
+                .bind::<BigInt, _>(next_vid)
+                .bind::<BigInt, _>(max_vid)
+                .bind::<BigInt, _>(&batch_size)
+                .get_result::<LastVid>(conn)
+            })?;
+            cancel.check_cancel()?;
+
+            total_rows += rows as usize;
+            reporter.copy_final_batch(
+                self.src.name.as_str(),
+                rows as usize,
+                total_rows,
+                last_vid >= max_vid,
+            );
+
+            if last_vid >= max_vid {
+                break;
+            }
+
+            batch_size.adapt(start.elapsed());
+            next_vid = last_vid + 1;
+        }
+
+        Ok(total_rows)
+    }
+
+    fn copy_nonfinal_entities(
+        &self,
+        conn: &PgConnection,
+        final_block: BlockNumber,
+    ) -> Result<usize, StoreError> {
+        let column_list = self.column_list();
+
+        sql_query(&format!(
+            "insert into {dst}({column_list}) \
+             select {column_list} from {src} \
+              where coalesce(upper(block_range), 2147483647) > $1 \
+                and block_range && int4range($1, null) \
+              order by vid",
+            dst = self.dst.qualified_name,
+            src = self.src.qualified_name,
+        ))
+        .bind::<Integer, _>(final_block)
+        .execute(conn)
+        .map_err(StoreError::from)
+    }
+
+    /// Replace the `src` table with the `dst` table. This makes sure (as
+    /// does the rest of the code in `TablePair`) that the table and all
+    /// associated objects (indexes, constraints, etc.) have the same names
+    /// as they had initially so that pruning can be performed again in the
+    /// future without any name clashes in the database.
+    fn switch(self, conn: &PgConnection, layout: &Layout) -> Result<(), StoreError> {
+        sql_query(&format!("drop table {}", self.src.qualified_name)).execute(conn)?;
+
+        let uses_excl =
+            catalog::has_exclusion_constraint(conn, &layout.site.namespace, &self.dst.name)?;
+        let mut query = String::new();
+        Table::rename_sql(&mut query, &layout, &self.dst, &self.src, uses_excl)?;
+        self.src.create_time_travel_indexes(&mut query, layout)?;
+        self.src.create_attribute_indexes(&mut query, layout)?;
+
+        conn.batch_execute(&query)?;
+
+        Ok(())
+    }
+
+    fn column_list(&self) -> String {
+        self.src
+            .column_names()
+            .map(|name| format!("\"{name}\""))
+            .join(", ")
+    }
+}
+
+impl Layout {
+    /// Remove all data from the underlying deployment that is not needed to
+    /// respond to queries before block `earliest_block`. The strategy
+    /// implemented here works well for situations in which pruning will
+    /// remove a large amount of data from the subgraph (at least 50%)
+    ///
+    /// Blocks before `final_block` are considered final and it is assumed
+    /// that they will not be modified in any way while pruning is running.
+    /// Only tables where the ratio of entities to entity versions is below
+    /// `prune_ratio` will actually be pruned.
+    pub fn prune_by_copying(
+        &self,
+        _logger: &Logger,
+        reporter: &mut dyn PruneReporter,
+        conn: &PgConnection,
+        earliest_block: BlockNumber,
+        final_block: BlockNumber,
+        prune_ratio: f64,
+        cancel: &CancelHandle,
+    ) -> Result<(), CancelableError<StoreError>> {
+        // Analyze all tables and get statistics for them
+        let mut tables: Vec<_> = self.tables.values().collect();
+        tables.sort_by_key(|table| table.name.as_str());
+        for table in tables {
+            reporter.start_analyze(table.name.as_str());
+            table.analyze(conn)?;
+            reporter.finish_analyze(table.name.as_str());
+            cancel.check_cancel()?;
+        }
+        let stats = catalog::stats(conn, &self.site.namespace)?;
+
+        // Determine which tables are prunable and create a shadow table for
+        // them via `TablePair::create`
+        let prunable_tables = {
+            let mut prunable_tables: Vec<TablePair> = self
+                .tables
+                .values()
+                .filter_map(|table| {
+                    stats
+                        .iter()
+                        .find(|s| s.tablename == table.name.as_str())
+                        .map(|s| (table, s))
+                })
+                .filter(|(_, stats)| stats.ratio <= prune_ratio)
+                .map(|(table, _)| TablePair::create(conn, self, table.cheap_clone()))
+                .collect::<Result<_, _>>()?;
+            prunable_tables.sort_by(|a, b| a.src.name.as_str().cmp(b.src.name.as_str()));
+            prunable_tables
+        };
+        cancel.check_cancel()?;
+
+        // Copy final entities. This can happen in parallel to indexing as
+        // that part of the table will not change
+        reporter.copy_final_start(earliest_block, final_block);
+        for table in &prunable_tables {
+            table.copy_final_entities(conn, reporter, earliest_block, final_block, cancel)?;
+        }
+        reporter.copy_final_finish();
+
+        let prunable_src: Vec<_> = prunable_tables
+            .iter()
+            .map(|table| table.src.clone())
+            .collect();
+
+        // Copy nonfinal entities, and replace the original `src` table with
+        // the smaller `dst` table
+        reporter.start_switch();
+        conn.transaction(|| -> Result<(), CancelableError<StoreError>> {
+            //  see also: deployment-lock-for-update
+            deployment::lock(conn, &self.site)?;
+
+            for table in &prunable_tables {
+                reporter.copy_nonfinal_start(table.src.name.as_str());
+                let rows = table.copy_nonfinal_entities(conn, final_block)?;
+                reporter.copy_nonfinal_finish(table.src.name.as_str(), rows);
+                cancel.check_cancel()?;
+            }
+
+            for table in prunable_tables {
+                table.switch(conn, self)?;
+                cancel.check_cancel()?;
+            }
+
+            Ok(())
+        })?;
+        reporter.finish_switch();
+
+        // Analyze the new tables
+        for table in prunable_src {
+            reporter.start_analyze(table.name.as_str());
+            table.analyze(conn)?;
+            reporter.finish_analyze(table.name.as_str());
+            cancel.check_cancel()?;
+        }
+
+        reporter.finish_prune();
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR resolves issue #3665 and adds a command `graphman prune <deployment>` that removes all history from a deployment before a given block. By default, that block is 10,000 blocks before the current subgraph head. After pruning, the deployment can only be queried at block numbers at least as high as that block.

Here's what it looks like when pruning something:
```
prune QmRuorV4Ck1sVdpfpAAwfYXnf3cfSkbDwZvvzWud9SH8Dg[130]
    latest: 15461533
     final: 15461283
  earliest: 15451533

Analyzed 14 tables in 80s
            table              |  entities  |  versions  |  ratio
-------------------------------+------------+------------+--------
add_liquidity_event            |      41750 |      41750 | 100.0%
eth_purchase_event             |    1156610 |    1156610 | 100.0%
exchange                       |        626 |    2186833 |   0.0%
exchange_day_data              |      19353 |    2185127 |   0.9%
exchange_historical_data       |    2508807 |    2508807 | 100.0%
poi2$                          |          1 |    1412019 |   0.0%
remove_liquidity_event         |      25698 |      25698 | 100.0%
token_purchase_event           |    1285494 |    1285494 | 100.0%
transaction                    |    2473179 |    2473179 | 100.0%
uniswap                        |          1 |    1410157 |   0.0%
uniswap_day_data               |       1288 |    1407878 |   0.1%
uniswap_historical_data        |      19804 |    2184587 |   0.9%
user                           |      98807 |      98807 | 100.0%
user_exchange_data             |      19008 |    2441509 |   0.8%

Copy final entities (versions live between 15451533 and 15461283)
            table              |  versions  |    time
-------------------------------+------------+------------
exchange                       |        182 |        70s
exchange_day_data              |        130 |         5s
poi2$                          |        172 |         5s
uniswap                        |        172 |         3s
uniswap_day_data               |        171 |         3s
uniswap_historical_data        |        130 |         4s
user_exchange_data             |        184 |        11s
Finished copying final entity versions in 103s

Blocking writes and switching tables
            table              |  versions  |    time
-------------------------------+------------+------------
exchange                       |       3095 |         3s
exchange_day_data              |     103159 |        70s
poi2$                          |         10 |         0s
uniswap                        |         10 |         0s
uniswap_day_data               |       1410 |         1s
uniswap_historical_data        |     103159 |        67s
user_exchange_data             |     223731 |       154s
Enabling writes. Switching took 362s

Analyzed 7 tables in 5s
            table              |  entities  |  versions  |  ratio
-------------------------------+------------+------------+--------
exchange                       |       3086 |       3277 |  94.2%
exchange_day_data              |     102822 |     103289 |  99.5%
poi2$                          |          1 |        182 |   0.5%
uniswap                        |          1 |        182 |   0.5%
uniswap_day_data               |       1401 |       1581 |  88.6%
uniswap_historical_data        |     102933 |     103289 |  99.7%
user_exchange_data             |     223127 |     223915 |  99.6%

Finished pruning in 553s
```

Space savings from pruning can be dramatic, depending on the subgraph. A test database with ~ 60 subgraphs shrank by about 1/3, with the size of some subgraphs being reduced by 90%.