### PR TITLE
Code reuse between `graphman` and `graph-node`

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -16,7 +16,7 @@ use graph_graphql::prelude::GraphQlRunner;
 use graph_node::config::{self, Config as Cfg};
 use graph_node::manager::commands;
 use graph_node::{
-    chain::create_ethereum_networks,
+    chain::create_all_ethereum_networks,
     manager::{deployment::DeploymentSearch, PanicSubscriptionManager},
     store_builder::StoreBuilder,
     MetricsContext,
@@ -699,7 +699,7 @@ impl Context {
     async fn ethereum_networks(&self) -> anyhow::Result<EthereumNetworks> {
         let logger = self.logger.clone();
         let registry = self.metrics_registry();
-        create_ethereum_networks(logger, registry, &self.config).await
+        create_all_ethereum_networks(logger, registry, &self.config).await
     }
 
     fn chain_store(self, chain_name: &str) -> anyhow::Result<Arc<ChainStore>> {

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 // The status of a provider that we learned from connecting to it
 #[derive(PartialEq)]
-enum ProviderNetworkStatus {
+pub enum ProviderNetworkStatus {
     Broken {
         chain_id: String,
         provider: String,

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -1,6 +1,6 @@
 use crate::config::{Config, ProviderDetails};
 use ethereum::{EthereumNetworks, ProviderEthRpcMetrics};
-use futures::future::join_all;
+use futures::future::{join_all, try_join_all};
 use futures::TryFutureExt;
 use graph::anyhow::Error;
 use graph::blockchain::{Block as BlockchainBlock, BlockchainKind, ChainIdentifier};
@@ -100,64 +100,6 @@ pub fn create_ipfs_clients(logger: &Logger, ipfs_addresses: &Vec<String>) -> Vec
             ipfs_client
         })
         .collect()
-}
-
-/// Parses an Ethereum connection string and returns the network name and Ethereum adapter.
-pub async fn create_ethereum_networks(
-    logger: Logger,
-    registry: Arc<dyn MetricsRegistryTrait>,
-    config: &Config,
-) -> Result<EthereumNetworks, anyhow::Error> {
-    let eth_rpc_metrics = Arc::new(ProviderEthRpcMetrics::new(registry));
-    let mut parsed_networks = EthereumNetworks::new();
-    for (name, chain) in &config.chains.chains {
-        if chain.protocol != BlockchainKind::Ethereum {
-            continue;
-        }
-
-        for provider in &chain.providers {
-            if let ProviderDetails::Web3(web3) = &provider.details {
-                let capabilities = web3.node_capabilities();
-
-                let logger = logger.new(o!("provider" => provider.label.clone()));
-                info!(
-                    logger,
-                    "Creating transport";
-                    "url" => &web3.url,
-                    "capabilities" => capabilities
-                );
-
-                use crate::config::Transport::*;
-
-                let transport = match web3.transport {
-                    Rpc => Transport::new_rpc(Url::parse(&web3.url)?, web3.headers.clone()),
-                    Ipc => Transport::new_ipc(&web3.url).await,
-                    Ws => Transport::new_ws(&web3.url).await,
-                };
-
-                let supports_eip_1898 = !web3.features.contains("no_eip1898");
-
-                parsed_networks.insert(
-                    name.to_string(),
-                    capabilities,
-                    Arc::new(
-                        graph_chain_ethereum::EthereumAdapter::new(
-                            logger,
-                            provider.label.clone(),
-                            &web3.url,
-                            transport,
-                            eth_rpc_metrics.clone(),
-                            supports_eip_1898,
-                        )
-                        .await,
-                    ),
-                    web3.limit_for(&config.node),
-                );
-            }
-        }
-    }
-    parsed_networks.sort();
-    Ok(parsed_networks)
 }
 
 pub fn create_substreams_networks(
@@ -421,9 +363,95 @@ where
     (firehose_networks, idents)
 }
 
+/// Parses all Ethereum connection strings and returns their network names and
+/// `EthereumAdapter`.
+pub async fn create_all_ethereum_networks(
+    logger: Logger,
+    registry: Arc<dyn MetricsRegistryTrait>,
+    config: &Config,
+) -> anyhow::Result<EthereumNetworks> {
+    let eth_rpc_metrics = Arc::new(ProviderEthRpcMetrics::new(registry));
+    let eth_networks_futures = config
+        .chains
+        .chains
+        .iter()
+        .filter(|(_, chain)| chain.protocol == BlockchainKind::Ethereum)
+        .map(|(name, _)| {
+            create_ethereum_networks_for_chain(&logger, eth_rpc_metrics.clone(), config, name)
+        });
+
+    Ok(try_join_all(eth_networks_futures)
+        .await?
+        .into_iter()
+        .reduce(|mut a, b| {
+            a.extend(b);
+            a
+        })
+        .unwrap_or_else(|| EthereumNetworks::new()))
+}
+
+/// Parses a single Ethereum connection string and returns its network name and `EthereumAdapter`.
+pub async fn create_ethereum_networks_for_chain(
+    logger: &Logger,
+    eth_rpc_metrics: Arc<ProviderEthRpcMetrics>,
+    config: &Config,
+    network_name: &str,
+) -> anyhow::Result<EthereumNetworks> {
+    let mut parsed_networks = EthereumNetworks::new();
+    let chain = config
+        .chains
+        .chains
+        .get(network_name)
+        .ok_or_else(|| anyhow!("unknown network {}", network_name))?;
+
+    for provider in &chain.providers {
+        if let ProviderDetails::Web3(web3) = &provider.details {
+            let capabilities = web3.node_capabilities();
+
+            let logger = logger.new(o!("provider" => provider.label.clone()));
+            info!(
+                logger,
+                "Creating transport";
+                "url" => &web3.url,
+                "capabilities" => capabilities
+            );
+
+            use crate::config::Transport::*;
+
+            let transport = match web3.transport {
+                Rpc => Transport::new_rpc(Url::parse(&web3.url)?, web3.headers.clone()),
+                Ipc => Transport::new_ipc(&web3.url).await,
+                Ws => Transport::new_ws(&web3.url).await,
+            };
+
+            let supports_eip_1898 = !web3.features.contains("no_eip1898");
+
+            parsed_networks.insert(
+                network_name.to_string(),
+                capabilities,
+                Arc::new(
+                    graph_chain_ethereum::EthereumAdapter::new(
+                        logger,
+                        provider.label.clone(),
+                        &web3.url,
+                        transport,
+                        eth_rpc_metrics.clone(),
+                        supports_eip_1898,
+                    )
+                    .await,
+                ),
+                web3.limit_for(&config.node),
+            );
+        }
+    }
+
+    parsed_networks.sort();
+    Ok(parsed_networks)
+}
+
 #[cfg(test)]
 mod test {
-    use crate::chain::create_ethereum_networks;
+    use crate::chain::create_all_ethereum_networks;
     use crate::config::{Config, Opt};
     use graph::log::logger;
     use graph::prelude::tokio;
@@ -462,7 +490,7 @@ mod test {
             prometheus_registry.clone(),
         ));
 
-        let ethereum_networks = create_ethereum_networks(logger, metrics_registry, &config)
+        let ethereum_networks = create_all_ethereum_networks(logger, metrics_registry, &config)
             .await
             .expect("Correctly parse Ethereum network args");
         let mut network_names = ethereum_networks.networks.keys().collect::<Vec<&String>>();

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -26,7 +26,7 @@ use graph_core::{
 };
 use graph_graphql::prelude::GraphQlRunner;
 use graph_node::chain::{
-    connect_ethereum_networks, connect_firehose_networks, create_ethereum_networks,
+    connect_ethereum_networks, connect_firehose_networks, create_all_ethereum_networks,
     create_firehose_networks, create_ipfs_clients, create_substreams_networks,
 };
 use graph_node::config::Config;
@@ -223,7 +223,7 @@ async fn main() {
     let eth_networks = if query_only {
         EthereumNetworks::new()
     } else {
-        create_ethereum_networks(logger.clone(), metrics_registry.clone(), &config)
+        create_all_ethereum_networks(logger.clone(), metrics_registry.clone(), &config)
             .await
             .expect("Failed to parse Ethereum networks")
     };


### PR DESCRIPTION
https://github.com/graphprotocol/graph-node/pull/3079 introduced some code duplication between `manager/run.rs` and `main.rs`, the intention was to fix things in an upcoming PR but we never came around to it.