### PR TITLE
Add support for Web3Call adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
  "envconfig",
  "futures 0.1.31",
  "graph",
+ "graph-mock",
  "graph-runtime-derive",
  "graph-runtime-wasm",
  "hex",

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -27,6 +27,7 @@ graph-runtime-derive = { path = "../../runtime/derive" }
 [dev-dependencies]
 test-store = { path = "../../store/test-store" }
 base64 = "0.20.0"
+graph-mock = { path = "../../mock" }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -176,7 +176,8 @@ impl TriggersAdapterSelector<Chain> for EthereumAdapterSelector {
                 traces: false,
             };
 
-            self.adapters.cheapest_with(&adjusted_capabilities)?
+            self.adapters
+                .call_or_cheapest(Some(&adjusted_capabilities))?
         } else {
             self.adapters.cheapest_with(capabilities)?
         };

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -43,13 +43,10 @@ impl blockchain::RuntimeAdapter<Chain> for RuntimeAdapter {
     fn host_fns(&self, ds: &DataSource) -> Result<Vec<HostFn>, Error> {
         let abis = ds.mapping.abis.clone();
         let call_cache = self.call_cache.cheap_clone();
-        let eth_adapter = self
-            .eth_adapters
-            .cheapest_with(&NodeCapabilities {
-                archive: ds.mapping.requires_archive()?,
-                traces: false,
-            })?
-            .cheap_clone();
+        let eth_adapter = self.eth_adapters.call_or_cheapest(Some(&NodeCapabilities {
+            archive: ds.mapping.requires_archive()?,
+            traces: false,
+        }))?;
 
         let ethereum_call = HostFn {
             name: "ethereum.call",

--- a/node/resources/tests/full_config.toml
+++ b/node/resources/tests/full_config.toml
@@ -47,6 +47,7 @@ ingestor = "index_0"
 shard = "primary"
 provider = [
   { label = "mainnet-0", url = "http://rpc.mainnet.io", features = ["archive", "traces"] },
+  { label = "mainnet-1", details = { type = "web3call", url = "http://rpc.mainnet.io", features = ["archive", "traces"] }},
   { label = "firehose", details = { type = "firehose", url = "http://localhost:9000", features = [] }},
   { label = "substreams", details = { type = "substreams", url = "http://localhost:9000", features = [] }},
 ]

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -2,7 +2,7 @@ use crate::config::{Config, ProviderDetails};
 use ethereum::{EthereumNetworks, ProviderEthRpcMetrics};
 use futures::future::{join_all, try_join_all};
 use futures::TryFutureExt;
-use graph::anyhow::Error;
+use graph::anyhow::{bail, Error};
 use graph::blockchain::{Block as BlockchainBlock, BlockchainKind, ChainIdentifier};
 use graph::cheap_clone::CheapClone;
 use graph::firehose::{FirehoseEndpoint, FirehoseNetworks};
@@ -410,44 +410,52 @@ pub async fn create_ethereum_networks_for_chain(
         .ok_or_else(|| anyhow!("unknown network {}", network_name))?;
 
     for provider in &chain.providers {
-        if let ProviderDetails::Web3(web3) = &provider.details {
-            let capabilities = web3.node_capabilities();
+        let (web3, call_only) = match &provider.details {
+            ProviderDetails::Web3Call(web3) => (web3, true),
+            ProviderDetails::Web3(web3) => (web3, false),
+            _ => continue,
+        };
 
-            let logger = logger.new(o!("provider" => provider.label.clone()));
-            info!(
-                logger,
-                "Creating transport";
-                "url" => &web3.url,
-                "capabilities" => capabilities
-            );
-
-            use crate::config::Transport::*;
-
-            let transport = match web3.transport {
-                Rpc => Transport::new_rpc(Url::parse(&web3.url)?, web3.headers.clone()),
-                Ipc => Transport::new_ipc(&web3.url).await,
-                Ws => Transport::new_ws(&web3.url).await,
-            };
-
-            let supports_eip_1898 = !web3.features.contains("no_eip1898");
-
-            parsed_networks.insert(
-                network_name.to_string(),
-                capabilities,
-                Arc::new(
-                    graph_chain_ethereum::EthereumAdapter::new(
-                        logger,
-                        provider.label.clone(),
-                        &web3.url,
-                        transport,
-                        eth_rpc_metrics.clone(),
-                        supports_eip_1898,
-                    )
-                    .await,
-                ),
-                web3.limit_for(&config.node),
-            );
+        let capabilities = web3.node_capabilities();
+        if call_only && !capabilities.archive {
+            bail!("Ethereum call-only adapters require archive features to be enabled");
         }
+
+        let logger = logger.new(o!("provider" => provider.label.clone()));
+        info!(
+            logger,
+            "Creating transport";
+            "url" => &web3.url,
+            "capabilities" => capabilities
+        );
+
+        use crate::config::Transport::*;
+
+        let transport = match web3.transport {
+            Rpc => Transport::new_rpc(Url::parse(&web3.url)?, web3.headers.clone()),
+            Ipc => Transport::new_ipc(&web3.url).await,
+            Ws => Transport::new_ws(&web3.url).await,
+        };
+
+        let supports_eip_1898 = !web3.features.contains("no_eip1898");
+
+        parsed_networks.insert(
+            network_name.to_string(),
+            capabilities,
+            Arc::new(
+                graph_chain_ethereum::EthereumAdapter::new(
+                    logger,
+                    provider.label.clone(),
+                    &web3.url,
+                    transport,
+                    eth_rpc_metrics.clone(),
+                    supports_eip_1898,
+                    call_only,
+                )
+                .await,
+            ),
+            web3.limit_for(&config.node),
+        );
     }
 
     parsed_networks.sort();
@@ -509,6 +517,7 @@ mod test {
             archive: true,
             traces: false,
         };
+
         let has_mainnet_with_traces = ethereum_networks
             .adapter_with_capabilities("mainnet".to_string(), &traces)
             .is_ok();

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -547,6 +547,7 @@ pub enum ProviderDetails {
     Firehose(FirehoseProvider),
     Web3(Web3Provider),
     Substreams(FirehoseProvider),
+    Web3Call(Web3Provider),
 }
 
 const FIREHOSE_FILTER_FEATURE: &str = "filters";
@@ -674,7 +675,7 @@ impl Provider {
                 }
             }
 
-            ProviderDetails::Web3(ref mut web3) => {
+            ProviderDetails::Web3Call(ref mut web3) | ProviderDetails::Web3(ref mut web3) => {
                 for feature in &web3.features {
                     if !PROVIDER_FEATURES.contains(&feature.as_str()) {
                         return Err(anyhow!(
@@ -1442,5 +1443,30 @@ mod tests {
         d.push(path);
 
         read_to_string(&d).expect(&format!("resource {:?} not found", &d))
+    }
+
+    #[test]
+    fn it_works_on_web3call_provider_without_transport_from_toml() {
+        let actual = toml::from_str(
+            r#"
+            label = "peering"
+            details = { type = "web3call", url = "http://localhost:8545", features = [] }
+        "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            Provider {
+                label: "peering".to_owned(),
+                details: ProviderDetails::Web3Call(Web3Provider {
+                    transport: Transport::Rpc,
+                    url: "http://localhost:8545".to_owned(),
+                    features: BTreeSet::new(),
+                    headers: HeaderMap::new(),
+                    rules: Vec::new(),
+                }),
+            },
+            actual
+        );
     }
 }

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -59,7 +59,10 @@ pub async fn chain(
         chain_store.cheap_clone(),
         chain_store,
         firehose_endpoints,
-        EthereumNetworkAdapters { adapters: vec![] },
+        EthereumNetworkAdapters {
+            adapters: vec![],
+            call_only_adapters: vec![],
+        },
         stores.chain_head_listener.cheap_clone(),
         block_stream_builder.clone(),
         Arc::new(StaticBlockRefetcher { x: PhantomData }),


### PR DESCRIPTION
- Always prefer web3call adapter for runtime adapter on ethereum if available
- Prevent non call functions on call_only adapters
- Add web3call type configuration
- Require Web3Call endpoints to have the "archive" feature

