### PR TITLE
Automatically close stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           # PRs
           days-before-pr-stale: 90
-          days-before-pr-close: 7
+          days-before-pr-close: 14
           stale-pr-message: >
             This pull request hasn't had any activity for the last 90 days. If
-            there's no more activity over the course of the next 7 days, it will
+            there's no more activity over the course of the next 14 days, it will
             automatically be closed.
           # Issues
           days-before-issue-stale: 180


### PR DESCRIPTION
- Warn about stale PRs after 90 days.
- Automatically close stale PRs after 90+7 days.
- Warn about stale stale issues after 180 days.

It would look like [this](https://github.com/actions/stale/pull/603).