### PR TITLE
store: Fix the query for retrieving replication lag

### DIFF
--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -629,7 +629,7 @@ pub(crate) fn replication_lag(conn: &PgConnection) -> Result<Duration, StoreErro
     }
 
     let lag = sql_query(
-        "select extract(milliseconds from max(greatest(write_lag, flush_lag, replay_lag)))::int as ms \
+        "select (extract(epoch from max(greatest(write_lag, flush_lag, replay_lag)))*1000)::int as ms \
            from pg_stat_replication",
     )
     .get_result::<Lag>(conn)?;


### PR DESCRIPTION
The old query was returning just the millisecond portion of the lag, not the lag in milliseconds

