### PR TITLE
fix(runtime): Add context to errors

### DIFF
--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -99,7 +99,8 @@ where
         host_metrics.cheap_clone(),
         timeout,
         experimental_features,
-    )?;
+    )
+    .context("module instantiation failed")?;
     section.end();
 
     let _section = host_metrics.stopwatch.start_section("run_handler");


### PR DESCRIPTION
This also better respects the comment `Caution: Make sure all exit paths from this function call exit_handler.` since the early return in `typed()?` could violate that.