### PR TITLE
fix: Allow grafts to add data sources

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -8,7 +8,7 @@ use graph::blockchain::Blockchain;
 use graph::blockchain::NodeCapabilities;
 use graph::blockchain::{BlockchainKind, TriggerFilter};
 use graph::components::subgraph::ProofOfIndexingVersion;
-use graph::data::subgraph::SPEC_VERSION_0_0_6;
+use graph::data::subgraph::{UnresolvedSubgraphManifest, SPEC_VERSION_0_0_6};
 use graph::prelude::{SubgraphInstanceManager as SubgraphInstanceManagerTrait, *};
 use graph::{blockchain::BlockchainMap, components::store::DeploymentLocator};
 use graph_runtime_wasm::module::ToAscPtr;
@@ -176,47 +176,49 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             .writable(logger.clone(), deployment.id)
             .await?;
 
+        let raw_yaml = serde_yaml::to_string(&manifest).unwrap();
+        let manifest = UnresolvedSubgraphManifest::parse(deployment.hash.cheap_clone(), manifest)?;
+
+        // Make sure the `raw_yaml` is present on both this subgraph and the graft base.
+        self.subgraph_store
+            .set_manifest_raw_yaml(&deployment.hash, raw_yaml)
+            .await?;
+        if let Some(graft) = &manifest.graft {
+            let file_bytes = self
+                .link_resolver
+                .cat(&logger, &graft.base.to_ipfs_link())
+                .await?;
+            let yaml = String::from_utf8(file_bytes)?;
+            self.subgraph_store
+                .set_manifest_raw_yaml(&graft.base, yaml)
+                .await?;
+        }
+
+        info!(logger, "Resolve subgraph files using IPFS");
+
+        // Allow for infinite retries for subgraph definition files.
+        let link_resolver = Arc::from(self.link_resolver.with_retries());
+        let mut manifest = manifest
+            .resolve(&link_resolver, &logger, ENV_VARS.max_spec_version.clone())
+            .await?;
+
+        info!(logger, "Successfully resolved subgraph files using IPFS");
+
+        let manifest_idx_and_name: Vec<(u32, String)> = manifest.template_idx_and_name().collect();
+
         // Start the subgraph deployment before reading dynamic data
         // sources; if the subgraph is a graft or a copy, starting it will
         // do the copying and dynamic data sources won't show up until after
         // that is done
         store.start_subgraph_deployment(&logger).await?;
 
-        let (manifest, manifest_idx_and_name, static_data_sources) = {
-            info!(logger, "Resolve subgraph files using IPFS");
-
-            let mut manifest = SubgraphManifest::resolve_from_raw(
-                deployment.hash.cheap_clone(),
-                manifest,
-                // Allow for infinite retries for subgraph definition files.
-                &Arc::from(self.link_resolver.with_retries()),
-                &logger,
-                ENV_VARS.max_spec_version.clone(),
-            )
-            .await
-            .context("Failed to resolve subgraph from IPFS")?;
-
-            // We cannot include static data sources in the map because a static data source and a
-            // template may have the same name in the manifest.
-            let ds_len = manifest.data_sources.len() as u32;
-            let manifest_idx_and_name: Vec<(u32, String)> = manifest
-                .templates
-                .iter()
-                .map(|t| t.name().to_owned())
-                .enumerate()
-                .map(|(idx, name)| (ds_len + idx as u32, name))
-                .collect();
-
-            let data_sources = load_dynamic_data_sources(
-                store.clone(),
-                logger.clone(),
-                &manifest,
-                manifest_idx_and_name.clone(),
-            )
-            .await
-            .context("Failed to load dynamic data sources")?;
-
-            info!(logger, "Successfully resolved subgraph files using IPFS");
+        // Dynamic data sources are loaded by appending them to the manifest.
+        //
+        // Refactor: Preferrably we'd avoid any mutation of the manifest.
+        let (manifest, static_data_sources) = {
+            let data_sources = load_dynamic_data_sources(store.clone(), logger.clone(), &manifest)
+                .await
+                .context("Failed to load dynamic data sources")?;
 
             let static_data_sources = manifest.data_sources.clone();
 
@@ -229,7 +231,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
                 manifest.data_sources.len()
             );
 
-            (manifest, manifest_idx_and_name, static_data_sources)
+            (manifest, static_data_sources)
         };
 
         let static_filters =

--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -9,8 +9,8 @@ pub async fn load_dynamic_data_sources<C: Blockchain>(
     store: Arc<dyn WritableStore>,
     logger: Logger,
     manifest: &SubgraphManifest<C>,
-    manifest_idx_and_name: Vec<(u32, String)>,
 ) -> Result<Vec<DataSource<C>>, Error> {
+    let manifest_idx_and_name = manifest.template_idx_and_name().collect();
     let start_time = Instant::now();
 
     let mut data_sources: Vec<DataSource<C>> = vec![];

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -552,6 +552,7 @@ async fn create_subgraph_version<C: Blockchain, S: SubgraphStore>(
     version_switching_mode: SubgraphVersionSwitchingMode,
     resolver: &Arc<dyn LinkResolver>,
 ) -> Result<DeploymentLocator, SubgraphRegistrarError> {
+    let raw_string = serde_yaml::to_string(&raw).unwrap();
     let unvalidated = UnvalidatedSubgraphManifest::<C>::resolve(
         deployment,
         raw,
@@ -618,7 +619,7 @@ async fn create_subgraph_version<C: Blockchain, S: SubgraphStore>(
 
     // Apply the subgraph versioning and deployment operations,
     // creating a new subgraph deployment if one doesn't exist.
-    let deployment = DeploymentCreate::new(&manifest, start_block)
+    let deployment = DeploymentCreate::new(raw_string, &manifest, start_block)
         .graft(base_block)
         .debug(debug_fork);
     deployment_store

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -152,6 +152,13 @@ pub trait SubgraphStore: Send + Sync + 'static {
 
     /// Find the deployment locators for the subgraph with the given hash
     fn locators(&self, hash: &str) -> Result<Vec<DeploymentLocator>, StoreError>;
+
+    /// This migrates subgraphs that existed before the raw_yaml column was added.
+    async fn set_manifest_raw_yaml(
+        &self,
+        hash: &DeploymentHash,
+        raw_yaml: String,
+    ) -> Result<(), StoreError>;
 }
 
 pub trait ReadStore: Send + Sync + 'static {

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -1,6 +1,6 @@
 //! Entity types that contain the graph-node state.
 
-use anyhow::{anyhow, Error};
+use anyhow::{anyhow, bail, Error};
 use hex;
 use lazy_static::lazy_static;
 use rand::rngs::OsRng;
@@ -110,11 +110,12 @@ pub struct DeploymentCreate {
 
 impl DeploymentCreate {
     pub fn new(
+        raw_manifest: String,
         source_manifest: &SubgraphManifest<impl Blockchain>,
         earliest_block: Option<BlockPtr>,
     ) -> Self {
         Self {
-            manifest: SubgraphManifestEntity::from(source_manifest),
+            manifest: SubgraphManifestEntity::new(raw_manifest, source_manifest),
             earliest_block: earliest_block.cheap_clone(),
             graft_base: None,
             graft_block: None,
@@ -163,17 +164,51 @@ pub struct SubgraphManifestEntity {
     pub repository: Option<String>,
     pub features: Vec<String>,
     pub schema: String,
+    pub raw_yaml: Option<String>,
 }
 
-impl<'a, C: Blockchain> From<&'a super::SubgraphManifest<C>> for SubgraphManifestEntity {
-    fn from(manifest: &'a super::SubgraphManifest<C>) -> Self {
+impl SubgraphManifestEntity {
+    pub fn new(raw_yaml: String, manifest: &super::SubgraphManifest<impl Blockchain>) -> Self {
         Self {
             spec_version: manifest.spec_version.to_string(),
             description: manifest.description.clone(),
             repository: manifest.repository.clone(),
             features: manifest.features.iter().map(|f| f.to_string()).collect(),
             schema: manifest.schema.document.clone().to_string(),
+            raw_yaml: Some(raw_yaml),
         }
+    }
+
+    pub fn template_idx_and_name(&self) -> Result<Vec<(i32, String)>, Error> {
+        #[derive(Debug, Deserialize)]
+        struct MinimalDs {
+            name: String,
+        }
+        #[derive(Debug, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct MinimalManifest {
+            data_sources: Vec<MinimalDs>,
+            #[serde(default)]
+            templates: Vec<MinimalDs>,
+        }
+
+        let raw_yaml = match &self.raw_yaml {
+            Some(raw_yaml) => raw_yaml,
+            None => bail!("raw_yaml not present"),
+        };
+
+        let manifest: MinimalManifest = serde_yaml::from_str(raw_yaml)?;
+
+        let ds_len = manifest.data_sources.len() as i32;
+        let template_idx_and_name = manifest
+            .templates
+            .iter()
+            .map(|t| t.name.to_owned())
+            .enumerate()
+            .map(move |(idx, name)| (ds_len + idx as i32, name))
+            .collect();
+
+        Ok(template_idx_and_name)
     }
 }
 

--- a/graph/src/util/error.rs
+++ b/graph/src/util/error.rs
@@ -17,3 +17,12 @@ macro_rules! ensure {
         }
     };
 }
+
+// `bail!` from `anyhow`, but calling `from`.
+// For context see https://github.com/dtolnay/anyhow/issues/112#issuecomment-704549251.
+#[macro_export]
+macro_rules! bail {
+    ($($err:tt)*) => {
+        return Err(anyhow::anyhow!($($err)*).into());
+    };
+}

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -267,7 +267,7 @@ async fn insert_test_entities(
     manifest: SubgraphManifest<graph_chain_ethereum::Chain>,
     id_type: IdType,
 ) -> DeploymentLocator {
-    let deployment = DeploymentCreate::new(&manifest, None);
+    let deployment = DeploymentCreate::new(String::new(), &manifest, None);
     let name = SubgraphName::new(manifest.id.as_str()).unwrap();
     let node_id = NodeId::new("test").unwrap();
     let deployment = store

--- a/store/postgres/migrations/2022-09-19-161239_add-raw-manifest-column/down.sql
+++ b/store/postgres/migrations/2022-09-19-161239_add-raw-manifest-column/down.sql
@@ -1,0 +1,1 @@
+alter table subgraphs.subgraph_manifest drop column raw_yaml;

--- a/store/postgres/migrations/2022-09-19-161239_add-raw-manifest-column/up.sql
+++ b/store/postgres/migrations/2022-09-19-161239_add-raw-manifest-column/up.sql
@@ -1,0 +1,1 @@
+alter table subgraphs.subgraph_manifest add column raw_yaml text;

--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -672,6 +672,8 @@ pub struct Connection {
     src: Arc<Layout>,
     dst: Arc<Layout>,
     target_block: BlockPtr,
+    src_manifest_idx_and_name: Vec<(i32, String)>,
+    dst_manifest_idx_and_name: Vec<(i32, String)>,
 }
 
 impl Connection {
@@ -687,6 +689,8 @@ impl Connection {
         src: Arc<Layout>,
         dst: Arc<Layout>,
         target_block: BlockPtr,
+        src_manifest_idx_and_name: Vec<(i32, String)>,
+        dst_manifest_idx_and_name: Vec<(i32, String)>,
     ) -> Result<Self, StoreError> {
         let logger = logger.new(o!("dst" => dst.site.namespace.to_string()));
 
@@ -712,6 +716,8 @@ impl Connection {
             src,
             dst,
             target_block,
+            src_manifest_idx_and_name,
+            dst_manifest_idx_and_name,
         })
     }
 
@@ -728,6 +734,8 @@ impl Connection {
                 &self.conn,
                 &DataSourcesTable::new(state.dst.site.namespace.clone()),
                 state.target_block.number,
+                &self.src_manifest_idx_and_name,
+                &self.dst_manifest_idx_and_name,
             )?;
         }
         Ok(())

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -113,6 +113,7 @@ table! {
         /// Parent of the smallest start block from the manifest
         start_block_number -> Nullable<Integer>,
         start_block_hash -> Nullable<Binary>,
+        raw_yaml -> Nullable<Text>,
     }
 }
 
@@ -273,6 +274,22 @@ pub fn features(conn: &PgConnection, site: &Site) -> Result<BTreeSet<SubgraphFea
         .iter()
         .map(|f| SubgraphFeature::from_str(f).map_err(StoreError::from))
         .collect()
+}
+
+/// This migrates subgraphs that existed before the raw_yaml column was added.
+pub fn set_manifest_raw_yaml(
+    conn: &PgConnection,
+    site: &Site,
+    raw_yaml: &str,
+) -> Result<(), StoreError> {
+    use subgraph_manifest as sm;
+
+    update(sm::table.filter(sm::id.eq(site.id)))
+        .filter(sm::raw_yaml.is_null())
+        .set(sm::raw_yaml.eq(raw_yaml))
+        .execute(conn)
+        .map(|_| ())
+        .map_err(|e| e.into())
 }
 
 pub fn transact_block(
@@ -889,6 +906,7 @@ pub fn create_deployment(
                 repository,
                 features,
                 schema,
+                raw_yaml,
             },
         earliest_block,
         graft_base,
@@ -932,6 +950,7 @@ pub fn create_deployment(
         m::use_bytea_prefix.eq(true),
         m::start_block_hash.eq(b(&earliest_block)),
         m::start_block_number.eq(earliest_block_number),
+        m::raw_yaml.eq(raw_yaml),
     );
 
     if exists && replace {

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1316,6 +1316,15 @@ impl DeploymentStore {
                 dst.catalog.site.namespace
             );
 
+            let src_manifest_idx_and_name = self
+                .load_deployment(&src.site)?
+                .manifest
+                .template_idx_and_name()?;
+            let dst_manifest_idx_and_name = self
+                .load_deployment(&dst.site)?
+                .manifest
+                .template_idx_and_name()?;
+
             // Copy subgraph data
             // We allow both not copying tables at all from the source, as well
             // as adding new tables in `self`; we only need to check that tables
@@ -1327,6 +1336,8 @@ impl DeploymentStore {
                 src.clone(),
                 dst.clone(),
                 block.clone(),
+                src_manifest_idx_and_name,
+                dst_manifest_idx_and_name,
             )?;
             let status = copy_conn.copy_data()?;
             if status == crate::copy::Status::Cancelled {
@@ -1586,6 +1597,17 @@ impl DeploymentStore {
         let id = site.id.clone();
         self.with_conn(move |conn, _| deployment::health(conn, id).map_err(Into::into))
             .await
+    }
+
+    pub(crate) async fn set_manifest_raw_yaml(
+        &self,
+        site: Arc<Site>,
+        raw_yaml: String,
+    ) -> Result<(), StoreError> {
+        self.with_conn(move |conn, _| {
+            deployment::set_manifest_raw_yaml(&conn, &site, &raw_yaml).map_err(Into::into)
+        })
+        .await
     }
 }
 

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -340,6 +340,7 @@ struct StoredSubgraphManifest {
     use_bytea_prefix: bool,
     start_block_number: Option<i32>,
     start_block_hash: Option<Bytes>,
+    raw_yaml: Option<String>,
 }
 
 impl From<StoredSubgraphManifest> for SubgraphManifestEntity {
@@ -350,6 +351,7 @@ impl From<StoredSubgraphManifest> for SubgraphManifestEntity {
             repository: value.repository,
             features: value.features,
             schema: value.schema,
+            raw_yaml: value.raw_yaml,
         }
     }
 }

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -144,7 +144,10 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
     };
 
     // Create SubgraphDeploymentEntity
-    let deployment = DeploymentCreate::new(&manifest, None);
+    let mut yaml = serde_yaml::Mapping::new();
+    yaml.insert("dataSources".into(), Vec::<serde_yaml::Value>::new().into());
+    let yaml = serde_yaml::to_string(&yaml).unwrap();
+    let deployment = DeploymentCreate::new(yaml, &manifest, None);
     let name = SubgraphName::new("test/graft").unwrap();
     let node_id = NodeId::new("test").unwrap();
     let deployment = store

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -170,7 +170,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
     };
 
     // Create SubgraphDeploymentEntity
-    let deployment = DeploymentCreate::new(&manifest, None);
+    let deployment = DeploymentCreate::new(String::new(), &manifest, None);
     let name = SubgraphName::new("test/store").unwrap();
     let node_id = NodeId::new("test").unwrap();
     let deployment = store
@@ -1296,7 +1296,8 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             chain: PhantomData,
         };
 
-        let deployment = DeploymentCreate::new(&manifest, Some(TEST_BLOCK_0_PTR.clone()));
+        let deployment =
+            DeploymentCreate::new(String::new(), &manifest, Some(TEST_BLOCK_0_PTR.clone()));
         let name = SubgraphName::new("test/entity-changes-are-fired").unwrap();
         let node_id = NodeId::new("test").unwrap();
         let deployment = store

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -148,7 +148,7 @@ fn create_subgraph() {
             templates: vec![],
             chain: PhantomData,
         };
-        let deployment = DeploymentCreate::new(&manifest, None);
+        let deployment = DeploymentCreate::new(String::new(), &manifest, None);
         let node_id = NodeId::new("left").unwrap();
 
         let (deployment, events) = tap_store_events(|| {

--- a/store/postgres/tests/writable.rs
+++ b/store/postgres/tests/writable.rs
@@ -47,7 +47,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
     };
 
     // Create SubgraphDeploymentEntity
-    let deployment = DeploymentCreate::new(&manifest, None);
+    let deployment = DeploymentCreate::new(String::new(), &manifest, None);
     let name = SubgraphName::new("test/writable").unwrap();
     let node_id = NodeId::new("test").unwrap();
     let deployment = store

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -167,7 +167,10 @@ pub async fn create_subgraph(
         chain: PhantomData,
     };
 
-    let deployment = DeploymentCreate::new(&manifest, None).graft(base);
+    let mut yaml = serde_yaml::Mapping::new();
+    yaml.insert("dataSources".into(), Vec::<serde_yaml::Value>::new().into());
+    let yaml = serde_yaml::to_string(&yaml).unwrap();
+    let deployment = DeploymentCreate::new(yaml, &manifest, None).graft(base);
     let name = {
         let mut name = subgraph_id.to_string();
         name.truncate(32);

--- a/tests/integration-tests/data-source-revert/grafted.yaml
+++ b/tests/integration-tests/data-source-revert/grafted.yaml
@@ -26,6 +26,26 @@ dataSources:
       blockHandlers:
         - handler: handleBlock
       file: ./src/mapping.ts
+  # Tests that adding a data source is possible in a graft
+  - kind: ethereum/contract
+    name: Contract2
+    network: test
+    source:
+      address: "0xCfEB869F69431e42cdB54A4F4f105C19C080A601"
+      abi: Contract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Gravatar
+      abis:
+        - name: Contract
+          file: ./abis/Contract.abi
+      callHandlers:
+        - handler: handleBlock
+          function: emitTrigger(uint16)
+      file: ./src/mapping.ts
 templates:
   - kind: ethereum/contract
     name: Template

--- a/tests/integration-tests/typename/subgraph.yaml
+++ b/tests/integration-tests/typename/subgraph.yaml
@@ -13,7 +13,7 @@ dataSources:
       abi: Contract
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.5
+      apiVersion: 0.0.6
       language: wasm/assemblyscript
       entities:
         - ExampleEntity


### PR DESCRIPTION
Resolves #3960. This is done by adding a `raw_yaml` column to the `subgraph_manifest` table, and using it to map the manifest idx from the source to the destination deployment. For existing deployments this column is migrated in the instance manager on subgraph startup. This also changes a bit the order in which things are done in the instance manager, now the subgraph is first fetched from IPFS before being started in the store.

The `data-source-revert` integration test was modified to also test this.