### PR TITLE
Fix `./docker/build.sh`

### DIFF
--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -831,7 +831,6 @@ impl SubgraphStoreInner {
         Ok(())
     }
 
-    #[cfg(debug_assertions)]
     pub fn status_for_id(&self, id: graph::components::store::DeploymentId) -> status::Info {
         let filter = status::Filter::DeploymentIds(vec![id]);
         self.status(filter).unwrap().into_iter().next().unwrap()


### PR DESCRIPTION
# Context

I noticed that the `./docker/build.sh` script currently fails due to a Rust [E0599](https://doc.rust-lang.org/error_codes/E0599.html) error. I initially thought I had an isolated issue related to my own machine (M1 Mac, Mac OS Ventura 13.0.1) but then realized the method in question was [introduced in a recent PR](https://github.com/graphprotocol/graph-node/commit/a8d184c87555967769e71c7a8c2bfb6f0e070b91#diff-fbebe8c1d9a66d5a40732d736208ae22810af9d9f5c321c0d7da9f23d3d8385eR835) to this repository, which made me suspect the `./docker/build/sh` may not have been tested with the new code.

# Proposed fix

In this PR I'm introducing a proposal to fix the `./docker/build.sh` script by including the `SubgraphStore::status_for_id` method in the default compilation step. I considered adding a new compilation profile but decided against that approach because it feels like a more serious semantic change.

#  Screenshots

###### Current `master` (1ef69c7)

<img width="1728" alt="Screenshot 2022-11-12 at 12 02 20" src="https://user-images.githubusercontent.com/11042411/201486331-30319e9b-d3b7-4e02-8153-7ba0e39888fa.png">

###### This PR

<img width="1728" alt="Screenshot 2022-11-12 at 12 16 23" src="https://user-images.githubusercontent.com/11042411/201486409-966c4994-3072-4ac8-b6ff-fbce29ee43af.png">
