### PR TITLE
Refactor: move data_sources out of EntityCache

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -259,7 +259,7 @@ where
 
             // Add entity operations for the new data sources to the block state
             // and add runtimes for the data sources to the subgraph instance.
-            self.persist_dynamic_data_sources(&mut block_state.entity_cache, data_sources);
+            self.persist_dynamic_data_sources(&mut block_state, data_sources);
 
             // Process the triggers in each host in the same order the
             // corresponding data sources have been created.
@@ -322,7 +322,6 @@ where
             .start_section("as_modifications");
         let ModificationsAndCache {
             modifications: mut mods,
-            data_sources,
             entity_lfu_cache: cache,
         } = block_state
             .entity_cache
@@ -376,6 +375,7 @@ where
 
         let BlockState {
             deterministic_errors,
+            persisted_data_sources,
             ..
         } = block_state;
 
@@ -387,7 +387,7 @@ where
                 firehose_cursor,
                 mods,
                 &self.metrics.host.stopwatch,
-                data_sources,
+                persisted_data_sources,
                 deterministic_errors,
                 self.inputs.manifest_idx_and_name.clone(),
                 processed_data_sources,
@@ -528,7 +528,7 @@ where
 
     fn persist_dynamic_data_sources(
         &mut self,
-        entity_cache: &mut EntityCache,
+        block_state: &mut BlockState<C>,
         data_sources: Vec<DataSource<C>>,
     ) {
         if !data_sources.is_empty() {
@@ -548,7 +548,7 @@ where
                 "name" => &data_source.name(),
                 "address" => &data_source.address().map(|address| hex::encode(address)).unwrap_or("none".to_string()),
             );
-            entity_cache.add_data_source(data_source);
+            block_state.persist_data_source(data_source.as_stored_dynamic_data_source());
         }
 
         // Merge filters from data sources into the block stream builder

--- a/graph/src/components/store/entity_cache.rs
+++ b/graph/src/components/store/entity_cache.rs
@@ -3,7 +3,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self, Debug};
 use std::sync::Arc;
 
-use crate::blockchain::BlockPtr;
 use crate::components::store::{
     self as s, Entity, EntityKey, EntityOp, EntityOperation, EntityType,
 };
@@ -340,21 +339,4 @@ impl LfuCache<EntityKey, Option<Entity>> {
             Some(data) => Ok(data.to_owned()),
         }
     }
-}
-
-/// Represents an item retrieved from an
-/// [`EthereumCallCache`](super::EthereumCallCache) implementor.
-pub struct CachedEthereumCall {
-    /// The BLAKE3 hash that uniquely represents this cache item. The way this
-    /// hash is constructed is an implementation detail.
-    pub blake3_id: Vec<u8>,
-
-    /// Block details related to this Ethereum call.
-    pub block_ptr: BlockPtr,
-
-    /// The address to the called contract.
-    pub contract_address: ethabi::Address,
-
-    /// The encoded return value of this call.
-    pub return_value: Vec<u8>,
 }

--- a/graph/src/components/store/entity_cache.rs
+++ b/graph/src/components/store/entity_cache.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use crate::components::store::{
     self as s, Entity, EntityKey, EntityOp, EntityOperation, EntityType,
 };
-use crate::data_source::DataSource;
 use crate::prelude::{Schema, ENV_VARS};
 use crate::util::lfu_cache::LfuCache;
 
@@ -31,8 +30,6 @@ pub struct EntityCache {
     // Marks whether updates should go in `handler_updates`.
     in_handler: bool,
 
-    data_sources: Vec<s::StoredDynamicDataSource>,
-
     /// The store is only used to read entities.
     pub store: Arc<dyn s::ReadStore>,
 
@@ -50,7 +47,6 @@ impl Debug for EntityCache {
 
 pub struct ModificationsAndCache {
     pub modifications: Vec<s::EntityModification>,
-    pub data_sources: Vec<s::StoredDynamicDataSource>,
     pub entity_lfu_cache: LfuCache<EntityKey, Option<Entity>>,
 }
 
@@ -61,7 +57,6 @@ impl EntityCache {
             updates: HashMap::new(),
             handler_updates: HashMap::new(),
             in_handler: false,
-            data_sources: vec![],
             schema: store.input_schema(),
             store,
         }
@@ -76,7 +71,6 @@ impl EntityCache {
             updates: HashMap::new(),
             handler_updates: HashMap::new(),
             in_handler: false,
-            data_sources: vec![],
             schema: store.input_schema(),
             store,
         }
@@ -189,12 +183,6 @@ impl EntityCache {
                 }
             }
         }
-    }
-
-    /// Add a dynamic data source
-    pub fn add_data_source<C: s::Blockchain>(&mut self, data_source: &DataSource<C>) {
-        self.data_sources
-            .push(data_source.as_stored_dynamic_data_source());
     }
 
     fn entity_op(&mut self, key: EntityKey, op: EntityOp) {
@@ -313,7 +301,6 @@ impl EntityCache {
 
         Ok(ModificationsAndCache {
             modifications: mods,
-            data_sources: self.data_sources,
             entity_lfu_cache: self.current,
         })
     }

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1,8 +1,8 @@
-mod cache;
+mod entity_cache;
 mod err;
 mod traits;
 
-pub use cache::{CachedEthereumCall, EntityCache, ModificationsAndCache};
+pub use entity_cache::{EntityCache, ModificationsAndCache};
 
 pub use err::StoreError;
 use itertools::Itertools;
@@ -20,7 +20,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-use crate::blockchain::{Block, Blockchain};
+use crate::blockchain::Block;
 use crate::data::store::scalar::Bytes;
 use crate::data::store::*;
 use crate::data::value::Word;
@@ -1111,4 +1111,21 @@ pub trait PruneReporter: Send + 'static {
     fn finish_switch(&mut self) {}
 
     fn finish_prune(&mut self) {}
+}
+
+/// Represents an item retrieved from an
+/// [`EthereumCallCache`](super::EthereumCallCache) implementor.
+pub struct CachedEthereumCall {
+    /// The BLAKE3 hash that uniquely represents this cache item. The way this
+    /// hash is constructed is an implementation detail.
+    pub blake3_id: Vec<u8>,
+
+    /// Block details related to this Ethereum call.
+    pub block_ptr: BlockPtr,
+
+    /// The address to the called contract.
+    pub contract_address: ethabi::Address,
+
+    /// The encoded return value of this call.
+    pub return_value: Vec<u8>,
 }

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -21,6 +21,9 @@ pub struct BlockState<C: Blockchain> {
     pub deterministic_errors: Vec<SubgraphError>,
     created_data_sources: Vec<DataSourceTemplateInfo<C>>,
 
+    // Data sources to be transacted into the store.
+    pub persisted_data_sources: Vec<StoredDynamicDataSource>,
+
     // Data sources created in the current handler.
     handler_created_data_sources: Vec<DataSourceTemplateInfo<C>>,
 
@@ -37,6 +40,7 @@ impl<C: Blockchain> BlockState<C> {
             entity_cache: EntityCache::with_current(Arc::new(store), lfu_cache),
             deterministic_errors: Vec::new(),
             created_data_sources: Vec::new(),
+            persisted_data_sources: Vec::new(),
             handler_created_data_sources: Vec::new(),
             processed_data_sources: Vec::new(),
             in_handler: false,
@@ -50,6 +54,7 @@ impl<C: Blockchain> BlockState<C> {
             entity_cache,
             deterministic_errors,
             created_data_sources,
+            persisted_data_sources,
             handler_created_data_sources,
             processed_data_sources,
             in_handler,
@@ -62,6 +67,7 @@ impl<C: Blockchain> BlockState<C> {
         deterministic_errors.extend(other.deterministic_errors);
         entity_cache.extend(other.entity_cache);
         processed_data_sources.extend(other.processed_data_sources);
+        persisted_data_sources.extend(other.persisted_data_sources);
     }
 
     pub fn has_errors(&self) -> bool {
@@ -103,5 +109,9 @@ impl<C: Blockchain> BlockState<C> {
     pub fn push_created_data_source(&mut self, ds: DataSourceTemplateInfo<C>) {
         assert!(self.in_handler);
         self.handler_created_data_sources.push(ds);
+    }
+
+    pub fn persist_data_source(&mut self, ds: StoredDynamicDataSource) {
+        self.persisted_data_sources.push(ds)
     }
 }


### PR DESCRIPTION
This is now tracked directly in the `BlockState`, so that the entity cache is only about entities. Also renames the module from `cache` to `entity_cache` and moves out the unrelated `CachedEthereumCall`.