### PR TITLE
docker: adds support for IPFS auth urls

### DIFF
--- a/docker/start
+++ b/docker/start
@@ -32,12 +32,12 @@ save_coredumps() {
 
 wait_for_ipfs() {
     # Take the IPFS URL in $1 apart and extract host and port. If no explicit
-    # host is given, use 443 for https, and 80 otherwise
-    if [[ "$1" =~ ^((https?)://)?([^:/]+)(:([0-9]+))? ]]
+    # port is given, use 443 for https, and 80 otherwise
+    if [[ "$1" =~ ^((https?)://)?((.*)@)?([^:/]+)(:([0-9]+))? ]]
     then
         proto=${BASH_REMATCH[2]:-http}
-        host=${BASH_REMATCH[3]}
-        port=${BASH_REMATCH[5]}
+        host=${BASH_REMATCH[5]}
+        port=${BASH_REMATCH[7]}
         if [ -z "$port" ]
         then
             [ "$proto" = "https" ] && port=443 || port=80


### PR DESCRIPTION
When using Infura as an IPFS provider, they require you authenticate the requests either by providing an Authorization header or by using basic authentication.

As graph-node doesn't support authentication by header for IPFS, the only way to use Infura is to use basic authentication.
The URL looks like this:
```
https://project_id:project_secret@ipfs.infura.io:5001/
```

The docker start script doesn't take into account that there could be a basic auth user and pass in the IPFS url and parses it incorrectly making the container stall for a long time on startup without any output. When used in K8S with liveness probes, the service keeps restarting.
I also added support for uppercase letters (`HTTP://LOCALHOST`).

I tested it with the following types or URLs and it seems to work properly:
```
-------------------
URL:  localhost
proto:  http
host:  localhost
port:  80
-------------------
URL:  localhost:5051
proto:  http
host:  localhost
port:  5051
-------------------
URL:  http://localhost
proto:  http
host:  localhost
port:  80
-------------------
URL:  http://localhost/path
proto:  http
host:  localhost
port:  80
-------------------
URL:  http://localhost:5051
proto:  http
host:  localhost
port:  5051
-------------------
URL:  http://localhost:5051/path
proto:  http
host:  localhost
port:  5051
-------------------
URL:  https://localhost
proto:  https
host:  localhost
port:  443
-------------------
URL:  https://localhost:5051
proto:  https
host:  localhost
port:  5051
-------------------
URL:  HTTP://LOCALHOST
proto:  http
host:  localhost
port:  80
-------------------
URL:  HTTP://LOCALHOST/PATH
proto:  http
host:  localhost
port:  80
-------------------
URL:  HTTP://LOCALHOST:5051
proto:  http
host:  localhost
port:  5051
-------------------
URL:  HTTP://LOCALHOST:5051/PATH
proto:  http
host:  localhost
port:  5051
-------------------
URL:  HTTPS://LOCALHOST
proto:  https
host:  localhost
port:  443
-------------------
URL:  HTTPS://LOCALHOST:5051
proto:  https
host:  localhost
port:  5051
-------------------
URL:  127.0.0.1
proto:  http
host:  127.0.0.1
port:  80
-------------------
URL:  127.0.0.1:5051
proto:  http
host:  127.0.0.1
port:  5051
-------------------
URL:  http://127.0.0.1
proto:  http
host:  127.0.0.1
port:  80
-------------------
URL:  http://127.0.0.1/path
proto:  http
host:  127.0.0.1
port:  80
-------------------
URL:  http://127.0.0.1:5051
proto:  http
host:  127.0.0.1
port:  5051
-------------------
URL:  http://127.0.0.1:5051/path
proto:  http
host:  127.0.0.1
port:  5051
-------------------
URL:  https://127.0.0.1
proto:  https
host:  127.0.0.1
port:  443
-------------------
URL:  https://127.0.0.1:5051
proto:  https
host:  127.0.0.1
port:  5051
-------------------
URL:  https://user:pass@127.0.0.1:5051
proto:  https
host:  127.0.0.1
port:  5051
-------------------
URL:  https://user:pass@127.0.0.1:5051/path
proto:  https
host:  127.0.0.1
port:  5051
```

