### PR TITLE
Macro sugar: `#[derive(Clone)]` and `thiserror`'s `#[from]`

### DIFF
--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -44,7 +44,7 @@ pub struct EthereumContractCall {
 #[derive(Error, Debug)]
 pub enum EthereumContractCallError {
     #[error("ABI error: {0}")]
-    ABIError(ABIError),
+    ABIError(#[from] ABIError),
     /// `Token` is not of expected `ParamType`
     #[error("type mismatch, token {0:?} is not of kind {1:?}")]
     TypeError(Token, ParamType),
@@ -56,12 +56,6 @@ pub enum EthereumContractCallError {
     Revert(String),
     #[error("ethereum node took too long to perform call")]
     Timeout,
-}
-
-impl From<ABIError> for EthereumContractCallError {
-    fn from(e: ABIError) -> Self {
-        EthereumContractCallError::ABIError(e)
-    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]

--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -410,7 +410,7 @@ impl From<&'_ Transaction> for EthereumTransactionData {
 }
 
 /// An Ethereum event logged from a specific contract address and block.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EthereumEventData {
     pub address: Address,
     pub log_index: U256,
@@ -421,29 +421,8 @@ pub struct EthereumEventData {
     pub params: Vec<LogParam>,
 }
 
-impl Clone for EthereumEventData {
-    fn clone(&self) -> Self {
-        EthereumEventData {
-            address: self.address,
-            log_index: self.log_index,
-            transaction_log_index: self.transaction_log_index,
-            log_type: self.log_type.clone(),
-            block: self.block.clone(),
-            transaction: self.transaction.clone(),
-            params: self
-                .params
-                .iter()
-                .map(|log_param| LogParam {
-                    name: log_param.name.clone(),
-                    value: log_param.value.clone(),
-                })
-                .collect(),
-        }
-    }
-}
-
 /// An Ethereum call executed within a transaction within a block to a contract address.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EthereumCallData {
     pub from: Address,
     pub to: Address,
@@ -451,31 +430,4 @@ pub struct EthereumCallData {
     pub transaction: EthereumTransactionData,
     pub inputs: Vec<LogParam>,
     pub outputs: Vec<LogParam>,
-}
-
-impl Clone for EthereumCallData {
-    fn clone(&self) -> Self {
-        EthereumCallData {
-            to: self.to,
-            from: self.from,
-            block: self.block.clone(),
-            transaction: self.transaction.clone(),
-            inputs: self
-                .inputs
-                .iter()
-                .map(|log_param| LogParam {
-                    name: log_param.name.clone(),
-                    value: log_param.value.clone(),
-                })
-                .collect(),
-            outputs: self
-                .outputs
-                .iter()
-                .map(|log_param| LogParam {
-                    name: log_param.name.clone(),
-                    value: log_param.value.clone(),
-                })
-                .collect(),
-        }
-    }
 }

--- a/core/src/subgraph/error.rs
+++ b/core/src/subgraph/error.rs
@@ -4,7 +4,7 @@ use graph::prelude::{thiserror, Error, StoreError};
 #[derive(thiserror::Error, Debug)]
 pub enum BlockProcessingError {
     #[error("{0:#}")]
-    Unknown(Error),
+    Unknown(#[from] Error),
 
     // The error had a deterministic cause but, for a possibly non-deterministic reason, we chose to
     // halt processing due to the error.
@@ -18,12 +18,6 @@ pub enum BlockProcessingError {
 impl BlockProcessingError {
     pub fn is_deterministic(&self) -> bool {
         matches!(self, BlockProcessingError::Deterministic(_))
-    }
-}
-
-impl From<Error> for BlockProcessingError {
-    fn from(e: Error) -> Self {
-        BlockProcessingError::Unknown(e)
     }
 }
 

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -37,13 +37,8 @@ impl Block for MockBlock {
     }
 }
 
+#[derive(Clone)]
 pub struct MockDataSource;
-
-impl Clone for MockDataSource {
-    fn clone(&self) -> Self {
-        todo!()
-    }
-}
 
 impl<C: Blockchain> TryFrom<DataSourceTemplateInfo<C>> for MockDataSource {
     type Error = Error;

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -157,13 +157,7 @@ pub enum IngestorError {
 
     /// An unexpected error occurred.
     #[error("Ingestor error: {0:#}")]
-    Unknown(Error),
-}
-
-impl From<Error> for IngestorError {
-    fn from(e: Error) -> Self {
-        IngestorError::Unknown(e)
-    }
+    Unknown(#[from] Error),
 }
 
 impl From<web3::Error> for IngestorError {

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -12,14 +12,8 @@ use crate::data::subgraph::*;
 use crate::prelude::q;
 use crate::{components::store::StoreError, prelude::CacheWeight};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CloneableAnyhowError(Arc<anyhow::Error>);
-
-impl Clone for CloneableAnyhowError {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
 
 impl From<anyhow::Error> for CloneableAnyhowError {
     fn from(f: anyhow::Error) -> Self {

--- a/graph/src/data/subgraph/api_version.rs
+++ b/graph/src/data/subgraph/api_version.rs
@@ -3,8 +3,6 @@ use semver::Version;
 use std::collections::BTreeSet;
 use thiserror::Error;
 
-use super::SubgraphManifestValidationError;
-
 pub const API_VERSION_0_0_2: Version = Version::new(0, 0, 2);
 
 /// This version adds a new subgraph validation step that rejects manifests whose mappings have
@@ -75,13 +73,7 @@ pub(super) fn format_versions(versions: &BTreeSet<Version>) -> String {
 
 #[derive(Error, Debug, PartialEq)]
 #[error("Expected a single apiVersion for mappings. Found: {}.", format_versions(.0))]
-pub struct DifferentMappingApiVersions(BTreeSet<Version>);
-
-impl From<DifferentMappingApiVersions> for SubgraphManifestValidationError {
-    fn from(versions: DifferentMappingApiVersions) -> Self {
-        SubgraphManifestValidationError::DifferentApiVersions(versions.0)
-    }
-}
+pub struct DifferentMappingApiVersions(pub BTreeSet<Version>);
 
 #[test]
 fn unified_mapping_api_version_from_iterator() {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -270,7 +270,7 @@ pub enum SubgraphRegistrarError {
     #[error("deployment assignment unchanged: {0}")]
     DeploymentAssignmentUnchanged(String),
     #[error("subgraph registrar internal query error: {0}")]
-    QueryExecutionError(QueryExecutionError),
+    QueryExecutionError(#[from] QueryExecutionError),
     #[error("subgraph registrar error with store: {0}")]
     StoreError(StoreError),
     #[error("subgraph validation error: {}", display_vector(.0))]
@@ -278,13 +278,7 @@ pub enum SubgraphRegistrarError {
     #[error("subgraph deployment error: {0}")]
     SubgraphDeploymentError(StoreError),
     #[error("subgraph registrar error: {0}")]
-    Unknown(anyhow::Error),
-}
-
-impl From<QueryExecutionError> for SubgraphRegistrarError {
-    fn from(e: QueryExecutionError) -> Self {
-        SubgraphRegistrarError::QueryExecutionError(e)
-    }
+    Unknown(#[from] anyhow::Error),
 }
 
 impl From<StoreError> for SubgraphRegistrarError {
@@ -293,12 +287,6 @@ impl From<StoreError> for SubgraphRegistrarError {
             StoreError::DeploymentNotFound(id) => SubgraphRegistrarError::DeploymentNotFound(id),
             e => SubgraphRegistrarError::StoreError(e),
         }
-    }
-}
-
-impl From<Error> for SubgraphRegistrarError {
-    fn from(e: Error) -> Self {
-        SubgraphRegistrarError::Unknown(e)
     }
 }
 
@@ -318,13 +306,7 @@ pub enum SubgraphAssignmentProviderError {
     #[error("Subgraph with ID {0} is not running")]
     NotRunning(DeploymentLocator),
     #[error("Subgraph provider error: {0}")]
-    Unknown(anyhow::Error),
-}
-
-impl From<Error> for SubgraphAssignmentProviderError {
-    fn from(e: Error) -> Self {
-        SubgraphAssignmentProviderError::Unknown(e)
-    }
+    Unknown(#[from] anyhow::Error),
 }
 
 impl From<::diesel::result::Error> for SubgraphAssignmentProviderError {
@@ -357,8 +339,8 @@ pub enum SubgraphManifestValidationError {
     SchemaValidationError(Vec<SchemaValidationError>),
     #[error("the graft base is invalid: {0}")]
     GraftBaseInvalid(String),
-    #[error("subgraph must use a single apiVersion across its data sources. Found: {}", format_versions(.0))]
-    DifferentApiVersions(BTreeSet<Version>),
+    #[error("subgraph must use a single apiVersion across its data sources. Found: {}", format_versions(&(.0).0))]
+    DifferentApiVersions(#[from] DifferentMappingApiVersions),
     #[error(transparent)]
     FeatureValidationError(#[from] SubgraphFeatureValidationError),
     #[error("data source {0} is invalid: {1}")]
@@ -368,19 +350,13 @@ pub enum SubgraphManifestValidationError {
 #[derive(Error, Debug)]
 pub enum SubgraphManifestResolveError {
     #[error("parse error: {0}")]
-    ParseError(serde_yaml::Error),
+    ParseError(#[from] serde_yaml::Error),
     #[error("subgraph is not UTF-8")]
     NonUtf8,
     #[error("subgraph is not valid YAML")]
     InvalidFormat,
     #[error("resolve error: {0}")]
     ResolveError(anyhow::Error),
-}
-
-impl From<serde_yaml::Error> for SubgraphManifestResolveError {
-    fn from(e: serde_yaml::Error) -> Self {
-        SubgraphManifestResolveError::ParseError(e)
-    }
 }
 
 /// Data source contexts are conveniently represented as entities.

--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -426,19 +426,13 @@ impl std::error::Error for DeterministicHostError {}
 #[derive(thiserror::Error, Debug)]
 pub enum HostExportError {
     #[error("{0:#}")]
-    Unknown(anyhow::Error),
+    Unknown(#[from] anyhow::Error),
 
     #[error("{0:#}")]
     PossibleReorg(anyhow::Error),
 
     #[error("{0:#}")]
     Deterministic(anyhow::Error),
-}
-
-impl From<anyhow::Error> for HostExportError {
-    fn from(e: anyhow::Error) -> Self {
-        HostExportError::Unknown(e)
-    }
 }
 
 impl From<DeterministicHostError> for HostExportError {

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -4,16 +4,11 @@ use graph::prometheus::{CounterVec, GaugeVec, HistogramOpts, HistogramVec};
 
 use std::collections::HashMap;
 
+#[derive(Clone)]
 pub struct MockMetricsRegistry {}
 
 impl MockMetricsRegistry {
     pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl Clone for MockMetricsRegistry {
-    fn clone(&self) -> Self {
         Self {}
     }
 }

--- a/runtime/wasm/src/asc_abi/class.rs
+++ b/runtime/wasm/src/asc_abi/class.rs
@@ -705,7 +705,7 @@ impl AscIndexId for AscResult<AscPtr<AscEnum<JsonValueKind>>, bool> {
 }
 
 #[repr(C)]
-#[derive(AscType)]
+#[derive(AscType, Copy, Clone)]
 pub struct AscWrapped<V: AscValue> {
     pub inner: V,
 }
@@ -720,12 +720,4 @@ impl AscIndexId for AscWrapped<bool> {
 
 impl AscIndexId for AscWrapped<AscPtr<AscEnum<JsonValueKind>>> {
     const INDEX_ASC_TYPE_ID: IndexForAscTypeId = IndexForAscTypeId::WrappedJsonValue;
-}
-
-impl<V: AscValue> Copy for AscWrapped<V> {}
-
-impl<V: AscValue> Clone for AscWrapped<V> {
-    fn clone(&self) -> Self {
-        Self { inner: self.inner }
-    }
 }

--- a/server/http/src/server.rs
+++ b/server/http/src/server.rs
@@ -11,13 +11,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum GraphQLServeError {
     #[error("Bind error: {0}")]
-    BindError(hyper::Error),
-}
-
-impl From<hyper::Error> for GraphQLServeError {
-    fn from(err: hyper::Error) -> Self {
-        GraphQLServeError::BindError(err)
-    }
+    BindError(#[from] hyper::Error),
 }
 
 /// A GraphQL server based on Hyper.

--- a/server/index-node/src/server.rs
+++ b/server/index-node/src/server.rs
@@ -16,13 +16,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum IndexNodeServeError {
     #[error("Bind error: {0}")]
-    BindError(hyper::Error),
-}
-
-impl From<hyper::Error> for IndexNodeServeError {
-    fn from(err: hyper::Error) -> Self {
-        IndexNodeServeError::BindError(err)
-    }
+    BindError(#[from] hyper::Error),
 }
 
 /// A GraphQL server based on Hyper.

--- a/server/metrics/src/lib.rs
+++ b/server/metrics/src/lib.rs
@@ -14,13 +14,7 @@ use graph::prelude::{MetricsServer as MetricsServerTrait, *};
 #[derive(Debug, Error)]
 pub enum PrometheusMetricsServeError {
     #[error("Bind error: {0}")]
-    BindError(hyper::Error),
-}
-
-impl From<hyper::Error> for PrometheusMetricsServeError {
-    fn from(err: hyper::Error) -> Self {
-        PrometheusMetricsServeError::BindError(err)
-    }
+    BindError(#[from] hyper::Error),
 }
 
 #[derive(Clone)]

--- a/server/metrics/src/lib.rs
+++ b/server/metrics/src/lib.rs
@@ -23,18 +23,10 @@ impl From<hyper::Error> for PrometheusMetricsServeError {
     }
 }
 
+#[derive(Clone)]
 pub struct PrometheusMetricsServer {
     logger: Logger,
     registry: Arc<Registry>,
-}
-
-impl Clone for PrometheusMetricsServer {
-    fn clone(&self) -> Self {
-        Self {
-            logger: self.logger.clone(),
-            registry: self.registry.clone(),
-        }
-    }
 }
 
 impl PrometheusMetricsServer {


### PR DESCRIPTION
- Remove some hand-written `Clone` implementations and replace them with derives.
- Replace from `From` implementations for specific error variants and use the `#[from]` macro from `thiserror`.