### PR TITLE
node: Change short for `graphman prune --history` to `-y`

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -230,7 +230,7 @@ pub enum Command {
         #[clap(long, short, default_value = "0.20")]
         prune_ratio: f64,
         /// How much history to keep in blocks
-        #[clap(long, short, default_value = "10000")]
+        #[clap(long, short = 'y', default_value = "10000")]
         history: usize,
     },
 


### PR DESCRIPTION
Using `-h` here conflicts with the autogenerated help option, and it seems better to keep `-h` for help even though `-y` for history is a bit goofy

The change is necessary since `graphman prune -h ..` panics since `-h` is short for both help and history
