### PR TITLE
Refactor Dockerfile to avoid unnecessary rebuilds and improve code readability.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,14 +40,23 @@ ADD server ./server
 ADD store ./store
 ADD tests ./tests
 
+
+RUN RUSTFLAGS="-g" cargo build --release --package graph-node
+
+
+RUN cp target/release/graph-node /usr/local/bin/graph-node
+RUN cp target/release/graphman /usr/local/bin/graphman
+
     # Reduce the size of the layer by removing unnecessary files.
-    && cargo clean \
-    && objcopy --only-keep-debug /usr/local/bin/graph-node /usr/local/bin/graph-node.debug \
+RUN cargo clean
+
+RUN objcopy --only-keep-debug /usr/local/bin/graph-node /usr/local/bin/graph-node.debug \
     && strip -g /usr/local/bin/graph-node \
-    && strip -g /usr/local/bin/graphman \
-    && cd /usr/local/bin \
-    && objcopy --add-gnu-debuglink=graph-node.debug graph-node \
-    && echo "REPO_NAME='$REPO_NAME'" > /etc/image-info \
+    && strip -g /usr/local/bin/graphman
+
+RUN objcopy --add-gnu-debuglink=/usr/local/bin/graph-node.debug /usr/local/bin/graph-node
+
+RUN echo "REPO_NAME='$REPO_NAME'" > /etc/image-info \
     && echo "TAG_NAME='$TAG_NAME'" >> /etc/image-info \
     && echo "BRANCH_NAME='$BRANCH_NAME'" >> /etc/image-info \
     && echo "COMMIT_SHA='$COMMIT_SHA'" >> /etc/image-info \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,12 +22,8 @@ ARG TAG_NAME=unknown
 
 WORKDIR /graph-node
 
-RUN apt-get update \
-    && apt-get install -y cmake protobuf-compiler && \
-    cd /graph-node && \
-    RUSTFLAGS="-g" cargo build --release --package graph-node \
-    && cp target/release/graph-node /usr/local/bin/graph-node \
-    && cp target/release/graphman /usr/local/bin/graphman \
+RUN apt-get update && apt-get install -y cmake protobuf-compiler
+
     # Reduce the size of the layer by removing unnecessary files.
     && cargo clean \
     && objcopy --only-keep-debug /usr/local/bin/graph-node /usr/local/bin/graph-node.debug \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,22 @@ WORKDIR /graph-node
 
 RUN apt-get update && apt-get install -y cmake protobuf-compiler
 
+# Only adding files needed for Rust to compile to avoid rebuilding on
+# changes in files irrelevant in the build process
+ADD Cargo.lock  ./Cargo.lock
+ADD Cargo.toml ./Cargo.toml
+ADD rust-toolchain.toml ./rust-toolchain.toml
+ADD chain ./chain
+ADD core ./core
+ADD graph ./graph
+ADD graphql ./graphql
+ADD mock ./mock
+ADD node ./node
+ADD runtime ./runtime
+ADD server ./server
+ADD store ./store
+ADD tests ./tests
+
     # Reduce the size of the layer by removing unnecessary files.
     && cargo clean \
     && objcopy --only-keep-debug /usr/local/bin/graph-node /usr/local/bin/graph-node.debug \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ ARG REPO_NAME=unknown
 ARG BRANCH_NAME=unknown
 ARG TAG_NAME=unknown
 
-ADD . /graph-node
+WORKDIR /graph-node
 
 RUN apt-get update \
     && apt-get install -y cmake protobuf-compiler && \


### PR DESCRIPTION
Thank you so much for your amazing work on this repo.

I would also like to contribute in any way as I could and found some potential improvements with the Dockerfile.

This PR does the following:

1. Added `WORKDIR` directive to avoid needing to do `cd` and other manual directory changes.
2. Separated `OS dep layer` from building Rust package. This is done so that we don't need to rebuild rust package
in case of any OS updates.
3. Explicitly adding all Rust member files. This was done so that updates in files that have
nothing to do with the Rust build don't re-trigger unnecessary rebuilds. For example, even changing anything in the docker folder will cause a re-build.
4. Improve general readablity of the Dockerfile.