### PR TITLE
ensure substreams-based-subgraphs can be started at specific block or rewound

### DIFF
--- a/chain/substreams/src/block_stream.rs
+++ b/chain/substreams/src/block_stream.rs
@@ -35,7 +35,7 @@ impl BlockStreamBuilderTrait<Chain> for BlockStreamBuilder {
         deployment: DeploymentLocator,
         block_cursor: FirehoseCursor,
         _start_blocks: Vec<BlockNumber>,
-        _subgraph_current_block: Option<BlockPtr>,
+        subgraph_current_block: Option<BlockPtr>,
         filter: Arc<TriggerFilter>,
         _unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Box<dyn BlockStream<Chain>>> {
@@ -51,7 +51,7 @@ impl BlockStreamBuilderTrait<Chain> for BlockStreamBuilder {
         Ok(Box::new(SubstreamsBlockStream::new(
             deployment.hash,
             firehose_endpoint,
-            None,
+            subgraph_current_block,
             block_cursor.as_ref().clone(),
             mapper,
             filter.modules.clone(),

--- a/graph/src/blockchain/substreams_block_stream.rs
+++ b/graph/src/blockchain/substreams_block_stream.rs
@@ -162,13 +162,20 @@ fn stream_blocks<C: Blockchain, F: SubstreamsMapper<C>>(
     module_name: String,
     manifest_start_block_num: BlockNumber,
     manifest_end_block_num: BlockNumber,
-    _subgraph_current_block: Option<BlockPtr>,
+    subgraph_current_block: Option<BlockPtr>,
     logger: Logger,
     metrics: SubstreamsBlockStreamMetrics,
 ) -> impl Stream<Item = Result<BlockStreamEvent<C>, Error>> {
     let mut latest_cursor = cursor.unwrap_or_else(|| "".to_string());
 
-    let start_block_num = manifest_start_block_num as i64;
+    let mut start_block_num = subgraph_current_block
+        .as_ref()
+        .map(|ptr| {
+            // current_block has already been processed, we start at next block
+            ptr.block_number() as i64 + 1
+        })
+        .unwrap_or(manifest_start_block_num as i64);
+
     let stop_block_num = manifest_end_block_num as u64;
 
     let request = Request {

--- a/graph/src/blockchain/substreams_block_stream.rs
+++ b/graph/src/blockchain/substreams_block_stream.rs
@@ -168,7 +168,7 @@ fn stream_blocks<C: Blockchain, F: SubstreamsMapper<C>>(
 ) -> impl Stream<Item = Result<BlockStreamEvent<C>, Error>> {
     let mut latest_cursor = cursor.unwrap_or_else(|| "".to_string());
 
-    let mut start_block_num = subgraph_current_block
+    let start_block_num = subgraph_current_block
         .as_ref()
         .map(|ptr| {
             // current_block has already been processed, we start at next block


### PR DESCRIPTION
Fixes https://github.com/graphprotocol/graph-node/issues/4195

This feature was omitted in substreams initially, but it is needed for `--start-block` feature, rewind, and probably in other "recovery" scenarios where we cannot start from a cursor.