### PR TITLE
fix(offchain): Update tower to fix polling monitor deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4722,7 +4722,7 @@ dependencies = [
 [[package]]
 name = "tower"
 version = "0.4.12"
-source = "git+https://github.com/tower-rs/tower.git#d27ba65891590b848fa9ba13a202d5d4aa5eda81"
+source = "git+https://github.com/tower-rs/tower.git#c9d84cde0c9a23e1d2d5b5ae7ae432629712658b"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -4765,7 +4765,7 @@ checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 [[package]]
 name = "tower-layer"
 version = "0.3.1"
-source = "git+https://github.com/tower-rs/tower.git#d27ba65891590b848fa9ba13a202d5d4aa5eda81"
+source = "git+https://github.com/tower-rs/tower.git#c9d84cde0c9a23e1d2d5b5ae7ae432629712658b"
 
 [[package]]
 name = "tower-service"
@@ -4776,12 +4776,12 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 [[package]]
 name = "tower-service"
 version = "0.3.1"
-source = "git+https://github.com/tower-rs/tower.git#d27ba65891590b848fa9ba13a202d5d4aa5eda81"
+source = "git+https://github.com/tower-rs/tower.git#c9d84cde0c9a23e1d2d5b5ae7ae432629712658b"
 
 [[package]]
 name = "tower-test"
 version = "0.4.0"
-source = "git+https://github.com/tower-rs/tower.git#d27ba65891590b848fa9ba13a202d5d4aa5eda81"
+source = "git+https://github.com/tower-rs/tower.git#c9d84cde0c9a23e1d2d5b5ae7ae432629712658b"
 dependencies = [
  "futures-util",
  "pin-project-lite",

--- a/tests/tests/runner.rs
+++ b/tests/tests/runner.rs
@@ -146,7 +146,7 @@ async fn file_data_sources() {
 
     // This test assumes the file data sources will be processed in the same block in which they are
     // created. But the test might fail due to a race condition if for some reason it takes longer
-    // than expectd to fetch the file from IPFS. The sleep here will conveniently happen after the
+    // than expected to fetch the file from IPFS. The sleep here will conveniently happen after the
     // data source is added to the offchain monitor but before the monitor is checked, in an an
     // attempt to ensure the monitor has enough time to fetch the file.
     let adapter_selector = NoopAdapterSelector {


### PR DESCRIPTION
The tower bug that caused a deadlock in `call_all` was fixed in https://github.com/tower-rs/tower/pull/709. This bug surfaced after the refactors in https://github.com/graphprotocol/graph-node/pull/4117. A test in graph node was also added.