### PR TITLE
Ship `envsubst` with the Docker image to facilitate TOML templating

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,14 @@
 # by running something like the following
 #   docker build --target STAGE -f docker/Dockerfile .
 
+FROM golang:buster as envsubst
+
+# v1.2.0
+ARG ENVSUBST_COMMIT_SHA=16035fe3571ad42c7796bf554f978bb2df64231b
+
+RUN go install github.com/a8m/envsubst/cmd/envsubst@$ENVSUBST_COMMIT_SHA \
+    && strip -g /go/bin/envsubst
+
 FROM rust:buster as graph-node-build
 
 ARG COMMIT_SHA=unknown
@@ -88,5 +96,6 @@ RUN apt-get update \
 ADD docker/wait_for docker/start /usr/local/bin/
 COPY --from=graph-node-build /usr/local/cargo/bin/graph-node /usr/local/cargo/bin/graphman /usr/local/bin/
 COPY --from=graph-node-build /etc/image-info /etc/image-info
+COPY --from=envsubst /go/bin/envsubst /usr/local/bin/
 COPY docker/Dockerfile /Dockerfile
 CMD start

--- a/docs/config.md
+++ b/docs/config.md
@@ -11,6 +11,11 @@ The TOML file consists of four sections:
 * `[ingestor]` sets the name of the node responsible for block ingestion.
 * `[deployment]` describes how to place newly deployed subgraphs.
 
+Some of these sections support environment variable expansion out of the box,
+most notably Postgres connection strings. The official `graph-node` Docker image
+includes [`envsubst`](https://github.com/a8m/envsubst) for more complex use
+cases.
+
 ## Configuring Multiple Databases
 
 For most use cases, a single Postgres database is sufficient to support a


### PR DESCRIPTION
`envsubst` takes care of all foreseeable templating needs that we might face for TOML configuration files.

From all `envsubst` implementations that I could find, I selected https://github.com/a8m/envsubst because it seemed to be the most complete and well adopted. More fully-fledged templating engines like http://www.confd.io/ are interesting but probably overkill.

Here's an example of a configuration pattern that `envsubst` can deal with, while our current variable expansion logic can't:

```toml
[chains.${CHAIN_0}]
shard = "${SHARD_0}"
provider = [ { label = "${CHAIN_0}", url = "${CHAIN_RPC_0}", features = ["${CHAIN_0_FEATURES}"] } ]
```

Closes #3946.