### PR TITLE
Feature/ethereum provider feature call only

### DIFF
--- a/chain/arweave/src/chain.rs
+++ b/chain/arweave/src/chain.rs
@@ -83,6 +83,14 @@ impl Blockchain for Chain {
 
     type NodeCapabilities = EmptyNodeCapabilities<Self>;
 
+    fn is_capabilities_fulfilled(
+        &self,
+        _capabilities: &Self::NodeCapabilities,
+        _logger: &Logger,
+    ) -> bool {
+        true
+    }
+
     fn triggers_adapter(
         &self,
         _loc: &DeploymentLocator,

--- a/chain/cosmos/src/chain.rs
+++ b/chain/cosmos/src/chain.rs
@@ -81,9 +81,18 @@ impl Blockchain for Chain {
 
     type NodeCapabilities = EmptyNodeCapabilities<Self>;
 
+    fn is_capabilities_fulfilled(
+        &self,
+        _capabilities: &Self::NodeCapabilities,
+        _logger: &Logger,
+    ) -> bool {
+        true
+    }
+
     fn is_refetch_block_required(&self) -> bool {
         false
     }
+
     async fn refetch_firehose_block(
         &self,
         _logger: &Logger,

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -63,6 +63,7 @@ pub struct EthereumAdapter {
     web3: Arc<Web3<Transport>>,
     metrics: Arc<ProviderEthRpcMetrics>,
     supports_eip_1898: bool,
+    pub(crate) call_only: bool,
 }
 
 /// Gas limit for `eth_call`. The value of 50_000_000 is a protocol-wide parameter so this
@@ -84,6 +85,7 @@ impl CheapClone for EthereumAdapter {
             web3: self.web3.cheap_clone(),
             metrics: self.metrics.cheap_clone(),
             supports_eip_1898: self.supports_eip_1898,
+            call_only: self.call_only,
         }
     }
 }
@@ -96,6 +98,7 @@ impl EthereumAdapter {
         transport: Transport,
         provider_metrics: Arc<ProviderEthRpcMetrics>,
         supports_eip_1898: bool,
+        call_only: bool,
     ) -> Self {
         // Unwrap: The transport was constructed with this url, so it is valid and has a host.
         let hostname = graph::url::Url::parse(url)
@@ -122,6 +125,7 @@ impl EthereumAdapter {
             web3,
             metrics: provider_metrics,
             supports_eip_1898: supports_eip_1898 && !is_ganache,
+            call_only,
         }
     }
 

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -45,7 +45,7 @@ impl blockchain::RuntimeAdapter<Chain> for RuntimeAdapter {
         let call_cache = self.call_cache.cheap_clone();
         let eth_adapter = self
             .eth_adapters
-            .cheapest_with(&NodeCapabilities {
+            .cheapest_call_only_with(&NodeCapabilities {
                 archive: ds.mapping.requires_archive()?,
                 traces: false,
             })?

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -146,6 +146,14 @@ impl Blockchain for Chain {
 
     type NodeCapabilities = EmptyNodeCapabilities<Chain>;
 
+    fn is_capabilities_fulfilled(
+        &self,
+        _capabilities: &Self::NodeCapabilities,
+        _logger: &Logger,
+    ) -> bool {
+        true
+    }
+
     fn triggers_adapter(
         &self,
         _loc: &DeploymentLocator,

--- a/chain/substreams/src/chain.rs
+++ b/chain/substreams/src/chain.rs
@@ -92,6 +92,14 @@ impl Blockchain for Chain {
 
     type NodeCapabilities = EmptyNodeCapabilities<Self>;
 
+    fn is_capabilities_fulfilled(
+        &self,
+        _capabilities: &Self::NodeCapabilities,
+        _logger: &Logger,
+    ) -> bool {
+        true
+    }
+
     fn triggers_adapter(
         &self,
         _log: &DeploymentLocator,

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -338,7 +338,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
 
         if !chain.is_capabilities_fulfilled(&required_capabilities, &logger) {
             return Err(anyhow!(
-                "deployment {} with required capabilities {} cannot be fulfilled by this instance",
+                "deployment {} with required capabilities '{}' cannot be fulfilled by this instance",
                 &deployment,
                 &required_capabilities
             ));

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -336,6 +336,14 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             self.metrics_registry.clone(),
         );
 
+        if !chain.is_capabilities_fulfilled(&required_capabilities, &logger) {
+            return Err(anyhow!(
+                "deployment {} with required capabilities {} cannot be fulfilled by this instance",
+                &deployment,
+                &required_capabilities
+            ));
+        }
+
         let unified_mapping_api_version = manifest.unified_mapping_api_version()?;
         let triggers_adapter = chain.triggers_adapter(&deployment, &required_capabilities, unified_mapping_api_version).map_err(|e|
                 anyhow!(

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -289,6 +289,14 @@ impl Blockchain for MockBlockchain {
 
     type NodeCapabilities = MockNodeCapabilities;
 
+    fn is_capabilities_fulfilled(
+        &self,
+        _capabilities: &Self::NodeCapabilities,
+        _logger: &slog::Logger,
+    ) -> bool {
+        todo!()
+    }
+
     fn triggers_adapter(
         &self,
         _loc: &crate::components::store::DeploymentLocator,

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -149,6 +149,12 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
 
     type NodeCapabilities: NodeCapabilities<Self> + std::fmt::Display;
 
+    fn is_capabilities_fulfilled(
+        &self,
+        capabilities: &Self::NodeCapabilities,
+        logger: &Logger,
+    ) -> bool;
+
     fn triggers_adapter(
         &self,
         log: &DeploymentLocator,

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -634,7 +634,7 @@ impl Web3Provider {
     }
 }
 
-const PROVIDER_FEATURES: [&str; 3] = ["traces", "archive", "no_eip1898"];
+const PROVIDER_FEATURES: [&str; 4] = ["traces", "archive", "no_eip1898", "call_only"];
 const DEFAULT_PROVIDER_FEATURES: [&str; 2] = ["traces", "archive"];
 
 impl Provider {

--- a/node/src/manager/commands/config.rs
+++ b/node/src/manager/commands/config.rs
@@ -110,6 +110,7 @@ pub async fn provider(
             archive: false,
             traces: false,
         };
+
         for feature in features.split(',') {
             match feature {
                 "archive" => caps.archive = true,

--- a/store/test-store/devel/docker-compose.yml
+++ b/store/test-store/devel/docker-compose.yml
@@ -1,20 +1,35 @@
 version: '3'
 services:
   ipfs:
-    image: ipfs/go-ipfs:v0.10.0
+    container_name: graph-tests-ipfs
+    image: ipfs/kubo:v0.14.0
     ports:
-      - '5001:5001'
+      - "5001:5001"
+      - "5002:8080"
     volumes:
       - ./data/ipfs:/data/ipfs
+      - ./data/ipfs-export:/export
   postgres:
-    image: postgres
+    container_name: graph-tests-postgres
+    image: postgres:14
     ports:
       - '5432:5432'
-    command: ["postgres", "-cshared_preload_libraries=pg_stat_statements", "-clog_statement=all"]
+    command:
+      [
+        "postgres",
+        "-cshared_preload_libraries=pg_stat_statements",
+        "-clog_statement=all"
+      ]
     environment:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in
       POSTGRES_DB: graph-node
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
       - ./initdb.d:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: [ "CMD", "nc", "-z", "localhost", "5432" ]
+      interval: 30s
+      timeout: 10s
+      retries: 15

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -55,7 +55,10 @@ pub async fn chain(
         chain_store.cheap_clone(),
         chain_store,
         firehose_endpoints,
-        EthereumNetworkAdapters { adapters: vec![] },
+        EthereumNetworkAdapters {
+            full_adapters: vec![],
+            call_only_adapters: vec![],
+        },
         stores.chain_head_listener.cheap_clone(),
         Arc::new(StaticStreamBuilder { chain: blocks }),
         Arc::new(StaticBlockRefetcher { x: PhantomData }),


### PR DESCRIPTION
Open a PR so we can discuss it at the weekly tomorrow, right now I feel the feature part is weird for `call_only` has it brings interesting problems like the fact that in most cases, "call_only" provider should never be actually selected. 

The current PR reflects that with a new `cheapest_with_for_call` which tries to use `call_only` provider first then fallback to normal behavior if none are found. So it's prioritizing `call_only` in this case but only in this case.