### PR TITLE
`index-node` endpoint to get a hash from a block number

### DIFF
--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -587,14 +587,17 @@ async fn resolve_field_value(
             .await
         }
 
-        s::Type::NamedType(ref name) => resolve_field_value_for_named_type(
-            ctx,
-            object_type,
-            field_value,
-            field,
-            field_definition,
-            name,
-        ),
+        s::Type::NamedType(ref name) => {
+            resolve_field_value_for_named_type(
+                ctx,
+                object_type,
+                field_value,
+                field,
+                field_definition,
+                name,
+            )
+            .await
+        }
 
         s::Type::ListType(inner_type) => {
             resolve_field_value_for_list_type(
@@ -611,7 +614,7 @@ async fn resolve_field_value(
 }
 
 /// Resolves the value of a field that corresponds to a named type.
-fn resolve_field_value_for_named_type(
+async fn resolve_field_value_for_named_type(
     ctx: &ExecutionContext<impl Resolver>,
     object_type: &s::ObjectType,
     field_value: Option<r::Value>,
@@ -641,6 +644,7 @@ fn resolve_field_value_for_named_type(
         s::TypeDefinition::Scalar(t) => {
             ctx.resolver
                 .resolve_scalar_value(object_type, field, t, field_value)
+                .await
         }
 
         s::TypeDefinition::Interface(i) => {

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -51,7 +51,7 @@ pub trait Resolver: Sized + Send + Sync + 'static {
     }
 
     /// Resolves a scalar value for a given scalar type.
-    fn resolve_scalar_value(
+    async fn resolve_scalar_value(
         &self,
         _parent_object_type: &s::ObjectType,
         _field: &a::Field,

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -745,7 +745,7 @@ impl<S: Store> Resolver for IndexNodeResolver<S> {
     }
 
     /// Resolves a scalar value for a given scalar type.
-    fn resolve_scalar_value(
+    async fn resolve_scalar_value(
         &self,
         parent_object_type: &s::ObjectType,
         field: &a::Field,

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -201,6 +201,75 @@ impl<S: Store> IndexNodeResolver<S> {
         })
     }
 
+    async fn resolve_block_hash_from_number(
+        &self,
+        field: &a::Field,
+    ) -> Result<r::Value, QueryExecutionError> {
+        let network = field
+            .get_required::<String>("network")
+            .expect("Valid network required");
+        let block_number = field
+            .get_required::<BlockNumber>("blockNumber")
+            .expect("Valid blockNumber required");
+
+        macro_rules! try_resolve_for_chain {
+            ( $typ:path ) => {
+                let blockchain = self.blockchain_map.get::<$typ>(network.to_string()).ok();
+
+                if let Some(blockchain) = blockchain {
+                    debug!(
+                        self.logger,
+                        "Fetching block hash from number";
+                        "network" => &network,
+                        "block_number" => block_number,
+                    );
+
+                    let block_ptr_res = blockchain
+                        .block_pointer_from_number(&self.logger, block_number)
+                        .await;
+
+                        if let Err(e) = block_ptr_res {
+                            warn!(
+                                self.logger,
+                                "Failed to fetch block hash from number";
+                                "network" => &network,
+                                "chain" => <$typ as Blockchain>::KIND.to_string(),
+                                "block_number" => block_number,
+                                "error" => e.to_string(),
+                            );
+                            return Ok(r::Value::Null);
+                        }
+
+                    let block_ptr = block_ptr_res.unwrap();
+                    return Ok(r::Value::String(block_ptr.hash_hex()));
+                }
+            };
+        }
+
+        // Ugly, but we can't get back an object trait from the `BlockchainMap`,
+        // so this seems like the next best thing.
+        try_resolve_for_chain!(graph_chain_ethereum::Chain);
+        try_resolve_for_chain!(graph_chain_arweave::Chain);
+        try_resolve_for_chain!(graph_chain_cosmos::Chain);
+        try_resolve_for_chain!(graph_chain_near::Chain);
+
+        // If you're adding support for a new chain and this `match` clause just
+        // gave you a compiler error, then this message is for you! You need to
+        // add a new `try_resolve!` macro invocation above for your new chain
+        // type.
+        match BlockchainKind::Ethereum {
+            // Note: we don't actually care about substreams here.
+            BlockchainKind::Substreams
+            | BlockchainKind::Arweave
+            | BlockchainKind::Ethereum
+            | BlockchainKind::Cosmos
+            | BlockchainKind::Near => (),
+        }
+
+        // The given network does not exist.
+        Ok(r::Value::Null)
+    }
+
     async fn resolve_cached_ethereum_calls(
         &self,
         field: &a::Field,
@@ -759,6 +828,9 @@ impl<S: Store> Resolver for IndexNodeResolver<S> {
         ) {
             ("Query", "proofOfIndexing", "Bytes") => self.resolve_proof_of_indexing(field),
             ("Query", "blockData", "JSONObject") => self.resolve_block_data(field),
+            ("Query", "blockHashFromNumber", "Bytes") => {
+                self.resolve_block_hash_from_number(field).await
+            }
 
             // Fallback to the same as is in the default trait implementation. There
             // is no way to call back into the default implementation for the trait.

--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -39,6 +39,7 @@ type Query {
   subgraphFeatures(subgraphId: String!): SubgraphFeatures!
   entityChangesInBlock(subgraphId: String!, blockNumber: Int!): EntityChanges!
   blockData(network: String!, blockHash: Bytes!): JSONObject
+  blockHashFromNumber(network: String!, blockNumber: Int!): Bytes
   cachedEthereumCalls(
     network: String!
     blockHash: Bytes!


### PR DESCRIPTION
This new endpoint fills a need that several services (namely EBO and indexer agent) that rely on `graph-node` have, i.e. to fetch a block hash starting from the number. The underlying implementation bridges over to the configured data ingestor for the requested network, allowing these services to get this data directly from `graph-node`.

I've used some declarative macro idiosyncracy to quickly abstract over `BlockchainMap` items with different concrete types.

```graphql
# Query example
{
  blockHashFromNumber(network: "mainnet", blockNumber: 15239780)
}
```