### PR TITLE
Remove usage of `cargo-chef`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,41 +13,22 @@ ARG ENVSUBST_COMMIT_SHA=16035fe3571ad42c7796bf554f978bb2df64231b
 RUN go install github.com/a8m/envsubst/cmd/envsubst@$ENVSUBST_COMMIT_SHA \
     && strip -g /go/bin/envsubst
 
-FROM rust:bullseye AS cargo-chef
-
-WORKDIR /app
-# Best thing in life after sliced bread.
-# <https://github.com/LukeMathWalker/cargo-chef>
-# We're not using cargo-chef's prebuilt image for security reasons (not that
-# there's anything wrong with it per se). The version is pinned to minimize the
-# risk of supply chain attacks.
-RUN cargo install cargo-chef --version 0.1.45
-
-FROM cargo-chef AS cargo-chef-plan
-
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-FROM cargo-chef AS graph-node-build
-
-WORKDIR /graph-node
+FROM rust:bullseye as graph-node-build
 
 ARG COMMIT_SHA=unknown
 ARG REPO_NAME=unknown
 ARG BRANCH_NAME=unknown
 ARG TAG_NAME=unknown
 
-COPY --from=cargo-chef-plan /app/recipe.json cargo-chef-recipe.json
+ADD . /graph-node
 
 RUN apt-get update \
-    && apt-get install -y cmake
-RUN RUSTFLAGS="-g" cargo chef cook --release --recipe-path cargo-chef-recipe.json
-
-ADD . .
-
-RUN RUSTFLAGS="-g" cargo build --release \
+    && apt-get install -y cmake && \
+    cd /graph-node && \
+    RUSTFLAGS="-g" cargo build --release --package graph-node \
     && cp target/release/graph-node /usr/local/bin/graph-node \
     && cp target/release/graphman /usr/local/bin/graphman \
+    # Reduce the size of the layer by removing unnecessary files.
     && cargo clean \
     && objcopy --only-keep-debug /usr/local/bin/graph-node /usr/local/bin/graph-node.debug \
     && strip -g /usr/local/bin/graph-node \
@@ -59,7 +40,8 @@ RUN RUSTFLAGS="-g" cargo build --release \
     && echo "BRANCH_NAME='$BRANCH_NAME'" >> /etc/image-info \
     && echo "COMMIT_SHA='$COMMIT_SHA'" >> /etc/image-info \
     && echo "CARGO_VERSION='$(cargo --version)'" >> /etc/image-info \
-    && echo "RUST_VERSION='$(rustc --version)'" >> /etc/image-info
+    && echo "RUST_VERSION='$(rustc --version)'" >> /etc/image-info \
+    && echo "CARGO_DEV_BUILD='$CARGO_DEV_BUILD'" >> /etc/image-info
 
 # Debug image to access core dumps
 FROM graph-node-build as graph-node-debug

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,6 @@ name = "graph-node"
 version.workspace = true
 edition.workspace = true
 default-run = "graph-node"
-rust-version = "1.64"
 
 [[bin]]
 name = "graph-node"
@@ -28,12 +27,12 @@ graph-chain-arweave = { path = "../chain/arweave" }
 graph-chain-ethereum = { path = "../chain/ethereum" }
 graph-chain-near = { path = "../chain/near" }
 graph-chain-cosmos = { path = "../chain/cosmos" }
-graph-chain-substreams= { path = "../chain/substreams" }
+graph-chain-substreams = { path = "../chain/substreams" }
 graph-graphql = { path = "../graphql" }
 graph-runtime-wasm = { path = "../runtime/wasm" }
 graph-server-http = { path = "../server/http" }
 graph-server-index-node = { path = "../server/index-node" }
-graph-server-json-rpc = { path = "../server/json-rpc"}
+graph-server-json-rpc = { path = "../server/json-rpc" }
 graph-server-websocket = { path = "../server/websocket" }
 graph-server-metrics = { path = "../server/metrics" }
 graph-store-postgres = { path = "../store/postgres" }
@@ -44,5 +43,5 @@ toml = "0.5.7"
 shellexpand = "2.1.0"
 diesel = "1.4.8"
 http = "0.2.5" # must be compatible with the version rust-web3 uses
-prometheus = { version ="0.13.3", features = ["push"] }
-json-structural-diff = {version = "0.1", features = ["colorize"] }
+prometheus = { version = "0.13.3", features = ["push"] }
+json-structural-diff = { version = "0.1", features = ["colorize"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-channel = "stable"
-components = ["rustfmt", "clippy"]
-profile = "minimal"
+channel = "1.65.0"
+profile = "default"


### PR DESCRIPTION
1. Removes `cargo-chef` from the Docker image, because there's no easy way to do layer caching in Cloudbuild. With this, CloudBuild times are back to normal.
2. After making sure that a new Rust release wouldn't break our build or invalidate our GH Actions caches, I feel confident reverting https://github.com/graphprotocol/graph-node/pull/4127.


See the `7ad9b110-50b9-4d59-a57f-4b9b55cb8dd2` build for an example build.