### PR TITLE
fix: Ensure retry backoff base is less than ceil

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -57,7 +57,10 @@ where
                 should_try_unfail_non_deterministic: true,
                 synced: false,
                 skip_ptr_updates_timer: Instant::now(),
-                backoff: ExponentialBackoff::new(MINUTE * 2, ENV_VARS.subgraph_error_retry_ceil),
+                backoff: ExponentialBackoff::new(
+                    (MINUTE * 2).min(ENV_VARS.subgraph_error_retry_ceil),
+                    ENV_VARS.subgraph_error_retry_ceil,
+                ),
                 entity_lfu_cache: LfuCache::new(),
             },
             logger,


### PR DESCRIPTION
This can be useful when testing.