### PR TITLE
Remove unused env. vars.

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -85,8 +85,6 @@ those.
 
 - `GRAPH_GRAPHQL_QUERY_TIMEOUT`: maximum execution time for a graphql query, in
   seconds. Default is unlimited.
-- `SUBSCRIPTION_THROTTLE_INTERVAL`: while a subgraph is syncing, subscriptions
-  to that subgraph get updated at most this often, in ms. Default is 1000ms.
 - `GRAPH_GRAPHQL_MAX_COMPLEXITY`: maximum complexity for a graphql query. See
   [here](https://developer.github.com/v4/guides/resource-limitations) for what
   that means. Default is unlimited. Typical introspection queries have a

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -579,11 +579,6 @@ impl<C: Blockchain> UnvalidatedSubgraphManifest<C> {
             });
 
         if let Some(graft) = &self.0.graft {
-            if ENV_VARS.disable_grafts {
-                errors.push(SubgraphManifestValidationError::GraftBaseInvalid(
-                    "Grafting of subgraphs is currently disabled".to_owned(),
-                ));
-            }
             if validate_graft_base {
                 if let Err(graft_err) = graft.validate(store).await {
                     errors.push(graft_err);

--- a/graph/src/env/graphql.rs
+++ b/graph/src/env/graphql.rs
@@ -8,7 +8,6 @@ pub struct EnvVarsGraphQl {
     pub enable_validations: bool,
     /// Set by the flag `SILENT_GRAPHQL_VALIDATIONS`. On by default.
     pub silent_graphql_validations: bool,
-    pub subscription_throttle_interval: Duration,
     /// This is the timeout duration for SQL queries.
     ///
     /// If it is not set, no statement timeout will be enforced. The statement
@@ -109,9 +108,6 @@ impl From<InnerGraphQl> for EnvVarsGraphQl {
         Self {
             enable_validations: x.enable_validations.0,
             silent_graphql_validations: x.silent_graphql_validations.0,
-            subscription_throttle_interval: Duration::from_millis(
-                x.subscription_throttle_interval_in_ms,
-            ),
             sql_statement_timeout: x.sql_statement_timeout_in_secs.map(Duration::from_secs),
             cached_subgraph_ids: if x.cached_subgraph_ids == "*" {
                 CachedSubgraphIds::All
@@ -152,8 +148,6 @@ pub struct InnerGraphQl {
     enable_validations: EnvVarBoolean,
     #[envconfig(from = "SILENT_GRAPHQL_VALIDATIONS", default = "true")]
     silent_graphql_validations: EnvVarBoolean,
-    #[envconfig(from = "SUBSCRIPTION_THROTTLE_INTERVAL", default = "1000")]
-    subscription_throttle_interval_in_ms: u64,
     #[envconfig(from = "GRAPH_SQL_STATEMENT_TIMEOUT")]
     sql_statement_timeout_in_secs: Option<u64>,
 

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -5,14 +5,7 @@ mod store;
 use envconfig::Envconfig;
 use lazy_static::lazy_static;
 use semver::Version;
-use std::{
-    collections::HashSet,
-    env::VarError,
-    fmt,
-    str::FromStr,
-    sync::atomic::{AtomicBool, Ordering},
-    time::Duration,
-};
+use std::{collections::HashSet, env::VarError, fmt, str::FromStr, time::Duration};
 
 use self::graphql::*;
 use self::mappings::*;
@@ -21,41 +14,8 @@ use crate::{
     components::subgraph::SubgraphVersionSwitchingMode, runtime::gas::CONST_MAX_GAS_PER_HANDLER,
 };
 
-pub static UNSAFE_CONFIG: AtomicBool = AtomicBool::new(false);
-
 lazy_static! {
     pub static ref ENV_VARS: EnvVars = EnvVars::from_env().unwrap();
-}
-
-// This is currently unused but is kept as a potentially useful mechanism.
-/// Panics if:
-/// - The value is not UTF8.
-/// - The value cannot be parsed as T.
-/// - The value differs from the default, and `--unsafe-config` flag is not set.
-pub fn unsafe_env_var<E: std::error::Error + Send + Sync, T: FromStr<Err = E> + Eq>(
-    name: &'static str,
-    default_value: T,
-) -> T {
-    let var = match std::env::var(name) {
-        Ok(var) => var,
-        Err(VarError::NotPresent) => return default_value,
-        Err(VarError::NotUnicode(_)) => panic!("environment variable {} is not UTF8", name),
-    };
-
-    let value = var
-        .parse::<T>()
-        .unwrap_or_else(|e| panic!("failed to parse environment variable {}: {}", name, e));
-
-    if !UNSAFE_CONFIG.load(Ordering::SeqCst) && value != default_value {
-        panic!(
-            "unsafe environment variable {} is set. The recommended action is to unset it. \
-             If this is not an indexer on the network, \
-             you may provide the `--unsafe-config` to allow setting this variable.",
-            name
-        )
-    }
-
-    value
 }
 
 /// Panics if:

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -112,8 +112,6 @@ pub struct EnvVars {
     /// Set by the environment variable `GRAPH_MAX_SPEC_VERSION`. The default
     /// value is `0.0.7`.
     pub max_spec_version: Version,
-    /// Set by the flag `GRAPH_DISABLE_GRAFTS`.
-    pub disable_grafts: bool,
     /// Set by the environment variable `GRAPH_LOAD_WINDOW_SIZE` (expressed in
     /// seconds). The default value is 300 seconds.
     pub load_window_size: Duration,
@@ -227,7 +225,6 @@ impl EnvVars {
                 .0
                 || cfg!(debug_assertions),
             max_spec_version: inner.max_spec_version,
-            disable_grafts: inner.disable_grafts.0,
             load_window_size: Duration::from_secs(inner.load_window_size_in_secs),
             load_bin_size: Duration::from_secs(inner.load_bin_size_in_secs),
             elastic_search_flush_interval: Duration::from_secs(
@@ -315,8 +312,6 @@ struct Inner {
     allow_non_deterministic_fulltext_search: EnvVarBoolean,
     #[envconfig(from = "GRAPH_MAX_SPEC_VERSION", default = "0.0.7")]
     max_spec_version: Version,
-    #[envconfig(from = "GRAPH_DISABLE_GRAFTS", default = "false")]
-    disable_grafts: EnvVarBoolean,
     #[envconfig(from = "GRAPH_LOAD_WINDOW_SIZE", default = "300")]
     load_window_size_in_secs: u64,
     #[envconfig(from = "GRAPH_LOAD_BIN_SIZE", default = "1")]

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -44,7 +44,6 @@ use near::NearStreamBuilder;
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use std::sync::atomic;
 use std::time::Duration;
 use std::{collections::HashMap, env};
 use tokio::sync::mpsc;
@@ -105,11 +104,6 @@ async fn main() {
         "Graph Node version: {}",
         render_testament!(TESTAMENT)
     );
-
-    if opt.unsafe_config {
-        warn!(logger, "allowing unsafe configurations");
-        graph::env::UNSAFE_CONFIG.store(true, atomic::Ordering::SeqCst);
-    }
 
     if !graph_server_index_node::PoiProtection::from_env(&ENV_VARS).is_active() {
         warn!(


### PR DESCRIPTION
- `SUBSCRIPTION_THROTTLE_INTERVAL` is currently not referenced anywhere in the code, so it's safe to delete.
- `GRAPH_DISABLE_GRAFTS` is a remnant from the dark old days when we grafting was still in development and performance was unacceptable, so we wanted to disable it on the hosted service. I think it's safe to delete now.
- We don't use `unsafe_env_vars`, it's effectively dead code, so it should be removed.