### PR TITLE
performance-tests: added workflow for running tests in CI (3️⃣)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,67 @@
+name: Benchmark
+
+on:
+  - pull_request
+
+jobs:
+  query:
+    name: Query
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: ["stable"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: test-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install lld
+        run: sudo apt-get install -y lld
+
+      - name: Build graph-node
+        env:
+          RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - name: Install Subgraph Dependencies
+        run: yarn
+        working-directory: ./performance-tests/subgraph
+
+      - name: Setup K6
+        run: |
+          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+          echo "deb https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update
+          sudo apt-get install k6=0.37.0
+
+      - name: Seed, Deploy & Test
+        uses: actions-rs/cargo@v1
+        env:
+          GITHUB_PR: ${{ github.event.number }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          command: run
+          args: --package performance-tests -- --nocapture


### PR DESCRIPTION
❗  Note: this PR is based on https://github.com/graphprotocol/graph-node/pull/4108 and https://github.com/graphprotocol/graph-node/pull/4109 and requires both to be merged first. 

### Background

As part of the effort done in https://github.com/graphprotocol/graph-node/pull/3410 , and based on a request from @dizzyd to break this PR into smaller pieces, here's part 3.

### Changes in this PR 

- [x] Added GitHub Actions workflow file to run and report performance issues on every PR. 