### PR TITLE
Remove `subgraph_deployment.earliest_ethereum_block_*`

### DIFF
--- a/docs/implementation/metadata.md
+++ b/docs/implementation/metadata.md
@@ -65,8 +65,7 @@ static data.
 | `deployment`                         | `text!`    | IPFS hash                                    |
 | `failed`                             | `boolean!` |                                              |
 | `synced`                             | `boolean!` |                                              |
-| `earliest_ethereum_block_hash`       | `bytea`    | start block from manifest (to be removed)    |
-| `earliest_ethereum_block_number`     | `numeric`  |                                              |
+| `earliest_block_number`              | `integer!` | earliest block for which we have data        |
 | `latest_ethereum_block_hash`         | `bytea`    | current subgraph head                        |
 | `latest_ethereum_block_number`       | `numeric`  |                                              |
 | `entity_count`                       | `numeric!` | total number of entities                     |

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -102,7 +102,7 @@ impl TryFromValue for SubgraphHealth {
 /// The deployment data that is needed to create a deployment
 pub struct DeploymentCreate {
     pub manifest: SubgraphManifestEntity,
-    pub earliest_block: Option<BlockPtr>,
+    pub start_block: Option<BlockPtr>,
     pub graft_base: Option<DeploymentHash>,
     pub graft_block: Option<BlockPtr>,
     pub debug_fork: Option<DeploymentHash>,
@@ -112,11 +112,11 @@ impl DeploymentCreate {
     pub fn new(
         raw_manifest: String,
         source_manifest: &SubgraphManifest<impl Blockchain>,
-        earliest_block: Option<BlockPtr>,
+        start_block: Option<BlockPtr>,
     ) -> Self {
         Self {
             manifest: SubgraphManifestEntity::new(raw_manifest, source_manifest),
-            earliest_block: earliest_block.cheap_clone(),
+            start_block: start_block.cheap_clone(),
             graft_base: None,
             graft_block: None,
             debug_fork: None,
@@ -147,7 +147,10 @@ pub struct SubgraphDeploymentEntity {
     pub synced: bool,
     pub fatal_error: Option<SubgraphError>,
     pub non_fatal_errors: Vec<SubgraphError>,
-    pub earliest_block: Option<BlockPtr>,
+    /// The earliest block for which we have data
+    pub earliest_block_number: BlockNumber,
+    /// The block at which indexing initially started
+    pub start_block: Option<BlockPtr>,
     pub latest_block: Option<BlockPtr>,
     pub graft_base: Option<DeploymentHash>,
     pub graft_block: Option<BlockPtr>,

--- a/store/postgres/migrations/2022-11-03-213140_drop_earliest_block/down.sql
+++ b/store/postgres/migrations/2022-11-03-213140_drop_earliest_block/down.sql
@@ -1,0 +1,9 @@
+alter table subgraphs.subgraph_deployment
+      add column earliest_ethereum_block_number numeric,
+      add column earliest_ethereum_block_hash bytea;
+
+update subgraphs.subgraph_deployment d
+   set earliest_ethereum_block_number = m.start_block_number,
+       earliest_ethereum_block_hash = m.start_block_hash
+  from subgraphs.subgraph_manifest m
+ where m.id = d.id;

--- a/store/postgres/migrations/2022-11-03-213140_drop_earliest_block/up.sql
+++ b/store/postgres/migrations/2022-11-03-213140_drop_earliest_block/up.sql
@@ -1,0 +1,3 @@
+alter table subgraphs.subgraph_deployment
+  drop column earliest_ethereum_block_number,
+  drop column earliest_ethereum_block_hash;

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -70,9 +70,6 @@ table! {
         synced -> Bool,
         fatal_error -> Nullable<Text>,
         non_fatal_errors -> Array<Text>,
-        // Not used anymore; only written to keep backwards compatible
-        earliest_ethereum_block_hash -> Nullable<Binary>,
-        earliest_ethereum_block_number -> Nullable<Numeric>,
         earliest_block_number -> Integer,
         latest_ethereum_block_hash -> Nullable<Binary>,
         latest_ethereum_block_number -> Nullable<Numeric>,
@@ -930,8 +927,6 @@ pub fn create_deployment(
         d::health.eq(SubgraphHealth::Healthy),
         d::fatal_error.eq::<Option<String>>(None),
         d::non_fatal_errors.eq::<Vec<String>>(vec![]),
-        d::earliest_ethereum_block_hash.eq(b(&start_block)),
-        d::earliest_ethereum_block_number.eq(n(&start_block)),
         d::earliest_block_number.eq(earliest_block_number),
         d::latest_ethereum_block_hash.eq(sql("null")),
         d::latest_ethereum_block_number.eq(sql("null")),

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -915,12 +915,12 @@ pub fn create_deployment(
                 schema,
                 raw_yaml,
             },
-        earliest_block,
+        start_block,
         graft_base,
         graft_block,
         debug_fork,
     } = deployment;
-    let earliest_block_number = earliest_block.as_ref().map(|ptr| ptr.number).unwrap_or(0);
+    let earliest_block_number = start_block.as_ref().map(|ptr| ptr.number).unwrap_or(0);
 
     let deployment_values = (
         d::id.eq(site.id),
@@ -930,8 +930,8 @@ pub fn create_deployment(
         d::health.eq(SubgraphHealth::Healthy),
         d::fatal_error.eq::<Option<String>>(None),
         d::non_fatal_errors.eq::<Vec<String>>(vec![]),
-        d::earliest_ethereum_block_hash.eq(b(&earliest_block)),
-        d::earliest_ethereum_block_number.eq(n(&earliest_block)),
+        d::earliest_ethereum_block_hash.eq(b(&start_block)),
+        d::earliest_ethereum_block_number.eq(n(&start_block)),
         d::earliest_block_number.eq(earliest_block_number),
         d::latest_ethereum_block_hash.eq(sql("null")),
         d::latest_ethereum_block_number.eq(sql("null")),
@@ -955,8 +955,8 @@ pub fn create_deployment(
         // New subgraphs index only a prefix of bytea columns
         // see: attr-bytea-prefix
         m::use_bytea_prefix.eq(true),
-        m::start_block_hash.eq(b(&earliest_block)),
-        m::start_block_number.eq(earliest_block_number),
+        m::start_block_hash.eq(b(&start_block)),
+        m::start_block_number.eq(start_block.as_ref().map(|ptr| ptr.number)),
         m::raw_yaml.eq(raw_yaml),
     );
 

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1396,6 +1396,12 @@ impl DeploymentStore {
                 info!(logger, "Counted the entities";
                       "time_ms" => start.elapsed().as_millis());
 
+                deployment::set_earliest_block(
+                    &conn,
+                    &dst.site,
+                    src_deployment.earliest_block_number,
+                )?;
+
                 // Analyze all tables for this deployment
                 for entity_name in dst.tables.keys() {
                     self.analyze_with_conn(site.cheap_clone(), entity_name.as_str(), &conn)?;

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -49,10 +49,7 @@ pub struct DeploymentDetail {
     pub synced: bool,
     fatal_error: Option<String>,
     non_fatal_errors: Vec<String>,
-    // Not used anymore; only written to keep backwards compatible
-    earliest_ethereum_block_hash: Option<Bytes>,
-    earliest_ethereum_block_number: Option<BigDecimal>,
-    // New tracker for earliest block number
+    /// The earliest block for which we have history
     earliest_block_number: i32,
     pub latest_ethereum_block_hash: Option<Bytes>,
     pub latest_ethereum_block_number: Option<BigDecimal>,

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -362,13 +362,13 @@ impl TryFrom<StoredDeploymentEntity> for SubgraphDeploymentEntity {
     type Error = StoreError;
 
     fn try_from(ent: StoredDeploymentEntity) -> Result<Self, Self::Error> {
-        let (detail, manifest) = (ent.0, ent.1.into());
+        let (detail, manifest) = (ent.0, ent.1);
 
-        let earliest_block = block(
+        let start_block = block(
             &detail.deployment,
-            "earliest_block",
-            detail.earliest_ethereum_block_hash,
-            detail.earliest_ethereum_block_number,
+            "start_block",
+            manifest.start_block_hash.clone(),
+            manifest.start_block_number.map(|n| n.into()),
         )?
         .map(|block| block.to_ptr());
 
@@ -401,13 +401,14 @@ impl TryFrom<StoredDeploymentEntity> for SubgraphDeploymentEntity {
             .map_err(|b| constraint_violation!("invalid debug fork `{}`", b))?;
 
         Ok(SubgraphDeploymentEntity {
-            manifest,
+            manifest: manifest.into(),
             failed: detail.failed,
             health: detail.health.into(),
             synced: detail.synced,
             fatal_error: None,
             non_fatal_errors: vec![],
-            earliest_block,
+            earliest_block_number: detail.earliest_block_number,
+            start_block,
             latest_block,
             graft_base,
             graft_block,

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -623,7 +623,7 @@ impl SubgraphStoreInner {
         // Transmogrify the deployment into a new one
         let deployment = DeploymentCreate {
             manifest: deployment.manifest,
-            earliest_block: deployment.earliest_block.clone(),
+            start_block: deployment.start_block.clone(),
             graft_base: Some(src.deployment.clone()),
             graft_block: Some(block),
             debug_fork: deployment.debug_fork,


### PR DESCRIPTION
These columns weren't really used since PR #3673 but left in place in case we needed to go back to them. This PR completely removes them.