### PR TITLE
store: Make it possible to restart a failed writer

### DIFF
--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -130,7 +130,12 @@ pub trait SubgraphStore: Send + Sync + 'static {
     /// Return a `WritableStore` that is used for indexing subgraphs. Only
     /// code that is part of indexing a subgraph should ever use this. The
     /// `logger` will be used to log important messages related to the
-    /// subgraph
+    /// subgraph.
+    ///
+    /// This function should only be called in situations where no
+    /// assumptions about the in-memory state of writing has been made; in
+    /// particular, no assumptions about whether previous writes have
+    /// actually been committed or not.
     async fn writable(
         self: Arc<Self>,
         logger: Logger,

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -791,6 +791,10 @@ impl Queue {
 
         Ok(dds)
     }
+
+    fn poisoned(&self) -> bool {
+        self.poisoned.load(Ordering::SeqCst)
+    }
 }
 
 /// A shim to allow bypassing any pipelined store handling if need be
@@ -908,6 +912,13 @@ impl Writer {
             Writer::Async(queue) => queue.load_dynamic_data_sources(manifest_idx_and_name).await,
         }
     }
+
+    fn poisoned(&self) -> bool {
+        match self {
+            Writer::Sync(_) => false,
+            Writer::Async(queue) => queue.poisoned(),
+        }
+    }
 }
 
 pub struct WritableStore {
@@ -940,6 +951,10 @@ impl WritableStore {
             block_cursor,
             writer,
         })
+    }
+
+    pub(crate) fn poisoned(&self) -> bool {
+        self.writer.poisoned()
     }
 }
 


### PR DESCRIPTION
So far, if the writer for a subgraph encounterd an error, it would stick around as 'poisoned' for as long as the process lived. That made it impossible to restart a subgraph (possibly after clearing some external error condition) With this change, `SubgraphStore.writable` will create a new writer if the old one has been poisoned.

