### PR TITLE
all: Indicate whether to only locate active deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         id: runner-tests-1
         uses: actions-rs/cargo@v1
         env:
-          TESTS_GANACHE_HARD_WAIT_SECONDS: "30"
+          TESTS_GANACHE_HARD_WAIT_SECONDS: "60"
         with:
           command: test
           args: --verbose --package graph-tests -- --skip parallel_integration_tests

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -411,21 +411,10 @@ where
         hash: &DeploymentHash,
         node_id: &NodeId,
     ) -> Result<(), SubgraphRegistrarError> {
-        let locations = self.store.locators(hash)?;
-        let deployment = match locations.len() {
-            0 => return Err(SubgraphRegistrarError::DeploymentNotFound(hash.to_string())),
-            1 => locations[0].clone(),
-            _ => {
-                return Err(SubgraphRegistrarError::StoreError(
-                    anyhow!(
-                        "there are {} different deployments with id {}",
-                        locations.len(),
-                        hash.as_str()
-                    )
-                    .into(),
-                ))
-            }
-        };
+        let locator = self.store.active_locator(hash)?;
+        let deployment =
+            locator.ok_or_else(|| SubgraphRegistrarError::DeploymentNotFound(hash.to_string()))?;
+
         self.store.reassign_subgraph(&deployment, node_id)?;
 
         Ok(())

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -156,8 +156,12 @@ pub trait SubgraphStore: Send + Sync + 'static {
 
     async fn is_healthy(&self, id: &DeploymentHash) -> Result<bool, StoreError>;
 
-    /// Find the deployment locators for the subgraph with the given hash
+    /// Find all deployment locators for the subgraph with the given hash.
     fn locators(&self, hash: &str) -> Result<Vec<DeploymentLocator>, StoreError>;
+
+    /// Find the deployment locator for the active deployment with the given
+    /// hash. Returns `None` if there is no deployment with that hash
+    fn active_locator(&self, hash: &str) -> Result<Option<DeploymentLocator>, StoreError>;
 
     /// This migrates subgraphs that existed before the raw_yaml column was added.
     async fn set_manifest_raw_yaml(

--- a/graphql/tests/query.rs
+++ b/graphql/tests/query.rs
@@ -138,7 +138,7 @@ async fn setup(
 
     global_init();
     let id = DeploymentHash::new(id).unwrap();
-    let loc = store.subgraph_store().locators(&id).unwrap().pop();
+    let loc = store.subgraph_store().active_locator(&id).unwrap();
 
     match loc {
         Some(loc) if id_type.deployment_id() == loc.hash.as_str() => loc,

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1397,6 +1397,17 @@ impl SubgraphStoreTrait for SubgraphStore {
             .collect())
     }
 
+    fn active_locator(&self, hash: &str) -> Result<Option<DeploymentLocator>, StoreError> {
+        let sites = self.mirror.find_sites(&[hash.to_string()], true)?;
+        if sites.len() > 1 {
+            return Err(constraint_violation!(
+                "There are {} active deployments for {hash}, there should only be one",
+                sites.len()
+            ));
+        }
+        Ok(sites.first().map(DeploymentLocator::from))
+    }
+
     async fn set_manifest_raw_yaml(
         &self,
         hash: &DeploymentHash,


### PR DESCRIPTION
The reassign_subgraph JSON-RPC call will fail if a deployment exists in multiple shards. To disambiguate that, change the call so that it only affects the active deployment.

Fixes https://github.com/graphprotocol/graph-node/issues/4394

