### PR TITLE
Release notes for `v0.28.1` and `v0.28.2` patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "graph"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-arweave"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "base64-url",
  "diesel",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-common"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-cosmos"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "graph",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-ethereum"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-near"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "base64",
  "diesel",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-substreams"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "graph-core"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "graph-graphql"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1742,14 +1742,14 @@ dependencies = [
 
 [[package]]
 name = "graph-mock"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "graph",
 ]
 
 [[package]]
 name = "graph-node"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-derive"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-test"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "graph",
  "graph-chain-ethereum",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-wasm"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-http"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "futures 0.1.31",
  "graph",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-index-node"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "blake3 1.3.1",
  "either",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-json-rpc"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "graph",
  "jsonrpsee",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-metrics"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "graph",
  "http",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-websocket"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "futures 0.1.31",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "graph-store-postgres"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "graph-tests"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "test-store"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "diesel",
  "graph",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "graph"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-arweave"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "base64-url",
  "diesel",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-common"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-cosmos"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "graph",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-ethereum"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-near"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "base64",
  "diesel",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-substreams"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "graph-core"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "graph-graphql"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1742,14 +1742,14 @@ dependencies = [
 
 [[package]]
 name = "graph-mock"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "graph",
 ]
 
 [[package]]
 name = "graph-node"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-derive"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-test"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "graph",
  "graph-chain-ethereum",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-wasm"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-http"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "futures 0.1.31",
  "graph",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-index-node"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "blake3 1.3.1",
  "either",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-json-rpc"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "graph",
  "jsonrpsee",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-metrics"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "graph",
  "http",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-websocket"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "futures 0.1.31",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "graph-store-postgres"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "graph-tests"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "test-store"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "diesel",
  "graph",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## v0.28.1
+
+
+**Indexers are advised to migrate to `v0.28.1`** and entirely bypass `v0.28.0`.
+
+Fixed a bug which would cause subgraphs to stop syncing under some `graph-node` deployment configurations. [#4046](https://github.com/graphprotocol/graph-node/pull/4046)
+
 ## v0.28.0
 
 #### Upgrade notes
@@ -52,22 +59,22 @@
 
 ### Dependency updates
 
-| Dependency | PR(s) | Old version | Current version |
-|----|----|------|----|
-| `serde_yaml` | [#3746](https://github.com/graphprotocol/graph-node/pull/3746) | `v0.8.24` | `v0.8.26` |
-| `web3` | [#3806](https://github.com/graphprotocol/graph-node/pull/3806) | `2760dbd` | `7f8eb6d` |
-| `clap` | [#3794](https://github.com/graphprotocol/graph-node/pull/3794), [#3848](https://github.com/graphprotocol/graph-node/pull/3848), [#3931](https://github.com/graphprotocol/graph-node/pull/3931) | `v3.2.8` | `3.2.21` |
-| `cid` | [#3824](https://github.com/graphprotocol/graph-node/pull/3824) | `v0.8.5` | `v0.8.6` |
-| `anyhow` | [#3826](https://github.com/graphprotocol/graph-node/pull/3826), [#3841](https://github.com/graphprotocol/graph-node/pull/3841), [#3865](https://github.com/graphprotocol/graph-node/pull/3865), [#3932](https://github.com/graphprotocol/graph-node/pull/3932) | `v1.0.57` | `1.0.65` |
-| `chrono` | [#3827](https://github.com/graphprotocol/graph-node/pull/3827), [#3849](https://github.com/graphprotocol/graph-node/pull/3839), [#3868](https://github.com/graphprotocol/graph-node/pull/3868) | `v0.4.19` | `v0.4.22` |
-| `proc-macro2` | [#3845](https://github.com/graphprotocol/graph-node/pull/3845) | `v1.0.40` | `1.0.43` |
-| `ethabi` | [#3847](https://github.com/graphprotocol/graph-node/pull/3847) | `v17.1.0` | `v17.2.0` |
-| `once_cell` | [#3870](https://github.com/graphprotocol/graph-node/pull/3870) | `v1.13.0` | `v1.13.1` |
-| `either` | [#3869](https://github.com/graphprotocol/graph-node/pull/3869) | `v1.7.0` | `v1.8.0` |
-| `sha2` | [#3904](https://github.com/graphprotocol/graph-node/pull/3904) | `v0.10.2` | `v0.10.5` |
-| `mockall` | [#3776](https://github.com/graphprotocol/graph-node/pull/3776) | `v0.9.1` | removed |
-| `croosbeam` | [#3772](https://github.com/graphprotocol/graph-node/pull/3772) | `v0.8.1` | `v0.8.2` |
-| `async-recursion` | [#3873](https://github.com/graphprotocol/graph-node/pull/3873) | none | `v1.0.0` |
+| Dependency        | PR(s)                                                                                                                                                                                                                                                          | Old version | Current version |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | --------------- |
+| `serde_yaml`      | [#3746](https://github.com/graphprotocol/graph-node/pull/3746)                                                                                                                                                                                                 | `v0.8.24`   | `v0.8.26`       |
+| `web3`            | [#3806](https://github.com/graphprotocol/graph-node/pull/3806)                                                                                                                                                                                                 | `2760dbd`   | `7f8eb6d`       |
+| `clap`            | [#3794](https://github.com/graphprotocol/graph-node/pull/3794), [#3848](https://github.com/graphprotocol/graph-node/pull/3848), [#3931](https://github.com/graphprotocol/graph-node/pull/3931)                                                                 | `v3.2.8`    | `3.2.21`        |
+| `cid`             | [#3824](https://github.com/graphprotocol/graph-node/pull/3824)                                                                                                                                                                                                 | `v0.8.5`    | `v0.8.6`        |
+| `anyhow`          | [#3826](https://github.com/graphprotocol/graph-node/pull/3826), [#3841](https://github.com/graphprotocol/graph-node/pull/3841), [#3865](https://github.com/graphprotocol/graph-node/pull/3865), [#3932](https://github.com/graphprotocol/graph-node/pull/3932) | `v1.0.57`   | `1.0.65`        |
+| `chrono`          | [#3827](https://github.com/graphprotocol/graph-node/pull/3827), [#3849](https://github.com/graphprotocol/graph-node/pull/3839), [#3868](https://github.com/graphprotocol/graph-node/pull/3868)                                                                 | `v0.4.19`   | `v0.4.22`       |
+| `proc-macro2`     | [#3845](https://github.com/graphprotocol/graph-node/pull/3845)                                                                                                                                                                                                 | `v1.0.40`   | `1.0.43`        |
+| `ethabi`          | [#3847](https://github.com/graphprotocol/graph-node/pull/3847)                                                                                                                                                                                                 | `v17.1.0`   | `v17.2.0`       |
+| `once_cell`       | [#3870](https://github.com/graphprotocol/graph-node/pull/3870)                                                                                                                                                                                                 | `v1.13.0`   | `v1.13.1`       |
+| `either`          | [#3869](https://github.com/graphprotocol/graph-node/pull/3869)                                                                                                                                                                                                 | `v1.7.0`    | `v1.8.0`        |
+| `sha2`            | [#3904](https://github.com/graphprotocol/graph-node/pull/3904)                                                                                                                                                                                                 | `v0.10.2`   | `v0.10.5`       |
+| `mockall`         | [#3776](https://github.com/graphprotocol/graph-node/pull/3776)                                                                                                                                                                                                 | `v0.9.1`    | removed         |
+| `croosbeam`       | [#3772](https://github.com/graphprotocol/graph-node/pull/3772)                                                                                                                                                                                                 | `v0.8.1`    | `v0.8.2`        |
+| `async-recursion` | [#3873](https://github.com/graphprotocol/graph-node/pull/3873)                                                                                                                                                                                                 | none        | `v1.0.0`        |
 
 <!--
 ### Leftover PRs from GitHub's auto-generated release notes. We don't care about these.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+## v0.28.2
+
+**Indexers are advised to migrate to `v0.28.2`** and entirely bypass `v0.28.0` and `v0.28.1`.
+
+Fixed a bug which would cause subgraphs to stop syncing under some `graph-node` deployment configurations. [#4046](https://github.com/graphprotocol/graph-node/pull/4046), [#4051](https://github.com/graphprotocol/graph-node/pull/4051)
+
 ## v0.28.1
 
-
-**Indexers are advised to migrate to `v0.28.1`** and entirely bypass `v0.28.0`.
-
-Fixed a bug which would cause subgraphs to stop syncing under some `graph-node` deployment configurations. [#4046](https://github.com/graphprotocol/graph-node/pull/4046)
+Yanked. Please migrate to `v0.28.2`.
 
 ## v0.28.0
 

--- a/chain/arweave/Cargo.toml
+++ b/chain/arweave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-arweave"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [build-dependencies]

--- a/chain/arweave/Cargo.toml
+++ b/chain/arweave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-arweave"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [build-dependencies]

--- a/chain/common/Cargo.toml
+++ b/chain/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-common"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/chain/common/Cargo.toml
+++ b/chain/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-common"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/chain/cosmos/Cargo.toml
+++ b/chain/cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-cosmos"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2018"
 
 [build-dependencies]

--- a/chain/cosmos/Cargo.toml
+++ b/chain/cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-cosmos"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2018"
 
 [build-dependencies]

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-ethereum"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-ethereum"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/chain/near/Cargo.toml
+++ b/chain/near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-near"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [build-dependencies]

--- a/chain/near/Cargo.toml
+++ b/chain/near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-near"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [build-dependencies]

--- a/chain/substreams/Cargo.toml
+++ b/chain/substreams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-substreams"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [build-dependencies]

--- a/chain/substreams/Cargo.toml
+++ b/chain/substreams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-chain-substreams"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [build-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-core"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-core"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-graphql"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-graphql"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-mock"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-mock"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-node"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 default-run = "graph-node"
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-node"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 default-run = "graph-node"
 

--- a/runtime/derive/Cargo.toml
+++ b/runtime/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-derive"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [lib]

--- a/runtime/derive/Cargo.toml
+++ b/runtime/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-derive"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [lib]

--- a/runtime/test/Cargo.toml
+++ b/runtime/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-test"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/runtime/test/Cargo.toml
+++ b/runtime/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-test"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-wasm"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-runtime-wasm"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-http"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-http"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-index-node"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-index-node"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/server/json-rpc/Cargo.toml
+++ b/server/json-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-json-rpc"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/server/json-rpc/Cargo.toml
+++ b/server/json-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-json-rpc"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/server/metrics/Cargo.toml
+++ b/server/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-metrics"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/server/metrics/Cargo.toml
+++ b/server/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-metrics"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-websocket"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-server-websocket"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-store-postgres"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-store-postgres"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-store"
-version = "0.28.0"
+version = "0.28.1"
 authors = ["Leonardo Yvens <leoyvens@gmail.com>"]
 edition = "2021"
 description = "Provides static store instance for tests."

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-store"
-version = "0.28.1"
+version = "0.28.2"
 authors = ["Leonardo Yvens <leoyvens@gmail.com>"]
 edition = "2021"
 description = "Provides static store instance for tests."

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-tests"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 
 [dependencies]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-tests"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Cargo version updates and release notes for `v0.28.1` and `v0.28.2`, which until now were confined in their respective branches.