### PR TITLE
graph-tests: move `docker` and other test utilities to `lib` (1️⃣ )

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 
 [dependencies]
 port_check = "0.1.5"
-anyhow = "1.0"
 futures = { version = "0.3", features = ["compat"] }
 graph = { path = "../graph" }
 tokio = { version = "1.16.1", features = ["rt", "macros", "process"] }
@@ -19,12 +18,13 @@ graph-store-postgres = { path = "../store/postgres" }
 slog = { version = "2.7.0", features = ["release_max_level_trace", "max_level_trace"] }
 graphql-parser = "0.4.0"
 hex = "0.4.3"
+bollard = "0.10"
+tokio-stream = "0.1"
+anyhow = "1.0.66"
 
 [dev-dependencies]
-bollard = "0.10"
-anyhow = "1.0.66"
 lazy_static = "1.4.0"
-tokio-stream = "0.1"
 serde_yaml = "0.8"
 cid = "0.8.6"
 graph-chain-near = { path = "../chain/near" }
+

--- a/tests/src/docker.rs
+++ b/tests/src/docker.rs
@@ -1,7 +1,7 @@
+use crate::helpers::{contains_subslice, postgres_test_database_name, MappedPorts};
 use bollard::image::CreateImageOptions;
 use bollard::models::HostConfig;
 use bollard::{container, Docker};
-use graph_tests::helpers::{contains_subslice, postgres_test_database_name, MappedPorts};
 use std::collections::HashMap;
 use tokio::time::{sleep, Duration};
 use tokio_stream::StreamExt;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,2 +1,5 @@
+pub mod docker;
 pub mod fixture;
 pub mod helpers;
+pub mod node;
+pub mod setup;

--- a/tests/src/node.rs
+++ b/tests/src/node.rs
@@ -1,0 +1,56 @@
+use crate::setup::{process_stdio, IntegrationTestSetup, StdIO};
+use anyhow::Context;
+use tokio::process::{Child, Command};
+
+pub async fn run_graph_node(test_setup: &IntegrationTestSetup) -> anyhow::Result<Child> {
+    use std::process::Stdio;
+
+    let mut command = Command::new(test_setup.graph_node_bin.as_os_str());
+    command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        // postgres
+        .arg("--postgres-url")
+        .arg(&test_setup.postgres_uri)
+        // ethereum
+        .arg("--ethereum-rpc")
+        .arg(&test_setup.ganache_uri)
+        // ipfs
+        .arg("--ipfs")
+        .arg(&test_setup.ipfs_uri)
+        // http port
+        .arg("--http-port")
+        .arg(test_setup.graph_node_ports.http.to_string())
+        // index node port
+        .arg("--index-node-port")
+        .arg(test_setup.graph_node_ports.index.to_string())
+        // ws  port
+        .arg("--ws-port")
+        .arg(test_setup.graph_node_ports.ws.to_string())
+        // admin  port
+        .arg("--admin-port")
+        .arg(test_setup.graph_node_ports.admin.to_string())
+        // metrics  port
+        .arg("--metrics-port")
+        .arg(test_setup.graph_node_ports.metrics.to_string());
+
+    command
+        .spawn()
+        .context("failed to start graph-node command.")
+}
+
+pub async fn stop_graph_node(child: &mut Child) -> anyhow::Result<StdIO> {
+    child.kill().await.context("Failed to kill graph-node")?;
+
+    // capture stdio
+    let stdout = match child.stdout.take() {
+        Some(mut data) => Some(process_stdio(&mut data, "[graph-node:stdout] ").await?),
+        None => None,
+    };
+    let stderr = match child.stderr.take() {
+        Some(mut data) => Some(process_stdio(&mut data, "[graph-node:stderr] ").await?),
+        None => None,
+    };
+
+    Ok(StdIO { stdout, stderr })
+}

--- a/tests/src/setup.rs
+++ b/tests/src/setup.rs
@@ -1,0 +1,62 @@
+use anyhow::Context;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::io::AsyncReadExt;
+
+use crate::helpers::{basename, pretty_output, GraphNodePorts};
+
+/// Contains all information a test command needs
+#[derive(Debug)]
+pub struct IntegrationTestSetup {
+    pub postgres_uri: String,
+    pub ipfs_uri: String,
+    pub ganache_port: u16,
+    pub ganache_uri: String,
+    pub graph_node_ports: GraphNodePorts,
+    pub graph_node_bin: Arc<PathBuf>,
+    pub test_directory: Option<PathBuf>,
+}
+
+impl IntegrationTestSetup {
+    pub fn test_name(&self) -> String {
+        match self.test_directory {
+            Some(ref test_directory) => basename(test_directory),
+            None => "".to_string(),
+        }
+    }
+
+    pub fn graph_node_admin_uri(&self) -> String {
+        let ws_port = self.graph_node_ports.admin;
+        format!("http://localhost:{}/", ws_port)
+    }
+}
+
+pub async fn process_stdio<T: AsyncReadExt + Unpin>(
+    stdio: &mut T,
+    prefix: &str,
+) -> anyhow::Result<String> {
+    let mut buffer: Vec<u8> = Vec::new();
+    stdio
+        .read_to_end(&mut buffer)
+        .await
+        .context("failed to read stdio")?;
+    Ok(pretty_output(&buffer, prefix))
+}
+
+#[derive(Debug)]
+pub struct StdIO {
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
+}
+
+impl std::fmt::Display for StdIO {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(ref stdout) = self.stdout {
+            write!(f, "{}", stdout)?;
+        }
+        if let Some(ref stderr) = self.stderr {
+            write!(f, "{}", stderr)?
+        }
+        Ok(())
+    }
+}

--- a/tests/tests/common/mod.rs
+++ b/tests/tests/common/mod.rs
@@ -1,1 +1,0 @@
-pub mod docker;

--- a/tests/tests/parallel_tests.rs
+++ b/tests/tests/parallel_tests.rs
@@ -1,16 +1,16 @@
-mod common;
 use anyhow::Context;
-use common::docker::{pull_images, DockerTestClient, TestContainerService};
 use futures::StreamExt;
+use graph_tests::docker::{pull_images, DockerTestClient, TestContainerService};
 use graph_tests::helpers::{
     basename, get_unique_ganache_counter, get_unique_postgres_counter, make_ganache_uri,
     make_ipfs_uri, make_postgres_uri, pretty_output, GraphNodePorts, MappedPorts,
 };
+use graph_tests::node::{run_graph_node, stop_graph_node};
+use graph_tests::setup::{IntegrationTestSetup, StdIO};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::io::AsyncReadExt;
-use tokio::process::{Child, Command};
+use tokio::process::Command;
 
 const DEFAULT_N_CONCURRENT_TESTS: usize = 15;
 
@@ -36,29 +36,6 @@ pub const INTEGRATION_TESTS_DIRECTORIES: [&str; 9] = [
     "value-roundtrip",
 ];
 
-/// Contains all information a test command needs
-#[derive(Debug)]
-struct IntegrationTestSetup {
-    postgres_uri: String,
-    ipfs_uri: String,
-    ganache_port: u16,
-    ganache_uri: String,
-    graph_node_ports: GraphNodePorts,
-    graph_node_bin: Arc<PathBuf>,
-    test_directory: PathBuf,
-}
-
-impl IntegrationTestSetup {
-    fn test_name(&self) -> String {
-        basename(&self.test_directory)
-    }
-
-    fn graph_node_admin_uri(&self) -> String {
-        let ws_port = self.graph_node_ports.admin;
-        format!("http://localhost:{}/", ws_port)
-    }
-}
-
 /// Info about a finished test command
 #[derive(Debug)]
 struct TestCommandResults {
@@ -66,23 +43,6 @@ struct TestCommandResults {
     _exit_code: Option<i32>,
     stdout: String,
     stderr: String,
-}
-
-#[derive(Debug)]
-struct StdIO {
-    stdout: Option<String>,
-    stderr: Option<String>,
-}
-impl std::fmt::Display for StdIO {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(ref stdout) = self.stdout {
-            write!(f, "{}", stdout)?;
-        }
-        if let Some(ref stderr) = self.stderr {
-            write!(f, "{}", stderr)?
-        }
-        Ok(())
-    }
 }
 
 // The results of a finished integration test
@@ -288,13 +248,13 @@ async fn run_integration_test(
         ganache_port,
         graph_node_bin,
         graph_node_ports: GraphNodePorts::get_ports(),
-        test_directory,
+        test_directory: Some(test_directory),
     };
 
     // spawn graph-node
     let mut graph_node_child_command = run_graph_node(&test_setup).await?;
 
-    println!("Test started: {}", basename(&test_setup.test_directory));
+    println!("Test started: {}", basename(&test_setup.test_name()));
     let test_command_results = run_test_command(&test_setup).await?;
 
     // stop graph-node
@@ -328,7 +288,12 @@ async fn run_test_command(test_setup: &IntegrationTestSetup) -> anyhow::Result<T
             test_setup.graph_node_ports.index.to_string(),
         )
         .env("IPFS_URI", &test_setup.ipfs_uri)
-        .current_dir(&test_setup.test_directory)
+        .current_dir(
+            &test_setup
+                .test_directory
+                .as_deref()
+                .expect("missing test dir"),
+        )
         .output()
         .await
         .context("failed to run test command")?;
@@ -343,70 +308,6 @@ async fn run_test_command(test_setup: &IntegrationTestSetup) -> anyhow::Result<T
         stdout: pretty_output(&output.stdout, &stdout_tag),
         stderr: pretty_output(&output.stderr, &stderr_tag),
     })
-}
-async fn run_graph_node(test_setup: &IntegrationTestSetup) -> anyhow::Result<Child> {
-    use std::process::Stdio;
-
-    let mut command = Command::new(test_setup.graph_node_bin.as_os_str());
-    command
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        // postgres
-        .arg("--postgres-url")
-        .arg(&test_setup.postgres_uri)
-        // ethereum
-        .arg("--ethereum-rpc")
-        .arg(&test_setup.ganache_uri)
-        // ipfs
-        .arg("--ipfs")
-        .arg(&test_setup.ipfs_uri)
-        // http port
-        .arg("--http-port")
-        .arg(test_setup.graph_node_ports.http.to_string())
-        // index node port
-        .arg("--index-node-port")
-        .arg(test_setup.graph_node_ports.index.to_string())
-        // ws  port
-        .arg("--ws-port")
-        .arg(test_setup.graph_node_ports.ws.to_string())
-        // admin  port
-        .arg("--admin-port")
-        .arg(test_setup.graph_node_ports.admin.to_string())
-        // metrics  port
-        .arg("--metrics-port")
-        .arg(test_setup.graph_node_ports.metrics.to_string());
-
-    command
-        .spawn()
-        .context("failed to start graph-node command.")
-}
-
-async fn stop_graph_node(child: &mut Child) -> anyhow::Result<StdIO> {
-    child.kill().await.context("Failed to kill graph-node")?;
-
-    // capture stdio
-    let stdout = match child.stdout.take() {
-        Some(mut data) => Some(process_stdio(&mut data, "[graph-node:stdout] ").await?),
-        None => None,
-    };
-    let stderr = match child.stderr.take() {
-        Some(mut data) => Some(process_stdio(&mut data, "[graph-node:stderr] ").await?),
-        None => None,
-    };
-
-    Ok(StdIO { stdout, stderr })
-}
-
-async fn process_stdio<T: AsyncReadExt + Unpin>(
-    stdio: &mut T,
-    prefix: &str,
-) -> anyhow::Result<String> {
-    let mut buffer: Vec<u8> = Vec::new();
-    stdio
-        .read_to_end(&mut buffer)
-        .await
-        .context("failed to read stdio")?;
-    Ok(pretty_output(&buffer, prefix))
 }
 
 /// run yarn to build everything


### PR DESCRIPTION
### Background 

As part of the effort done in https://github.com/graphprotocol/graph-node/pull/3410 , and based on a request from @dizzyd to break this PR into smaller pieces, here's part 1. 

The goal of this PR is to move all the common parts from `tests` to live under `lib`, so other crates can eventually reuse those. 

### Changes

In this PR, I changed the following: 
- [x] Move `docker` utilities and expose them as part of `graph-tests` lib 
- [x] Adjust some dependencies and move from `dev-dependencies` to `dependencies`
- [x] Move `run_graph_node` and `stop_graph_node`
- [x] Move `IntegrationTestSetup` and a few more utilties

The goal is to eventually be able to reuse these helpers from another crate (`performance-tests`) that will be introduced in the next PR. 