### PR TITLE
fix(server): Make '/subgraphs' return 404

### DIFF
--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -254,8 +254,7 @@ where
             (Method::GET, path @ ["subgraphs", "id", _])
             | (Method::GET, path @ ["subgraphs", "name", _])
             | (Method::GET, path @ ["subgraphs", "name", _, _])
-            | (Method::GET, path @ ["subgraphs", "network", _, _])
-            | (Method::GET, path @ ["subgraphs"]) => {
+            | (Method::GET, path @ ["subgraphs", "network", _, _]) => {
                 let dest = format!("/{}/graphql", path.join("/"));
                 self.handle_temp_redirect(dest).boxed()
             }


### PR DESCRIPTION
Currently it returns a graphiql which returns 404 from all queries. I don't think that's useful for anyone.