### PR TITLE
Forcefully set `DISABLE_BLOCK_INGESTOR=false` for combined nodes

### DIFF
--- a/docker/start
+++ b/docker/start
@@ -90,6 +90,8 @@ start_index_node() {
 }
 
 start_combined_node() {
+    # No valid reason to disable the block ingestor in this case.
+    export DISABLE_BLOCK_INGESTOR=false
     run_graph_node
 }
 


### PR DESCRIPTION
Fixes the regression introduced with https://github.com/graphprotocol/graph-node/pull/3964.