### PR TITLE
Instrument `RecentBlocksCache` with metrics

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -820,7 +820,7 @@ impl Context {
             &self.node_id,
             &self.config,
             self.fork_base,
-            self.registry,
+            self.registry.clone(),
         );
 
         for pool in pools.values() {
@@ -833,6 +833,7 @@ impl Context {
             subgraph_store,
             HashMap::default(),
             vec![],
+            self.registry,
         );
 
         (store, pools)

--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -20,8 +20,9 @@ use graph::{
 };
 
 use crate::{
-    chain_head_listener::ChainHeadUpdateSender, connection_pool::ConnectionPool,
-    primary::Mirror as PrimaryMirror, ChainStore, NotificationSender, Shard, PRIMARY_SHARD,
+    chain_head_listener::ChainHeadUpdateSender, chain_store::ChainStoreMetrics,
+    connection_pool::ConnectionPool, primary::Mirror as PrimaryMirror, ChainStore,
+    NotificationSender, Shard, PRIMARY_SHARD,
 };
 
 #[cfg(debug_assertions)]
@@ -183,6 +184,7 @@ pub struct BlockStore {
     sender: Arc<NotificationSender>,
     mirror: PrimaryMirror,
     chain_head_cache: TimedCache<String, HashMap<String, BlockPtr>>,
+    chain_store_metrics: Arc<ChainStoreMetrics>,
 }
 
 impl BlockStore {
@@ -204,6 +206,7 @@ impl BlockStore {
         // shard -> pool
         pools: HashMap<Shard, ConnectionPool>,
         sender: Arc<NotificationSender>,
+        chain_store_metrics: Arc<ChainStoreMetrics>,
     ) -> Result<Self, StoreError> {
         // Cache chain head pointers for this long when returning
         // information from `chain_head_pointers`
@@ -220,6 +223,7 @@ impl BlockStore {
             sender,
             mirror,
             chain_head_cache,
+            chain_store_metrics,
         };
 
         fn reduce_idents(
@@ -373,6 +377,7 @@ impl BlockStore {
             sender,
             pool,
             ENV_VARS.store.recent_blocks_cache_capacity,
+            self.chain_store_metrics.clone(),
         );
         if create {
             store.create(&ident)?;

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -3,7 +3,9 @@ use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use diesel::sql_types::Text;
 use diesel::{insert_into, update};
+use graph::components::metrics::MetricsRegistryTrait;
 use graph::parking_lot::RwLock;
+use graph::prometheus::{CounterVec, GaugeVec};
 
 use std::{
     collections::HashMap,
@@ -1322,6 +1324,76 @@ from (
     }
 }
 
+#[derive(Debug)]
+pub struct ChainStoreMetrics {
+    chain_head_cache_size: Box<GaugeVec>,
+    chain_head_cache_oldest_block_num: Box<GaugeVec>,
+    chain_head_cache_latest_block_num: Box<GaugeVec>,
+    chain_head_cache_hits: Box<CounterVec>,
+    chain_head_cache_misses: Box<CounterVec>,
+}
+
+impl ChainStoreMetrics {
+    pub fn new(registry: Arc<dyn MetricsRegistryTrait>) -> Self {
+        let chain_head_cache_size = registry
+            .new_gauge_vec(
+                "chain_head_cache_num_blocks",
+                "Number of blocks in the chain head cache",
+                vec!["network".to_string()],
+            )
+            .expect("Can't register the gauge");
+        let chain_head_cache_oldest_block_num = registry
+            .new_gauge_vec(
+                "chain_head_cache_oldest_block",
+                "Block number of the oldest block currently present in the chain head cache",
+                vec!["network".to_string()],
+            )
+            .expect("Can't register the gauge");
+        let chain_head_cache_latest_block_num = registry
+            .new_gauge_vec(
+                "chain_head_cache_latest_block",
+                "Block number of the latest block currently present in the chain head cache",
+                vec!["network".to_string()],
+            )
+            .expect("Can't register the gauge");
+
+        let chain_head_cache_hits = registry
+            .new_counter_vec(
+                "chain_head_cache_hits",
+                "Number of times the chain head cache was hit",
+                vec!["network".to_string()],
+            )
+            .expect("Can't register the counter");
+        let chain_head_cache_misses = registry
+            .new_counter_vec(
+                "chain_head_cache_misses",
+                "Number of times the chain head cache was missed",
+                vec!["network".to_string()],
+            )
+            .expect("Can't register the counter");
+
+        Self {
+            chain_head_cache_size,
+            chain_head_cache_oldest_block_num,
+            chain_head_cache_latest_block_num,
+            chain_head_cache_hits,
+            chain_head_cache_misses,
+        }
+    }
+
+    pub fn add_block(&self, network: &str) {
+        self.chain_head_cache_size
+            .with_label_values(&[network])
+            .inc();
+    }
+
+    pub fn remove_block(&self, network: &str) {
+        self.chain_head_cache_size
+            .with_label_values(&[network])
+            .dec();
+    }
+}
+
 pub struct ChainStore {
     pool: ConnectionPool,
     pub chain: String,
@@ -1347,7 +1419,10 @@ impl ChainStore {
         chain_head_update_sender: ChainHeadUpdateSender,
         pool: ConnectionPool,
         recent_blocks_cache_capacity: usize,
+        metrics: Arc<ChainStoreMetrics>,
     ) -> Self {
+        let recent_blocks_cache =
+            RecentBlocksCache::new(recent_blocks_cache_capacity, chain.clone(), metrics);
         ChainStore {
             pool,
             chain,
@@ -1355,7 +1430,7 @@ impl ChainStore {
             genesis_block_ptr: BlockPtr::new(net_identifier.genesis_block_hash.clone(), 0),
             status,
             chain_head_update_sender,
-            recent_blocks_cache: RecentBlocksCache::new(recent_blocks_cache_capacity),
+            recent_blocks_cache,
         }
     }
 
@@ -1832,6 +1907,8 @@ mod recent_blocks_cache {
     }
 
     struct Inner {
+        network: String,
+        metrics: Arc<ChainStoreMetrics>,
         // Note: we only ever store blocks in this cache that have a continuous
         // line of ancestry between each other. Line of ancestry is verified by
         // comparing parent hashes. Because of NEAR, however, we cannot
@@ -1875,6 +1952,42 @@ mod recent_blocks_cache {
             while self.blocks.len() > self.capacity {
                 self.blocks.pop_first();
             }
+        }
+
+        fn record_cache_hit(&self) {
+            self.metrics
+                .chain_head_cache_hits
+                .get_metric_with_label_values(&[&self.network])
+                .unwrap()
+                .inc();
+        }
+
+        fn record_cache_miss(&self) {
+            self.metrics
+                .chain_head_cache_misses
+                .get_metric_with_label_values(&[&self.network])
+                .unwrap()
+                .inc();
+        }
+
+        fn update_write_metrics(&self) {
+            self.metrics
+                .chain_head_cache_size
+                .get_metric_with_label_values(&[&self.network])
+                .unwrap()
+                .set(self.blocks.len() as f64);
+
+            self.metrics
+                .chain_head_cache_oldest_block_num
+                .get_metric_with_label_values(&[&self.network])
+                .unwrap()
+                .set(self.earliest_block().map(|b| b.ptr.number).unwrap_or(0) as f64);
+
+            self.metrics
+                .chain_head_cache_latest_block_num
+                .get_metric_with_label_values(&[&self.network])
+                .unwrap()
+                .set(self.earliest_block().map(|b| b.ptr.number).unwrap_or(0) as f64);
         }
 
         fn insert_block(
@@ -1936,9 +2049,11 @@ mod recent_blocks_cache {
     }
 
     impl RecentBlocksCache {
-        pub fn new(capacity: usize) -> Self {
+        pub fn new(capacity: usize, network: String, metrics: Arc<ChainStoreMetrics>) -> Self {
             RecentBlocksCache {
                 inner: RwLock::new(Inner {
+                    network,
+                    metrics,
                     blocks: BTreeMap::new(),
                     capacity,
                 }),
@@ -1951,7 +2066,8 @@ mod recent_blocks_cache {
         }
 
         pub fn clear(&self) {
-            self.inner.write().blocks.clear()
+            self.inner.write().blocks.clear();
+            self.inner.read().update_write_metrics();
         }
 
         pub fn get_block(
@@ -1959,10 +2075,19 @@ mod recent_blocks_cache {
             child: &BlockPtr,
             offset: BlockNumber,
         ) -> Option<(BlockPtr, Option<json::Value>)> {
-            self.inner
+            let block_opt = self
+                .inner
                 .read()
                 .get_block(child, offset)
-                .map(|b| (b.0.clone(), b.1.cloned()))
+                .map(|b| (b.0.clone(), b.1.cloned()));
+
+            if block_opt.is_some() {
+                self.inner.read().record_cache_hit();
+            } else {
+                self.inner.read().record_cache_miss();
+            }
+
+            block_opt
         }
 
         /// Tentatively caches the `ancestor` of a [`BlockPtr`] (`child`), together with
@@ -1975,7 +2100,8 @@ mod recent_blocks_cache {
             data: Option<json::Value>,
             parent_hash: BlockHash,
         ) {
-            self.inner.write().insert_block(ptr, data, parent_hash)
+            self.inner.write().insert_block(ptr, data, parent_hash);
+            self.inner.read().update_write_metrics();
         }
     }
 }

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -55,7 +55,7 @@ pub mod layout_for_tests {
 
 pub use self::block_store::BlockStore;
 pub use self::chain_head_listener::ChainHeadUpdateListener;
-pub use self::chain_store::ChainStore;
+pub use self::chain_store::{ChainStore, ChainStoreMetrics};
 pub use self::detail::DeploymentDetail;
 pub use self::jobs::register as register_jobs;
 pub use self::notification_listener::NotificationSender;


### PR DESCRIPTION
Fixes #4391. These new metrics could help us with identifying and root-causing performance and load issues on the database.