### PR TITLE
graphql: fields of object should be ANDed always

### DIFF
--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -2128,7 +2128,7 @@ fn deterministic_error() {
 fn can_query_with_or_filter() {
     const QUERY: &str = "
     query {
-        musicians(where: { or: [{ name: \"John\", id: \"m2\" }] }) {
+        musicians(where: { or: [{ name: \"John\" }, { id: \"m2\" }] }) {
             name
             id
         }
@@ -2141,6 +2141,26 @@ fn can_query_with_or_filter() {
                 object! { name: "John", id: "m1" },
                 object! { name: "Lisa", id: "m2" },
             ],
+        };
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    })
+}
+
+#[test]
+fn can_query_with_or_filter_fields_always_and() {
+    const QUERY: &str = "
+    query {
+        musicians(where: { or: [{ name: \"John\", id: \"m2\" }] }) {
+            name
+            id
+        }
+    }
+    ";
+
+    run_query(QUERY, |result, _| {
+        let exp = object! {
+            musicians: r::Value::List(vec![]),
         };
         let data = extract_data!(result).unwrap();
         assert_eq!(data, exp);


### PR DESCRIPTION
Let's take this query as an example
```graphql
{
  musicians(where: { or: [{name: "John", id: "m2"},{bandId: "7j"}]}){
    id
  }
}
```

**Before** when the filter for `OR/AND` was parsed and SQL was generated it would flatten all the filters and then all the fields were ORed so it would look like

```rust
EntityFilter::Or([{name: "John"}, {id: "m2"}, {bandId: "7j"}])
```

**After** this PR it will alway AND the fields in an object and then OR the adjacent fields so it would look like

```rust
EntityFilter::Or([EntityFilter::And([{name: "John"}, {id: "m2"}]), EntityFilter::And([{bandId: "7j"}])])
```




