### PR TITLE
Use a `rust-toolchain.toml` to simplify CI and minimize confusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ env:
 jobs:
   unit-tests:
     name: Run unit tests
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: ["stable"]
     runs-on: ubuntu-latest
     services:
       ipfs:
@@ -47,13 +43,6 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: test-cargo-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
 
       - name: Install lld
         run: sudo apt-get install -y lld
@@ -68,10 +57,6 @@ jobs:
 
   runner-tests:
     name: Subgraph Runner integration tests
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: ["stable"]
     runs-on: ubuntu-latest
     services:
       ipfs:
@@ -101,13 +86,6 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: test-cargo-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
 
       - name: Install lld
         run: sudo apt-get install -y lld
@@ -124,10 +102,6 @@ jobs:
 
   integration-tests:
     name: Run integration tests
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: ["stable"]
     runs-on: ubuntu-latest
 
     steps:
@@ -146,13 +120,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "14"
-
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
 
       - name: Install lld and jq
         run: sudo apt-get install -y lld jq
@@ -191,18 +158,9 @@ jobs:
 
   rustfmt:
     name: Check rustfmt style
-    strategy:
-      matrix:
-        rust: ["stable"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          components: rustfmt
-          override: true
 
       - name: Check formatting
         uses: actions-rs/cargo@v1
@@ -214,18 +172,9 @@ jobs:
 
   clippy:
     name: Report Clippy warnings
-    strategy:
-      matrix:
-        rust: ["stable"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          components: clippy
-          override: true
       # Unlike rustfmt, Clippy actually compiles stuff so it benefits from
       # caching.
       - name: Cache cargo registry
@@ -246,17 +195,9 @@ jobs:
 
   release-check:
     name: Build in release mode
-    strategy:
-      matrix:
-        rust: ["stable"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
       - name: Cache cargo registry
         uses: actions/cache@v2
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.64"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
Would avoid bug reports like https://github.com/graphprotocol/graph-node/issues/4097 and https://github.com/graphprotocol/graph-node/issues/3230 in the future.