### PR TITLE
node, store: Warn if reassigning to a new node

### DIFF
--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -58,5 +58,14 @@ pub fn reassign(
     };
     conn.send_store_event(sender, &StoreEvent::new(changes))?;
 
+    // It's easy to make a typo in the name of the node; if this operation
+    // assigns to a node that wasn't used before, warn the user that they
+    // might have mistyped the node name
+    let mirror = catalog::Mirror::primary_only(primary);
+    let count = mirror.assignments(&node)?.len();
+    if count == 1 {
+        println!("warning: this is the only deployment assigned to {node}");
+        println!("         are you sure it is spelled correctly?");
+    }
     Ok(())
 }

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -71,11 +71,11 @@ pub mod command_support {
         pub use crate::block_store::primary as block_store;
         pub use crate::catalog::{account_like, stats};
         pub use crate::copy::{copy_state, copy_table_state};
-        pub use crate::primary::Connection;
         pub use crate::primary::{
             active_copies, deployment_schemas, ens_names, subgraph, subgraph_deployment_assignment,
             subgraph_version, Site,
         };
+        pub use crate::primary::{Connection, Mirror};
     }
     pub mod index {
         pub use crate::relational::index::{CreateIndex, Method};

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1566,6 +1566,15 @@ impl Mirror {
         Mirror { pools }
     }
 
+    /// Create a mirror that only uses the primary. Such a mirror will not
+    /// be able to do anything if the primary is down, and should only be
+    /// used for non-critical uses like command line tools
+    pub fn primary_only(primary: ConnectionPool) -> Mirror {
+        Mirror {
+            pools: vec![primary],
+        }
+    }
+
     /// Execute the function `f` with connections from each of our pools in
     /// order until for one of them we get any result other than
     /// `Err(StoreError::DatabaseUnavailable)`. In other words, we try to


### PR DESCRIPTION
Making a sharp edge a little less sharp by warning users that they might have typoed a node name