### PR TITLE
`BlockchainBuilder` abstraction to simplify instantiating chains

### DIFF
--- a/chain/arweave/src/chain.rs
+++ b/chain/arweave/src/chain.rs
@@ -1,8 +1,10 @@
 use graph::blockchain::client::ChainClient;
-use graph::blockchain::{Block, BlockchainKind, BuildableBlockchain, EmptyNodeCapabilities};
+use graph::blockchain::{
+    BasicBlockchainBuilder, Block, BlockchainBuilder, BlockchainKind, EmptyNodeCapabilities,
+};
 use graph::cheap_clone::CheapClone;
 use graph::data::subgraph::UnifiedMappingApiVersion;
-use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints};
+use graph::firehose::FirehoseEndpoint;
 use graph::prelude::MetricsRegistry;
 use graph::{
     blockchain::{
@@ -44,20 +46,14 @@ impl std::fmt::Debug for Chain {
     }
 }
 
-impl BuildableBlockchain for Chain {
-    fn build(
-        logger_factory: LoggerFactory,
-        chain_id: String,
-        chain_store: Arc<dyn ChainStore>,
-        fh_endpoints: FirehoseEndpoints,
-        registry: Arc<dyn MetricsRegistry>,
-    ) -> Self {
-        Self {
-            logger_factory,
-            name: chain_id,
-            client: Arc::new(ChainClient::<Self>::new_firehose(fh_endpoints)),
-            chain_store,
-            metrics_registry: registry,
+impl BlockchainBuilder<Chain> for BasicBlockchainBuilder {
+    fn build(self) -> Chain {
+        Chain {
+            logger_factory: self.logger_factory,
+            name: self.name,
+            client: Arc::new(ChainClient::<Chain>::new_firehose(self.firehose_endpoints)),
+            chain_store: self.chain_store,
+            metrics_registry: self.metrics_registry,
         }
     }
 }

--- a/chain/arweave/src/chain.rs
+++ b/chain/arweave/src/chain.rs
@@ -1,5 +1,5 @@
 use graph::blockchain::client::ChainClient;
-use graph::blockchain::{Block, BlockchainKind, EmptyNodeCapabilities};
+use graph::blockchain::{Block, BlockchainKind, BuildableBlockchain, EmptyNodeCapabilities};
 use graph::cheap_clone::CheapClone;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints};
@@ -41,6 +41,24 @@ pub struct Chain {
 impl std::fmt::Debug for Chain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "chain: arweave")
+    }
+}
+
+impl BuildableBlockchain for Chain {
+    fn build(
+        logger_factory: LoggerFactory,
+        chain_id: String,
+        chain_store: Arc<dyn ChainStore>,
+        fh_endpoints: FirehoseEndpoints,
+        registry: Arc<dyn MetricsRegistry>,
+    ) -> Self {
+        Chain::new(
+            logger_factory,
+            chain_id,
+            chain_store,
+            fh_endpoints,
+            registry,
+        )
     }
 }
 

--- a/chain/arweave/src/chain.rs
+++ b/chain/arweave/src/chain.rs
@@ -52,30 +52,12 @@ impl BuildableBlockchain for Chain {
         fh_endpoints: FirehoseEndpoints,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
-        Chain::new(
+        Self {
             logger_factory,
-            chain_id,
+            name: chain_id,
+            client: Arc::new(ChainClient::<Self>::new_firehose(fh_endpoints)),
             chain_store,
-            fh_endpoints,
-            registry,
-        )
-    }
-}
-
-impl Chain {
-    pub fn new(
-        logger_factory: LoggerFactory,
-        name: String,
-        chain_store: Arc<dyn ChainStore>,
-        firehose_endpoints: FirehoseEndpoints,
-        metrics_registry: Arc<dyn MetricsRegistry>,
-    ) -> Self {
-        Chain {
-            logger_factory,
-            name,
-            client: Arc::new(ChainClient::<Self>::new_firehose(firehose_endpoints)),
-            chain_store,
-            metrics_registry,
+            metrics_registry: registry,
         }
     }
 }

--- a/chain/cosmos/src/chain.rs
+++ b/chain/cosmos/src/chain.rs
@@ -46,33 +46,15 @@ impl std::fmt::Debug for Chain {
 impl BuildableBlockchain for Chain {
     fn build(
         logger_factory: LoggerFactory,
-        chain_id: String,
-        chain_store: Arc<dyn ChainStore>,
-        fh_endpoints: FirehoseEndpoints,
-        registry: Arc<dyn MetricsRegistry>,
-    ) -> Self {
-        Chain::new(
-            logger_factory,
-            chain_id,
-            chain_store,
-            fh_endpoints,
-            registry,
-        )
-    }
-}
-
-impl Chain {
-    pub fn new(
-        logger_factory: LoggerFactory,
         name: String,
         chain_store: Arc<dyn ChainStore>,
-        firehose_endpoints: FirehoseEndpoints,
+        fh_endpoints: FirehoseEndpoints,
         metrics_registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
-        Chain {
+        Self {
             logger_factory,
             name,
-            client: Arc::new(ChainClient::new_firehose(firehose_endpoints)),
+            client: Arc::new(ChainClient::new_firehose(fh_endpoints)),
             chain_store,
             metrics_registry,
         }

--- a/chain/cosmos/src/chain.rs
+++ b/chain/cosmos/src/chain.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use graph::blockchain::block_stream::FirehoseCursor;
 use graph::blockchain::client::ChainClient;
-use graph::blockchain::BuildableBlockchain;
+use graph::blockchain::{BasicBlockchainBuilder, BlockchainBuilder};
 use graph::cheap_clone::CheapClone;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::prelude::MetricsRegistry;
@@ -17,7 +17,7 @@ use graph::{
         IngestorError, RuntimeAdapter as RuntimeAdapterTrait,
     },
     components::store::DeploymentLocator,
-    firehose::{self, FirehoseEndpoint, FirehoseEndpoints, ForkStep},
+    firehose::{self, FirehoseEndpoint, ForkStep},
     prelude::{async_trait, o, BlockNumber, ChainStore, Error, Logger, LoggerFactory},
 };
 use prost::Message;
@@ -43,20 +43,14 @@ impl std::fmt::Debug for Chain {
     }
 }
 
-impl BuildableBlockchain for Chain {
-    fn build(
-        logger_factory: LoggerFactory,
-        name: String,
-        chain_store: Arc<dyn ChainStore>,
-        fh_endpoints: FirehoseEndpoints,
-        metrics_registry: Arc<dyn MetricsRegistry>,
-    ) -> Self {
-        Self {
-            logger_factory,
-            name,
-            client: Arc::new(ChainClient::new_firehose(fh_endpoints)),
-            chain_store,
-            metrics_registry,
+impl BlockchainBuilder<Chain> for BasicBlockchainBuilder {
+    fn build(self) -> Chain {
+        Chain {
+            logger_factory: self.logger_factory,
+            name: self.name,
+            client: Arc::new(ChainClient::new_firehose(self.firehose_endpoints)),
+            chain_store: self.chain_store,
+            metrics_registry: self.metrics_registry,
         }
     }
 }

--- a/chain/cosmos/src/chain.rs
+++ b/chain/cosmos/src/chain.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use graph::blockchain::block_stream::FirehoseCursor;
 use graph::blockchain::client::ChainClient;
+use graph::blockchain::BuildableBlockchain;
 use graph::cheap_clone::CheapClone;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::prelude::MetricsRegistry;
@@ -39,6 +40,24 @@ pub struct Chain {
 impl std::fmt::Debug for Chain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "chain: cosmos")
+    }
+}
+
+impl BuildableBlockchain for Chain {
+    fn build(
+        logger_factory: LoggerFactory,
+        chain_id: String,
+        chain_store: Arc<dyn ChainStore>,
+        fh_endpoints: FirehoseEndpoints,
+        registry: Arc<dyn MetricsRegistry>,
+    ) -> Self {
+        Chain::new(
+            logger_factory,
+            chain_id,
+            chain_store,
+            fh_endpoints,
+            registry,
+        )
     }
 }
 

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -108,38 +108,18 @@ impl std::fmt::Debug for Chain {
 impl BuildableBlockchain for Chain {
     fn build(
         logger_factory: LoggerFactory,
-        chain_id: String,
-        chain_store: Arc<dyn ChainStore>,
-        fh_endpoints: FirehoseEndpoints,
-        registry: Arc<dyn MetricsRegistry>,
-    ) -> Self {
-        Chain::new(
-            logger_factory,
-            chain_id,
-            chain_store,
-            fh_endpoints,
-            registry,
-            Arc::new(NearStreamBuilder {}),
-        )
-    }
-}
-
-impl Chain {
-    pub fn new(
-        logger_factory: LoggerFactory,
         name: String,
         chain_store: Arc<dyn ChainStore>,
-        firehose_endpoints: FirehoseEndpoints,
+        fh_endpoints: FirehoseEndpoints,
         metrics_registry: Arc<dyn MetricsRegistry>,
-        block_stream_builder: Arc<dyn BlockStreamBuilder<Self>>,
     ) -> Self {
-        Chain {
+        Self {
             logger_factory,
             name,
-            client: Arc::new(ChainClient::new_firehose(firehose_endpoints)),
             chain_store,
+            client: Arc::new(ChainClient::new_firehose(fh_endpoints)),
             metrics_registry,
-            block_stream_builder,
+            block_stream_builder: Arc::new(NearStreamBuilder {}),
         }
     }
 }

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -1,8 +1,8 @@
 use graph::blockchain::client::ChainClient;
-use graph::blockchain::{BlockchainKind, BuildableBlockchain};
+use graph::blockchain::{BasicBlockchainBuilder, BlockchainBuilder, BlockchainKind};
 use graph::cheap_clone::CheapClone;
 use graph::data::subgraph::UnifiedMappingApiVersion;
-use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints};
+use graph::firehose::FirehoseEndpoint;
 use graph::prelude::{MetricsRegistry, TryFutureExt};
 use graph::{
     anyhow::Result,
@@ -105,20 +105,14 @@ impl std::fmt::Debug for Chain {
     }
 }
 
-impl BuildableBlockchain for Chain {
-    fn build(
-        logger_factory: LoggerFactory,
-        name: String,
-        chain_store: Arc<dyn ChainStore>,
-        fh_endpoints: FirehoseEndpoints,
-        metrics_registry: Arc<dyn MetricsRegistry>,
-    ) -> Self {
-        Self {
-            logger_factory,
-            name,
-            chain_store,
-            client: Arc::new(ChainClient::new_firehose(fh_endpoints)),
-            metrics_registry,
+impl BlockchainBuilder<Chain> for BasicBlockchainBuilder {
+    fn build(self) -> Chain {
+        Chain {
+            logger_factory: self.logger_factory,
+            name: self.name,
+            chain_store: self.chain_store,
+            client: Arc::new(ChainClient::new_firehose(self.firehose_endpoints)),
+            metrics_registry: self.metrics_registry,
             block_stream_builder: Arc::new(NearStreamBuilder {}),
         }
     }

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -1,5 +1,5 @@
 use graph::blockchain::client::ChainClient;
-use graph::blockchain::BlockchainKind;
+use graph::blockchain::{BlockchainKind, BuildableBlockchain};
 use graph::cheap_clone::CheapClone;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints};
@@ -102,6 +102,25 @@ pub struct Chain {
 impl std::fmt::Debug for Chain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "chain: near")
+    }
+}
+
+impl BuildableBlockchain for Chain {
+    fn build(
+        logger_factory: LoggerFactory,
+        chain_id: String,
+        chain_store: Arc<dyn ChainStore>,
+        fh_endpoints: FirehoseEndpoints,
+        registry: Arc<dyn MetricsRegistry>,
+    ) -> Self {
+        Chain::new(
+            logger_factory,
+            chain_id,
+            chain_store,
+            fh_endpoints,
+            registry,
+            Arc::new(NearStreamBuilder {}),
+        )
     }
 }
 

--- a/graph/src/blockchain/builder.rs
+++ b/graph/src/blockchain/builder.rs
@@ -1,0 +1,25 @@
+use super::Blockchain;
+use crate::{
+    components::{metrics::MetricsRegistry, store::ChainStore},
+    firehose::FirehoseEndpoints,
+    prelude::LoggerFactory,
+};
+use std::sync::Arc;
+
+/// An implementor of [`BlockchainBuilder`] for chains that don't require
+/// particularly fancy builder logic.
+pub struct BasicBlockchainBuilder {
+    pub logger_factory: LoggerFactory,
+    pub name: String,
+    pub chain_store: Arc<dyn ChainStore>,
+    pub firehose_endpoints: FirehoseEndpoints,
+    pub metrics_registry: Arc<dyn MetricsRegistry>,
+}
+
+/// Something that can build a [`Blockchain`].
+pub trait BlockchainBuilder<C>
+where
+    C: Blockchain,
+{
+    fn build(self) -> C;
+}

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -15,10 +15,14 @@ mod types;
 // Try to reexport most of the necessary types
 use crate::{
     cheap_clone::CheapClone,
-    components::store::{DeploymentLocator, StoredDynamicDataSource},
+    components::{
+        metrics::MetricsRegistry,
+        store::{DeploymentLocator, StoredDynamicDataSource},
+    },
     data::subgraph::UnifiedMappingApiVersion,
     data_source,
-    prelude::DataSourceContext,
+    firehose::FirehoseEndpoints,
+    prelude::{DataSourceContext, LoggerFactory},
     runtime::{gas::GasCounter, AscHeap, HostExportError},
 };
 use crate::{
@@ -134,6 +138,19 @@ impl ChainStoreBlock {
 //     Firehose(FirehoseEndpoints),
 //     Rpc(C::Client),
 // }
+
+/// A chain-agnostic interface for instantiating chains of a specific kind. Not
+/// all chains may support this interface, but that's okay, as some may require
+/// special logic.
+pub trait BuildableBlockchain: Blockchain {
+    fn build(
+        logger_factory: LoggerFactory,
+        chain_id: String,
+        chain_store: Arc<dyn ChainStore>,
+        fh_endpoints: FirehoseEndpoints,
+        registry: Arc<dyn MetricsRegistry>,
+    ) -> Self;
+}
 
 #[async_trait]
 // This is only `Debug` because some tests require that

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -3,6 +3,7 @@
 //! trait which is the centerpiece of this module.
 
 pub mod block_stream;
+mod builder;
 pub mod client;
 mod empty_node_capabilities;
 pub mod firehose_block_ingestor;
@@ -15,14 +16,10 @@ mod types;
 // Try to reexport most of the necessary types
 use crate::{
     cheap_clone::CheapClone,
-    components::{
-        metrics::MetricsRegistry,
-        store::{DeploymentLocator, StoredDynamicDataSource},
-    },
+    components::store::{DeploymentLocator, StoredDynamicDataSource},
     data::subgraph::UnifiedMappingApiVersion,
     data_source,
-    firehose::FirehoseEndpoints,
-    prelude::{DataSourceContext, LoggerFactory},
+    prelude::DataSourceContext,
     runtime::{gas::GasCounter, AscHeap, HostExportError},
 };
 use crate::{
@@ -47,6 +44,7 @@ use std::{
 use web3::types::H256;
 
 pub use block_stream::{ChainHeadUpdateListener, ChainHeadUpdateStream, TriggersAdapter};
+pub use builder::{BasicBlockchainBuilder, BlockchainBuilder};
 pub use empty_node_capabilities::EmptyNodeCapabilities;
 pub use types::{BlockHash, BlockPtr, ChainIdentifier};
 
@@ -138,19 +136,6 @@ impl ChainStoreBlock {
 //     Firehose(FirehoseEndpoints),
 //     Rpc(C::Client),
 // }
-
-/// A chain-agnostic interface for instantiating chains of a specific kind. Not
-/// all chains may support this interface, but that's okay, as some may require
-/// special logic.
-pub trait BuildableBlockchain: Blockchain {
-    fn build(
-        logger_factory: LoggerFactory,
-        chain_id: String,
-        chain_store: Arc<dyn ChainStore>,
-        fh_endpoints: FirehoseEndpoints,
-        registry: Arc<dyn MetricsRegistry>,
-    ) -> Self;
-}
 
 #[async_trait]
 // This is only `Debug` because some tests require that

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -7,7 +7,9 @@ use ethereum::{
 use git_testament::{git_testament, render_testament};
 use graph::blockchain::client::ChainClient;
 use graph::blockchain::firehose_block_ingestor::{FirehoseBlockIngestor, Transforms};
-use graph::blockchain::{Block as BlockchainBlock, Blockchain, BlockchainKind, BlockchainMap};
+use graph::blockchain::{
+    Block as BlockchainBlock, Blockchain, BlockchainKind, BlockchainMap, BuildableBlockchain,
+};
 use graph::components::store::BlockStore;
 use graph::data::graphql::effort::LoadManager;
 use graph::env::EnvVars;
@@ -40,7 +42,6 @@ use graph_server_json_rpc::JsonRpcServer;
 use graph_server_metrics::PrometheusMetricsServer;
 use graph_server_websocket::SubscriptionServer as GraphQLSubscriptionServer;
 use graph_store_postgres::{register_jobs as register_store_jobs, ChainHeadUpdateListener, Store};
-use near::NearStreamBuilder;
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -297,7 +298,7 @@ async fn main() {
 
         let network_store = store_builder.network_store(network_identifiers);
 
-        let arweave_chains = arweave_networks_as_chains(
+        let arweave_chains = networks_as_chains::<arweave::Chain>(
             &mut blockchain_map,
             &logger,
             &arweave_networks,
@@ -320,7 +321,7 @@ async fn main() {
             metrics_registry.clone(),
         );
 
-        let near_chains = near_networks_as_chains(
+        let near_chains = networks_as_chains::<near::Chain>(
             &mut blockchain_map,
             &logger,
             &near_networks,
@@ -329,7 +330,7 @@ async fn main() {
             metrics_registry.clone(),
         );
 
-        let cosmos_chains = cosmos_networks_as_chains(
+        let cosmos_chains = networks_as_chains::<cosmos::Chain>(
             &mut blockchain_map,
             &logger,
             &cosmos_networks,
@@ -613,15 +614,15 @@ async fn main() {
     futures::future::pending::<()>().await;
 }
 
-/// Return the hashmap of Arweave chains and also add them to `blockchain_map`.
-fn arweave_networks_as_chains(
+/// Return the hashmap of chains and also add them to `blockchain_map`.
+fn networks_as_chains<C: BuildableBlockchain>(
     blockchain_map: &mut BlockchainMap,
     logger: &Logger,
     firehose_networks: &FirehoseNetworks,
     store: &Store,
     logger_factory: &LoggerFactory,
     metrics_registry: Arc<MetricsRegistry>,
-) -> HashMap<String, FirehoseChain<arweave::Chain>> {
+) -> HashMap<String, FirehoseChain<C>> {
     let chains: Vec<_> = firehose_networks
         .networks
         .iter()
@@ -633,7 +634,9 @@ fn arweave_networks_as_chains(
                 .or_else(|| {
                     error!(
                         logger,
-                        "No store configured for Arweave chain {}; ignoring this chain", chain_id
+                        "No store configured for {} chain {}; ignoring this chain",
+                        C::KIND,
+                        chain_id
                     );
                     None
                 })
@@ -642,7 +645,7 @@ fn arweave_networks_as_chains(
             (
                 chain_id.clone(),
                 FirehoseChain {
-                    chain: Arc::new(arweave::Chain::new(
+                    chain: Arc::new(C::build(
                         logger_factory.clone(),
                         chain_id.clone(),
                         chain_store,
@@ -656,7 +659,7 @@ fn arweave_networks_as_chains(
         .collect();
 
     for (chain_id, firehose_chain) in chains.iter() {
-        blockchain_map.insert::<arweave::Chain>(chain_id.clone(), firehose_chain.chain.clone())
+        blockchain_map.insert::<C>(chain_id.clone(), firehose_chain.chain.clone())
     }
 
     HashMap::from_iter(chains)
@@ -759,106 +762,6 @@ fn ethereum_networks_as_chains(
                 )),
             );
         }
-    }
-
-    HashMap::from_iter(chains)
-}
-
-fn cosmos_networks_as_chains(
-    blockchain_map: &mut BlockchainMap,
-    logger: &Logger,
-    firehose_networks: &FirehoseNetworks,
-    store: &Store,
-    logger_factory: &LoggerFactory,
-    metrics_registry: Arc<MetricsRegistry>,
-) -> HashMap<String, FirehoseChain<cosmos::Chain>> {
-    let chains: Vec<_> = firehose_networks
-        .networks
-        .iter()
-        .filter_map(|(network_name, firehose_endpoints)| {
-            store
-                .block_store()
-                .chain_store(network_name)
-                .map(|chain_store| (network_name, chain_store, firehose_endpoints))
-                .or_else(|| {
-                    error!(
-                        logger,
-                        "No store configured for Cosmos chain {}; ignoring this chain",
-                        network_name
-                    );
-                    None
-                })
-        })
-        .map(|(network_name, chain_store, firehose_endpoints)| {
-            (
-                network_name.clone(),
-                FirehoseChain {
-                    chain: Arc::new(cosmos::Chain::new(
-                        logger_factory.clone(),
-                        network_name.clone(),
-                        chain_store,
-                        firehose_endpoints.clone(),
-                        metrics_registry.clone(),
-                    )),
-                    firehose_endpoints: firehose_endpoints.clone(),
-                },
-            )
-        })
-        .collect();
-
-    for (network_name, firehose_chain) in chains.iter() {
-        blockchain_map.insert::<cosmos::Chain>(network_name.clone(), firehose_chain.chain.clone())
-    }
-
-    HashMap::from_iter(chains)
-}
-
-/// Return the hashmap of NEAR chains and also add them to `blockchain_map`.
-fn near_networks_as_chains(
-    blockchain_map: &mut BlockchainMap,
-    logger: &Logger,
-    firehose_networks: &FirehoseNetworks,
-    store: &Store,
-    logger_factory: &LoggerFactory,
-    metrics_registry: Arc<MetricsRegistry>,
-) -> HashMap<String, FirehoseChain<near::Chain>> {
-    let chains: Vec<_> = firehose_networks
-        .networks
-        .iter()
-        .filter_map(|(chain_id, endpoints)| {
-            store
-                .block_store()
-                .chain_store(chain_id)
-                .map(|chain_store| (chain_id, chain_store, endpoints))
-                .or_else(|| {
-                    error!(
-                        logger,
-                        "No store configured for NEAR chain {}; ignoring this chain", chain_id
-                    );
-                    None
-                })
-        })
-        .map(|(chain_id, chain_store, endpoints)| {
-            (
-                chain_id.clone(),
-                FirehoseChain {
-                    chain: Arc::new(near::Chain::new(
-                        logger_factory.clone(),
-                        chain_id.clone(),
-                        chain_store,
-                        endpoints.clone(),
-                        metrics_registry.clone(),
-                        Arc::new(NearStreamBuilder {}),
-                    )),
-                    firehose_endpoints: endpoints.clone(),
-                },
-            )
-        })
-        .collect();
-
-    for (chain_id, firehose_chain) in chains.iter() {
-        blockchain_map
-            .insert::<graph_chain_near::Chain>(chain_id.clone(), firehose_chain.chain.clone())
     }
 
     HashMap::from_iter(chains)


### PR DESCRIPTION
NEAR, Cosmos and Arweave all share the same `Chain::new` type signature. By putting that method into a trait, we can reduce code duplication in the `_networks_as_chains` family of functions in `main.rs`.