### PR TITLE
store(test-store): use C locale for DB

### DIFF
--- a/store/test-store/devel/docker-compose.yml
+++ b/store/test-store/devel/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in
       POSTGRES_DB: graph-node
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
       - ./initdb.d:/docker-entrypoint-initdb.d


### PR DESCRIPTION
while working on tests for #3214 I had to make this change. But useful to just land it upstream since it is unrelated to that PR
