### PR TITLE
Allow retrieving query traces over HTTP

### DIFF
--- a/core/tests/interfaces.rs
+++ b/core/tests/interfaces.rs
@@ -25,7 +25,7 @@ async fn insert_and_query(
 
     let document = graphql_parser::parse_query(query).unwrap().into_static();
     let target = QueryTarget::Deployment(subgraph_id, Default::default());
-    let query = Query::new(document, None);
+    let query = Query::new(document, None, false);
     Ok(execute_subgraph_query(query, target)
         .await
         .first()
@@ -1481,12 +1481,12 @@ async fn derived_interface_bytes() {
         id: Bytes!,
         trades: [Trade!]! @derivedFrom(field: "pool")
       }
-      
+
       interface Trade {
        id: Bytes!
        pool: Pool!
       }
-      
+
       type Sell implements Trade @entity {
           id: Bytes!
           pool: Pool!

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -123,7 +123,14 @@ those.
 - `SILENT_GRAPHQL_VALIDATIONS`: If `ENABLE_GRAPHQL_VALIDATIONS` is enabled, you are also able to just
   silently print the GraphQL validation errors, without failing the actual query. Note: queries
   might still fail as part of the later stage validations running, during GraphQL engine execution.
-- `GRAPH_GRAPHQL_DISABLE_BOOL_FILTERS`: disables the ability to use AND/OR filters. This is useful if we want to disable filters because of performance reasons.
+- `GRAPH_GRAPHQL_DISABLE_BOOL_FILTERS`: disables the ability to use AND/OR
+  filters. This is useful if we want to disable filters because of
+  performance reasons.
+- `GRAPH_GRAPHQL_TRACE_TOKEN`: the token to use to enable query tracing for
+  a GraphQL request. If this is set, requests that have a header
+  `X-GraphTraceQuery` set to this value will include a trace of the SQL
+  queries that were run. Defaults to the empty string which disables
+  tracing.
 
 ### GraphQL caching
 
@@ -201,7 +208,7 @@ those.
   identified as unused, `graph-node` will wait at least this long before
   actually deleting the data (value is in minutes, defaults to 360, i.e. 6
   hours)
-- `GRAPH_ALLOW_NON_DETERMINISTIC_IPFS`: enables indexing of subgraphs which 
+- `GRAPH_ALLOW_NON_DETERMINISTIC_IPFS`: enables indexing of subgraphs which
   use `ipfs.cat` as part of subgraph mappings. **This is an experimental
   feature which is not deterministic, and will be removed in future**.
 - `GRAPH_STORE_BATCH_TARGET_DURATION`: How long batch operations during

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -435,6 +435,8 @@ pub struct EntityQuery {
 
     pub query_id: Option<String>,
 
+    pub trace: bool,
+
     _force_use_of_new: (),
 }
 
@@ -453,6 +455,7 @@ impl EntityQuery {
             range: EntityRange::first(100),
             logger: None,
             query_id: None,
+            trace: false,
             _force_use_of_new: (),
         }
     }

--- a/graph/src/data/query/query.rs
+++ b/graph/src/data/query/query.rs
@@ -132,14 +132,16 @@ pub struct Query {
     pub shape_hash: u64,
     pub query_text: Arc<String>,
     pub variables_text: Arc<String>,
+    pub trace: bool,
     _force_use_of_new: (),
 }
 
 impl Query {
-    pub fn new(document: q::Document, variables: Option<QueryVariables>) -> Self {
+    pub fn new(document: q::Document, variables: Option<QueryVariables>, trace: bool) -> Self {
         let shape_hash = shape_hash(&document);
 
-        let (query_text, variables_text) = if ENV_VARS.log_gql_timing()
+        let (query_text, variables_text) = if trace
+            || ENV_VARS.log_gql_timing()
             || (ENV_VARS.graphql.enable_validations && ENV_VARS.graphql.silent_graphql_validations)
         {
             (
@@ -158,6 +160,7 @@ impl Query {
             shape_hash,
             query_text: Arc::new(query_text),
             variables_text: Arc::new(variables_text),
+            trace,
             _force_use_of_new: (),
         }
     }

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -78,6 +78,14 @@ impl QueryResults {
     pub fn traces(&self) -> Vec<&Trace> {
         self.results.iter().map(|res| &res.trace).collect()
     }
+
+    pub fn errors(&self) -> Vec<QueryError> {
+        self.results
+            .iter()
+            .map(|r| r.errors.clone())
+            .flatten()
+            .collect()
+    }
 }
 
 impl Serialize for QueryResults {

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -91,7 +91,14 @@ impl Serialize for QueryResults {
         if has_errors {
             len += 1;
         }
-
+        let first_trace = self
+            .results
+            .iter()
+            .find(|r| !r.trace.is_none())
+            .map(|r| &r.trace);
+        if first_trace.is_some() {
+            len += 1;
+        }
         let mut state = serializer.serialize_struct("QueryResults", len)?;
 
         // Serialize data.
@@ -127,6 +134,9 @@ impl Serialize for QueryResults {
             state.serialize_field("errors", &SerError(self))?;
         }
 
+        if let Some(trace) = first_trace {
+            state.serialize_field("trace", trace)?;
+        }
         state.end()
     }
 }

--- a/graph/src/data/query/trace.rs
+++ b/graph/src/data/query/trace.rs
@@ -5,7 +5,7 @@ use std::{
 
 use serde::{ser::SerializeMap, Serialize};
 
-use crate::prelude::CheapClone;
+use crate::{components::store::BlockNumber, prelude::CheapClone};
 
 #[derive(Debug)]
 pub enum Trace {
@@ -14,6 +14,7 @@ pub enum Trace {
         query: Arc<String>,
         variables: Arc<String>,
         query_id: String,
+        block: BlockNumber,
         elapsed: Mutex<Duration>,
         children: Vec<(String, Trace)>,
     },
@@ -37,6 +38,7 @@ impl Trace {
         query: &Arc<String>,
         variables: &Arc<String>,
         query_id: &str,
+        block: BlockNumber,
         do_trace: bool,
     ) -> Trace {
         if do_trace {
@@ -44,6 +46,7 @@ impl Trace {
                 query: query.cheap_clone(),
                 variables: variables.cheap_clone(),
                 query_id: query_id.to_string(),
+                block,
                 elapsed: Mutex::new(Duration::from_millis(0)),
                 children: Vec::new(),
             }
@@ -103,6 +106,7 @@ impl Serialize for Trace {
                 query,
                 variables,
                 query_id,
+                block,
                 elapsed,
                 children,
             } => {
@@ -112,6 +116,7 @@ impl Serialize for Trace {
                     map.serialize_entry("variables", variables)?;
                 }
                 map.serialize_entry("query_id", query_id)?;
+                map.serialize_entry("block", block)?;
                 map.serialize_entry("elapsed_ms", &elapsed.lock().unwrap().as_millis())?;
                 for (child, trace) in children {
                     map.serialize_entry(child, trace)?;

--- a/graph/src/env/graphql.rs
+++ b/graph/src/env/graphql.rs
@@ -87,6 +87,11 @@ pub struct EnvVarsGraphQl {
     /// Set by the flag `GRAPH_GRAPHQL_DISABLE_BOOL_FILTERS`. Off by default.
     /// Disables AND/OR filters
     pub disable_bool_filters: bool,
+    /// Set by `GRAPH_GRAPHQL_TRACE_TOKEN`, the token to use to enable query
+    /// tracing for a GraphQL request. If this is set, requests that have a
+    /// header `X-GraphTraceQuery` set to this value will include a trace of
+    /// the SQL queries that were run.
+    pub query_trace_token: String,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -132,6 +137,7 @@ impl From<InnerGraphQl> for EnvVarsGraphQl {
             error_result_size: x.error_result_size.0 .0,
             max_operations_per_connection: x.max_operations_per_connection,
             disable_bool_filters: x.disable_bool_filters.0,
+            query_trace_token: x.query_trace_token,
         }
     }
 }
@@ -179,4 +185,6 @@ pub struct InnerGraphQl {
     max_operations_per_connection: usize,
     #[envconfig(from = "GRAPH_GRAPHQL_DISABLE_BOOL_FILTERS", default = "false")]
     pub disable_bool_filters: EnvVarBoolean,
+    #[envconfig(from = "GRAPH_GRAPHQL_TRACE_TOKEN", default = "")]
+    query_trace_token: String,
 }

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -204,6 +204,9 @@ where
 
     /// Records whether this was a cache hit, used for logging.
     pub(crate) cache_status: AtomicCell<CacheStatus>,
+
+    /// Whether to include an execution trace in the result
+    pub trace: bool,
 }
 
 pub(crate) fn get_field<'a>(
@@ -236,6 +239,7 @@ where
 
             // `cache_status` is a dead value for the introspection context.
             cache_status: AtomicCell::new(CacheStatus::Miss),
+            trace: ENV_VARS.log_sql_timing(),
         }
     }
 }

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,4 +1,4 @@
-use graph::prelude::{BlockPtr, CheapClone, QueryExecutionError, QueryResult, ENV_VARS};
+use graph::prelude::{BlockPtr, CheapClone, QueryExecutionError, QueryResult};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -27,6 +27,9 @@ pub struct QueryExecutionOptions<R> {
     pub max_skip: u32,
 
     pub load_manager: Arc<LoadManager>,
+
+    /// Whether to include an execution trace in the result
+    pub trace: bool,
 }
 
 /// Executes a query and returns a result.
@@ -49,7 +52,7 @@ where
         max_first: options.max_first,
         max_skip: options.max_skip,
         cache_status: Default::default(),
-        trace: ENV_VARS.log_sql_timing(),
+        trace: options.trace,
     });
 
     if !query.is_query() {

--- a/graphql/src/query/mod.rs
+++ b/graphql/src/query/mod.rs
@@ -1,4 +1,4 @@
-use graph::prelude::{BlockPtr, CheapClone, QueryExecutionError, QueryResult};
+use graph::prelude::{BlockPtr, CheapClone, QueryExecutionError, QueryResult, ENV_VARS};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -49,6 +49,7 @@ where
         max_first: options.max_first,
         max_skip: options.max_skip,
         cache_status: Default::default(),
+        trace: ENV_VARS.log_sql_timing(),
     });
 
     if !query.is_query() {

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -123,6 +123,7 @@ where
             .unwrap_or(state);
 
         let max_depth = max_depth.unwrap_or(ENV_VARS.graphql.max_depth);
+        let trace = query.trace;
         let query = crate::execution::Query::new(
             &self.logger,
             schema,
@@ -168,6 +169,7 @@ where
                     max_first: max_first.unwrap_or(ENV_VARS.graphql.max_first),
                     max_skip: max_skip.unwrap_or(ENV_VARS.graphql.max_skip),
                     load_manager: self.load_manager.clone(),
+                    trace,
                 },
             )
             .await;

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -499,7 +499,7 @@ fn execute_root_selection_set(
     ctx: &ExecutionContext<impl Resolver>,
     selection_set: &a::SelectionSet,
 ) -> Result<(Vec<Node>, Trace), Vec<QueryExecutionError>> {
-    let trace = Trace::root(ctx.query.query_text.clone());
+    let trace = Trace::root(ctx.query.query_text.clone(), ctx.trace);
     // Execute the root selection set against the root query type
     execute_selection_set(resolver, ctx, make_root_node(), trace, selection_set)
 }

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -499,7 +499,12 @@ fn execute_root_selection_set(
     ctx: &ExecutionContext<impl Resolver>,
     selection_set: &a::SelectionSet,
 ) -> Result<(Vec<Node>, Trace), Vec<QueryExecutionError>> {
-    let trace = Trace::root(ctx.query.query_text.clone(), ctx.trace);
+    let trace = Trace::root(
+        &ctx.query.query_text,
+        &ctx.query.variables_text,
+        &ctx.query.query_id,
+        ctx.trace,
+    );
     // Execute the root selection set against the root query type
     execute_selection_set(resolver, ctx, make_root_node(), trace, selection_set)
 }

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Error};
 use graph::constraint_violation;
 use graph::data::query::Trace;
 use graph::data::value::{Object, Word};
-use graph::prelude::{r, CacheWeight};
+use graph::prelude::{r, CacheWeight, CheapClone};
 use graph::slog::warn;
 use graph::util::cache_weight;
 use lazy_static::lazy_static;
@@ -17,10 +17,9 @@ use graph::{components::store::EntityType, data::graphql::*};
 use graph::{
     data::graphql::ext::DirectiveFinder,
     prelude::{
-        s, ApiSchema, AttributeNames, BlockNumber, ChildMultiplicity, EntityCollection,
-        EntityFilter, EntityLink, EntityOrder, EntityWindow, Logger, ParentLink,
-        QueryExecutionError, QueryStore, StoreError, Value as StoreValue, WindowAttribute,
-        ENV_VARS,
+        s, ApiSchema, AttributeNames, ChildMultiplicity, EntityCollection, EntityFilter,
+        EntityLink, EntityOrder, EntityWindow, ParentLink, QueryExecutionError, StoreError,
+        Value as StoreValue, WindowAttribute, ENV_VARS,
     },
 };
 
@@ -637,18 +636,12 @@ fn execute_field(
     };
 
     fetch(
-        ctx.logger.clone(),
-        resolver.store.as_ref(),
+        resolver,
+        ctx,
         parents,
         join,
-        ctx.query.schema.as_ref(),
         field,
         multiplicity,
-        ctx.query.schema.types_for_interface(),
-        resolver.block_number(),
-        ctx.max_first,
-        ctx.max_skip,
-        ctx.query.query_id.clone(),
         selected_attrs,
     )
     .map_err(|e| vec![e])
@@ -658,31 +651,25 @@ fn execute_field(
 /// in which child field to look for the parent's id/join field. When
 /// `is_single` is `true`, there is at most one child per parent.
 fn fetch(
-    logger: Logger,
-    store: &(impl QueryStore + ?Sized),
+    resolver: &StoreResolver,
+    ctx: &ExecutionContext<impl Resolver>,
     parents: &[&mut Node],
     join: &Join<'_>,
-    schema: &ApiSchema,
     field: &a::Field,
     multiplicity: ChildMultiplicity,
-    types_for_interface: &BTreeMap<EntityType, Vec<s::ObjectType>>,
-    block: BlockNumber,
-    max_first: u32,
-    max_skip: u32,
-    query_id: String,
     selected_attrs: SelectedAttributes,
 ) -> Result<(Vec<Node>, Trace), QueryExecutionError> {
     let mut query = build_query(
         join.child_type,
-        block,
+        resolver.block_number(),
         field,
-        types_for_interface,
-        max_first,
-        max_skip,
+        ctx.query.schema.types_for_interface(),
+        ctx.max_first,
+        ctx.max_skip,
         selected_attrs,
-        schema,
+        &ctx.query.schema,
     )?;
-    query.query_id = Some(query_id);
+    query.query_id = Some(ctx.query.query_id.clone());
 
     if multiplicity == ChildMultiplicity::Single {
         // Suppress 'order by' in lookups of scalar values since
@@ -690,7 +677,7 @@ fn fetch(
         query.order = EntityOrder::Unordered;
     }
 
-    query.logger = Some(logger);
+    query.logger = Some(ctx.logger.cheap_clone());
     if let Some(r::Value::String(id)) = field.argument_value(ARG_ID.as_str()) {
         query.filter = Some(
             EntityFilter::Equal(ARG_ID.to_owned(), StoreValue::from(id.to_owned()))
@@ -707,12 +694,15 @@ fn fetch(
         }
         query.collection = EntityCollection::Window(windows);
     }
-    store.find_query_values(query).map(|(values, trace)| {
-        (
-            values.into_iter().map(|entity| entity.into()).collect(),
-            trace,
-        )
-    })
+    resolver
+        .store
+        .find_query_values(query)
+        .map(|(values, trace)| {
+            (
+                values.into_iter().map(|entity| entity.into()).collect(),
+                trace,
+            )
+        })
 }
 
 #[derive(Debug, Default, Clone)]

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -669,6 +669,7 @@ fn fetch(
         selected_attrs,
         &ctx.query.schema,
     )?;
+    query.trace = ctx.trace;
     query.query_id = Some(ctx.query.query_id.clone());
 
     if multiplicity == ChildMultiplicity::Single {

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -503,6 +503,7 @@ fn execute_root_selection_set(
         &ctx.query.query_text,
         &ctx.query.variables_text,
         &ctx.query.query_id,
+        resolver.block_number(),
         ctx.trace,
     );
     // Execute the root selection set against the root query type

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -97,6 +97,7 @@ fn create_source_event_stream(
         max_first: options.max_first,
         max_skip: options.max_skip,
         cache_status: Default::default(),
+        trace: ENV_VARS.log_sql_timing(),
     };
 
     let subscription_type = ctx
@@ -222,6 +223,7 @@ async fn execute_subscription_event(
         max_first,
         max_skip,
         cache_status: Default::default(),
+        trace: ENV_VARS.log_sql_timing(),
     });
 
     let subscription_type = match ctx.query.schema.subscription_type.as_ref() {

--- a/graphql/tests/introspection.rs
+++ b/graphql/tests/introspection.rs
@@ -560,6 +560,7 @@ async fn introspection_query(schema: Schema, query: &str) -> QueryResult {
     let query = Query::new(
         graphql_parser::parse_query(query).unwrap().into_static(),
         None,
+        false,
     );
 
     // Execute it
@@ -570,6 +571,7 @@ async fn introspection_query(schema: Schema, query: &str) -> QueryResult {
         max_first: std::u32::MAX,
         max_skip: std::u32::MAX,
         load_manager: LOAD_MANAGER.clone(),
+        trace: false,
     };
 
     let schema = Arc::new(ApiSchema::from_api_schema(schema).unwrap());

--- a/node/src/manager/commands/query.rs
+++ b/node/src/manager/commands/query.rs
@@ -58,6 +58,7 @@ pub async fn run(
     let query = Query::new(
         document,
         Some(QueryVariables::new(HashMap::from_iter(vars))),
+        true,
     );
 
     let res = runner.run_query(query, target).await;

--- a/node/src/manager/commands/query.rs
+++ b/node/src/manager/commands/query.rs
@@ -62,6 +62,10 @@ pub async fn run(
     );
 
     let res = runner.run_query(query, target).await;
+    if let Some(err) = res.errors().first().cloned() {
+        return Err(err.into());
+    }
+
     if let Some(output) = output {
         let mut f = File::create(output)?;
         let json = serde_json::to_string(&res)?;

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -128,11 +128,8 @@ where
             GraphQLServerError::ClientError(format!("Invalid subgraph name {:?}", subgraph_name))
         })?;
 
-        self.handle_graphql_query(
-            QueryTarget::Name(subgraph_name, version),
-            request.into_body(),
-        )
-        .await
+        self.handle_graphql_query(QueryTarget::Name(subgraph_name, version), request)
+            .await
     }
 
     fn handle_graphql_query_by_id(
@@ -150,7 +147,7 @@ where
         match res {
             Err(_) => self.handle_not_found(),
             Ok((id, version)) => self
-                .handle_graphql_query(QueryTarget::Deployment(id, version), request.into_body())
+                .handle_graphql_query(QueryTarget::Deployment(id, version), request)
                 .boxed(),
         }
     }
@@ -158,15 +155,27 @@ where
     async fn handle_graphql_query(
         self,
         target: QueryTarget,
-        request_body: Body,
+        request: Request<Body>,
     ) -> GraphQLServiceResult {
         let service = self.clone();
 
         let start = Instant::now();
-        let body = hyper::body::to_bytes(request_body)
+        let trace = {
+            !ENV_VARS.graphql.query_trace_token.is_empty()
+                && request
+                    .headers()
+                    .get("X-GraphTraceQuery")
+                    .map(|v| {
+                        v.to_str()
+                            .map(|s| s == &ENV_VARS.graphql.query_trace_token)
+                            .unwrap_or(false)
+                    })
+                    .unwrap_or(false)
+        };
+        let body = hyper::body::to_bytes(request.into_body())
             .map_err(|_| GraphQLServerError::InternalError("Failed to read request body".into()))
             .await?;
-        let query = parse_graphql_request(&body);
+        let query = parse_graphql_request(&body, trace);
         let query_parsing_time = start.elapsed();
 
         let result = match query {

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -160,6 +160,7 @@ where
                 max_first: std::u32::MAX,
                 max_skip: std::u32::MAX,
                 load_manager,
+                trace: false,
             };
             let result = execute_query(query_clone.cheap_clone(), None, None, options).await;
             query_clone.log_execution(0);
@@ -355,7 +356,7 @@ impl ValidatedRequest {
             )),
         }?;
 
-        let query = Query::new(document, variables);
+        let query = Query::new(document, variables, false);
         let bearer_token = bearer_token(headers)
             .map(<[u8]>::to_vec)
             .map(String::from_utf8)

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -301,7 +301,7 @@ where
                     let subscription = Subscription {
                         // Subscriptions currently do not benefit from the generational cache
                         // anyways, so don't bother passing a network.
-                        query: Query::new(query, variables),
+                        query: Query::new(query, variables, false),
                     };
 
                     debug!(logger, "Start operation";

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -238,17 +238,11 @@ impl DeploymentStore {
     ) -> Result<(Vec<T>, Trace), QueryExecutionError> {
         let layout = self.layout(conn, site)?;
 
-        let logger = query.logger.unwrap_or_else(|| self.logger.clone());
-        layout.query(
-            &logger,
-            conn,
-            query.collection,
-            query.filter,
-            query.order,
-            query.range,
-            query.block,
-            query.query_id,
-        )
+        let logger = query
+            .logger
+            .cheap_clone()
+            .unwrap_or_else(|| self.logger.cheap_clone());
+        layout.query(&logger, conn, query)
     }
 
     fn check_interface_entity_uniqueness(

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -3,6 +3,7 @@ use diesel::connection::SimpleConnection as _;
 use diesel::pg::PgConnection;
 use graph::components::store::EntityKey;
 use graph::data::store::scalar;
+use graph::prelude::EntityQuery;
 use graph_mock::MockMetricsRegistry;
 use hex_literal::hex;
 use lazy_static::lazy_static;
@@ -12,8 +13,8 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use graph::prelude::{
     o, slog, web3::types::H256, AttributeNames, ChildMultiplicity, DeploymentHash, Entity,
-    EntityCollection, EntityLink, EntityOrder, EntityRange, EntityWindow, Logger, ParentLink,
-    Schema, StopwatchMetrics, Value, WindowAttribute, BLOCK_NUMBER_MAX,
+    EntityCollection, EntityLink, EntityWindow, Logger, ParentLink, Schema, StopwatchMetrics,
+    Value, WindowAttribute, BLOCK_NUMBER_MAX,
 };
 use graph::{
     components::store::EntityType,
@@ -389,17 +390,10 @@ fn make_thing_tree(conn: &PgConnection, layout: &Layout) -> (Entity, Entity, Ent
 #[test]
 fn query() {
     fn fetch(conn: &PgConnection, layout: &Layout, coll: EntityCollection) -> Vec<String> {
+        let id = DeploymentHash::new("QmXW3qvxV7zXnwRntpj7yoK8HZVtaraZ67uMqaLRvXdxha").unwrap();
+        let query = EntityQuery::new(id, BLOCK_NUMBER_MAX, coll).first(10);
         layout
-            .query::<Entity>(
-                &*LOGGER,
-                conn,
-                coll,
-                None,
-                EntityOrder::Default,
-                EntityRange::first(10),
-                BLOCK_NUMBER_MAX,
-                None,
-            )
+            .query::<Entity>(&*LOGGER, conn, query)
             .map(|(entities, _)| entities)
             .expect("the query succeeds")
             .into_iter()

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -446,6 +446,7 @@ async fn execute_subgraph_query_internal(
     )
     .unwrap();
     let network = Some(status[0].chains[0].network.clone());
+    let trace = query.trace;
     let query = return_err!(PreparedQuery::new(
         &logger,
         schema,
@@ -489,6 +490,7 @@ async fn execute_subgraph_query_internal(
                     load_manager: LOAD_MANAGER.clone(),
                     max_first: std::u32::MAX,
                     max_skip: std::u32::MAX,
+                    trace,
                 },
             )
             .await,

--- a/tests/src/fixture.rs
+++ b/tests/src/fixture.rs
@@ -220,6 +220,7 @@ impl TestContext {
         let query = Query::new(
             graphql_parser::parse_query(query).unwrap().into_static(),
             None,
+            false,
         );
         let query_res = self.graphql_runner.clone().run_query(query, target).await;
         query_res.first().unwrap().duplicate().to_result()


### PR DESCRIPTION
With these changes, if the request header `X-GraphTraceQuery` is set to the right value, the response to a GraphQL query will include a trace of the SQL queries that were run to generate the GraphQL response. That trace looks like
```
{
  "data": { .. },
  "trace": {
    "query": "<GraphQL query>",
    "query_id": "e89d81e9ce262e07-d019a5d7d56a8920",
    "block": 10096796,
    "elapsed_ms": 6,
    "pairs": {
      "query": "/* controller='filter',application='sgd44',route='e89d81e9ce262e07-d019a5d7d56a8920',action='10096796' */\tselect 'Pair' as entity, to_jsonb(c.*) as data from (select  * \t  from \"sgd44\".\"pair\" c\t where c.block_range @> $1\t\t order by \"id\", block_range\t limit 2) c -- binds: [10096796]",
      "elapsed_ms": 0,
      "entity_count": 2,
      "token0": {
        "query": "<SQL query>",
        "elapsed_ms": 0,
        "entity_count": 2
      },
      "token1": {
        "query": "<SQL query>",
        "elapsed_ms": 0,
        "entity_count": 2
      }
    },
    "tokens": {
      "query": "<SQL query>",
      "elapsed_ms": 0,
      "entity_count": 2
    }
  }
}
```

Since generating traces can be expensive, the right value for `X-GraphTraceQuery` is configurable through the environment variable `GRAPH_GRAPHQL_TRACE_TOKEN`; only if the header contains that token will a trace be generated.

This PR also simplifies the usage of `graphman query`: it is no longer necessary to set `GRAPH_LOG_QUERY_TIMING` when running it to get the query output and trace from the command line. The JSON that `graphman query` generates as a trace is the same as is returned for HTTP queries, and much more readable than it was before.