### PR TITLE
Enable thin LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,10 @@ license = "MIT OR Apache-2.0"
 [profile.test]
 incremental = false
 
+[profile.release]
+lto = "thin"
+codegen-units = 1
+incremental = false
+
 [profile.dev]
 incremental = false


### PR DESCRIPTION
I would hardly expect this to cause a performance regression; at most we won't see any improvements. So I think we're good rolling this out before further investigation.

This results in a x2.12 `--release` compilation time increase on my machine.

@lutter @leoyvens 