### PR TITLE
Correctly unset `DISABLE_BLOCK_INGESTOR` for `combined-node`'s

### DIFF
--- a/docker/start
+++ b/docker/start
@@ -91,7 +91,7 @@ start_index_node() {
 
 start_combined_node() {
     # No valid reason to disable the block ingestor in this case.
-    export DISABLE_BLOCK_INGESTOR=false
+    unset DISABLE_BLOCK_INGESTOR
     run_graph_node
 }
 


### PR DESCRIPTION
The fix in https://github.com/graphprotocol/graph-node/pull/4046 was not working at all due to wrongful assumptions about `structopt`'s parsing logic.