### PR TITLE
Fix non-0 return code of `stale` action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,6 +32,3 @@ jobs:
           stale-issue-message: >
             Looks like this issue has been open for 6 months with no activity.
             Is it still relevant? If not, please remember to close it.
-
-      - name: Print stale outputs
-        run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
The `stale` GH Action works, but it's marked as failed because of a borked final step that invokes `echo`.