### PR TITLE
Backwards compatibility in firehose for pre-0.0.5 subgraphs with call handlers

### DIFF
--- a/chain/arweave/src/chain.rs
+++ b/chain/arweave/src/chain.rs
@@ -88,9 +88,11 @@ impl Blockchain for Chain {
         &self,
         _loc: &DeploymentLocator,
         _capabilities: &Self::NodeCapabilities,
-        _unified_api_version: UnifiedMappingApiVersion,
+        unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Arc<dyn TriggersAdapterTrait<Self>>, Error> {
-        let adapter = TriggersAdapter {};
+        let adapter = TriggersAdapter {
+            unified_api_version,
+        };
         Ok(Arc::new(adapter))
     }
 
@@ -165,7 +167,9 @@ impl Blockchain for Chain {
     }
 }
 
-pub struct TriggersAdapter {}
+pub struct TriggersAdapter {
+    unified_api_version: UnifiedMappingApiVersion,
+}
 
 #[async_trait]
 impl TriggersAdapterTrait<Chain> for TriggersAdapter {
@@ -235,6 +239,9 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             hash: BlockHash::from(vec![0xff; 48]),
             number: block.number.saturating_sub(1),
         }))
+    }
+    fn unified_api_version(&self) -> UnifiedMappingApiVersion {
+        self.unified_api_version.clone()
     }
 }
 

--- a/chain/cosmos/src/chain.rs
+++ b/chain/cosmos/src/chain.rs
@@ -86,9 +86,11 @@ impl Blockchain for Chain {
         &self,
         _loc: &DeploymentLocator,
         _capabilities: &Self::NodeCapabilities,
-        _unified_api_version: UnifiedMappingApiVersion,
+        unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Arc<dyn TriggersAdapterTrait<Self>>, Error> {
-        let adapter = TriggersAdapter {};
+        let adapter = TriggersAdapter {
+            unified_api_version,
+        };
         Ok(Arc::new(adapter))
     }
 
@@ -165,7 +167,9 @@ impl Blockchain for Chain {
     }
 }
 
-pub struct TriggersAdapter {}
+pub struct TriggersAdapter {
+    unified_api_version: UnifiedMappingApiVersion,
+}
 
 #[async_trait]
 impl TriggersAdapterTrait<Chain> for TriggersAdapter {
@@ -282,6 +286,10 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             hash: BlockHash::from(vec![0xff; 32]),
             number: block.number.saturating_sub(1),
         }))
+    }
+
+    fn unified_api_version(&self) -> UnifiedMappingApiVersion {
+        self.unified_api_version.clone()
     }
 }
 

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -29,6 +29,7 @@ use std::collections::HashSet;
 use std::iter::FromIterator;
 use std::sync::Arc;
 
+use crate::codec::ToEthereumBlockWithCalls;
 use crate::data_source::DataSourceTemplate;
 use crate::data_source::UnresolvedDataSourceTemplate;
 use crate::{
@@ -577,6 +578,10 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
 
         Ok(blocks[0].parent_ptr())
     }
+
+    fn unified_api_version(&self) -> UnifiedMappingApiVersion {
+        self.unified_api_version.clone()
+    }
 }
 
 pub struct FirehoseMapper {}
@@ -615,7 +620,8 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
             StepNew => {
                 // See comment(437a9f17-67cc-478f-80a3-804fe554b227) ethereum_block.calls is always Some even if calls
                 // is empty
-                let ethereum_block: EthereumBlockWithCalls = (&block).try_into()?;
+                let ethereum_block =
+                    (&block).to_ethereum_block_with_calls(adapter.unified_api_version())?;
 
                 // triggers in block never actually calls the ethereum traces api.
                 // TODO: Split the trigger parsing from call retrieving.

--- a/chain/ethereum/src/codec.rs
+++ b/chain/ethereum/src/codec.rs
@@ -18,8 +18,6 @@ use graph::{
 use std::sync::Arc;
 use std::{convert::TryFrom, fmt::Debug};
 
-use crate::chain::BlockFinality;
-
 pub use pbcodec::*;
 
 trait TryDecodeProto<U, V>: Sized

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -146,9 +146,11 @@ impl Blockchain for Chain {
         &self,
         _loc: &DeploymentLocator,
         _capabilities: &Self::NodeCapabilities,
-        _unified_api_version: UnifiedMappingApiVersion,
+        unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Arc<dyn TriggersAdapterTrait<Self>>, Error> {
-        let adapter = TriggersAdapter {};
+        let adapter = TriggersAdapter {
+            unified_api_version,
+        };
         Ok(Arc::new(adapter))
     }
 
@@ -211,7 +213,9 @@ impl Blockchain for Chain {
     }
 }
 
-pub struct TriggersAdapter {}
+pub struct TriggersAdapter {
+    unified_api_version: UnifiedMappingApiVersion,
+}
 
 #[async_trait]
 impl TriggersAdapterTrait<Chain> for TriggersAdapter {
@@ -306,6 +310,10 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             hash: BlockHash::from(vec![0xff; 32]),
             number: block.number.saturating_sub(1),
         }))
+    }
+
+    fn unified_api_version(&self) -> UnifiedMappingApiVersion {
+        self.unified_api_version.clone()
     }
 }
 

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -8,6 +8,7 @@ use graph::{
         subgraph::{MappingError, ProofOfIndexingEvent, SharedProofOfIndexing},
     },
     data::store::scalar::Bytes,
+    data::subgraph::UnifiedMappingApiVersion,
     data_source,
     prelude::{
         anyhow, async_trait, BigDecimal, BigInt, BlockHash, BlockNumber, BlockState, Entity,
@@ -133,6 +134,10 @@ impl blockchain::TriggersAdapter<Chain> for TriggersAdapter {
             hash: BlockHash::from(vec![0xff; 32]),
             number: block.number.saturating_sub(1),
         }))
+    }
+
+    fn unified_api_version(&self) -> UnifiedMappingApiVersion {
+        unimplemented!()
     }
 }
 

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -234,6 +234,9 @@ pub trait TriggersAdapter<C: Blockchain>: Send + Sync {
 
     /// Get pointer to parent of `block`. This is called when reverting `block`.
     async fn parent_ptr(&self, block: &BlockPtr) -> Result<Option<BlockPtr>, Error>;
+
+    /// Get unified api version
+    fn unified_api_version(&self) -> UnifiedMappingApiVersion;
 }
 
 #[async_trait]

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -19,6 +19,8 @@ use super::{
     TriggersAdapter, UnresolvedDataSource, UnresolvedDataSourceTemplate,
 };
 
+use crate::blockchain::UnifiedMappingApiVersion;
+
 #[derive(Debug)]
 pub struct MockBlockchain;
 
@@ -204,6 +206,10 @@ impl<C: Blockchain> TriggersAdapter<C> for MockTriggersAdapter {
     }
 
     async fn parent_ptr(&self, _block: &BlockPtr) -> Result<Option<BlockPtr>, Error> {
+        todo!()
+    }
+
+    fn unified_api_version(&self) -> UnifiedMappingApiVersion {
         todo!()
     }
 }

--- a/tests/src/fixture.rs
+++ b/tests/src/fixture.rs
@@ -20,6 +20,7 @@ use graph::cheap_clone::CheapClone;
 use graph::components::store::{BlockStore, DeploymentLocator};
 use graph::data::graphql::effort::LoadManager;
 use graph::data::query::{Query, QueryTarget};
+use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::env::EnvVars;
 use graph::ipfs_client::IpfsClient;
 use graph::prelude::ethabi::ethereum_types::H256;
@@ -539,5 +540,9 @@ impl<C: Blockchain> TriggersAdapter<C> for NoopTriggersAdapter<C> {
                 number: n - 1,
             })),
         }
+    }
+
+    fn unified_api_version(&self) -> UnifiedMappingApiVersion {
+        unimplemented!("noop triggers does not implement unified_api_version")
     }
 }


### PR DESCRIPTION
THIS IS INCOMPLETE (blocked by https://github.com/graphprotocol/graph-node/issues/4130)
 -> the additional filtering for non-final blocks is preventing the behavior attempted by this PR.

This introduces backward compatibility with pre-0.0.5 version for call_handlers:
conversion of protobuf ethereum blocks from firehose natively removes the "failed" calls (or calls that are reverted because of a failed transaction).

This is now how the previous (RPC) implementation works, it lets them through for those older subgraphs.

This mimics this behavior by passing down the unified_mapping_api_version to the ethereum block converter.