### PR TITLE
Improve how we apply database migrations

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -21,6 +21,7 @@ use graph_node::{
     store_builder::StoreBuilder,
     MetricsContext,
 };
+use graph_store_postgres::connection_pool::PoolCoordinator;
 use graph_store_postgres::ChainStore;
 use graph_store_postgres::{
     connection_pool::ConnectionPool, BlockStore, NotificationSender, Shard, Store, SubgraphStore,
@@ -587,13 +588,14 @@ impl Context {
 
     fn primary_pool(self) -> ConnectionPool {
         let primary = self.config.primary_store();
+        let coord = Arc::new(PoolCoordinator::new(Arc::new(vec![])));
         let pool = StoreBuilder::main_pool(
             &self.logger,
             &self.node_id,
             PRIMARY_SHARD.as_str(),
             primary,
             self.metrics_registry(),
-            Arc::new(vec![]),
+            coord,
         );
         pool.skip_setup();
         pool

--- a/node/src/manager/commands/database.rs
+++ b/node/src/manager/commands/database.rs
@@ -1,0 +1,22 @@
+use std::time::Instant;
+
+use graph::prelude::anyhow;
+use graph_store_postgres::connection_pool::PoolCoordinator;
+
+pub async fn remap(coord: &PoolCoordinator) -> Result<(), anyhow::Error> {
+    let pools = coord.pools();
+    let servers = coord.servers();
+
+    for server in servers.iter() {
+        for pool in pools.iter() {
+            let start = Instant::now();
+            print!(
+                "Remapping imports from {} in shard {}",
+                server.shard, pool.shard
+            );
+            pool.remap(server)?;
+            println!(" (done in {}s)", start.elapsed().as_secs());
+        }
+    }
+    Ok(())
+}

--- a/node/src/manager/commands/mod.rs
+++ b/node/src/manager/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod check_blocks;
 pub mod config;
 pub mod copy;
 pub mod create;
+pub mod database;
 pub mod index;
 pub mod info;
 pub mod listen;

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -28,6 +28,7 @@ pub struct StoreBuilder {
     chain_head_update_listener: Arc<PostgresChainHeadUpdateListener>,
     /// Map network names to the shards where they are/should be stored
     chains: HashMap<String, ShardName>,
+    pub coord: Arc<PoolCoordinator>,
 }
 
 impl StoreBuilder {
@@ -49,7 +50,7 @@ impl StoreBuilder {
             registry.clone(),
         ));
 
-        let (store, pools) = Self::make_subgraph_store_and_pools(
+        let (store, pools, coord) = Self::make_subgraph_store_and_pools(
             logger,
             node,
             config,
@@ -82,6 +83,7 @@ impl StoreBuilder {
             subscription_manager,
             chain_head_update_listener,
             chains,
+            coord,
         }
     }
 
@@ -94,7 +96,11 @@ impl StoreBuilder {
         config: &Config,
         fork_base: Option<Url>,
         registry: Arc<dyn MetricsRegistry>,
-    ) -> (Arc<SubgraphStore>, HashMap<ShardName, ConnectionPool>) {
+    ) -> (
+        Arc<SubgraphStore>,
+        HashMap<ShardName, ConnectionPool>,
+        Arc<PoolCoordinator>,
+    ) {
         let notification_sender = Arc::new(NotificationSender::new(registry.cheap_clone()));
 
         let servers = config
@@ -150,7 +156,7 @@ impl StoreBuilder {
             registry,
         ));
 
-        (store, pools)
+        (store, pools, coord)
     }
 
     pub fn make_store(

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -161,7 +161,7 @@ fn get_text_columns(
 
 pub fn table_exists(
     conn: &PgConnection,
-    namespace: &Namespace,
+    namespace: &str,
     table: &SqlName,
 ) -> Result<bool, StoreError> {
     #[derive(Debug, QueryableByName)]
@@ -186,7 +186,7 @@ pub fn supports_proof_of_indexing(
     lazy_static! {
         static ref POI_TABLE_NAME: SqlName = SqlName::verbatim(POI_TABLE.to_owned());
     }
-    table_exists(conn, namespace, &POI_TABLE_NAME)
+    table_exists(conn, namespace.as_str(), &POI_TABLE_NAME)
 }
 
 /// Whether the given table has an exclusion constraint. When we create

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -673,7 +673,7 @@ impl HandleEvent for EventHandler {
 #[derive(Clone)]
 pub struct PoolInner {
     logger: Logger,
-    shard: Shard,
+    pub shard: Shard,
     pool: Pool<ConnectionManager<PgConnection>>,
     // A separate pool for connections that will use foreign data wrappers.
     // Once such a connection accesses a foreign table, Postgres keeps a
@@ -1053,7 +1053,7 @@ impl PoolInner {
     // The foreign server `server` had schema changes, and we therefore need
     // to remap anything that we are importing via fdw to make sure we are
     // using this updated schema
-    fn remap(&self, server: &ForeignServer) -> Result<(), StoreError> {
+    pub fn remap(&self, server: &ForeignServer) -> Result<(), StoreError> {
         if &server.shard == &*PRIMARY_SHARD {
             info!(&self.logger, "Mapping primary");
             let conn = self.get()?;
@@ -1175,5 +1175,18 @@ impl PoolCoordinator {
             pool.remap(server)?;
         }
         Ok(())
+    }
+
+    pub fn pools(&self) -> Vec<Arc<PoolInner>> {
+        self.pools
+            .lock()
+            .unwrap()
+            .values()
+            .map(|pool| pool.clone())
+            .collect()
+    }
+
+    pub fn servers(&self) -> Arc<Vec<ForeignServer>> {
+        self.servers.clone()
     }
 }

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -25,7 +25,7 @@ use graph::{
 
 use std::fmt::{self, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{collections::HashMap, sync::RwLock};
 
@@ -158,9 +158,6 @@ impl ForeignServer {
 
     /// Map key tables from the primary into our local schema. If we are the
     /// primary, set them up as views.
-    ///
-    /// We recreate this mapping on every server start so that migrations that
-    /// change one of the mapped tables actually show up in the imported tables
     fn map_primary(conn: &PgConnection, shard: &Shard) -> Result<(), StoreError> {
         catalog::recreate_schema(conn, Self::PRIMARY_PUBLIC)?;
 
@@ -226,7 +223,7 @@ const FDW_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 enum PoolState {
     /// A connection pool, and all the servers for which we need to
     /// establish fdw mappings when we call `setup` on the pool
-    Created(Arc<PoolInner>, Arc<Vec<ForeignServer>>),
+    Created(Arc<PoolInner>, Arc<PoolCoordinator>),
     /// The pool has been successfully set up
     Ready(Arc<PoolInner>),
     /// The pool has been disabled by setting its size to 0
@@ -300,7 +297,7 @@ impl PoolStateTracker {
 }
 
 impl ConnectionPool {
-    pub fn create(
+    fn create(
         shard_name: &str,
         pool_name: PoolName,
         postgres_url: String,
@@ -308,7 +305,7 @@ impl ConnectionPool {
         fdw_pool_size: Option<u32>,
         logger: &Logger,
         registry: Arc<dyn MetricsRegistry>,
-        servers: Arc<Vec<ForeignServer>>,
+        coord: Arc<PoolCoordinator>,
     ) -> ConnectionPool {
         let state_tracker = PoolStateTracker::new();
         let shard =
@@ -330,7 +327,7 @@ impl ConnectionPool {
                 if pool_name.is_replica() {
                     PoolState::Ready(Arc::new(pool))
                 } else {
-                    PoolState::Created(Arc::new(pool), servers)
+                    PoolState::Created(Arc::new(pool), coord)
                 }
             }
         };
@@ -968,7 +965,7 @@ impl PoolInner {
     /// # Panics
     ///
     /// If any errors happen during the migration, the process panics
-    pub fn setup(&self, servers: Arc<Vec<ForeignServer>>) -> Result<(), StoreError> {
+    fn setup(&self, coord: Arc<PoolCoordinator>) -> Result<(), StoreError> {
         fn die(logger: &Logger, msg: &'static str, err: &dyn std::fmt::Display) -> ! {
             crit!(logger, "{}", msg; "error" => format!("{:#}", err));
             panic!("{}: {}", msg, err);
@@ -980,11 +977,29 @@ impl PoolInner {
         let start = Instant::now();
         advisory_lock::lock_migration(&conn)
             .unwrap_or_else(|err| die(&pool.logger, "failed to get migration lock", &err));
+        // This code can cause a race in database setup: if pool A has had
+        // schema changes and pool B then tries to map tables from pool A,
+        // but does so before the concurrent thread running this code for
+        // pool B has at least finished `configure_fdw`, mapping tables will
+        // fail. In that case, the node must be restarted. The restart is
+        // guaranteed because this failure will lead to a panic in the setup
+        // for pool A
+        //
+        // This code can also leave the table mappings in a state where they
+        // have not been updated if the process is killed after migrating
+        // the schema but before finishing remapping in all shards.
+        // Addressing that would require keeping track of the need to remap
+        // in the database instead of just in memory
         let result = pool
-            .configure_fdw(servers.as_ref())
+            .configure_fdw(coord.servers.as_ref())
             .and_then(|()| migrate_schema(&pool.logger, &conn))
-            .and_then(|had_migrations| pool.map_primary())
-            .and_then(|()| pool.map_metadata(servers.as_ref()));
+            .and_then(|had_migrations| {
+                if had_migrations {
+                    coord.propagate_schema_change(&self.shard)
+                } else {
+                    Ok(())
+                }
+            });
         debug!(&pool.logger, "Release migration lock");
         advisory_lock::unlock_migration(&conn).unwrap_or_else(|err| {
             die(&pool.logger, "failed to release migration lock", &err);
@@ -1021,17 +1036,6 @@ impl PoolInner {
         })
     }
 
-    /// Map key tables from the primary into our local schema. If we are the
-    /// primary, set them up as views.
-    ///
-    /// We recreate this mapping on every server start so that migrations that
-    /// change one of the mapped tables actually show up in the imported tables
-    fn map_primary(&self) -> Result<(), StoreError> {
-        info!(&self.logger, "Mapping primary");
-        let conn = self.get()?;
-        conn.transaction(|| ForeignServer::map_primary(&conn, &self.shard))
-    }
-
     /// Copy the data from key tables in the primary into our local schema
     /// so it can be used as a fallback when the primary goes down
     pub async fn mirror_primary_tables(&self) -> Result<(), StoreError> {
@@ -1046,18 +1050,21 @@ impl PoolInner {
         .await
     }
 
-    // Map some tables from the `subgraphs` metadata schema from foreign
-    // servers to ourselves. The mapping is recreated on every server start
-    // so that we pick up possible schema changes in the mappings
-    fn map_metadata(&self, servers: &[ForeignServer]) -> Result<(), StoreError> {
-        info!(&self.logger, "Mapping metadata");
-        let conn = self.get()?;
-        conn.transaction(|| {
-            for server in servers.iter().filter(|server| server.shard != self.shard) {
-                server.map_metadata(&conn)?;
-            }
-            Ok(())
-        })
+    // The foreign server `server` had schema changes, and we therefore need
+    // to remap anything that we are importing via fdw to make sure we are
+    // using this updated schema
+    fn remap(&self, server: &ForeignServer) -> Result<(), StoreError> {
+        if &server.shard == &*PRIMARY_SHARD {
+            info!(&self.logger, "Mapping primary");
+            let conn = self.get()?;
+            conn.transaction(|| ForeignServer::map_primary(&conn, &self.shard))?;
+        }
+        if &server.shard != &self.shard {
+            info!(&self.logger, "Mapping metadata");
+            let conn = self.get()?;
+            conn.transaction(|| server.map_metadata(&conn))?;
+        }
+        Ok(())
     }
 }
 
@@ -1100,4 +1107,73 @@ fn migrate_schema(logger: &Logger, conn: &PgConnection) -> Result<bool, StoreErr
     }
 
     Ok(had_migrations)
+}
+
+/// Helper to coordinate propagating schema changes from the database that
+/// changes schema to all other shards so they can update their fdw mappings
+/// of tables imported from that shard
+pub struct PoolCoordinator {
+    pools: Mutex<HashMap<Shard, Arc<PoolInner>>>,
+    servers: Arc<Vec<ForeignServer>>,
+}
+
+impl PoolCoordinator {
+    pub fn new(servers: Arc<Vec<ForeignServer>>) -> Self {
+        Self {
+            pools: Mutex::new(HashMap::new()),
+            servers,
+        }
+    }
+
+    pub fn create_pool(
+        self: Arc<Self>,
+        logger: &Logger,
+        name: &str,
+        pool_name: PoolName,
+        postgres_url: String,
+        pool_size: u32,
+        fdw_pool_size: Option<u32>,
+        registry: Arc<dyn MetricsRegistry>,
+    ) -> ConnectionPool {
+        let pool = ConnectionPool::create(
+            name,
+            pool_name,
+            postgres_url,
+            pool_size,
+            fdw_pool_size,
+            logger,
+            registry,
+            self.cheap_clone(),
+        );
+        // It is safe to take this lock here since nobody has seen the pool
+        // yet. We remember the `PoolInner` so that later, when we have to
+        // call `remap()`, we do not have to take this lock as that will be
+        // already held in `get_ready()`
+        match &*pool.inner.lock(logger) {
+            PoolState::Created(inner, _) | PoolState::Ready(inner) => {
+                self.pools
+                    .lock()
+                    .unwrap()
+                    .insert(pool.shard.clone(), inner.clone());
+            }
+            PoolState::Disabled => { /* nothing to do */ }
+        }
+        pool
+    }
+
+    /// Propagate changes to the schema in `shard` to all other pools. Those
+    /// other pools will then recreate any tables that they imported from
+    /// `shard`
+    fn propagate_schema_change(&self, shard: &Shard) -> Result<(), StoreError> {
+        let server = self
+            .servers
+            .iter()
+            .find(|server| &server.shard == shard)
+            .ok_or_else(|| constraint_violation!("unknown shard {shard}"))?;
+
+        for pool in self.pools.lock().unwrap().values() {
+            pool.remap(server)?;
+        }
+        Ok(())
+    }
 }

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -41,7 +41,7 @@ impl TablePair {
         let dst = src.new_like(&layout.site.namespace, &new_name);
 
         let mut query = String::new();
-        if catalog::table_exists(conn, &layout.site.namespace, &dst.name)? {
+        if catalog::table_exists(conn, layout.site.namespace.as_str(), &dst.name)? {
             writeln!(query, "truncate table {nsp}.{new_name};")?;
         } else {
             dst.create_table(&mut query, layout)?;


### PR DESCRIPTION
In the hosted service, restarting a node can take a long time. That can be almost entirely attributed to the fact that we rebuild the fdw mappings between shards on every start, and sometimes nodes have to wait for other activity to stop before that rebuild can happen. We rebuild the mappings on every start since we don't properly propagate whether the schema in a shard was changed to the other shards that import tables from that shard.

With this PR, the fdw mappings are only rebuilt if there were actually schema changes, i.e., in the vast majority of cases the rebuild can be skipped and startups will be much faster.

Since interrupting `graph-node` startup at the wrong time (right after migrations ran but before remapping is done) can cause fdw mappings to not be updated, `graphman` now has a command `graphman database remap` to kick off remapping manually. 

It also now has a command `graphman database migrate` to apply schema migrations, though `graph-node` still does that on startup.