### PR TITLE
Fixes to how we map/remap shards into other shards

### DIFF
--- a/node/src/manager/commands/database.rs
+++ b/node/src/manager/commands/database.rs
@@ -1,21 +1,59 @@
-use std::time::Instant;
+use std::{io::Write, time::Instant};
 
 use graph::prelude::anyhow;
 use graph_store_postgres::connection_pool::PoolCoordinator;
 
-pub async fn remap(coord: &PoolCoordinator) -> Result<(), anyhow::Error> {
-    let pools = coord.pools();
+pub async fn remap(
+    coord: &PoolCoordinator,
+    src: Option<String>,
+    dst: Option<String>,
+    force: bool,
+) -> Result<(), anyhow::Error> {
+    let pools = {
+        let mut pools = coord.pools();
+        pools.sort_by(|pool1, pool2| pool1.shard.as_str().cmp(pool2.shard.as_str()));
+        pools
+    };
     let servers = coord.servers();
 
-    for server in servers.iter() {
-        for pool in pools.iter() {
+    if let Some(src) = &src {
+        if !servers.iter().any(|srv| srv.shard.as_str() == src) {
+            return Err(anyhow!("unknown source shard {src}"));
+        }
+    }
+    if let Some(dst) = &dst {
+        if !pools.iter().any(|pool| pool.shard.as_str() == dst) {
+            return Err(anyhow!("unknown destination shard {dst}"));
+        }
+    }
+
+    let servers = servers.iter().filter(|srv| match &src {
+        None => true,
+        Some(src) => srv.shard.as_str() == src,
+    });
+
+    for server in servers {
+        let pools = pools.iter().filter(|pool| match &dst {
+            None => true,
+            Some(dst) => pool.shard.as_str() == dst,
+        });
+
+        for pool in pools {
             let start = Instant::now();
             print!(
                 "Remapping imports from {} in shard {}",
                 server.shard, pool.shard
             );
-            pool.remap(server)?;
-            println!(" (done in {}s)", start.elapsed().as_secs());
+            std::io::stdout().flush().ok();
+            if let Err(e) = pool.remap(server) {
+                println!(" FAILED");
+                println!("  error: {e}");
+                if !force {
+                    return Ok(());
+                }
+            } else {
+                println!(" (done in {}s)", start.elapsed().as_secs());
+            }
         }
     }
     Ok(())

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -1179,7 +1179,10 @@ impl PoolCoordinator {
             .ok_or_else(|| constraint_violation!("unknown shard {shard}"))?;
 
         for pool in self.pools.lock().unwrap().values() {
-            pool.remap(server)?;
+            if let Err(e) = pool.remap(server) {
+                error!(pool.logger, "Failed to map imports from {}", server.shard; "error" => e.to_string());
+                return Err(e);
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
The current code fails when adding a new shard since it tries to issue a bunch of DDL against replicas. This PR fixes that, and makes the `graphman database remap` command more usable.