### PR TITLE
Refactor some code in Cosmos' `trigger.rs`

### DIFF
--- a/chain/cosmos/src/trigger.rs
+++ b/chain/cosmos/src/trigger.rs
@@ -69,23 +69,7 @@ pub enum CosmosTrigger {
     Message(Arc<codec::MessageData>),
 }
 
-impl CheapClone for CosmosTrigger {
-    fn cheap_clone(&self) -> CosmosTrigger {
-        match self {
-            CosmosTrigger::Block(block) => CosmosTrigger::Block(block.cheap_clone()),
-            CosmosTrigger::Event { event_data, origin } => CosmosTrigger::Event {
-                event_data: event_data.cheap_clone(),
-                origin: *origin,
-            },
-            CosmosTrigger::Transaction(transaction_data) => {
-                CosmosTrigger::Transaction(transaction_data.cheap_clone())
-            }
-            CosmosTrigger::Message(message_data) => {
-                CosmosTrigger::Message(message_data.cheap_clone())
-            }
-        }
-    }
-}
+impl CheapClone for CosmosTrigger {}
 
 impl PartialEq for CosmosTrigger {
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
1. `CheapClone::cheap_clone` mirrors `Clone` functionality by default, so it rarely needs to use custom code.
2. ~~Although not immediately obvious, I'm pretty sure the custom implementation of `PartialEq` is identical to what `derive` what do, so I'm removing it.~~ nvm, I don't want to deal with determinism issues at this time so I'll leave it as it is.