### PR TITLE
Skip migrations in integration tests

### DIFF
--- a/tests/integration-tests/api-version-v0-0-4/package.json
+++ b/tests/integration-tests/api-version-v0-0-4/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build-contracts": "../common/build-contracts.sh",
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "test": "yarn build-contracts && truffle test --compile-none --network test",
     "create:test": "graph create test/api-version-v0-0-4 --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test": "graph deploy test/api-version-v0-0-4 --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"

--- a/tests/integration-tests/data-source-revert/package.json
+++ b/tests/integration-tests/data-source-revert/package.json
@@ -2,7 +2,7 @@
   "name": "data-source-revert",
   "version": "0.1.0",
   "scripts": {
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "deploy:test": "graph deploy test/data-source-revert --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test-grafted": "graph deploy test/data-source-revert-grafted grafted.yaml --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },

--- a/tests/integration-tests/dynamic-data-source/package.json
+++ b/tests/integration-tests/dynamic-data-source/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build-contracts": "../common/build-contracts.sh",
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "test": "yarn build-contracts && truffle test --compile-none --network test",
     "create:test": "graph create test/dynamic-data-source --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test": "graph deploy test/dynamic-data-source --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"

--- a/tests/integration-tests/fatal-error/package.json
+++ b/tests/integration-tests/fatal-error/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build-contracts": "../common/build-contracts.sh",
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "test": "yarn build-contracts && truffle test --compile-none --network test",
     "create:test": "graph create test/fatal-error --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test": "graph deploy test/fatal-error --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"

--- a/tests/integration-tests/file-data-sources/package.json
+++ b/tests/integration-tests/file-data-sources/package.json
@@ -2,7 +2,7 @@
   "name": "file-data-sources",
   "version": "0.1.0",
   "scripts": {
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "create:test": "graph create test/file-data-sources --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test": "graph deploy test/file-data-sources --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },

--- a/tests/integration-tests/ganache-reverts/package.json
+++ b/tests/integration-tests/ganache-reverts/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build-contracts": "../common/build-contracts.sh",
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "test": "yarn build-contracts && truffle test --compile-none --network test",
     "create:test": "graph create test/ganache-reverts --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test": "graph deploy test/ganache-reverts --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"

--- a/tests/integration-tests/host-exports/package.json
+++ b/tests/integration-tests/host-exports/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build-contracts": "../common/build-contracts.sh",
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "test": "yarn build-contracts && truffle test --compile-none --network test",
     "create:test": "graph create test/host-exports --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test": "graph deploy test/host-exports --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"

--- a/tests/integration-tests/non-fatal-errors/package.json
+++ b/tests/integration-tests/non-fatal-errors/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build-contracts": "../common/build-contracts.sh",
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "test": "yarn build-contracts && truffle test --compile-none --network test",
     "create:test": "graph create test/non-fatal-errors --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test": "graph deploy test/non-fatal-errors --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"

--- a/tests/integration-tests/overloaded-contract-functions/package.json
+++ b/tests/integration-tests/overloaded-contract-functions/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build-contracts": "../common/build-contracts.sh",
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "test": "yarn build-contracts && truffle test --compile-none --network test",
     "create:test": "graph create test/overloaded-contract-functions --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test": "graph deploy test/overloaded-contract-functions --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"

--- a/tests/integration-tests/poi-for-failed-subgraph/package.json
+++ b/tests/integration-tests/poi-for-failed-subgraph/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build-contracts": "../common/build-contracts.sh",
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "test": "yarn build-contracts && truffle test --compile-none --network test",
     "create:test": "graph create test/poi-for-failed-subgraph --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test": "graph deploy test/poi-for-failed-subgraph --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"

--- a/tests/integration-tests/remove-then-update/package.json
+++ b/tests/integration-tests/remove-then-update/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build-contracts": "../common/build-contracts.sh",
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "test": "yarn build-contracts && truffle test --compile-none --network test",
     "create:test": "graph create test/remove-then-update --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test": "graph deploy test/remove-then-update --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"

--- a/tests/integration-tests/typename/package.json
+++ b/tests/integration-tests/typename/package.json
@@ -2,7 +2,7 @@
   "name": "typename",
   "version": "0.1.0",
   "scripts": {
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "create:test": "graph create test/typename --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test": "graph deploy test/typename --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
   },

--- a/tests/integration-tests/value-roundtrip/package.json
+++ b/tests/integration-tests/value-roundtrip/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build-contracts": "../common/build-contracts.sh",
-    "codegen": "graph codegen",
+    "codegen": "graph codegen --skip-migrations",
     "test": "yarn build-contracts && truffle test --compile-none --network test",
     "create:test": "graph create test/value-roundtrip --node $GRAPH_NODE_ADMIN_URI",
     "deploy:test": "graph deploy test/value-roundtrip --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"


### PR DESCRIPTION
So we don't leave the directory with dirty changes.