### PR TITLE
Solve some clippy warnings

### DIFF
--- a/chain/arweave/src/data_source.rs
+++ b/chain/arweave/src/data_source.rs
@@ -71,7 +71,7 @@ impl blockchain::DataSource<Chain> for DataSource {
 
         Ok(Some(TriggerWithHandler::<Chain>::new(
             trigger.cheap_clone(),
-            handler.to_owned(),
+            handler.clone(),
             block.ptr(),
         )))
     }

--- a/chain/arweave/src/runtime/abi.rs
+++ b/chain/arweave/src/runtime/abi.rs
@@ -29,7 +29,7 @@ impl ToAscObj<AscTransactionArray> for Vec<Vec<u8>> {
             .iter()
             .map(|x| asc_new(heap, x.as_slice(), gas))
             .collect::<Result<Vec<AscPtr<Uint8Array>>, _>>()?;
-        Ok(AscTransactionArray(Array::new(&*content, heap, gas)?))
+        Ok(AscTransactionArray(Array::new(&content, heap, gas)?))
     }
 }
 
@@ -43,7 +43,7 @@ impl ToAscObj<AscTagArray> for Vec<codec::Tag> {
             .iter()
             .map(|x| asc_new(heap, x, gas))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(AscTagArray(Array::new(&*content, heap, gas)?))
+        Ok(AscTagArray(Array::new(&content, heap, gas)?))
     }
 }
 

--- a/chain/common/src/lib.rs
+++ b/chain/common/src/lib.rs
@@ -102,7 +102,7 @@ impl From<&FieldDescriptorProto> for Field {
         let options = fd.options.unknown_fields();
 
         let type_name = if let Some(type_name) = fd.type_name.as_ref() {
-            type_name.to_owned()
+            type_name.clone()
         } else if let Type::TYPE_BYTES = fd.type_() {
             "Vec<u8>".to_owned()
         } else {

--- a/chain/common/src/lib.rs
+++ b/chain/common/src/lib.rs
@@ -197,7 +197,6 @@ where
 
     let file_name = file_path
         .as_ref()
-        .clone()
         .file_name()
         .unwrap()
         .to_str()

--- a/chain/common/src/lib.rs
+++ b/chain/common/src/lib.rs
@@ -195,12 +195,7 @@ where
     assert!(fd.file.len() == 1);
     assert!(fd.file[0].has_name());
 
-    let file_name = file_path
-        .as_ref()
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap();
+    let file_name = file_path.as_ref().file_name().unwrap().to_str().unwrap();
     assert!(fd.file[0].name() == file_name);
 
     let ret_val = fd

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -195,9 +195,9 @@ pub(crate) struct EthereumLogFilter {
     wildcard_events: HashMap<EventSignature, bool>,
 }
 
-impl Into<Vec<LogFilter>> for EthereumLogFilter {
-    fn into(self) -> Vec<LogFilter> {
-        self.eth_get_logs_filters()
+impl From<EthereumLogFilter> for Vec<LogFilter> {
+    fn from(val: EthereumLogFilter) -> Self {
+        val.eth_get_logs_filters()
             .map(
                 |EthGetLogsFilter {
                      contracts,

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -326,8 +326,8 @@ impl EthereumLogFilter {
         // Start with the wildcard event filters.
         let mut filters = self
             .wildcard_events
-            .into_iter()
-            .map(|(event, _)| EthGetLogsFilter::from_event(event))
+            .into_keys()
+            .map(|event| EthGetLogsFilter::from_event(event))
             .collect_vec();
 
         // The current algorithm is to repeatedly find the maximum cardinality vertex and turn all

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -637,12 +637,9 @@ impl EthereumBlockFilter {
                 filter_opt.extend(Self {
                     trigger_every_block: has_block_handler_without_filter,
                     contract_addresses: if has_block_handler_with_call_filter {
-                        vec![(
-                            data_source.start_block,
-                            data_source.address.unwrap().clone(),
-                        )]
-                        .into_iter()
-                        .collect()
+                        vec![(data_source.start_block, data_source.address.unwrap())]
+                            .into_iter()
+                            .collect()
                     } else {
                         HashSet::default()
                     },

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -639,7 +639,7 @@ impl EthereumBlockFilter {
                     contract_addresses: if has_block_handler_with_call_filter {
                         vec![(
                             data_source.start_block,
-                            data_source.address.unwrap().to_owned(),
+                            data_source.address.unwrap().clone(),
                         )]
                         .into_iter()
                         .collect()

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -391,7 +391,7 @@ impl Blockchain for Chain {
                 .random()?
                 .block_ptr_for_number::<HeaderOnlyBlock>(logger, number)
                 .await
-                .map_err(|e| IngestorError::Unknown(e)),
+                .map_err(IngestorError::Unknown),
             ChainClient::Rpc(adapters) => {
                 let adapter = adapters
                     .cheapest()

--- a/chain/ethereum/src/codec.rs
+++ b/chain/ethereum/src/codec.rs
@@ -36,9 +36,9 @@ impl TryDecodeProto<[u8; 256], H2048> for &[u8] {}
 impl TryDecodeProto<[u8; 32], H256> for &[u8] {}
 impl TryDecodeProto<[u8; 20], H160> for &[u8] {}
 
-impl Into<web3::types::U256> for &BigInt {
-    fn into(self) -> web3::types::U256 {
-        web3::types::U256::from_big_endian(&self.bytes)
+impl From<&BigInt> for web3::types::U256 {
+    fn from(val: &BigInt) -> Self {
+        web3::types::U256::from_big_endian(&val.bytes)
     }
 }
 
@@ -97,9 +97,9 @@ impl TryInto<web3::types::Call> for Call {
     }
 }
 
-impl Into<web3::types::CallType> for CallType {
-    fn into(self) -> web3::types::CallType {
-        match self {
+impl From<CallType> for web3::types::CallType {
+    fn from(val: CallType) -> Self {
+        match val {
             CallType::Unspecified => web3::types::CallType::None,
             CallType::Call => web3::types::CallType::Call,
             CallType::Callcode => web3::types::CallType::CallCode,
@@ -149,9 +149,9 @@ impl<'a> TryInto<web3::types::Log> for LogAt<'a> {
     }
 }
 
-impl Into<web3::types::U64> for TransactionTraceStatus {
-    fn into(self) -> web3::types::U64 {
-        let status: Option<web3::types::U64> = self.into();
+impl From<TransactionTraceStatus> for web3::types::U64 {
+    fn from(val: TransactionTraceStatus) -> Self {
+        let status: Option<web3::types::U64> = val.into();
         status.unwrap_or_else(|| web3::types::U64::from(0))
     }
 }
@@ -457,11 +457,11 @@ impl HeaderOnlyBlock {
     }
 }
 
-impl Into<ChainStoreData> for &BlockHeader {
-    fn into(self) -> ChainStoreData {
+impl From<&BlockHeader> for ChainStoreData {
+    fn from(val: &BlockHeader) -> Self {
         ChainStoreData {
             block: ChainStoreBlock::new(
-                self.timestamp.as_ref().unwrap().seconds,
+                val.timestamp.as_ref().unwrap().seconds,
                 jsonrpc_core::Value::Null,
             ),
         }

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -178,7 +178,7 @@ impl blockchain::DataSource<Chain> for DataSource {
                 .context
                 .as_ref()
                 .as_ref()
-                .map(|ctx| serde_json::to_value(&ctx).unwrap()),
+                .map(|ctx| serde_json::to_value(ctx).unwrap()),
             creation_block: self.creation_block,
             done_at: None,
             causality_region: CausalityRegion::ONCHAIN,

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -364,7 +364,7 @@ impl DataSource {
                 .mapping
                 .block_handlers
                 .iter()
-                .find(move |handler| handler.filter == None)
+                .find(move |handler| handler.filter.is_none())
                 .cloned(),
             EthereumBlockTriggerType::WithCallTo(_address) => self
                 .mapping

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1215,7 +1215,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
         };
 
         debug!(logger, "eth_call";
-            "address" => hex::encode(&call.address),
+            "address" => hex::encode(call.address),
             "data" => hex::encode(&call_data)
         );
 

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1449,7 +1449,7 @@ pub(crate) async fn blocks_with_triggers(
 
     // Make sure `to` is included, even if empty.
     block_hashes.insert(to_hash);
-    triggers_by_block.entry(to).or_insert(Vec::new());
+    triggers_by_block.entry(to).or_default();
 
     let logger2 = logger.cheap_clone();
 

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -306,7 +306,7 @@ impl EthereumAdapter {
         };
 
         let eth = self;
-        let logger = logger.to_owned();
+        let logger = logger.clone();
         stream::unfold(from, move |start| {
             if start > to {
                 return None;

--- a/chain/ethereum/src/network.rs
+++ b/chain/ethereum/src/network.rs
@@ -155,10 +155,7 @@ impl EthereumNetworks {
         adapter: Arc<EthereumAdapter>,
         limit: SubgraphLimit,
     ) {
-        let network_adapters = self
-            .networks
-            .entry(name)
-            .or_insert(EthereumNetworkAdapters::default());
+        let network_adapters = self.networks.entry(name).or_default();
 
         network_adapters.push_adapter(EthereumNetworkAdapter {
             capabilities,

--- a/chain/ethereum/src/runtime/abi.rs
+++ b/chain/ethereum/src/runtime/abi.rs
@@ -45,7 +45,7 @@ impl ToAscObj<AscLogParamArray> for Vec<ethabi::LogParam> {
     ) -> Result<AscLogParamArray, DeterministicHostError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
-        Ok(AscLogParamArray(Array::new(&*content, heap, gas)?))
+        Ok(AscLogParamArray(Array::new(&content, heap, gas)?))
     }
 }
 

--- a/chain/ethereum/tests/manifest.rs
+++ b/chain/ethereum/tests/manifest.rs
@@ -36,8 +36,7 @@ struct TextResolver {
 
 impl TextResolver {
     fn add(&mut self, link: &str, text: &impl AsRef<[u8]>) {
-        self.texts
-            .insert(link.to_owned(), text.as_ref().iter().cloned().collect());
+        self.texts.insert(link.to_owned(), text.as_ref().to_vec());
     }
 }
 

--- a/chain/near/src/data_source.rs
+++ b/chain/near/src/data_source.rs
@@ -139,7 +139,7 @@ impl blockchain::DataSource<Chain> for DataSource {
 
         Ok(Some(TriggerWithHandler::<Chain>::new(
             trigger.cheap_clone(),
-            handler.to_owned(),
+            handler.clone(),
             block.ptr(),
         )))
     }

--- a/chain/near/src/runtime/abi.rs
+++ b/chain/near/src/runtime/abi.rs
@@ -99,7 +99,7 @@ impl ToAscObj<AscChunkHeaderArray> for Vec<codec::ChunkHeader> {
     ) -> Result<AscChunkHeaderArray, DeterministicHostError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
-        Ok(AscChunkHeaderArray(Array::new(&*content, heap, gas)?))
+        Ok(AscChunkHeaderArray(Array::new(&content, heap, gas)?))
     }
 }
 
@@ -203,7 +203,7 @@ impl ToAscObj<AscActionEnumArray> for Vec<codec::Action> {
     ) -> Result<AscActionEnumArray, DeterministicHostError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
-        Ok(AscActionEnumArray(Array::new(&*content, heap, gas)?))
+        Ok(AscActionEnumArray(Array::new(&content, heap, gas)?))
     }
 }
 
@@ -395,7 +395,7 @@ impl ToAscObj<AscDataReceiverArray> for Vec<codec::DataReceiver> {
     ) -> Result<AscDataReceiverArray, DeterministicHostError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
-        Ok(AscDataReceiverArray(Array::new(&*content, heap, gas)?))
+        Ok(AscDataReceiverArray(Array::new(&content, heap, gas)?))
     }
 }
 
@@ -490,7 +490,7 @@ impl ToAscObj<AscMerklePathItemArray> for Vec<codec::MerklePathItem> {
     ) -> Result<AscMerklePathItemArray, DeterministicHostError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
-        Ok(AscMerklePathItemArray(Array::new(&*content, heap, gas)?))
+        Ok(AscMerklePathItemArray(Array::new(&content, heap, gas)?))
     }
 }
 
@@ -524,7 +524,7 @@ impl ToAscObj<AscSignatureArray> for Vec<codec::Signature> {
     ) -> Result<AscSignatureArray, DeterministicHostError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
-        Ok(AscSignatureArray(Array::new(&*content, heap, gas)?))
+        Ok(AscSignatureArray(Array::new(&content, heap, gas)?))
     }
 }
 
@@ -572,7 +572,7 @@ impl ToAscObj<AscValidatorStakeArray> for Vec<codec::ValidatorStake> {
     ) -> Result<AscValidatorStakeArray, DeterministicHostError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
-        Ok(AscValidatorStakeArray(Array::new(&*content, heap, gas)?))
+        Ok(AscValidatorStakeArray(Array::new(&content, heap, gas)?))
     }
 }
 
@@ -597,7 +597,7 @@ impl ToAscObj<AscSlashedValidatorArray> for Vec<codec::SlashedValidator> {
     ) -> Result<AscSlashedValidatorArray, DeterministicHostError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
-        Ok(AscSlashedValidatorArray(Array::new(&*content, heap, gas)?))
+        Ok(AscSlashedValidatorArray(Array::new(&content, heap, gas)?))
     }
 }
 
@@ -619,7 +619,7 @@ impl ToAscObj<AscCryptoHashArray> for Vec<codec::CryptoHash> {
     ) -> Result<AscCryptoHashArray, DeterministicHostError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
-        Ok(AscCryptoHashArray(Array::new(&*content, heap, gas)?))
+        Ok(AscCryptoHashArray(Array::new(&content, heap, gas)?))
     }
 }
 

--- a/chain/substreams/src/block_stream.rs
+++ b/chain/substreams/src/block_stream.rs
@@ -57,7 +57,7 @@ impl BlockStreamBuilderTrait<Chain> for BlockStreamBuilder {
             mapper,
             filter.modules.clone(),
             filter.module_name.clone(),
-            filter.start_block.map(|x| vec![x]).unwrap_or(vec![]),
+            filter.start_block.map(|x| vec![x]).unwrap_or_default(),
             vec![],
             logger,
             chain.metrics_registry.clone(),

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -267,7 +267,7 @@ fn decode_value(value: &crate::codec::value::Typed) -> Result<Value, MappingErro
             Ok(Value::String(string))
         }
 
-        Typed::Bytes(new_value) => base64::decode(&new_value)
+        Typed::Bytes(new_value) => base64::decode(new_value)
             .map(|bs| Value::Bytes(Bytes::from(bs.as_ref())))
             .map_err(|err| MappingError::Unknown(anyhow::Error::from(err))),
 

--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -201,7 +201,7 @@ impl LinkResolverTrait for LinkResolver {
         if data.len() <= max_cache_file_size {
             let mut cache = self.cache.lock().unwrap();
             if !cache.contains_key(&path) {
-                cache.insert(path.to_owned(), data.clone());
+                cache.insert(path.clone(), data.clone());
             }
         } else {
             debug!(logger, "File too large for cache";

--- a/core/src/polling_monitor/ipfs_service.rs
+++ b/core/src/polling_monitor/ipfs_service.rs
@@ -136,7 +136,7 @@ mod test {
 
         let cl: ipfs::IpfsClient = ipfs::IpfsClient::default();
 
-        let rsp = cl.add_path(&path).await.unwrap();
+        let rsp = cl.add_path(path).await.unwrap();
 
         let ipfs_folder = rsp.iter().find(|rsp| rsp.name == "ipfs_folder").unwrap();
 

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -437,7 +437,7 @@ async fn handle_assignment_event(
     provider: Arc<impl SubgraphAssignmentProviderTrait>,
     logger: Logger,
 ) -> Result<(), CancelableError<SubgraphAssignmentProviderError>> {
-    let logger = logger.to_owned();
+    let logger = logger.clone();
 
     debug!(logger, "Received assignment event: {:?}", event);
 

--- a/graph/examples/stress.rs
+++ b/graph/examples/stress.rs
@@ -295,9 +295,7 @@ impl Template for HashMap<String, String> {
 
     fn sample(&self, size: usize, _rng: Option<&mut SmallRng>) -> Box<Self> {
         Box::new(HashMap::from_iter(
-            self.iter()
-                .take(size)
-                .map(|(k, v)| (k.to_owned(), v.to_owned())),
+            self.iter().take(size).map(|(k, v)| (k.clone(), v.clone())),
         ))
     }
 }
@@ -364,7 +362,7 @@ impl Template for Object {
             Box::new(Object::from_iter(
                 self.iter()
                     .take(size)
-                    .map(|(k, v)| (k.to_owned(), v.to_owned())),
+                    .map(|(k, v)| (k.to_owned(), v.clone())),
             ))
         } else {
             Box::new(make_object(size, rng))
@@ -387,7 +385,7 @@ impl Template for QueryResult {
                     .unwrap()
                     .iter()
                     .take(size)
-                    .map(|(k, v)| (k.to_owned(), v.to_owned())),
+                    .map(|(k, v)| (k.to_owned(), v.clone())),
             )))
         } else {
             Box::new(QueryResult::new(make_domains(size, rng)))
@@ -451,7 +449,7 @@ impl Template for ValueMap {
                 self.0
                     .iter()
                     .take(size)
-                    .map(|(k, v)| (k.to_owned(), v.to_owned())),
+                    .map(|(k, v)| (k.clone(), v.clone())),
             )))
         } else {
             Box::new(Self::make_map(size, rng))

--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -113,7 +113,7 @@ where
             ExponentialBackoff::new(Duration::from_millis(250), Duration::from_secs(30));
         loop {
             match self.chain_store.clone().chain_head_cursor() {
-                Ok(cursor) => return cursor.unwrap_or_else(|| "".to_string()),
+                Ok(cursor) => return cursor.unwrap_or_default(),
                 Err(e) => {
                     error!(self.logger, "Fetching chain head cursor failed: {:#}", e);
 

--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -21,9 +21,9 @@ pub enum Transforms {
     EthereumHeaderOnly,
 }
 
-impl Into<Any> for &Transforms {
-    fn into(self) -> Any {
-        match self {
+impl From<&Transforms> for Any {
+    fn from(val: &Transforms) -> Self {
+        match val {
             Transforms::EthereumHeaderOnly => Any {
                 type_url: TRANSFORM_ETHEREUM_HEADER_ONLY.to_owned(),
                 value: HeaderOnly {}.encode_to_vec(),

--- a/graph/src/blockchain/substreams_block_stream.rs
+++ b/graph/src/blockchain/substreams_block_stream.rs
@@ -166,7 +166,7 @@ fn stream_blocks<C: Blockchain, F: SubstreamsMapper<C>>(
     logger: Logger,
     metrics: SubstreamsBlockStreamMetrics,
 ) -> impl Stream<Item = Result<BlockStreamEvent<C>, Error>> {
-    let mut latest_cursor = cursor.unwrap_or_else(|| "".to_string());
+    let mut latest_cursor = cursor.unwrap_or_default();
 
     let start_block_num = subgraph_current_block
         .as_ref()

--- a/graph/src/components/store/entity_cache.rs
+++ b/graph/src/components/store/entity_cache.rs
@@ -311,7 +311,7 @@ impl LfuCache<EntityKey, Option<Entity>> {
                 self.insert(key.clone(), entity.clone());
                 Ok(entity)
             }
-            Some(data) => Ok(data.to_owned()),
+            Some(data) => Ok(data.clone()),
         }
     }
 }

--- a/graph/src/components/store/entity_cache.rs
+++ b/graph/src/components/store/entity_cache.rs
@@ -102,7 +102,7 @@ impl EntityCache {
         let mut entity = self.current.get_entity(&*self.store, eref)?;
 
         // Always test the cache consistency in debug mode.
-        debug_assert!(entity == self.store.get(&eref).unwrap());
+        debug_assert!(entity == self.store.get(eref).unwrap());
 
         if let Some(op) = self.updates.get(eref).cloned() {
             entity = op.apply_to(entity)

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -204,15 +204,11 @@ impl fmt::Display for EntityFilter {
             LessThan(a, v) => write!(f, "{a} < {v}"),
             GreaterOrEqual(a, v) => write!(f, "{a} >= {v}"),
             LessOrEqual(a, v) => write!(f, "{a} <= {v}"),
-            In(a, vs) => write!(
-                f,
-                "{a} in ({})",
-                vs.into_iter().map(|v| v.to_string()).join(",")
-            ),
+            In(a, vs) => write!(f, "{a} in ({})", vs.iter().map(|v| v.to_string()).join(",")),
             NotIn(a, vs) => write!(
                 f,
                 "{a} not in ({})",
-                vs.into_iter().map(|v| v.to_string()).join(",")
+                vs.iter().map(|v| v.to_string()).join(",")
             ),
             Contains(a, v) => write!(f, "{a} ~ *{v}*"),
             ContainsNoCase(a, v) => write!(f, "{a} ~ *{v}*i"),

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -230,9 +230,7 @@ impl fmt::Display for EntityFilter {
             Child(child /* a, et, cf, _ */) => write!(
                 f,
                 "join on {} with {}({})",
-                child.attr,
-                child.entity_type,
-                child.filter
+                child.attr, child.entity_type, child.filter
             ),
         }
     }

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -232,7 +232,7 @@ impl fmt::Display for EntityFilter {
                 "join on {} with {}({})",
                 child.attr,
                 child.entity_type,
-                child.filter.to_string()
+                child.filter
             ),
         }
     }

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -63,13 +63,13 @@ impl fmt::Display for EntityType {
 
 impl<'a> From<&s::ObjectType<'a, String>> for EntityType {
     fn from(object_type: &s::ObjectType<'a, String>) -> Self {
-        EntityType::new(object_type.name.to_owned())
+        EntityType::new(object_type.name.clone())
     }
 }
 
 impl<'a> From<&s::InterfaceType<'a, String>> for EntityType {
     fn from(interface_type: &s::InterfaceType<'a, String>) -> Self {
-        EntityType::new(interface_type.name.to_owned())
+        EntityType::new(interface_type.name.clone())
     }
 }
 
@@ -547,15 +547,15 @@ impl EntityQuery {
                     if let EntityLink::Direct(attribute, _) = &window.link {
                         let filter = match attribute {
                             WindowAttribute::Scalar(name) => {
-                                EntityFilter::Equal(name.to_owned(), id.into())
+                                EntityFilter::Equal(name.clone(), id.into())
                             }
                             WindowAttribute::List(name) => {
-                                EntityFilter::Contains(name.to_owned(), Value::from(vec![id]))
+                                EntityFilter::Contains(name.clone(), Value::from(vec![id]))
                             }
                         };
                         self.filter = Some(filter.and_maybe(self.filter));
                         self.collection = EntityCollection::All(vec![(
-                            window.child_type.to_owned(),
+                            window.child_type.clone(),
                             window.column_names.clone(),
                         )]);
                     }

--- a/graph/src/components/subgraph/proof_of_indexing/mod.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/mod.rs
@@ -109,7 +109,7 @@ mod tests {
             }
 
             let online = hex::encode(finisher.finish());
-            let offline = hex::encode(&offline);
+            let offline = hex::encode(offline);
             assert_eq!(&online, &offline);
             assert_eq!(&online, hardcoded);
 

--- a/graph/src/components/versions/registry.rs
+++ b/graph/src/components/versions/registry.rs
@@ -53,7 +53,7 @@ impl ApiVersion {
     fn resolve(version_requirement: &VersionReq) -> Result<&Version, String> {
         for version in VERSIONS.iter() {
             if version_requirement.matches(version) {
-                return Ok(version.clone());
+                return Ok(version);
             }
         }
 

--- a/graph/src/components/versions/registry.rs
+++ b/graph/src/components/versions/registry.rs
@@ -34,7 +34,7 @@ impl ApiVersion {
             version: version.clone(),
             features: VERSION_COLLECTION
                 .get(version)
-                .expect(format!("Version {:?} is not supported", version).as_str())
+                .unwrap_or_else(|| panic!("Version {:?} is not supported", version))
                 .to_vec(),
         })
     }

--- a/graph/src/components/versions/registry.rs
+++ b/graph/src/components/versions/registry.rs
@@ -28,12 +28,12 @@ pub struct ApiVersion {
 
 impl ApiVersion {
     pub fn new(version_requirement: &VersionReq) -> Result<Self, String> {
-        let version = Self::resolve(&version_requirement)?;
+        let version = Self::resolve(version_requirement)?;
 
         Ok(Self {
             version: version.clone(),
             features: VERSION_COLLECTION
-                .get(&version)
+                .get(version)
                 .expect(format!("Version {:?} is not supported", version).as_str())
                 .to_vec(),
         })

--- a/graph/src/components/versions/registry.rs
+++ b/graph/src/components/versions/registry.rs
@@ -35,7 +35,7 @@ impl ApiVersion {
             features: VERSION_COLLECTION
                 .get(version)
                 .unwrap_or_else(|| panic!("Version {:?} is not supported", version))
-                .to_vec(),
+                .clone(),
         })
     }
 

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -80,11 +80,7 @@ impl QueryResults {
     }
 
     pub fn errors(&self) -> Vec<QueryError> {
-        self.results
-            .iter()
-            .map(|r| r.errors.clone())
-            .flatten()
-            .collect()
+        self.results.iter().flat_map(|r| r.errors.clone()).collect()
     }
 }
 

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -910,14 +910,14 @@ impl Schema {
         match self
             .subgraph_schema_object_type()
             .and_then(|subgraph_schema_type| {
-                if !subgraph_schema_type
+                if subgraph_schema_type
                     .directives
                     .iter()
                     .filter(|directive| {
                         !directive.name.eq("import") && !directive.name.eq("fulltext")
                     })
                     .next()
-                    .is_none()
+                    .is_some()
                 {
                     Some(SchemaValidationError::InvalidSchemaTypeDirectives)
                 } else {

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -137,7 +137,7 @@ pub enum FulltextLanguage {
 impl TryFrom<&str> for FulltextLanguage {
     type Error = String;
     fn try_from(language: &str) -> Result<Self, Self::Error> {
-        match &language[..] {
+        match language {
             "simple" => Ok(FulltextLanguage::Simple),
             "da" => Ok(FulltextLanguage::Danish),
             "nl" => Ok(FulltextLanguage::Dutch),

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -1348,7 +1348,7 @@ impl Schema {
             .get_object_type_definitions()
             .iter()
             .filter(|t| t.find_directive("entity").is_none() && !t.name.eq(SCHEMA_TYPE_NAME))
-            .map(|t| t.name.to_owned())
+            .map(|t| t.name.clone())
             .collect::<Vec<_>>();
         if types_without_entity_directive.is_empty() {
             Ok(())
@@ -1367,7 +1367,7 @@ impl Schema {
             reason: &str,
         ) -> SchemaValidationError {
             SchemaValidationError::InvalidDerivedFrom(
-                object_type.name.to_owned(),
+                object_type.name.clone(),
                 field_name.to_owned(),
                 reason.to_owned(),
             )

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -40,7 +40,7 @@ pub struct Strings(Vec<String>);
 
 impl fmt::Display for Strings {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let s = (&self.0).join(", ");
+        let s = self.0.join(", ");
         write!(f, "{}", s)
     }
 }

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -776,7 +776,7 @@ impl Schema {
                     .directives
                     .iter()
                     .filter(|directive| directive.name.eq("import"))
-                    .map(|import| {
+                    .flat_map(|import| {
                         import.argument("from").map_or(vec![], |from| {
                             SchemaReference::parse(from).map_or(vec![], |schema_ref| {
                                 parse_types(import)
@@ -786,7 +786,6 @@ impl Schema {
                             })
                         })
                     })
-                    .flatten()
                     .collect::<HashMap<ImportedType, SchemaReference>>()
             })
     }

--- a/graph/src/data/schema.rs
+++ b/graph/src/data/schema.rs
@@ -1074,11 +1074,11 @@ impl Schema {
             .count()
             > 1
         {
-            return vec![SchemaValidationError::FulltextNameConflict(
+            vec![SchemaValidationError::FulltextNameConflict(
                 name.to_string(),
-            )];
+            )]
         } else {
-            return vec![];
+            vec![]
         }
     }
 
@@ -1180,7 +1180,7 @@ impl Schema {
             }
         }
         // Fulltext include validations all passed, so we return an empty vector
-        return vec![];
+        vec![]
     }
 
     fn validate_import_directives(&self) -> Vec<SchemaValidationError> {

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -942,15 +942,13 @@ fn entity_validation() {
                 id,
                 err.unwrap_err()
             );
+        } else if let Err(e) = err {
+            assert_eq!(errmsg, e.to_string(), "checking entity {}", id);
         } else {
-            if let Err(e) = err {
-                assert_eq!(errmsg, e.to_string(), "checking entity {}", id);
-            } else {
-                panic!(
-                    "Expected error `{}` but got ok when checking entity {}",
-                    errmsg, id
-                );
-            }
+            panic!(
+                "Expected error `{}` but got ok when checking entity {}",
+                errmsg, id
+            );
         }
     }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -655,7 +655,7 @@ impl Entity {
     pub fn id(&self) -> Result<String, Error> {
         match self.get("id") {
             None => Err(anyhow!("Entity is missing an `id` attribute")),
-            Some(Value::String(s)) => Ok(s.to_owned()),
+            Some(Value::String(s)) => Ok(s.clone()),
             Some(Value::Bytes(b)) => Ok(b.to_string()),
             _ => Err(anyhow!("Entity has non-string `id` attribute")),
         }

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -636,7 +636,7 @@ mod test {
     #[test]
     fn bigint_to_from_u64() {
         for n in 0..100 {
-            let u = U64::from(n as u64);
+            let u = U64::from(n);
             let bn = BigInt::from(u);
             assert_eq!(n, bn.to_u64());
         }

--- a/graph/src/data/subgraph/features.rs
+++ b/graph/src/data/subgraph/features.rs
@@ -112,7 +112,7 @@ fn detect_grafting<C: Blockchain>(manifest: &SubgraphManifest<C>) -> Option<Subg
 
 fn detect_full_text_search(schema: &Schema) -> Option<SubgraphFeature> {
     match schema.document.get_fulltext_directives() {
-        Ok(directives) => (!directives.is_empty()).then(|| SubgraphFeature::FullTextSearch),
+        Ok(directives) => (!directives.is_empty()).then_some(SubgraphFeature::FullTextSearch),
 
         Err(_) => {
             // Currently we return an error from `get_fulltext_directives` function if the

--- a/graph/src/data/subgraph/features.rs
+++ b/graph/src/data/subgraph/features.rs
@@ -23,7 +23,7 @@ use super::calls_host_fn;
 /// This array must contain all IPFS-related functions that are exported by the host WASM runtime.
 ///
 /// For reference, search this codebase for: ff652476-e6ad-40e4-85b8-e815d6c6e5e2
-const IPFS_ON_ETHEREUM_CONTRACTS_FUNCTION_NAMES: [&'static str; 3] =
+const IPFS_ON_ETHEREUM_CONTRACTS_FUNCTION_NAMES: [&str; 3] =
     ["ipfs.cat", "ipfs.getBlock", "ipfs.map"];
 
 #[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -223,7 +223,7 @@ impl SubgraphManifestEntity {
         let template_idx_and_name = manifest
             .templates
             .iter()
-            .map(|t| t.name.to_owned())
+            .map(|t| t.name.clone())
             .enumerate()
             .map(move |(idx, name)| (ds_len + idx as i32, name))
             .collect();

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -13,7 +13,7 @@ pub struct Word(Box<str>);
 
 impl Word {
     pub fn as_str(&self) -> &str {
-        &*self.0
+        &self.0
     }
 }
 
@@ -27,7 +27,7 @@ impl std::ops::Deref for Word {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
-        &*self.0
+        &self.0
     }
 }
 

--- a/graph/src/data_source/mod.rs
+++ b/graph/src/data_source/mod.rs
@@ -81,7 +81,7 @@ impl EntityTypeAccess {
 impl<C: Blockchain> DataSource<C> {
     pub fn as_onchain(&self) -> Option<&C::DataSource> {
         match self {
-            Self::Onchain(ds) => Some(&ds),
+            Self::Onchain(ds) => Some(ds),
             Self::Offchain(_) => None,
         }
     }
@@ -89,7 +89,7 @@ impl<C: Blockchain> DataSource<C> {
     pub fn as_offchain(&self) -> Option<&offchain::DataSource> {
         match self {
             Self::Onchain(_) => None,
-            Self::Offchain(ds) => Some(&ds),
+            Self::Offchain(ds) => Some(ds),
         }
     }
 
@@ -260,7 +260,7 @@ impl<C: Blockchain> DataSourceTemplate<C> {
     pub fn as_offchain(&self) -> Option<&offchain::DataSourceTemplate> {
         match self {
             Self::Onchain(_) => None,
-            Self::Offchain(t) => Some(&t),
+            Self::Offchain(t) => Some(t),
         }
     }
 

--- a/graph/src/data_source/offchain.rs
+++ b/graph/src/data_source/offchain.rs
@@ -154,7 +154,7 @@ impl DataSource {
             .context
             .as_ref()
             .as_ref()
-            .map(|ctx| serde_json::to_value(&ctx).unwrap());
+            .map(|ctx| serde_json::to_value(ctx).unwrap());
 
         StoredDynamicDataSource {
             manifest_idx: self.manifest_idx,

--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -124,7 +124,7 @@ impl FirehoseEndpoint {
     // inside FirehoseEndpoints that is not used (is always cloned).
     pub fn has_subgraph_capacity(self: &Arc<Self>) -> bool {
         self.subgraph_limit
-            .has_capacity(Arc::strong_count(&self).checked_sub(1).unwrap_or(0))
+            .has_capacity(Arc::strong_count(self).checked_sub(1).unwrap_or(0))
     }
 
     pub async fn get_block<M>(

--- a/graph/src/ipfs_client.rs
+++ b/graph/src/ipfs_client.rs
@@ -256,17 +256,14 @@ mod test {
                 name: "correct no slashes, no file",
                 input: cid_str.to_string(),
                 path: cid_str.to_string(),
-                expected: Ok(CidFile {
-                    cid: cid,
-                    path: None,
-                }),
+                expected: Ok(CidFile { cid, path: None }),
             },
             Case {
                 name: "correct with file path",
                 input: format!("{}/file.json", cid),
                 path: format!("{}/file.json", cid_str),
                 expected: Ok(CidFile {
-                    cid: cid,
+                    cid,
                     path: Some("file.json".into()),
                 }),
             },
@@ -274,10 +271,7 @@ mod test {
                 name: "correct cid with trailing slash",
                 input: format!("{}/", cid),
                 path: format!("{}", cid),
-                expected: Ok(CidFile {
-                    cid: cid,
-                    path: None,
-                }),
+                expected: Ok(CidFile { cid, path: None }),
             },
             Case {
                 name: "incorrect, empty",
@@ -290,7 +284,7 @@ mod test {
                 input: format!("{}//", cid),
                 path: format!("{}//", cid),
                 expected: Ok(CidFile {
-                    cid: cid,
+                    cid,
                     path: Some("/".into()),
                 }),
             },

--- a/graph/src/runtime/asc_ptr.rs
+++ b/graph/src/runtime/asc_ptr.rs
@@ -156,11 +156,11 @@ impl<C: AscType> AscPtr<C> {
             ((gc_info.len() + gc_info2.len() + rt_id.len() + rt_size.len() + full_length) as u32)
                 .to_le_bytes();
 
-        header.extend(&mm_info);
-        header.extend(&gc_info);
-        header.extend(&gc_info2);
-        header.extend(&rt_id);
-        header.extend(&rt_size);
+        header.extend(mm_info);
+        header.extend(gc_info);
+        header.extend(gc_info2);
+        header.extend(rt_id);
+        header.extend(rt_size);
 
         Ok(header)
     }

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -50,7 +50,7 @@ use tokio_retry::Retry;
 pub fn retry<I, E>(operation_name: impl ToString, logger: &Logger) -> RetryConfig<I, E> {
     RetryConfig {
         operation_name: operation_name.to_string(),
-        logger: logger.to_owned(),
+        logger: logger.clone(),
         condition: RetryIf::Error,
         log_after: 1,
         warn_after: 10,

--- a/graph/src/util/jobs.rs
+++ b/graph/src/util/jobs.rs
@@ -122,7 +122,7 @@ mod tests {
         let job = CounterJob {
             count: count.clone(),
         };
-        let mut runner = Runner::new(&*LOGGER);
+        let mut runner = Runner::new(&LOGGER);
         runner.register(Arc::new(job), Duration::from_millis(10));
         let stop = runner.stop.clone();
 

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -49,7 +49,7 @@ impl MockStore {
 
 impl ReadStore for MockStore {
     fn get(&self, key: &EntityKey) -> Result<Option<Entity>, StoreError> {
-        Ok(self.get_many_res.get(&key).cloned())
+        Ok(self.get_many_res.get(key).cloned())
     }
 
     fn get_many(

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -801,9 +801,9 @@ async fn complete_value(
                     resolved_value.coerce_scalar(scalar_type).map_err(|value| {
                         vec![QueryExecutionError::ScalarCoercionError(
                             field.position,
-                            field.name.to_owned(),
+                            field.name.clone(),
                             value.into(),
-                            scalar_type.name.to_owned(),
+                            scalar_type.name.clone(),
                         )]
                     })
                 }
@@ -813,13 +813,13 @@ async fn complete_value(
                     resolved_value.coerce_enum(enum_type).map_err(|value| {
                         vec![QueryExecutionError::EnumCoercionError(
                             field.position,
-                            field.name.to_owned(),
+                            field.name.clone(),
                             value.into(),
-                            enum_type.name.to_owned(),
+                            enum_type.name.clone(),
                             enum_type
                                 .values
                                 .iter()
-                                .map(|value| value.name.to_owned())
+                                .map(|value| value.name.clone())
                                 .collect(),
                         )]
                     })

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -288,7 +288,7 @@ pub(crate) async fn execute_root_selection_set_uncached(
             execute_selection_set_to_map(
                 &ictx,
                 ctx.query.selection_set.as_ref(),
-                &*INTROSPECTION_QUERY_TYPE,
+                &INTROSPECTION_QUERY_TYPE,
                 None,
             )
             .await?,

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -405,7 +405,7 @@ pub fn coerce_variables(
         if !schema.is_input_type(&variable_def.var_type) {
             errors.push(QueryExecutionError::InvalidVariableTypeError(
                 variable_def.position,
-                variable_def.name.to_owned(),
+                variable_def.name.clone(),
             ));
             continue;
         }
@@ -427,7 +427,7 @@ pub fn coerce_variables(
                 if sast::is_non_null_type(&variable_def.var_type) {
                     errors.push(QueryExecutionError::MissingVariableError(
                         variable_def.position,
-                        variable_def.name.to_owned(),
+                        variable_def.name.clone(),
                     ));
                 };
                 continue;
@@ -438,7 +438,7 @@ pub fn coerce_variables(
         // We have a variable value, attempt to coerce it to the value type
         // of the variable definition
         coerced_values.insert(
-            variable_def.name.to_owned(),
+            variable_def.name.clone(),
             coerce_variable(schema, variable_def, value)?,
         );
     }
@@ -462,7 +462,7 @@ fn coerce_variable(
     coerce_value(value, &variable_def.var_type, &resolver).map_err(|value| {
         vec![QueryExecutionError::InvalidArgumentError(
             variable_def.position,
-            variable_def.name.to_owned(),
+            variable_def.name.clone(),
             value.into(),
         )]
     })

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -32,7 +32,7 @@ fn schema_type_objects(schema: &Schema) -> TypeObjectsMap {
 fn type_object(schema: &Schema, type_objects: &mut TypeObjectsMap, t: &s::Type) -> r::Value {
     match t {
         // We store the name of the named type here to be able to resolve it dynamically later
-        s::Type::NamedType(s) => r::Value::String(s.to_owned()),
+        s::Type::NamedType(s) => r::Value::String(s.clone()),
         s::Type::ListType(ref inner) => list_type_object(schema, type_objects, inner),
         s::Type::NonNullType(ref inner) => non_null_type_object(schema, type_objects, inner),
     }
@@ -91,7 +91,7 @@ fn type_definition_object(
 fn enum_type_object(enum_type: &s::EnumType) -> r::Value {
     object! {
         kind: r::Value::Enum(String::from("ENUM")),
-        name: enum_type.name.to_owned(),
+        name: enum_type.name.clone(),
         description: enum_type.description.clone(),
         enumValues: enum_values(enum_type),
     }
@@ -103,7 +103,7 @@ fn enum_values(enum_type: &s::EnumType) -> r::Value {
 
 fn enum_value(enum_value: &s::EnumValue) -> r::Value {
     object! {
-        name: enum_value.name.to_owned(),
+        name: enum_value.name.clone(),
         description: enum_value.description.clone(),
         isDeprecated: false,
         deprecationReason: r::Value::Null,
@@ -117,7 +117,7 @@ fn input_object_type_object(
 ) -> r::Value {
     let input_values = input_values(schema, type_objects, &input_object_type.fields);
     object! {
-        name: input_object_type.name.to_owned(),
+        name: input_object_type.name.clone(),
         kind: r::Value::Enum(String::from("INPUT_OBJECT")),
         description: input_object_type.description.clone(),
         inputFields: input_values,
@@ -130,14 +130,14 @@ fn interface_type_object(
     interface_type: &s::InterfaceType,
 ) -> r::Value {
     object! {
-        name: interface_type.name.to_owned(),
+        name: interface_type.name.clone(),
         kind: r::Value::Enum(String::from("INTERFACE")),
         description: interface_type.description.clone(),
         fields:
             field_objects(schema, type_objects, &interface_type.fields),
         possibleTypes: schema.types_for_interface()[interface_type.name.as_str()]
             .iter()
-            .map(|object_type| r::Value::String(object_type.name.to_owned()))
+            .map(|object_type| r::Value::String(object_type.name.clone()))
             .collect::<Vec<_>>(),
     }
 }
@@ -153,13 +153,13 @@ fn object_type_object(
         .unwrap_or_else(|| {
             let type_object = object! {
                 kind: r::Value::Enum(String::from("OBJECT")),
-                name: object_type.name.to_owned(),
+                name: object_type.name.clone(),
                 description: object_type.description.clone(),
                 fields: field_objects(schema, type_objects, &object_type.fields),
                 interfaces: object_interfaces(schema, type_objects, object_type),
             };
 
-            type_objects.insert(object_type.name.to_owned(), type_object.clone());
+            type_objects.insert(object_type.name.clone(), type_object.clone());
             type_object
         })
 }
@@ -180,7 +180,7 @@ fn field_objects(
 
 fn field_object(schema: &Schema, type_objects: &mut TypeObjectsMap, field: &s::Field) -> r::Value {
     object! {
-        name: field.name.to_owned(),
+        name: field.name.clone(),
         description: field.description.clone(),
         args: input_values(schema, type_objects, &field.arguments),
         type: type_object(schema, type_objects, &field.field_type),
@@ -206,7 +206,7 @@ fn object_interfaces(
 
 fn scalar_type_object(scalar_type: &s::ScalarType) -> r::Value {
     object! {
-        name: scalar_type.name.to_owned(),
+        name: scalar_type.name.clone(),
         kind: r::Value::Enum(String::from("SCALAR")),
         description: scalar_type.description.clone(),
         isDeprecated: false,
@@ -216,7 +216,7 @@ fn scalar_type_object(scalar_type: &s::ScalarType) -> r::Value {
 
 fn union_type_object(schema: &Schema, union_type: &s::UnionType) -> r::Value {
     object! {
-        name: union_type.name.to_owned(),
+        name: union_type.name.clone(),
         kind: r::Value::Enum(String::from("UNION")),
         description: union_type.description.clone(),
         possibleTypes:
@@ -228,7 +228,7 @@ fn union_type_object(schema: &Schema, union_type: &s::UnionType) -> r::Value {
                         .iter()
                         .any(|implemented_name| implemented_name == &union_type.name)
                 })
-                .map(|object_type| r::Value::String(object_type.name.to_owned()))
+                .map(|object_type| r::Value::String(object_type.name.clone()))
                 .collect::<Vec<_>>(),
     }
 }
@@ -254,7 +254,7 @@ fn directive_object(
     directive: &s::DirectiveDefinition,
 ) -> r::Value {
     object! {
-        name: directive.name.to_owned(),
+        name: directive.name.clone(),
         description: directive.description.clone(),
         locations: directive_locations(directive),
         args: input_values(schema, type_objects, &directive.arguments),
@@ -289,7 +289,7 @@ fn input_value(
     input_value: &s::InputValue,
 ) -> r::Value {
     object! {
-        name: input_value.name.to_owned(),
+        name: input_value.name.clone(),
         description: input_value.description.clone(),
         type: type_object(schema, type_objects, &input_value.value_type),
         defaultValue:

--- a/graphql/src/query/ext.rs
+++ b/graphql/src/query/ext.rs
@@ -49,7 +49,7 @@ impl ValueExt for q::Value {
         match self {
             q::Value::Variable(name) => vars
                 .get(name)
-                .ok_or_else(|| QueryExecutionError::MissingVariableError(pos, name.to_owned())),
+                .ok_or_else(|| QueryExecutionError::MissingVariableError(pos, name.clone())),
             _ => Ok(self),
         }
     }

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -177,7 +177,7 @@ fn field_enum_values(
         enum_values.push(EnumValue {
             position: Pos::default(),
             description: None,
-            name: field.name.to_owned(),
+            name: field.name.clone(),
             directives: vec![],
         });
         enum_values.extend(field_enum_values_from_child_entity(schema, field)?);
@@ -259,7 +259,7 @@ fn add_filter_type(
                     description: None,
                     name: "and".to_string(),
                     value_type: Type::ListType(Box::new(Type::NamedType(
-                        filter_type_name.to_owned(),
+                        filter_type_name.clone(),
                     ))),
                     default_value: None,
                     directives: vec![],
@@ -270,7 +270,7 @@ fn add_filter_type(
                     description: None,
                     name: "or".to_string(),
                     value_type: Type::ListType(Box::new(Type::NamedType(
-                        filter_type_name.to_owned(),
+                        filter_type_name.clone(),
                     ))),
                     default_value: None,
                     directives: vec![],
@@ -397,7 +397,7 @@ fn field_scalar_filter_input_values(
     }
     .into_iter()
     .map(|filter_type| {
-        let field_type = Type::NamedType(field_type.name.to_owned());
+        let field_type = Type::NamedType(field_type.name.clone());
         let value_type = match filter_type {
             "in" | "not_in" => Type::ListType(Box::new(Type::NonNullType(Box::new(field_type)))),
             _ => field_type,
@@ -429,7 +429,7 @@ fn field_enum_filter_input_values(
     vec!["", "not", "in", "not_in"]
         .into_iter()
         .map(|filter_type| {
-            let field_type = Type::NamedType(field_type.name.to_owned());
+            let field_type = Type::NamedType(field_type.name.clone());
             let value_type = match filter_type {
                 "in" | "not_in" => {
                     Type::ListType(Box::new(Type::NonNullType(Box::new(field_type))))
@@ -462,8 +462,8 @@ fn field_list_filter_input_values(
                     (Some(Type::NamedType("String".into())), Some(name.clone()))
                 }
             }
-            TypeDefinition::Scalar(ref t) => (Some(Type::NamedType(t.name.to_owned())), None),
-            TypeDefinition::Enum(ref t) => (Some(Type::NamedType(t.name.to_owned())), None),
+            TypeDefinition::Scalar(ref t) => (Some(Type::NamedType(t.name.clone())), None),
+            TypeDefinition::Enum(ref t) => (Some(Type::NamedType(t.name.clone())), None),
             TypeDefinition::InputObject(_) | TypeDefinition::Union(_) => (None, None),
         };
 
@@ -1172,7 +1172,7 @@ mod tests {
             user_filter_type
                 .fields
                 .iter()
-                .map(|field| field.name.to_owned())
+                .map(|field| field.name.clone())
                 .collect::<Vec<String>>(),
             [
                 "id",
@@ -1277,7 +1277,7 @@ mod tests {
             pet_filter_type
                 .fields
                 .iter()
-                .map(|field| field.name.to_owned())
+                .map(|field| field.name.clone())
                 .collect::<Vec<String>>(),
             [
                 "id",
@@ -1395,7 +1395,7 @@ mod tests {
             user_filter_type
                 .fields
                 .iter()
-                .map(|field| field.name.to_owned())
+                .map(|field| field.name.clone())
                 .collect::<Vec<String>>(),
             [
                 "id",
@@ -1503,7 +1503,7 @@ mod tests {
             user_singular_field
                 .arguments
                 .iter()
-                .map(|input_value| input_value.name.to_owned())
+                .map(|input_value| input_value.name.clone())
                 .collect::<Vec<String>>(),
             vec![
                 "id".to_string(),
@@ -1529,7 +1529,7 @@ mod tests {
             user_plural_field
                 .arguments
                 .iter()
-                .map(|input_value| input_value.name.to_owned())
+                .map(|input_value| input_value.name.clone())
                 .collect::<Vec<String>>(),
             [
                 "skip",
@@ -1600,7 +1600,7 @@ mod tests {
             singular_field
                 .arguments
                 .iter()
-                .map(|input_value| input_value.name.to_owned())
+                .map(|input_value| input_value.name.clone())
                 .collect::<Vec<String>>(),
             vec![
                 "id".to_string(),
@@ -1626,7 +1626,7 @@ mod tests {
             plural_field
                 .arguments
                 .iter()
-                .map(|input_value| input_value.name.to_owned())
+                .map(|input_value| input_value.name.clone())
                 .collect::<Vec<String>>(),
             [
                 "skip",

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -1489,7 +1489,7 @@ mod tests {
             .expect("Query type is missing in derived API schema");
 
         let user_singular_field = match query_type {
-            TypeDefinition::Object(t) => ast::get_field(t, &"user".to_string()),
+            TypeDefinition::Object(t) => ast::get_field(t, "user"),
             _ => None,
         }
         .expect("\"user\" field is missing on Query type");
@@ -1513,7 +1513,7 @@ mod tests {
         );
 
         let user_plural_field = match query_type {
-            TypeDefinition::Object(t) => ast::get_field(t, &"users".to_string()),
+            TypeDefinition::Object(t) => ast::get_field(t, "users"),
             _ => None,
         }
         .expect("\"users\" field is missing on Query type");
@@ -1546,7 +1546,7 @@ mod tests {
         );
 
         let user_profile_singular_field = match query_type {
-            TypeDefinition::Object(t) => ast::get_field(t, &"userProfile".to_string()),
+            TypeDefinition::Object(t) => ast::get_field(t, "userProfile"),
             _ => None,
         }
         .expect("\"userProfile\" field is missing on Query type");
@@ -1557,7 +1557,7 @@ mod tests {
         );
 
         let user_profile_plural_field = match query_type {
-            TypeDefinition::Object(t) => ast::get_field(t, &"userProfiles".to_string()),
+            TypeDefinition::Object(t) => ast::get_field(t, "userProfiles"),
             _ => None,
         }
         .expect("\"userProfiles\" field is missing on Query type");
@@ -1586,7 +1586,7 @@ mod tests {
             .expect("Query type is missing in derived API schema");
 
         let singular_field = match query_type {
-            TypeDefinition::Object(ref t) => ast::get_field(t, &"node".to_string()),
+            TypeDefinition::Object(ref t) => ast::get_field(t, "node"),
             _ => None,
         }
         .expect("\"node\" field is missing on Query type");
@@ -1610,7 +1610,7 @@ mod tests {
         );
 
         let plural_field = match query_type {
-            TypeDefinition::Object(ref t) => ast::get_field(t, &"nodes".to_string()),
+            TypeDefinition::Object(ref t) => ast::get_field(t, "nodes"),
             _ => None,
         }
         .expect("\"nodes\" field is missing on Query type");

--- a/graphql/src/schema/api.rs
+++ b/graphql/src/schema/api.rs
@@ -258,9 +258,7 @@ fn add_filter_type(
                     position: Pos::default(),
                     description: None,
                     name: "and".to_string(),
-                    value_type: Type::ListType(Box::new(Type::NamedType(
-                        filter_type_name.clone(),
-                    ))),
+                    value_type: Type::ListType(Box::new(Type::NamedType(filter_type_name.clone()))),
                     default_value: None,
                     directives: vec![],
                 });
@@ -269,9 +267,7 @@ fn add_filter_type(
                     position: Pos::default(),
                     description: None,
                     name: "or".to_string(),
-                    value_type: Type::ListType(Box::new(Type::NamedType(
-                        filter_type_name.clone(),
-                    ))),
+                    value_type: Type::ListType(Box::new(Type::NamedType(filter_type_name.clone()))),
                     default_value: None,
                     directives: vec![],
                 });

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -453,15 +453,13 @@ fn entity_validation() {
                 id,
                 err.unwrap_err()
             );
+        } else if let Err(e) = err {
+            assert_eq!(errmsg, e.to_string(), "checking entity {}", id);
         } else {
-            if let Err(e) = err {
-                assert_eq!(errmsg, e.to_string(), "checking entity {}", id);
-            } else {
-                panic!(
-                    "Expected error `{}` but got ok when checking entity {}",
-                    errmsg, id
-                );
-            }
+            panic!(
+                "Expected error `{}` but got ok when checking entity {}",
+                errmsg, id
+            );
         }
     }
 

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -177,7 +177,7 @@ impl Node {
     fn id(&self) -> Result<String, Error> {
         match self.get("id") {
             None => Err(anyhow!("Entity is missing an `id` attribute")),
-            Some(r::Value::String(s)) => Ok(s.to_owned()),
+            Some(r::Value::String(s)) => Ok(s.clone()),
             _ => Err(anyhow!("Entity has non-string `id` attribute")),
         }
     }
@@ -442,7 +442,7 @@ impl<'a> Join<'a> {
                 parents_by_id.dedup_by(|(id1, _), (id2, _)| id1 == id2);
 
                 let (ids, link) = cond.entity_link(parents_by_id, multiplicity);
-                let child_type: EntityType = cond.child_type.to_owned();
+                let child_type: EntityType = cond.child_type.clone();
                 let column_names = match column_names_map.get(&child_type) {
                     Some(column_names) => column_names.clone(),
                     None => AttributeNames::All,
@@ -687,7 +687,7 @@ fn fetch(
     query.logger = Some(ctx.logger.cheap_clone());
     if let Some(r::Value::String(id)) = field.argument_value(ARG_ID.as_str()) {
         query.filter = Some(
-            EntityFilter::Equal(ARG_ID.to_owned(), StoreValue::from(id.to_owned()))
+            EntityFilter::Equal(ARG_ID.to_owned(), StoreValue::from(id.clone()))
                 .and_maybe(query.filter),
         );
     }

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -300,7 +300,7 @@ impl<'a> JoinCond<'a> {
                         let (ids, child_ids): (Vec<_>, Vec<_>) = parents_by_id
                             .into_iter()
                             .filter_map(|(id, node)| {
-                                node.get(*child_field)
+                                node.get(child_field)
                                     .and_then(|value| value.as_str())
                                     .map(|child_id| (id, child_id.to_owned()))
                             })
@@ -315,7 +315,7 @@ impl<'a> JoinCond<'a> {
                         let (ids, child_ids): (Vec<_>, Vec<_>) = parents_by_id
                             .into_iter()
                             .filter_map(|(id, node)| {
-                                node.get(*child_field)
+                                node.get(child_field)
                                     .and_then(|value| match value {
                                         r::Value::List(values) => {
                                             let values: Vec<_> = values

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -212,7 +212,7 @@ fn parse_change_block_filter(value: &r::Value) -> Result<BlockNumber, QueryExecu
         r::Value::Object(object) => i32::try_from_value(
             object
                 .get("number_gte")
-                .ok_or_else(|| QueryExecutionError::InvalidFilterError)?,
+                .ok_or(QueryExecutionError::InvalidFilterError)?,
         )
         .map_err(|_| QueryExecutionError::InvalidFilterError),
         _ => Err(QueryExecutionError::InvalidFilterError),

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -307,7 +307,7 @@ fn build_filter_from_object(
     object: &Object,
     schema: &ApiSchema,
 ) -> Result<Vec<EntityFilter>, QueryExecutionError> {
-    Ok(object
+    object
         .iter()
         .map(|(key, value)| {
             // Special handling for _change_block input filter since its not a
@@ -375,7 +375,7 @@ fn build_filter_from_object(
                 }
             })
         })
-        .collect::<Result<Vec<EntityFilter>, QueryExecutionError>>()?)
+        .collect::<Result<Vec<EntityFilter>, QueryExecutionError>>()
 }
 
 fn build_child_filter_from_object(

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -448,7 +448,7 @@ fn build_child_filter_from_object(
                     };
 
                     Ok(EntityFilter::Child(Child {
-                        attr: attr,
+                        attr,
                         entity_type: EntityType::new(child_entity.name().to_string()),
                         filter: filter.clone(),
                         derived,

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -545,7 +545,7 @@ fn build_order_by(
                     QueryExecutionError::EntityFieldError(entity.name().to_owned(), name.clone())
                 })?;
                 sast::get_field_value_type(&field.field_type)
-                    .map(|value_type| Some((name.to_owned(), value_type, None)))
+                    .map(|value_type| Some((name.clone(), value_type, None)))
                     .map_err(|_| {
                         QueryExecutionError::OrderByNotSupportedError(
                             entity.name().to_owned(),
@@ -622,7 +622,7 @@ fn build_order_by(
                 };
 
                 sast::get_field_value_type(&child_field.field_type)
-                    .map(|value_type| Some((child_field_name.to_owned(), value_type, Some(child))))
+                    .map(|value_type| Some((child_field_name.clone(), value_type, Some(child))))
                     .map_err(|_| {
                         QueryExecutionError::OrderByNotSupportedError(
                             child_entity.name().to_owned(),
@@ -719,7 +719,7 @@ pub(crate) fn collect_entities_from_query_field(
                         // Obtain the subgraph ID from the object type
                         if let Ok(subgraph_id) = parse_subgraph_id(object_type) {
                             // Add the (subgraph_id, entity_name) tuple to the result set
-                            entities.insert((subgraph_id, object_type.name.to_owned()));
+                            entities.insert((subgraph_id, object_type.name.clone()));
                         }
                     }
 

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -448,7 +448,7 @@ fn build_child_filter_from_object(
                     };
 
                     Ok(EntityFilter::Child(Child {
-                        attr: attr.clone(),
+                        attr: attr,
                         entity_type: EntityType::new(child_entity.name().to_string()),
                         filter: filter.clone(),
                         derived,

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -225,7 +225,7 @@ fn build_entity_filter(
     operation: FilterOp,
     store_value: Value,
 ) -> Result<EntityFilter, QueryExecutionError> {
-    return match operation {
+    match operation {
         FilterOp::Not => Ok(EntityFilter::Not(field_name, store_value)),
         FilterOp::GreaterThan => Ok(EntityFilter::GreaterThan(field_name, store_value)),
         FilterOp::LessThan => Ok(EntityFilter::LessThan(field_name, store_value)),
@@ -255,7 +255,7 @@ fn build_entity_filter(
         FilterOp::NotEndsWithNoCase => Ok(EntityFilter::NotEndsWithNoCase(field_name, store_value)),
         FilterOp::Equal => Ok(EntityFilter::Equal(field_name, store_value)),
         _ => unreachable!(),
-    };
+    }
 }
 
 /// Iterate over the list and generate an EntityFilter from it
@@ -266,23 +266,23 @@ fn build_list_filter_from_value(
 ) -> Result<Vec<EntityFilter>, QueryExecutionError> {
     // We have object like this
     // { or: [{ name: \"John\", id: \"m1\" }, { mainBand: \"b2\" }] }
-    return match value {
+    match value {
         r::Value::List(list) => Ok(list
             .iter()
             .map(|item| {
                 // It is each filter in the object
                 // { name: \"John\", id: \"m1\" }
                 // the fields within the object are ANDed together
-                return match item {
+                match item {
                     r::Value::Object(object) => Ok(EntityFilter::And(build_filter_from_object(
                         entity, object, schema,
                     )?)),
                     _ => Err(QueryExecutionError::InvalidFilterError),
-                };
+                }
             })
             .collect::<Result<Vec<EntityFilter>, QueryExecutionError>>()?),
         _ => Err(QueryExecutionError::InvalidFilterError),
-    };
+    }
 }
 
 /// build a filter which has list of nested filters
@@ -293,9 +293,7 @@ fn build_list_filter_from_object(
 ) -> Result<Vec<EntityFilter>, QueryExecutionError> {
     Ok(object
         .iter()
-        .map(|(_, value)| {
-            return build_list_filter_from_value(entity, schema, value);
-        })
+        .map(|(_, value)| build_list_filter_from_value(entity, schema, value))
         .collect::<Result<Vec<Vec<EntityFilter>>, QueryExecutionError>>()?
         .into_iter()
         // We iterate an object so all entity filters are flattened into one list

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -331,9 +331,9 @@ impl Resolver for StoreResolver {
 
                 return Err(QueryExecutionError::AmbiguousDerivedFromResult(
                     field.position,
-                    field.name.to_owned(),
+                    field.name.clone(),
                     object_type.name().to_owned(),
-                    derived_from_field.name.to_owned(),
+                    derived_from_field.name.clone(),
                 ));
             } else {
                 Ok(children.into_iter().next().unwrap_or(r::Value::Null))

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -246,7 +246,6 @@ impl StoreResolver {
 
             let timestamp = self.block_ptr.as_ref().map(|ptr| {
                 ptr.timestamp
-                    .clone()
                     .map(|ts| r::Value::Int(ts as i64))
                     .unwrap_or(r::Value::Null)
             });

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -241,7 +241,7 @@ impl StoreResolver {
             let number = self
                 .block_ptr
                 .as_ref()
-                .map(|ptr| r::Value::Int((ptr.ptr.number as i32).into()))
+                .map(|ptr| r::Value::Int(ptr.ptr.number.into()))
                 .unwrap_or(r::Value::Null);
 
             let timestamp = self.block_ptr.as_ref().map(|ptr| {

--- a/graphql/src/values/coercion.rs
+++ b/graphql/src/values/coercion.rs
@@ -129,7 +129,7 @@ pub(crate) fn coerce_input_value<'a>(
             return if schema::ast::is_non_null_type(&def.value_type) {
                 Err(QueryExecutionError::MissingArgumentError(
                     def.position,
-                    def.name.to_owned(),
+                    def.name.clone(),
                 ))
             } else {
                 Ok(None)
@@ -140,7 +140,7 @@ pub(crate) fn coerce_input_value<'a>(
 
     Ok(Some(
         coerce_value(value, &def.value_type, resolver).map_err(|val| {
-            QueryExecutionError::InvalidArgumentError(def.position, def.name.to_owned(), val.into())
+            QueryExecutionError::InvalidArgumentError(def.position, def.name.clone(), val.into())
         })?,
     ))
 }

--- a/graphql/src/values/coercion.rs
+++ b/graphql/src/values/coercion.rs
@@ -309,7 +309,7 @@ mod tests {
             Ok(Value::String("23".to_string()))
         );
         assert_eq!(
-            coerce_to_definition(Value::Int((-5 as i32).into()), "", &resolver,),
+            coerce_to_definition(Value::Int((-5_i32).into()), "", &resolver,),
             Ok(Value::String("-5".to_string())),
         );
 
@@ -390,7 +390,7 @@ mod tests {
             Ok(Value::String("1234".to_string()))
         );
         assert_eq!(
-            coerce_to_definition(Value::Int((-1234 as i32).into()), "", &resolver,),
+            coerce_to_definition(Value::Int((-1234_i32).into()), "", &resolver,),
             Ok(Value::String("-1234".to_string()))
         );
     }
@@ -417,8 +417,8 @@ mod tests {
             Ok(Value::Int(13289123.into()))
         );
         assert_eq!(
-            coerce_to_definition(Value::Int((-13289123 as i32).into()), "", &resolver,),
-            Ok(Value::Int((-13289123 as i32).into()))
+            coerce_to_definition(Value::Int((-13289123_i32).into()), "", &resolver,),
+            Ok(Value::Int((-13289123_i32).into()))
         );
     }
 }

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -1561,7 +1561,7 @@ fn instant_timeout() {
         match first_result(
             execute_subgraph_query_with_deadline(
                 query,
-                QueryTarget::Deployment(deployment.hash.into(), Default::default()),
+                QueryTarget::Deployment(deployment.hash, Default::default()),
                 Some(Instant::now()),
             )
             .await,
@@ -2578,7 +2578,7 @@ fn trace_works() {
 
         let result = execute_subgraph_query(
             query,
-            QueryTarget::Deployment(deployment.hash.into(), Default::default()),
+            QueryTarget::Deployment(deployment.hash, Default::default()),
         )
         .await;
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -347,7 +347,7 @@ async fn insert_test_entities(
 
         test_store::transact_and_wait(
             &STORE.subgraph_store(),
-            &deployment,
+            deployment,
             block_ptr,
             insert_ops.collect::<Vec<_>>(),
         )
@@ -2154,7 +2154,7 @@ fn query_detects_reorg() {
     async fn query_at(deployment: &DeploymentLocator, block: i32) -> QueryResult {
         let query =
             format!("query {{ musician(id: \"m1\", block: {{ number: {block} }}) {{ id }} }}");
-        execute_query(&deployment, &query).await
+        execute_query(deployment, &query).await
     }
 
     run_test_sequentially(|store| async move {

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -373,7 +373,7 @@ async fn execute_query_document_with_variables(
     variables: Option<QueryVariables>,
 ) -> QueryResult {
     let runner = Arc::new(GraphQlRunner::new(
-        &*LOGGER,
+        &LOGGER,
         STORE.clone(),
         SUBSCRIPTION_MANAGER.clone(),
         LOAD_MANAGER.clone(),
@@ -484,7 +484,7 @@ where
                     .into_static();
                 let variables = variables.clone();
                 let runner = Arc::new(GraphQlRunner::new(
-                    &*LOGGER,
+                    &LOGGER,
                     STORE.clone(),
                     SUBSCRIPTION_MANAGER.clone(),
                     LOAD_MANAGER.clone(),
@@ -2093,10 +2093,10 @@ fn query_at_block() {
     musicians_at("number: 0", Ok(vec!["m1", "m2"]), "n0");
     musicians_at("number: 1", Ok(vec!["m1", "m2", "m3", "m4"]), "n1");
 
-    musicians_at(&hash(&*GENESIS_BLOCK), Ok(vec!["m1", "m2"]), "h0");
-    musicians_at(&hash(&*BLOCK_ONE), Ok(vec!["m1", "m2", "m3", "m4"]), "h1");
-    musicians_at(&hash(&*BLOCK_TWO), Err(BLOCK_NOT_INDEXED2), "h2");
-    musicians_at(&hash(&*BLOCK_THREE), Err(BLOCK_HASH_NOT_FOUND), "h3");
+    musicians_at(&hash(&GENESIS_BLOCK), Ok(vec!["m1", "m2"]), "h0");
+    musicians_at(&hash(&BLOCK_ONE), Ok(vec!["m1", "m2", "m3", "m4"]), "h1");
+    musicians_at(&hash(&BLOCK_TWO), Err(BLOCK_NOT_INDEXED2), "h2");
+    musicians_at(&hash(&BLOCK_THREE), Err(BLOCK_HASH_NOT_FOUND), "h3");
 }
 
 #[test]
@@ -2182,7 +2182,7 @@ fn query_detects_reorg() {
         );
 
         // Revert one block
-        revert_block(&*STORE, &deployment, &*GENESIS_PTR).await;
+        revert_block(&STORE, &deployment, &GENESIS_PTR).await;
 
         // A query is still fine since we query at block 0; we were at block
         // 1 when we got `state`, and reorged once by one block, which can
@@ -2302,7 +2302,7 @@ fn non_fatal_errors() {
             deterministic: true,
         };
 
-        transact_errors(&*STORE, &deployment, BLOCK_TWO.block_ptr(), vec![err])
+        transact_errors(&STORE, &deployment, BLOCK_TWO.block_ptr(), vec![err])
             .await
             .unwrap();
 
@@ -2358,7 +2358,7 @@ fn non_fatal_errors() {
         assert_eq!(expected, serde_json::to_value(&result).unwrap());
 
         // Test error reverts.
-        revert_block(&*STORE, &deployment, &*BLOCK_ONE).await;
+        revert_block(&STORE, &deployment, &BLOCK_ONE).await;
         let query = "query { musician(id: \"m1\") { id }  _meta { hasIndexingErrors } }";
         let result = execute_query(&deployment, query).await;
         let expected = json!({
@@ -2408,7 +2408,7 @@ fn deterministic_error() {
             deterministic: true,
         };
 
-        transact_errors(&*STORE, &deployment, BLOCK_TWO.block_ptr(), vec![err])
+        transact_errors(&STORE, &deployment, BLOCK_TWO.block_ptr(), vec![err])
             .await
             .unwrap();
 

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -457,7 +457,7 @@ impl From<(&str, r::Value)> for QueryArgs {
 /// replaced with the id's of songs 1 through 4 before running the query.
 fn run_query<F>(args: impl Into<QueryArgs>, test: F)
 where
-    F: Fn(QueryResult, IdType) -> () + Send + 'static,
+    F: Fn(QueryResult, IdType) + Send + 'static,
 {
     let QueryArgs {
         query,

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -2037,7 +2037,7 @@ fn check_musicians_at(query0: &str, block_var: r::Value, expected: Expected, qid
     run_query((query0, block_var), move |result, id_type| {
         match &expected {
             Ok(ids) => {
-                let ids: Vec<_> = ids.into_iter().map(|id| object! { id: *id }).collect();
+                let ids: Vec<_> = ids.iter().map(|id| object! { id: *id }).collect();
                 let expected = Some(object_value(vec![("musicians", r::Value::List(ids))]));
                 let data = match result.to_result() {
                     Err(errors) => panic!("unexpected error: {:?} ({})\n", errors, qid),

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -542,7 +542,7 @@ async fn run_subscription(
         .api_schema(&deployment.hash, &Default::default())
         .unwrap();
 
-    execute_subscription(Subscription { query }, schema.clone(), options)
+    execute_subscription(Subscription { query }, schema, options)
 }
 
 #[test]
@@ -677,7 +677,7 @@ fn can_query_many_to_many_relationship() {
             musicians: vec![
                 object! { name: "John", bands: vec![ the_musicians.clone(), the_amateurs.clone() ]},
                 object! { name: "Lisa", bands: vec![ the_musicians.clone() ] },
-                object! { name: "Tom", bands: vec![ the_musicians.clone(), the_amateurs.clone() ] },
+                object! { name: "Tom", bands: vec![ the_musicians, the_amateurs ] },
                 object! { name: "Valerie", bands: Vec::<String>::new() }
             ]
         };
@@ -984,7 +984,7 @@ fn can_query_with_child_filter_on_list_type_field() {
         let exp = object! {
             musicians: vec![
                 object! { name: "John", bands: vec![ the_musicians.clone(), the_amateurs.clone() ]},
-                object! { name: "Tom", bands: vec![ the_musicians.clone(), the_amateurs.clone() ] },
+                object! { name: "Tom", bands: vec![ the_musicians, the_amateurs ] },
             ]
         };
 

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -766,7 +766,7 @@ impl Context {
 
         Arc::new(SubscriptionManager::new(
             self.logger.clone(),
-            primary.connection.to_owned(),
+            primary.connection.clone(),
             self.registry.clone(),
         ))
     }

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -126,7 +126,7 @@ pub fn create_substreams_networks(
 
                 let parsed_networks = networks_by_kind
                     .entry(chain.protocol)
-                    .or_insert_with(|| FirehoseNetworks::new());
+                    .or_insert_with(FirehoseNetworks::new);
 
                 for i in 0..firehose.conn_pool_size {
                     parsed_networks.insert(
@@ -172,7 +172,7 @@ pub fn create_firehose_networks(
 
                 let parsed_networks = networks_by_kind
                     .entry(chain.protocol)
-                    .or_insert_with(|| FirehoseNetworks::new());
+                    .or_insert_with(FirehoseNetworks::new);
 
                 // Create n FirehoseEndpoints where n is the size of the pool. If a
                 // subgraph limit is defined for this endpoint then each endpoint
@@ -400,7 +400,7 @@ pub async fn create_all_ethereum_networks(
             a.extend(b);
             a
         })
-        .unwrap_or_else(|| EthereumNetworks::new()))
+        .unwrap_or_else(EthereumNetworks::new))
 }
 
 /// Parses a single Ethereum connection string and returns its network name and `EthereumAdapter`.

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -353,10 +353,9 @@ where
                     ProviderNetworkStatus::Broken { chain_id, provider } => {
                         firehose_networks.remove(&chain_id, &provider)
                     }
-                    ProviderNetworkStatus::Version { chain_id, ident } => networks
-                        .entry(chain_id)
-                        .or_default()
-                        .push(ident),
+                    ProviderNetworkStatus::Version { chain_id, ident } => {
+                        networks.entry(chain_id).or_default().push(ident)
+                    }
                 }
                 networks
             });

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -549,8 +549,7 @@ mod test {
             .get("goerli")
             .unwrap()
             .adapters
-            .iter()
-            .next()
+            .first()
             .unwrap()
             .capabilities;
         let mainnet_capability = ethereum_networks
@@ -558,8 +557,7 @@ mod test {
             .get("mainnet")
             .unwrap()
             .adapters
-            .iter()
-            .next()
+            .first()
             .unwrap()
             .capabilities;
         assert_eq!(

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -75,7 +75,7 @@ pub fn create_ipfs_clients(logger: &Logger, ipfs_addresses: &Vec<String>) -> Vec
             let ipfs_ok_logger = logger.clone();
             let ipfs_err_logger = logger.clone();
             let ipfs_address_for_ok = ipfs_address.clone();
-            let ipfs_address_for_err = ipfs_address.clone();
+            let ipfs_address_for_err = ipfs_address;
             graph::spawn(async move {
                 ipfs_test
                     .test()
@@ -271,7 +271,7 @@ pub async fn connect_ethereum_networks(
                     ProviderNetworkStatus::Version {
                         chain_id: network,
                         ident,
-                    } => networks.entry(network.to_string()).or_default().push(ident),
+                    } => networks.entry(network).or_default().push(ident),
                 }
                 networks
             });
@@ -354,7 +354,7 @@ where
                         firehose_networks.remove(&chain_id, &provider)
                     }
                     ProviderNetworkStatus::Version { chain_id, ident } => networks
-                        .entry(chain_id.to_string())
+                        .entry(chain_id)
                         .or_default()
                         .push(ident),
                 }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1074,7 +1074,7 @@ fn replace_host(url: &str, host: &str) -> String {
         Err(_) => panic!("Invalid Postgres URL {}", url),
     };
     if let Err(e) = url.set_host(Some(host)) {
-        panic!("Invalid Postgres url {}: {}", url, e.to_string());
+        panic!("Invalid Postgres url {}: {}", url, e);
     }
     String::from(url)
 }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -169,7 +169,7 @@ impl Config {
     pub fn from_str(config: &str, node: &str) -> Result<Config> {
         let mut config: Config = toml::from_str(&config)?;
         config.node =
-            NodeId::new(node.clone()).map_err(|()| anyhow!("invalid node id {}", node))?;
+            NodeId::new(node).map_err(|()| anyhow!("invalid node id {}", node))?;
         config.validate()?;
         Ok(config)
     }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -527,9 +527,9 @@ fn btree_map_to_http_headers(kvs: BTreeMap<String, String>) -> HeaderMap {
     for (k, v) in kvs.into_iter() {
         headers.insert(
             k.parse::<http::header::HeaderName>()
-                .expect(&format!("invalid HTTP header name: {}", k)),
+                .unwrap_or_else(|_| panic!("invalid HTTP header name: {}", k)),
             v.parse::<http::header::HeaderValue>()
-                .expect(&format!("invalid HTTP header value: {}: {}", k, v)),
+                .unwrap_or_else(|_| panic!("invalid HTTP header value: {}: {}", k, v)),
         );
     }
     headers
@@ -1656,7 +1656,7 @@ mod tests {
         d.push("resources/tests");
         d.push(path);
 
-        read_to_string(&d).expect(&format!("resource {:?} not found", &d))
+        read_to_string(&d).unwrap_or_else(|_| panic!("resource {:?} not found", &d))
     }
 
     #[test]

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -832,7 +832,7 @@ impl<'de> Deserialize<'de> for Provider {
                         transport: transport.unwrap_or(Transport::Rpc),
                         features: features
                             .ok_or_else(|| serde::de::Error::missing_field("features"))?,
-                        headers: headers.unwrap_or_else(|| HeaderMap::new()),
+                        headers: headers.unwrap_or_else(HeaderMap::new),
                         rules: nodes,
                     }),
                 };

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -111,7 +111,7 @@ impl Config {
             ));
         }
         for (key, shard) in self.stores.iter_mut() {
-            shard.validate(&key)?;
+            shard.validate(key)?;
         }
         self.deployment.validate()?;
 
@@ -167,7 +167,7 @@ impl Config {
     }
 
     pub fn from_str(config: &str, node: &str) -> Result<Config> {
-        let mut config: Config = toml::from_str(&config)?;
+        let mut config: Config = toml::from_str(config)?;
         config.node = NodeId::new(node).map_err(|()| anyhow!("invalid node id {}", node))?;
         config.validate()?;
         Ok(config)
@@ -270,11 +270,11 @@ impl Shard {
             .as_ref()
             .expect("validation checked that postgres_url is set");
         let pool_size = PoolSize::Fixed(opt.store_connection_pool_size);
-        pool_size.validate(is_primary, &postgres_url)?;
+        pool_size.validate(is_primary, postgres_url)?;
         let mut replicas = BTreeMap::new();
         for (i, host) in opt.postgres_secondary_hosts.iter().enumerate() {
             let replica = Replica {
-                connection: replace_host(&postgres_url, &host),
+                connection: replace_host(postgres_url, host),
                 weight: opt.postgres_host_weights.get(i + 1).cloned().unwrap_or(1),
                 pool_size: pool_size.clone(),
             };

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -168,8 +168,7 @@ impl Config {
 
     pub fn from_str(config: &str, node: &str) -> Result<Config> {
         let mut config: Config = toml::from_str(&config)?;
-        config.node =
-            NodeId::new(node).map_err(|()| anyhow!("invalid node id {}", node))?;
+        config.node = NodeId::new(node).map_err(|()| anyhow!("invalid node id {}", node))?;
         config.validate()?;
         Ok(config)
     }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -841,7 +841,7 @@ impl<'de> Deserialize<'de> for Provider {
             }
         }
 
-        const FIELDS: &'static [&'static str] = &[
+        const FIELDS: &[&str] = &[
             "label",
             "details",
             "transport",

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -440,10 +440,10 @@ impl ChainSection {
                 // Parse string (format is "NETWORK_NAME:NETWORK_CAPABILITIES:URL" OR
                 // "NETWORK_NAME::URL" which will default to NETWORK_CAPABILITIES="archive,traces")
                 let colon = arg.find(':').ok_or_else(|| {
-                    return anyhow!(
+                    anyhow!(
                         "A network name must be provided alongside the \
                          Ethereum node location. Try e.g. 'mainnet:URL'."
-                    );
+                    )
                 })?;
 
                 let (name, rest_with_delim) = arg.split_at(colon);
@@ -456,10 +456,10 @@ impl ChainSection {
                 }
 
                 let colon = rest.find(':').ok_or_else(|| {
-                    return anyhow!(
+                    anyhow!(
                         "A network name must be provided alongside the \
                          Ethereum node location. Try e.g. 'mainnet:URL'."
-                    );
+                    )
                 })?;
 
                 let (features, url_str) = rest.split_at(colon);

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -402,7 +402,9 @@ async fn main() {
                                     let firehose_endpoints = eth_firehose_endpoints
                                         .networks
                                         .get(&name)
-                                        .expect(&format!("chain {} to have endpoints", name))
+                                        .unwrap_or_else(|| {
+                                            panic!("chain {} to have endpoints", name)
+                                        })
                                         .clone();
                                     (
                                         name,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -158,7 +158,7 @@ async fn main() {
     let fork_base = match &opt.fork_base {
         Some(url) => {
             // Make sure the endpoint ends with a terminating slash.
-            let url = if !url.ends_with("/") {
+            let url = if !url.ends_with('/') {
                 let mut url = url.clone();
                 url.push('/');
                 Url::parse(&url)
@@ -520,7 +520,7 @@ async fn main() {
             let start_block = opt
                 .start_block
                 .map(|block| {
-                    let mut split = block.split(":");
+                    let mut split = block.split(':');
                     (
                         // BlockHash
                         split.next().unwrap().to_owned(),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -270,7 +270,7 @@ async fn main() {
             &logger,
             firehose_networks_by_kind
                 .remove(&BlockchainKind::Arweave)
-                .unwrap_or_else(|| FirehoseNetworks::new()),
+                .unwrap_or_else(FirehoseNetworks::new),
         )
         .await;
 
@@ -282,7 +282,7 @@ async fn main() {
                 &logger,
                 firehose_networks_by_kind
                     .remove(&BlockchainKind::Near)
-                    .unwrap_or_else(|| FirehoseNetworks::new()),
+                    .unwrap_or_else(FirehoseNetworks::new),
             )
             .await;
 
@@ -290,7 +290,7 @@ async fn main() {
             &logger,
             firehose_networks_by_kind
                 .remove(&BlockchainKind::Cosmos)
-                .unwrap_or_else(|| FirehoseNetworks::new()),
+                .unwrap_or_else(FirehoseNetworks::new),
         )
         .await;
 
@@ -701,7 +701,7 @@ fn ethereum_networks_as_chains(
         .map(|(network_name, eth_adapters, chain_store, is_ingestible)| {
             let firehose_endpoints = firehose_networks
                 .and_then(|v| v.networks.get(network_name))
-                .map_or_else(|| FirehoseEndpoints::new(), |v| v.clone());
+                .map_or_else(FirehoseEndpoints::new, |v| v.clone());
 
             let client = Arc::new(ChainClient::<graph_chain_ethereum::Chain>::new(
                 firehose_endpoints,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -186,7 +186,7 @@ async fn main() {
         .elasticsearch_url
         .clone()
         .map(|endpoint| ElasticLoggingConfig {
-            endpoint: endpoint.clone(),
+            endpoint: endpoint,
             username: opt.elasticsearch_user.clone(),
             password: opt.elasticsearch_password.clone(),
             client: reqwest::Client::new(),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -184,7 +184,7 @@ async fn main() {
         .elasticsearch_url
         .clone()
         .map(|endpoint| ElasticLoggingConfig {
-            endpoint: endpoint,
+            endpoint,
             username: opt.elasticsearch_user.clone(),
             password: opt.elasticsearch_password.clone(),
             client: reqwest::Client::new(),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -74,7 +74,7 @@ fn read_expensive_queries(
                     let msg = format!(
                         "invalid GraphQL query in {}: {}\n{}",
                         expensive_queries_filename,
-                        e.to_string(),
+                        e,
                         line
                     );
                     std::io::Error::new(std::io::ErrorKind::InvalidData, msg)

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -878,11 +878,7 @@ fn start_block_ingestor(
         logger,
         "Starting block ingestors with {} chains [{}]",
         chains.len(),
-        chains
-            .keys()
-            .map(|v| v.clone())
-            .collect::<Vec<String>>()
-            .join(", ")
+        chains.keys().cloned().collect::<Vec<String>>().join(", ")
     );
 
     // Create Ethereum block ingestors and spawn a thread to run each
@@ -948,11 +944,7 @@ fn start_firehose_block_ingestor<C, M>(
         logger,
         "Starting firehose block ingestors with {} chains [{}]",
         chains.len(),
-        chains
-            .keys()
-            .map(|v| v.clone())
-            .collect::<Vec<String>>()
-            .join(", ")
+        chains.keys().cloned().collect::<Vec<String>>().join(", ")
     );
 
     // Create Firehose block ingestors and spawn a thread to run each

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -73,9 +73,7 @@ fn read_expensive_queries(
                 .map_err(|e| {
                     let msg = format!(
                         "invalid GraphQL query in {}: {}\n{}",
-                        expensive_queries_filename,
-                        e,
-                        line
+                        expensive_queries_filename, e, line
                     );
                     std::io::Error::new(std::io::ErrorKind::InvalidData, msg)
                 })?

--- a/node/src/manager/commands/chain.rs
+++ b/node/src/manager/commands/chain.rs
@@ -68,7 +68,7 @@ pub async fn info(
     hashes: bool,
 ) -> Result<(), Error> {
     fn row(label: &str, value: impl std::fmt::Display) {
-        println!("{:<16} | {}", label, value.to_string());
+        println!("{:<16} | {}", label, value);
     }
 
     fn print_ptr(label: &str, ptr: Option<BlockPtr>, hashes: bool) {

--- a/node/src/manager/commands/copy.rs
+++ b/node/src/manager/commands/copy.rs
@@ -108,7 +108,7 @@ pub async fn create(
 
     let chain_store = store
         .block_store()
-        .chain_store(&network)
+        .chain_store(network)
         .ok_or_else(|| anyhow!("could not find chain store for network {}", network))?;
     let mut hashes = chain_store.block_hashes_by_block_number(src_number)?;
     let hash = match hashes.len() {
@@ -248,7 +248,7 @@ pub fn status(pools: HashMap<Shard, ConnectionPool>, dst: &DeploymentSearch) -> 
         .get(&*PRIMARY_SHARD)
         .ok_or_else(|| anyhow!("can not find deployment with id {}", dst))?;
     let pconn = primary.get()?;
-    let dst = dst.locate_unique(&primary)?.id.0;
+    let dst = dst.locate_unique(primary)?.id.0;
 
     let (shard, deployment) = ds::table
         .filter(ds::id.eq(dst as i32))

--- a/node/src/manager/commands/copy.rs
+++ b/node/src/manager/commands/copy.rs
@@ -251,7 +251,7 @@ pub fn status(pools: HashMap<Shard, ConnectionPool>, dst: &DeploymentSearch) -> 
     let dst = dst.locate_unique(primary)?.id.0;
 
     let (shard, deployment) = ds::table
-        .filter(ds::id.eq(dst as i32))
+        .filter(ds::id.eq(dst))
         .select((ds::shard, ds::subgraph))
         .get_result::<(Shard, String)>(&pconn)?;
 

--- a/node/src/manager/commands/index.rs
+++ b/node/src/manager/commands/index.rs
@@ -115,7 +115,7 @@ pub async fn list(
             } => {
                 let unique = if *unique { " unique" } else { "" };
                 let start = format!("{unique} using {method}");
-                let columns = columns.into_iter().map(|c| c.to_string()).join(", ");
+                let columns = columns.iter().map(|c| c.to_string()).join(", ");
 
                 term.green()?;
                 if index.is_default_index() {

--- a/node/src/manager/commands/index.rs
+++ b/node/src/manager/commands/index.rs
@@ -193,7 +193,7 @@ pub async fn drop(
 ) -> Result<(), anyhow::Error> {
     let deployment_locator = search.locate_unique(&pool)?;
     store
-        .drop_index_for_deployment(&deployment_locator, &index_name)
+        .drop_index_for_deployment(&deployment_locator, index_name)
         .await?;
     println!("Dropped index {index_name}");
     Ok(())

--- a/node/src/manager/commands/index.rs
+++ b/node/src/manager/commands/index.rs
@@ -150,16 +150,10 @@ pub async fn list(
             .indexes_for_entity(&deployment_locator, entity_name)
             .await?;
         if no_attribute_indexes {
-            indexes = indexes
-                .into_iter()
-                .filter(|idx| !idx.is_attribute_index())
-                .collect();
+            indexes.retain(|idx| !idx.is_attribute_index());
         }
         if no_default_indexes {
-            indexes = indexes
-                .into_iter()
-                .filter(|idx| !idx.is_default_index())
-                .collect();
+            indexes.retain(|idx| !idx.is_default_index());
         }
         indexes
     };

--- a/node/src/manager/commands/listen.rs
+++ b/node/src/manager/commands/listen.rs
@@ -23,7 +23,7 @@ async fn listen(
         .inspect(move |event| {
             serde_json::to_writer_pretty(std::io::stdout(), event)
                 .expect("event can be serialized to JSON");
-            writeln!(std::io::stdout(), "").unwrap();
+            writeln!(std::io::stdout()).unwrap();
             std::io::stdout().flush().unwrap();
         })
         .collect()

--- a/node/src/manager/commands/query.rs
+++ b/node/src/manager/commands/query.rs
@@ -42,10 +42,7 @@ pub async fn run(
         .map(|v| {
             let mut pair = v.splitn(2, '=').map(|s| s.to_string());
             let key = pair.next();
-            let value = pair
-                .next()
-                .map(|s| r::Value::String(s))
-                .unwrap_or(r::Value::Null);
+            let value = pair.next().map(r::Value::String).unwrap_or(r::Value::Null);
             match key {
                 Some(key) => Ok((key, value)),
                 None => Err(anyhow!(

--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -25,7 +25,7 @@ async fn block_ptr(
     let chains = deployments.iter().map(|d| &d.chain).collect::<HashSet<_>>();
     if chains.len() > 1 {
         let names = searches
-            .into_iter()
+            .iter()
             .map(|s| s.to_string())
             .collect::<Vec<_>>()
             .join(", ");

--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -44,15 +44,13 @@ async fn block_ptr(
                 block_ptr_to.number
             );
         }
-    } else {
-        if !force {
-            bail!(
-                "the chain {} does not have a block with hash {} \
-                   (run with --force to avoid this error)",
-                chain,
-                block_ptr_to.hash
-            );
-        }
+    } else if !force {
+        bail!(
+            "the chain {} does not have a block with hash {} \
+               (run with --force to avoid this error)",
+            chain,
+            block_ptr_to.hash
+        );
     }
     Ok(block_ptr_to)
 }

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -113,7 +113,7 @@ pub async fn run(
     let chain_store = network_store
         .block_store()
         .chain_store(network_name.as_ref())
-        .expect(format!("No chain store for {}", &network_name).as_ref());
+        .unwrap_or_else(|| panic!("No chain store for {}", &network_name));
 
     let client = Arc::new(ChainClient::new(firehose_endpoints, eth_adapters));
 

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -83,7 +83,7 @@ pub async fn run(
     let firehose_networks = firehose_networks_by_kind.get(&BlockchainKind::Ethereum);
     let firehose_endpoints = firehose_networks
         .and_then(|v| v.networks.get(&network_name))
-        .map_or_else(|| FirehoseEndpoints::new(), |v| v.clone());
+        .map_or_else(FirehoseEndpoints::new, |v| v.clone());
 
     let eth_adapters = match eth_networks.networks.get(&network_name) {
         Some(adapters) => adapters.clone(),

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -32,7 +32,7 @@ use graph_core::{
 };
 
 fn locate(store: &dyn SubgraphStore, hash: &str) -> Result<DeploymentLocator, anyhow::Error> {
-    let mut locators = store.locators(&hash)?;
+    let mut locators = store.locators(hash)?;
     match locators.len() {
         0 => bail!("could not find subgraph {hash} we just created"),
         1 => Ok(locators.pop().unwrap()),

--- a/node/src/manager/commands/stats.rs
+++ b/node/src/manager/commands/stats.rs
@@ -134,7 +134,7 @@ fn analyze_loc(
         Some(entity_name) => println!("Analyzing table sgd{}.{entity_name}", locator.id),
         None => println!("Analyzing all tables for sgd{}", locator.id),
     }
-    store.analyze(&locator, entity_name).map_err(|e| anyhow!(e))
+    store.analyze(locator, entity_name).map_err(|e| anyhow!(e))
 }
 
 pub fn target(

--- a/node/src/manager/commands/unused_deployments.rs
+++ b/node/src/manager/commands/unused_deployments.rs
@@ -58,11 +58,7 @@ pub fn record(store: Arc<SubgraphStore>) -> Result<(), Error> {
     let recorded = store.record_unused_deployments()?;
 
     for unused in store.list_unused_deployments(unused::Filter::New)? {
-        if recorded
-            .iter()
-            .find(|r| r.deployment == unused.deployment)
-            .is_some()
-        {
+        if recorded.iter().any(|r| r.deployment == unused.deployment) {
             add_row(&mut list, unused);
         }
     }

--- a/node/src/manager/commands/unused_deployments.rs
+++ b/node/src/manager/commands/unused_deployments.rs
@@ -18,7 +18,7 @@ fn add_row(list: &mut List, deployment: UnusedDeployment) {
         entity_count,
         ..
     } = deployment;
-    let subgraphs = subgraphs.unwrap_or(vec![]).join(", ");
+    let subgraphs = subgraphs.unwrap_or_default().join(", ");
 
     list.append(vec![
         id.to_string(),

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -46,7 +46,7 @@ impl StoreBuilder {
 
         let subscription_manager = Arc::new(SubscriptionManager::new(
             logger.cheap_clone(),
-            primary_shard.connection.to_owned(),
+            primary_shard.connection.clone(),
             registry.clone(),
         ));
 
@@ -73,7 +73,7 @@ impl StoreBuilder {
         let chain_head_update_listener = Arc::new(PostgresChainHeadUpdateListener::new(
             logger,
             registry.cheap_clone(),
-            primary_shard.connection.to_owned(),
+            primary_shard.connection.clone(),
         ));
 
         Self {
@@ -222,7 +222,7 @@ impl StoreBuilder {
             &logger,
             name,
             PoolName::Main,
-            shard.connection.to_owned(),
+            shard.connection.clone(),
             pool_size,
             Some(fdw_pool_size),
             registry.cheap_clone(),

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -180,7 +180,7 @@ impl StoreBuilder {
             DieselBlockStore::new(
                 logger,
                 networks,
-                pools.clone(),
+                pools,
                 subgraph_store.notification_sender(),
             )
             .expect("Creating the BlockStore works"),

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -203,14 +203,14 @@ impl StoreBuilder {
         coord: Arc<PoolCoordinator>,
     ) -> ConnectionPool {
         let logger = logger.new(o!("pool" => "main"));
-        let pool_size = shard.pool_size.size_for(node, name).expect(&format!(
-            "cannot determine the pool size for store {}",
-            name
-        ));
-        let fdw_pool_size = shard.fdw_pool_size.size_for(node, name).expect(&format!(
-            "cannot determine the fdw pool size for store {}",
-            name
-        ));
+        let pool_size = shard
+            .pool_size
+            .size_for(node, name)
+            .unwrap_or_else(|_| panic!("cannot determine the pool size for store {}", name));
+        let fdw_pool_size = shard
+            .fdw_pool_size
+            .size_for(node, name)
+            .unwrap_or_else(|_| panic!("cannot determine the fdw pool size for store {}", name));
         info!(
             logger,
             "Connecting to Postgres";
@@ -254,10 +254,9 @@ impl StoreBuilder {
                         "weight" => replica.weight
                     );
                     weights.push(replica.weight);
-                    let pool_size = replica.pool_size.size_for(node, name).expect(&format!(
-                        "we can determine the pool size for replica {}",
-                        name
-                    ));
+                    let pool_size = replica.pool_size.size_for(node, name).unwrap_or_else(|_| {
+                        panic!("we can determine the pool size for replica {}", name)
+                    });
 
                     coord.clone().create_pool(
                         &logger,

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -62,7 +62,7 @@ impl StoreBuilder {
         // attempt doesn't work for all of them because the database is
         // unavailable, they will try again later in the normal course of
         // using the pool
-        join_all(pools.iter().map(|(_, pool)| pool.setup())).await;
+        join_all(pools.values().map(|pool| pool.setup())).await;
 
         let chains = HashMap::from_iter(config.chains.chains.iter().map(|(name, chain)| {
             let shard = ShardName::new(chain.shard.to_string())

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -71,7 +71,7 @@ impl StoreBuilder {
         }));
 
         let chain_head_update_listener = Arc::new(PostgresChainHeadUpdateListener::new(
-            &logger,
+            logger,
             registry.cheap_clone(),
             primary_shard.connection.to_owned(),
         ));

--- a/runtime/derive/src/generate_array_type.rs
+++ b/runtime/derive/src/generate_array_type.rs
@@ -17,7 +17,7 @@ pub fn generate_array_type(metadata: TokenStream, input: TokenStream) -> TokenSt
         .filter_map(|a| {
             if let NestedMeta::Meta(Meta::Path(Path { segments, .. })) = a {
                 if let Some(p) = segments.last() {
-                    return Some(p.ident.to_string().to_owned());
+                    return Some(p.ident.to_string());
                 }
             }
             None

--- a/runtime/derive/src/generate_array_type.rs
+++ b/runtime/derive/src/generate_array_type.rs
@@ -7,8 +7,8 @@ pub fn generate_array_type(metadata: TokenStream, input: TokenStream) -> TokenSt
     let item_struct = parse_macro_input!(input as ItemStruct);
     let name = item_struct.ident.clone();
 
-    let asc_name = Ident::new(&format!("Asc{}", name.to_string()), Span::call_site());
-    let asc_name_array = Ident::new(&format!("Asc{}Array", name.to_string()), Span::call_site());
+    let asc_name = Ident::new(&format!("Asc{}", name), Span::call_site());
+    let asc_name_array = Ident::new(&format!("Asc{}Array", name), Span::call_site());
 
     let args = parse_macro_input!(metadata as AttributeArgs);
 

--- a/runtime/derive/src/generate_asc_type.rs
+++ b/runtime/derive/src/generate_asc_type.rs
@@ -13,7 +13,7 @@ pub fn generate_asc_type(metadata: TokenStream, input: TokenStream) -> TokenStre
     let enum_names = args
         .vars
         .iter()
-        .filter(|f| f.ident.to_string() != super::REQUIRED_IDENT_NAME)
+        .filter(|f| f.ident != super::REQUIRED_IDENT_NAME)
         .map(|f| f.ident.to_string())
         .collect::<Vec<String>>();
 
@@ -27,7 +27,7 @@ pub fn generate_asc_type(metadata: TokenStream, input: TokenStream) -> TokenStre
     //extend fields list with enum's variants
     args.vars
         .iter()
-        .filter(|f| f.ident.to_string() != super::REQUIRED_IDENT_NAME)
+        .filter(|f| f.ident != super::REQUIRED_IDENT_NAME)
         .flat_map(|f| f.fields.named.iter())
         .for_each(|f| fields.push(f));
 

--- a/runtime/derive/src/generate_asc_type.rs
+++ b/runtime/derive/src/generate_asc_type.rs
@@ -8,7 +8,7 @@ pub fn generate_asc_type(metadata: TokenStream, input: TokenStream) -> TokenStre
     let args = parse_macro_input!(metadata as super::Args);
 
     let name = item_struct.ident.clone();
-    let asc_name = Ident::new(&format!("Asc{}", name.to_string()), Span::call_site());
+    let asc_name = Ident::new(&format!("Asc{}", name), Span::call_site());
 
     let enum_names = args
         .vars

--- a/runtime/derive/src/generate_asc_type.rs
+++ b/runtime/derive/src/generate_asc_type.rs
@@ -79,7 +79,7 @@ fn field_type_map(tp: String) -> String {
     } else {
         match tp.as_ref() {
             "String" => "graph_runtime_wasm::asc_abi::class::AscString".into(),
-            _ => tp.to_owned(),
+            _ => tp.clone(),
         }
     }
 }

--- a/runtime/derive/src/generate_from_rust_type.rs
+++ b/runtime/derive/src/generate_from_rust_type.rs
@@ -197,7 +197,7 @@ fn field_type(fld: &syn::Field) -> String {
 
 fn is_required(fld: &syn::Field, req_list: &[String]) -> bool {
     let fld_name = fld.ident.as_ref().unwrap().to_string();
-    req_list.iter().find(|r| *r == &fld_name).is_some()
+    req_list.iter().any(|r| r == &fld_name)
 }
 
 fn is_nullable(fld: &syn::Field) -> bool {

--- a/runtime/derive/src/generate_from_rust_type.rs
+++ b/runtime/derive/src/generate_from_rust_type.rs
@@ -46,13 +46,13 @@ pub fn generate_from_rust_type(metadata: TokenStream, input: TokenStream) -> Tok
     );
 
     let name = item_struct.ident.clone();
-    let asc_name = Ident::new(&format!("Asc{}", name.to_string()), Span::call_site());
+    let asc_name = Ident::new(&format!("Asc{}", name), Span::call_site());
 
     //generate enum fields validator
     let enum_validation = enum_fields.iter().map(|f|{
         let fld_name = f.ident.as_ref().unwrap(); //empty, maybe call it "sum"?
-        let type_nm = format!("\"{}\"", name.to_string()).parse::<proc_macro2::TokenStream>().unwrap();
-        let fld_nm = format!("\"{}\"", fld_name.to_string()).parse::<proc_macro2::TokenStream>().unwrap();
+        let type_nm = format!("\"{}\"", name).parse::<proc_macro2::TokenStream>().unwrap();
+        let fld_nm = format!("\"{}\"", fld_name).parse::<proc_macro2::TokenStream>().unwrap();
 
         quote! {
             let #fld_name = self.#fld_name.as_ref()
@@ -75,8 +75,8 @@ pub fn generate_from_rust_type(metadata: TokenStream, input: TokenStream) -> Tok
             let setter =
                 if is_nullable(&f) {
                     if is_required{
-                        let type_nm = format!("\"{}\"", name.to_string()).parse::<proc_macro2::TokenStream>().unwrap();
-                        let fld_nm = format!("\"{}\"", fld_name.to_string()).parse::<proc_macro2::TokenStream>().unwrap();
+                        let type_nm = format!("\"{}\"", name).parse::<proc_macro2::TokenStream>().unwrap();
+                        let fld_nm = format!("\"{}\"", fld_name).parse::<proc_macro2::TokenStream>().unwrap();
 
                         quote! {
                             #fld_name: graph::runtime::asc_new_or_missing(heap, &#self_ref, gas, #type_nm, #fld_nm)?,

--- a/runtime/derive/src/generate_from_rust_type.rs
+++ b/runtime/derive/src/generate_from_rust_type.rs
@@ -86,15 +86,13 @@ pub fn generate_from_rust_type(metadata: TokenStream, input: TokenStream) -> Tok
                             #fld_name: graph::runtime::asc_new_or_null(heap, &#self_ref, gas)?,
                         }
                     }
-                } else {
-                    if is_scalar(&field_type(f)){
-                        quote!{
-                            #fld_name: #self_ref,
-                        }
-                    }else{
-                        quote! {
-                            #fld_name: graph::runtime::asc_new(heap, &#self_ref, gas)?,
-                        }
+                } else if is_scalar(&field_type(f)){
+                    quote!{
+                        #fld_name: #self_ref,
+                    }
+                }else{
+                    quote! {
+                        #fld_name: graph::runtime::asc_new(heap, &#self_ref, gas)?,
                     }
                 };
             setter

--- a/runtime/derive/src/generate_from_rust_type.rs
+++ b/runtime/derive/src/generate_from_rust_type.rs
@@ -73,7 +73,7 @@ pub fn generate_from_rust_type(metadata: TokenStream, input: TokenStream) -> Tok
             let is_required = is_required(f, &required_flds);
 
             let setter =
-                if is_nullable(&f) {
+                if is_nullable(f) {
                     if is_required{
                         let type_nm = format!("\"{}\"", name).parse::<proc_macro2::TokenStream>().unwrap();
                         let fld_nm = format!("\"{}\"", fld_name).parse::<proc_macro2::TokenStream>().unwrap();

--- a/runtime/derive/src/generate_from_rust_type.rs
+++ b/runtime/derive/src/generate_from_rust_type.rs
@@ -188,7 +188,7 @@ fn is_scalar(fld: &str) -> bool {
 fn field_type(fld: &syn::Field) -> String {
     if let syn::Type::Path(tp) = &fld.ty {
         if let Some(ps) = tp.path.segments.last() {
-            return ps.ident.to_string();
+            ps.ident.to_string()
         } else {
             "N/A".into()
         }

--- a/runtime/derive/src/generate_from_rust_type.rs
+++ b/runtime/derive/src/generate_from_rust_type.rs
@@ -52,7 +52,7 @@ pub fn generate_from_rust_type(metadata: TokenStream, input: TokenStream) -> Tok
     let enum_validation = enum_fields.iter().map(|f|{
         let fld_name = f.ident.as_ref().unwrap(); //empty, maybe call it "sum"?
         let type_nm = format!("\"{}\"", name.to_string()).parse::<proc_macro2::TokenStream>().unwrap();
-        let fld_nm = format!("\"{}\"", fld_name.to_string()).to_string().parse::<proc_macro2::TokenStream>().unwrap();
+        let fld_nm = format!("\"{}\"", fld_name.to_string()).parse::<proc_macro2::TokenStream>().unwrap();
 
         quote! {
             let #fld_name = self.#fld_name.as_ref()

--- a/runtime/derive/src/generate_from_rust_type.rs
+++ b/runtime/derive/src/generate_from_rust_type.rs
@@ -28,7 +28,7 @@ pub fn generate_from_rust_type(metadata: TokenStream, input: TokenStream) -> Tok
         .iter()
         .filter(|f| {
             let nm = f.ident.as_ref().unwrap().to_string();
-            !enum_names.contains(&nm) && !nm.starts_with("_")
+            !enum_names.contains(&nm) && !nm.starts_with('_')
         })
         .collect::<Vec<&Field>>();
 

--- a/runtime/derive/src/generate_from_rust_type.rs
+++ b/runtime/derive/src/generate_from_rust_type.rs
@@ -10,14 +10,14 @@ pub fn generate_from_rust_type(metadata: TokenStream, input: TokenStream) -> Tok
     let enum_names = args
         .vars
         .iter()
-        .filter(|f| f.ident.to_string() != super::REQUIRED_IDENT_NAME)
+        .filter(|f| f.ident != super::REQUIRED_IDENT_NAME)
         .map(|f| f.ident.to_string())
         .collect::<Vec<String>>();
 
     let required_flds = args
         .vars
         .iter()
-        .filter(|f| f.ident.to_string() == super::REQUIRED_IDENT_NAME)
+        .filter(|f| f.ident == super::REQUIRED_IDENT_NAME)
         .flat_map(|f| f.fields.named.iter())
         .map(|f| f.ident.as_ref().unwrap().to_string())
         .collect::<Vec<String>>();

--- a/runtime/derive/src/generate_from_rust_type.rs
+++ b/runtime/derive/src/generate_from_rust_type.rs
@@ -119,8 +119,7 @@ pub fn generate_from_rust_type(metadata: TokenStream, input: TokenStream) -> Tok
             let mod_name = item_struct.ident.to_string().to_snake_case();
             let varian_type_name = format!("{}::{}::{}",mod_name, var_type_name, varian_type_name).parse::<proc_macro2::TokenStream>().unwrap();
 
-            let setter =
-                if is_byte_array(f){
+            if is_byte_array(f){
                     quote! {
                         #fld_nm: if let #varian_type_name(v) = #var_nm {graph::runtime::asc_new(heap, &graph_runtime_wasm::asc_abi::class::Bytes(v), gas)? } else {graph::runtime::AscPtr::null()},
                     }
@@ -128,9 +127,7 @@ pub fn generate_from_rust_type(metadata: TokenStream, input: TokenStream) -> Tok
                     quote! {
                         #fld_nm: if let #varian_type_name(v) = #var_nm {graph::runtime::asc_new(heap, v, gas)? } else {graph::runtime::AscPtr::null()},
                     }
-                };
-
-            setter
+                }
         })
         .for_each(|ts| methods.push(ts));
     }

--- a/runtime/derive/src/generate_network_type_id.rs
+++ b/runtime/derive/src/generate_network_type_id.rs
@@ -10,7 +10,7 @@ pub fn generate_network_type_id(metadata: TokenStream, input: TokenStream) -> To
     let asc_name = if name.to_string().to_uppercase().starts_with("ASC") {
         name.clone()
     } else {
-        Ident::new(&format!("Asc{}", name.to_string()), Span::call_site())
+        Ident::new(&format!("Asc{}", name), Span::call_site())
     };
 
     let no_asc_name = if name.to_string().to_uppercase().starts_with("ASC") {

--- a/runtime/derive/src/generate_network_type_id.rs
+++ b/runtime/derive/src/generate_network_type_id.rs
@@ -26,7 +26,7 @@ pub fn generate_network_type_id(metadata: TokenStream, input: TokenStream) -> To
         .filter_map(|a| {
             if let NestedMeta::Meta(Meta::Path(Path { segments, .. })) = a {
                 if let Some(p) = segments.last() {
-                    return Some(p.ident.to_string().to_owned());
+                    return Some(p.ident.to_string());
                 }
             }
             None

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -451,7 +451,7 @@ async fn run_ipfs_map(
         let _runtime_guard = runtime.enter();
 
         let (mut module, _, _) = graph::block_on(test_valid_module_and_store(
-            &subgraph_id,
+            subgraph_id,
             mock_data_source(
                 &wasm_file_path("ipfs_map.wasm", api_version.clone()),
                 api_version.clone(),

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -127,7 +127,7 @@ pub async fn test_module(
 pub async fn test_module_latest(subgraph_id: &str, wasm_file: &str) -> WasmInstance<Chain> {
     let version = ENV_VARS.mappings.max_api_version.clone();
     let ds = mock_data_source(
-        &wasm_file_path(wasm_file, API_VERSION_0_0_5.clone()),
+        &wasm_file_path(wasm_file, API_VERSION_0_0_5),
         version.clone(),
     );
     test_valid_module_and_store(subgraph_id, ds, version)

--- a/runtime/test/src/test/abi.rs
+++ b/runtime/test/src/test/abi.rs
@@ -304,8 +304,7 @@ async fn test_abi_store_value(api_version: Version) {
 
     // Value::Bool
     let boolean = true;
-    let new_value_ptr =
-        module.takes_val_returns_ptr("value_from_bool", if boolean { 1 } else { 0 });
+    let new_value_ptr = module.takes_val_returns_ptr("value_from_bool", boolean as i32);
     let new_value: Value = module.asc_get(new_value_ptr).unwrap();
     assert_eq!(new_value, Value::Bool(boolean));
 

--- a/runtime/test/src/test/abi.rs
+++ b/runtime/test/src/test/abi.rs
@@ -441,7 +441,7 @@ async fn test_abi_big_int(api_version: Version) {
     let new_uint_obj: AscPtr<AscBigInt> =
         module.invoke_export1("test_uint", &BigInt::from_unsigned_u256(&old_uint));
     let new_uint: BigInt = module.asc_get(new_uint_obj).unwrap();
-    assert_eq!(new_uint, BigInt::from(1 as i32));
+    assert_eq!(new_uint, BigInt::from(1_i32));
     let new_uint = new_uint.to_unsigned_u256();
     assert_eq!(new_uint, U256([1, 0, 0, 0]));
 
@@ -449,7 +449,7 @@ async fn test_abi_big_int(api_version: Version) {
     let old_uint = BigInt::from(-50);
     let new_uint_obj: AscPtr<AscBigInt> = module.invoke_export1("test_uint", &old_uint);
     let new_uint: BigInt = module.asc_get(new_uint_obj).unwrap();
-    assert_eq!(new_uint, BigInt::from(-49 as i32));
+    assert_eq!(new_uint, BigInt::from(-49_i32));
     let new_uint_from_u256 = BigInt::from_signed_u256(&new_uint.to_signed_u256());
     assert_eq!(new_uint, new_uint_from_u256);
 }

--- a/runtime/wasm/src/asc_abi/class.rs
+++ b/runtime/wasm/src/asc_abi/class.rs
@@ -447,7 +447,7 @@ impl From<f64> for EnumPayload {
 
 impl From<bool> for EnumPayload {
     fn from(b: bool) -> EnumPayload {
-        EnumPayload(if b { 1 } else { 0 })
+        EnumPayload(b.into())
     }
 }
 

--- a/runtime/wasm/src/asc_abi/v0_0_4.rs
+++ b/runtime/wasm/src/asc_abi/v0_0_4.rs
@@ -87,8 +87,8 @@ impl AscType for ArrayBuffer {
         let mut asc_layout: Vec<u8> = Vec::new();
 
         let byte_length: [u8; 4] = self.byte_length.to_le_bytes();
-        asc_layout.extend(&byte_length);
-        asc_layout.extend(&self.padding);
+        asc_layout.extend(byte_length);
+        asc_layout.extend(self.padding);
         asc_layout.extend(self.content.iter());
 
         // Allocate extra capacity to next power of two, as required by asc.
@@ -212,7 +212,7 @@ impl AscType for AscString {
         let mut asc_layout: Vec<u8> = Vec::new();
 
         let length: [u8; 4] = self.length.to_le_bytes();
-        asc_layout.extend(&length);
+        asc_layout.extend(length);
 
         // Write the code points, in little-endian (LE) order.
         for &code_unit in self.content.iter() {

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -182,7 +182,7 @@ impl<C: Blockchain> HostExports<C> {
         gas.consume_host_fn(gas::STORE_SET.with_args(complexity::Linear, (&key, &data)))?;
 
         let entity = Entity::from(data);
-        state.entity_cache.set(key.clone(), entity)?;
+        state.entity_cache.set(key, entity)?;
 
         Ok(())
     }

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -194,7 +194,7 @@ impl ValidModule {
             .unwrap(); // Safe because this only panics if size passed is 0.
 
         let engine = &wasmtime::Engine::new(&config)?;
-        let module = wasmtime::Module::from_binary(&engine, &raw_module)?;
+        let module = wasmtime::Module::from_binary(engine, &raw_module)?;
 
         let mut import_name_to_modules: BTreeMap<String, Vec<String>> = BTreeMap::new();
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -1237,7 +1237,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
             &self.ctx.host_exports.link_resolver.clone(),
             self,
             link.clone(),
-            &*callback,
+            &callback,
             user_data,
             flags,
         )?;
@@ -1688,7 +1688,7 @@ impl<C: Blockchain> WasmInstanceContext<C> {
         }
 
         let hash: String = asc_get(self, hash_ptr, gas)?;
-        let name = self.ctx.host_exports.ens_name_by_hash(&*hash)?;
+        let name = self.ctx.host_exports.ens_name_by_hash(&hash)?;
         if name.is_none() && self.ctx.host_exports.is_ens_data_empty()? {
             return Err(anyhow!(
                 "Missing ENS data: see https://github.com/graphprotocol/ens-rainbow"

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -1678,8 +1678,6 @@ impl<C: Blockchain> WasmInstanceContext<C> {
         hash_ptr: AscPtr<AscString>,
     ) -> Result<AscPtr<AscString>, HostExportError> {
         // Not enabled on the network, no gas consumed.
-        drop(gas);
-
         // This is unrelated to IPFS, but piggyback on the config to disallow it on the network.
         if !self.experimental_features.allow_non_deterministic_ipfs {
             return Err(HostExportError::Deterministic(anyhow!(

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -159,11 +159,11 @@ impl ToAscObj<AscEnum<EthereumValueKind>> for ethabi::Token {
                 asc_new::<Uint8Array, _, _>(heap, &**bytes, gas)?.to_payload()
             }
             Int(uint) => {
-                let n = BigInt::from_signed_u256(&uint);
+                let n = BigInt::from_signed_u256(uint);
                 asc_new(heap, &n, gas)?.to_payload()
             }
             Uint(uint) => {
-                let n = BigInt::from_unsigned_u256(&uint);
+                let n = BigInt::from_unsigned_u256(uint);
                 asc_new(heap, &n, gas)?.to_payload()
             }
             Bool(b) => *b as u64,

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -140,7 +140,7 @@ impl ToAscObj<Array<AscPtr<AscString>>> for Vec<String> {
     ) -> Result<Array<AscPtr<AscString>>, DeterministicHostError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
-        Ok(Array::new(&content, heap, gas)?)
+        Array::new(&content, heap, gas)
     }
 }
 

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -140,7 +140,7 @@ impl ToAscObj<Array<AscPtr<AscString>>> for Vec<String> {
     ) -> Result<Array<AscPtr<AscString>>, DeterministicHostError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
-        Ok(Array::new(&*content, heap, gas)?)
+        Ok(Array::new(&content, heap, gas)?)
     }
 }
 

--- a/runtime/wasm/src/to_from/mod.rs
+++ b/runtime/wasm/src/to_from/mod.rs
@@ -92,7 +92,7 @@ impl<C: AscType + AscIndexId, T: ToAscObj<C>> ToAscObj<Array<AscPtr<C>>> for [T]
     ) -> Result<Array<AscPtr<C>>, DeterministicHostError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
-        Array::new(&*content, heap, gas)
+        Array::new(&content, heap, gas)
     }
 }
 

--- a/server/index-node/src/explorer.rs
+++ b/server/index-node/src/explorer.rs
@@ -87,8 +87,8 @@ where
     fn handle_subgraph_version(&self, version: &str) -> Result<Response<Body>, GraphQLServerError> {
         let vi = self.version_info(version)?;
 
-        let latest_ethereum_block_number = vi.latest_ethereum_block_number.map(|n| n);
-        let total_ethereum_blocks_count = vi.total_ethereum_blocks_count.map(|n| n);
+        let latest_ethereum_block_number = vi.latest_ethereum_block_number;
+        let total_ethereum_blocks_count = vi.total_ethereum_blocks_count;
         let value = object! {
             createdAt: vi.created_at.as_str(),
             deploymentId: vi.deployment_id.as_str(),

--- a/server/index-node/src/explorer.rs
+++ b/server/index-node/src/explorer.rs
@@ -87,8 +87,8 @@ where
     fn handle_subgraph_version(&self, version: &str) -> Result<Response<Body>, GraphQLServerError> {
         let vi = self.version_info(version)?;
 
-        let latest_ethereum_block_number = vi.latest_ethereum_block_number.map(|n| n as i32);
-        let total_ethereum_blocks_count = vi.total_ethereum_blocks_count.map(|n| n as i32);
+        let latest_ethereum_block_number = vi.latest_ethereum_block_number.map(|n| n);
+        let total_ethereum_blocks_count = vi.total_ethereum_blocks_count.map(|n| n);
         let value = object! {
             createdAt: vi.created_at.as_str(),
             deploymentId: vi.deployment_id.as_str(),

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -54,7 +54,7 @@ impl IntoValue for PublicProofOfIndexingResult {
                 number: self.block.number,
                 hash: self.block.hash.map(|hash| hash.hash_hex()),
             },
-            proofOfIndexing: self.proof_of_indexing.map(|poi| format!("0x{}", hex::encode(&poi))),
+            proofOfIndexing: self.proof_of_indexing.map(|poi| format!("0x{}", hex::encode(poi))),
         }
     }
 }
@@ -389,7 +389,7 @@ impl<S: Store> IndexNodeResolver<S> {
             .store
             .get_proof_of_indexing(&deployment_id, &indexer, block.clone());
         let poi = match futures::executor::block_on(poi_fut) {
-            Ok(Some(poi)) => r::Value::String(format!("0x{}", hex::encode(&poi))),
+            Ok(Some(poi)) => r::Value::String(format!("0x{}", hex::encode(poi))),
             Ok(None) => r::Value::Null,
             Err(e) => {
                 error!(

--- a/server/index-node/src/schema.rs
+++ b/server/index-node/src/schema.rs
@@ -3,7 +3,7 @@ use graph::prelude::*;
 lazy_static! {
     pub static ref SCHEMA: Arc<ApiSchema> = {
         let raw_schema = include_str!("./schema.graphql");
-        let document = graphql_parser::parse_schema(&raw_schema).unwrap();
+        let document = graphql_parser::parse_schema(raw_schema).unwrap();
         Arc::new(
             ApiSchema::from_api_schema(
                 Schema::new(DeploymentHash::new("indexnode").unwrap(), document).unwrap(),

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -291,7 +291,7 @@ where
                             return send_error_string(
                                 &msg_sink,
                                 id,
-                                format!("Invalid variables provided (must be an object)"),
+                                "Invalid variables provided (must be an object)".to_string(),
                             );
                         }
                     };

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -89,7 +89,7 @@ fn print_diesel_tables(layout: &Layout) {
 
     for table in &tables {
         println!("    table! {{");
-        let name = table.qualified_name.as_str().replace("\"", "");
+        let name = table.qualified_name.as_str().replace('\"', "");
         println!("        {} (vid) {{", name);
         println!("            vid -> BigInt,");
         for column in &table.as_ref().columns {

--- a/store/postgres/src/advisory_lock.rs
+++ b/store/postgres/src/advisory_lock.rs
@@ -35,14 +35,14 @@ pub(crate) fn unlock_migration(conn: &PgConnection) -> Result<(), StoreError> {
 }
 
 pub(crate) fn lock_copying(conn: &PgConnection, dst: &Site) -> Result<(), StoreError> {
-    sql_query(&format!("select pg_advisory_lock(1, {})", dst.id))
+    sql_query(format!("select pg_advisory_lock(1, {})", dst.id))
         .execute(conn)
         .map(|_| ())
         .map_err(StoreError::from)
 }
 
 pub(crate) fn unlock_copying(conn: &PgConnection, dst: &Site) -> Result<(), StoreError> {
-    sql_query(&format!("select pg_advisory_unlock(1, {})", dst.id))
+    sql_query(format!("select pg_advisory_unlock(1, {})", dst.id))
         .execute(conn)
         .map(|_| ())
         .map_err(StoreError::from)
@@ -61,7 +61,7 @@ pub(crate) fn lock_deployment_session(
         locked: bool,
     }
 
-    sql_query(&format!(
+    sql_query(format!(
         "select pg_try_advisory_lock(2, {}) as locked",
         site.id
     ))
@@ -75,7 +75,7 @@ pub(crate) fn unlock_deployment_session(
     conn: &PgConnection,
     site: &Site,
 ) -> Result<(), StoreError> {
-    sql_query(&format!("select pg_advisory_unlock(2, {})", site.id))
+    sql_query(format!("select pg_advisory_unlock(2, {})", site.id))
         .execute(conn)
         .map(|_| ())
         .map_err(StoreError::from)

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -405,7 +405,7 @@ pub fn account_like(conn: &PgConnection, site: &Site) -> Result<HashSet<String>,
         .select((ts::table_name, ts::is_account_like))
         .get_results::<(String, Option<bool>)>(conn)
         .optional()?
-        .unwrap_or(vec![])
+        .unwrap_or_default()
         .into_iter()
         .filter_map(|(name, account_like)| {
             if account_like == Some(true) {

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -679,8 +679,7 @@ pub fn stats(conn: &PgConnection, namespace: &Namespace) -> Result<Vec<VersionSt
     // values there are in the `id` column) See the [Postgres
     // docs](https://www.postgresql.org/docs/current/view-pg-stats.html) for
     // the precise meaning of n_distinct
-    let query = format!(
-        "select case when s.n_distinct < 0 then (- s.n_distinct * c.reltuples)::int4
+    let query = "select case when s.n_distinct < 0 then (- s.n_distinct * c.reltuples)::int4
                      else s.n_distinct::int4
                  end as entities,
                  c.reltuples::int4  as versions,
@@ -696,7 +695,7 @@ pub fn stats(conn: &PgConnection, namespace: &Namespace) -> Result<Vec<VersionSt
             and s.attname = 'id'
             and c.relname = s.tablename
           order by c.relname"
-    );
+        .to_string();
 
     let stats = sql_query(query)
         .bind::<Text, _>(namespace.as_str())

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -451,7 +451,7 @@ pub fn copy_account_like(conn: &PgConnection, src: &Site, dst: &Site) -> Result<
           where ts.deployment = $1",
         src_nsp = src_nsp
     );
-    Ok(sql_query(&query)
+    Ok(sql_query(query)
         .bind::<Integer, _>(src.id)
         .bind::<Integer, _>(dst.id)
         .execute(conn)?)
@@ -641,7 +641,7 @@ pub(crate) fn drop_index(
     index_name: &str,
 ) -> Result<(), StoreError> {
     let query = format!("drop index concurrently {schema_name}.{index_name}");
-    sql_query(&query)
+    sql_query(query)
         .bind::<Text, _>(schema_name)
         .bind::<Text, _>(index_name)
         .execute(conn)

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -391,7 +391,7 @@ pub fn drop_schema(conn: &PgConnection, nsp: &str) -> Result<(), StoreError> {
 pub fn migration_count(conn: &PgConnection) -> Result<i64, StoreError> {
     use __diesel_schema_migrations as m;
 
-    if !table_exists(conn, NAMESPACE_PUBLIC, &*MIGRATIONS_TABLE)? {
+    if !table_exists(conn, NAMESPACE_PUBLIC, &MIGRATIONS_TABLE)? {
         return Ok(0);
     }
 

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -166,7 +166,7 @@ impl ChainHeadUpdateListener {
 
                 // Observe the latest chain head for each network to monitor block ingestion
                 metrics
-                    .set_chain_head_number(&update.network_name, *&update.head_block_number as i64);
+                    .set_chain_head_number(&update.network_name, update.head_block_number as i64);
 
                 // If there are subscriptions for this network, notify them.
                 if let Some(watcher) = watchers.read(&logger).get(&update.network_name) {

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -2069,7 +2069,7 @@ impl EthereumCallCache for ChainStore {
                 conn,
                 id.as_ref(),
                 contract_address.as_ref(),
-                block.number as i32,
+                block.number,
                 return_value,
             )
         })

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -1831,7 +1831,7 @@ impl ChainStoreTrait for ChainStore {
     ) -> Result<Vec<LightTransactionReceipt>, StoreError> {
         let pool = self.pool.clone();
         let storage = self.storage.clone();
-        let block_hash = block_hash.clone();
+        let block_hash = *block_hash;
         pool.with_conn(move |conn, _| {
             storage
                 .find_transaction_receipts_in_block(conn, block_hash)

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -1705,7 +1705,7 @@ impl ChainStoreTrait for ChainStore {
 
         // Check the local cache first.
         if let Some(data) = self.recent_blocks_cache.get_block(&block_ptr, offset) {
-            return Ok(data.1.clone());
+            return Ok(data.1);
         }
 
         let block_ptr_clone = block_ptr.clone();

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -1831,7 +1831,7 @@ impl ChainStoreTrait for ChainStore {
     ) -> Result<Vec<LightTransactionReceipt>, StoreError> {
         let pool = self.pool.clone();
         let storage = self.storage.clone();
-        let block_hash = block_hash.to_owned();
+        let block_hash = block_hash.clone();
         pool.with_conn(move |conn, _| {
             storage
                 .find_transaction_receipts_in_block(conn, block_hash)

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -180,7 +180,7 @@ impl ForeignServer {
                     NAMESPACE_PUBLIC,
                     table_name,
                     Self::PRIMARY_PUBLIC,
-                    Self::name(&*PRIMARY_SHARD).as_str(),
+                    Self::name(&PRIMARY_SHARD).as_str(),
                 )?
             };
             write!(query, "{}", create_stmt)?;

--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -408,7 +408,7 @@ impl TableState {
         } else {
             "lower(block_range) <= $1"
         };
-        let target_vid = sql_query(&format!(
+        let target_vid = sql_query(format!(
             "select coalesce(max(vid), -1) as max_vid from {} where {}",
             src.qualified_name.as_str(),
             max_block_clause

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -632,7 +632,7 @@ pub fn exists_and_synced(conn: &PgConnection, id: &str) -> Result<bool, StoreErr
 fn insert_subgraph_error(conn: &PgConnection, error: &SubgraphError) -> anyhow::Result<String> {
     use subgraph_error as e;
 
-    let error_id = hex::encode(&stable_hash_legacy::utils::stable_hash::<SetHasher, _>(
+    let error_id = hex::encode(stable_hash_legacy::utils::stable_hash::<SetHasher, _>(
         &error,
     ));
     let SubgraphError {
@@ -881,7 +881,7 @@ pub(crate) fn copy_errors(
         src_nsp = src_nsp
     );
 
-    Ok(sql_query(&query)
+    Ok(sql_query(query)
         .bind::<Text, _>(src.deployment.as_str())
         .bind::<Text, _>(dst.deployment.as_str())
         .bind::<Integer, _>(target_block.number)

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -904,7 +904,7 @@ pub fn drop_schema(
         "set local lock_timeout=2000; drop schema if exists {} cascade",
         namespace
     );
-    Ok(conn.batch_execute(&*query)?)
+    Ok(conn.batch_execute(&query)?)
 }
 
 pub fn drop_metadata(conn: &PgConnection, site: &Site) -> Result<(), StoreError> {

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1013,7 +1013,7 @@ impl DeploymentStore {
             .map(|e| {
                 let causality_region = e.id()?;
                 let digest = match e.get("digest") {
-                    Some(Value::Bytes(b)) => Ok(b.to_owned()),
+                    Some(Value::Bytes(b)) => Ok(b.clone()),
                     other => Err(anyhow::anyhow!(
                         "Entity has non-bytes digest attribute: {:?}",
                         other

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -808,10 +808,7 @@ impl DeploymentStore {
             let indexes =
                 catalog::indexes_for_table(conn, schema_name.as_str(), table_name.as_str())
                     .map_err(StoreError::from)?;
-            Ok(indexes
-                .into_iter()
-                .map(|defn| CreateIndex::parse(defn))
-                .collect())
+            Ok(indexes.into_iter().map(CreateIndex::parse).collect())
         })
         .await
     }

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -552,7 +552,7 @@ impl DeploymentStore {
             deployment::manifest_info(conn, site)?;
 
         let graft_block =
-            deployment::graft_point(conn, &site.deployment)?.map(|(_, ptr)| ptr.number as i32);
+            deployment::graft_point(conn, &site.deployment)?.map(|(_, ptr)| ptr.number);
 
         let debug_fork = deployment::debug_fork(conn, &site.deployment)?;
 

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -687,7 +687,7 @@ impl DeploymentStore {
         let conn = self.get_conn()?;
         let layout = self.layout(&conn, site)?;
         let tables = entity
-            .map(|entity| resolve_table_name(&layout, &entity))
+            .map(|entity| resolve_table_name(&layout, entity))
             .transpose()?
             .map(|table| vec![table])
             .unwrap_or_else(|| layout.tables.values().map(Arc::as_ref).collect());
@@ -719,7 +719,7 @@ impl DeploymentStore {
         let layout = self.layout(&conn, site.clone())?;
 
         let tables = entity
-            .map(|entity| resolve_table_name(&layout, &entity))
+            .map(|entity| resolve_table_name(&layout, entity))
             .transpose()?
             .map(|table| vec![table])
             .unwrap_or_else(|| layout.tables.values().map(Arc::as_ref).collect());
@@ -1048,7 +1048,7 @@ impl DeploymentStore {
     ) -> Result<Option<Entity>, StoreError> {
         let conn = self.get_conn()?;
         let layout = self.layout(&conn, site)?;
-        layout.find(&conn, &key, block)
+        layout.find(&conn, key, block)
     }
 
     /// Retrieve all the entities matching `ids_for_type`, both the type and causality region, from
@@ -1544,7 +1544,7 @@ impl DeploymentStore {
                     warn!(self.logger, "Subgraph error does not have same block hash as deployment head";
                         "subgraph_id" => deployment_id,
                         "error_id" => &subgraph_error.id,
-                        "error_block_hash" => format!("0x{}", hex::encode(&hash_bytes)),
+                        "error_block_hash" => format!("0x{}", hex::encode(hash_bytes)),
                         "deployment_head" => format!("{}", current_ptr.hash),
                     );
 

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -315,7 +315,7 @@ pub(crate) fn deployment_statuses(
     details_with_fatal_error
         .into_iter()
         .map(|(detail, fatal)| {
-            let non_fatal = non_fatal_errors.remove(&detail.id).unwrap_or(vec![]);
+            let non_fatal = non_fatal_errors.remove(&detail.id).unwrap_or_default();
             info_from_details(detail, fatal, non_fatal, sites)
         })
         .collect()

--- a/store/postgres/src/dynds/private.rs
+++ b/store/postgres/src/dynds/private.rs
@@ -266,7 +266,7 @@ impl DataSourcesTable {
                 dst = dst.qname
             );
 
-            count += sql_query(&query)
+            count += sql_query(query)
                 .bind::<Integer, _>(target_block)
                 .bind::<sql_types::Range<Integer>, _>(block_range)
                 .bind::<Integer, _>(dst_manifest_idx)

--- a/store/postgres/src/dynds/shared.rs
+++ b/store/postgres/src/dynds/shared.rs
@@ -115,7 +115,7 @@ pub(super) fn insert(
     }
 
     let dds: Vec<_> = data_sources
-        .into_iter()
+        .iter()
         .map(|ds| {
             let StoredDynamicDataSource {
                 manifest_idx: _,

--- a/store/postgres/src/dynds/shared.rs
+++ b/store/postgres/src/dynds/shared.rs
@@ -213,7 +213,7 @@ pub(crate) fn copy(
         src_nsp = src_nsp
     );
 
-    Ok(sql_query(&query)
+    Ok(sql_query(query)
         .bind::<Text, _>(src.deployment.as_str())
         .bind::<Text, _>(dst.deployment.as_str())
         .bind::<Integer, _>(target_block)

--- a/store/postgres/src/fork.rs
+++ b/store/postgres/src/fork.rs
@@ -159,7 +159,7 @@ impl SubgraphFork {
             .iter()
             .map(|f| {
                 let fname = f.name.to_string();
-                let ftype = f.field_type.to_string().replace(&['!', '[', ']'], "");
+                let ftype = f.field_type.to_string().replace(['!', '[', ']'], "");
                 match ValueType::from_str(&ftype) {
                     Ok(_) => fname,
                     Err(_) => {

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -526,17 +526,15 @@ mod queries {
             } else {
                 ds::table.load::<Schema>(conn)?
             }
+        } else if only_active {
+            ds::table
+                .filter(ds::active)
+                .filter(ds::subgraph.eq_any(ids))
+                .load::<Schema>(conn)?
         } else {
-            if only_active {
-                ds::table
-                    .filter(ds::active)
-                    .filter(ds::subgraph.eq_any(ids))
-                    .load::<Schema>(conn)?
-            } else {
-                ds::table
-                    .filter(ds::subgraph.eq_any(ids))
-                    .load::<Schema>(conn)?
-            }
+            ds::table
+                .filter(ds::subgraph.eq_any(ids))
+                .load::<Schema>(conn)?
         };
         schemas
             .into_iter()

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1406,7 +1406,7 @@ impl<'a> Connection<'a> {
                 detail.latest_ethereum_block_number.clone(),
             )?
             .map(|b| b.to_ptr())
-            .map(|ptr| (Some(Vec::from(ptr.hash_slice())), Some(ptr.number as i32)))
+            .map(|ptr| (Some(Vec::from(ptr.hash_slice())), Some(ptr.number)))
             .unwrap_or((None, None));
             let entity_count = detail.entity_count.to_u64().unwrap_or(0) as i32;
 

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1273,7 +1273,7 @@ impl<'a> Connection<'a> {
         // Any shards that have no deployments in them will not be in
         // 'used'; add them in with a count of 0
         let missing = shards
-            .into_iter()
+            .iter()
             .filter(|shard| !used.iter().any(|(s, _)| s == shard.as_str()))
             .map(|shard| (shard.as_str(), 0));
 
@@ -1557,7 +1557,7 @@ impl Mirror {
             .expect("we always have a primary pool")
             .clone();
         let pools = pools
-            .into_iter()
+            .iter()
             .filter(|(shard, _)| *shard != &*PRIMARY_SHARD)
             .fold(vec![primary], |mut pools, (_, pool)| {
                 pools.push(pool.clone());

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1668,7 +1668,7 @@ impl Mirror {
 
         // Repopulate `SUBGRAPHS_TABLES` but only copy the data we actually
         // need to respond to queries when the primary is down
-        let src_nsp = ForeignServer::metadata_schema(&*PRIMARY_SHARD);
+        let src_nsp = ForeignServer::metadata_schema(&PRIMARY_SHARD);
         let dst_nsp = NAMESPACE_SUBGRAPHS;
 
         run_query(

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1659,7 +1659,7 @@ impl Mirror {
         for table_name in PUBLIC_TABLES {
             copy_table(
                 conn,
-                &*ForeignServer::PRIMARY_PUBLIC,
+                ForeignServer::PRIMARY_PUBLIC,
                 NAMESPACE_PUBLIC,
                 table_name,
             )?;

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -756,7 +756,7 @@ impl Layout {
         let table = self.table_for_entity(entity_type)?;
         if table.immutable {
             let ids = entities
-                .into_iter()
+                .iter_mut()
                 .map(|(key, _)| key.entity_id.as_str())
                 .collect::<Vec<_>>()
                 .join(", ");

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -653,7 +653,7 @@ impl Layout {
                 return Trace::None;
             }
 
-            let mut text = debug_query(&query).to_string().replace("\n", "\t");
+            let mut text = debug_query(&query).to_string().replace('\n', "\t");
 
             let trace = if trace {
                 Trace::query(&text, elapsed, entity_count)

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -190,7 +190,7 @@ impl TryFrom<&s::ObjectType> for IdType {
 
     fn try_from(obj_type: &s::ObjectType) -> Result<Self, Self::Error> {
         let pk = obj_type
-            .field(&PRIMARY_KEY_COLUMN.to_owned())
+            .field(PRIMARY_KEY_COLUMN)
             .expect("Each ObjectType has an `id` field");
         Self::try_from(&pk.field_type)
     }

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1484,7 +1484,7 @@ impl LayoutCache {
             .lock()
             .unwrap()
             .remove(&site.deployment)
-            .map(|CacheEntry { value, expires: _ }| value.clone())
+            .map(|CacheEntry { value, expires: _ }| value)
     }
 
     // Only needed for tests

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -252,7 +252,7 @@ impl Layout {
                             enum_type
                                 .values
                                 .iter()
-                                .map(|value| value.name.to_owned())
+                                .map(|value| value.name.clone())
                                 .collect::<BTreeSet<_>>(),
                         ),
                     ))
@@ -288,7 +288,7 @@ impl Layout {
                         // they have a String `id` field
                         // see also: id-type-for-unimplemented-interfaces
                         let id_type = types.iter().next().cloned().unwrap_or(IdType::String);
-                        Ok((interface.to_owned(), id_type))
+                        Ok((interface.clone(), id_type))
                     }
                 })
         });

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -986,7 +986,7 @@ impl ColumnType {
 
         // Check if it's an enum, and if it is, return an appropriate
         // ColumnType::Enum
-        if let Some(values) = enums.get(&*name) {
+        if let Some(values) = enums.get(name) {
             // We do things this convoluted way to make sure field_type gets
             // snakecased, but the `.` must stay a `.`
             let name = SqlName::qualified_name(&catalog.site.namespace, &SqlName::from(name));
@@ -1363,7 +1363,7 @@ fn named_type(field_type: &q::Type) -> &str {
 fn is_object_type(field_type: &q::Type, enums: &EnumMap) -> bool {
     let name = named_type(field_type);
 
-    !enums.contains_key(&*name) && !ValueType::is_scalar(name)
+    !enums.contains_key(name) && !ValueType::is_scalar(name)
 }
 
 #[derive(Clone)]

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -687,7 +687,7 @@ impl Layout {
             FilterCollection::new(self, query.collection, query.filter.as_ref(), query.block)?;
         let query = FilterQuery::new(
             &filter_collection,
-            &self,
+            self,
             query.filter.as_ref(),
             query.order,
             query.range,
@@ -1276,7 +1276,7 @@ impl Table {
         let other = Table {
             object: self.object.clone(),
             name: name.clone(),
-            qualified_name: SqlName::qualified_name(namespace, &name),
+            qualified_name: SqlName::qualified_name(namespace, name),
             columns: self.columns.clone(),
             is_account_like: self.is_account_like,
             position: self.position,

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -432,8 +432,7 @@ impl Layout {
         self.tables
             .values()
             .filter_map(|dst| base.table(&dst.name).map(|src| (dst, src)))
-            .map(|(dst, src)| dst.can_copy_from(src))
-            .flatten()
+            .flat_map(|(dst, src)| dst.can_copy_from(src))
             .collect()
     }
 

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1065,7 +1065,7 @@ impl Column {
         enums: &EnumMap,
         id_types: &IdTypeMap,
     ) -> Result<Column, StoreError> {
-        SqlName::check_valid_identifier(&*field.name, "attribute")?;
+        SqlName::check_valid_identifier(&field.name, "attribute")?;
 
         let sql_name = SqlName::from(&*field.name);
         let is_reference =
@@ -1241,7 +1241,7 @@ impl Table {
         position: u32,
         has_causality_region: bool,
     ) -> Result<Table, StoreError> {
-        SqlName::check_valid_identifier(&*defn.name, "object")?;
+        SqlName::check_valid_identifier(&defn.name, "object")?;
 
         let table_name = SqlName::from(&*defn.name);
         let columns = defn
@@ -1344,9 +1344,9 @@ impl Table {
 
     pub(crate) fn block_column(&self) -> &SqlName {
         if self.immutable {
-            &*crate::block_range::BLOCK_COLUMN_SQL
+            &crate::block_range::BLOCK_COLUMN_SQL
         } else {
-            &*crate::block_range::BLOCK_RANGE_COLUMN_SQL
+            &crate::block_range::BLOCK_RANGE_COLUMN_SQL
         }
     }
 }

--- a/store/postgres/src/relational/index.rs
+++ b/store/postgres/src/relational/index.rs
@@ -362,7 +362,7 @@ impl CreateIndex {
             )
             .unwrap();
 
-            let cap = rx.captures(&defn)?;
+            let cap = rx.captures(defn)?;
             let unique = cap.name("unique").is_some();
             let name = field(&cap, "name")?;
             let nsp = field(&cap, "nsp")?;

--- a/store/postgres/src/relational/index.rs
+++ b/store/postgres/src/relational/index.rs
@@ -303,7 +303,7 @@ impl Display for CreateIndex {
                 if let Some(with) = with {
                     write!(f, " with {with}")?;
                 }
-                writeln!(f, "")?;
+                writeln!(f)?;
             }
         }
         Ok(())

--- a/store/postgres/src/relational/index.rs
+++ b/store/postgres/src/relational/index.rs
@@ -235,7 +235,7 @@ impl Cond {
         if &cond == "coalesce(upper(block_range), 2147483647) < 2147483647" {
             Cond::Closed
         } else {
-            parse_partial(&cond).unwrap_or_else(|| Cond::Unknown(cond))
+            parse_partial(&cond).unwrap_or(Cond::Unknown(cond))
         }
     }
 
@@ -386,7 +386,7 @@ impl CreateIndex {
         }
 
         defn.make_ascii_lowercase();
-        new_parsed(&defn).unwrap_or_else(|| CreateIndex::Unknown { defn })
+        new_parsed(&defn).unwrap_or(CreateIndex::Unknown { defn })
     }
 
     pub fn create<C: Into<Vec<Expr>>>(

--- a/store/postgres/src/relational/index.rs
+++ b/store/postgres/src/relational/index.rs
@@ -229,7 +229,7 @@ impl Cond {
             caps.name("number")
                 .map(|number| number.as_str())
                 .and_then(|number| number.parse::<BlockNumber>().ok())
-                .map(|number| Cond::Partial(number))
+                .map(Cond::Partial)
         }
 
         if &cond == "coalesce(upper(block_range), 2147483647) < 2147483647" {
@@ -631,7 +631,7 @@ fn parse() {
                 columns,
                 cond,
             } = p;
-            let columns: Vec<_> = columns.iter().map(|c| Expr::from(c)).collect();
+            let columns: Vec<_> = columns.iter().map(Expr::from).collect();
             let cond = cond.map(Cond::from);
             CreateIndex::Parsed {
                 unique,

--- a/store/postgres/src/relational/index.rs
+++ b/store/postgres/src/relational/index.rs
@@ -652,7 +652,7 @@ fn parse() {
         let exp = CreateIndex::from(exp);
         assert_eq!(exp, act);
 
-        let defn = defn.replace("\"", "").to_ascii_lowercase();
+        let defn = defn.replace('\"', "").to_ascii_lowercase();
         assert_eq!(defn, act.to_sql(false, false).unwrap());
     }
 

--- a/store/postgres/src/relational/index.rs
+++ b/store/postgres/src/relational/index.rs
@@ -294,7 +294,7 @@ impl Display for CreateIndex {
                 cond,
                 with,
             } => {
-                let columns = columns.into_iter().map(|c| c.to_string()).join(", ");
+                let columns = columns.iter().map(|c| c.to_string()).join(", ");
                 let unique = if *unique { "[uq]" } else { "" };
                 write!(f, "{name}{unique} {method}({columns})")?;
                 if let Some(cond) = cond {
@@ -543,7 +543,7 @@ impl CreateIndex {
                 let unique = if *unique { "unique " } else { "" };
                 let concurrent = if concurrent { "concurrently " } else { "" };
                 let if_not_exists = if if_not_exists { "if not exists " } else { "" };
-                let columns = columns.into_iter().map(|c| c.to_sql()).join(", ");
+                let columns = columns.iter().map(|c| c.to_sql()).join(", ");
 
                 let mut sql = format!("create {unique}index {concurrent}{if_not_exists}{name} on {nsp}.{table} using {method} ({columns})");
                 if let Some(with) = with {
@@ -631,7 +631,7 @@ fn parse() {
                 columns,
                 cond,
             } = p;
-            let columns: Vec<_> = columns.into_iter().map(|c| Expr::from(c)).collect();
+            let columns: Vec<_> = columns.iter().map(|c| Expr::from(c)).collect();
             let cond = cond.map(Cond::from);
             CreateIndex::Parsed {
                 unique,

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -130,12 +130,7 @@ impl TablePair {
 
             batch_size.adapt(start.elapsed());
 
-            reporter.copy_final_batch(
-                self.src.name.as_str(),
-                rows as usize,
-                total_rows,
-                next_vid > max_vid,
-            );
+            reporter.copy_final_batch(self.src.name.as_str(), rows, total_rows, next_vid > max_vid);
         }
         Ok(total_rows)
     }
@@ -198,7 +193,7 @@ impl TablePair {
 
             reporter.copy_nonfinal_batch(
                 self.src.name.as_str(),
-                rows as usize,
+                rows,
                 total_rows,
                 next_vid > max_vid,
             );

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -78,7 +78,7 @@ impl TablePair {
         let column_list = self.column_list();
 
         // Determine the last vid that we need to copy
-        let VidRange { min_vid, max_vid } = sql_query(&format!(
+        let VidRange { min_vid, max_vid } = sql_query(format!(
             "select coalesce(min(vid), 0) as min_vid, \
                     coalesce(max(vid), -1) as max_vid from {src} \
               where lower(block_range) <= $2 \
@@ -105,7 +105,7 @@ impl TablePair {
                 // since they could still be reverted while we copy.
                 // The conditions on `block_range` are expressed redundantly
                 // to make more indexes useable
-                sql_query(&format!(
+                sql_query(format!(
                     "insert into {dst}({column_list}) \
                      select {column_list} from {src} \
                       where lower(block_range) <= $2 \
@@ -152,7 +152,7 @@ impl TablePair {
         let column_list = self.column_list();
 
         // Determine the last vid that we need to copy
-        let VidRange { min_vid, max_vid } = sql_query(&format!(
+        let VidRange { min_vid, max_vid } = sql_query(format!(
             "select coalesce(min(vid), 0) as min_vid, \
                     coalesce(max(vid), -1) as max_vid from {src} \
               where coalesce(upper(block_range), 2147483647) > $1 \
@@ -174,7 +174,7 @@ impl TablePair {
                 // starting right after `final_block`.
                 // The conditions on `block_range` are expressed redundantly
                 // to make more indexes useable
-                sql_query(&format!(
+                sql_query(format!(
                     "insert into {dst}({column_list}) \
                      select {column_list} from {src} \
                       where coalesce(upper(block_range), 2147483647) > $1 \

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2560,7 +2560,7 @@ impl<'a> FilterCollection<'a> {
             FilterCollection::SingleWindow(window) => Ok(Some(window.parent_type())),
             FilterCollection::MultiWindow(windows, _) => {
                 if windows.iter().map(FilterWindow::parent_type).all_equal() {
-                    Ok(Some(windows[0].parent_type().clone()))
+                    Ok(Some(windows[0].parent_type()))
                 } else {
                     Err(graph::constraint_violation!(
                         "all implementors of an interface must use the same type for their `id`"

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2443,12 +2443,8 @@ impl<'a> fmt::Display for FilterCollection<'a> {
                     }
                     TableLink::Parent(_, ParentIds::List(css)) => {
                         let css = css
-                            .into_iter()
-                            .map(|cs| {
-                                cs.into_iter()
-                                    .filter_map(|c| c.as_ref().map(|s| &s.0))
-                                    .join(",")
-                            })
+                            .iter()
+                            .map(|cs| cs.iter().filter_map(|c| c.as_ref().map(|s| &s.0)).join(","))
                             .join("],[");
                         write!(f, "uniq:id=[{}]", css)?
                     }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1301,8 +1301,8 @@ impl<'a> QueryFilter<'a> {
         if have_non_nulls {
             if column.use_prefix_comparison
                 && values.iter().all(|v| match v {
-                    Value::String(s) => s.len() <= STRING_PREFIX_SIZE - 1,
-                    Value::Bytes(b) => b.len() <= BYTE_ARRAY_PREFIX_SIZE - 1,
+                    Value::String(s) => s.len() < STRING_PREFIX_SIZE,
+                    Value::Bytes(b) => b.len() < BYTE_ARRAY_PREFIX_SIZE,
                     _ => false,
                 })
             {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -1727,7 +1727,7 @@ impl<'a> InsertQuery<'a> {
                 }
             }
         }
-        hashmap.into_iter().map(|(_key, value)| value).collect()
+        hashmap.into_values().collect()
     }
 
     /// Return the maximum number of entities that can be inserted with one

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -3885,8 +3885,7 @@ impl<'a> FilterQuery<'a> {
                     &window.column_names,
                 )
             })
-            .enumerate()
-            .into_iter();
+            .enumerate();
 
         for (i, window) in unique_child_tables {
             if i > 0 {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -46,7 +46,7 @@ use crate::{
 };
 
 /// Those are columns that we always want to fetch from the database.
-const BASE_SQL_COLUMNS: [&'static str; 2] = ["id", "vid"];
+const BASE_SQL_COLUMNS: [&str; 2] = ["id", "vid"];
 
 /// The maximum number of bind variables that can be used in a query
 const POSTGRES_MAX_PARAMETERS: usize = u16::MAX as usize; // 65535

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -814,7 +814,7 @@ impl<'a> QueryFragment<Pg> for PrefixComparison<'a> {
         //
         // For `op` either `<=` or `>=`, we can write (using '<=' as an example)
         //   uv <= st <=> u < s || u = s && uv <= st
-        let large = self.kind.is_large(&self.text).map_err(|()| {
+        let large = self.kind.is_large(self.text).map_err(|()| {
             constraint_violation!(
                 "column {} has type {} and can't be compared with the value `{}` using {}",
                 self.column.name(),
@@ -1064,7 +1064,7 @@ impl<'a> QueryFilter<'a> {
         out.push_sql(" and ");
 
         // Match by block
-        BlockRangeColumn::new(&child_table, child_prefix, self.block).contains(&mut out)?;
+        BlockRangeColumn::new(child_table, child_prefix, self.block).contains(&mut out)?;
 
         out.push_sql(" and ");
 
@@ -1143,7 +1143,7 @@ impl<'a> QueryFilter<'a> {
                 out.push_sql("position(");
                 out.push_bind_param::<Binary, _>(&b.as_slice())?;
                 out.push_sql(" in ");
-                out.push_sql(&self.table_prefix);
+                out.push_sql(self.table_prefix);
                 out.push_identifier(column.name.as_str())?;
                 if negated {
                     out.push_sql(") = 0")
@@ -1154,11 +1154,11 @@ impl<'a> QueryFilter<'a> {
             Value::List(_) => {
                 if negated {
                     out.push_sql(" not ");
-                    out.push_sql(&self.table_prefix);
+                    out.push_sql(self.table_prefix);
                     out.push_identifier(column.name.as_str())?;
                     out.push_sql(" && ");
                 } else {
-                    out.push_sql(&self.table_prefix);
+                    out.push_sql(self.table_prefix);
                     out.push_identifier(column.name.as_str())?;
                     out.push_sql(" @> ");
                 }
@@ -1204,12 +1204,12 @@ impl<'a> QueryFilter<'a> {
         } else if column.use_prefix_comparison {
             PrefixComparison::new(op, column, value)?.walk_ast(out.reborrow())?;
         } else if column.is_fulltext() {
-            out.push_sql(&self.table_prefix);
+            out.push_sql(self.table_prefix);
             out.push_identifier(column.name.as_str())?;
             out.push_sql(Comparison::Match.as_str());
             QueryValue(value, &column.column_type).walk_ast(out)?;
         } else {
-            out.push_sql(&self.table_prefix);
+            out.push_sql(self.table_prefix);
             out.push_identifier(column.name.as_str())?;
             out.push_sql(op.as_str());
             QueryValue(value, &column.column_type).walk_ast(out)?;
@@ -1229,7 +1229,7 @@ impl<'a> QueryFilter<'a> {
         if column.use_prefix_comparison {
             PrefixComparison::new(op, column, value)?.walk_ast(out.reborrow())?;
         } else {
-            out.push_sql(&self.table_prefix);
+            out.push_sql(self.table_prefix);
             out.push_identifier(column.name.as_str())?;
             out.push_sql(op.as_str());
             match value {
@@ -1285,7 +1285,7 @@ impl<'a> QueryFilter<'a> {
         }
 
         if have_nulls {
-            out.push_sql(&self.table_prefix);
+            out.push_sql(self.table_prefix);
             out.push_identifier(column.name.as_str())?;
             if negated {
                 out.push_sql(" is not null");
@@ -1314,7 +1314,7 @@ impl<'a> QueryFilter<'a> {
                 // is happening here
                 PrefixType::new(column)?.push_column_prefix(&mut out)?;
             } else {
-                out.push_sql(&self.table_prefix);
+                out.push_sql(self.table_prefix);
                 out.push_identifier(column.name.as_str())?;
             }
             if negated {
@@ -1359,7 +1359,7 @@ impl<'a> QueryFilter<'a> {
     ) -> QueryResult<()> {
         let column = self.column(attribute);
 
-        out.push_sql(&self.table_prefix);
+        out.push_sql(self.table_prefix);
         out.push_identifier(column.name.as_str())?;
         out.push_sql(op);
         match value {
@@ -1875,7 +1875,7 @@ impl<'a> QueryFragment<Pg> for ConflictingEntityQuery<'a> {
             out.push_sql(" as entity from ");
             out.push_sql(table.qualified_name.as_str());
             out.push_sql(" where id = ");
-            table.primary_key().bind_id(&self.entity_id, &mut out)?;
+            table.primary_key().bind_id(self.entity_id, &mut out)?;
         }
         Ok(())
     }
@@ -2069,7 +2069,7 @@ impl<'a> FilterWindow<'a> {
         }
 
         let query_filter = entity_filter
-            .map(|filter| QueryFilter::new(&filter, table, layout, block))
+            .map(|filter| QueryFilter::new(filter, table, layout, block))
             .transpose()?;
         let link = TableLink::new(layout, table, link)?;
         Ok(FilterWindow {
@@ -3527,9 +3527,9 @@ impl<'a> SortKey<'a> {
                 ChildKey::Single(child) => {
                     add(
                         block,
-                        &child.child_table,
-                        &child.child_join_column,
-                        &child.parent_join_column,
+                        child.child_table,
+                        child.child_join_column,
+                        child.parent_join_column,
                         &child.prefix,
                         out,
                     )?;
@@ -3538,9 +3538,9 @@ impl<'a> SortKey<'a> {
                     for child in children.iter() {
                         add(
                             block,
-                            &child.child_table,
-                            &child.child_join_column,
-                            &child.parent_join_column,
+                            child.child_table,
+                            child.child_join_column,
+                            child.parent_join_column,
                             &child.prefix,
                             out,
                         )?;
@@ -3550,9 +3550,9 @@ impl<'a> SortKey<'a> {
                     for child in children.iter() {
                         add(
                             block,
-                            &child.child_table,
-                            &child.child_join_column,
-                            &child.parent_join_column,
+                            child.child_table,
+                            child.child_join_column,
+                            child.parent_join_column,
                             &child.prefix,
                             out,
                         )?;
@@ -3561,9 +3561,9 @@ impl<'a> SortKey<'a> {
                 ChildKey::IdAsc(child, _) | ChildKey::IdDesc(child, _) => {
                     add(
                         block,
-                        &child.child_table,
-                        &child.child_join_column,
-                        &child.parent_join_column,
+                        child.child_table,
+                        child.child_join_column,
+                        child.parent_join_column,
                         &child.prefix,
                         out,
                     )?;
@@ -3681,7 +3681,7 @@ impl<'a> FilterQuery<'a> {
         self.sort_key.add_child(self.block, &mut out)?;
 
         out.push_sql("\n where ");
-        BlockRangeColumn::new(&table, "c.", self.block).contains(&mut out)?;
+        BlockRangeColumn::new(table, "c.", self.block).contains(&mut out)?;
         if let Some(filter) = table_filter {
             out.push_sql(" and ");
             filter.walk_ast(out.reborrow())?;
@@ -3738,7 +3738,7 @@ impl<'a> FilterQuery<'a> {
         window: &FilterWindow,
         mut out: AstPass<Pg>,
     ) -> QueryResult<()> {
-        Self::select_entity_and_data(&window.table, &mut out);
+        Self::select_entity_and_data(window.table, &mut out);
         out.push_sql(" from (\n");
         out.push_sql("select c.*, p.id::text as g$parent_id");
         window.children(
@@ -3862,7 +3862,7 @@ impl<'a> FilterQuery<'a> {
         out.push_sql("select c.* from ");
         out.push_sql("unnest(");
         // windows always has at least 2 entries
-        windows[0].parent_type().bind_ids(&parent_ids, &mut out)?;
+        windows[0].parent_type().bind_ids(parent_ids, &mut out)?;
         out.push_sql(") as q(id)\n");
         out.push_sql(" cross join lateral (");
         for (i, window) in windows.iter().enumerate() {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2560,7 +2560,7 @@ impl<'a> FilterCollection<'a> {
             FilterCollection::SingleWindow(window) => Ok(Some(window.parent_type())),
             FilterCollection::MultiWindow(windows, _) => {
                 if windows.iter().map(FilterWindow::parent_type).all_equal() {
-                    Ok(Some(windows[0].parent_type().to_owned()))
+                    Ok(Some(windows[0].parent_type().clone()))
                 } else {
                     Err(graph::constraint_violation!(
                         "all implementors of an interface must use the same type for their `id`"

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -981,7 +981,7 @@ impl<'a> QueryFilter<'a> {
             table: self.table,
             layout: self.layout,
             block: self.block,
-            table_prefix: self.table_prefix.clone(),
+            table_prefix: self.table_prefix,
         }
     }
 

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2377,12 +2377,8 @@ impl<'a> FilterWindow<'a> {
 
     /// Collect all the parent id's from all windows
     fn collect_parents(windows: &[FilterWindow]) -> Vec<String> {
-        let parent_ids: HashSet<String> = HashSet::from_iter(
-            windows
-                .iter()
-                .map(|window| window.ids.iter().cloned())
-                .flatten(),
-        );
+        let parent_ids: HashSet<String> =
+            HashSet::from_iter(windows.iter().flat_map(|window| window.ids.iter().cloned()));
         parent_ids.into_iter().collect()
     }
 }

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -111,7 +111,7 @@ impl StatusStore for Store {
         let ptrs = self.block_store.chain_head_pointers()?;
         for info in &mut infos {
             for chain in &mut info.chains {
-                chain.chain_head_block = ptrs.get(&chain.network).map(|ptr| ptr.to_owned().into());
+                chain.chain_head_block = ptrs.get(&chain.network).map(|ptr| ptr.clone().into());
             }
         }
         Ok(infos)

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -882,7 +882,7 @@ impl SubgraphStoreInner {
             let id = DeploymentHash::new(deployment_id.clone())
                 .map_err(|id| constraint_violation!("illegal deployment id {}", id))?;
             let (store, site) = self.store(&id)?;
-            let statuses = store.deployment_statuses(&vec![site.clone()])?;
+            let statuses = store.deployment_statuses(&[site.clone()])?;
             let status = statuses
                 .first()
                 .ok_or_else(|| StoreError::DeploymentNotFound(deployment_id.clone()))?;

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -26,10 +26,9 @@ use graph::{
     prelude::StoreEvent,
     prelude::{
         anyhow, futures03::future::join_all, lazy_static, o, web3::types::Address, ApiSchema,
-        ApiVersion, BlockHash, BlockNumber, BlockPtr, ChainStore, DeploymentHash, EntityOperation,
-        Logger, MetricsRegistry, NodeId, PartialBlockPtr, Schema, StoreError,
-        SubgraphDeploymentEntity, SubgraphName, SubgraphStore as SubgraphStoreTrait,
-        SubgraphVersionSwitchingMode,
+        ApiVersion, BlockNumber, BlockPtr, ChainStore, DeploymentHash, EntityOperation, Logger,
+        MetricsRegistry, NodeId, PartialBlockPtr, Schema, StoreError, SubgraphDeploymentEntity,
+        SubgraphName, SubgraphStore as SubgraphStoreTrait, SubgraphVersionSwitchingMode,
     },
     url::Url,
     util::timed_cache::TimedCache,
@@ -977,7 +976,7 @@ impl SubgraphStoreInner {
         }
 
         // This `unwrap` is safe to do now
-        let block_hash = BlockHash::from(hashes.pop().unwrap());
+        let block_hash = hashes.pop().unwrap();
 
         let block_for_poi_query = BlockPtr::new(block_hash.clone(), block_number);
         let indexer = Some(Address::zero());

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -65,9 +65,9 @@ const SITES_CACHE_TTL: Duration = Duration::from_secs(120);
 impl Shard {
     pub fn new(name: String) -> Result<Self, StoreError> {
         if name.is_empty() {
-            return Err(StoreError::InvalidIdentifier(format!(
-                "shard names must not be empty"
-            )));
+            return Err(StoreError::InvalidIdentifier(
+                "shard names must not be empty".to_string(),
+            ));
         }
         if name.len() > 30 {
             return Err(StoreError::InvalidIdentifier(format!(

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -961,7 +961,7 @@ impl SubgraphStoreInner {
         block_number: BlockNumber,
         block_store: Arc<impl BlockStore>,
     ) -> Result<Option<(PartialBlockPtr, [u8; 32])>, StoreError> {
-        let (store, site) = self.store(&id)?;
+        let (store, site) = self.store(id)?;
 
         let chain_store = match block_store.chain_store(&site.network) {
             Some(chain_store) => chain_store,

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -808,14 +808,13 @@ impl SubgraphStoreInner {
 
         // Check that it is not current/pending for any subgraph if it is
         // the active deployment of that subgraph
-        if site.active {
-            if !self
+        if site.active
+            && !self
                 .primary_conn()?
                 .subgraphs_using_deployment(site.as_ref())?
                 .is_empty()
-            {
-                removable = false;
-            }
+        {
+            removable = false;
         }
 
         if removable {

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -853,7 +853,7 @@ impl Writer {
                 &block_ptr_to,
                 &firehose_cursor,
                 &mods,
-                &stopwatch,
+                stopwatch,
                 &data_sources,
                 &deterministic_errors,
                 &manifest_idx_and_name,

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -786,10 +786,7 @@ impl Queue {
                 } => {
                     if tracker.visible(block_ptr) {
                         dds.extend(data_sources.clone());
-                        dds = dds
-                            .into_iter()
-                            .filter(|dds| !processed_data_sources.contains(dds))
-                            .collect();
+                        dds.retain(|dds| !processed_data_sources.contains(dds));
                     }
                 }
                 Request::RevertTo { .. } | Request::Stop => { /* nothing to do */ }

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -489,7 +489,7 @@ impl Request {
             } => store
                 .revert_block_operations(block_ptr.clone(), firehose_cursor)
                 .map(|()| ExecResult::Continue),
-            Request::Stop => return Ok(ExecResult::Stop),
+            Request::Stop => Ok(ExecResult::Stop),
         }
     }
 }

--- a/store/postgres/tests/chain_head.rs
+++ b/store/postgres/tests/chain_head.rs
@@ -291,12 +291,12 @@ fn ancestor_block_simple() {
     ];
 
     run_test(chain, move |store, _| -> Result<(), Error> {
-        check_ancestor(&store, &*BLOCK_FIVE, 1, &*BLOCK_FOUR)?;
-        check_ancestor(&store, &*BLOCK_FIVE, 2, &*BLOCK_THREE)?;
-        check_ancestor(&store, &*BLOCK_FIVE, 3, &*BLOCK_TWO)?;
-        check_ancestor(&store, &*BLOCK_FIVE, 4, &*BLOCK_ONE)?;
-        check_ancestor(&store, &*BLOCK_FIVE, 5, &*GENESIS_BLOCK)?;
-        check_ancestor(&store, &*BLOCK_THREE, 2, &*BLOCK_ONE)?;
+        check_ancestor(&store, &BLOCK_FIVE, 1, &BLOCK_FOUR)?;
+        check_ancestor(&store, &BLOCK_FIVE, 2, &BLOCK_THREE)?;
+        check_ancestor(&store, &BLOCK_FIVE, 3, &BLOCK_TWO)?;
+        check_ancestor(&store, &BLOCK_FIVE, 4, &BLOCK_ONE)?;
+        check_ancestor(&store, &BLOCK_FIVE, 5, &GENESIS_BLOCK)?;
+        check_ancestor(&store, &BLOCK_THREE, 2, &BLOCK_ONE)?;
 
         for offset in [6, 7, 8, 50].iter() {
             let offset = *offset;
@@ -324,10 +324,10 @@ fn ancestor_block_ommers() {
     ];
 
     run_test(chain, move |store, _| -> Result<(), Error> {
-        check_ancestor(&store, &*BLOCK_ONE, 1, &*GENESIS_BLOCK)?;
-        check_ancestor(&store, &*BLOCK_ONE_SIBLING, 1, &*GENESIS_BLOCK)?;
-        check_ancestor(&store, &*BLOCK_TWO, 1, &*BLOCK_ONE)?;
-        check_ancestor(&store, &*BLOCK_TWO, 2, &*GENESIS_BLOCK)?;
+        check_ancestor(&store, &BLOCK_ONE, 1, &GENESIS_BLOCK)?;
+        check_ancestor(&store, &BLOCK_ONE_SIBLING, 1, &GENESIS_BLOCK)?;
+        check_ancestor(&store, &BLOCK_TWO, 1, &BLOCK_ONE)?;
+        check_ancestor(&store, &BLOCK_TWO, 2, &GENESIS_BLOCK)?;
         Ok(())
     });
 }

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -316,7 +316,7 @@ async fn check_graft(
 
     // Make sure we caught Shaqueeena at block 1, before the change in
     // email address
-    let mut shaq = entities.first().unwrap().to_owned();
+    let mut shaq = entities.first().unwrap().clone();
     assert_eq!(Some(&Value::from("queensha@email.com")), shaq.get("email"));
 
     // Make our own entries for block 2
@@ -400,7 +400,7 @@ fn graft() {
 
         let (entities, ids) = find_entities(store.as_ref(), &deployment);
         assert_eq!(vec!["1"], ids);
-        let shaq = entities.first().unwrap().to_owned();
+        let shaq = entities.first().unwrap().clone();
         assert_eq!(Some(&Value::from("tonofjohn@email.com")), shaq.get("email"));
         Ok(())
     })

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -432,7 +432,7 @@ fn copy() {
             .cheap_clone()
             .writable(LOGGER.clone(), deployment.id)
             .await?
-            .start_subgraph_deployment(&*LOGGER)
+            .start_subgraph_deployment(&LOGGER)
             .await?;
 
         store.activate(&deployment)?;

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -474,7 +474,7 @@ macro_rules! assert_entity_eq {
 /// Test harness for running database integration tests.
 fn run_test<F>(test: F)
 where
-    F: FnOnce(&PgConnection, &Layout) -> (),
+    F: FnOnce(&PgConnection, &Layout),
 {
     run_test_with_conn(|conn| {
         // Reset state before starting

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -745,13 +745,7 @@ fn delete() {
         let entity_type = EntityType::from("Scalar");
         let mut entity_keys = vec![key.entity_id.as_str()];
         let count = layout
-            .delete(
-                &conn,
-                &entity_type,
-                &entity_keys,
-                1,
-                &MOCK_STOPWATCH,
-            )
+            .delete(&conn, &entity_type, &entity_keys, 1, &MOCK_STOPWATCH)
             .expect("Failed to delete");
         assert_eq!(0, count);
         assert_eq!(2, count_scalar_entities(conn, layout));
@@ -872,11 +866,7 @@ fn conflicting_entity() {
 
         // Chairs are not pets
         let chair = EntityType::from("Chair");
-        let result = layout.conflicting_entity(
-            &conn,
-            &id.to_string(),
-            vec![dog, ferret, chair],
-        );
+        let result = layout.conflicting_entity(&conn, &id.to_string(), vec![dog, ferret, chair]);
         assert!(result.is_err());
         assert_eq!("unknown table 'Chair'", result.err().unwrap().to_string());
     }

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -175,13 +175,13 @@ lazy_static! {
             bool: true,
             int: std::i32::MAX,
             bigDecimal: decimal.clone(),
-            bigDecimalArray: vec![decimal.clone(), (decimal + 1.into()).clone()],
+            bigDecimalArray: vec![decimal.clone(), (decimal + 1.into())],
             string: "scalar",
             strings: vec!["left", "right", "middle"],
             bytes: *BYTES_VALUE,
             byteArray: vec![*BYTES_VALUE, *BYTES_VALUE2, *BYTES_VALUE3],
             bigInt: big_int.clone(),
-            bigIntArray: vec![big_int.clone(), (big_int + 1.into()).clone()],
+            bigIntArray: vec![big_int.clone(), (big_int + 1.into())],
             color: "yellow",
         }
     };
@@ -563,7 +563,7 @@ fn update() {
         entity.set("string", "updated");
         entity.remove("strings");
         entity.set("bool", Value::Null);
-        let key = EntityKey::data("Scalar".to_owned(), entity.id().unwrap().clone());
+        let key = EntityKey::data("Scalar".to_owned(), entity.id().unwrap());
 
         let entity_type = EntityType::from("Scalar");
         let mut entities = vec![(&key, Cow::from(&entity))];
@@ -747,7 +747,7 @@ fn delete() {
         let count = layout
             .delete(
                 &conn,
-                &entity_type.clone(),
+                &entity_type,
                 &entity_keys,
                 1,
                 &MOCK_STOPWATCH,
@@ -834,7 +834,7 @@ async fn layout_cache() {
             sleep(Duration::from_millis(50));
 
             let layout = cache
-                .get(&*LOGGER, &conn, site.clone())
+                .get(&*LOGGER, &conn, site)
                 .expect("we can get the layout");
             let table = layout.table(&table_name).unwrap();
             assert_eq!(false, table.is_account_like);
@@ -875,7 +875,7 @@ fn conflicting_entity() {
         let result = layout.conflicting_entity(
             &conn,
             &id.to_string(),
-            vec![dog.clone(), ferret.clone(), chair.clone()],
+            vec![dog, ferret, chair],
         );
         assert!(result.is_err());
         assert_eq!("unknown table 'Chair'", result.err().unwrap().to_string());

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -639,7 +639,7 @@ fn update_many() {
                         &EntityKey::data(SCALAR.as_str(), id),
                         BLOCK_NUMBER_MAX,
                     )
-                    .expect(&format!("Failed to read Scalar[{}]", id))
+                    .unwrap_or_else(|_| panic!("Failed to read Scalar[{}]", id))
                     .unwrap()
             })
             .collect();

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -323,7 +323,7 @@ fn make_user(
         bin_name: bin_name,
         email: email,
         age: age,
-        seconds_age: BigInt::from(age) * BigInt::from(31557600 as u64),
+        seconds_age: BigInt::from(age) * BigInt::from(31557600_u64),
         weight: BigDecimal::from(weight),
         coffee: coffee,
         favorite_color: favorite_color
@@ -342,7 +342,7 @@ fn insert_users(conn: &PgConnection, layout: &Layout) {
         "User",
         "Johnton",
         "tonofjohn@email.com",
-        67 as i32,
+        67_i32,
         184.4,
         false,
         Some("yellow"),
@@ -356,7 +356,7 @@ fn insert_users(conn: &PgConnection, layout: &Layout) {
         "User",
         "Cindini",
         "dinici@email.com",
-        43 as i32,
+        43_i32,
         159.1,
         true,
         Some("red"),
@@ -370,7 +370,7 @@ fn insert_users(conn: &PgConnection, layout: &Layout) {
         "User",
         "Shaqueeena",
         "teeko@email.com",
-        28 as i32,
+        28_i32,
         111.7,
         false,
         None,
@@ -999,7 +999,7 @@ impl<'a> QueryChecker<'a> {
             "User",
             "Jono",
             "achangedemail@email.com",
-            67 as i32,
+            67_i32,
             184.4,
             false,
             Some("yellow"),
@@ -1107,7 +1107,7 @@ fn check_block_finds() {
             "User",
             "Johnton",
             "tonofjohn@email.com",
-            67 as i32,
+            67_i32,
             184.4,
             false,
             Some("yellow"),
@@ -1386,20 +1386,20 @@ fn check_find() {
             .check(
                 vec!["1"],
                 user_query()
-                    .filter(EntityFilter::Equal("age".to_owned(), Value::Int(67 as i32)))
+                    .filter(EntityFilter::Equal("age".to_owned(), Value::Int(67_i32)))
                     .desc("name"),
             )
             .check(
                 vec!["3", "2"],
                 user_query()
-                    .filter(EntityFilter::Not("age".to_owned(), Value::Int(67 as i32)))
+                    .filter(EntityFilter::Not("age".to_owned(), Value::Int(67_i32)))
                     .desc("name"),
             )
             .check(
                 vec!["1"],
                 user_query().filter(EntityFilter::GreaterThan(
                     "age".to_owned(),
-                    Value::Int(43 as i32),
+                    Value::Int(43_i32),
                 )),
             )
             .check(
@@ -1407,17 +1407,14 @@ fn check_find() {
                 user_query()
                     .filter(EntityFilter::GreaterOrEqual(
                         "age".to_owned(),
-                        Value::Int(43 as i32),
+                        Value::Int(43_i32),
                     ))
                     .asc("name"),
             )
             .check(
                 vec!["2", "3"],
                 user_query()
-                    .filter(EntityFilter::LessThan(
-                        "age".to_owned(),
-                        Value::Int(50 as i32),
-                    ))
+                    .filter(EntityFilter::LessThan("age".to_owned(), Value::Int(50_i32)))
                     .asc("name"),
             )
             .check(
@@ -1425,26 +1422,20 @@ fn check_find() {
                 user_query()
                     .filter(EntityFilter::LessOrEqual(
                         "age".to_owned(),
-                        Value::Int(43 as i32),
+                        Value::Int(43_i32),
                     ))
                     .asc("name"),
             )
             .check(
                 vec!["3", "2"],
                 user_query()
-                    .filter(EntityFilter::LessThan(
-                        "age".to_owned(),
-                        Value::Int(50 as i32),
-                    ))
+                    .filter(EntityFilter::LessThan("age".to_owned(), Value::Int(50_i32)))
                     .desc("name"),
             )
             .check(
                 vec!["2"],
                 user_query()
-                    .filter(EntityFilter::LessThan(
-                        "age".to_owned(),
-                        Value::Int(67 as i32),
-                    ))
+                    .filter(EntityFilter::LessThan("age".to_owned(), Value::Int(67_i32)))
                     .desc("name")
                     .first(1)
                     .skip(1),
@@ -1454,7 +1445,7 @@ fn check_find() {
                 user_query()
                     .filter(EntityFilter::In(
                         "age".to_owned(),
-                        vec![Value::Int(67 as i32), Value::Int(43 as i32)],
+                        vec![Value::Int(67_i32), Value::Int(43_i32)],
                     ))
                     .desc("name")
                     .first(5),
@@ -1464,7 +1455,7 @@ fn check_find() {
                 user_query()
                     .filter(EntityFilter::NotIn(
                         "age".to_owned(),
-                        vec![Value::Int(67 as i32), Value::Int(43 as i32)],
+                        vec![Value::Int(67_i32), Value::Int(43_i32)],
                     ))
                     .desc("name")
                     .first(5),

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -425,7 +425,7 @@ fn create_schema(conn: &PgConnection) -> Layout {
         NETWORK_NAME.to_string(),
     );
     let query = format!("create schema {}", NAMESPACE.as_str());
-    conn.batch_execute(&*query).unwrap();
+    conn.batch_execute(&query).unwrap();
 
     Layout::create_relational_schema(&conn, Arc::new(site), &schema, BTreeSet::new())
         .expect("Failed to create relational schema")
@@ -502,7 +502,7 @@ fn find() {
             )
             .expect("Failed to read Scalar[one]")
             .unwrap();
-        assert_entity_eq!(scrub(&*SCALAR_ENTITY), entity);
+        assert_entity_eq!(scrub(&SCALAR_ENTITY), entity);
 
         // Find non-existing entity
         let entity = layout
@@ -549,7 +549,7 @@ fn insert_null_fulltext_fields() {
             )
             .expect("Failed to read NullableStrings[one]")
             .unwrap();
-        assert_entity_eq!(scrub(&*EMPTY_NULLABLESTRINGS_ENTITY), entity);
+        assert_entity_eq!(scrub(&EMPTY_NULLABLESTRINGS_ENTITY), entity);
     });
 }
 
@@ -726,7 +726,7 @@ fn count_scalar_entities(conn: &PgConnection, layout: &Layout) -> usize {
         .filter(filter);
     query.range.first = None;
     layout
-        .query::<Entity>(&*LOGGER, &conn, query)
+        .query::<Entity>(&LOGGER, &conn, query)
         .map(|(entities, _)| entities)
         .expect("Count query failed")
         .len()
@@ -812,7 +812,7 @@ async fn layout_cache() {
 
             // Without an entry, account_like is false
             let layout = cache
-                .get(&*LOGGER, &conn, site.clone())
+                .get(&LOGGER, &conn, site.clone())
                 .expect("we can get the layout");
             let table = layout.table(&table_name).unwrap();
             assert_eq!(false, table.is_account_like);
@@ -823,7 +823,7 @@ async fn layout_cache() {
 
             // Flip account_like to true
             let layout = cache
-                .get(&*LOGGER, &conn, site.clone())
+                .get(&LOGGER, &conn, site.clone())
                 .expect("we can get the layout");
             let table = layout.table(&table_name).unwrap();
             assert_eq!(true, table.is_account_like);
@@ -834,7 +834,7 @@ async fn layout_cache() {
             sleep(Duration::from_millis(50));
 
             let layout = cache
-                .get(&*LOGGER, &conn, site)
+                .get(&LOGGER, &conn, site)
                 .expect("we can get the layout");
             let table = layout.table(&table_name).unwrap();
             assert_eq!(false, table.is_account_like);
@@ -953,7 +953,7 @@ fn revert_block() {
                 .first(100)
                 .order(EntityOrder::Ascending("order".to_string(), ValueType::Int));
             let marties: Vec<Entity> = layout
-                .query(&*LOGGER, conn, query)
+                .query(&LOGGER, conn, query)
                 .map(|(entities, _)| entities)
                 .expect("loading all marties works");
 
@@ -1027,7 +1027,7 @@ impl<'a> QueryChecker<'a> {
         query.block = BLOCK_NUMBER_MAX;
         let entities = self
             .layout
-            .query::<Entity>(&*LOGGER, self.conn, query)
+            .query::<Entity>(&LOGGER, self.conn, query)
             .expect("layout.query failed to execute query")
             .0;
 
@@ -1676,7 +1676,7 @@ impl<'a> FilterChecker<'a> {
 
         let entities = self
             .layout
-            .query::<Entity>(&*LOGGER, &self.conn, query)
+            .query::<Entity>(&LOGGER, &self.conn, query)
             .expect("layout.query failed to execute query")
             .0;
 

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -1024,7 +1024,7 @@ impl<'a> QueryChecker<'a> {
         let mut entity_ids: Vec<_> = entities
             .into_iter()
             .map(|entity| match entity.get("id") {
-                Some(Value::String(id)) => id.to_owned(),
+                Some(Value::String(id)) => id.clone(),
                 Some(_) => panic!("layout.query returned entity with non-string ID attribute"),
                 None => panic!("layout.query returned entity with no ID attribute"),
             })
@@ -1664,7 +1664,7 @@ impl<'a> FilterChecker<'a> {
         let entity_ids: Vec<_> = entities
             .into_iter()
             .map(|entity| match entity.get("id") {
-                Some(Value::String(id)) => id.to_owned(),
+                Some(Value::String(id)) => id.clone(),
                 Some(_) => panic!("layout.query returned entity with non-string ID attribute"),
                 None => panic!("layout.query returned entity with no ID attribute"),
             })

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -622,7 +622,7 @@ fn update_many() {
         let entities_vec = vec![one, two, three];
         let mut entities: Vec<(&EntityKey, Cow<'_, Entity>)> = keys
             .iter()
-            .zip(entities_vec.iter().map(|e| Cow::Borrowed(e)))
+            .zip(entities_vec.iter().map(Cow::Borrowed))
             .collect();
 
         layout

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -122,7 +122,7 @@ fn create_schema(conn: &PgConnection) -> Layout {
     let schema = Schema::parse(THINGS_GQL, THINGS_SUBGRAPH_ID.clone()).unwrap();
 
     let query = format!("create schema {}", NAMESPACE.as_str());
-    conn.batch_execute(&*query).unwrap();
+    conn.batch_execute(&query).unwrap();
 
     let site = make_dummy_site(
         THINGS_SUBGRAPH_ID.clone(),
@@ -252,7 +252,7 @@ fn find() {
             .find(conn, &EntityKey::data(THING.as_str(), ID), BLOCK_NUMBER_MAX)
             .expect("Failed to read Thing[deadbeef]")
             .unwrap();
-        assert_entity_eq!(scrub(&*BEEF_ENTITY), entity);
+        assert_entity_eq!(scrub(&BEEF_ENTITY), entity);
         assert!(CausalityRegion::from_entity(&entity) == CausalityRegion::ONCHAIN);
 
         // Find non-existing entity
@@ -425,7 +425,7 @@ fn query() {
         let id = DeploymentHash::new("QmXW3qvxV7zXnwRntpj7yoK8HZVtaraZ67uMqaLRvXdxha").unwrap();
         let query = EntityQuery::new(id, BLOCK_NUMBER_MAX, coll).first(10);
         layout
-            .query::<Entity>(&*LOGGER, conn, query)
+            .query::<Entity>(&LOGGER, conn, query)
             .map(|(entities, _)| entities)
             .expect("the query succeeds")
             .into_iter()

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -323,7 +323,7 @@ fn update() {
         let actual = layout
             .find(
                 conn,
-                &EntityKey::data(THING.as_str(), &entity_id),
+                &EntityKey::data(THING.as_str(), entity_id),
                 BLOCK_NUMBER_MAX,
             )
             .expect("Failed to read Thing[deadbeef]")

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -931,9 +931,7 @@ async fn check_events(
         })
     }
 
-    let expected = Mutex::new(as_set(
-        expected.into_iter().map(|event| Arc::new(event)).collect(),
-    ));
+    let expected = Mutex::new(as_set(expected.into_iter().map(Arc::new).collect()));
     // Capture extra changes here; this is only needed for debugging, really.
     // It's permissible that we get more changes than we expected because of
     // how store events group changes together

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1005,7 +1005,7 @@ async fn check_basic_revert(
     assert_eq!(1, returned_entities.len());
 
     // Check if the first user in the result vector has email "queensha@email.com"
-    let returned_name = returned_entities[0].get(&"email".to_owned());
+    let returned_name = returned_entities[0].get("email");
     let test_value = Value::String("queensha@email.com".to_owned());
     assert!(returned_name.is_some());
     assert_eq!(&test_value, returned_name.unwrap());
@@ -1067,7 +1067,7 @@ fn revert_block_with_delete() {
         assert_eq!(1, returned_entities.len());
 
         // Check if "dinici@email.com" is in result set
-        let returned_name = returned_entities[0].get(&"email".to_owned());
+        let returned_name = returned_entities[0].get("email");
         let test_value = Value::String("dinici@email.com".to_owned());
         assert!(returned_name.is_some());
         assert_eq!(&test_value, returned_name.unwrap());

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1397,7 +1397,7 @@ fn throttle_subscription_delivers() {
                 store
                     .clone()
                     .query_store(
-                        QueryTarget::Deployment(deployment.hash.clone().into(), Default::default()),
+                        QueryTarget::Deployment(deployment.hash.clone(), Default::default()),
                         true,
                     )
                     .await

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -539,7 +539,7 @@ impl QueryChecker {
         let entity_ids: Vec<_> = entities
             .into_iter()
             .map(|entity| match entity.get("id") {
-                Some(Value::String(id)) => id.to_owned(),
+                Some(Value::String(id)) => id.clone(),
                 Some(_) => panic!("store.find returned entity with non-string ID attribute"),
                 None => panic!("store.find returned entity with no ID attribute"),
             })
@@ -1326,8 +1326,8 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             added_entities
                 .iter()
                 .map(|(id, data)| EntityOperation::Set {
-                    key: EntityKey::data(USER.to_owned(), id.to_owned()),
-                    data: data.to_owned(),
+                    key: EntityKey::data(USER.to_owned(), id.clone()),
+                    data: data.clone(),
                 })
                 .collect(),
         )
@@ -1809,7 +1809,7 @@ impl WindowQuery {
             .expect("store.find failed to execute query")
             .into_iter()
             .map(|entity| match entity.get("id") {
-                Some(Value::String(id)) => id.to_owned(),
+                Some(Value::String(id)) => id.clone(),
                 Some(_) => panic!("store.find returned entity with non-string ID attribute"),
                 None => panic!("store.find returned entity with no ID attribute"),
             })

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -952,11 +952,13 @@ async fn check_events(
         .compat()
         .timeout(Duration::from_secs(3))
         .await
-        .expect(&format!(
-            "timed out waiting for events\n  still waiting for {:?}\n  got extra events {:?}",
-            expected.lock().unwrap().clone(),
-            extra.lock().unwrap().clone()
-        ))
+        .unwrap_or_else(|_| {
+            panic!(
+                "timed out waiting for events\n  still waiting for {:?}\n  got extra events {:?}",
+                expected.lock().unwrap().clone(),
+                extra.lock().unwrap().clone()
+            )
+        })
         .expect("something went wrong getting events");
     // Check again that we really got everything
     assert_eq!(HashSet::new(), expected.lock().unwrap().clone());

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -189,7 +189,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
         USER,
         "Johnton",
         "tonofjohn@email.com",
-        67 as i32,
+        67_i32,
         184.4,
         false,
         None,
@@ -208,7 +208,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
         USER,
         "Cindini",
         "dinici@email.com",
-        43 as i32,
+        43_i32,
         159.1,
         true,
         Some("red"),
@@ -218,7 +218,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
         USER,
         "Shaqueeena",
         "queensha@email.com",
-        28 as i32,
+        28_i32,
         111.7,
         false,
         Some("blue"),
@@ -237,7 +237,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
         USER,
         "Shaqueeena",
         "teeko@email.com",
-        28 as i32,
+        28_i32,
         111.7,
         false,
         None,
@@ -349,7 +349,7 @@ fn get_entity_1() {
             Value::Bytes("Johnton".as_bytes().into()),
         );
         expected_entity.insert("email".to_owned(), "tonofjohn@email.com".into());
-        expected_entity.insert("age".to_owned(), Value::Int(67 as i32));
+        expected_entity.insert("age".to_owned(), Value::Int(67_i32));
         expected_entity.insert(
             "seconds_age".to_owned(),
             Value::BigInt(BigInt::from(2114359200)),
@@ -379,7 +379,7 @@ fn get_entity_3() {
             Value::Bytes("Shaqueeena".as_bytes().into()),
         );
         expected_entity.insert("email".to_owned(), "teeko@email.com".into());
-        expected_entity.insert("age".to_owned(), Value::Int(28 as i32));
+        expected_entity.insert("age".to_owned(), Value::Int(28_i32));
         expected_entity.insert(
             "seconds_age".to_owned(),
             Value::BigInt(BigInt::from(883612800)),
@@ -402,7 +402,7 @@ fn insert_entity() {
             USER,
             "Wanjon",
             "wanawana@email.com",
-            76 as i32,
+            76_i32,
             111.7,
             true,
             Some("green"),
@@ -433,7 +433,7 @@ fn update_existing() {
             USER,
             "Wanjon",
             "wanawana@email.com",
-            76 as i32,
+            76_i32,
             111.7,
             true,
             Some("green"),
@@ -740,20 +740,20 @@ fn find() {
             .check(
                 vec!["1"],
                 user_query()
-                    .filter(EntityFilter::Equal("age".to_owned(), Value::Int(67 as i32)))
+                    .filter(EntityFilter::Equal("age".to_owned(), Value::Int(67_i32)))
                     .desc("name"),
             )
             .check(
                 vec!["3", "2"],
                 user_query()
-                    .filter(EntityFilter::Not("age".to_owned(), Value::Int(67 as i32)))
+                    .filter(EntityFilter::Not("age".to_owned(), Value::Int(67_i32)))
                     .desc("name"),
             )
             .check(
                 vec!["1"],
                 user_query().filter(EntityFilter::GreaterThan(
                     "age".to_owned(),
-                    Value::Int(43 as i32),
+                    Value::Int(43_i32),
                 )),
             )
             .check(
@@ -761,17 +761,14 @@ fn find() {
                 user_query()
                     .filter(EntityFilter::GreaterOrEqual(
                         "age".to_owned(),
-                        Value::Int(43 as i32),
+                        Value::Int(43_i32),
                     ))
                     .asc("name"),
             )
             .check(
                 vec!["2", "3"],
                 user_query()
-                    .filter(EntityFilter::LessThan(
-                        "age".to_owned(),
-                        Value::Int(50 as i32),
-                    ))
+                    .filter(EntityFilter::LessThan("age".to_owned(), Value::Int(50_i32)))
                     .asc("name"),
             )
             .check(
@@ -779,26 +776,20 @@ fn find() {
                 user_query()
                     .filter(EntityFilter::LessOrEqual(
                         "age".to_owned(),
-                        Value::Int(43 as i32),
+                        Value::Int(43_i32),
                     ))
                     .asc("name"),
             )
             .check(
                 vec!["3", "2"],
                 user_query()
-                    .filter(EntityFilter::LessThan(
-                        "age".to_owned(),
-                        Value::Int(50 as i32),
-                    ))
+                    .filter(EntityFilter::LessThan("age".to_owned(), Value::Int(50_i32)))
                     .desc("name"),
             )
             .check(
                 vec!["2"],
                 user_query()
-                    .filter(EntityFilter::LessThan(
-                        "age".to_owned(),
-                        Value::Int(67 as i32),
-                    ))
+                    .filter(EntityFilter::LessThan("age".to_owned(), Value::Int(67_i32)))
                     .desc("name")
                     .first(1)
                     .skip(1),
@@ -808,7 +799,7 @@ fn find() {
                 user_query()
                     .filter(EntityFilter::In(
                         "age".to_owned(),
-                        vec![Value::Int(67 as i32), Value::Int(43 as i32)],
+                        vec![Value::Int(67_i32), Value::Int(43_i32)],
                     ))
                     .desc("name")
                     .first(5),
@@ -818,7 +809,7 @@ fn find() {
                 user_query()
                     .filter(EntityFilter::NotIn(
                         "age".to_owned(),
-                        vec![Value::Int(67 as i32), Value::Int(43 as i32)],
+                        vec![Value::Int(67_i32), Value::Int(43_i32)],
                     ))
                     .desc("name")
                     .first(5),
@@ -1420,7 +1411,7 @@ fn throttle_subscription_delivers() {
             USER,
             "Steve",
             "nieve@email.com",
-            72 as i32,
+            72_i32,
             120.7,
             false,
             None,
@@ -1465,7 +1456,7 @@ fn throttle_subscription_throttles() {
             USER,
             "Steve",
             "nieve@email.com",
-            72 as i32,
+            72_i32,
             120.7,
             false,
             None,

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -926,7 +926,7 @@ async fn check_events(
 ) {
     fn as_set(events: Vec<Arc<StoreEvent>>) -> HashSet<EntityChange> {
         events.into_iter().fold(HashSet::new(), |mut set, event| {
-            set.extend(event.changes.iter().map(|change| change.clone()));
+            set.extend(event.changes.iter().cloned());
             set
         })
     }

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1543,9 +1543,7 @@ fn handle_large_string_with_index() {
         // the repeated text compresses so well. This leads to an error
         // 'index row requires 11488 bytes, maximum size is 8191' if
         // used with a btree index without size limitation
-        let long_text = std::iter::repeat("Quo usque tandem")
-            .take(62500)
-            .collect::<String>();
+        let long_text = "Quo usque tandem".repeat(62500);
         let other_text = long_text.clone() + "X";
 
         let metrics_registry = Arc::new(MockMetricsRegistry::new());
@@ -1636,10 +1634,7 @@ fn handle_large_bytea_with_index() {
         // repeated text compresses so well. This leads to an error 'index
         // row size 2784 exceeds btree version 4 maximum 2704' if used with
         // a btree index without size limitation
-        let long_bytea = std::iter::repeat("Quo usque tandem")
-            .take(15000)
-            .collect::<String>()
-            .into_bytes();
+        let long_bytea = "Quo usque tandem".repeat(15000).into_bytes();
         let other_bytea = {
             let mut other_bytea = long_bytea.clone();
             other_bytea.push(b'X');

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1008,7 +1008,7 @@ async fn check_basic_revert(
     assert_eq!(&deployment.hash, &state.id);
 
     // Revert block 3
-    revert_block(&store, &deployment, &*TEST_BLOCK_1_PTR).await;
+    revert_block(&store, &deployment, &TEST_BLOCK_1_PTR).await;
 
     let returned_entities = store
         .subgraph_store()
@@ -1068,7 +1068,7 @@ fn revert_block_with_delete() {
 
         // Revert deletion
         let count = get_entity_count(store.clone(), &deployment.hash);
-        revert_block(&store, &deployment, &*TEST_BLOCK_2_PTR).await;
+        revert_block(&store, &deployment, &TEST_BLOCK_2_PTR).await;
         assert_eq!(count + 1, get_entity_count(store.clone(), &deployment.hash));
 
         // Query after revert
@@ -1124,7 +1124,7 @@ fn revert_block_with_partial_update() {
 
         // Perform revert operation, reversing the partial update
         let count = get_entity_count(store.clone(), &deployment.hash);
-        revert_block(&store, &deployment, &*TEST_BLOCK_2_PTR).await;
+        revert_block(&store, &deployment, &TEST_BLOCK_2_PTR).await;
         assert_eq!(count, get_entity_count(store.clone(), &deployment.hash));
 
         // Obtain the reverted entity from the store
@@ -1247,7 +1247,7 @@ fn revert_block_with_dynamic_data_source_operations() {
         let subscription = subscribe(&deployment.hash, USER);
 
         // Revert block that added the user and the dynamic data source
-        revert_block(&store, &deployment, &*TEST_BLOCK_2_PTR).await;
+        revert_block(&store, &deployment, &TEST_BLOCK_2_PTR).await;
 
         // Verify that the user is the original again
         assert_eq!(
@@ -1405,7 +1405,7 @@ fn throttle_subscription_delivers() {
     run_test(|store, _, deployment| async move {
         let subscription = subscribe(&deployment.hash, USER)
             .throttle_while_syncing(
-                &*LOGGER,
+                &LOGGER,
                 store
                     .clone()
                     .query_store(
@@ -1450,7 +1450,7 @@ fn throttle_subscription_throttles() {
         // Throttle for a very long time (30s)
         let subscription = subscribe(&deployment.hash, USER)
             .throttle_while_syncing(
-                &*LOGGER,
+                &LOGGER,
                 store
                     .clone()
                     .query_store(
@@ -2152,11 +2152,11 @@ fn reorg_tracking() {
         check_state!(store, 0, 0, 4);
 
         // Back to block 3
-        revert_block(&store, &deployment, &*TEST_BLOCK_3_PTR).await;
+        revert_block(&store, &deployment, &TEST_BLOCK_3_PTR).await;
         check_state!(store, 1, 1, 3);
 
         // Back to block 2
-        revert_block(&store, &deployment, &*TEST_BLOCK_2_PTR).await;
+        revert_block(&store, &deployment, &TEST_BLOCK_2_PTR).await;
         check_state!(store, 2, 2, 2);
 
         // Forward to block 3
@@ -2172,13 +2172,13 @@ fn reorg_tracking() {
         check_state!(store, 2, 2, 5);
 
         // Revert all the way back to block 2
-        revert_block(&store, &deployment, &*TEST_BLOCK_4_PTR).await;
+        revert_block(&store, &deployment, &TEST_BLOCK_4_PTR).await;
         check_state!(store, 3, 2, 4);
 
-        revert_block(&store, &deployment, &*TEST_BLOCK_3_PTR).await;
+        revert_block(&store, &deployment, &TEST_BLOCK_3_PTR).await;
         check_state!(store, 4, 2, 3);
 
-        revert_block(&store, &deployment, &*TEST_BLOCK_2_PTR).await;
+        revert_block(&store, &deployment, &TEST_BLOCK_2_PTR).await;
         check_state!(store, 5, 3, 2);
     })
 }

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -315,7 +315,7 @@ fn delete_entity() {
         // Check that there is an entity to remove.
         writable.get(&entity_key).unwrap().unwrap();
 
-        let count = get_entity_count(store.clone(), &&deployment.hash);
+        let count = get_entity_count(store.clone(), &deployment.hash);
         transact_and_wait(
             &store.subgraph_store(),
             &deployment,
@@ -326,10 +326,7 @@ fn delete_entity() {
         )
         .await
         .unwrap();
-        assert_eq!(
-            count,
-            get_entity_count(store.clone(), &&deployment.hash) + 1
-        );
+        assert_eq!(count, get_entity_count(store.clone(), &deployment.hash) + 1);
 
         // Check that that the deleted entity id is not present
         assert!(writable.get(&entity_key).unwrap().is_none());
@@ -410,7 +407,7 @@ fn insert_entity() {
             true,
             Some("green"),
         );
-        let count = get_entity_count(store.clone(), &&deployment.hash);
+        let count = get_entity_count(store.clone(), &deployment.hash);
         transact_and_wait(
             &store.subgraph_store(),
             &deployment,
@@ -956,7 +953,7 @@ async fn check_events(
         .take_while(|event| {
             let mut expected = expected.lock().unwrap();
             for change in &event.changes {
-                if !expected.remove(&change) {
+                if !expected.remove(change) {
                     extra.lock().unwrap().insert(change.clone());
                 }
             }
@@ -1008,7 +1005,7 @@ async fn check_basic_revert(
     assert_eq!(&deployment.hash, &state.id);
 
     // Revert block 3
-    revert_block(&store, &deployment, &TEST_BLOCK_1_PTR).await;
+    revert_block(&store, deployment, &TEST_BLOCK_1_PTR).await;
 
     let returned_entities = store
         .subgraph_store()

--- a/store/postgres/tests/subgraph.rs
+++ b/store/postgres/tests/subgraph.rs
@@ -136,7 +136,7 @@ fn create_subgraph() {
         let schema = Schema::parse(SUBGRAPH_GQL, id.clone()).unwrap();
 
         let manifest = SubgraphManifest::<graph_chain_ethereum::Chain> {
-            id: id,
+            id,
             spec_version: Version::new(1, 0, 0),
             features: Default::default(),
             description: None,

--- a/store/postgres/tests/writable.rs
+++ b/store/postgres/tests/writable.rs
@@ -50,7 +50,8 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
     let deployment = DeploymentCreate::new(String::new(), &manifest, None);
     let name = SubgraphName::new("test/writable").unwrap();
     let node_id = NodeId::new("test").unwrap();
-    let deployment = store
+
+    store
         .create_subgraph_deployment(
             name,
             &TEST_SUBGRAPH_SCHEMA,
@@ -59,8 +60,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
             NETWORK_NAME.to_string(),
             SubgraphVersionSwitchingMode::Instant,
         )
-        .unwrap();
-    deployment
+        .unwrap()
 }
 
 /// Removes test data from the database behind the store.

--- a/store/postgres/tests/writable.rs
+++ b/store/postgres/tests/writable.rs
@@ -120,13 +120,13 @@ async fn insert_count(store: &Arc<DieselSubgraphStore>, deployment: &DeploymentL
 }
 
 async fn pause_writer(deployment: &DeploymentLocator) {
-    flush(&deployment).await.unwrap();
+    flush(deployment).await.unwrap();
     writable::allow_steps(0).await;
 }
 
 async fn resume_writer(deployment: &DeploymentLocator, steps: usize) {
     writable::allow_steps(steps).await;
-    flush(&deployment).await.unwrap();
+    flush(deployment).await.unwrap();
 }
 
 #[test]

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -53,7 +53,7 @@ lazy_static! {
     pub static ref METRICS_REGISTRY: Arc<MockMetricsRegistry> =
         Arc::new(MockMetricsRegistry::new());
     pub static ref LOAD_MANAGER: Arc<LoadManager> = Arc::new(LoadManager::new(
-        &*LOGGER,
+        &LOGGER,
         Vec::new(),
         METRICS_REGISTRY.clone(),
     ));
@@ -190,7 +190,7 @@ pub async fn create_subgraph(
         .cheap_clone()
         .writable(LOGGER.clone(), deployment.id)
         .await?
-        .start_subgraph_deployment(&*LOGGER)
+        .start_subgraph_deployment(&LOGGER)
         .await?;
     Ok(deployment)
 }
@@ -362,7 +362,7 @@ pub async fn insert_entities(
         });
 
     transact_entity_operations(
-        &*SUBGRAPH_STORE,
+        &SUBGRAPH_STORE,
         deployment,
         GENESIS_PTR.clone(),
         insert_ops.collect::<Vec<_>>(),
@@ -545,12 +545,12 @@ fn build_store() -> (Arc<Store>, ConnectionPool, Config, Arc<SubscriptionManager
     }
     opt.store_connection_pool_size = CONN_POOL_SIZE;
 
-    let config = Config::load(&*LOGGER, &opt)
+    let config = Config::load(&LOGGER, &opt)
         .unwrap_or_else(|_| panic!("config is not valid (file={:?})", &opt.config));
     let registry = Arc::new(MockMetricsRegistry::new());
     std::thread::spawn(move || {
         STORE_RUNTIME.handle().block_on(async {
-            let builder = StoreBuilder::new(&*LOGGER, &*NODE_ID, &config, None, registry).await;
+            let builder = StoreBuilder::new(&LOGGER, &NODE_ID, &config, None, registry).await;
             let subscription_manager = builder.subscription_manager();
             let primary_pool = builder.primary_pool();
 

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -504,7 +504,7 @@ async fn execute_subgraph_query_internal(
 pub async fn deployment_state(store: &Store, subgraph_id: &DeploymentHash) -> DeploymentState {
     store
         .query_store(
-            QueryTarget::Deployment(subgraph_id.to_owned(), Default::default()),
+            QueryTarget::Deployment(subgraph_id.clone(), Default::default()),
             false,
         )
         .await

--- a/tests/src/docker_utils.rs
+++ b/tests/src/docker_utils.rs
@@ -175,7 +175,7 @@ impl ServiceContainer {
             ),
         };
 
-        Ok(to_mapped_ports(ports.to_vec()))
+        Ok(to_mapped_ports(ports.clone()))
     }
 
     /// halts execution until a trigger message is detected on stdout or, optionally,

--- a/tests/src/docker_utils.rs
+++ b/tests/src/docker_utils.rs
@@ -225,7 +225,7 @@ impl ServiceContainer {
         for attempt in 1..=EXEC_TRIES {
             // 1. Create Exec
             let config = exec::CreateExecOptions {
-                cmd: Some(vec!["createdb", "-E", "UTF8", "--locale=C", &db_name]),
+                cmd: Some(vec!["createdb", "-E", "UTF8", "--locale=C", db_name]),
                 user: Some("postgres"),
                 attach_stdout: Some(true),
                 ..Default::default()

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -55,10 +55,10 @@ pub async fn chain(
     let block_stream_builder = Arc::new(MutexBlockStreamBuilder(Mutex::new(static_block_stream)));
 
     let chain = Chain::new(
-        logger_factory.clone(),
+        logger_factory,
         stores.network_name.clone(),
         node_id,
-        mock_registry.clone(),
+        mock_registry,
         chain_store.cheap_clone(),
         chain_store,
         client,

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -100,7 +100,7 @@ pub fn empty_block(
     // A 0x000.. transaction is used so `push_test_log` can use it
     let transactions = vec![Transaction {
         hash: H256::zero(),
-        block_hash: Some(H256::from_slice(ptr.hash.as_slice().into())),
+        block_hash: Some(H256::from_slice(ptr.hash.as_slice())),
         block_number: Some(ptr.number.into()),
         transaction_index: Some(0.into()),
         from: Some(H160::zero()),
@@ -128,7 +128,7 @@ pub fn push_test_log(block: &mut BlockWithTriggers<Chain>, payload: impl Into<St
             data: ethabi::encode(&[ethabi::Token::String(payload.into())]).into(),
             block_hash: Some(H256::from_slice(block.ptr().hash.as_slice())),
             block_number: Some(block.ptr().number.into()),
-            transaction_hash: Some(H256::from_low_u64_be(0).into()),
+            transaction_hash: Some(H256::from_low_u64_be(0)),
             transaction_index: Some(0.into()),
             log_index: Some(0.into()),
             transaction_log_index: Some(0.into()),

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -306,7 +306,7 @@ pub async fn stores(store_config_path: &str) -> Stores {
     let chain_store = network_store
         .block_store()
         .chain_store(network_name.as_ref())
-        .expect(format!("No chain store for {}", &network_name).as_ref());
+        .unwrap_or_else(|| panic!("No chain store for {}", &network_name));
 
     Stores {
         network_name,

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -578,7 +578,7 @@ where
                 .enumerate()
                 .find(|(_, b)| b.ptr() == current_block)
                 .unwrap()
-                .0 as usize
+                .0
         });
         Ok(Box::new(StaticStream {
             stream: Box::pin(stream_events(self.chain.clone(), current_idx)),

--- a/tests/tests/runner_tests.rs
+++ b/tests/tests/runner_tests.rs
@@ -218,7 +218,7 @@ async fn file_data_sources() {
     let writable = ctx
         .store
         .clone()
-        .writable(ctx.logger.clone(), ctx.deployment.id.clone())
+        .writable(ctx.logger.clone(), ctx.deployment.id)
         .await
         .unwrap();
     let data_sources = writable.load_dynamic_data_sources(vec![]).await.unwrap();

--- a/tests/tests/runner_tests.rs
+++ b/tests/tests/runner_tests.rs
@@ -366,7 +366,7 @@ async fn retry_create_ds() {
             number: 1,
             hash: H256::from_low_u64_be(12).into(),
         };
-        let block1_reorged = empty_block(block0.ptr(), block1_reorged_ptr.clone());
+        let block1_reorged = empty_block(block0.ptr(), block1_reorged_ptr);
         let block2 = empty_block(block1_reorged.ptr(), test_ptr(2));
         vec![block0, block1, block1_reorged, block2]
     };

--- a/tests/tests/runner_tests.rs
+++ b/tests/tests/runner_tests.rs
@@ -475,7 +475,7 @@ async fn build_subgraph_with_yarn_cmd(dir: &str, yarn_cmd: &str) -> DeploymentHa
     );
 
     // Run codegen.
-    run_cmd(Command::new("yarn").arg("codegen").current_dir(&dir));
+    run_cmd(Command::new("yarn").arg("codegen").current_dir(dir));
 
     // Run `deploy` for the side effect of uploading to IPFS, the graph node url
     // is fake and the actual deploy call is meant to fail.

--- a/tests/tests/runner_tests.rs
+++ b/tests/tests/runner_tests.rs
@@ -188,7 +188,7 @@ async fn file_data_sources() {
 
     assert_json_eq!(
         query_res,
-        Some(object! { ipfsFile: object!{ id: id.clone() , content: content.clone() } })
+        Some(object! { ipfsFile: object!{ id: id, content: content.clone() } })
     );
 
     // assert whether duplicate data sources are created.


### PR DESCRIPTION
To ease review I separated commits by `clippy` lint rules so it is easier to revert each, but we can squash before merge if necessary.

Special attention to `3729a474719d76caa7977a31ed7b34b5777d034d` as that required manual intervention. The others were automatic.

About #4169 - I suggest adding to CI the lints that everyone agrees that should be an error (which can be an empty set right now). Then we can fix a category and enable on CI incrementally.