### PR TITLE
store: Remove ability to recount entities

### DIFF
--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1164,14 +1164,7 @@ impl DeploymentStore {
                     )?;
                 }
 
-                deployment::transact_block(
-                    &conn,
-                    &site,
-                    block_ptr_to,
-                    firehose_cursor,
-                    layout.count_query.as_str(),
-                    count,
-                )?;
+                deployment::transact_block(&conn, &site, block_ptr_to, firehose_cursor, count)?;
 
                 Ok(event)
             })
@@ -1227,12 +1220,7 @@ impl DeploymentStore {
                 // changes that might need to be reverted
                 Layout::revert_metadata(conn, &site, block)?;
 
-                deployment::update_entity_count(
-                    conn,
-                    site.as_ref(),
-                    layout.count_query.as_str(),
-                    count,
-                )?;
+                deployment::update_entity_count(conn, site.as_ref(), count)?;
                 Ok(event)
             })
         })?;


### PR DESCRIPTION
We used to send very clever SQL to the database on every block to make it possible to force a recount of the entities in a subgraph by setting the entity_count to -1 or null. The SQL that got sent could be very complicated, and might introduce some overhead.

This facility hasn't been used in a very long time, and since it might cause an overhead, it's better to remove it. If recounting entities is something that we do need, it should be added as a `graphman` command and not be something that might cause headaches on the busiest code path.

