### PR TITLE
Ongoing pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
@@ -1468,7 +1468,7 @@ checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2604,9 +2604,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.131"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linked-hash-map"
@@ -2755,24 +2755,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2895,15 +2885,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -3115,7 +3096,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.2.10",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.32.0",
 ]
 
 [[package]]
@@ -4170,9 +4151,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.4.1"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -4431,7 +4412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -4497,21 +4478,22 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5094,6 +5076,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5526,12 +5514,42 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5540,10 +5558,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5552,16 +5582,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -479,7 +479,7 @@ impl Blockchain for Chain {
                 // present in the DB.
                 Box::new(PollingBlockIngestor::new(
                     logger,
-                    crate::ENV_VARS.reorg_threshold,
+                    graph::env::ENV_VARS.reorg_threshold,
                     eth_adapter,
                     self.chain_store().cheap_clone(),
                     self.polling_ingestor_interval,

--- a/chain/ethereum/src/env.rs
+++ b/chain/ethereum/src/env.rs
@@ -20,9 +20,6 @@ pub struct EnvVars {
     /// default value is 2000.
     pub get_logs_max_contracts: usize,
 
-    /// Set by the environment variable `ETHEREUM_REORG_THRESHOLD`. The default
-    /// value is 250 blocks.
-    pub reorg_threshold: BlockNumber,
     /// Set by the environment variable `ETHEREUM_TRACE_STREAM_STEP_SIZE`. The
     /// default value is 50 blocks.
     pub trace_stream_step_size: BlockNumber,
@@ -111,7 +108,6 @@ impl From<Inner> for EnvVars {
                 .filter(|s| !s.is_empty())
                 .map(str::to_string)
                 .collect(),
-            reorg_threshold: x.reorg_threshold,
             trace_stream_step_size: x.trace_stream_step_size,
             max_event_only_range: x.max_event_only_range,
             block_batch_size: x.block_batch_size,
@@ -145,9 +141,6 @@ struct Inner {
     #[envconfig(from = "GRAPH_ETH_GET_LOGS_MAX_CONTRACTS", default = "2000")]
     get_logs_max_contracts: usize,
 
-    // JSON-RPC specific.
-    #[envconfig(from = "ETHEREUM_REORG_THRESHOLD", default = "250")]
-    reorg_threshold: BlockNumber,
     #[envconfig(from = "ETHEREUM_TRACE_STREAM_STEP_SIZE", default = "50")]
     trace_stream_step_size: BlockNumber,
     #[envconfig(from = "GRAPH_ETHEREUM_MAX_EVENT_ONLY_RANGE", default = "500")]

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -222,6 +222,11 @@ those.
 - `GRAPH_FORK_BASE`: api url for where the graph node will fork from, use `https://api.thegraph.com/subgraphs/id/`
   for the hosted service.
 - `GRAPH_DEBUG_FORK`: the IPFS hash id of the subgraph to fork.
+- `GRAPH_STORE_HISTORY_SLACK_FACTOR`: How much history a subgraph with
+  limited history can accumulate before it will be pruned. Setting this to
+  1.1 means that the subgraph will be pruned every time it contains 10%
+  more history (in blocks) than its history limit. The default value is 1.2
+  and the value must be at least 1.01
 - `GRAPH_STORE_HISTORY_COPY_THRESHOLD`,
   `GRAPH_STORE_HISTORY_DELETE_THRESHOLD`: when pruning, prune by copying the
   entities we will keep to new tables if we estimate that we will remove

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -222,3 +222,14 @@ those.
 - `GRAPH_FORK_BASE`: api url for where the graph node will fork from, use `https://api.thegraph.com/subgraphs/id/`
   for the hosted service.
 - `GRAPH_DEBUG_FORK`: the IPFS hash id of the subgraph to fork.
+- `GRAPH_STORE_HISTORY_COPY_THRESHOLD`,
+  `GRAPH_STORE_HISTORY_DELETE_THRESHOLD`: when pruning, prune by copying the
+  entities we will keep to new tables if we estimate that we will remove
+  more than a factor of `COPY_THRESHOLD` of the deployment's history. If we
+  estimate to remove a factor between `COPY_THRESHOLD` and
+  `DELETE_THRESHOLD`, prune by deleting from the existing tables of the
+  deployment. If we estimate to remove less than `DELETE_THRESHOLD`
+  entities, do not change the table. Both settings are floats, and default
+  to 0.5 for the `COPY_THRESHOLD` and 0.05 for the `DELETE_THRESHOLD`; they
+  must be between 0 and 1, and `COPY_THRESHOLD` must be bigger than
+  `DELETE_THRESHOLD`.

--- a/docs/implementation/metadata.md
+++ b/docs/implementation/metadata.md
@@ -106,6 +106,7 @@ shard alongside the deployment's data in `sgdNNN`.
 | `start_block_hash`      | `bytea`    | Parent of the smallest start block from the manifest |
 | `start_block_number`    | `int4`     |                                                      |
 | `on_sync`               | `text`     | Additional behavior when deployment becomes synced   |
+| `history_blocks`        | `int4!`    | How many blocks of history to keep                   |
 
 ### `subgraph_deployment_assignment`
 

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -44,7 +44,7 @@ slog-envlogger = "2.1.0"
 slog-term = "2.7.0"
 petgraph = "0.6.3"
 tiny-keccak = "1.5.0"
-tokio = { version = "1.16.1", features = ["time", "sync", "macros", "test-util", "rt-multi-thread", "parking_lot"] }
+tokio = { version = "1.26.0", features = ["time", "sync", "macros", "test-util", "rt-multi-thread", "parking_lot"] }
 tokio-stream = { version = "0.1.12", features = ["sync"] }
 tokio-retry = "0.3.0"
 url = "2.3.1"

--- a/graph/src/components/store/err.rs
+++ b/graph/src/components/store/err.rs
@@ -58,6 +58,8 @@ pub enum StoreError {
         DeploymentSchemaVersion::LATEST
     )]
     UnsupportedDeploymentSchemaVersion(i32),
+    #[error("pruning failed: {0}")]
+    PruneFailure(String),
 }
 
 // Convenience to report a constraint violation

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1255,12 +1255,12 @@ impl PruneRequest {
                 "the delete threshold must be between 0 and 1 but is {delete_threshold}"
             ));
         }
-        if history_blocks < reorg_threshold {
+        if history_blocks <= reorg_threshold {
             return Err(constraint_violation!(
                 "the deployment {} needs to keep at least {} blocks \
                    of history and can't be pruned to only {} blocks of history",
                 deployment,
-                reorg_threshold,
+                reorg_threshold + 1,
                 history_blocks
             ));
         }

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1204,6 +1204,7 @@ pub enum PruningStrategy {
     Delete,
 }
 
+#[derive(Copy, Clone)]
 /// A request to prune a deployment. This struct encapsulates decision
 /// making around the best strategy for pruning (deleting historical
 /// entities or copying current ones) It needs to be filled with accurate

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1166,6 +1166,10 @@ pub trait PruneReporter: Send + 'static {
     fn finish_switch(&mut self) {}
 
     fn finish_prune(&mut self) {}
+
+    fn start_table(&mut self, table: &str) {}
+
+    fn finish_table(&mut self, table: &str) {}
 }
 
 /// Represents an item retrieved from an

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1149,7 +1149,11 @@ pub trait PruneReporter: Send + 'static {
     fn start_analyze(&mut self) {}
     fn start_analyze_table(&mut self, table: &str) {}
     fn finish_analyze_table(&mut self, table: &str) {}
-    fn finish_analyze(&mut self, stats: &[VersionStats]) {}
+
+    /// Analyzing tables has finished. `stats` are the stats for all tables
+    /// in the deployment, `analyzed ` are the names of the tables that were
+    /// actually analyzed
+    fn finish_analyze(&mut self, stats: &[VersionStats], analyzed: &[&str]) {}
 
     fn copy_final_start(&mut self, earliest_block: BlockNumber, final_block: BlockNumber) {}
     fn copy_final_batch(&mut self, table: &str, rows: usize, total_rows: usize, finished: bool) {}

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1142,6 +1142,13 @@ pub struct VersionStats {
     pub ratio: f64,
 }
 
+/// What phase of pruning we are working on
+pub enum PrunePhase {
+    /// Handling final entities
+    CopyFinal,
+    /// Handling nonfinal entities
+    CopyNonfinal,
+}
 /// Callbacks for `SubgraphStore.prune` so that callers can report progress
 /// of the pruning procedure to users
 #[allow(unused_variables)]
@@ -1155,21 +1162,14 @@ pub trait PruneReporter: Send + 'static {
     /// actually analyzed
     fn finish_analyze(&mut self, stats: &[VersionStats], analyzed: &[&str]) {}
 
-    fn copy_final_start(&mut self, earliest_block: BlockNumber, final_block: BlockNumber) {}
-    fn copy_final_batch(&mut self, table: &str, rows: usize, total_rows: usize, finished: bool) {}
-    fn copy_final_finish(&mut self) {}
-
+    fn start_copy(&mut self) {}
+    fn start_table(&mut self, table: &str) {}
+    fn prune_batch(&mut self, table: &str, rows: usize, phase: PrunePhase, finished: bool) {}
     fn start_switch(&mut self) {}
-    fn copy_nonfinal_start(&mut self, table: &str) {}
-    fn copy_nonfinal_batch(&mut self, table: &str, rows: usize, total_rows: usize, finished: bool) {
-    }
     fn finish_switch(&mut self) {}
+    fn finish_table(&mut self, table: &str) {}
 
     fn finish_prune(&mut self) {}
-
-    fn start_table(&mut self, table: &str) {}
-
-    fn finish_table(&mut self, table: &str) {}
 }
 
 /// Represents an item retrieved from an

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -180,6 +180,7 @@ pub struct SubgraphManifestEntity {
     pub schema: String,
     pub raw_yaml: Option<String>,
     pub entities_with_causality_region: Vec<EntityType>,
+    pub history_blocks: BlockNumber,
 }
 
 impl SubgraphManifestEntity {
@@ -196,6 +197,7 @@ impl SubgraphManifestEntity {
             schema: manifest.schema.document.clone().to_string(),
             raw_yaml: Some(raw_yaml),
             entities_with_causality_region,
+            history_blocks: BLOCK_NUMBER_MAX,
         }
     }
 

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -11,7 +11,8 @@ use self::graphql::*;
 use self::mappings::*;
 use self::store::*;
 use crate::{
-    components::subgraph::SubgraphVersionSwitchingMode, runtime::gas::CONST_MAX_GAS_PER_HANDLER,
+    components::{store::BlockNumber, subgraph::SubgraphVersionSwitchingMode},
+    runtime::gas::CONST_MAX_GAS_PER_HANDLER,
 };
 
 lazy_static! {
@@ -168,6 +169,9 @@ pub struct EnvVars {
     /// Maximum number of Dynamic Data Sources after which a Subgraph will
     /// switch to using static filter.
     pub static_filters_threshold: usize,
+    /// Set by the environment variable `ETHEREUM_REORG_THRESHOLD`. The default
+    /// value is 250 blocks.
+    pub reorg_threshold: BlockNumber,
 }
 
 impl EnvVars {
@@ -224,6 +228,7 @@ impl EnvVars {
             external_http_base_url: inner.external_http_base_url,
             external_ws_base_url: inner.external_ws_base_url,
             static_filters_threshold: inner.static_filters_threshold,
+            reorg_threshold: inner.reorg_threshold,
         })
     }
 
@@ -340,6 +345,9 @@ struct Inner {
     // Setting this to be unrealistically high so it doesn't get triggered.
     #[envconfig(from = "GRAPH_STATIC_FILTERS_THRESHOLD", default = "100000000")]
     static_filters_threshold: usize,
+    // JSON-RPC specific.
+    #[envconfig(from = "ETHEREUM_REORG_THRESHOLD", default = "250")]
+    reorg_threshold: BlockNumber,
 }
 
 #[derive(Clone, Debug)]

--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -182,7 +182,7 @@ pub struct InnerStore {
     batch_target_duration_in_secs: u64,
     #[envconfig(from = "GRAPH_STORE_HISTORY_COPY_THRESHOLD", default = "0.5")]
     copy_threshold: ZeroToOneF64,
-    #[envconfig(from = "GRAPH_STORE_HISTORY_COPY_THRESHOLD", default = "0.05")]
+    #[envconfig(from = "GRAPH_STORE_HISTORY_DELETE_THRESHOLD", default = "0.05")]
     delete_threshold: ZeroToOneF64,
     #[envconfig(from = "GRAPH_STORE_HISTORY_SLACK_FACTOR", default = "1.2")]
     history_slack_factor: HistorySlackF64,

--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -92,6 +92,12 @@ pub struct EnvVarsStore {
     /// versions, but fewer than `copy_threshold`, by deleting. Set by
     /// `GRAPH_STORE_HISTORY_DELETE_THRESHOLD`. The default is 0.05
     pub delete_threshold: f64,
+    /// How much history a subgraph with limited history can accumulate
+    /// before it will be pruned. Setting this to 1.1 means that the
+    /// subgraph will be pruned every time it contains 10% more history (in
+    /// blocks) than its history limit. The default value is 1.2 and the
+    /// value must be at least 1.01
+    pub history_slack_factor: f64,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -130,6 +136,7 @@ impl From<InnerStore> for EnvVarsStore {
             batch_target_duration: Duration::from_secs(x.batch_target_duration_in_secs),
             copy_threshold: x.copy_threshold.0,
             delete_threshold: x.delete_threshold.0,
+            history_slack_factor: x.history_slack_factor.0,
         }
     }
 }
@@ -177,6 +184,8 @@ pub struct InnerStore {
     copy_threshold: ZeroToOneF64,
     #[envconfig(from = "GRAPH_STORE_HISTORY_COPY_THRESHOLD", default = "0.05")]
     delete_threshold: ZeroToOneF64,
+    #[envconfig(from = "GRAPH_STORE_HISTORY_SLACK_FACTOR", default = "1.2")]
+    history_slack_factor: HistorySlackF64,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -191,6 +200,22 @@ impl FromStr for ZeroToOneF64 {
             bail!("invalid value: {s} must be between 0 and 1");
         } else {
             Ok(ZeroToOneF64(f))
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct HistorySlackF64(f64);
+
+impl FromStr for HistorySlackF64 {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let f = s.parse::<f64>()?;
+        if f < 1.01 {
+            bail!("invalid value: {s} must be bigger than 1.01");
+        } else {
+            Ok(HistorySlackF64(f))
         }
     }
 }

--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::bail;
+
 use super::*;
 
 #[derive(Clone)]
@@ -81,6 +83,15 @@ pub struct EnvVarsStore {
     /// Set by `GRAPH_STORE_BATCH_TARGET_DURATION` (expressed in seconds).
     /// The default is 180s.
     pub batch_target_duration: Duration,
+
+    /// Prune tables where we will remove at least this fraction of entity
+    /// versions by copying. Set by `GRAPH_STORE_HISTORY_COPY_THRESHOLD`.
+    /// The default is 0.5
+    pub copy_threshold: f64,
+    /// Prune tables where we will remove at least this fraction of entity
+    /// versions, but fewer than `copy_threshold`, by deleting. Set by
+    /// `GRAPH_STORE_HISTORY_DELETE_THRESHOLD`. The default is 0.05
+    pub delete_threshold: f64,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -117,6 +128,8 @@ impl From<InnerStore> for EnvVarsStore {
             connection_idle_timeout: Duration::from_secs(x.connection_idle_timeout_in_secs),
             write_queue_size: x.write_queue_size,
             batch_target_duration: Duration::from_secs(x.batch_target_duration_in_secs),
+            copy_threshold: x.copy_threshold.0,
+            delete_threshold: x.delete_threshold.0,
         }
     }
 }
@@ -160,4 +173,24 @@ pub struct InnerStore {
     write_queue_size: usize,
     #[envconfig(from = "GRAPH_STORE_BATCH_TARGET_DURATION", default = "180")]
     batch_target_duration_in_secs: u64,
+    #[envconfig(from = "GRAPH_STORE_HISTORY_COPY_THRESHOLD", default = "0.5")]
+    copy_threshold: ZeroToOneF64,
+    #[envconfig(from = "GRAPH_STORE_HISTORY_COPY_THRESHOLD", default = "0.05")]
+    delete_threshold: ZeroToOneF64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ZeroToOneF64(f64);
+
+impl FromStr for ZeroToOneF64 {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let f = s.parse::<f64>()?;
+        if f < 0.0 || f > 1.0 {
+            bail!("invalid value: {s} must be between 0 and 1");
+        } else {
+            Ok(ZeroToOneF64(f))
+        }
+    }
 }

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -240,7 +240,15 @@ pub enum Command {
     #[clap(subcommand)]
     Index(IndexCommand),
 
-    /// Prune deployments
+    /// Prune a deployment
+    ///
+    /// Keep only entity versions that are needed to respond to queries at
+    /// block heights that are within `history` blocks of the subgraph head;
+    /// all other entity versions are removed.
+    ///
+    /// Unless `--once` is given, this setting is permanent and the subgraph
+    /// will periodically be pruned to remove history as the subgraph head
+    /// moves forward.
     Prune {
         /// The deployment to prune (see `help info`)
         deployment: DeploymentSearch,
@@ -250,6 +258,9 @@ pub enum Command {
         /// How much history to keep in blocks
         #[clap(long, short = 'y', default_value = "10000")]
         history: usize,
+        /// Prune only this once
+        #[clap(long, short)]
+        once: bool,
     },
 
     /// General database management
@@ -1372,9 +1383,10 @@ async fn main() -> anyhow::Result<()> {
             deployment,
             history,
             prune_ratio,
+            once,
         } => {
             let (store, primary_pool) = ctx.store_and_primary();
-            commands::prune::run(store, primary_pool, deployment, history, prune_ratio).await
+            commands::prune::run(store, primary_pool, deployment, history, prune_ratio, once).await
         }
         Drop {
             deployment,

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -252,9 +252,15 @@ pub enum Command {
     Prune {
         /// The deployment to prune (see `help info`)
         deployment: DeploymentSearch,
-        /// Prune tables with a ratio of entities to entity versions lower than this
-        #[clap(long, short, default_value = "0.20")]
-        prune_ratio: f64,
+        /// Prune by copying when removing more than this fraction of
+        /// history. Defaults to GRAPH_STORE_HISTORY_COPY_THRESHOLD
+        #[clap(long, short)]
+        copy_threshold: Option<f64>,
+        /// Prune by deleting when removing more than this fraction of
+        /// history but less than copy_threshold. Defaults to
+        /// GRAPH_STORE_HISTORY_DELETE_THRESHOLD
+        #[clap(long, short)]
+        delete_threshold: Option<f64>,
         /// How much history to keep in blocks
         #[clap(long, short = 'y', default_value = "10000")]
         history: usize,
@@ -1382,11 +1388,21 @@ async fn main() -> anyhow::Result<()> {
         Prune {
             deployment,
             history,
-            prune_ratio,
+            copy_threshold,
+            delete_threshold,
             once,
         } => {
             let (store, primary_pool) = ctx.store_and_primary();
-            commands::prune::run(store, primary_pool, deployment, history, prune_ratio, once).await
+            commands::prune::run(
+                store,
+                primary_pool,
+                deployment,
+                history,
+                copy_threshold,
+                delete_threshold,
+                once,
+            )
+            .await
         }
         Drop {
             deployment,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -718,7 +718,7 @@ fn ethereum_networks_as_chains(
                 Arc::new(EthereumBlockRefetcher {}),
                 Arc::new(adapter_selector),
                 runtime_adapter,
-                ethereum::ENV_VARS.reorg_threshold,
+                ENV_VARS.reorg_threshold,
                 ethereum::ENV_VARS.ingestor_polling_interval,
                 is_ingestible,
             );

--- a/node/src/manager/commands/prune.rs
+++ b/node/src/manager/commands/prune.rs
@@ -149,6 +149,7 @@ pub async fn run(
     search: DeploymentSearch,
     history: usize,
     prune_ratio: f64,
+    once: bool,
 ) -> Result<(), anyhow::Error> {
     let history = history as BlockNumber;
     let deployment = search.locate_unique(&primary_pool)?;
@@ -191,6 +192,13 @@ pub async fn run(
             prune_ratio,
         )
         .await?;
+
+    // Only after everything worked out, make the history setting permanent
+    if !once {
+        store
+            .subgraph_store()
+            .set_history_blocks(&deployment, history, ETH_ENV.reorg_threshold)?;
+    }
 
     Ok(())
 }

--- a/node/src/manager/commands/prune.rs
+++ b/node/src/manager/commands/prune.rs
@@ -67,10 +67,14 @@ impl PruneReporter for Progress {
         std::io::stdout().flush().ok();
     }
 
-    fn finish_analyze(&mut self, stats: &[graph::components::store::VersionStats]) {
+    fn finish_analyze(
+        &mut self,
+        stats: &[graph::components::store::VersionStats],
+        analyzed: &[&str],
+    ) {
         println!(
             "\rAnalyzed {} tables in {}s",
-            stats.len(),
+            analyzed.len(),
             self.analyze_start.elapsed().as_secs()
         );
         show_stats(stats, HashSet::new()).ok();

--- a/node/src/manager/commands/prune.rs
+++ b/node/src/manager/commands/prune.rs
@@ -183,7 +183,7 @@ pub async fn run(
         .prune(
             reporter,
             &deployment,
-            latest - history,
+            Some(history),
             // Using the setting for eth chains is a bit lazy; the value
             // should really depend on the chain, but we don't have a
             // convenient way to figure out how each chain deals with

--- a/node/src/manager/commands/prune.rs
+++ b/node/src/manager/commands/prune.rs
@@ -75,8 +75,7 @@ fn print_batch(
 
 impl PruneReporter for Progress {
     fn start(&mut self, req: &PruneRequest) {
-        let history_pct = req.history_pct * 100.0;
-        println!("Remove {history_pct:.2}% of historical blocks");
+        println!("Prune to {} historical blocks", req.history_blocks);
     }
 
     fn start_analyze(&mut self) {

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -147,7 +147,7 @@ pub async fn run(
             call_cache: chain_store.cheap_clone(),
             eth_adapters: Arc::new(eth_adapters2),
         }),
-        ethereum::ENV_VARS.reorg_threshold,
+        graph::env::ENV_VARS.reorg_threshold,
         ethereum::ENV_VARS.ingestor_polling_interval,
         // We assume the tested chain is always ingestible for now
         true,

--- a/node/src/manager/commands/stats.rs
+++ b/node/src/manager/commands/stats.rs
@@ -108,7 +108,7 @@ pub fn show(
 ) -> Result<(), anyhow::Error> {
     let (site, conn) = site_and_conn(pools, search)?;
 
-    let stats = store_catalog::stats(&conn, &site.namespace)?;
+    let stats = store_catalog::stats(&conn, &site)?;
 
     let account_like = store_catalog::account_like(&conn, &site)?;
 

--- a/node/src/manager/deployment.rs
+++ b/node/src/manager/deployment.rs
@@ -199,7 +199,13 @@ impl Deployment {
             "node_id",
         ];
         if !statuses.is_empty() {
-            rows.extend(vec!["synced", "health", "latest block", "chain head block"]);
+            rows.extend(vec![
+                "synced",
+                "health",
+                "earliest block",
+                "latest block",
+                "chain head block",
+            ]);
         }
 
         let mut list = List::new(rows);
@@ -224,6 +230,7 @@ impl Deployment {
                 rows.extend(vec![
                     status.synced.to_string(),
                     status.health.as_str().to_string(),
+                    chain.earliest_block_number.to_string(),
                     chain
                         .latest_block
                         .as_ref()

--- a/store/postgres/migrations/2023-03-06-002954_add_pruning/down.sql
+++ b/store/postgres/migrations/2023-03-06-002954_add_pruning/down.sql
@@ -1,0 +1,2 @@
+alter table subgraphs.subgraph_manifest
+      drop column history_blocks;

--- a/store/postgres/migrations/2023-03-06-002954_add_pruning/up.sql
+++ b/store/postgres/migrations/2023-03-06-002954_add_pruning/up.sql
@@ -1,0 +1,4 @@
+alter table subgraphs.subgraph_manifest
+  add column history_blocks int4
+             not null default 2147483647
+             check (history_blocks > 0);

--- a/store/postgres/migrations/2023-03-06-233030_add_last_pruned_block/down.sql
+++ b/store/postgres/migrations/2023-03-06-233030_add_last_pruned_block/down.sql
@@ -1,0 +1,2 @@
+alter table subgraphs.table_stats
+      drop column last_pruned_block;

--- a/store/postgres/migrations/2023-03-06-233030_add_last_pruned_block/up.sql
+++ b/store/postgres/migrations/2023-03-06-233030_add_last_pruned_block/up.sql
@@ -1,0 +1,2 @@
+alter table subgraphs.table_stats
+  add column last_pruned_block int4;

--- a/store/postgres/src/advisory_lock.rs
+++ b/store/postgres/src/advisory_lock.rs
@@ -67,6 +67,7 @@ impl Scope {
 
 const COPY: Scope = Scope { id: 1 };
 const WRITE: Scope = Scope { id: 2 };
+const PRUNE: Scope = Scope { id: 3 };
 
 /// Get a lock for running migrations. Blocks until we get the lock.
 pub(crate) fn lock_migration(conn: &PgConnection) -> Result<(), StoreError> {
@@ -109,4 +110,14 @@ pub(crate) fn unlock_deployment_session(
     site: &Site,
 ) -> Result<(), StoreError> {
     WRITE.unlock(conn, site.id)
+}
+
+/// Try to take the lock used to prevent two prune operations from running at the
+/// same time. Return `true` if we got the lock, and `false` otherwise.
+pub(crate) fn try_lock_pruning(conn: &PgConnection, site: &Site) -> Result<bool, StoreError> {
+    PRUNE.try_lock(conn, site.id)
+}
+
+pub(crate) fn unlock_pruning(conn: &PgConnection, site: &Site) -> Result<(), StoreError> {
+    PRUNE.unlock(conn, site.id)
 }

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -8,6 +8,7 @@ use diesel::{
 };
 use graph::components::store::EntityType;
 use graph::components::store::VersionStats;
+use graph::prelude::BlockNumber;
 use itertools::Itertools;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Write;
@@ -100,6 +101,7 @@ table! {
         deployment -> Integer,
         table_name -> Text,
         is_account_like -> Nullable<Bool>,
+        last_pruned_block -> Nullable<Integer>,
     }
 }
 
@@ -445,8 +447,8 @@ pub fn copy_account_like(conn: &PgConnection, src: &Site, dst: &Site) -> Result<
         ForeignServer::metadata_schema(&src.shard)
     };
     let query = format!(
-        "insert into subgraphs.table_stats(deployment, table_name, is_account_like)
-         select $2 as deployment, ts.table_name, ts.is_account_like
+        "insert into subgraphs.table_stats(deployment, table_name, is_account_like, last_pruned_block)
+         select $2 as deployment, ts.table_name, ts.is_account_like, ts.last_pruned_block
            from {src_nsp}.table_stats ts
           where ts.deployment = $1",
         src_nsp = src_nsp
@@ -455,6 +457,27 @@ pub fn copy_account_like(conn: &PgConnection, src: &Site, dst: &Site) -> Result<
         .bind::<Integer, _>(src.id)
         .bind::<Integer, _>(dst.id)
         .execute(conn)?)
+}
+
+pub fn set_last_pruned_block(
+    conn: &PgConnection,
+    site: &Site,
+    table_name: &SqlName,
+    last_pruned_block: BlockNumber,
+) -> Result<(), StoreError> {
+    use table_stats as ts;
+
+    insert_into(ts::table)
+        .values((
+            ts::deployment.eq(site.id),
+            ts::table_name.eq(table_name.as_str()),
+            ts::last_pruned_block.eq(last_pruned_block),
+        ))
+        .on_conflict((ts::deployment, ts::table_name))
+        .do_update()
+        .set(ts::last_pruned_block.eq(last_pruned_block))
+        .execute(conn)?;
+    Ok(())
 }
 
 pub(crate) mod table_schema {
@@ -649,7 +672,7 @@ pub(crate) fn drop_index(
     Ok(())
 }
 
-pub fn stats(conn: &PgConnection, namespace: &Namespace) -> Result<Vec<VersionStats>, StoreError> {
+pub fn stats(conn: &PgConnection, site: &Site) -> Result<Vec<VersionStats>, StoreError> {
     #[derive(Queryable, QueryableByName)]
     pub struct DbStats {
         #[sql_type = "Integer"]
@@ -661,6 +684,8 @@ pub fn stats(conn: &PgConnection, namespace: &Namespace) -> Result<Vec<VersionSt
         /// The ratio `entities / versions`
         #[sql_type = "Double"]
         pub ratio: f64,
+        #[sql_type = "Nullable<Integer>"]
+        pub last_pruned_block: Option<i32>,
     }
 
     impl From<DbStats> for VersionStats {
@@ -670,6 +695,7 @@ pub fn stats(conn: &PgConnection, namespace: &Namespace) -> Result<Vec<VersionSt
                 versions: s.versions,
                 tablename: s.tablename,
                 ratio: s.ratio,
+                last_pruned_block: s.last_pruned_block,
             }
         }
     }
@@ -687,9 +713,13 @@ pub fn stats(conn: &PgConnection, namespace: &Namespace) -> Result<Vec<VersionSt
                 case when c.reltuples = 0 then 0::float8
                      when s.n_distinct < 0 then (-s.n_distinct)::float8
                      else greatest(s.n_distinct, 1)::float8 / c.reltuples::float8
-                 end as ratio
+                 end as ratio,
+                 ts.last_pruned_block
            from pg_namespace n, pg_class c, pg_stats s
-          where n.nspname = $1
+                left outer join subgraphs.table_stats ts
+                     on (ts.table_name = s.tablename
+                     and ts.deployment = $1)
+          where n.nspname = $2
             and c.relnamespace = n.oid
             and s.schemaname = n.nspname
             and s.attname = 'id'
@@ -698,7 +728,8 @@ pub fn stats(conn: &PgConnection, namespace: &Namespace) -> Result<Vec<VersionSt
         .to_string();
 
     let stats = sql_query(query)
-        .bind::<Text, _>(namespace.as_str())
+        .bind::<Integer, _>(site.id)
+        .bind::<Text, _>(site.namespace.as_str())
         .load::<DbStats>(conn)
         .map_err(StoreError::from)?;
 

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -410,7 +410,7 @@ pub fn transact_block(
     ptr: &BlockPtr,
     firehose_cursor: &FirehoseCursor,
     count: i32,
-) -> Result<(), StoreError> {
+) -> Result<BlockNumber, StoreError> {
     use crate::diesel::BoolExpressionMethods;
     use subgraph_deployment as d;
 
@@ -419,7 +419,7 @@ pub fn transact_block(
 
     let count_sql = entity_count_sql(count);
 
-    let row_count = update(
+    let rows = update(
         d::table.filter(d::id.eq(site.id)).filter(
             // Asserts that the processing direction is forward.
             d::latest_ethereum_block_number
@@ -434,12 +434,13 @@ pub fn transact_block(
         d::entity_count.eq(sql(&count_sql)),
         d::current_reorg_depth.eq(0),
     ))
-    .execute(conn)
+    .returning(d::earliest_block_number)
+    .get_results::<BlockNumber>(conn)
     .map_err(StoreError::from)?;
 
-    match row_count {
+    match rows.len() {
         // Common case: A single row was updated.
-        1 => Ok(()),
+        1 => Ok(rows[0]),
 
         // No matching rows were found. This is an error. By the filter conditions, this can only be
         // due to a missing deployment (which `block_ptr` catches) or duplicate block processing.

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -179,6 +179,9 @@ table! {
         // Names stored as present in the schema, not in snake case.
         entities_with_causality_region -> Array<Text>,
         on_sync -> Nullable<Text>,
+        // How many blocks of history to keep, defaults to `i32::max` for
+        // unlimited history
+        history_blocks -> Integer,
     }
 }
 

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -1146,6 +1146,11 @@ pub fn set_entity_count(
     Ok(())
 }
 
+/// Set the earliest block of `site` to the larger of `earliest_block` and
+/// the current value. This means that the `earliest_block_number` can never
+/// go backwards, only forward. This is important so that copying into
+/// `site` can not move the earliest block backwards if `site` was also
+/// pruned while the copy was running.
 pub fn set_earliest_block(
     conn: &PgConnection,
     site: &Site,
@@ -1155,6 +1160,7 @@ pub fn set_earliest_block(
 
     update(d::table.filter(d::id.eq(site.id)))
         .set(d::earliest_block_number.eq(earliest_block))
+        .filter(d::earliest_block_number.lt(earliest_block))
         .execute(conn)?;
     Ok(())
 }

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -349,6 +349,30 @@ impl ManifestInfo {
     }
 }
 
+// Return how many blocks of history this subgraph should keep
+pub fn history_blocks(conn: &PgConnection, site: &Site) -> Result<BlockNumber, StoreError> {
+    use subgraph_manifest as sm;
+    sm::table
+        .select(sm::history_blocks)
+        .filter(sm::id.eq(site.id))
+        .first::<BlockNumber>(conn)
+        .map_err(StoreError::from)
+}
+
+pub fn set_history_blocks(
+    conn: &PgConnection,
+    site: &Site,
+    history_blocks: BlockNumber,
+) -> Result<(), StoreError> {
+    use subgraph_manifest as sm;
+
+    update(sm::table.filter(sm::id.eq(site.id)))
+        .set(sm::history_blocks.eq(history_blocks))
+        .execute(conn)
+        .map(|_| ())
+        .map_err(StoreError::from)
+}
+
 #[allow(dead_code)]
 pub fn features(conn: &PgConnection, site: &Site) -> Result<BTreeSet<SubgraphFeature>, StoreError> {
     use subgraph_manifest as sm;

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -1047,6 +1047,7 @@ pub fn create_deployment(
                 schema,
                 raw_yaml,
                 entities_with_causality_region,
+                history_blocks,
             },
         start_block,
         graft_base,
@@ -1091,6 +1092,7 @@ pub fn create_deployment(
         m::start_block_number.eq(start_block.as_ref().map(|ptr| ptr.number)),
         m::raw_yaml.eq(raw_yaml),
         m::entities_with_causality_region.eq(entities_with_causality_region),
+        m::history_blocks.eq(history_blocks),
     );
 
     if exists && replace {

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1583,6 +1583,12 @@ impl DeploymentStore {
                     src_deployment.earliest_block_number,
                 )?;
 
+                deployment::set_history_blocks(
+                    &conn,
+                    &dst.site,
+                    src_deployment.manifest.history_blocks,
+                )?;
+
                 // Analyze all tables for this deployment
                 for entity_name in dst.tables.keys() {
                     self.analyze_with_conn(site.cheap_clone(), entity_name.as_str(), &conn)?;

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -888,12 +888,6 @@ impl DeploymentStore {
             ));
         }
 
-        if history_blocks <= 0 {
-            return Err(constraint_violation!(
-                "history_blocks must be a positive number"
-            ));
-        }
-
         // Invalidate the layout cache for this site so that the next access
         // will use the updated value
         self.layout_cache.remove(site);

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -896,7 +896,7 @@ impl DeploymentStore {
         self: &Arc<Self>,
         mut reporter: Box<dyn PruneReporter>,
         site: Arc<Site>,
-        earliest_block: BlockNumber,
+        history_blocks: Option<BlockNumber>,
         reorg_threshold: BlockNumber,
         prune_ratio: f64,
     ) -> Result<Box<dyn PruneReporter>, StoreError> {
@@ -905,24 +905,24 @@ impl DeploymentStore {
             let layout = store.layout(conn, site.clone())?;
             cancel.check_cancel()?;
             let state = deployment::state(conn, site.deployment.clone())?;
+            let history_blocks = history_blocks.unwrap_or(layout.history_blocks);
 
-            if state.latest_block.number <= reorg_threshold {
+            if state.latest_block.number <= history_blocks {
+                // We haven't accumulated enough history yet, nothing to prune
                 return Ok(reporter);
             }
 
+            let earliest_block = state.latest_block.number - history_blocks;
+
             if state.earliest_block_number > earliest_block {
-                return Err(constraint_violation!("earliest block can not move back from {} to {}", state.earliest_block_number, earliest_block).into());
+                // We already have less history than we need (e.g., because
+                // of a manual onetime prune), nothing to prune
+                return Ok(reporter)
             }
 
             let final_block = state.latest_block.number - reorg_threshold;
             if final_block <= earliest_block {
                 return Err(constraint_violation!("the earliest block {} must be at least {} blocks before the current latest block {}", earliest_block, reorg_threshold, state.latest_block.number).into());
-            }
-
-            if let Some((_, graft)) = deployment::graft_point(conn, &site.deployment)? {
-                if graft.block_number() >= earliest_block {
-                    return Err(constraint_violation!("the earliest block {} must be after the graft point {}", earliest_block, graft.block_number()).into());
-                }
             }
 
             cancel.check_cancel()?;

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1831,7 +1831,6 @@ impl PruneReporter for OngoingPruneReporter {
     fn start(&mut self, req: &PruneRequest) {
         self.start = Instant::now();
         info!(&self.logger, "Start pruning historical entities";
-              "history_pct" => format!("{:.2}", req.history_pct * 100.0),
               "history_blocks" => req.history_blocks,
               "earliest_block" => req.earliest_block,
               "latest_block" => req.latest_block);

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -341,6 +341,7 @@ struct StoredSubgraphManifest {
     raw_yaml: Option<String>,
     entities_with_causality_region: Vec<EntityType>,
     on_sync: Option<String>,
+    history_blocks: i32,
 }
 
 impl From<StoredSubgraphManifest> for SubgraphManifestEntity {

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -354,6 +354,7 @@ impl From<StoredSubgraphManifest> for SubgraphManifestEntity {
             schema: value.schema,
             raw_yaml: value.raw_yaml,
             entities_with_causality_region: value.entities_with_causality_region,
+            history_blocks: value.history_blocks,
         }
     }
 }

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -32,6 +32,7 @@ mod primary;
 pub mod query_store;
 mod relational;
 mod relational_queries;
+mod retry;
 mod sql_value;
 mod store;
 mod store_events;

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -17,6 +17,10 @@ mod query_tests;
 pub(crate) mod index;
 mod prune;
 
+use diesel::pg::Pg;
+use diesel::serialize::Output;
+use diesel::sql_types::Text;
+use diesel::types::{FromSql, ToSql};
 use diesel::{connection::SimpleConnection, Connection};
 use diesel::{debug_query, OptionalExtension, PgConnection, RunQueryDsl};
 use graph::cheap_clone::CheapClone;
@@ -165,6 +169,18 @@ impl fmt::Display for SqlName {
 impl Borrow<str> for &SqlName {
     fn borrow(&self) -> &str {
         self.as_str()
+    }
+}
+
+impl FromSql<Text, Pg> for SqlName {
+    fn from_sql(bytes: Option<&[u8]>) -> diesel::deserialize::Result<Self> {
+        <String as FromSql<Text, Pg>>::from_sql(bytes).map(|s| SqlName::verbatim(s))
+    }
+}
+
+impl ToSql<Text, Pg> for SqlName {
+    fn to_sql<W: std::io::Write>(&self, out: &mut Output<W, Pg>) -> diesel::serialize::Result {
+        <String as ToSql<Text, Pg>>::to_sql(&self.0, out)
     }
 }
 

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -134,7 +134,7 @@ impl TablePair {
                 // The conditions on `block_range` are expressed redundantly
                 // to make more indexes useable
                 sql_query(format!(
-                    "/* controller=prune,phase=final,start_vid={next_vid},next_vid={batch_size} */ \
+                    "/* controller=prune,phase=final,start_vid={next_vid},batch_size={batch_size} */ \
                      insert into {dst}({column_list}) \
                      select {column_list} from {src} \
                       where lower(block_range) <= $2 \
@@ -197,7 +197,7 @@ impl TablePair {
                 // The conditions on `block_range` are expressed redundantly
                 // to make more indexes useable
                 sql_query(format!(
-                    "/* controller=prune,phase=nonfinal,start_vid={next_vid},next_vid={batch_size} */ \
+                    "/* controller=prune,phase=nonfinal,start_vid={next_vid},batch_size={batch_size} */ \
                      insert into {dst}({column_list}) \
                      select {column_list} from {src} \
                       where coalesce(upper(block_range), 2147483647) > $1 \
@@ -458,7 +458,7 @@ impl Layout {
                     while next_vid <= max_vid {
                         let start = Instant::now();
                         let rows = sql_query(format!(
-                            "/* controller=prune,phase=delete,next_vid={next_vid},batch_size={batch_size} */ \
+                            "/* controller=prune,phase=delete,start_vid={next_vid},batch_size={batch_size} */ \
                              delete from {qname} \
                                           where coalesce(upper(block_range), 2147483647) <= $1 \
                                             and vid >= $2 and vid < $2 + $3",

--- a/store/postgres/src/retry.rs
+++ b/store/postgres/src/retry.rs
@@ -1,0 +1,68 @@
+//! Helpers to retry an operation indefinitely with exponential backoff
+//! while the database is not available
+use std::time::Duration;
+
+use graph::{
+    prelude::StoreError,
+    slog::{warn, Logger},
+    util::backoff::ExponentialBackoff,
+};
+
+const BACKOFF_BASE: Duration = Duration::from_millis(100);
+const BACKOFF_CEIL: Duration = Duration::from_secs(10);
+
+fn log_backoff_warning(logger: &Logger, op: &str, backoff: &ExponentialBackoff) {
+    warn!(logger,
+            "database unavailable, will retry";
+            "operation" => op,
+            "attempt" => backoff.attempt,
+            "delay_ms" => backoff.delay().as_millis());
+}
+
+/// Run `f` with exponential backoff until it succeeds or it produces an
+/// error other than `DatabaseUnavailable`. In other words, keep retrying
+/// `f` until the database is available.
+///
+/// Do not use this from an async context since it will block the current
+/// thread. Use `forever_async` instead
+pub(crate) fn forever<T, F>(logger: &Logger, op: &str, f: F) -> Result<T, StoreError>
+where
+    F: Fn() -> Result<T, StoreError>,
+{
+    let mut backoff = ExponentialBackoff::new(BACKOFF_BASE, BACKOFF_CEIL);
+    loop {
+        match f() {
+            Ok(v) => return Ok(v),
+            Err(StoreError::DatabaseUnavailable) => {
+                log_backoff_warning(logger, op, &backoff);
+            }
+            Err(e) => return Err(e),
+        }
+        backoff.sleep();
+    }
+}
+
+/// Run `f` with exponential backoff until it succeeds or it produces an
+/// error other than `DatabaseUnavailable`. In other words, keep retrying
+/// `f` until the database is available.
+pub(crate) async fn forever_async<T, F, Fut>(
+    logger: &Logger,
+    op: &str,
+    f: F,
+) -> Result<T, StoreError>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<T, StoreError>>,
+{
+    let mut backoff = ExponentialBackoff::new(BACKOFF_BASE, BACKOFF_CEIL);
+    loop {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(StoreError::DatabaseUnavailable) => {
+                log_backoff_warning(logger, op, &backoff);
+            }
+            Err(e) => return Err(e),
+        }
+        backoff.sleep_async().await;
+    }
+}

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1151,6 +1151,18 @@ impl SubgraphStoreInner {
             .await
     }
 
+    pub fn set_history_blocks(
+        &self,
+        deployment: &DeploymentLocator,
+        history_blocks: BlockNumber,
+        reorg_threshold: BlockNumber,
+    ) -> Result<(), StoreError> {
+        let site = self.find_site(deployment.id.into())?;
+        let store = self.for_site(&site)?;
+
+        store.set_history_blocks(&site, history_blocks, reorg_threshold)
+    }
+
     pub fn load_deployment(&self, site: &Site) -> Result<SubgraphDeploymentEntity, StoreError> {
         let src_store = self.for_site(site)?;
         src_store.load_deployment(site)

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1113,8 +1113,11 @@ impl SubgraphStoreInner {
         store.set_account_like(site, table, is_account_like).await
     }
 
-    /// Remove the history that is only needed to respond to queries before
-    /// block number `earliest_block` from the given deployment
+    /// Remove the history exceeding `history_blocks` blocks setting. Only
+    /// entity versions needed for queries at block heights within
+    /// `history_blocks` blocks of the current subgraph head will be kept.
+    /// If `history_blocks` is `None`, use the subgraph's `history_blocks`
+    /// setting.
     ///
     /// Only tables with a ratio of entities to entity versions below
     /// `prune_ratio` will be pruned; that ratio is determined by looking at
@@ -1137,7 +1140,7 @@ impl SubgraphStoreInner {
         &self,
         reporter: Box<dyn PruneReporter>,
         deployment: &DeploymentLocator,
-        earliest_block: BlockNumber,
+        history_blocks: Option<BlockNumber>,
         reorg_threshold: BlockNumber,
         prune_ratio: f64,
     ) -> Result<Box<dyn PruneReporter>, StoreError> {
@@ -1147,7 +1150,7 @@ impl SubgraphStoreInner {
         let store = self.for_site(&site)?;
 
         store
-            .prune(reporter, site, earliest_block, reorg_threshold, prune_ratio)
+            .prune(reporter, site, history_blocks, reorg_threshold, prune_ratio)
             .await
     }
 

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -261,6 +261,7 @@ impl SyncStore {
     ) -> Result<(), StoreError> {
         self.retry("transact_block_operations", move || {
             let event = self.writable.transact_block_operations(
+                &self.logger,
                 self.site.clone(),
                 block_ptr_to,
                 firehose_cursor,

--- a/store/postgres/tests/graft.rs
+++ b/store/postgres/tests/graft.rs
@@ -6,7 +6,7 @@ use test_store::*;
 
 use graph::components::store::{
     DeploymentLocator, EntityKey, EntityOrder, EntityQuery, EntityType, PruneReporter,
-    PruneRequest, PruningStrategy,
+    PruneRequest, PruningStrategy, VersionStats,
 };
 use graph::data::store::scalar;
 use graph::data::subgraph::schema::*;
@@ -622,9 +622,16 @@ fn prune() {
                 }
             }
             // We have 5 versions for 3 entities
+            let stats = VersionStats {
+                entities: 3,
+                versions: 5,
+                tablename: USER.to_ascii_lowercase(),
+                ratio: 3.0 / 5.0,
+                last_pruned_block: None,
+            };
             assert_eq!(
                 Some(strategy),
-                req.strategy(3.0 / 5.0),
+                req.strategy(&stats),
                 "changing thresholds didn't yield desired strategy"
             );
             store

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -14,14 +14,14 @@ use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints, SubgraphLimit};
 use graph::prelude::ethabi::ethereum_types::H256;
 use graph::prelude::web3::types::{Address, Log, Transaction, H160};
 use graph::prelude::{
-    ethabi, tiny_keccak, LightEthereumBlock, LoggerFactory, MetricsRegistry, NodeId,
+    ethabi, tiny_keccak, LightEthereumBlock, LoggerFactory, MetricsRegistry, NodeId, ENV_VARS,
 };
 use graph::{blockchain::block_stream::BlockWithTriggers, prelude::ethabi::ethereum_types::U64};
+use graph_chain_ethereum::Chain;
 use graph_chain_ethereum::{
     chain::BlockFinality,
     trigger::{EthereumBlockTriggerType, EthereumTrigger},
 };
-use graph_chain_ethereum::{Chain, ENV_VARS};
 
 pub async fn chain(
     blocks: Vec<BlockWithTriggers<Chain>>,
@@ -71,7 +71,7 @@ pub async fn chain(
         triggers_adapter,
         Arc::new(NoopRuntimeAdapter { x: PhantomData }),
         ENV_VARS.reorg_threshold,
-        ENV_VARS.ingestor_polling_interval,
+        graph_chain_ethereum::ENV_VARS.ingestor_polling_interval,
         // We assume the tested chain is always ingestible for now
         true,
     );


### PR DESCRIPTION
This is still work-in-progress, and I am still testing correctness and performance, but for greater visibility, opening a PR already.

This PR adds the ability to perform pruning on an ongoing basis; each deployment now has an optional flag `history_blocks` that indicates how much history the deployment should retain. While the deployment is processing blocks, it checks whether the deployment currently has more history than configured and prunes itself if that is the case. Pruning happens in line with normal block processing, so processing can get blocked by pruning, though the details depend on how full the write queue gets.

The frequency with which pruning is performed is set with `GRAPH_STORE_HISTORY_SLACK_FACTOR`: once a deployment has more than `history_blocks * GRAPH_STORE_HISTORY_SLACK_FACTOR`, pruning is kicked off. 

Pruning can now use two different strategies: copying and deleting, and selects the strategy based on how much of each table is historical and therefore has to be removed. For large removals, copying is used, and for smaller removals, we delete (configured with `GRAPH_STORE_HISTORY_COPY_THRESHOLD` and `GRAPH_STORE_HISTORY_DELETE_THRESHOLD`.

The amount of data we are likely to remove is estimated, since getting precise numbers would be too slow as it onvolves counting the entries in each table. The estimate is based on how much history the table retains and the ratio of entities to entity versions. When that ratio is high, it's likely that pruning will remove only few rows, and when it is low, it's likely that pruning will remove many rows. Similarly, if the ratio of `history_blocks` to the number of blocks for which a table has data is high, we expect to remove only few blocks since a lot of rows are still current. The number of blocks for which a table has data is stored in `table_stats.last_pruned_block` - since a table will not necessarily have data removed on every pruning run, that block can be substantially before the deployment's earliest block.

Pruning is controlled with `graphman prune`; besides performing an initial prune, it now also sets the deployment's `history_blocks` by default, which can be turned off by passing `--once`.