### PR TITLE
fix(offchain): Enforce entities list on offchain data sources

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -683,6 +683,12 @@ where
                 "Attempted to create data source in offchain data source handler. This is not yet supported.",
             );
 
+            // This propagates any deterministic error as a non-deterministic one. Which might make
+            // sense considering offchain data sources are non-deterministic.
+            if let Some(err) = block_state.deterministic_errors.into_iter().next() {
+                return Err(anyhow!("{}", err.to_string()));
+            }
+
             mods.extend(block_state.entity_cache.as_modifications()?.modifications);
             processed_data_sources.extend(block_state.processed_data_sources);
         }

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -215,7 +215,7 @@ impl SubgraphManifestEntity {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SubgraphError {
     pub subgraph_id: DeploymentHash,
     pub message: String,

--- a/graph/src/data_source/mod.rs
+++ b/graph/src/data_source/mod.rs
@@ -43,6 +43,15 @@ pub enum DataSourceCreationError {
 }
 
 /// Which entity types a data source can read and write to.
+///
+/// Currently this is only enforced on offchain data sources and templates, based on the `entities`
+/// key in the manifest. This informs which entity tables need an explicit `causality_region` column
+/// and which will always have `causality_region == 0`.
+///
+/// Note that this is just an optimization and not sufficient for causality region isolation, since
+/// generally the causality region is a property of the entity, not of the entity type.
+///
+/// See also: entity-type-access
 pub enum EntityTypeAccess {
     Any,
     Restriced(Vec<EntityType>),

--- a/graph/src/data_source/mod.rs
+++ b/graph/src/data_source/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     components::{
         link_resolver::LinkResolver,
-        store::{BlockNumber, StoredDynamicDataSource},
+        store::{BlockNumber, EntityType, StoredDynamicDataSource},
     },
     data_source::offchain::OFFCHAIN_KINDS,
     prelude::{CheapClone as _, DataSourceContext},
@@ -40,6 +40,33 @@ pub enum DataSourceCreationError {
     /// Other errors.
     #[error("error creating data source: {0:#}")]
     Unknown(#[from] Error),
+}
+
+/// Which entity types a data source can read and write to.
+pub enum EntityTypeAccess {
+    Any,
+    Restriced(Vec<EntityType>),
+}
+
+impl fmt::Display for EntityTypeAccess {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            Self::Any => write!(f, "Any"),
+            Self::Restriced(entities) => {
+                let strings = entities.iter().map(|e| e.as_str()).collect::<Vec<_>>();
+                write!(f, "{}", strings.join(", "))
+            }
+        }
+    }
+}
+
+impl EntityTypeAccess {
+    pub fn allows(&self, entity_type: &EntityType) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Restriced(types) => types.contains(entity_type),
+        }
+    }
 }
 
 impl<C: Blockchain> DataSource<C> {
@@ -103,6 +130,15 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.runtime(),
             Self::Offchain(ds) => Some(ds.mapping.runtime.cheap_clone()),
+        }
+    }
+
+    pub fn entities(&self) -> EntityTypeAccess {
+        match self {
+            // Note: Onchain data sources have an `entities` field in the manifest, but it has never
+            // been enforced.
+            Self::Onchain(_) => EntityTypeAccess::Any,
+            Self::Offchain(ds) => EntityTypeAccess::Restriced(ds.mapping.entities.clone()),
         }
     }
 

--- a/graph/src/data_source/offchain.rs
+++ b/graph/src/data_source/offchain.rs
@@ -3,7 +3,7 @@ use crate::{
     blockchain::{BlockPtr, Blockchain},
     components::{
         link_resolver::LinkResolver,
-        store::{BlockNumber, StoredDynamicDataSource},
+        store::{BlockNumber, EntityType, StoredDynamicDataSource},
         subgraph::DataSourceTemplateInfo,
     },
     data::store::scalar::Bytes,
@@ -245,7 +245,7 @@ pub enum Source {
 pub struct Mapping {
     pub language: String,
     pub api_version: semver::Version,
-    pub entities: Vec<String>,
+    pub entities: Vec<EntityType>,
     pub handler: String,
     pub runtime: Arc<Vec<u8>>,
     pub link: Link,
@@ -271,7 +271,7 @@ pub struct UnresolvedMapping {
     pub language: String,
     pub file: Link,
     pub handler: String,
-    pub entities: Vec<String>,
+    pub entities: Vec<EntityType>,
 }
 
 impl UnresolvedDataSource {

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -15,7 +15,7 @@ use graph::components::subgraph::{
     PoICausalityRegion, ProofOfIndexingEvent, SharedProofOfIndexing,
 };
 use graph::data::store;
-use graph::data_source::{DataSource, DataSourceTemplate};
+use graph::data_source::{DataSource, DataSourceTemplate, EntityTypeAccess};
 use graph::ensure;
 use graph::prelude::ethabi::param_type::Reader;
 use graph::prelude::ethabi::{decode, encode, Token};
@@ -63,6 +63,7 @@ pub struct HostExports<C: Blockchain> {
     data_source_address: Vec<u8>,
     subgraph_network: String,
     data_source_context: Arc<Option<DataSourceContext>>,
+    entity_type_access: EntityTypeAccess,
 
     /// Some data sources have indeterminism or different notions of time. These
     /// need to be each be stored separately to separate causality between them,
@@ -89,11 +90,26 @@ impl<C: Blockchain> HostExports<C> {
             data_source_name: data_source.name().to_owned(),
             data_source_address: data_source.address().unwrap_or_default(),
             data_source_context: data_source.context().cheap_clone(),
+            entity_type_access: data_source.entities(),
             causality_region: PoICausalityRegion::from_network(&subgraph_network),
             subgraph_network,
             templates,
             link_resolver,
             ens_lookup,
+        }
+    }
+
+    fn check_entity_type_access(&self, entity_type: &EntityType) -> Result<(), HostExportError> {
+        match self.entity_type_access.allows(entity_type) {
+            true => Ok(()),
+            false => Err(HostExportError::Deterministic(anyhow!(
+                "entity type `{}` is not on the 'entities' list for data source `{}`. \
+                 Hint: Add `{}` to the 'entities' list, which currently is: `{}`.",
+                entity_type,
+                self.data_source_name,
+                entity_type,
+                self.entity_type_access
+            ))),
         }
     }
 
@@ -139,7 +155,7 @@ impl<C: Blockchain> HostExports<C> {
         data: HashMap<String, Value>,
         stopwatch: &StopwatchMetrics,
         gas: &GasCounter,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), HostExportError> {
         let poi_section = stopwatch.start_section("host_export_store_set__proof_of_indexing");
         write_poi_event(
             proof_of_indexing,
@@ -157,6 +173,7 @@ impl<C: Blockchain> HostExports<C> {
             entity_type: EntityType::new(entity_type),
             entity_id: entity_id.into(),
         };
+        self.check_entity_type_access(&key.entity_type)?;
 
         gas.consume_host_fn(gas::STORE_SET.with_args(complexity::Linear, (&key, &data)))?;
 
@@ -188,6 +205,7 @@ impl<C: Blockchain> HostExports<C> {
             entity_type: EntityType::new(entity_type),
             entity_id: entity_id.into(),
         };
+        self.check_entity_type_access(&key.entity_type)?;
 
         gas.consume_host_fn(gas::STORE_REMOVE.with_args(complexity::Size, &key))?;
 
@@ -207,6 +225,7 @@ impl<C: Blockchain> HostExports<C> {
             entity_type: EntityType::new(entity_type),
             entity_id: entity_id.into(),
         };
+        self.check_entity_type_access(&store_key.entity_type)?;
 
         let result = state.entity_cache.get(&store_key)?;
         gas.consume_host_fn(gas::STORE_GET.with_args(complexity::Linear, (&store_key, &result)))?;

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -99,6 +99,7 @@ impl<C: Blockchain> HostExports<C> {
         }
     }
 
+    /// Enfore the entity type access restrictions. See also: entity-type-access
     fn check_entity_type_access(&self, entity_type: &EntityType) -> Result<(), HostExportError> {
         match self.entity_type_access.allows(entity_type) {
             true => Ok(()),

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -831,6 +831,12 @@ impl SubgraphStoreInner {
         Ok(())
     }
 
+    #[cfg(debug_assertions)]
+    pub fn status_for_id(&self, id: graph::components::store::DeploymentId) -> status::Info {
+        let filter = status::Filter::DeploymentIds(vec![id]);
+        self.status(filter).unwrap().into_iter().next().unwrap()
+    }
+
     pub(crate) fn status(&self, filter: status::Filter) -> Result<Vec<status::Info>, StoreError> {
         let sites = match filter {
             status::Filter::SubgraphName(name) => {

--- a/tests/integration-tests/file-data-sources/src/mapping.ts
+++ b/tests/integration-tests/file-data-sources/src/mapping.ts
@@ -1,4 +1,4 @@
-import { ethereum, dataSource, BigInt, Bytes } from '@graphprotocol/graph-ts'
+import { ethereum, dataSource, BigInt, Bytes, DataSourceContext } from '@graphprotocol/graph-ts'
 import { IpfsFile, IpfsFile1 } from '../generated/schema'
 
 export function handleBlock(block: ethereum.Block): void {
@@ -20,6 +20,11 @@ export function handleBlock(block: ethereum.Block): void {
   // to test whether same cid is triggered across different data source.
   if (block.number == BigInt.fromI32(3)) {
     dataSource.create("File1", ["QmVkvoPGi9jvvuxsHDVJDgzPEzagBaWSZRYoRDzU244HjZ"])
+  }
+
+  // Will fail the subgraph when processed due to mismatch in the entity type and 'entities'.
+  if (block.number == BigInt.fromI32(5)) {
+    dataSource.create("File2", ["QmVkvoPGi9jvvuxsHDVJDgzPEzagBaWSZRYoRDzU244HjZ"])
   }
 }
 

--- a/tests/integration-tests/file-data-sources/subgraph.yaml
+++ b/tests/integration-tests/file-data-sources/subgraph.yaml
@@ -28,7 +28,7 @@ templates:
       apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
-        - Gravatar
+        - IpfsFile
       abis:
         - name: Contract
           file: ./abis/Contract.abi
@@ -42,6 +42,19 @@ templates:
       language: wasm/assemblyscript
       entities:
         - IpfsFile1
+      abis:
+        - name: Contract
+          file: ./abis/Contract.abi
+      handler: handleFile1
+      file: ./src/mapping.ts
+  - kind: file/ipfs
+    name: File2
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - IpfsFile # will trigger an error, should be IpfsFile1
       abis:
         - name: Contract
           file: ./abis/Contract.abi


### PR DESCRIPTION
First part of #3770.

This enforces that file data sources can only call `entity.get`, `entity.set` and `entity.remove` on entity types they've declared in the `entities:` array in the manifest.