### PR TITLE
graph,node: Migrate from structopt to clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,15 +55,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,33 +485,32 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
- "term_size",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap",
 ]
 
 [[package]]
-name = "clap"
-version = "3.2.21"
+name = "clap_derive"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed5341b2301a26ab80be5cbdced622e80ed808483c52e45e3310a877d3b37d7"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "atty",
- "bitflags",
- "clap_lex",
- "indexmap",
- "strsim 0.10.0",
- "termcolor",
- "textwrap 0.15.0",
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -886,7 +876,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -1494,6 +1484,7 @@ dependencies = [
  "bytes",
  "chrono",
  "cid",
+ "clap",
  "diesel",
  "diesel_derives",
  "envconfig",
@@ -1530,7 +1521,6 @@ dependencies = [
  "slog-term",
  "stable-hash 0.3.3",
  "stable-hash 0.4.2",
- "structopt",
  "strum",
  "strum_macros",
  "test-store",
@@ -1722,7 +1712,7 @@ dependencies = [
 name = "graph-node"
 version = "0.27.0"
 dependencies = [
- "clap 3.2.21",
+ "clap",
  "crossbeam-channel",
  "diesel",
  "env_logger 0.9.0",
@@ -1752,7 +1742,6 @@ dependencies = [
  "serde",
  "serde_regex",
  "shellexpand",
- "structopt",
  "toml",
  "url",
 ]
@@ -1887,7 +1876,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "blake3 1.3.1",
- "clap 3.2.21",
+ "clap",
  "derive_more",
  "diesel",
  "diesel-derive-enum",
@@ -4071,39 +4060,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "strum"
@@ -4202,16 +4161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4248,19 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "term_size",
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -4856,12 +4795,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -66,8 +66,8 @@ serde_plain = "1.0.0"
 
 [dev-dependencies]
 test-store = { path = "../store/test-store" }
+clap = { version = "3.2.22", features = ["derive", "env"] }
 maplit = "1.0.2"
-structopt = { version = "0.3" }
 
 [build-dependencies]
 tonic-build = { version = "0.7.2", features = ["prost","compression"] }

--- a/graph/examples/stress.rs
+++ b/graph/examples/stress.rs
@@ -5,12 +5,12 @@ use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use clap::Parser;
 use graph::data::value::{Object, Word};
 use graph::object;
 use graph::prelude::{lazy_static, q, r, BigDecimal, BigInt, QueryResult};
 use rand::SeedableRng;
 use rand::{rngs::SmallRng, Rng};
-use structopt::StructOpt;
 
 use graph::util::cache_weight::CacheWeight;
 use graph::util::lfu_cache::LfuCache;
@@ -523,32 +523,32 @@ impl<T: Template> From<T> for Entry<T> {
 }
 
 // Command line arguments
-#[derive(StructOpt)]
-#[structopt(name = "stress", about = "Stress test for the LFU Cache")]
+#[derive(Parser)]
+#[clap(name = "stress", about = "Stress test for the LFU Cache")]
 struct Opt {
     /// Number of cache evictions and insertions
-    #[structopt(short, long, default_value = "1000")]
+    #[clap(short, long, default_value = "1000")]
     niter: usize,
     /// Print this many intermediate messages
-    #[structopt(short, long, default_value = "10")]
+    #[clap(short, long, default_value = "10")]
     print_count: usize,
     /// Use objects of size 0 up to this size, chosen unifromly randomly
     /// unless `--fixed` is given
-    #[structopt(short, long, default_value = "1024")]
+    #[clap(short, long, default_value = "1024")]
     obj_size: usize,
-    #[structopt(short, long, default_value = "1000000")]
+    #[clap(short, long, default_value = "1000000")]
     cache_size: usize,
-    #[structopt(short, long, default_value = "vec")]
+    #[clap(short, long, default_value = "vec")]
     template: String,
-    #[structopt(short, long)]
+    #[clap(short, long)]
     samples: bool,
     /// Always use objects of size `--obj-size`
-    #[structopt(short, long)]
+    #[clap(short, long)]
     fixed: bool,
     /// The seed of the random number generator. A seed of 0 means that all
     /// samples are taken from the same template object, and only differ in
     /// size
-    #[structopt(long)]
+    #[clap(long)]
     seed: Option<u64>,
 }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -13,7 +13,7 @@ name = "graphman"
 path = "src/bin/manager.rs"
 
 [dependencies]
-clap = "3.2.21"
+clap = { version = "3.2.22", features = ["derive", "env"] }
 env_logger = "0.9.0"
 git-testament = "0.2"
 graphql-parser = "0.4.0"
@@ -39,7 +39,6 @@ graph-store-postgres = { path = "../store/postgres" }
 regex = "1.5.4"
 serde = { version = "1.0.126", features = ["derive", "rc"] }
 serde_regex = "1.1.0"
-structopt = { version = "0.3.26", features = ["wrap_help"] }
 toml = "0.5.7"
 shellexpand = "2.1.0"
 diesel = "1.4.8"

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,3 +1,4 @@
+use clap::Parser as _;
 use ethereum::chain::{EthereumAdapterSelector, EthereumStreamBuilder};
 use ethereum::{
     BlockIngestor as EthereumBlockIngestor, EthereumAdapterTrait, EthereumNetworks, RuntimeAdapter,
@@ -44,7 +45,6 @@ use std::path::Path;
 use std::sync::atomic;
 use std::time::Duration;
 use std::{collections::HashMap, env};
-use structopt::StructOpt;
 use tokio::sync::mpsc;
 
 git_testament!(TESTAMENT);
@@ -93,7 +93,7 @@ fn read_expensive_queries(
 async fn main() {
     env_logger::init();
 
-    let opt = opt::Opt::from_args();
+    let opt = opt::Opt::parse();
 
     // Set up logger
     let logger = logger(opt.debug);

--- a/node/src/opt.rs
+++ b/node/src/opt.rs
@@ -1,6 +1,6 @@
+use clap::Parser;
 use git_testament::{git_testament, render_testament};
 use lazy_static::lazy_static;
-use structopt::StructOpt;
 
 use crate::config;
 
@@ -9,15 +9,15 @@ lazy_static! {
     static ref RENDERED_TESTAMENT: String = render_testament!(TESTAMENT);
 }
 
-#[derive(Clone, Debug, StructOpt)]
-#[structopt(
+#[derive(Clone, Debug, Parser)]
+#[clap(
     name = "graph-node",
     about = "Scalable queries for a decentralized future",
     author = "Graph Protocol, Inc.",
     version = RENDERED_TESTAMENT.as_str()
 )]
 pub struct Opt {
-    #[structopt(
+    #[clap(
         long,
         env = "GRAPH_NODE_CONFIG",
         conflicts_with_all = &["postgres-url", "postgres-secondary-hosts", "postgres-host-weights"],
@@ -25,9 +25,9 @@ pub struct Opt {
         help = "the name of the configuration file",
     )]
     pub config: Option<String>,
-    #[structopt(long, help = "validate the configuration and exit")]
+    #[clap(long, help = "validate the configuration and exit")]
     pub check_config: bool,
-    #[structopt(
+    #[clap(
         long,
         value_name = "[NAME:]IPFS_HASH",
         env = "SUBGRAPH",
@@ -35,14 +35,14 @@ pub struct Opt {
     )]
     pub subgraph: Option<String>,
 
-    #[structopt(
+    #[clap(
         long,
         value_name = "BLOCK_HASH:BLOCK_NUMBER",
         help = "block hash and number that the subgraph passed will start indexing at"
     )]
     pub start_block: Option<String>,
 
-    #[structopt(
+    #[clap(
         long,
         value_name = "URL",
         env = "POSTGRES_URL",
@@ -51,7 +51,7 @@ pub struct Opt {
         help = "Location of the Postgres database used for storing entities"
     )]
     pub postgres_url: Option<String>,
-    #[structopt(
+    #[clap(
         long,
         value_name = "URL,",
         use_delimiter = true,
@@ -62,7 +62,7 @@ pub struct Opt {
     )]
     // FIXME: Make sure delimiter is ','
     pub postgres_secondary_hosts: Vec<String>,
-    #[structopt(
+    #[clap(
         long,
         value_name = "WEIGHT,",
         use_delimiter = true,
@@ -74,7 +74,7 @@ pub struct Opt {
     Defaults to weight 1 for each host"
     )]
     pub postgres_host_weights: Vec<usize>,
-    #[structopt(
+    #[clap(
         long,
         min_values=0,
         required_unless_one = &["ethereum-ws", "ethereum-ipc", "config"],
@@ -84,7 +84,7 @@ pub struct Opt {
         help= "Ethereum network name (e.g. 'mainnet'), optional comma-seperated capabilities (eg 'full,archive'), and an Ethereum RPC URL, separated by a ':'",
     )]
     pub ethereum_rpc: Vec<String>,
-    #[structopt(long, min_values=0,
+    #[clap(long, min_values=0,
         required_unless_one = &["ethereum-rpc", "ethereum-ipc", "config"],
         conflicts_with_all = &["ethereum-rpc", "ethereum-ipc", "config"],
         value_name="NETWORK_NAME:[CAPABILITIES]:URL",
@@ -92,7 +92,7 @@ pub struct Opt {
         help= "Ethereum network name (e.g. 'mainnet'), optional comma-seperated capabilities (eg 'full,archive`, and an Ethereum WebSocket URL, separated by a ':'",
     )]
     pub ethereum_ws: Vec<String>,
-    #[structopt(long, min_values=0,
+    #[clap(long, min_values=0,
         required_unless_one = &["ethereum-rpc", "ethereum-ws", "config"],
         conflicts_with_all = &["ethereum-rpc", "ethereum-ws", "config"],
         value_name="NETWORK_NAME:[CAPABILITIES]:FILE",
@@ -100,14 +100,14 @@ pub struct Opt {
         help= "Ethereum network name (e.g. 'mainnet'), optional comma-seperated capabilities (eg 'full,archive'), and an Ethereum IPC pipe, separated by a ':'",
     )]
     pub ethereum_ipc: Vec<String>,
-    #[structopt(
+    #[clap(
         long,
         value_name = "HOST:PORT",
         env = "IPFS",
         help = "HTTP addresses of IPFS nodes"
     )]
     pub ipfs: Vec<String>,
-    #[structopt(
+    #[clap(
         long,
         default_value = "8000",
         value_name = "PORT",
@@ -115,14 +115,14 @@ pub struct Opt {
         env = "GRAPH_GRAPHQL_HTTP_PORT"
     )]
     pub http_port: u16,
-    #[structopt(
+    #[clap(
         long,
         default_value = "8030",
         value_name = "PORT",
         help = "Port for the index node server"
     )]
     pub index_node_port: u16,
-    #[structopt(
+    #[clap(
         long,
         default_value = "8001",
         value_name = "PORT",
@@ -130,21 +130,21 @@ pub struct Opt {
         env = "GRAPH_GRAPHQL_WS_PORT"
     )]
     pub ws_port: u16,
-    #[structopt(
+    #[clap(
         long,
         default_value = "8020",
         value_name = "PORT",
         help = "Port for the JSON-RPC admin server"
     )]
     pub admin_port: u16,
-    #[structopt(
+    #[clap(
         long,
         default_value = "8040",
         value_name = "PORT",
         help = "Port for the Prometheus metrics server"
     )]
     pub metrics_port: u16,
-    #[structopt(
+    #[clap(
         long,
         default_value = "default",
         value_name = "NODE_ID",
@@ -152,7 +152,7 @@ pub struct Opt {
         help = "a unique identifier for this node. Should have the same value between consecutive node restarts"
     )]
     pub node_id: String,
-    #[structopt(
+    #[clap(
         long,
         value_name = "FILE",
         env = "GRAPH_NODE_EXPENSIVE_QUERIES_FILE",
@@ -160,24 +160,24 @@ pub struct Opt {
         help = "a file with a list of expensive queries, one query per line. Attempts to run these queries will return a QueryExecutionError::TooExpensive to clients"
     )]
     pub expensive_queries_filename: String,
-    #[structopt(long, help = "Enable debug logging")]
+    #[clap(long, help = "Enable debug logging")]
     pub debug: bool,
 
-    #[structopt(
+    #[clap(
         long,
         value_name = "URL",
         env = "ELASTICSEARCH_URL",
         help = "Elasticsearch service to write subgraph logs to"
     )]
     pub elasticsearch_url: Option<String>,
-    #[structopt(
+    #[clap(
         long,
         value_name = "USER",
         env = "ELASTICSEARCH_USER",
         help = "User to use for Elasticsearch logging"
     )]
     pub elasticsearch_user: Option<String>,
-    #[structopt(
+    #[clap(
         long,
         value_name = "PASSWORD",
         env = "ELASTICSEARCH_PASSWORD",
@@ -185,7 +185,7 @@ pub struct Opt {
         help = "Password to use for Elasticsearch logging"
     )]
     pub elasticsearch_password: Option<String>,
-    #[structopt(
+    #[clap(
         long,
         value_name = "MILLISECONDS",
         default_value = "1000",
@@ -193,14 +193,14 @@ pub struct Opt {
         help = "How often to poll the Ethereum node for new blocks"
     )]
     pub ethereum_polling_interval: u64,
-    #[structopt(
+    #[clap(
         long,
         value_name = "DISABLE_BLOCK_INGESTOR",
         env = "DISABLE_BLOCK_INGESTOR",
         help = "Ensures that the block ingestor component does not execute"
     )]
     pub disable_block_ingestor: bool,
-    #[structopt(
+    #[clap(
         long,
         value_name = "STORE_CONNECTION_POOL_SIZE",
         default_value = "10",
@@ -208,20 +208,20 @@ pub struct Opt {
         help = "Limits the number of connections in the store's connection pool"
     )]
     pub store_connection_pool_size: u32,
-    #[structopt(
+    #[clap(
         long,
         help = "Allows setting configurations that may result in incorrect Proofs of Indexing."
     )]
     pub unsafe_config: bool,
 
-    #[structopt(
+    #[clap(
         long,
         value_name = "IPFS_HASH",
         help = "IPFS hash of the subgraph manifest that you want to fork"
     )]
     pub debug_fork: Option<String>,
 
-    #[structopt(long, value_name = "URL", help = "Base URL for forking subgraphs")]
+    #[clap(long, value_name = "URL", help = "Base URL for forking subgraphs")]
     pub fork_base: Option<String>,
 }
 

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -36,7 +36,7 @@ hex = "0.4.3"
 
 [dev-dependencies]
 futures = "0.3"
-clap = "3.2.21"
+clap = "3.2.22"
 graphql-parser = "0.4.0"
 test-store = { path = "../test-store" }
 hex-literal = "0.3"


### PR DESCRIPTION
The `structopt` crate is in maintenance mode, and authors suggest that users migrate to `clap`, which now has derive macros in a similar fashion.

This PR updates all `structopt` occurrences in favor of `clap` without altering the CLI usage. 