### PR TITLE
Env. vars. for forking

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -215,3 +215,7 @@ those.
   copying or grafting should take. This limits how long transactions for
   such long running operations will be, and therefore helps control bloat
   in other tables. Value is in seconds and defaults to 180s.
+- `GRAPH_START_BLOCK`: block hash:block number where the forked subgraph will start indexing at.
+- `GRAPH_FORK_BASE`: api url for where the graph node will fork from, use `https://api.thegraph.com/subgraphs/id/`
+  for the hosted service.
+- `GRAPH_DEBUG_FORK`: the IPFS hash id of the subgraph to fork.

--- a/node/src/opt.rs
+++ b/node/src/opt.rs
@@ -37,6 +37,7 @@ pub struct Opt {
 
     #[clap(
         long,
+        env = "GRAPH_START_BLOCK",
         value_name = "BLOCK_HASH:BLOCK_NUMBER",
         help = "block hash and number that the subgraph passed will start indexing at"
     )]
@@ -217,11 +218,17 @@ pub struct Opt {
     #[clap(
         long,
         value_name = "IPFS_HASH",
+        env = "GRAPH_DEBUG_FORK",
         help = "IPFS hash of the subgraph manifest that you want to fork"
     )]
     pub debug_fork: Option<String>,
 
-    #[clap(long, value_name = "URL", help = "Base URL for forking subgraphs")]
+    #[clap(
+        long,
+        value_name = "URL",
+        env = "GRAPH_FORK_BASE",
+        help = "Base URL for forking subgraphs"
+    )]
     pub fork_base: Option<String>,
 }
 


### PR DESCRIPTION
Supersedes https://github.com/graphprotocol/graph-node/pull/3408 (rebased and added `GRAPH_` prefix to the env. vars.).