### PR TITLE
Enforce Clippy in the CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
+# Warnings create a lot of noise, we only print errors.
 check-clippy = "clippy --no-deps -- --allow warnings"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+check-clippy = "clippy --no-deps -- --allow warnings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
           args: --all -- --check
 
   clippy:
-    name: Report Clippy warnings
+    name: Clippy linting
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -165,15 +165,14 @@ jobs:
       # Unlike rustfmt, Clippy actually compiles stuff so it benefits from
       # caching.
       - uses: Swatinem/rust-cache@v2
-
+      - name: Install deps
+        run: sudo apt-get install -y protobuf-compiler
       - name: Run Clippy
         uses: actions-rs/cargo@v1
-        # We do *not* block builds if Clippy complains. It's just here to let us
-        # keep an eye out on the warnings it produces.
-        continue-on-error: true
         with:
           command: clippy
-          args: --no-deps
+          # Warnings create a lot of noise, we only print errors.
+          args: --no-deps -- --allow warnings
 
   release-check:
     name: Build in release mode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,9 +170,7 @@ jobs:
       - name: Run Clippy
         uses: actions-rs/cargo@v1
         with:
-          command: clippy
-          # Warnings create a lot of noise, we only print errors.
-          args: --no-deps -- --allow warnings
+          command: check-clippy
 
   release-check:
     name: Build in release mode

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -327,7 +327,7 @@ impl EthereumLogFilter {
         let mut filters = self
             .wildcard_events
             .into_keys()
-            .map(|event| EthGetLogsFilter::from_event(event))
+            .map(EthGetLogsFilter::from_event)
             .collect_vec();
 
         // The current algorithm is to repeatedly find the maximum cardinality vertex and turn all

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -176,7 +176,7 @@ impl TriggersAdapterSelector<Chain> for EthereumAdapterSelector {
             chain_client: self.client.cheap_clone(),
             chain_store: self.chain_store.cheap_clone(),
             unified_api_version,
-            capabilities: capabilities.clone(),
+            capabilities: *capabilities,
         };
         Ok(Arc::new(adapter))
     }

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1528,7 +1528,7 @@ pub(crate) async fn get_calls(
             } else {
                 client
                     .rpc()?
-                    .cheapest_with(&capabilities)?
+                    .cheapest_with(capabilities)?
                     .calls_in_block(
                         &logger,
                         subgraph_metrics.clone(),
@@ -1961,7 +1961,7 @@ async fn get_logs_and_transactions(
 
     // Obtain receipts externally
     let transaction_receipts_by_hash = get_transaction_receipts_for_transaction_hashes(
-        &adapter,
+        adapter,
         &transaction_hashes_by_block,
         subgraph_metrics,
         logger.cheap_clone(),

--- a/graph/src/data/graphql/effort.rs
+++ b/graph/src/data/graphql/effort.rs
@@ -494,9 +494,9 @@ impl LoadManager {
 #[async_trait]
 impl QueryLoadManager for LoadManager {
     fn record_work(&self, shape_hash: u64, duration: Duration, cache_status: CacheStatus) {
-        self.query_counters
-            .get(&cache_status)
-            .map(|counter| counter.inc());
+        if let Some(counter) = self.query_counters.get(&cache_status) {
+            counter.inc()
+        }
         if !ENV_VARS.load_management_is_disabled() {
             self.effort.add(shape_hash, duration, &self.effort_gauge);
         }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -64,7 +64,7 @@ impl NodeId {
         let s = s.into();
 
         // Enforce minimum and maximum length limit
-        if s.len() > 63 || s.len() < 1 {
+        if s.len() > 63 || s.is_empty() {
             return Err(());
         }
 
@@ -935,7 +935,7 @@ fn entity_validation() {
         let key = EntityKey::data("Thing".to_owned(), id.clone());
 
         let err = thing.validate(&schema, &key);
-        if errmsg == "" {
+        if errmsg.is_empty() {
             assert!(
                 err.is_ok(),
                 "checking entity {}: expected ok but got {}",

--- a/graph/src/data/subgraph/api_version.rs
+++ b/graph/src/data/subgraph/api_version.rs
@@ -59,7 +59,7 @@ impl UnifiedMappingApiVersion {
 
         let unified_version: Option<Version> = match (all_below_referential_version, all_the_same) {
             (false, false) => return Err(DifferentMappingApiVersions(unique_versions)),
-            (false, true) => Some(unique_versions.iter().nth(0).unwrap().clone()),
+            (false, true) => Some(unique_versions.iter().next().unwrap().clone()),
             (true, _) => None,
         };
 

--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -124,7 +124,7 @@ impl FirehoseEndpoint {
     // inside FirehoseEndpoints that is not used (is always cloned).
     pub fn has_subgraph_capacity(self: &Arc<Self>) -> bool {
         self.subgraph_limit
-            .has_capacity(Arc::strong_count(self).checked_sub(1).unwrap_or(0))
+            .has_capacity(Arc::strong_count(self).saturating_sub(1))
     }
 
     pub async fn get_block<M>(

--- a/graphql/src/schema/ast.rs
+++ b/graphql/src/schema/ast.rs
@@ -446,7 +446,7 @@ fn entity_validation() {
         let key = EntityKey::data("Thing".to_owned(), id.clone());
 
         let err = thing.validate(&schema, &key);
-        if errmsg == "" {
+        if errmsg.is_empty() {
             assert!(
                 err.is_ok(),
                 "checking entity {}: expected ok but got {}",

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -557,7 +557,7 @@ fn build_order_by(
                 if entity.is_interface() {
                     return Err(QueryExecutionError::OrderByNotSupportedError(
                         entity.name().to_owned(),
-                        parent_field_name.clone(),
+                        parent_field_name,
                     ));
                 }
 
@@ -632,12 +632,8 @@ fn build_order_by(
             }
         },
         _ => match field.argument_value("text") {
-            Some(r::Value::Object(filter)) => {
-                build_fulltext_order_by_from_object(filter).map(|order_by| match order_by {
-                    Some((attr, value)) => Some((attr, value, None)),
-                    None => None,
-                })
-            }
+            Some(r::Value::Object(filter)) => build_fulltext_order_by_from_object(filter)
+                .map(|order_by| order_by.map(|(attr, value)| (attr, value, None))),
             None => Ok(None),
             _ => Err(QueryExecutionError::InvalidFilterError),
         },

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -282,7 +282,7 @@ impl Shard {
         }
         Ok(Self {
             connection: postgres_url.clone(),
-            weight: opt.postgres_host_weights.get(0).cloned().unwrap_or(1),
+            weight: opt.postgres_host_weights.first().cloned().unwrap_or(1),
             pool_size,
             fdw_pool_size: PoolSize::five(),
             replicas,

--- a/node/src/manager/commands/copy.rs
+++ b/node/src/manager/commands/copy.rs
@@ -315,7 +315,7 @@ pub fn status(pools: HashMap<Shard, ConnectionPool>, dst: &DeploymentSearch) -> 
     let mut lst = List::new(lst);
     lst.append(vals);
     lst.render();
-    println!("");
+    println!();
 
     println!(
         "{:^30} | {:^8} | {:^8} | {:^8} | {:^8}",

--- a/node/src/manager/commands/prune.rs
+++ b/node/src/manager/commands/prune.rs
@@ -74,7 +74,7 @@ impl PruneReporter for Progress {
             self.analyze_start.elapsed().as_secs()
         );
         show_stats(stats, HashSet::new()).ok();
-        println!("");
+        println!();
     }
 
     fn copy_final_start(&mut self, earliest_block: BlockNumber, final_block: BlockNumber) {
@@ -88,7 +88,7 @@ impl PruneReporter for Progress {
     fn copy_final_batch(&mut self, table: &str, _rows: usize, total_rows: usize, finished: bool) {
         print_copy_row(table, total_rows, self.table_start.elapsed());
         if finished {
-            println!("");
+            println!();
             self.table_start = Instant::now();
         }
         std::io::stdout().flush().ok();
@@ -128,7 +128,7 @@ impl PruneReporter for Progress {
     ) {
         print_copy_row(table, total_rows, self.table_start.elapsed());
         if finished {
-            println!("");
+            println!();
             self.table_start = Instant::now();
         }
         std::io::stdout().flush().ok();

--- a/node/src/manager/commands/txn_speed.rs
+++ b/node/src/manager/commands/txn_speed.rs
@@ -41,7 +41,7 @@ pub fn run(pool: ConnectionPool, delay: u64) -> Result<(), anyhow::Error> {
     );
     sleep(Duration::from_secs(delay));
     println!("Number of transactions/minute");
-    println!("{:10} {:>7} {}", "database", "all", "write");
+    println!("{:10} {:>7} write", "database", "all");
     for (datname, all_txn, write_txn) in query(&conn)? {
         let (all_speed, write_speed) = speeds
             .get(&datname)

--- a/runtime/derive/src/generate_array_type.rs
+++ b/runtime/derive/src/generate_array_type.rs
@@ -25,7 +25,7 @@ pub fn generate_array_type(metadata: TokenStream, input: TokenStream) -> TokenSt
         .collect::<Vec<String>>();
 
     assert!(
-        args.len() > 0,
+        !args.is_empty(),
         "arguments not found! generate_array_type(<network-name>)"
     );
 

--- a/runtime/derive/src/generate_network_type_id.rs
+++ b/runtime/derive/src/generate_network_type_id.rs
@@ -34,7 +34,7 @@ pub fn generate_network_type_id(metadata: TokenStream, input: TokenStream) -> To
         .collect::<Vec<String>>();
 
     assert!(
-        args.len() > 0,
+        !args.is_empty(),
         "arguments not found! generate_network_type_id(<network-name>)"
     );
 

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -9,7 +9,7 @@ use graph_chain_ethereum::{Chain, DataSource};
 use graph_mock::MockMetricsRegistry;
 use graph_runtime_wasm::asc_abi::class::{Array, AscBigInt, AscEntity, AscString, Uint8Array};
 use graph_runtime_wasm::{ExperimentalFeatures, ValidModule, WasmInstance};
-use hex;
+
 use semver::Version;
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
@@ -464,7 +464,7 @@ async fn run_ipfs_map(
 
         // Invoke the callback
         let func = module.get_func("ipfsMap").typed().unwrap().clone();
-        let _: () = func.call((value.wasm_ptr(), user_data.wasm_ptr()))?;
+        func.call((value.wasm_ptr(), user_data.wasm_ptr()))?;
         let mut mods = module
             .take_ctx()
             .ctx

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -316,7 +316,7 @@ impl Layout {
                     i as u32,
                     catalog
                         .entities_with_causality_region
-                        .contains(&EntityType::from(obj_type.clone())),
+                        .contains(&EntityType::from(*obj_type)),
                 )
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -3280,11 +3280,9 @@ impl<'a> SortKey<'a> {
                 out.push_sql("order by g$parent_id, ");
                 SortKey::sort_expr(column, value, direction, None, None, out)
             }
-            SortKey::ChildKey(_) => {
-                return Err(diesel::result::Error::QueryBuilderError(
-                    "SortKey::ChildKey cannot be used for parent ordering (yet)".into(),
-                ));
-            }
+            SortKey::ChildKey(_) => Err(diesel::result::Error::QueryBuilderError(
+                "SortKey::ChildKey cannot be used for parent ordering (yet)".into(),
+            )),
         }
     }
 

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -3027,7 +3027,7 @@ impl<'a> SortKey<'a> {
                                 child_join_column: asd.child_join_column,
                                 sort_by_column: asd.sort_by_column,
                                 prefix: asd.prefix.clone(),
-                                direction: asd.direction.clone(),
+                                direction: asd.direction,
                             })
                             .collect(),
                     )))

--- a/tests/src/docker_utils.rs
+++ b/tests/src/docker_utils.rs
@@ -118,7 +118,7 @@ impl ServiceContainer {
         let client =
             Docker::connect_with_local_defaults().expect("Failed to connect to docker daemon.");
         let container_name =
-            format!("{}-{}", service.name(), uuid::Uuid::new_v4()).replace("-", "_");
+            format!("{}-{}", service.name(), uuid::Uuid::new_v4()).replace('-', "_");
 
         let docker_test_client = Self {
             container_name: container_name.clone(),

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -315,7 +315,7 @@ async fn run_integration_test(
     ganache_hard_wait: Duration,
 ) -> anyhow::Result<IntegrationTestSummary> {
     let db_name =
-        format!("{}-{}", basename(&test_directory), uuid::Uuid::new_v4()).replace("-", "_");
+        format!("{}-{}", basename(&test_directory), uuid::Uuid::new_v4()).replace('-', "_");
 
     let (ganache, _) = tokio::try_join!(
         // Start a dedicated Ganache container for this test.


### PR DESCRIPTION
Now that we've merged https://github.com/graphprotocol/graph-node/pull/4349, we can start enforcing Clippy on the CI. The defaults look like a good choice for now.