### PR TITLE
store: Treat 'no connection to the server' as db not available

### DIFF
--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -566,7 +566,6 @@ impl r2d2::HandleError<r2d2::Error> for ErrorHandler {
         // in a locale other than English. In that case, their database will
         // be marked as unavailable even though it is perfectly fine.
         if msg.contains("canceling statement")
-            || msg.contains("no connection to the server")
             || msg.contains("terminating connection due to conflict with recovery")
         {
             return;


### PR DESCRIPTION
So far we treated the Postgres error "no connection to the server" as not indicating that the database was not available. It's a little murky what exactly that error indicates, but it seems to indicate that an existing connection got killed, e.g., because the database crashed.

We now treat this as an indication that the database is not available, which will trigger the right action further up in the stack. For example, on indexing, db operations will be retried instead of causing the subgraph to fail. Queries will be aborted with an error message.

