### PR TITLE
Make our CI faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,12 @@ jobs:
           args: --bin graph-node
 
       # Integration tests are a bit flaky, running them twice increases the
-      # chances of one run succeeding
+      # chances of one run succeeding.
       - name: Run integration tests (round 1)
         id: integration-tests-1
         uses: actions-rs/cargo@v1
         env:
+          N_CONCURRENT_TESTS: "4"
           TESTS_GANACHE_HARD_WAIT_SECONDS: "30"
         with:
           command: test
@@ -129,6 +130,7 @@ jobs:
         uses: actions-rs/cargo@v1
         if: ${{ steps.integration-tests-1.outcome == 'failure' }}
         env:
+          N_CONCURRENT_TESTS: "4"
           TESTS_GANACHE_HARD_WAIT_SECONDS: "30"
         with:
           command: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,25 +32,18 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+    env:
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-
-      - name: Cache cargo registry
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: test-cargo-${{ hashFiles('**/Cargo.toml') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install lld
         run: sudo apt-get install -y lld
 
       - name: Run unit tests
         uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
         with:
           command: test
           args: --verbose --workspace --exclude graph-tests -- --nocapture
@@ -75,17 +68,12 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+    env:
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-
-      - name: Cache cargo registry
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: test-cargo-${{ hashFiles('**/Cargo.toml') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install lld
         run: sudo apt-get install -y lld
@@ -94,7 +82,6 @@ jobs:
         id: runner-tests-1
         uses: actions-rs/cargo@v1
         env:
-          RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
           TESTS_GANACHE_HARD_WAIT_SECONDS: "30"
         with:
           command: test
@@ -103,33 +90,28 @@ jobs:
   integration-tests:
     name: Run integration tests
     runs-on: ubuntu-latest
-
+    env:
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-
-      - name: Cache cargo registry
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: test-cargo-${{ hashFiles('**/Cargo.toml') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install Node 14
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "14"
+          cache: yarn
+          cache-dependency-path: "tests/integration-tests/yarn.lock"
 
       - name: Install lld and jq
         run: sudo apt-get install -y lld jq
 
       - name: Build graph-node
-        env:
-          RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
         uses: actions-rs/cargo@v1
         with:
           command: build
+          args: --bin graph-node
 
       # Integration tests are a bit flaky, running them twice increases the
       # chances of one run succeeding
@@ -137,8 +119,6 @@ jobs:
         id: integration-tests-1
         uses: actions-rs/cargo@v1
         env:
-          RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
-          N_CONCURRENT_TESTS: "1"
           TESTS_GANACHE_HARD_WAIT_SECONDS: "30"
         with:
           command: test
@@ -149,8 +129,6 @@ jobs:
         uses: actions-rs/cargo@v1
         if: ${{ steps.integration-tests-1.outcome == 'failure' }}
         env:
-          RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
-          N_CONCURRENT_TESTS: "1"
           TESTS_GANACHE_HARD_WAIT_SECONDS: "30"
         with:
           command: test
@@ -159,13 +137,13 @@ jobs:
   rustfmt:
     name: Check rustfmt style
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
 
       - name: Check formatting
         uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: "-D warnings"
         with:
           command: fmt
           args: --all -- --check
@@ -177,13 +155,7 @@ jobs:
       - uses: actions/checkout@v2
       # Unlike rustfmt, Clippy actually compiles stuff so it benefits from
       # caching.
-      - name: Cache cargo registry
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: check-cargo-${{ hashFiles('**/Cargo.toml') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run Clippy
         uses: actions-rs/cargo@v1
@@ -192,37 +164,4 @@ jobs:
         continue-on-error: true
         with:
           command: clippy
-
-  release-check:
-    name: Build in release mode
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Cache cargo registry
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: check-cargo-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libpq-dev
-
-      - name: Cargo check (debug)
-        uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: "-D warnings"
-        with:
-          command: check
-          args: --tests
-
-      - name: Cargo check (release)
-        env:
-          RUSTFLAGS: "-D warnings"
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --release
+          args: --no-deps

--- a/tests/tests/parallel_tests.rs
+++ b/tests/tests/parallel_tests.rs
@@ -411,6 +411,7 @@ async fn process_stdio<T: AsyncReadExt + Unpin>(
 
 /// run yarn to build everything
 async fn run_yarn_command(base_directory: &impl AsRef<Path>) {
+    let timer = std::time::Instant::now();
     println!("Running `yarn` command in integration tests root directory.");
     let output = Command::new("yarn")
         .current_dir(base_directory)
@@ -419,6 +420,7 @@ async fn run_yarn_command(base_directory: &impl AsRef<Path>) {
         .expect("failed to run yarn command");
 
     if output.status.success() {
+        println!("`yarn` command finished in {}s", timer.elapsed().as_secs());
         return;
     }
     println!("Yarn command failed.");


### PR DESCRIPTION
- Switch to `swatinem/rust-cache@v2` for caching Cargo dependencies, which automatically takes care of many subtleties for us and caches as much as possible without reusing artifacts which it shouldn't.
- Set `RUSTFLAGS` as a job-wide environment variable, thus ensuring it becomes part of the cache key.
- Cache `yarn` dependencies - not sure how effective this will be, maybe we'll remove it if it doesn't help.
- Run integration tests concurrently. This is a big one and should help quite a bit, @tilacog the integration testing framework still supports concurrent tests without issues, correct? Setting this to `N_CONCURRENT_TESTS` to 4 because it seems to get the best times out of the GitHub runners. Setting it too high (e.g. 15, the default) results in starvation and the job takes too long.
- Remove our release builds in the CI. They take a long time and rarely, if ever, pick up problems that `cargo test` doesn't.
- Be more selective when `cargo build`ing, ensuring that we're not building unnecessary stuff.

Steps now run noticeably (but not substantially) faster. Integration tests are still by far our bottleneck and more work needs to be done to further optimize them (or just pay up for larger runners).

Example: https://github.com/graphprotocol/graph-node/actions/runs/3328853325/jobs/5505338075 (failed because of a flaky unit test, but otherwise all previous runs looks good).