### PR TITLE
Extend provider load control (match config) to substreams

### DIFF
--- a/chain/ethereum/examples/firehose.rs
+++ b/chain/ethereum/examples/firehose.rs
@@ -1,6 +1,7 @@
 use anyhow::Error;
 use graph::{
     env::env_var,
+    firehose::SubgraphLimit,
     prelude::{prost, tokio, tonic},
     {firehose, firehose::FirehoseEndpoint},
 };
@@ -25,6 +26,7 @@ async fn main() -> Result<(), Error> {
         token,
         false,
         false,
+        SubgraphLimit::Unlimited,
     ));
 
     loop {

--- a/chain/substreams/examples/substreams.rs
+++ b/chain/substreams/examples/substreams.rs
@@ -1,6 +1,7 @@
 use anyhow::{format_err, Context, Error};
 use graph::blockchain::block_stream::BlockStreamEvent;
 use graph::blockchain::substreams_block_stream::SubstreamsBlockStream;
+use graph::firehose::SubgraphLimit;
 use graph::prelude::{info, tokio, DeploymentHash, Registry};
 use graph::tokio_stream::StreamExt;
 use graph::{env::env_var, firehose::FirehoseEndpoint, log::logger, substreams};
@@ -46,6 +47,7 @@ async fn main() -> Result<(), Error> {
         token,
         false,
         false,
+        SubgraphLimit::Unlimited,
     ));
 
     let mut stream: SubstreamsBlockStream<graph_chain_substreams::Chain> =

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use graph::blockchain::{BlockPtr, TriggersAdapterSelector};
 use graph::cheap_clone::CheapClone;
-use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints};
+use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints, SubgraphLimit};
 use graph::prelude::ethabi::ethereum_types::H256;
 use graph::prelude::web3::types::{Address, Log, Transaction, H160};
 use graph::prelude::{ethabi, tiny_keccak, LightEthereumBlock, LoggerFactory, NodeId};
@@ -45,6 +45,7 @@ pub async fn chain(
         None,
         true,
         false,
+        SubgraphLimit::Unlimited,
     ))]
     .into();
 


### PR DESCRIPTION
- Fixes issue #4338
- Adds rules to ProviderDetails::Firehose
- FirehoseEndpoints::random now checks for capacity before returning an endpoint

