### PR TITLE
store: Use a different locking strategy for deployments

### DIFF
--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -1,7 +1,7 @@
 //! Utilities for dealing with deployment metadata. Any connection passed
 //! into these methods must be for the shard that holds the actual
 //! deployment data and metadata
-use crate::{detail::GraphNodeVersion, primary::DeploymentId};
+use crate::{advisory_lock, detail::GraphNodeVersion, primary::DeploymentId};
 use diesel::{
     connection::SimpleConnection,
     dsl::{count, delete, insert_into, select, sql, update},
@@ -1043,18 +1043,11 @@ pub fn set_earliest_block(
     Ok(())
 }
 
-/// Lock the row for `site` in `subgraph_deployment` for update for the
-/// remainder of the current transaction. This lock is used to coordinate
-/// the changes that the subgraph writer makes with changes that other parts
-/// of the system, in particular, pruning make
+/// Lock the deployment `site` for writes for the remainder of the current
+/// transaction. This lock is used to coordinate the changes that the
+/// subgraph writer makes with changes that other parts of the system, in
+/// particular, pruning make
 //  see also: deployment-lock-for-update
 pub fn lock(conn: &PgConnection, site: &Site) -> Result<(), StoreError> {
-    use subgraph_deployment as d;
-
-    d::table
-        .select(d::id)
-        .filter(d::id.eq(site.id))
-        .for_update()
-        .get_result::<DeploymentId>(conn)?;
-    Ok(())
+    advisory_lock::lock_deployment_xact(conn, site)
 }


### PR DESCRIPTION
We used 'select for update' to lock a deployment against concurrent writes. It seems that that has bad consequences for performance in general; advisory locks are more lightweight than locking table rows, hopefully using them here will help write performance.

