### PR TITLE
firehose: Dont use debug format on firehose errors

### DIFF
--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -73,7 +73,7 @@ where
                     latest_cursor = self.process_blocks(latest_cursor, stream).await
                 }
                 Err(e) => {
-                    error!(self.logger, "Unable to connect to endpoint: {:?}", e);
+                    error!(self.logger, "Unable to connect to endpoint: {:#}", e);
                 }
             }
 
@@ -89,7 +89,7 @@ where
             match self.chain_store.clone().chain_head_cursor() {
                 Ok(cursor) => return cursor.unwrap_or_else(|| "".to_string()),
                 Err(e) => {
-                    error!(self.logger, "Fetching chain head cursor failed: {:?}", e);
+                    error!(self.logger, "Fetching chain head cursor failed: {:#}", e);
 
                     backoff.sleep_async().await;
                 }
@@ -128,7 +128,7 @@ where
                     };
 
                     if let Err(e) = result {
-                        error!(self.logger, "Process block failed: {:?}", e);
+                        error!(self.logger, "Process block failed: {:#}", e);
                         break;
                     }
 

--- a/graph/src/blockchain/substreams_block_stream.rs
+++ b/graph/src/blockchain/substreams_block_stream.rs
@@ -264,7 +264,7 @@ fn stream_blocks<C: Blockchain, F: SubstreamsMapper<C>>(
 
                     metrics.observe_failed_connection(&mut connect_start);
 
-                    error!(logger, "Unable to connect to endpoint: {:?}", e);
+                    error!(logger, "Unable to connect to endpoint: {:#}", e);
                 }
             }
 
@@ -287,7 +287,7 @@ async fn process_substreams_response<C: Blockchain, F: SubstreamsMapper<C>>(
 ) -> Result<Option<BlockResponse<C>>, Error> {
     let response = match result {
         Ok(v) => v,
-        Err(e) => return Err(anyhow!("An error occurred while streaming blocks: {:?}", e)),
+        Err(e) => return Err(anyhow!("An error occurred while streaming blocks: {:#}", e)),
     };
 
     match response.message {


### PR DESCRIPTION
This would print the error with newlines, the best is to use `{:#}` to print with causes.