### PR TITLE
graph, graphql: expose metrics for GraphQL validations failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "graphql-tools"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a71c3ac880d8383537914ea7b45d99c6946e15976faa33a42b6c339ef4a2fb8"
+checksum = "7bc3a979aca9d796ff03ff71f4013e203a1f69bf1f37899ae4a8e676bb236608"
 dependencies = [
  "graphql-parser",
  "lazy_static",

--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -17,7 +17,6 @@ pub enum GraphQlTarget {
     SubgraphName(String),
     Deployment(DeploymentHash),
 }
-
 /// A component that can run GraphqL queries against a [Store](../store/trait.Store.html).
 #[async_trait]
 pub trait GraphQlRunner: Send + Sync + 'static {
@@ -51,6 +50,7 @@ pub trait GraphQLMetrics: Send + Sync + 'static {
     fn observe_query_execution(&self, duration: Duration, results: &QueryResults);
     fn observe_query_parsing(&self, duration: Duration, results: &QueryResults);
     fn observe_query_validation(&self, duration: Duration, id: &DeploymentHash);
+    fn observe_query_validation_error(&self, error_codes: Vec<&str>, id: &DeploymentHash);
 }
 
 #[async_trait]

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 crossbeam = "0.8"
 graph = { path = "../graph" }
 graphql-parser = "0.4.0"
-graphql-tools = "0.2.0"
+graphql-tools = "0.2.1"
 indexmap = "1.9"
 Inflector = "0.11.3"
 lazy_static = "1.2.0"

--- a/graphql/src/metrics.rs
+++ b/graphql/src/metrics.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use graph::data::query::QueryResults;
 use graph::prelude::{DeploymentHash, GraphQLMetrics as GraphQLMetricsTrait, MetricsRegistry};
-use graph::prometheus::{Gauge, Histogram, HistogramVec};
+use graph::prometheus::{CounterVec, Gauge, Histogram, HistogramVec};
 
 pub struct GraphQLMetrics {
     query_execution_time: Box<HistogramVec>,
@@ -13,6 +13,7 @@ pub struct GraphQLMetrics {
     query_validation_time: Box<HistogramVec>,
     query_result_size: Box<Histogram>,
     query_result_size_max: Box<Gauge>,
+    query_validation_error_counter: Box<CounterVec>,
 }
 
 impl fmt::Debug for GraphQLMetrics {
@@ -64,6 +65,14 @@ impl GraphQLMetricsTrait for GraphQLMetrics {
             .with_label_values(&[id.as_str()])
             .observe(duration.as_secs_f64());
     }
+
+    fn observe_query_validation_error(&self, error_codes: Vec<&str>, id: &DeploymentHash) {
+        for code in error_codes.iter() {
+            self.query_validation_error_counter
+                .with_label_values(&[id.as_str(), *code])
+                .inc();
+        }
+    }
 }
 
 impl GraphQLMetrics {
@@ -111,12 +120,21 @@ impl GraphQLMetrics {
             )
             .unwrap();
 
+        let query_validation_error_counter = registry
+            .new_counter_vec(
+                "query_validation_error_counter",
+                "a counter for the number of validation errors",
+                vec![String::from("deployment"), String::from("error_code")],
+            )
+            .unwrap();
+
         Self {
             query_execution_time,
             query_parsing_time,
             query_validation_time,
             query_result_size,
             query_result_size_max,
+            query_validation_error_counter,
         }
     }
 

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -370,6 +370,7 @@ mod tests {
         fn observe_query_execution(&self, _duration: Duration, _results: &QueryResults) {}
         fn observe_query_parsing(&self, _duration: Duration, _results: &QueryResults) {}
         fn observe_query_validation(&self, _duration: Duration, _id: &DeploymentHash) {}
+        fn observe_query_validation_error(&self, _error_codes: Vec<&str>, _id: &DeploymentHash) {}
     }
 
     #[async_trait]

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -20,6 +20,7 @@ impl GraphQLMetrics for TestGraphQLMetrics {
     fn observe_query_execution(&self, _duration: Duration, _results: &QueryResults) {}
     fn observe_query_parsing(&self, _duration: Duration, _results: &QueryResults) {}
     fn observe_query_validation(&self, _duration: Duration, _id: &DeploymentHash) {}
+    fn observe_query_validation_error(&self, _error_codes: Vec<&str>, _id: &DeploymentHash) {}
 }
 
 /// A simple stupid query runner for testing.

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -27,6 +27,7 @@ impl GraphQLMetrics for NoopGraphQLMetrics {
     fn observe_query_execution(&self, _duration: Duration, _results: &QueryResults) {}
     fn observe_query_parsing(&self, _duration: Duration, _results: &QueryResults) {}
     fn observe_query_validation(&self, _duration: Duration, _id: &DeploymentHash) {}
+    fn observe_query_validation_error(&self, _error_codes: Vec<&str>, _id: &DeploymentHash) {}
 }
 
 /// An asynchronous response to a GraphQL request.


### PR DESCRIPTION
This PR adds a Counter metric for Prom, which counts validation error instances, with the `deployment_id` and `error_code` metrics. 
This is needed because we can't use/search/aggregate the logs of validations in Grafana (queries are very limited). Using metrics instead of logs should allow us to get better insights.  