### PR TITLE
fix(docker): incorrect config PGDATA

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,6 +40,9 @@ services:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in
       POSTGRES_DB: graph-node
+      # FIXME: remove this env. var. which we shouldn't need. Introduced by
+      # <https://github.com/graphprotocol/graph-node/pull/3511>, maybe as a
+      # workaround for https://github.com/docker/for-mac/issues/6270?
       PGDATA: "/var/lib/postgresql/data"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,6 +40,6 @@ services:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in
       POSTGRES_DB: graph-node
-      PGDATA: "/data/postgres"
+      PGDATA: "/var/lib/postgresql/data"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data


### PR DESCRIPTION
We are mounting our volume at `/var/lib/postgresql/data` while telling the container to use `/data/postgres` instead, fix the inconsistency so db persistency works as expected.

