### PR TITLE
improve(metrics): Turn "Flushing logs to Elasticsearch" log into metric

### DIFF
--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -57,7 +57,7 @@ pub async fn run(
 
     let env_vars = Arc::new(EnvVars::from_env().unwrap());
     let metrics_registry = metrics_ctx.registry.clone();
-    let logger_factory = LoggerFactory::new(logger.clone(), None);
+    let logger_factory = LoggerFactory::new(logger.clone(), None, metrics_ctx.registry.clone());
 
     // FIXME: Hard-coded IPFS config, take it from config file instead?
     let ipfs_clients: Vec<_> = create_ipfs_clients(&logger, &ipfs_url);

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -89,6 +89,8 @@ impl GraphQlRunner for TestGraphQlRunner {
 
 #[cfg(test)]
 mod test {
+    use graph_mock::MockMetricsRegistry;
+
     use super::*;
 
     lazy_static! {
@@ -101,7 +103,7 @@ mod test {
         runtime
             .block_on(async {
                 let logger = Logger::root(slog::Discard, o!());
-                let logger_factory = LoggerFactory::new(logger, None);
+                let logger_factory = LoggerFactory::new(logger, None, Arc::new(MockMetricsRegistry::new()));
                 let id = USERS.clone();
                 let query_runner = Arc::new(TestGraphQlRunner);
                 let node_id = NodeId::new("test").unwrap();
@@ -142,7 +144,8 @@ mod test {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
-            let logger_factory = LoggerFactory::new(logger, None);
+            let logger_factory =
+                LoggerFactory::new(logger, None, Arc::new(MockMetricsRegistry::new()));
             let id = USERS.clone();
             let query_runner = Arc::new(TestGraphQlRunner);
             let node_id = NodeId::new("test").unwrap();
@@ -222,7 +225,8 @@ mod test {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
-            let logger_factory = LoggerFactory::new(logger, None);
+            let logger_factory =
+                LoggerFactory::new(logger, None, Arc::new(MockMetricsRegistry::new()));
             let id = USERS.clone();
             let query_runner = Arc::new(TestGraphQlRunner);
             let node_id = NodeId::new("test").unwrap();
@@ -267,7 +271,8 @@ mod test {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let _ = runtime.block_on(async {
             let logger = Logger::root(slog::Discard, o!());
-            let logger_factory = LoggerFactory::new(logger, None);
+            let logger_factory =
+                LoggerFactory::new(logger, None, Arc::new(MockMetricsRegistry::new()));
             let id = USERS.clone();
             let query_runner = Arc::new(TestGraphQlRunner);
             let node_id = NodeId::new("test").unwrap();

--- a/tests/src/fixture.rs
+++ b/tests/src/fixture.rs
@@ -377,8 +377,8 @@ pub async fn setup<C: Blockchain>(
     });
 
     let logger = graph::log::logger(true);
-    let logger_factory = LoggerFactory::new(logger.clone(), None);
     let mock_registry: Arc<dyn MetricsRegistry> = Arc::new(MockMetricsRegistry::new());
+    let logger_factory = LoggerFactory::new(logger.clone(), None, mock_registry.clone());
     let node_id = NodeId::new(NODE_ID).unwrap();
 
     // Make sure we're starting from a clean state.

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -31,9 +31,9 @@ pub async fn chain(
         x: PhantomData,
     }));
     let logger = graph::log::logger(true);
-    let logger_factory = LoggerFactory::new(logger.cheap_clone(), None);
-    let node_id = NodeId::new(NODE_ID).unwrap();
     let mock_registry = Arc::new(MockMetricsRegistry::new());
+    let logger_factory = LoggerFactory::new(logger.cheap_clone(), None, mock_registry.clone());
+    let node_id = NodeId::new(NODE_ID).unwrap();
 
     let chain_store = stores.chain_store.cheap_clone();
 


### PR DESCRIPTION
This log is very noisy, and can perfectly be substituted by a metric.