### PR TITLE
Refactor firehose/rpc decision to happen earlier in the flow

### DIFF
--- a/chain/arweave/src/chain.rs
+++ b/chain/arweave/src/chain.rs
@@ -65,6 +65,7 @@ impl Chain {
 impl Blockchain for Chain {
     const KIND: BlockchainKind = BlockchainKind::Arweave;
 
+    type Client = ();
     type Block = codec::Block;
 
     type DataSource = DataSource;
@@ -173,10 +174,6 @@ impl Blockchain for Chain {
 
     fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapterTrait<Self>> {
         Arc::new(RuntimeAdapter {})
-    }
-
-    fn is_firehose_supported(&self) -> bool {
-        true
     }
 }
 

--- a/chain/cosmos/src/chain.rs
+++ b/chain/cosmos/src/chain.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use graph::blockchain::block_stream::FirehoseCursor;
+use graph::blockchain::client::ChainClient;
 use graph::cheap_clone::CheapClone;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::prelude::MetricsRegistry;
@@ -30,7 +31,7 @@ use crate::{codec, TriggerFilter};
 pub struct Chain {
     logger_factory: LoggerFactory,
     name: String,
-    firehose_endpoints: Arc<FirehoseEndpoints>,
+    client: Arc<ChainClient<Self>>,
     chain_store: Arc<dyn ChainStore>,
     metrics_registry: Arc<dyn MetricsRegistry>,
 }
@@ -52,7 +53,7 @@ impl Chain {
         Chain {
             logger_factory,
             name,
-            firehose_endpoints: Arc::new(firehose_endpoints),
+            client: Arc::new(ChainClient::new_firehose(firehose_endpoints)),
             chain_store,
             metrics_registry,
         }
@@ -120,7 +121,7 @@ impl Blockchain for Chain {
             )
             .unwrap_or_else(|_| panic!("no adapter for network {}", self.name));
 
-        let firehose_endpoint = self.firehose_endpoints.random()?;
+        let firehose_endpoint = self.client.firehose_endpoint()?;
 
         let logger = self
             .logger_factory
@@ -163,7 +164,7 @@ impl Blockchain for Chain {
         logger: &Logger,
         number: BlockNumber,
     ) -> Result<BlockPtr, IngestorError> {
-        let firehose_endpoint = self.firehose_endpoints.random()?;
+        let firehose_endpoint = self.client.firehose_endpoint()?;
 
         firehose_endpoint
             .block_ptr_for_number::<codec::HeaderOnlyBlock>(logger, number)
@@ -173,6 +174,10 @@ impl Blockchain for Chain {
 
     fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapterTrait<Self>> {
         Arc::new(RuntimeAdapter {})
+    }
+
+    fn chain_client(&self) -> Arc<ChainClient<Self>> {
+        self.client.clone()
     }
 }
 

--- a/chain/cosmos/src/chain.rs
+++ b/chain/cosmos/src/chain.rs
@@ -63,6 +63,7 @@ impl Chain {
 impl Blockchain for Chain {
     const KIND: BlockchainKind = BlockchainKind::Cosmos;
 
+    type Client = ();
     type Block = codec::Block;
 
     type DataSource = DataSource;
@@ -172,10 +173,6 @@ impl Blockchain for Chain {
 
     fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapterTrait<Self>> {
         Arc::new(RuntimeAdapter {})
-    }
-
-    fn is_firehose_supported(&self) -> bool {
-        true
     }
 }
 

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -726,7 +726,7 @@ impl From<ProviderStatus> for f64 {
 }
 
 const STATUS_HELP: &str = "0 = ok, 1 = net_version failed, 2 = get genesis failed, 3 = net_version timeout, 4 = get genesis timeout";
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ProviderEthRpcMetrics {
     request_duration: Box<HistogramVec>,
     errors: Box<CounterVec>,

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -426,6 +426,10 @@ impl Blockchain for Chain {
     fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapterTrait<Self>> {
         self.runtime_adapter.clone()
     }
+
+    fn chain_client(&self) -> Arc<ChainClient<Self>> {
+        self.client.clone()
+    }
 }
 
 /// This is used in `EthereumAdapter::triggers_in_block`, called when re-processing a block for

--- a/chain/ethereum/src/env.rs
+++ b/chain/ethereum/src/env.rs
@@ -11,12 +11,6 @@ lazy_static! {
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct EnvVars {
-    /// Controls if firehose should be preferred over RPC if Firehose endpoints
-    /// are present, if not set, the default behavior is is kept which is to
-    /// automatically favor Firehose.
-    ///
-    /// Set by the flag `GRAPH_ETHEREUM_IS_FIREHOSE_PREFERRED`. On by default.
-    pub is_firehose_preferred: bool,
     /// Additional deterministic errors that have not yet been hardcoded.
     ///
     /// Set by the environment variable `GRAPH_GETH_ETH_CALL_ERRORS`, separated
@@ -107,7 +101,6 @@ impl EnvVars {
 impl From<Inner> for EnvVars {
     fn from(x: Inner) -> Self {
         Self {
-            is_firehose_preferred: x.is_firehose_preferred.0,
             get_logs_max_contracts: x.get_logs_max_contracts,
             geth_eth_call_errors: x
                 .geth_eth_call_errors
@@ -143,8 +136,6 @@ impl Default for EnvVars {
 
 #[derive(Clone, Debug, Envconfig)]
 struct Inner {
-    #[envconfig(from = "GRAPH_ETHEREUM_IS_FIREHOSE_PREFERRED", default = "true")]
-    is_firehose_preferred: EnvVarBoolean,
     #[envconfig(from = "GRAPH_GETH_ETH_CALL_ERRORS", default = "")]
     geth_eth_call_errors: String,
     #[envconfig(from = "GRAPH_ETH_GET_LOGS_MAX_CONTRACTS", default = "2000")]

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1502,6 +1502,7 @@ pub(crate) async fn blocks_with_triggers(
     Ok(blocks)
 }
 
+#[inline]
 pub(crate) fn with_cheapest_rpc_adapter(
     adapter: &Arc<ChainClient<Chain>>,
     capabilities: &NodeCapabilities,

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -54,7 +54,7 @@ use crate::{
     TriggerFilter, ENV_VARS,
 };
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct EthereumAdapter {
     logger: Logger,
     url_hostname: Arc<String>,

--- a/chain/ethereum/src/network.rs
+++ b/chain/ethereum/src/network.rs
@@ -13,7 +13,7 @@ use crate::adapter::EthereumAdapter as _;
 use crate::capabilities::NodeCapabilities;
 use crate::EthereumAdapter;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct EthereumNetworkAdapter {
     pub capabilities: NodeCapabilities,
     adapter: Arc<EthereumAdapter>,
@@ -30,7 +30,7 @@ impl EthereumNetworkAdapter {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct EthereumNetworkAdapters {
     pub adapters: Vec<EthereumNetworkAdapter>,
     pub call_only_adapters: Vec<EthereumNetworkAdapter>,

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -43,6 +43,7 @@ impl blockchain::RuntimeAdapter<Chain> for RuntimeAdapter {
     fn host_fns(&self, ds: &DataSource) -> Result<Vec<HostFn>, Error> {
         let abis = ds.mapping.abis.clone();
         let call_cache = self.call_cache.cheap_clone();
+        // Ethereum calls should prioritise call-only adapters if one is available.
         let eth_adapter = self.eth_adapters.call_or_cheapest(Some(&NodeCapabilities {
             archive: ds.mapping.requires_archive()?,
             traces: false,

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -128,6 +128,7 @@ impl Chain {
 impl Blockchain for Chain {
     const KIND: BlockchainKind = BlockchainKind::Near;
 
+    type Client = ();
     type Block = codec::Block;
 
     type DataSource = DataSource;
@@ -220,10 +221,6 @@ impl Blockchain for Chain {
 
     fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapterTrait<Self>> {
         Arc::new(RuntimeAdapter {})
-    }
-
-    fn is_firehose_supported(&self) -> bool {
-        true
     }
 }
 

--- a/chain/substreams/src/block_stream.rs
+++ b/chain/substreams/src/block_stream.rs
@@ -7,6 +7,7 @@ use graph::{
             BlockStream, BlockStreamBuilder as BlockStreamBuilderTrait, FirehoseCursor,
         },
         substreams_block_stream::SubstreamsBlockStream,
+        Blockchain,
     },
     components::store::DeploymentLocator,
     data::subgraph::UnifiedMappingApiVersion,
@@ -39,7 +40,7 @@ impl BlockStreamBuilderTrait<Chain> for BlockStreamBuilder {
         filter: Arc<TriggerFilter>,
         _unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Box<dyn BlockStream<Chain>>> {
-        let firehose_endpoint = chain.endpoints.random()?;
+        let firehose_endpoint = chain.chain_client().firehose_endpoint()?;
 
         let mapper = Arc::new(Mapper {});
 

--- a/chain/substreams/src/chain.rs
+++ b/chain/substreams/src/chain.rs
@@ -73,6 +73,7 @@ impl std::fmt::Debug for Chain {
 impl Blockchain for Chain {
     const KIND: BlockchainKind = BlockchainKind::Substreams;
 
+    type Client = ();
     type Block = Block;
     type DataSource = DataSource;
     type UnresolvedDataSource = UnresolvedDataSource;
@@ -165,10 +166,6 @@ impl Blockchain for Chain {
     }
     fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapterTrait<Self>> {
         Arc::new(RuntimeAdapter {})
-    }
-
-    fn is_firehose_supported(&self) -> bool {
-        true
     }
 }
 

--- a/core/src/subgraph/stream.rs
+++ b/core/src/subgraph/stream.rs
@@ -12,8 +12,7 @@ pub async fn new_block_stream<C: Blockchain>(
     filter: &C::TriggerFilter,
     metrics: &SubgraphInstanceMetrics,
 ) -> Result<Box<dyn BlockStream<C>>, Error> {
-    // let is_firehose = inputs.chain.is_firehose_supported();
-    let is_firehose = true;
+    let is_firehose = inputs.chain.chain_client().is_firehose();
 
     let buffer_size = match is_firehose {
         true => BUFFERED_FIREHOSE_STREAM_SIZE,

--- a/core/src/subgraph/stream.rs
+++ b/core/src/subgraph/stream.rs
@@ -12,7 +12,8 @@ pub async fn new_block_stream<C: Blockchain>(
     filter: &C::TriggerFilter,
     metrics: &SubgraphInstanceMetrics,
 ) -> Result<Box<dyn BlockStream<C>>, Error> {
-    let is_firehose = inputs.chain.is_firehose_supported();
+    // let is_firehose = inputs.chain.is_firehose_supported();
+    let is_firehose = true;
 
     let buffer_size = match is_firehose {
         true => BUFFERED_FIREHOSE_STREAM_SIZE,

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -87,7 +87,6 @@ pub trait BlockStream<C: Blockchain>:
 /// BlockRefetcher abstraction allows a chain to decide if a block must be refetched after a dynamic data source was added
 #[async_trait]
 pub trait BlockRefetcher<C: Blockchain>: Send + Sync {
-    //    type Block: Block + Clone + Debug + Default;
     fn required(&self, chain: &C) -> bool;
 
     async fn get_block(

--- a/graph/src/blockchain/client.rs
+++ b/graph/src/blockchain/client.rs
@@ -1,6 +1,8 @@
-use crate::firehose::FirehoseEndpoints;
+use std::sync::Arc;
 
 use super::Blockchain;
+use crate::firehose::{FirehoseEndpoint, FirehoseEndpoints};
+use anyhow::anyhow;
 
 // EthereumClient represents the mode in which the ethereum chain block can be retrieved,
 // alongside their requirements.
@@ -35,6 +37,13 @@ impl<C: Blockchain> ChainClient<C> {
         match self {
             ChainClient::Firehose(_) => true,
             ChainClient::Rpc(_) => false,
+        }
+    }
+
+    pub fn firehose_endpoint(&self) -> anyhow::Result<Arc<FirehoseEndpoint>> {
+        match self {
+            ChainClient::Firehose(endpoints) => endpoints.random(),
+            _ => Err(anyhow!("rpc unsupported on arweave")),
         }
     }
 }

--- a/graph/src/blockchain/client.rs
+++ b/graph/src/blockchain/client.rs
@@ -1,0 +1,40 @@
+use crate::firehose::FirehoseEndpoints;
+
+use super::Blockchain;
+
+// EthereumClient represents the mode in which the ethereum chain block can be retrieved,
+// alongside their requirements.
+// Rpc requires an rpc client which have different `NodeCapabilities`
+// Firehose requires FirehoseEndpoints and an adapter that can at least resolve eth calls
+// Substreams only requires the FirehoseEndpoints.
+#[derive(Debug)]
+pub enum ChainClient<C: Blockchain> {
+    Firehose(FirehoseEndpoints),
+    Rpc(C::Client),
+}
+
+impl<C: Blockchain> ChainClient<C> {
+    pub fn new_firehose(firehose_endpoints: FirehoseEndpoints) -> Self {
+        Self::new(firehose_endpoints, C::Client::default())
+    }
+    pub fn new(firehose_endpoints: FirehoseEndpoints, adapters: C::Client) -> Self {
+        // If we can get a firehose endpoint then we should prioritise it.
+        // the reason we want to test this by getting an adapter is because
+        // adapter limits in the configuration can effectively disable firehose
+        // by setting a limit to 0.
+        // In this case we should fallback to an rpc client.
+        let firehose_available = firehose_endpoints.random().is_ok();
+
+        match firehose_available {
+            true => Self::Firehose(firehose_endpoints),
+            false => Self::Rpc(adapters),
+        }
+    }
+
+    pub fn is_firehose(&self) -> bool {
+        match self {
+            ChainClient::Firehose(_) => true,
+            ChainClient::Rpc(_) => false,
+        }
+    }
+}

--- a/graph/src/blockchain/client.rs
+++ b/graph/src/blockchain/client.rs
@@ -43,7 +43,14 @@ impl<C: Blockchain> ChainClient<C> {
     pub fn firehose_endpoint(&self) -> anyhow::Result<Arc<FirehoseEndpoint>> {
         match self {
             ChainClient::Firehose(endpoints) => endpoints.random(),
-            _ => Err(anyhow!("rpc unsupported on arweave")),
+            _ => Err(anyhow!("firehose endpoint requested on rpc chain client")),
+        }
+    }
+
+    pub fn rpc(&self) -> anyhow::Result<&C::Client> {
+        match self {
+            Self::Rpc(rpc) => Ok(rpc),
+            _ => Err(anyhow!("rpc endpoint requested on firehose chain client")),
         }
     }
 }

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -10,6 +10,7 @@ use std::{convert::TryFrom, sync::Arc};
 
 use super::{
     block_stream::{self, FirehoseCursor},
+    client::ChainClient,
     HostFn, IngestorError, TriggerWithHandler,
 };
 
@@ -347,6 +348,10 @@ impl Blockchain for MockBlockchain {
     }
 
     fn runtime_adapter(&self) -> std::sync::Arc<dyn RuntimeAdapter<Self>> {
+        todo!()
+    }
+
+    fn chain_client(&self) -> Arc<ChainClient<MockBlockchain>> {
         todo!()
     }
 }

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -271,6 +271,7 @@ impl<C: Blockchain> RuntimeAdapter<C> for MockRuntimeAdapter {
 impl Blockchain for MockBlockchain {
     const KIND: BlockchainKind = BlockchainKind::Ethereum;
 
+    type Client = ();
     type Block = MockBlock;
 
     type DataSource = MockDataSource;
@@ -346,10 +347,6 @@ impl Blockchain for MockBlockchain {
     }
 
     fn runtime_adapter(&self) -> std::sync::Arc<dyn RuntimeAdapter<Self>> {
-        todo!()
-    }
-
-    fn is_firehose_supported(&self) -> bool {
         todo!()
     }
 }

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -122,12 +122,22 @@ impl ChainStoreBlock {
     }
 }
 
+// // ChainClient represents the type of client used to ingest data from the chain. For most chains
+// // this will be either firehose or some sort of rpc client.
+// // If a specific chain requires more than one adapter this should be handled by the chain specifically
+// // as it's not common behavior across chains.
+// pub enum ChainClient<C: Blockchain> {
+//     Firehose(FirehoseEndpoints),
+//     Rpc(C::Client),
+// }
+
 #[async_trait]
 // This is only `Debug` because some tests require that
 pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
     const KIND: BlockchainKind;
     const ALIASES: &'static [&'static str] = &[];
 
+    type Client: Debug;
     // The `Clone` bound is used when reprocessing a block, because `triggers_in_block` requires an
     // owned `Block`. It would be good to come up with a way to remove this bound.
     type Block: Block + Clone + Debug + Default;
@@ -192,8 +202,6 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
     fn is_refetch_block_required(&self) -> bool;
 
     fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapter<Self>>;
-
-    fn is_firehose_supported(&self) -> bool;
 }
 
 #[derive(Error, Debug)]

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -46,7 +46,10 @@ pub use block_stream::{ChainHeadUpdateListener, ChainHeadUpdateStream, TriggersA
 pub use empty_node_capabilities::EmptyNodeCapabilities;
 pub use types::{BlockHash, BlockPtr, ChainIdentifier};
 
-use self::block_stream::{BlockStream, FirehoseCursor};
+use self::{
+    block_stream::{BlockStream, FirehoseCursor},
+    client::ChainClient,
+};
 
 pub trait TriggersAdapterSelector<C: Blockchain>: Sync + Send {
     fn triggers_adapter(
@@ -203,6 +206,8 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
     fn is_refetch_block_required(&self) -> bool;
 
     fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapter<Self>>;
+
+    fn chain_client(&self) -> Arc<ChainClient<Self>>;
 }
 
 #[derive(Error, Debug)]

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -3,6 +3,7 @@
 //! trait which is the centerpiece of this module.
 
 pub mod block_stream;
+pub mod client;
 mod empty_node_capabilities;
 pub mod firehose_block_ingestor;
 pub mod firehose_block_stream;
@@ -137,7 +138,7 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
     const KIND: BlockchainKind;
     const ALIASES: &'static [&'static str] = &[];
 
-    type Client: Debug;
+    type Client: Debug + Default;
     // The `Clone` bound is used when reprocessing a block, because `triggers_in_block` requires an
     // owned `Block`. It would be good to come up with a way to remove this bound.
     type Block: Block + Clone + Debug + Default;

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,12 +1,11 @@
 use clap::Parser as _;
-use ethereum::chain::{
-    EthereumAdapterSelector, EthereumBlockRefetcher, EthereumClient, EthereumStreamBuilder,
-};
+use ethereum::chain::{EthereumAdapterSelector, EthereumBlockRefetcher, EthereumStreamBuilder};
 use ethereum::codec::HeaderOnlyBlock;
 use ethereum::{
     BlockIngestor as EthereumBlockIngestor, EthereumAdapterTrait, EthereumNetworks, RuntimeAdapter,
 };
 use git_testament::{git_testament, render_testament};
+use graph::blockchain::client::ChainClient;
 use graph::blockchain::firehose_block_ingestor::{FirehoseBlockIngestor, Transforms};
 use graph::blockchain::{Block as BlockchainBlock, Blockchain, BlockchainKind, BlockchainMap};
 use graph::components::store::BlockStore;
@@ -706,7 +705,7 @@ fn ethereum_networks_as_chains(
                 .and_then(|v| v.networks.get(network_name))
                 .map_or_else(|| FirehoseEndpoints::new(), |v| v.clone());
 
-            let client = Arc::new(EthereumClient::new(
+            let client = Arc::new(ChainClient::<graph_chain_ethereum::Chain>::new(
                 firehose_endpoints,
                 eth_adapters.clone(),
             ));

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -383,7 +383,7 @@ async fn main() {
                 let (firehose_eth_chains, polling_eth_chains): (HashMap<_, _>, HashMap<_, _>) =
                     ethereum_chains
                         .into_iter()
-                        .partition(|(_, chain)| chain.client.is_firehose());
+                        .partition(|(_, chain)| chain.chain_client().is_firehose());
 
                 start_block_ingestor(
                     &logger,
@@ -731,9 +731,7 @@ fn ethereum_networks_as_chains(
                 client.clone(),
                 chain_head_update_listener.clone(),
                 Arc::new(EthereumStreamBuilder {}),
-                Arc::new(EthereumBlockRefetcher {
-                    requires_refetch: client.is_firehose(),
-                }),
+                Arc::new(EthereumBlockRefetcher {}),
                 Arc::new(adapter_selector),
                 runtime_adapter,
                 ethereum::ENV_VARS.reorg_threshold,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,5 +1,7 @@
 use clap::Parser as _;
-use ethereum::chain::{EthereumAdapterSelector, EthereumBlockRefetcher, EthereumStreamBuilder};
+use ethereum::chain::{
+    EthereumAdapterSelector, EthereumBlockRefetcher, EthereumClient, EthereumStreamBuilder,
+};
 use ethereum::codec::HeaderOnlyBlock;
 use ethereum::{
     BlockIngestor as EthereumBlockIngestor, EthereumAdapterTrait, EthereumNetworks, RuntimeAdapter,
@@ -382,7 +384,7 @@ async fn main() {
                 let (firehose_eth_chains, polling_eth_chains): (HashMap<_, _>, HashMap<_, _>) =
                     ethereum_chains
                         .into_iter()
-                        .partition(|(_, chain)| chain.is_firehose_supported());
+                        .partition(|(_, chain)| chain.client.is_firehose());
 
                 start_block_ingestor(
                     &logger,
@@ -700,16 +702,17 @@ fn ethereum_networks_as_chains(
                 })
         })
         .map(|(network_name, eth_adapters, chain_store, is_ingestible)| {
-            let firehose_endpoints = firehose_networks.and_then(|v| v.networks.get(network_name));
+            let firehose_endpoints = firehose_networks
+                .and_then(|v| v.networks.get(network_name))
+                .map_or_else(|| FirehoseEndpoints::new(), |v| v.clone());
 
+            let client = Arc::new(EthereumClient::new(
+                firehose_endpoints,
+                eth_adapters.clone(),
+            ));
             let adapter_selector = EthereumAdapterSelector::new(
                 logger_factory.clone(),
-                Arc::new(eth_adapters.clone()),
-                Arc::new(
-                    firehose_endpoints
-                        .map(|fe| fe.clone())
-                        .unwrap_or(FirehoseEndpoints::new()),
-                ),
+                client.clone(),
                 registry.clone(),
                 chain_store.clone(),
             );
@@ -726,11 +729,12 @@ fn ethereum_networks_as_chains(
                 registry.clone(),
                 chain_store.cheap_clone(),
                 chain_store,
-                firehose_endpoints.map_or_else(|| FirehoseEndpoints::new(), |v| v.clone()),
-                eth_adapters.clone(),
+                client.clone(),
                 chain_head_update_listener.clone(),
                 Arc::new(EthereumStreamBuilder {}),
-                Arc::new(EthereumBlockRefetcher {}),
+                Arc::new(EthereumBlockRefetcher {
+                    requires_refetch: client.is_firehose(),
+                }),
                 Arc::new(adapter_selector),
                 runtime_adapter,
                 ethereum::ENV_VARS.reorg_threshold,

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -127,9 +127,7 @@ pub async fn run(
         client.clone(),
         chain_head_update_listener,
         Arc::new(EthereumStreamBuilder {}),
-        Arc::new(EthereumBlockRefetcher {
-            requires_refetch: client.is_firehose(),
-        }),
+        Arc::new(EthereumBlockRefetcher {}),
         Arc::new(EthereumAdapterSelector::new(
             logger_factory.clone(),
             client,

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -10,11 +10,10 @@ use crate::config::Config;
 use crate::manager::PanicSubscriptionManager;
 use crate::store_builder::StoreBuilder;
 use crate::MetricsContext;
-use ethereum::chain::{
-    EthereumAdapterSelector, EthereumBlockRefetcher, EthereumClient, EthereumStreamBuilder,
-};
+use ethereum::chain::{EthereumAdapterSelector, EthereumBlockRefetcher, EthereumStreamBuilder};
 use ethereum::{ProviderEthRpcMetrics, RuntimeAdapter as EthereumRuntimeAdapter};
 use graph::anyhow::{bail, format_err};
+use graph::blockchain::client::ChainClient;
 use graph::blockchain::{BlockchainKind, BlockchainMap};
 use graph::cheap_clone::CheapClone;
 use graph::components::store::{BlockStore as _, DeploymentLocator};
@@ -116,7 +115,7 @@ pub async fn run(
         .chain_store(network_name.as_ref())
         .expect(format!("No chain store for {}", &network_name).as_ref());
 
-    let client = Arc::new(EthereumClient::new(firehose_endpoints, eth_adapters));
+    let client = Arc::new(ChainClient::new(firehose_endpoints, eth_adapters));
 
     let chain = ethereum::Chain::new(
         logger_factory.clone(),

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -6,6 +6,7 @@ use super::{
     test_ptr, MutexBlockStreamBuilder, NoopAdapterSelector, NoopRuntimeAdapter,
     StaticBlockRefetcher, StaticStreamBuilder, Stores, TestChain, NODE_ID,
 };
+use graph::blockchain::client::ChainClient;
 use graph::blockchain::{BlockPtr, TriggersAdapterSelector};
 use graph::cheap_clone::CheapClone;
 use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints, SubgraphLimit};
@@ -13,8 +14,6 @@ use graph::prelude::ethabi::ethereum_types::H256;
 use graph::prelude::web3::types::{Address, Log, Transaction, H160};
 use graph::prelude::{ethabi, tiny_keccak, LightEthereumBlock, LoggerFactory, NodeId};
 use graph::{blockchain::block_stream::BlockWithTriggers, prelude::ethabi::ethereum_types::U64};
-use graph_chain_ethereum::chain::EthereumClient;
-use graph_chain_ethereum::network::EthereumNetworkAdapters;
 use graph_chain_ethereum::{
     chain::BlockFinality,
     trigger::{EthereumBlockTriggerType, EthereumTrigger},
@@ -50,13 +49,7 @@ pub async fn chain(
     ))]
     .into();
 
-    let client = Arc::new(EthereumClient::new(
-        firehose_endpoints,
-        EthereumNetworkAdapters {
-            adapters: vec![],
-            call_only_adapters: vec![],
-        },
-    ));
+    let client = Arc::new(ChainClient::<Chain>::new_firehose(firehose_endpoints));
 
     let static_block_stream = Arc::new(StaticStreamBuilder { chain: blocks });
     let block_stream_builder = Arc::new(MutexBlockStreamBuilder(Mutex::new(static_block_stream)));

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -13,6 +13,7 @@ use graph::prelude::ethabi::ethereum_types::H256;
 use graph::prelude::web3::types::{Address, Log, Transaction, H160};
 use graph::prelude::{ethabi, tiny_keccak, LightEthereumBlock, LoggerFactory, NodeId};
 use graph::{blockchain::block_stream::BlockWithTriggers, prelude::ethabi::ethereum_types::U64};
+use graph_chain_ethereum::chain::EthereumClient;
 use graph_chain_ethereum::network::EthereumNetworkAdapters;
 use graph_chain_ethereum::{
     chain::BlockFinality,
@@ -49,6 +50,14 @@ pub async fn chain(
     ))]
     .into();
 
+    let client = Arc::new(EthereumClient::new(
+        firehose_endpoints,
+        EthereumNetworkAdapters {
+            adapters: vec![],
+            call_only_adapters: vec![],
+        },
+    ));
+
     let static_block_stream = Arc::new(StaticStreamBuilder { chain: blocks });
     let block_stream_builder = Arc::new(MutexBlockStreamBuilder(Mutex::new(static_block_stream)));
 
@@ -59,11 +68,7 @@ pub async fn chain(
         mock_registry.clone(),
         chain_store.cheap_clone(),
         chain_store,
-        firehose_endpoints,
-        EthereumNetworkAdapters {
-            adapters: vec![],
-            call_only_adapters: vec![],
-        },
+        client,
         stores.chain_head_listener.cheap_clone(),
         block_stream_builder.clone(),
         Arc::new(StaticBlockRefetcher { x: PhantomData }),


### PR DESCRIPTION
- Remove IS_FIREHOSE_PREFERRED env var as it was being poorly handled in different parts of the code
- Introduce EthereumClient which decouples the decision of which endpoint to use
- Remove is_firehose_supported in favour of checking the endpoint type
- Building blocks to refactor the ingestor, block stream building and TriggersAdapter for firehose
- Try to fix the flaky createdb operation

