### PR TITLE
Manage the statistics target for a deployment

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -483,8 +483,9 @@ pub enum StatsCommand {
     Analyze {
         /// The deployment (see `help info`).
         deployment: DeploymentSearch,
-        /// The name of the Entity to ANALYZE, in camel case
-        entity: String,
+        /// The name of the Entity to ANALYZE, in camel case. Analyze all
+        /// tables if omitted
+        entity: Option<String>,
     },
     /// Show statistics targets for the statistics collector
     ///
@@ -1151,7 +1152,12 @@ async fn main() -> anyhow::Result<()> {
                 Analyze { deployment, entity } => {
                     let (store, primary_pool) = ctx.store_and_primary();
                     let subgraph_store = store.subgraph_store();
-                    commands::stats::analyze(subgraph_store, primary_pool, deployment, &entity)
+                    commands::stats::analyze(
+                        subgraph_store,
+                        primary_pool,
+                        deployment,
+                        entity.as_deref(),
+                    )
                 }
                 Target { deployment } => {
                     let (store, primary_pool) = ctx.store_and_primary();

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -486,6 +486,14 @@ pub enum StatsCommand {
         /// The name of the Entity to ANALYZE, in camel case
         entity: String,
     },
+    /// Show statistics targets for the statistics collector
+    ///
+    /// For all tables in the given deployment, show the target for each
+    /// column. A value of `-1` means that the global default is used
+    Target {
+        /// The deployment (see `help info`).
+        deployment: DeploymentSearch,
+    },
 }
 
 #[derive(Clone, Debug, Subcommand)]
@@ -1144,6 +1152,11 @@ async fn main() -> anyhow::Result<()> {
                     let (store, primary_pool) = ctx.store_and_primary();
                     let subgraph_store = store.subgraph_store();
                     commands::stats::analyze(subgraph_store, primary_pool, deployment, &entity)
+                }
+                Target { deployment } => {
+                    let (store, primary_pool) = ctx.store_and_primary();
+                    let subgraph_store = store.subgraph_store();
+                    commands::stats::target(subgraph_store, primary_pool, &deployment)
                 }
             }
         }

--- a/node/src/manager/commands/stats.rs
+++ b/node/src/manager/commands/stats.rs
@@ -6,6 +6,7 @@ use crate::manager::deployment::DeploymentSearch;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::PooledConnection;
 use diesel::PgConnection;
+use graph::components::store::DeploymentLocator;
 use graph::components::store::VersionStats;
 use graph::prelude::anyhow;
 use graph_store_postgres::command_support::catalog as store_catalog;
@@ -121,6 +122,14 @@ pub fn analyze(
     entity_name: Option<&str>,
 ) -> Result<(), anyhow::Error> {
     let locator = search.locate_unique(&pool)?;
+    analyze_loc(store, &locator, entity_name)
+}
+
+fn analyze_loc(
+    store: Arc<SubgraphStore>,
+    locator: &DeploymentLocator,
+    entity_name: Option<&str>,
+) -> Result<(), anyhow::Error> {
     match entity_name {
         Some(entity_name) => println!("Analyzing table sgd{}.{entity_name}", locator.id),
         None => println!("Analyzing all tables for sgd{}", locator.id),
@@ -162,6 +171,31 @@ pub fn target(
             "no statistics targets set for sgd{}, global default is {default}",
             locator.id
         );
+    }
+    Ok(())
+}
+
+pub fn set_target(
+    store: Arc<SubgraphStore>,
+    primary: ConnectionPool,
+    search: &DeploymentSearch,
+    entity: Option<&str>,
+    columns: Vec<String>,
+    target: i32,
+    no_analyze: bool,
+) -> Result<(), anyhow::Error> {
+    let columns = if columns.is_empty() {
+        vec!["id".to_string(), "block_range".to_string()]
+    } else {
+        columns
+    };
+
+    let locator = search.locate_unique(&primary)?;
+
+    store.set_stats_target(&locator, entity, columns, target)?;
+
+    if !no_analyze {
+        analyze_loc(store, &locator, entity)?;
     }
     Ok(())
 }

--- a/node/src/manager/commands/stats.rs
+++ b/node/src/manager/commands/stats.rs
@@ -118,10 +118,13 @@ pub fn analyze(
     store: Arc<SubgraphStore>,
     pool: ConnectionPool,
     search: DeploymentSearch,
-    entity_name: &str,
+    entity_name: Option<&str>,
 ) -> Result<(), anyhow::Error> {
     let locator = search.locate_unique(&pool)?;
-    println!("Analyzing table sgd{}.{entity_name}", locator.id);
+    match entity_name {
+        Some(entity_name) => println!("Analyzing table sgd{}.{entity_name}", locator.id),
+        None => println!("Analyzing all tables for sgd{}", locator.id),
+    }
     store.analyze(&locator, entity_name).map_err(|e| anyhow!(e))
 }
 

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -7,9 +7,9 @@ use diesel::sql_types::{Integer, Range};
 use std::io::Write;
 use std::ops::{Bound, RangeBounds, RangeFrom};
 
-use graph::prelude::{BlockNumber, BlockPtr, BLOCK_NUMBER_MAX};
+use graph::prelude::{lazy_static, BlockNumber, BlockPtr, BLOCK_NUMBER_MAX};
 
-use crate::relational::Table;
+use crate::relational::{SqlName, Table};
 
 /// The name of the column in which we store the block range for mutable
 /// entities
@@ -38,6 +38,12 @@ pub(crate) const UNVERSIONED_RANGE: (Bound<i32>, Bound<i32>) =
 /// The name of the column in which we store the block from which an
 /// immutable entity is visible
 pub(crate) const BLOCK_COLUMN: &str = "block$";
+
+lazy_static! {
+    pub(crate) static ref BLOCK_RANGE_COLUMN_SQL: SqlName =
+        SqlName::verbatim(BLOCK_RANGE_COLUMN.to_string());
+    pub(crate) static ref BLOCK_COLUMN_SQL: SqlName = SqlName::verbatim(BLOCK_COLUMN.to_string());
+}
 
 /// The range of blocks for which an entity is valid. We need this struct
 /// to bind ranges into Diesel queries.

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -688,6 +688,17 @@ impl DeploymentStore {
         self.analyze_with_conn(site, entity_name, &conn)
     }
 
+    pub(crate) fn stats_targets(
+        &self,
+        site: Arc<Site>,
+    ) -> Result<(i32, BTreeMap<SqlName, BTreeMap<SqlName, i32>>), StoreError> {
+        let conn = self.get_conn()?;
+        let default = catalog::default_stats_target(&conn)?;
+        let targets = catalog::stats_targets(&conn, &site.namespace)?;
+
+        Ok((default, targets))
+    }
+
     /// Runs the SQL `ANALYZE` command in a table, with a shared connection.
     pub(crate) fn analyze_with_conn(
         &self,

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1658,7 +1658,7 @@ fn resolve_table_name<'a>(layout: &'a Layout, name: &'_ str) -> Result<&'a Table
 fn resolve_column_names<'a, T: AsRef<str>>(
     table: &'a Table,
     field_names: &[T],
-) -> Result<Vec<&'a str>, StoreError> {
+) -> Result<Vec<&'a SqlName>, StoreError> {
     field_names
         .iter()
         .map(|f| {
@@ -1670,7 +1670,7 @@ fn resolve_column_names<'a, T: AsRef<str>>(
                         .column(&sql_name)
                         .ok_or_else(|| StoreError::UnknownField(f.as_ref().to_string()))
                 })
-                .map(|column| column.name.as_str())
+                .map(|column| &column.name)
         })
         .collect()
 }

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -27,7 +27,7 @@ use graph::prelude::{q, s, StopwatchMetrics, ENV_VARS};
 use graph::slog::warn;
 use inflector::Inflector;
 use lazy_static::lazy_static;
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::{From, TryFrom};
 use std::fmt::{self, Write};
@@ -159,6 +159,12 @@ impl From<String> for SqlName {
 impl fmt::Display for SqlName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+impl Borrow<str> for &SqlName {
+    fn borrow(&self) -> &str {
+        self.as_str()
     }
 }
 

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -90,7 +90,7 @@ lazy_static! {
 /// Postgres, we would create the same table twice. We consider this case
 /// to be pathological and so unlikely in practice that we do not try to work
 /// around it in the application.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Hash, Ord)]
 pub struct SqlName(String);
 
 impl SqlName {

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1322,6 +1322,14 @@ impl Table {
         conn.execute(&sql)?;
         Ok(())
     }
+
+    pub(crate) fn block_column(&self) -> &SqlName {
+        if self.immutable {
+            &*crate::block_range::BLOCK_COLUMN_SQL
+        } else {
+            &*crate::block_range::BLOCK_RANGE_COLUMN_SQL
+        }
+    }
 }
 
 /// Return the enclosed named type for a field type, i.e., the type after

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1048,6 +1048,20 @@ impl SubgraphStoreInner {
         store.stats_targets(site)
     }
 
+    /// Set the statistics target for columns `columns` in `deployment`. If
+    /// `entity` is `Some`, only set it for the table for that entity, if it
+    /// is `None`, set it for all tables in the deployment.
+    pub fn set_stats_target(
+        &self,
+        deployment: &DeploymentLocator,
+        entity: Option<&str>,
+        columns: Vec<String>,
+        target: i32,
+    ) -> Result<(), StoreError> {
+        let (store, site) = self.store(&deployment.hash)?;
+        store.set_stats_target(site, entity, columns, target)
+    }
+
     pub async fn create_manual_index(
         &self,
         deployment: &DeploymentLocator,

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1030,7 +1030,7 @@ impl SubgraphStoreInner {
     pub fn analyze(
         &self,
         deployment: &DeploymentLocator,
-        entity_name: &str,
+        entity_name: Option<&str>,
     ) -> Result<(), StoreError> {
         let (store, site) = self.store(&deployment.hash)?;
         store.analyze(site, entity_name)


### PR DESCRIPTION
Show, set or reset the target for a deployment. The statistics target determines how much of a table Postgres will sample when it analyzes a table. This can be particularly beneficial when Postgres chooses suboptimal query plans for some queries. Increasing the target will make analyzing tables take longer and will require more space in Postgres' internal statistics storage.

See also https://www.postgresql.org/docs/15/planner-stats.html#id-1.5.13.5.3