### PR TITLE
graphman: new command to hastly delete a subgraph

### DIFF
--- a/docs/graphman.md
+++ b/docs/graphman.md
@@ -1,0 +1,229 @@
+## Graphman Commands
+
+- [Info](#info)
+- [Remove](#remove)
+- [Unassign](#unassign)
+- [Unused Record](#unused-record)
+- [Unused Remove](#unused-remove)
+
+<a id="info"></a>
+# ⌘ Info
+
+### SYNOPSIS
+
+    Prints the details of a deployment
+
+    The deployment can be specified as either a subgraph name, an IPFS hash `Qm..`, or the database
+    namespace `sgdNNN`. Since the same IPFS hash can be deployed in multiple shards, it is possible to
+    specify the shard by adding `:shard` to the IPFS hash.
+
+    USAGE:
+        graphman --config <CONFIG> info [OPTIONS] <DEPLOYMENT>
+
+    ARGS:
+        <DEPLOYMENT>
+                The deployment (see above)
+
+    OPTIONS:
+        -c, --current
+                List only current version
+
+        -h, --help
+                Print help information
+
+        -p, --pending
+                List only pending versions
+
+        -s, --status
+                Include status information
+
+        -u, --used
+                List only used (current and pending) versions
+
+### DESCRIPTION
+
+The `info` command fetches details for a given deployment from the database.
+
+By default, it shows the following attributes for the deployment:
+
+-   **name**
+-   **status** *(`pending` or `current`)*
+-   **id** *(the `Qm...` identifier for the deployment's subgraph)*
+-   **namespace** *(The database schema which contain's that deployment data tables)*
+-   **shard**
+-   **active** *(If there are multiple entries for the same subgraph, only one of them will be active. That's the one we use for querying)*
+-   **chain**
+-   **graph node id**
+
+### OPTIONS
+
+If the `--status` option is enabled, extra attributes are also returned:
+
+-   **synced*** *(Whether or not the subgraph has synced all the way to the current chain head)*
+-   **health** *(Can be either `healthy`, `unhealthy` (syncing with errors) or `failed`)*
+-   **latest indexed block**
+-   **current chain head block**
+
+### EXAMPLES
+
+Describe a deployment by its name:
+
+    graphman --config config.toml info subgraph-name
+
+Describe a deployment by its hash:
+
+    graphman --config config.toml info QmfWRZCjT8pri4Amey3e3mb2Bga75Vuh2fPYyNVnmPYL66
+
+Describe a deployment with extra info:
+
+    graphman --config config.toml info QmfWRZCjT8pri4Amey3e3mb2Bga75Vuh2fPYyNVnmPYL66 --status
+
+<a id="remove"></a>
+# ⌘ Remove
+
+### SYNOPSIS
+
+    Remove a named subgraph
+
+    USAGE:
+        graphman --config <CONFIG> remove <NAME>
+
+    ARGS:
+        <NAME>    The name of the subgraph to remove
+
+    OPTIONS:
+        -h, --help    Print help information
+
+### DESCRIPTION
+
+Removes the association between a subgraph name and a deployment.
+
+No indexed data is lost as a result of this command.
+
+It is used mostly for stopping query traffic based on the subgraph's name, and to release that name for
+another deployment to use.
+
+### EXAMPLES
+
+Remove a named subgraph:
+
+    graphman --config config.toml remove subgraph-name
+
+<a id="unassign"></a>
+# ⌘ Unassign
+
+#### SYNOPSIS
+
+    Unassign a deployment
+
+    USAGE:
+        graphman --config <CONFIG> unassign <DEPLOYMENT>
+
+    ARGS:
+        <DEPLOYMENT>    The deployment (see `help info`)
+
+    OPTIONS:
+        -h, --help    Print help information
+
+#### DESCRIPTION
+
+Makes `graph-node` stop indexing a deployment permanently.
+
+No indexed data is lost as a result of this command.
+
+Refer to the [Maintenance Documentation](https://github.com/graphprotocol/graph-node/blob/master/docs/maintenance.md#modifying-assignments) for more details about how Graph Node manages its deployment
+assignments.
+
+#### EXAMPLES
+
+Unassign a deployment by its name:
+
+    graphman --config config.toml unassign subgraph-name
+
+Unassign a deployment by its hash:
+
+    graphman --config config.toml unassign QmfWRZCjT8pri4Amey3e3mb2Bga75Vuh2fPYyNVnmPYL66
+
+<a id="unused-record"></a>
+# ⌘ Unused Record
+
+### SYNOPSIS
+
+    graphman-unused-record
+    Update and record currently unused deployments
+
+    USAGE:
+        graphman unused record
+
+    OPTIONS:
+        -h, --help    Print help information
+
+
+### DESCRIPTION
+
+Inspects every shard for unused deployments and registers them in the `unused_deployments` table in the
+primary shard.
+
+No indexed data is lost as a result of this command.
+
+This sub-command is used as previus step towards removing all data from unused subgraphs, followed by
+`graphman unused remove`.
+
+A deployment is unused if it fulfills all of these criteria:
+
+1.  It is not assigned to a node.
+2.  It is either not marked as active or is neither the current or pending version of a subgraph.
+3.  It is not the source of a currently running copy operation
+
+### EXAMPLES
+
+To record all unused deployments:
+
+    graphman --config config.toml unused record
+
+<a id="unused-remove"></a>
+# ⌘ Unused Remove
+
+### SYNOPSIS
+
+    Remove deployments that were marked as unused with `record`.
+
+    Deployments are removed in descending order of number of entities, i.e., smaller deployments are
+    removed before larger ones
+
+    USAGE:
+        graphman unused remove [OPTIONS]
+
+    OPTIONS:
+        -c, --count <COUNT>
+                How many unused deployments to remove (default: all)
+
+        -d, --deployment <DEPLOYMENT>
+                Remove a specific deployment
+
+        -h, --help
+                Print help information
+
+        -o, --older <OLDER>
+                Remove unused deployments that were recorded at least this many minutes ago
+
+### DESCRIPTION
+
+Removes from database all indexed data from deployments previously marked as unused by the `graphman unused
+record` command.
+
+This operation is irreversible.
+
+### EXAMPLES
+
+Remove all unused deployments
+
+    graphman --config config.toml unused remove
+
+Remove all unused deployments older than 12 hours (720 minutes)
+
+    graphman --config config.toml unused remove --older 720
+
+Remove a specific unused deployment
+
+    graphman --config config.toml unused remove --deployment QmfWRZCjT8pri4Amey3e3mb2Bga75Vuh2fPYyNVnmPYL66

--- a/docs/graphman.md
+++ b/docs/graphman.md
@@ -5,6 +5,7 @@
 - [Unassign](#unassign)
 - [Unused Record](#unused-record)
 - [Unused Remove](#unused-remove)
+- [Drop](#drop)
 
 <a id="info"></a>
 # ⌘ Info
@@ -227,3 +228,62 @@ Remove all unused deployments older than 12 hours (720 minutes)
 Remove a specific unused deployment
 
     graphman --config config.toml unused remove --deployment QmfWRZCjT8pri4Amey3e3mb2Bga75Vuh2fPYyNVnmPYL66
+
+<a id="drop"></a>
+# ⌘ Drop
+
+### SYNOPSIS
+
+    Delete a deployment and all it's indexed data
+
+    The deployment can be specified as either a subgraph name, an IPFS hash `Qm..`, or the database
+    namespace `sgdNNN`. Since the same IPFS hash can be deployed in multiple shards, it is possible to
+    specify the shard by adding `:shard` to the IPFS hash.
+
+    USAGE:
+        graphman --config <CONFIG> drop [OPTIONS] <DEPLOYMENT>
+
+    ARGS:
+        <DEPLOYMENT>
+                The deployment identifier
+
+    OPTIONS:
+        -c, --current
+                Search only for current versions
+
+        -f, --force
+                Skip confirmation prompt
+
+        -h, --help
+                Print help information
+
+        -p, --pending
+                Search only for pending versions
+
+        -u, --used
+                Search only for used (current and pending) versions
+
+### DESCRIPTION
+
+Stops, unassigns and remove all data from deployments matching the search term.
+
+This operation is irreversible.
+
+This command is a combination of other graphman commands applied in sequence:
+
+1. `graphman info <search term>`
+2. `graphman unassign <deployment id>`
+3. `graphman remove <deployment name>`
+4. `graphman unused record`
+5. `graphman unused remove <deployment id>`
+
+### EXAMPLES
+
+Stop, unassign and delete all indexed data from a specific deployment by its deployment id
+
+    graphman --config config.toml drop QmfWRZCjT8pri4Amey3e3mb2Bga75Vuh2fPYyNVnmPYL66
+
+
+Stop, unassign and delete all indexed data from a specific deployment by its subgraph name
+
+    graphman --config config.toml drop autor/subgraph-name

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -247,13 +247,13 @@ pub enum Command {
     Drop {
         /// The deployment identifier
         deployment: DeploymentSearch,
-        /// List only current version
+        /// Search only for current version
         #[clap(long, short)]
         current: bool,
-        /// List only pending versions
+        /// Search only for pending versions
         #[clap(long, short)]
         pending: bool,
-        /// List only used (current and pending) versions
+        /// Search only for used (current and pending) versions
         #[clap(long, short)]
         used: bool,
         /// Skip confirmation prompt

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -869,7 +869,7 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
-        Remove { name } => commands::remove::run(ctx.subgraph_store(), name),
+        Remove { name } => commands::remove::run(ctx.subgraph_store(), &name),
         Create { name } => commands::create::run(ctx.subgraph_store(), name),
         Unassign { deployment } => {
             let sender = ctx.notification_sender();

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -256,7 +256,7 @@ pub enum Command {
         /// List only used (current and pending) versions
         #[clap(long, short)]
         used: bool,
-        /// Skips confirmation prompt
+        /// Skip confirmation prompt
         #[clap(long, short)]
         force: bool,
     },

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -256,6 +256,9 @@ pub enum Command {
         /// List only used (current and pending) versions
         #[clap(long, short)]
         used: bool,
+        /// Skips confirmation prompt
+        #[clap(long, short)]
+        force: bool,
     },
 }
 
@@ -1122,6 +1125,7 @@ async fn main() -> anyhow::Result<()> {
             current,
             pending,
             used,
+            force,
         } => {
             let sender = ctx.notification_sender();
             let (store, mut pools) = ctx.store_and_pools();
@@ -1137,6 +1141,7 @@ async fn main() -> anyhow::Result<()> {
                 current,
                 pending,
                 used,
+                force,
             )
             .await
         }

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -1128,11 +1128,9 @@ async fn main() -> anyhow::Result<()> {
             force,
         } => {
             let sender = ctx.notification_sender();
-            let (store, mut pools) = ctx.store_and_pools();
+            let (store, primary_pool) = ctx.store_and_primary();
             let subgraph_store = store.subgraph_store();
-            let primary_pool = pools
-                .remove(&*PRIMARY_SHARD)
-                .expect("there is a primary pool");
+
             commands::drop::run(
                 primary_pool,
                 subgraph_store,

--- a/node/src/manager/commands/drop.rs
+++ b/node/src/manager/commands/drop.rs
@@ -7,7 +7,7 @@ use graph::anyhow::{self, bail};
 use graph_store_postgres::{connection_pool::ConnectionPool, NotificationSender, SubgraphStore};
 use std::sync::Arc;
 
-/// Finds, unassings, record and remove matching deployments.
+/// Finds, unassigns, record and remove matching deployments.
 ///
 /// Asks for confirmation before removing any data.
 /// This is a convenience fuction that to call a series of other graphman commands.

--- a/node/src/manager/commands/drop.rs
+++ b/node/src/manager/commands/drop.rs
@@ -19,6 +19,7 @@ pub async fn run(
     current: bool,
     pending: bool,
     used: bool,
+    skip_confirmation: bool,
 ) -> anyhow::Result<()> {
     // call `graphman info` to find matching deployments
     let deployments = crate::manager::commands::info::find(
@@ -32,7 +33,7 @@ pub async fn run(
         bail!("Found no deployment for search_term: {search_term}")
     } else {
         print_deployments(&deployments);
-        if !prompt_for_confirmation("\nContinue?")? {
+        if !skip_confirmation && !prompt_for_confirmation("\nContinue?")? {
             bail!("Execution aborted by user")
         }
     }

--- a/node/src/manager/commands/drop.rs
+++ b/node/src/manager/commands/drop.rs
@@ -22,13 +22,7 @@ pub async fn run(
     skip_confirmation: bool,
 ) -> anyhow::Result<()> {
     // call `graphman info` to find matching deployments
-    let deployments = crate::manager::commands::info::find(
-        primary_pool.clone(),
-        search_term.clone(),
-        current,
-        pending,
-        used,
-    )?;
+    let deployments = search_term.find(primary_pool.clone(), current, pending, used)?;
     if deployments.is_empty() {
         bail!("Found no deployment for search_term: {search_term}")
     } else {

--- a/node/src/manager/commands/drop.rs
+++ b/node/src/manager/commands/drop.rs
@@ -1,6 +1,7 @@
 use crate::manager::{
     deployment::{Deployment, DeploymentSearch},
     display::List,
+    prompt::prompt_for_confirmation,
 };
 use graph::anyhow::{self, bail};
 use graph_store_postgres::{connection_pool::ConnectionPool, NotificationSender, SubgraphStore};
@@ -27,8 +28,11 @@ pub async fn run(
         bail!("Found no deployment for search_term: {search_term}")
     } else {
         print_deployments(&deployments);
+        if !prompt_for_confirmation("\nContinue?")? {
+            bail!("Execution aborted by user")
+        }
     }
-    // graphman unassign -> so it stops syncing if active
+    // call graphman unassign -> so it stops syncing if active
     crate::manager::commands::assign::unassign(primary_pool, &sender, &search_term).await?;
 
     // graphman remove -> to unregister the subgraph's name

--- a/node/src/manager/commands/drop.rs
+++ b/node/src/manager/commands/drop.rs
@@ -1,0 +1,57 @@
+use crate::manager::deployment::DeploymentSearch;
+use graph::anyhow::{self, bail};
+use graph_store_postgres::{connection_pool::ConnectionPool, NotificationSender, SubgraphStore};
+use std::sync::Arc;
+
+pub async fn run(
+    primary_pool: ConnectionPool,
+    subgraph_store: Arc<SubgraphStore>,
+    sender: Arc<NotificationSender>,
+    deployment: DeploymentSearch,
+    current: bool,
+    pending: bool,
+    used: bool,
+) -> anyhow::Result<()> {
+    // graphman info -> find subgraph
+    let subgraph_names = crate::manager::commands::info::find(
+        primary_pool.clone(),
+        deployment.clone(),
+        current,
+        pending,
+        used,
+    )?;
+    if subgraph_names.is_empty() {
+        bail!("Found no deployment for identifier: {deployment}")
+    } else {
+        println!("Found {} subgraph(s) to remove:", subgraph_names.len());
+        for (idx, deployment) in subgraph_names.iter().enumerate() {
+            println!(
+                "  {}: name={}, deployment={}",
+                idx + 1,
+                deployment.name,
+                deployment.deployment
+            )
+        }
+    }
+    // graphman unassign -> so it stops syncing if active
+    crate::manager::commands::assign::unassign(primary_pool, &sender, &deployment).await?;
+
+    // graphman remove -> to unregister the subgraph's name
+    for deployment in &subgraph_names {
+        crate::manager::commands::remove::run(subgraph_store.clone(), &deployment.name)?;
+    }
+
+    // graphman unused record ->  to register the deployment as unused
+    crate::manager::commands::unused_deployments::record(subgraph_store.clone())?;
+
+    // graphman unused remove -> to remove the deployment's data
+    for deployment in &subgraph_names {
+        crate::manager::commands::unused_deployments::remove(
+            subgraph_store.clone(),
+            1_000_000,
+            Some(&deployment.name),
+            None,
+        )?;
+    }
+    Ok(())
+}

--- a/node/src/manager/commands/drop.rs
+++ b/node/src/manager/commands/drop.rs
@@ -34,7 +34,8 @@ pub async fn run(
     } else {
         print_deployments(&deployments);
         if !skip_confirmation && !prompt_for_confirmation("\nContinue?")? {
-            bail!("Execution aborted by user")
+            println!("Execution aborted by user");
+            return Ok(());
         }
     }
     // call `graphman unassign` to stop any active deployments

--- a/node/src/manager/commands/info.rs
+++ b/node/src/manager/commands/info.rs
@@ -5,7 +5,7 @@ use graph_store_postgres::{connection_pool::ConnectionPool, Store};
 
 use crate::manager::deployment::{Deployment, DeploymentSearch};
 
-fn find(
+pub fn find(
     pool: ConnectionPool,
     search: DeploymentSearch,
     current: bool,

--- a/node/src/manager/commands/info.rs
+++ b/node/src/manager/commands/info.rs
@@ -5,31 +5,6 @@ use graph_store_postgres::{connection_pool::ConnectionPool, Store};
 
 use crate::manager::deployment::{Deployment, DeploymentSearch};
 
-pub fn find(
-    pool: ConnectionPool,
-    search: DeploymentSearch,
-    current: bool,
-    pending: bool,
-    used: bool,
-) -> Result<Vec<Deployment>, anyhow::Error> {
-    let current = current || used;
-    let pending = pending || used;
-
-    let deployments = search.lookup(&pool)?;
-    // Filter by status; if neither `current` or `pending` are set, list
-    // all deployments
-    let deployments: Vec<_> = deployments
-        .into_iter()
-        .filter(|deployment| match (current, pending) {
-            (true, false) => deployment.status == "current",
-            (false, true) => deployment.status == "pending",
-            (true, true) => deployment.status == "current" || deployment.status == "pending",
-            (false, false) => true,
-        })
-        .collect();
-    Ok(deployments)
-}
-
 pub fn run(
     pool: ConnectionPool,
     store: Option<Arc<Store>>,
@@ -38,7 +13,7 @@ pub fn run(
     pending: bool,
     used: bool,
 ) -> Result<(), anyhow::Error> {
-    let deployments = find(pool, search, current, pending, used)?;
+    let deployments = search.find(pool, current, pending, used)?;
     let ids: Vec<_> = deployments.iter().map(|d| d.locator().id).collect();
     let statuses = match store {
         Some(store) => store.status(status::Filter::DeploymentIds(ids))?,

--- a/node/src/manager/commands/mod.rs
+++ b/node/src/manager/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod copy;
 pub mod create;
 pub mod database;
+pub mod drop;
 pub mod index;
 pub mod info;
 pub mod listen;

--- a/node/src/manager/commands/remove.rs
+++ b/node/src/manager/commands/remove.rs
@@ -3,9 +3,8 @@ use std::sync::Arc;
 use graph::prelude::{anyhow, Error, SubgraphName, SubgraphStore as _};
 use graph_store_postgres::SubgraphStore;
 
-pub fn run(store: Arc<SubgraphStore>, name: String) -> Result<(), Error> {
-    let name = SubgraphName::new(name.clone())
-        .map_err(|()| anyhow!("illegal subgraph name `{}`", name))?;
+pub fn run(store: Arc<SubgraphStore>, name: &str) -> Result<(), Error> {
+    let name = SubgraphName::new(name).map_err(|()| anyhow!("illegal subgraph name `{}`", name))?;
 
     println!("Removing subgraph {}", name);
     store.remove_subgraph(name)?;

--- a/node/src/manager/commands/unused_deployments.rs
+++ b/node/src/manager/commands/unused_deployments.rs
@@ -76,7 +76,7 @@ pub fn record(store: Arc<SubgraphStore>) -> Result<(), Error> {
 pub fn remove(
     store: Arc<SubgraphStore>,
     count: usize,
-    deployment: Option<String>,
+    deployment: Option<&str>,
     older: Option<chrono::Duration>,
 ) -> Result<(), Error> {
     let filter = match older {
@@ -88,7 +88,7 @@ pub fn remove(
         None => unused,
         Some(deployment) => unused
             .into_iter()
-            .filter(|u| u.deployment.as_str() == deployment)
+            .filter(|u| &u.deployment == deployment)
             .collect::<Vec<_>>(),
     };
 

--- a/node/src/manager/mod.rs
+++ b/node/src/manager/mod.rs
@@ -9,6 +9,7 @@ pub mod catalog;
 pub mod commands;
 pub mod deployment;
 mod display;
+pub mod prompt;
 
 /// A dummy subscription manager that always panics
 pub struct PanicSubscriptionManager;

--- a/node/src/manager/prompt.rs
+++ b/node/src/manager/prompt.rs
@@ -1,0 +1,17 @@
+use graph::anyhow;
+use std::io::{self, Write};
+
+/// Asks users if they are certain about a certain action.
+pub fn prompt_for_confirmation(prompt: &str) -> anyhow::Result<bool> {
+    print!("{prompt} [y/N] ");
+    io::stdout().flush()?;
+
+    let mut answer = String::new();
+    io::stdin().read_line(&mut answer)?;
+    answer.make_ascii_lowercase();
+
+    match answer.trim() {
+        "y" | "yes" => Ok(true),
+        _ => Ok(false),
+    }
+}


### PR DESCRIPTION
Introduces a new graphman command to promptly delete all data from a deployment, even if it is running.

TODO: 
- [x] Decide the name and placement for this command
- [x] Documentation

