### PR TITLE
Fix attestability of ValueParseError, EnumCoercionError, ScalarCoercionError

### DIFF
--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -107,6 +107,8 @@ impl QueryExecutionError {
             | AttributeTypeError(_, _)
             | EmptySelectionSet(_)
             | Unimplemented(_)
+            | EnumCoercionError(_, _, _, _, _)
+            | ScalarCoercionError(_, _, _, _)
             | CyclicalFragment(_)
             | UndefinedFragment(_)
             | FulltextQueryInvalidSyntax(_)
@@ -117,8 +119,6 @@ impl QueryExecutionError {
             | EntityParseError(_)
             | StoreError(_)
             | Timeout
-            | EnumCoercionError(_, _, _, _, _)
-            | ScalarCoercionError(_, _, _, _)
             | AmbiguousDerivedFromResult(_, _, _, _)
             | TooComplex(_, _)
             | TooDeep(_)

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -103,6 +103,7 @@ impl QueryExecutionError {
             | EntityFieldError(_, _)
             | ListTypesError(_, _)
             | ListFilterError(_)
+            | ValueParseError(_, _)
             | AttributeTypeError(_, _)
             | EmptySelectionSet(_)
             | Unimplemented(_)
@@ -113,7 +114,6 @@ impl QueryExecutionError {
             ListValueError(_, _)
             | ResolveEntitiesError(_)
             | RangeArgumentsError(_, _, _)
-            | ValueParseError(_, _)
             | EntityParseError(_)
             | StoreError(_)
             | Timeout


### PR DESCRIPTION
It seems that `ValueParseError` should be attestable. Feel free to quickly scan through to check for other miscategorizations.