### PR TITLE
Ipfs polling rate limiting and backoff from errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4712,11 +4722,14 @@ dependencies = [
 [[package]]
 name = "tower"
 version = "0.4.12"
-source = "git+https://github.com/tower-rs/tower.git#c049ded33f6267de3c09b336d7a9bb9b09d842d1"
+source = "git+https://github.com/tower-rs/tower.git#d27ba65891590b848fa9ba13a202d5d4aa5eda81"
 dependencies = [
  "futures-core",
  "futures-util",
+ "hdrhistogram",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "tokio",
  "tokio-util 0.7.1",
  "tower-layer 0.3.1 (git+https://github.com/tower-rs/tower.git)",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
 # Switch to crates.io once tower 0.5 is released
-tower = { git = "https://github.com/tower-rs/tower.git", features = ["util", "limit"] }
+tower = { git = "https://github.com/tower-rs/tower.git", features = ["full"] }
 graph-runtime-wasm = { path = "../runtime/wasm" }
 cid = "0.8.6"
 anyhow = "1.0"

--- a/core/src/polling_monitor/ipfs_service.rs
+++ b/core/src/polling_monitor/ipfs_service.rs
@@ -121,7 +121,7 @@ mod test {
     use ipfs::IpfsApi;
     use ipfs_api as ipfs;
     use std::{fs, str::FromStr, time::Duration};
-    use tower::{Service, ServiceExt};
+    use tower::ServiceExt;
 
     use cid::Cid;
     use graph::{ipfs_client::IpfsClient, tokio};

--- a/core/src/subgraph/context.rs
+++ b/core/src/subgraph/context.rs
@@ -1,8 +1,6 @@
 pub mod instance;
 
-use crate::polling_monitor::{
-    ipfs_service::IpfsService, spawn_monitor, PollingMonitor, PollingMonitorMetrics,
-};
+use crate::polling_monitor::{spawn_monitor, IpfsService, PollingMonitor, PollingMonitorMetrics};
 use anyhow::{self, Error};
 use bytes::Bytes;
 use graph::{

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -1,4 +1,4 @@
-use crate::polling_monitor::ipfs_service::IpfsService;
+use crate::polling_monitor::IpfsService;
 use crate::subgraph::context::{IndexingContext, SharedInstanceKeepAliveMap};
 use crate::subgraph::inputs::IndexingInputs;
 use crate::subgraph::loader::load_dynamic_data_sources;
@@ -338,7 +338,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             logger.cheap_clone(),
             registry.cheap_clone(),
             &manifest.id,
-            self.ipfs_service.cheap_clone(),
+            self.ipfs_service.clone(),
         );
 
         // Initialize deployment_head with current deployment head. Any sort of trouble in

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -78,7 +78,8 @@ those.
   may use (in bytes, defaults to 256MB).
 - `GRAPH_MAX_IPFS_CACHE_SIZE`: maximum number of files cached (defaults to 50).
 - `GRAPH_MAX_IPFS_CACHE_FILE_SIZE`: maximum size of each cached file (in bytes, defaults to 1MiB).
-- `GRAPH_MAX_IPFS_CONCURRENT_REQUESTS`: maximum concurrent requests to IPFS from file data sources (defaults to 100).
+- `GRAPH_IPFS_REQUEST_LIMIT`: Limits both concurrent and per second requests to IPFS for file data
+   sources. Defaults to 100.
 
 ## GraphQL
 

--- a/graph/src/env/mappings.rs
+++ b/graph/src/env/mappings.rs
@@ -48,7 +48,12 @@ pub struct EnvVarsMapping {
     /// Set by the environment variable `GRAPH_MAX_IPFS_FILE_BYTES` (expressed in
     /// bytes). Defaults to 256 MiB.
     pub max_ipfs_file_bytes: usize,
-    pub max_ipfs_concurrent_requests: u16,
+
+    /// Limits both concurrent and per second requests to IPFS for file data sources.
+    ///
+    /// Set by the environment variable `GRAPH_IPFS_REQUEST_LIMIT`. Defaults to 100.
+    pub ipfs_request_limit: u16,
+
     /// Set by the flag `GRAPH_ALLOW_NON_DETERMINISTIC_IPFS`. Off by
     /// default.
     pub allow_non_deterministic_ipfs: bool,
@@ -76,7 +81,7 @@ impl From<InnerMappingHandlers> for EnvVarsMapping {
             ipfs_timeout: Duration::from_secs(x.ipfs_timeout_in_secs),
             max_ipfs_map_file_size: x.max_ipfs_map_file_size.0,
             max_ipfs_file_bytes: x.max_ipfs_file_bytes.0,
-            max_ipfs_concurrent_requests: x.max_ipfs_concurrent_requests,
+            ipfs_request_limit: x.ipfs_request_limit,
             allow_non_deterministic_ipfs: x.allow_non_deterministic_ipfs.0,
         }
     }
@@ -106,8 +111,8 @@ pub struct InnerMappingHandlers {
     max_ipfs_map_file_size: WithDefaultUsize<usize, { 256 * 1024 * 1024 }>,
     #[envconfig(from = "GRAPH_MAX_IPFS_FILE_BYTES", default = "")]
     max_ipfs_file_bytes: WithDefaultUsize<usize, { 256 * 1024 * 1024 }>,
-    #[envconfig(from = "GRAPH_MAX_IPFS_CONCURRENT_REQUESTS", default = "100")]
-    max_ipfs_concurrent_requests: u16,
+    #[envconfig(from = "GRAPH_IPFS_REQUEST_LIMIT", default = "100")]
+    ipfs_request_limit: u16,
     #[envconfig(from = "GRAPH_ALLOW_NON_DETERMINISTIC_IPFS", default = "false")]
     allow_non_deterministic_ipfs: EnvVarBoolean,
 }

--- a/graph/src/ipfs_client.rs
+++ b/graph/src/ipfs_client.rs
@@ -14,7 +14,7 @@ use std::{str::FromStr, sync::Arc};
 
 /// Represents a file on Ipfs. This file can be the CID or a path within a folder CID.
 /// The path cannot have a prefix (ie CID/hello.json would be cid: CID path: "hello.json")
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Eq, PartialEq, Hash)]
 pub struct CidFile {
     pub cid: Cid,
     pub path: Option<String>,

--- a/graph/src/ipfs_client.rs
+++ b/graph/src/ipfs_client.rs
@@ -14,7 +14,7 @@ use std::{str::FromStr, sync::Arc};
 
 /// Represents a file on Ipfs. This file can be the CID or a path within a folder CID.
 /// The path cannot have a prefix (ie CID/hello.json would be cid: CID path: "hello.json")
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct CidFile {
     pub cid: Cid,
     pub path: Option<String>,

--- a/graph/src/util/monitored.rs
+++ b/graph/src/util/monitored.rs
@@ -29,7 +29,9 @@ impl<T> MonitoredVecDeque<T> {
     pub fn pop_front(&mut self) -> Option<T> {
         let item = self.vec_deque.pop_front();
         self.depth.set(self.vec_deque.len() as f64);
-        self.popped.inc();
+        if item.is_some() {
+            self.popped.inc();
+        }
         item
     }
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -19,7 +19,7 @@ use graph_chain_cosmos::{self as cosmos, Block as CosmosFirehoseBlock};
 use graph_chain_ethereum as ethereum;
 use graph_chain_near::{self as near, HeaderOnlyBlock as NearFirehoseHeaderOnlyBlock};
 use graph_chain_substreams as substreams;
-use graph_core::polling_monitor::ipfs_service::IpfsService;
+use graph_core::polling_monitor::ipfs_service;
 use graph_core::{
     LinkResolver, MetricsRegistry, SubgraphAssignmentProvider as IpfsSubgraphAssignmentProvider,
     SubgraphInstanceManager, SubgraphRegistrar as IpfsSubgraphRegistrar,
@@ -195,11 +195,11 @@ async fn main() {
     // Try to create IPFS clients for each URL specified in `--ipfs`
     let ipfs_clients: Vec<_> = create_ipfs_clients(&logger, &opt.ipfs);
     let ipfs_client = ipfs_clients.first().cloned().expect("Missing IPFS client");
-    let ipfs_service = IpfsService::new(
+    let ipfs_service = ipfs_service(
         ipfs_client,
         ENV_VARS.mappings.max_ipfs_file_bytes as u64,
         ENV_VARS.mappings.ipfs_timeout,
-        ENV_VARS.mappings.max_ipfs_concurrent_requests,
+        ENV_VARS.mappings.ipfs_request_limit,
     );
 
     // Convert the clients into a link resolver. Since we want to get past

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -24,7 +24,7 @@ use graph::prelude::{
 };
 use graph::slog::{debug, info, Logger};
 use graph_chain_ethereum::{self as ethereum};
-use graph_core::polling_monitor::ipfs_service::IpfsService;
+use graph_core::polling_monitor::ipfs_service;
 use graph_core::{
     LinkResolver, SubgraphAssignmentProvider as IpfsSubgraphAssignmentProvider,
     SubgraphInstanceManager, SubgraphRegistrar as IpfsSubgraphRegistrar,
@@ -61,11 +61,11 @@ pub async fn run(
     // FIXME: Hard-coded IPFS config, take it from config file instead?
     let ipfs_clients: Vec<_> = create_ipfs_clients(&logger, &ipfs_url);
     let ipfs_client = ipfs_clients.first().cloned().expect("Missing IPFS client");
-    let ipfs_service = IpfsService::new(
+    let ipfs_service = ipfs_service(
         ipfs_client,
         ENV_VARS.mappings.max_ipfs_file_bytes as u64,
         ENV_VARS.mappings.ipfs_timeout,
-        ENV_VARS.mappings.max_ipfs_concurrent_requests,
+        ENV_VARS.mappings.ipfs_request_limit,
     );
 
     // Convert the clients into a link resolver. Since we want to get past

--- a/tests/src/fixture.rs
+++ b/tests/src/fixture.rs
@@ -29,7 +29,7 @@ use graph::prelude::{
     SubgraphRegistrar, SubgraphStore as _, SubgraphVersionSwitchingMode,
 };
 use graph::slog::crit;
-use graph_core::polling_monitor::ipfs_service::IpfsService;
+use graph_core::polling_monitor::ipfs_service;
 use graph_core::{
     LinkResolver, SubgraphAssignmentProvider as IpfsSubgraphAssignmentProvider,
     SubgraphInstanceManager, SubgraphRegistrar as IpfsSubgraphRegistrar,
@@ -243,11 +243,11 @@ pub async fn setup<C: Blockchain>(
         vec![ipfs.cheap_clone()],
         Default::default(),
     ));
-    let ipfs_service = IpfsService::new(
+    let ipfs_service = ipfs_service(
         ipfs,
         env_vars.mappings.max_ipfs_file_bytes as u64,
         env_vars.mappings.ipfs_timeout,
-        env_vars.mappings.max_ipfs_concurrent_requests,
+        env_vars.mappings.ipfs_request_limit,
     );
 
     let blockchain_map = Arc::new(blockchain_map);


### PR DESCRIPTION
Resolves https://github.com/graphprotocol/graph-node/issues/4088.

The first commit is a fix for metrics.

The second refactors the ipfs service and adds a rate limit. The refactor seeks to better use tower composability and built-ins.

The third adds a backoff to errored requests in the polling monitor.