### PR TITLE
feat(graph, graphql): Added `extensions` to GraphQL response, and expose `validation_errors`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ checksum = "ed2f2e73fffe9455141e170fb9c1feb0ac521ec7e7dcd47a7cab72a658490fb8"
 dependencies = [
  "chrono",
  "serde",
- "serde_with",
+ "serde_with 1.9.4",
 ]
 
 [[package]]
@@ -894,8 +894,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.0",
+ "darling_macro 0.13.0",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+dependencies = [
+ "darling_core 0.14.3",
+ "darling_macro 0.14.3",
 ]
 
 [[package]]
@@ -913,12 +923,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.0",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+dependencies = [
+ "darling_core 0.14.3",
  "quote",
  "syn",
 ]
@@ -2007,14 +2042,15 @@ dependencies = [
 
 [[package]]
 name = "graphql-tools"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc3a979aca9d796ff03ff71f4013e203a1f69bf1f37899ae4a8e676bb236608"
+checksum = "75d2dfa6acdbc75512d42db1e6a618bd9af333bad889492f7bc6a06a315bdbf2"
 dependencies = [
  "graphql-parser",
  "lazy_static",
  "serde",
  "serde_json",
+ "serde_with 2.2.0",
 ]
 
 [[package]]
@@ -4007,7 +4043,23 @@ checksum = "1ad9fdbb69badc8916db738c25efd04f0a65297d26c2f8de4b62e57b8c12bc72"
 dependencies = [
  "rustversion",
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.4.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros 2.2.0",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -4016,7 +4068,19 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1569374bd54623ec8bd592cf22ba6e03c0f177ff55fbc8c29a49e296e7adecf"
 dependencies = [
- "darling",
+ "darling 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
+dependencies = [
+ "darling 0.14.3",
  "proc-macro2",
  "quote",
  "syn",

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -1,5 +1,6 @@
 use super::error::{QueryError, QueryExecutionError};
 use crate::data::value::Object;
+use crate::prelude::serde_json::Value;
 use crate::prelude::{r, CacheWeight, DeploymentHash};
 use http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
@@ -42,6 +43,7 @@ where
 }
 
 pub type Data = Object;
+pub type Extensions = Value;
 
 #[derive(Debug)]
 /// A collection of query results that is serialized as a single result.
@@ -221,6 +223,8 @@ pub struct QueryResult {
     data: Option<Data>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     errors: Vec<QueryError>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extensions: Option<Extensions>,
     #[serde(skip_serializing)]
     pub deployment: Option<DeploymentHash>,
     #[serde(skip_serializing)]
@@ -232,6 +236,7 @@ impl QueryResult {
         QueryResult {
             data: Some(data),
             errors: Vec::new(),
+            extensions: None,
             deployment: None,
             trace: Trace::None,
         }
@@ -244,6 +249,7 @@ impl QueryResult {
         Self {
             data: self.data.clone(),
             errors: self.errors.clone(),
+            extensions: self.extensions.clone(),
             deployment: self.deployment.clone(),
             trace: Trace::None,
         }
@@ -300,6 +306,7 @@ impl From<QueryExecutionError> for QueryResult {
         QueryResult {
             data: None,
             errors: vec![e.into()],
+            extensions: None,
             deployment: None,
             trace: Trace::None,
         }
@@ -311,6 +318,7 @@ impl From<QueryError> for QueryResult {
         QueryResult {
             data: None,
             errors: vec![e],
+            extensions: None,
             deployment: None,
             trace: Trace::None,
         }
@@ -322,6 +330,7 @@ impl From<Vec<QueryExecutionError>> for QueryResult {
         QueryResult {
             data: None,
             errors: e.into_iter().map(QueryError::from).collect(),
+            extensions: None,
             deployment: None,
             trace: Trace::None,
         }

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 crossbeam = "0.8"
 graph = { path = "../graph" }
 graphql-parser = "0.4.0"
-graphql-tools = "0.2.1"
+graphql-tools = "0.2.2"
 indexmap = "1.9"
 Inflector = "0.11.3"
 lazy_static = "1.2.0"


### PR DESCRIPTION
- [x] Added `extensions` to `QueryResult`
- [x] Added validations errors to `extensions` when `SILENT_GRAPHQL_VALIDATIONS` is turned on (in addition to logging in)
- [x] Remove previously-used logging for `SILENT_GRAPHQL_VALIDATIONS` (the metric we have there is more useful) 
- [ ] Testing