### PR TITLE
Revert "fix: Allow grafts to add data sources (#3989)"

### DIFF
--- a/core/src/subgraph/loader.rs
+++ b/core/src/subgraph/loader.rs
@@ -9,8 +9,8 @@ pub async fn load_dynamic_data_sources<C: Blockchain>(
     store: Arc<dyn WritableStore>,
     logger: Logger,
     manifest: &SubgraphManifest<C>,
+    manifest_idx_and_name: Vec<(u32, String)>,
 ) -> Result<Vec<DataSource<C>>, Error> {
-    let manifest_idx_and_name = manifest.template_idx_and_name().collect();
     let start_time = Instant::now();
 
     let mut data_sources: Vec<DataSource<C>> = vec![];

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -552,7 +552,6 @@ async fn create_subgraph_version<C: Blockchain, S: SubgraphStore>(
     version_switching_mode: SubgraphVersionSwitchingMode,
     resolver: &Arc<dyn LinkResolver>,
 ) -> Result<DeploymentLocator, SubgraphRegistrarError> {
-    let raw_string = serde_yaml::to_string(&raw).unwrap();
     let unvalidated = UnvalidatedSubgraphManifest::<C>::resolve(
         deployment,
         raw,
@@ -619,7 +618,7 @@ async fn create_subgraph_version<C: Blockchain, S: SubgraphStore>(
 
     // Apply the subgraph versioning and deployment operations,
     // creating a new subgraph deployment if one doesn't exist.
-    let deployment = DeploymentCreate::new(raw_string, &manifest, start_block)
+    let deployment = DeploymentCreate::new(&manifest, start_block)
         .graft(base_block)
         .debug(debug_fork);
     deployment_store

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -152,13 +152,6 @@ pub trait SubgraphStore: Send + Sync + 'static {
 
     /// Find the deployment locators for the subgraph with the given hash
     fn locators(&self, hash: &str) -> Result<Vec<DeploymentLocator>, StoreError>;
-
-    /// This migrates subgraphs that existed before the raw_yaml column was added.
-    async fn set_manifest_raw_yaml(
-        &self,
-        hash: &DeploymentHash,
-        raw_yaml: String,
-    ) -> Result<(), StoreError>;
 }
 
 pub trait ReadStore: Send + Sync + 'static {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -10,12 +10,13 @@ pub mod status;
 
 pub use features::{SubgraphFeature, SubgraphFeatureValidationError};
 
+use anyhow::ensure;
 use anyhow::{anyhow, Error};
 use futures03::{future::try_join3, stream::FuturesOrdered, TryStreamExt as _};
 use semver::Version;
 use serde::{de, ser};
 use serde_yaml;
-use slog::{info, Logger};
+use slog::{debug, info, Logger};
 use stable_hash::{FieldAddress, StableHash};
 use stable_hash_legacy::SequenceNumber;
 use std::{collections::BTreeSet, marker::PhantomData};
@@ -24,7 +25,6 @@ use wasmparser;
 use web3::types::Address;
 
 use crate::{
-    bail,
     blockchain::{BlockPtr, Blockchain, DataSource as _},
     components::{
         link_resolver::LinkResolver,
@@ -41,7 +41,6 @@ use crate::{
         offchain::OFFCHAIN_KINDS, DataSource, DataSourceTemplate, UnresolvedDataSource,
         UnresolvedDataSourceTemplate,
     },
-    ensure,
     prelude::{r, CheapClone, ENV_VARS},
 };
 
@@ -357,7 +356,7 @@ pub enum SubgraphManifestResolveError {
     #[error("subgraph is not valid YAML")]
     InvalidFormat,
     #[error("resolve error: {0}")]
-    ResolveError(#[from] anyhow::Error),
+    ResolveError(anyhow::Error),
 }
 
 /// Data source contexts are conveniently represented as entities.
@@ -497,7 +496,7 @@ pub struct BaseSubgraphManifest<C, S, D, T> {
 }
 
 /// SubgraphManifest with IPFS links unresolved
-pub type UnresolvedSubgraphManifest<C> = BaseSubgraphManifest<
+type UnresolvedSubgraphManifest<C> = BaseSubgraphManifest<
     C,
     UnresolvedSchema,
     UnresolvedDataSource<C>,
@@ -615,16 +614,35 @@ impl<C: Blockchain> SubgraphManifest<C> {
     /// Entry point for resolving a subgraph definition.
     pub async fn resolve_from_raw(
         id: DeploymentHash,
-        raw: serde_yaml::Mapping,
+        mut raw: serde_yaml::Mapping,
         resolver: &Arc<dyn LinkResolver>,
         logger: &Logger,
         max_spec_version: semver::Version,
     ) -> Result<Self, SubgraphManifestResolveError> {
-        let unresolved = UnresolvedSubgraphManifest::parse(id, raw)?;
+        // Inject the IPFS hash as the ID of the subgraph into the definition.
+        raw.insert("id".into(), id.to_string().into());
+
+        // Parse the YAML data into an UnresolvedSubgraphManifest
+        let unresolved: UnresolvedSubgraphManifest<C> = serde_yaml::from_value(raw.into())?;
+
+        debug!(logger, "Features {:?}", unresolved.features);
 
         let resolved = unresolved
             .resolve(resolver, logger, max_spec_version)
-            .await?;
+            .await
+            .map_err(SubgraphManifestResolveError::ResolveError)?;
+
+        if (resolved.spec_version < SPEC_VERSION_0_0_7)
+            && resolved
+                .data_sources
+                .iter()
+                .any(|ds| OFFCHAIN_KINDS.contains(&ds.kind()))
+        {
+            return Err(SubgraphManifestResolveError::ResolveError(anyhow!(
+                "Offchain data sources not supported prior to {}",
+                SPEC_VERSION_0_0_7
+            )));
+        }
 
         Ok(resolved)
     }
@@ -667,37 +685,15 @@ impl<C: Blockchain> SubgraphManifest<C> {
     ) -> Result<UnifiedMappingApiVersion, DifferentMappingApiVersions> {
         UnifiedMappingApiVersion::try_from_versions(self.api_versions())
     }
-
-    pub fn template_idx_and_name(&self) -> impl Iterator<Item = (u32, String)> + '_ {
-        // We cannot include static data sources in the map because a static data source and a
-        // template may have the same name in the manifest. Duplicated with
-        // `UnresolvedSubgraphManifest::template_idx_and_name`.
-        let ds_len = self.data_sources.len() as u32;
-        self.templates
-            .iter()
-            .map(|t| t.name().to_owned())
-            .enumerate()
-            .map(move |(idx, name)| (ds_len + idx as u32, name))
-    }
 }
 
 impl<C: Blockchain> UnresolvedSubgraphManifest<C> {
-    pub fn parse(
-        id: DeploymentHash,
-        mut raw: serde_yaml::Mapping,
-    ) -> Result<Self, SubgraphManifestResolveError> {
-        // Inject the IPFS hash as the ID of the subgraph into the definition.
-        raw.insert("id".into(), id.to_string().into());
-
-        serde_yaml::from_value(raw.into()).map_err(Into::into)
-    }
-
     pub async fn resolve(
         self,
         resolver: &Arc<dyn LinkResolver>,
         logger: &Logger,
         max_spec_version: semver::Version,
-    ) -> Result<SubgraphManifest<C>, SubgraphManifestResolveError> {
+    ) -> Result<SubgraphManifest<C>, anyhow::Error> {
         let UnresolvedSubgraphManifest {
             id,
             spec_version,
@@ -718,14 +714,14 @@ impl<C: Blockchain> UnresolvedSubgraphManifest<C> {
                 max_spec_version,
                 id,
                 spec_version
-            ).into());
+            ));
         }
 
         let ds_count = data_sources.len();
         if ds_count as u64 + templates.len() as u64 > u32::MAX as u64 {
-            return Err(
-                anyhow!("Subgraph has too many declared data sources and templates",).into(),
-            );
+            return Err(anyhow!(
+                "Subgraph has too many declared data sources and templates",
+            ));
         }
 
         let (schema, data_sources, templates) = try_join3(
@@ -755,17 +751,6 @@ impl<C: Blockchain> UnresolvedSubgraphManifest<C> {
                 "The maximum supported mapping API version of this indexer is {}, but `{}` was found",
                 ENV_VARS.mappings.max_api_version,
                 ds.api_version()
-            );
-        }
-
-        if spec_version < SPEC_VERSION_0_0_7
-            && data_sources
-                .iter()
-                .any(|ds| OFFCHAIN_KINDS.contains(&ds.kind()))
-        {
-            bail!(
-                "Offchain data sources not supported prior to {}",
-                SPEC_VERSION_0_0_7
             );
         }
 

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -1,6 +1,6 @@
 //! Entity types that contain the graph-node state.
 
-use anyhow::{anyhow, bail, Error};
+use anyhow::{anyhow, Error};
 use hex;
 use lazy_static::lazy_static;
 use rand::rngs::OsRng;
@@ -110,12 +110,11 @@ pub struct DeploymentCreate {
 
 impl DeploymentCreate {
     pub fn new(
-        raw_manifest: String,
         source_manifest: &SubgraphManifest<impl Blockchain>,
         earliest_block: Option<BlockPtr>,
     ) -> Self {
         Self {
-            manifest: SubgraphManifestEntity::new(raw_manifest, source_manifest),
+            manifest: SubgraphManifestEntity::from(source_manifest),
             earliest_block: earliest_block.cheap_clone(),
             graft_base: None,
             graft_block: None,
@@ -164,51 +163,17 @@ pub struct SubgraphManifestEntity {
     pub repository: Option<String>,
     pub features: Vec<String>,
     pub schema: String,
-    pub raw_yaml: Option<String>,
 }
 
-impl SubgraphManifestEntity {
-    pub fn new(raw_yaml: String, manifest: &super::SubgraphManifest<impl Blockchain>) -> Self {
+impl<'a, C: Blockchain> From<&'a super::SubgraphManifest<C>> for SubgraphManifestEntity {
+    fn from(manifest: &'a super::SubgraphManifest<C>) -> Self {
         Self {
             spec_version: manifest.spec_version.to_string(),
             description: manifest.description.clone(),
             repository: manifest.repository.clone(),
             features: manifest.features.iter().map(|f| f.to_string()).collect(),
             schema: manifest.schema.document.clone().to_string(),
-            raw_yaml: Some(raw_yaml),
         }
-    }
-
-    pub fn template_idx_and_name(&self) -> Result<Vec<(i32, String)>, Error> {
-        #[derive(Debug, Deserialize)]
-        struct MinimalDs {
-            name: String,
-        }
-        #[derive(Debug, Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct MinimalManifest {
-            data_sources: Vec<MinimalDs>,
-            #[serde(default)]
-            templates: Vec<MinimalDs>,
-        }
-
-        let raw_yaml = match &self.raw_yaml {
-            Some(raw_yaml) => raw_yaml,
-            None => bail!("raw_yaml not present"),
-        };
-
-        let manifest: MinimalManifest = serde_yaml::from_str(raw_yaml)?;
-
-        let ds_len = manifest.data_sources.len() as i32;
-        let template_idx_and_name = manifest
-            .templates
-            .iter()
-            .map(|t| t.name.to_owned())
-            .enumerate()
-            .map(move |(idx, name)| (ds_len + idx as i32, name))
-            .collect();
-
-        Ok(template_idx_and_name)
     }
 }
 

--- a/graph/src/util/error.rs
+++ b/graph/src/util/error.rs
@@ -17,12 +17,3 @@ macro_rules! ensure {
         }
     };
 }
-
-// `bail!` from `anyhow`, but calling `from`.
-// For context see https://github.com/dtolnay/anyhow/issues/112#issuecomment-704549251.
-#[macro_export]
-macro_rules! bail {
-    ($($err:tt)*) => {
-        return Err(anyhow::anyhow!($($err)*).into());
-    };
-}

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -267,7 +267,7 @@ async fn insert_test_entities(
     manifest: SubgraphManifest<graph_chain_ethereum::Chain>,
     id_type: IdType,
 ) -> DeploymentLocator {
-    let deployment = DeploymentCreate::new(String::new(), &manifest, None);
+    let deployment = DeploymentCreate::new(&manifest, None);
     let name = SubgraphName::new(manifest.id.as_str()).unwrap();
     let node_id = NodeId::new("test").unwrap();
     let deployment = store

--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -672,8 +672,6 @@ pub struct Connection {
     src: Arc<Layout>,
     dst: Arc<Layout>,
     target_block: BlockPtr,
-    src_manifest_idx_and_name: Vec<(i32, String)>,
-    dst_manifest_idx_and_name: Vec<(i32, String)>,
 }
 
 impl Connection {
@@ -689,8 +687,6 @@ impl Connection {
         src: Arc<Layout>,
         dst: Arc<Layout>,
         target_block: BlockPtr,
-        src_manifest_idx_and_name: Vec<(i32, String)>,
-        dst_manifest_idx_and_name: Vec<(i32, String)>,
     ) -> Result<Self, StoreError> {
         let logger = logger.new(o!("dst" => dst.site.namespace.to_string()));
 
@@ -716,8 +712,6 @@ impl Connection {
             src,
             dst,
             target_block,
-            src_manifest_idx_and_name,
-            dst_manifest_idx_and_name,
         })
     }
 
@@ -734,8 +728,6 @@ impl Connection {
                 &self.conn,
                 &DataSourcesTable::new(state.dst.site.namespace.clone()),
                 state.target_block.number,
-                &self.src_manifest_idx_and_name,
-                &self.dst_manifest_idx_and_name,
             )?;
         }
         Ok(())

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1323,15 +1323,6 @@ impl DeploymentStore {
                     dst.catalog.site.namespace
                 );
 
-                let src_manifest_idx_and_name = self
-                    .load_deployment(&src.site)?
-                    .manifest
-                    .template_idx_and_name()?;
-                let dst_manifest_idx_and_name = self
-                    .load_deployment(&dst.site)?
-                    .manifest
-                    .template_idx_and_name()?;
-
                 // Copy subgraph data
                 // We allow both not copying tables at all from the source, as well
                 // as adding new tables in `self`; we only need to check that tables
@@ -1343,8 +1334,6 @@ impl DeploymentStore {
                     src.clone(),
                     dst.clone(),
                     block.clone(),
-                    src_manifest_idx_and_name,
-                    dst_manifest_idx_and_name,
                 )?;
                 let status = copy_conn.copy_data()?;
                 if status == crate::copy::Status::Cancelled {
@@ -1605,17 +1594,6 @@ impl DeploymentStore {
         let id = site.id.clone();
         self.with_conn(move |conn, _| deployment::health(conn, id).map_err(Into::into))
             .await
-    }
-
-    pub(crate) async fn set_manifest_raw_yaml(
-        &self,
-        site: Arc<Site>,
-        raw_yaml: String,
-    ) -> Result<(), StoreError> {
-        self.with_conn(move |conn, _| {
-            deployment::set_manifest_raw_yaml(&conn, &site, &raw_yaml).map_err(Into::into)
-        })
-        .await
     }
 }
 

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -340,7 +340,6 @@ struct StoredSubgraphManifest {
     use_bytea_prefix: bool,
     start_block_number: Option<i32>,
     start_block_hash: Option<Bytes>,
-    raw_yaml: Option<String>,
 }
 
 impl From<StoredSubgraphManifest> for SubgraphManifestEntity {
@@ -351,7 +350,6 @@ impl From<StoredSubgraphManifest> for SubgraphManifestEntity {
             repository: value.repository,
             features: value.features,
             schema: value.schema,
-            raw_yaml: value.raw_yaml,
         }
     }
 }

--- a/store/postgres/src/dynds/private.rs
+++ b/store/postgres/src/dynds/private.rs
@@ -8,7 +8,6 @@ use diesel::{
 };
 
 use graph::{
-    anyhow::Context,
     components::store::StoredDynamicDataSource,
     constraint_violation,
     prelude::{serde_json, BlockNumber, StoreError},
@@ -207,8 +206,6 @@ impl DataSourcesTable {
         conn: &PgConnection,
         dst: &DataSourcesTable,
         target_block: BlockNumber,
-        src_manifest_idx_and_name: &[(i32, String)],
-        dst_manifest_idx_and_name: &[(i32, String)],
     ) -> Result<usize, StoreError> {
         // Check if there are any data sources for dst which indicates we already copied
         let count = dst.table.clone().count().get_result::<i64>(conn)?;
@@ -216,71 +213,30 @@ impl DataSourcesTable {
             return Ok(count as usize);
         }
 
-        type Tuple = (
-            (Bound<i32>, Bound<i32>),
-            i32,
-            Option<Vec<u8>>,
-            Option<serde_json::Value>,
-            i32,
+        let query = format!(
+            "\
+            insert into {dst}(block_range, causality_region, manifest_idx, parent, id, param, context)
+            select case
+                when upper(e.block_range) <= $1 then e.block_range
+                else int4range(lower(e.block_range), null)
+            end,
+            e.causality_region, e.manifest_idx, e.parent, e.id, e.param, e.context
+            from {src} e
+            where lower(e.block_range) <= $1
+            ",
+            src = self.qname,
+            dst = dst.qname
         );
 
-        let src_tuples = self
-            .table
-            .clone()
-            .filter(diesel::dsl::sql("lower(block_range) <= ").bind::<Integer, _>(target_block))
-            .select((
-                &self.block_range,
-                &self.manifest_idx,
-                &self.param,
-                &self.context,
-                &self.causality_region,
-            ))
-            .order_by(&self.vid)
-            .load::<Tuple>(conn)?;
+        let count = sql_query(&query)
+            .bind::<Integer, _>(target_block)
+            .execute(conn)?;
 
-        let mut count = 0;
-        for (block_range, src_manifest_idx, param, context, causality_region) in src_tuples {
-            let name = &src_manifest_idx_and_name
-                .iter()
-                .find(|(idx, _)| idx == &src_manifest_idx)
-                .context("manifest_idx not found in src")?
-                .1;
-            let dst_manifest_idx = dst_manifest_idx_and_name
-                .iter()
-                .find(|(_, n)| n == name)
-                .context("name not found in dst")?
-                .0;
-
-            let query = format!(
-                "\
-            insert into {dst}(block_range, manifest_idx, param, context, causality_region)
-            values(case
-                when upper($2) <= $1 then $2
-                else int4range(lower($2), null)
-            end,
-            $3, $4, $5, $6)
-            ",
-                dst = dst.qname
-            );
-
-            count += sql_query(&query)
-                .bind::<Integer, _>(target_block)
-                .bind::<sql_types::Range<Integer>, _>(block_range)
-                .bind::<Integer, _>(dst_manifest_idx)
-                .bind::<Nullable<Binary>, _>(param)
-                .bind::<Nullable<Jsonb>, _>(context)
-                .bind::<Integer, _>(causality_region)
-                .execute(conn)?;
-        }
-
-        // If the manifest idxes remained constant, we can test that both tables have the same
-        // contents.
-        if src_manifest_idx_and_name == dst_manifest_idx_and_name {
-            debug_assert!(
-                self.load(conn, target_block).map_err(|e| e.to_string())
-                    == dst.load(conn, target_block).map_err(|e| e.to_string())
-            );
-        }
+        // Test that both tables have the same contents.
+        debug_assert!(
+            self.load(conn, target_block).map_err(|e| e.to_string())
+                == dst.load(conn, target_block).map_err(|e| e.to_string())
+        );
 
         Ok(count)
     }

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -27,9 +27,8 @@ use graph::{
     prelude::{
         anyhow, futures03::future::join_all, lazy_static, o, web3::types::Address, ApiSchema,
         ApiVersion, BlockHash, BlockNumber, BlockPtr, ChainStore, DeploymentHash, EntityOperation,
-        Logger, MetricsRegistry, NodeId, PartialBlockPtr, Schema, StoreError,
-        SubgraphDeploymentEntity, SubgraphName, SubgraphStore as SubgraphStoreTrait,
-        SubgraphVersionSwitchingMode,
+        Logger, MetricsRegistry, NodeId, PartialBlockPtr, Schema, StoreError, SubgraphName,
+        SubgraphStore as SubgraphStoreTrait, SubgraphVersionSwitchingMode,
     },
     url::Url,
     util::timed_cache::TimedCache,
@@ -1093,11 +1092,6 @@ impl SubgraphStoreInner {
             .prune(reporter, site, earliest_block, reorg_threshold, prune_ratio)
             .await
     }
-
-    pub fn load_deployment(&self, site: &Site) -> Result<SubgraphDeploymentEntity, StoreError> {
-        let src_store = self.for_site(site)?;
-        src_store.load_deployment(site)
-    }
 }
 
 struct EnsLookup {
@@ -1291,14 +1285,5 @@ impl SubgraphStoreTrait for SubgraphStore {
             .iter()
             .map(|site| site.into())
             .collect())
-    }
-
-    async fn set_manifest_raw_yaml(
-        &self,
-        hash: &DeploymentHash,
-        raw_yaml: String,
-    ) -> Result<(), StoreError> {
-        let (store, site) = self.store(hash)?;
-        store.set_manifest_raw_yaml(site, raw_yaml).await
     }
 }

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -144,10 +144,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
     };
 
     // Create SubgraphDeploymentEntity
-    let mut yaml = serde_yaml::Mapping::new();
-    yaml.insert("dataSources".into(), Vec::<serde_yaml::Value>::new().into());
-    let yaml = serde_yaml::to_string(&yaml).unwrap();
-    let deployment = DeploymentCreate::new(yaml, &manifest, None);
+    let deployment = DeploymentCreate::new(&manifest, None);
     let name = SubgraphName::new("test/graft").unwrap();
     let node_id = NodeId::new("test").unwrap();
     let deployment = store

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -170,7 +170,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
     };
 
     // Create SubgraphDeploymentEntity
-    let deployment = DeploymentCreate::new(String::new(), &manifest, None);
+    let deployment = DeploymentCreate::new(&manifest, None);
     let name = SubgraphName::new("test/store").unwrap();
     let node_id = NodeId::new("test").unwrap();
     let deployment = store
@@ -1296,8 +1296,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             chain: PhantomData,
         };
 
-        let deployment =
-            DeploymentCreate::new(String::new(), &manifest, Some(TEST_BLOCK_0_PTR.clone()));
+        let deployment = DeploymentCreate::new(&manifest, Some(TEST_BLOCK_0_PTR.clone()));
         let name = SubgraphName::new("test/entity-changes-are-fired").unwrap();
         let node_id = NodeId::new("test").unwrap();
         let deployment = store

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -148,7 +148,7 @@ fn create_subgraph() {
             templates: vec![],
             chain: PhantomData,
         };
-        let deployment = DeploymentCreate::new(String::new(), &manifest, None);
+        let deployment = DeploymentCreate::new(&manifest, None);
         let node_id = NodeId::new("left").unwrap();
 
         let (deployment, events) = tap_store_events(|| {

--- a/store/postgres/tests/writable.rs
+++ b/store/postgres/tests/writable.rs
@@ -47,7 +47,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
     };
 
     // Create SubgraphDeploymentEntity
-    let deployment = DeploymentCreate::new(String::new(), &manifest, None);
+    let deployment = DeploymentCreate::new(&manifest, None);
     let name = SubgraphName::new("test/writable").unwrap();
     let node_id = NodeId::new("test").unwrap();
     let deployment = store

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -167,10 +167,7 @@ pub async fn create_subgraph(
         chain: PhantomData,
     };
 
-    let mut yaml = serde_yaml::Mapping::new();
-    yaml.insert("dataSources".into(), Vec::<serde_yaml::Value>::new().into());
-    let yaml = serde_yaml::to_string(&yaml).unwrap();
-    let deployment = DeploymentCreate::new(yaml, &manifest, None).graft(base);
+    let deployment = DeploymentCreate::new(&manifest, None).graft(base);
     let name = {
         let mut name = subgraph_id.to_string();
         name.truncate(32);

--- a/tests/integration-tests/data-source-revert/grafted.yaml
+++ b/tests/integration-tests/data-source-revert/grafted.yaml
@@ -26,26 +26,6 @@ dataSources:
       blockHandlers:
         - handler: handleBlock
       file: ./src/mapping.ts
-  # Tests that adding a data source is possible in a graft
-  - kind: ethereum/contract
-    name: Contract2
-    network: test
-    source:
-      address: "0xCfEB869F69431e42cdB54A4F4f105C19C080A601"
-      abi: Contract
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.6
-      language: wasm/assemblyscript
-      entities:
-        - Gravatar
-      abis:
-        - name: Contract
-          file: ./abis/Contract.abi
-      callHandlers:
-        - handler: handleBlock
-          function: emitTrigger(uint16)
-      file: ./src/mapping.ts
 templates:
   - kind: ethereum/contract
     name: Template

--- a/tests/integration-tests/typename/subgraph.yaml
+++ b/tests/integration-tests/typename/subgraph.yaml
@@ -13,7 +13,7 @@ dataSources:
       abi: Contract
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.5
       language: wasm/assemblyscript
       entities:
         - ExampleEntity


### PR DESCRIPTION
This reverts commit 3b3b458ecabffcc1006a82bacf2df7f17f2859e5. It's causing existing grafted subgraphs to stop indexing.

Just the migration to add the raw_yaml colum is kept. 