### PR TITLE
Release `0.28.0-rc.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "graph"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-arweave"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64-url",
  "diesel",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-common"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-cosmos"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "graph",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-ethereum"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-near"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64",
  "diesel",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-substreams"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "graph-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "graph-graphql"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1704,14 +1704,14 @@ dependencies = [
 
 [[package]]
 name = "graph-mock"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "graph",
 ]
 
 [[package]]
 name = "graph-node"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "clap 3.2.21",
  "crossbeam-channel",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-derive"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-test"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "graph",
  "graph-chain-ethereum",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-wasm"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-http"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "futures 0.1.31",
  "graph",
@@ -1816,7 +1816,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-index-node"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "blake3 1.3.1",
  "either",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-json-rpc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "graph",
  "jsonrpc-http-server",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-metrics"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "graph",
  "http",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-websocket"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "futures 0.1.31",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "graph-store-postgres"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "graph-tests"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "test-store"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "diesel",
  "graph",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,13 +2,103 @@
 
 ## Unreleased
 
-### New DB table for dynamic data sources
+## v0.28.0
 
-For new subgraph deployments, dynamic data sources will be recorded under the `sgd*.data_sources$`
-table, rather than `subgraphs.dynamic_ethereum_contract_data_source`. As a consequence
-new deployments will not work correctly on earlier graph node versions, so
-_downgrading to an earlier graph node version is not supported_.
-See issue #3405 for other details.
+#### Upgrade notes
+
+- **New DB table for dynamic data sources.**
+  For new subgraph deployments, dynamic data sources will be recorded under the `sgd*.data_sources$` table, rather than `subgraphs.dynamic_ethereum_contract_data_source`. As a consequence new deployments will not work correctly on earlier graph node versions, so _downgrading to an earlier graph node version is not supported_.  
+  See issue [#3405](https://github.com/graphprotocol/graph-node/issues/3405) for other details.
+
+### What's new
+
+- The filepath which "too expensive qeueries" are sourced from is now configurable. You can use either the `GRAPH_NODE_EXPENSIVE_QUERIES_FILE` environment variable or the `expensive_queries_filename` option in the TOML configuration. [#3710](https://github.com/graphprotocol/graph-node/pull/3710)
+- The output you'll get from `graphman query` is less cluttered and overall nicer. The new options `--output` and `--trace` are available for detailed query information. [#3860](https://github.com/graphprotocol/graph-node/pull/3860)
+- `docker build` will now `--target` the production build stage by default. When you want to get the debug build, you now need `--target graph-node-debug`. [#3814](https://github.com/graphprotocol/graph-node/pull/3814)
+- Node IDs can now contain any character. The Docker start script still replaces hyphens with underscores for backwards compatibility reasons, but this behavior can be changed with the `GRAPH_NODE_ID_USE_LITERAL_VALUE` environment variable. With this new option, you can now seamlessly use the K8s-provided host names as node IDs, provided you reassign your deployments accordingly. [#3688](https://github.com/graphprotocol/graph-node/pull/3688)
+- You can now use the `conn_pool_size` option in TOML configuration files to configure the connection pool size for Firehose providers. [#3833](https://github.com/graphprotocol/graph-node/pull/3833)
+- Index nodes now have an endpoint to perform block number to canonical hash conversion, which will unblock further work towards multichain support. [#3942](https://github.com/graphprotocol/graph-node/pull/3942)
+- `_meta.block.timestamp` is now available for subgraphs indexing EVM chains. [#3738](https://github.com/graphprotocol/graph-node/pull/3738), [#3902](https://github.com/graphprotocol/graph-node/pull/3902)
+- The `deployment_eth_rpc_request_duration` metric now also observes `eth_getTransactionReceipt` requests' duration. [#3903](https://github.com/graphprotocol/graph-node/pull/3903)
+- New Prometheus metrics `query_parsing_time` and `query_validation_time` for monitoring query processing performance. [#3760](https://github.com/graphprotocol/graph-node/pull/3760)
+- New command `graphman config provider`, which shows what providers are available for new deployments on a given network and node. [#3816](https://github.com/graphprotocol/graph-node/pull/3816)
+  E.g. `$ graphman --node-id index_node_0 --config graph-node.toml config provider mainnet`
+- Experimental support for GraphQL API versioning has landed. [#3185](https://github.com/graphprotocol/graph-node/pull/3185)
+- Progress towards experimental support for off-chain data sources. [#3791](https://github.com/graphprotocol/graph-node/pull/3791)
+- Experimental integration for substreams. [#3777](https://github.com/graphprotocol/graph-node/pull/3777), [#3784](https://github.com/graphprotocol/graph-node/pull/3784), [#3897](https://github.com/graphprotocol/graph-node/pull/3897), [#3765](https://github.com/graphprotocol/graph-node/pull/3765), and others 
+
+### Bug fixes
+
+- `graphman stats` now complains instead of failing silently when incorrectly setting `account-like` optimizations. [#3918](https://github.com/graphprotocol/graph-node/pull/3918)
+- Fixed inconsistent logic in the provider selection when the `limit` TOML configuration option was set. [#3816](https://github.com/graphprotocol/graph-node/pull/3816)
+- Fixed issues that would arise from dynamic data sources' names clashing against template names. [#3851](https://github.com/graphprotocol/graph-node/pull/3851)
+- Dynamic data sources triggers are now processed by insertion order. [#3851](https://github.com/graphprotocol/graph-node/pull/3851), [#3854](https://github.com/graphprotocol/graph-node/pull/3854)
+- When starting, the Docker image now replaces the `bash` process with the `graph-node` process (with a PID of 1). [#3803](https://github.com/graphprotocol/graph-node/pull/3803)
+- Refactor subgraph store tests by @evaporei in https://github.com/graphprotocol/graph-node/pull/3662
+- The `ethereum_chain_head_number` metric doesn't get out of sync anymore on chains that use Firehose. [#3771](https://github.com/graphprotocol/graph-node/pull/3771), [#3732](https://github.com/graphprotocol/graph-node/issues/3732)
+- Fixed a crash caused by bad block data from the provider. [#3944](https://github.com/graphprotocol/graph-node/pull/3944)
+- Fixed some minor Firehose connectivity issues via TCP keepalive, connection and request timeouts, and connection window size tweaks. [#3822](https://github.com/graphprotocol/graph-node/pull/3822), [#3855](https://github.com/graphprotocol/graph-node/pull/3855), [#3877](https://github.com/graphprotocol/graph-node/pull/3877), [#3810](https://github.com/graphprotocol/graph-node/pull/3810), [#3818](https://github.com/graphprotocol/graph-node/pull/3818)
+- Copying private data sources' tables across shards now works as expected. [#3836](https://github.com/graphprotocol/graph-node/pull/3836)
+
+### Performance improvements
+
+- Firehose GRPC stream requests are now compressed with `gzip`, if the server supports it. [#3893](https://github.com/graphprotocol/graph-node/pull/3893)
+- Memory efficiency improvements within the entity cache. [#3594](https://github.com/graphprotocol/graph-node/pull/3594)
+- Identical queries now benefit from GraphQL validation caching, and responses are served faster. [#3759](https://github.com/graphprotocol/graph-node/pull/3759)
+
+### Other
+
+- Avoid leaking some sensitive information in logs. [#3812](https://github.com/graphprotocol/graph-node/pull/3812)
+
+### Dependency updates
+
+| Dependency | PR(s) | Old version | Current version |
+|----|----|------|----|
+| `serde_yaml` | [#3746](https://github.com/graphprotocol/graph-node/pull/3746) | `v0.8.24` | `v0.8.26` |
+| `web3` | [#3806](https://github.com/graphprotocol/graph-node/pull/3806) | `2760dbd` | `7f8eb6d` |
+| `clap` | [#3794](https://github.com/graphprotocol/graph-node/pull/3794), [#3848](https://github.com/graphprotocol/graph-node/pull/3848), [#3931](https://github.com/graphprotocol/graph-node/pull/3931) | `v3.2.8` | `3.2.21` |
+| `cid` | [#3824](https://github.com/graphprotocol/graph-node/pull/3824) | `v0.8.5` | `v0.8.6` |
+| `anyhow` | [#3826](https://github.com/graphprotocol/graph-node/pull/3826), [#3841](https://github.com/graphprotocol/graph-node/pull/3841), [#3865](https://github.com/graphprotocol/graph-node/pull/3865), [#3932](https://github.com/graphprotocol/graph-node/pull/3932) | `v1.0.57` | `1.0.65` |
+| `chrono` | [#3827](https://github.com/graphprotocol/graph-node/pull/3827), [#3849](https://github.com/graphprotocol/graph-node/pull/3839), [#3868](https://github.com/graphprotocol/graph-node/pull/3868) | `v0.4.19` | `v0.4.22` |
+| `proc-macro2` | [#3845](https://github.com/graphprotocol/graph-node/pull/3845) | `v1.0.40` | `1.0.43` |
+| `ethabi` | [#3847](https://github.com/graphprotocol/graph-node/pull/3847) | `v17.1.0` | `v17.2.0` |
+| `once_cell` | [#3870](https://github.com/graphprotocol/graph-node/pull/3870) | `v1.13.0` | `v1.13.1` |
+| `either` | [#3869](https://github.com/graphprotocol/graph-node/pull/3869) | `v1.7.0` | `v1.8.0` |
+| `sha2` | [#3904](https://github.com/graphprotocol/graph-node/pull/3904) | `v0.10.2` | `v0.10.5` |
+| `mockall` | [#3776](https://github.com/graphprotocol/graph-node/pull/3776) | `v0.9.1` | removed |
+| `croosbeam` | [#3772](https://github.com/graphprotocol/graph-node/pull/3772) | `v0.8.1` | `v0.8.2` |
+| `async-recursion` | [#3873](https://github.com/graphprotocol/graph-node/pull/3873) | none | `v1.0.0` |
+
+<!--
+### Leftover PRs from GitHub's auto-generated release notes. We don't care about these.
+
+
+- [x] wire substreams by @mangas in https://github.com/graphprotocol/graph-node/pull/3813
+- [x] Feature/substream data source by @Eduard-Voiculescu in https://github.com/graphprotocol/graph-node/pull/3780
+- [x] Feature/substreams v2 blocks by @Eduard-Voiculescu in https://github.com/graphprotocol/graph-node/pull/3876
+- [x] Substreams' Protobuf. [#3765](https://github.com/graphprotocol/graph-node/pull/3765)
+- [x] substreams trigger processor by @mangas in https://github.com/graphprotocol/graph-node/pull/3787
+- [x] substreams: data source validation by @mangas in https://github.com/graphprotocol/graph-node/pull/3783
+- [x] Filipe/test run substream fixes by @mangas in https://github.com/graphprotocol/graph-node/pull/3857
+- [x] fix(ipfs): Allowlist of safe hashes by @leoyvens in https://github.com/graphprotocol/graph-node/pull/3792
+- [x] firehose: fix request for v2 by @leoyvens in https://github.com/graphprotocol/graph-node/pull/3837
+- [x] Polling file monitor by @leoyvens in https://github.com/graphprotocol/graph-node/pull/3411
+- [x] test(store): Fix race condition in graft test by @leoyvens in https://github.com/graphprotocol/graph-node/pull/3790
+- [x] Automated generation of the `Asc` types by @pienkowb in https://github.com/graphprotocol/graph-node/pull/3722
+- [x] node: Remove assert-cli tests by leoyvens in https://github.com/graphprotocol/graph-node/pull/3789
+- [x] Adding tests for decoding of gRPC server response from substreams by @Eduard-Voiculescu in https://github.com/graphprotocol/graph-node/pull/3896
+- [x] Small improvements to `graphman stats` by @lutter in https://github.com/graphprotocol/graph-node/pull/3918
+- [x] graphql: Add deterministic error test by @leoyvens in https://github.com/graphprotocol/graph-node/pull/3788
+- [x] core: add missing word in MetricsRegistry initialization error msg by @tilacog in https://github.com/graphprotocol/graph-node/pull/3859
+- [x] async && refactor block_number by @mangas in https://github.com/graphprotocol/graph-node/pull/3873
+- [x] Release 0.27.0 by @evaporei in https://github.com/graphprotocol/graph-node/pull/3778
+- [x] firehose: Print error messages without whitespace by @leoyvens in https://github.com/graphprotocol/graph-node/pull/3856
+- [x] Move `DEAD_WEIGHT` env. flag initialization logic under the global `struct EnvVars` by @neysofu in https://github.com/graphprotocol/graph-node/pull/3744
+- [x] graphql,server: make `Resolver::resolve_object` async by @tilacog in https://github.com/graphprotocol/graph-node/pull/3938
+- [x] Fix: typos by @omahs in https://github.com/graphprotocol/graph-node/pull/3910
+- [x] Derive `IndexNodeResolver`'s `Clone` implementation by @neysofu in https://github.com/graphprotocol/graph-node/pull/3943
+
+-->
 
 ## 0.27.0
 

--- a/chain/arweave/Cargo.toml
+++ b/chain/arweave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-arweave"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [build-dependencies]

--- a/chain/common/Cargo.toml
+++ b/chain/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-common"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/chain/cosmos/Cargo.toml
+++ b/chain/cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-cosmos"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2018"
 
 [build-dependencies]

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-ethereum"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/chain/near/Cargo.toml
+++ b/chain/near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-near"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [build-dependencies]

--- a/chain/substreams/Cargo.toml
+++ b/chain/substreams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-substreams"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [build-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-core"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-graphql"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-mock"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-node"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 default-run = "graph-node"
 

--- a/runtime/derive/Cargo.toml
+++ b/runtime/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-derive"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [lib]

--- a/runtime/test/Cargo.toml
+++ b/runtime/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-test"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-wasm"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-http"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-index-node"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/server/json-rpc/Cargo.toml
+++ b/server/json-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-json-rpc"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/server/metrics/Cargo.toml
+++ b/server/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-metrics"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-websocket"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-store-postgres"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-store"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Leonardo Yvens <leoyvens@gmail.com>"]
 edition = "2021"
 description = "Provides static store instance for tests."

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-tests"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This is the first release candidate for `v0.28.0`. `NEWS.md` has been updated with the release notes from [this](https://github.com/graphprotocol/graph-node/compare/v0.27.0...1435fceb5840c479209c54330ce0dc6b5a3c1b6e) commit range.