### PR TITLE
Use `rust-version` to specify minimum supported `rustc`

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,6 +3,7 @@ name = "graph-node"
 version.workspace = true
 edition.workspace = true
 default-run = "graph-node"
+rust-version = "1.64"
 
 [[bin]]
 name = "graph-node"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.64"
+channel = "stable"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
We're currently enforcing the same `rustc` version all across the codebase (1.64). However, when setting `rust-version` in `Cargo.toml` instead of `rust-toolchain.toml`, we now allow all `rustc` versions that are 1.64 *or higher*.