### PR TITLE
config: Bump default ipfs timeout to 60 seconds

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -69,7 +69,7 @@ those.
 ## IPFS
 
 - `GRAPH_IPFS_TIMEOUT`: timeout for IPFS, which includes requests for manifest files
-  and from mappings (in seconds, default is 30).
+  and from mappings (in seconds, default is 60).
 - `GRAPH_MAX_IPFS_FILE_BYTES`: maximum size for a file that can be retrieved (in bytes, default is 256 MiB).
 - `GRAPH_MAX_IPFS_MAP_FILE_SIZE`: maximum size of files that can be processed
   with `ipfs.map`. When a file is processed through `ipfs.map`, the entities

--- a/graph/src/env/mappings.rs
+++ b/graph/src/env/mappings.rs
@@ -36,7 +36,7 @@ pub struct EnvVarsMapping {
     /// The timeout for all IPFS requests.
     ///
     /// Set by the environment variable `GRAPH_IPFS_TIMEOUT` (expressed in
-    /// seconds). The default value is 30s.
+    /// seconds). The default value is 60s.
     pub ipfs_timeout: Duration,
     /// Sets the `ipfs.map` file size limit.
     ///
@@ -105,7 +105,7 @@ pub struct InnerMappingHandlers {
     max_ipfs_cache_file_size: WithDefaultUsize<usize, { 1024 * 1024 }>,
     #[envconfig(from = "GRAPH_MAX_IPFS_CACHE_SIZE", default = "50")]
     max_ipfs_cache_size: u64,
-    #[envconfig(from = "GRAPH_IPFS_TIMEOUT", default = "30")]
+    #[envconfig(from = "GRAPH_IPFS_TIMEOUT", default = "60")]
     ipfs_timeout_in_secs: u64,
     #[envconfig(from = "GRAPH_MAX_IPFS_MAP_FILE_SIZE", default = "")]
     max_ipfs_map_file_size: WithDefaultUsize<usize, { 256 * 1024 * 1024 }>,


### PR DESCRIPTION
It used to be that 30 seconds was sufficient, but now we see ipfs requests taking minutes to find a file in the DHT. So 60 seconds seems like a reasonable step.