### PR TITLE
graph-server-index-node: Use ApiVersion instead of undefined SubgraphVersion

### DIFF
--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -43,7 +43,7 @@ type Query {
     network: String!
     blockHash: Bytes!
   ): [CachedEthereumCall!]
-  apiVersions(subgraphId: String!): [SubgraphVersion!]!
+  apiVersions(subgraphId: String!): [ApiVersion!]!
 }
 
 type SubgraphIndexingStatus {


### PR DESCRIPTION
Related #3923

The `SubgraphVersion` type was never defined.