### PR TITLE
Improve running subgraph metric accuracy

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -1,5 +1,5 @@
 use crate::polling_monitor::IpfsService;
-use crate::subgraph::context::{IndexingContext, SharedInstanceKeepAliveMap};
+use crate::subgraph::context::{IndexingContext, SubgraphKeepAlive};
 use crate::subgraph::inputs::IndexingInputs;
 use crate::subgraph::loader::load_dynamic_data_sources;
 
@@ -27,7 +27,7 @@ pub struct SubgraphInstanceManager<S: SubgraphStore> {
     subgraph_store: Arc<S>,
     chains: Arc<BlockchainMap>,
     metrics_registry: Arc<dyn MetricsRegistry>,
-    instances: SharedInstanceKeepAliveMap,
+    instances: SubgraphKeepAlive,
     link_resolver: Arc<dyn LinkResolver>,
     ipfs_service: IpfsService,
     static_filters: bool,
@@ -174,9 +174,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             subgraph_store,
             chains,
             metrics_registry: metrics_registry.cheap_clone(),
-            instances: SharedInstanceKeepAliveMap::new(Arc::new(
-                SubgraphInstanceManagerMetrics::new(metrics_registry),
-            )),
+            instances: SubgraphKeepAlive::new(metrics_registry),
             link_resolver,
             ipfs_service,
             static_filters,

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -27,7 +27,6 @@ pub struct SubgraphInstanceManager<S: SubgraphStore> {
     subgraph_store: Arc<S>,
     chains: Arc<BlockchainMap>,
     metrics_registry: Arc<dyn MetricsRegistry>,
-    manager_metrics: Arc<SubgraphInstanceManagerMetrics>,
     instances: SharedInstanceKeepAliveMap,
     link_resolver: Arc<dyn LinkResolver>,
     ipfs_service: IpfsService,
@@ -46,7 +45,6 @@ impl<S: SubgraphStore> SubgraphInstanceManagerTrait for SubgraphInstanceManager<
         let logger = self.logger_factory.subgraph_logger(&loc);
         let err_logger = logger.clone();
         let instance_manager = self.cheap_clone();
-        let manager_metrics = instance_manager.manager_metrics.clone();
 
         let subgraph_start_future = async move {
             match BlockchainKind::from_manifest(&manifest)? {
@@ -130,7 +128,7 @@ impl<S: SubgraphStore> SubgraphInstanceManagerTrait for SubgraphInstanceManager<
         // manager does not hang because of that work.
         graph::spawn(async move {
             match subgraph_start_future.await {
-                Ok(()) => manager_metrics.subgraph_count.inc(),
+                Ok(()) => {}
                 Err(err) => error!(
                     err_logger,
                     "Failed to start subgraph";
@@ -151,11 +149,7 @@ impl<S: SubgraphStore> SubgraphInstanceManagerTrait for SubgraphInstanceManager<
             }
         }
 
-        // Drop the cancel guard to shut down the subgraph now
-        let mut instances = self.instances.write().unwrap();
-        instances.remove(&loc.id);
-
-        self.manager_metrics.subgraph_count.dec();
+        self.instances.remove(&loc.id);
 
         info!(logger, "Stopped subgraph");
     }
@@ -179,11 +173,10 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             logger_factory,
             subgraph_store,
             chains,
-            manager_metrics: Arc::new(SubgraphInstanceManagerMetrics::new(
-                metrics_registry.cheap_clone(),
+            metrics_registry: metrics_registry.cheap_clone(),
+            instances: SharedInstanceKeepAliveMap::new(Arc::new(
+                SubgraphInstanceManagerMetrics::new(metrics_registry),
             )),
-            metrics_registry,
-            instances: SharedInstanceKeepAliveMap::default(),
             link_resolver,
             ipfs_service,
             static_filters,

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -145,8 +145,6 @@ where
             // deployment is unassigned
             self.ctx
                 .instances
-                .write()
-                .unwrap()
                 .insert(self.inputs.deployment.id, block_stream_canceler);
 
             debug!(self.logger, "Starting block stream");
@@ -827,11 +825,7 @@ where
 
                 if matches!(action, Action::Restart) {
                     // Cancel the stream for real
-                    self.ctx
-                        .instances
-                        .write()
-                        .unwrap()
-                        .remove(&self.inputs.deployment.id);
+                    self.ctx.instances.remove(&self.inputs.deployment.id);
 
                     // And restart the subgraph
                     return Ok(Action::Restart);
@@ -897,11 +891,7 @@ where
                         // Retry logic below:
 
                         // Cancel the stream for real.
-                        self.ctx
-                            .instances
-                            .write()
-                            .unwrap()
-                            .remove(&self.inputs.deployment.id);
+                        self.ctx.instances.remove(&self.inputs.deployment.id);
 
                         let message = format!("{:#}", e).replace('\n', "\t");
                         error!(self.logger, "Subgraph failed with non-deterministic error: {}", message;

--- a/graph/src/components/metrics/subgraph.rs
+++ b/graph/src/components/metrics/subgraph.rs
@@ -86,6 +86,7 @@ impl SubgraphInstanceMetrics {
     }
 }
 
+#[derive(Debug)]
 pub struct SubgraphInstanceManagerMetrics {
     pub subgraph_count: Box<Gauge>,
 }

--- a/graph/src/components/metrics/subgraph.rs
+++ b/graph/src/components/metrics/subgraph.rs
@@ -87,11 +87,11 @@ impl SubgraphInstanceMetrics {
 }
 
 #[derive(Debug)]
-pub struct SubgraphInstanceManagerMetrics {
+pub struct SubgraphCountMetric {
     pub subgraph_count: Box<Gauge>,
 }
 
-impl SubgraphInstanceManagerMetrics {
+impl SubgraphCountMetric {
     pub fn new(registry: Arc<dyn MetricsRegistry>) -> Self {
         let subgraph_count = registry
             .new_gauge(


### PR DESCRIPTION
- Always modify alive instances alongside metrics

Ran locally with a forced error, the count is now correctly decreased while waiting for the retry sleep 

