### PR TITLE
Handle rapid deletion and recreation of subgraphs more gracefully

### DIFF
--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -81,7 +81,7 @@ impl<I: SubgraphInstanceManager> SubgraphAssignmentProviderTrait for SubgraphAss
             .remove(&deployment.id)
         {
             // Shut down subgraph processing
-            self.instance_manager.stop_subgraph(deployment);
+            self.instance_manager.stop_subgraph(deployment).await;
             Ok(())
         } else {
             Err(SubgraphAssignmentProviderError::NotRunning(deployment))

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -142,6 +142,10 @@ pub trait SubgraphStore: Send + Sync + 'static {
         deployment: DeploymentId,
     ) -> Result<Arc<dyn WritableStore>, StoreError>;
 
+    /// Initiate a graceful shutdown of the writable that a previous call to
+    /// `writable` might have started
+    async fn stop_subgraph(&self, deployment: &DeploymentLocator) -> Result<(), StoreError>;
+
     /// Return the minimum block pointer of all deployments with this `id`
     /// that we would use to query or copy from; in particular, this will
     /// ignore any instances of this deployment that are in the process of

--- a/graph/src/components/subgraph/instance_manager.rs
+++ b/graph/src/components/subgraph/instance_manager.rs
@@ -16,5 +16,5 @@ pub trait SubgraphInstanceManager: Send + Sync + 'static {
         manifest: serde_yaml::Mapping,
         stop_block: Option<BlockNumber>,
     );
-    fn stop_subgraph(&self, deployment: DeploymentLocator);
+    async fn stop_subgraph(&self, deployment: DeploymentLocator);
 }

--- a/graph/src/util/timed_cache.rs
+++ b/graph/src/util/timed_cache.rs
@@ -90,6 +90,21 @@ impl<K, V> TimedCache<K, V> {
             .find(move |entry| pred(entry.value.as_ref()))
             .map(|entry| entry.value.clone())
     }
+
+    /// Remove an entry from the cache. If there was an entry for `key`,
+    /// return the value associated with it and whether the entry is still
+    /// live
+    pub fn remove<Q: ?Sized>(&self, key: &Q) -> Option<(Arc<V>, bool)>
+    where
+        K: Borrow<Q> + Eq + Hash,
+        Q: Hash + Eq,
+    {
+        self.entries
+            .write()
+            .unwrap()
+            .remove(key)
+            .map(|CacheEntry { value, expires }| (value, expires >= Instant::now()))
+    }
 }
 
 #[test]

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1444,6 +1444,14 @@ impl LayoutCache {
         }
     }
 
+    pub(crate) fn remove(&self, site: &Site) -> Option<Arc<Layout>> {
+        self.entries
+            .lock()
+            .unwrap()
+            .remove(&site.deployment)
+            .map(|CacheEntry { value, expires: _ }| value.clone())
+    }
+
     // Only needed for tests
     #[cfg(debug_assertions)]
     pub(crate) fn clear(&self) {

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1264,6 +1264,16 @@ impl SubgraphStoreTrait for SubgraphStore {
         Ok(writable)
     }
 
+    async fn stop_subgraph(&self, loc: &DeploymentLocator) -> Result<(), StoreError> {
+        // Remove the writable from the cache and stop it
+        let deployment = loc.id.into();
+        let writable = self.writables.lock().unwrap().remove(&deployment);
+        match writable {
+            Some(writable) => writable.stop().await,
+            None => Ok(()),
+        }
+    }
+
     fn is_deployed(&self, id: &DeploymentHash) -> Result<bool, StoreError> {
         match self.site(id) {
             Ok(_) => Ok(true),


### PR DESCRIPTION
In development and similar settings, often a subgraph gets deleted, completely removed and then immediately redeployed. This usually fails because of some internal caches that `graph-node` keeps. This PR removes these failures on indexing nodes. If there are dedicated query nodes, they will still not pick up the deployment until their internal caches get updated (by default in at most 5 minutes) Installations that use a single node, or when the main concern is the index node, will no longer be affected by this cache issue.