### PR TITLE
graphql,server: make `Resolver::resolve_object` async

### DIFF
--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -587,14 +587,17 @@ async fn resolve_field_value(
             .await
         }
 
-        s::Type::NamedType(ref name) => resolve_field_value_for_named_type(
-            ctx,
-            object_type,
-            field_value,
-            field,
-            field_definition,
-            name,
-        ),
+        s::Type::NamedType(ref name) => {
+            resolve_field_value_for_named_type(
+                ctx,
+                object_type,
+                field_value,
+                field,
+                field_definition,
+                name,
+            )
+            .await
+        }
 
         s::Type::ListType(inner_type) => {
             resolve_field_value_for_list_type(
@@ -611,7 +614,7 @@ async fn resolve_field_value(
 }
 
 /// Resolves the value of a field that corresponds to a named type.
-fn resolve_field_value_for_named_type(
+async fn resolve_field_value_for_named_type(
     ctx: &ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
     field_value: Option<r::Value>,
@@ -630,6 +633,7 @@ fn resolve_field_value_for_named_type(
         s::TypeDefinition::Object(t) => {
             ctx.resolver
                 .resolve_object(field_value, field, field_definition, t.into())
+                .await
         }
 
         // Let the resolver decide how values in the resolved object value
@@ -646,6 +650,7 @@ fn resolve_field_value_for_named_type(
         s::TypeDefinition::Interface(i) => {
             ctx.resolver
                 .resolve_object(field_value, field, field_definition, i.into())
+                .await
         }
 
         s::TypeDefinition::Union(_) => Err(QueryExecutionError::Unimplemented("unions".to_owned())),

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -32,7 +32,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
     ) -> Result<r::Value, QueryExecutionError>;
 
     /// Resolves an object, `prefetched_object` is `Some` if the parent already calculated the value.
-    fn resolve_object(
+    async fn resolve_object(
         &self,
         prefetched_object: Option<r::Value>,
         field: &a::Field,

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -412,7 +412,7 @@ impl Resolver for IntrospectionResolver {
         }
     }
 
-    fn resolve_object(
+    async fn resolve_object(
         &self,
         prefetched_object: Option<r::Value>,
         field: &a::Field,

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -313,7 +313,7 @@ impl Resolver for StoreResolver {
         }
     }
 
-    fn resolve_object(
+    async fn resolve_object(
         &self,
         prefetched_object: Option<r::Value>,
         field: &a::Field,

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -42,7 +42,7 @@ impl Resolver for MockResolver {
         Ok(r::Value::Null)
     }
 
-    fn resolve_object(
+    async fn resolve_object(
         &self,
         __: Option<r::Value>,
         _field: &a::Field,

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -797,7 +797,7 @@ impl<S: Store> Resolver for IndexNodeResolver<S> {
         }
     }
 
-    fn resolve_object(
+    async fn resolve_object(
         &self,
         prefetched_object: Option<r::Value>,
         field: &a::Field,
@@ -812,7 +812,7 @@ impl<S: Store> Resolver for IndexNodeResolver<S> {
             (None, "indexingStatusForPendingVersion") => {
                 self.resolve_indexing_status_for_version(field, false)
             }
-            (None, "subgraphFeatures") => graph::block_on(self.resolve_subgraph_features(field)),
+            (None, "subgraphFeatures") => self.resolve_subgraph_features(field).await,
             (None, "entityChangesInBlock") => self.resolve_entity_changes_in_block(field),
             // The top-level `subgraphVersions` field
             (None, "apiVersions") => self.resolve_api_versions(field),


### PR DESCRIPTION
Currently, the `subgraphFeatures` route is panicking because `Store`s implementation of `Resolver::resolve_object` calls `block_on` from within an async context.

This fix makes the `Resolver::resolve_object` an async method, allowing us to `await` instead of blocking the execution.