### PR TITLE
docker: use exec form for CMD directive

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -121,4 +121,4 @@ COPY --from=graph-node-build /usr/local/bin/graph-node /usr/local/bin/graphman /
 COPY --from=graph-node-build /etc/image-info /etc/image-info
 COPY --from=envsubst /go/bin/envsubst /usr/local/bin/
 COPY docker/Dockerfile /Dockerfile
-CMD start
+CMD ["start"]


### PR DESCRIPTION
the `CMD start` is equal with `CMD sh -c start`, so pid of graph node is not 1

<img width="604" alt="image" src="https://user-images.githubusercontent.com/24730006/202811091-2a7c31b3-bc96-4c3b-bdf0-863698dfffdf.png">

#4186