### PR TITLE
Fix: run locale check after migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: graph_node_test
+          POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -63,6 +64,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: graph_node_test
+          POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,5 +44,6 @@ services:
       # <https://github.com/graphprotocol/graph-node/pull/3511>, maybe as a
       # workaround for https://github.com/docker/for-mac/issues/6270?
       PGDATA: "/var/lib/postgresql/data"
+      POSTGRES_INITDB_ARGS: "--locale=C"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,6 +44,6 @@ services:
       # <https://github.com/graphprotocol/graph-node/pull/3511>, maybe as a
       # workaround for https://github.com/docker/for-mac/issues/6270?
       PGDATA: "/var/lib/postgresql/data"
-      POSTGRES_INITDB_ARGS: "--locale=C"
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -1011,8 +1011,8 @@ impl PoolInner {
             die(&pool.logger, "failed to release migration lock", &err);
         });
         result.unwrap_or_else(|err| die(&pool.logger, "migrations failed", &err));
-        debug!(&pool.logger, "Setup finished"; "setup_time_s" => start.elapsed().as_secs());
 
+        // Locale check
         if let Err(msg) = catalog::Locale::load(&conn)?.suitable() {
             if &self.shard == &*PRIMARY_SHARD && primary::is_empty(&conn)? {
                 die(
@@ -1026,6 +1026,7 @@ impl PoolInner {
             }
         }
 
+        debug!(&pool.logger, "Setup finished"; "setup_time_s" => start.elapsed().as_secs());
         Ok(())
     }
 

--- a/tests/tests/common/docker.rs
+++ b/tests/tests/common/docker.rs
@@ -240,7 +240,7 @@ impl DockerTestClient {
 
         // 1. Create Exec
         let config = exec::CreateExecOptions {
-            cmd: Some(vec!["createdb", &database_name]),
+            cmd: Some(vec!["createdb", "-E", "UTF8", "--locale=C", &database_name]),
             user: Some("postgres"),
             attach_stdout: Some(true),
             ..Default::default()


### PR DESCRIPTION
PR #4163 introduced a locale check, which runs before migrations are applied.

This PR alters this check, so it runs immediately after migrations. 