### PR TITLE
Add facilities to gte more details during indexing

### DIFF
--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -172,6 +172,7 @@ where
         causality_region: &str,
         _debug_fork: &Option<Arc<dyn SubgraphFork>>,
         _subgraph_metrics: &Arc<graph::prelude::SubgraphInstanceMetrics>,
+        _instrument: bool,
     ) -> Result<BlockState<Chain>, MappingError> {
         for entity_change in block.changes.entity_changes.iter() {
             match entity_change.operation() {

--- a/core/src/subgraph/context.rs
+++ b/core/src/subgraph/context.rs
@@ -93,6 +93,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
         causality_region: &str,
         debug_fork: &Option<Arc<dyn SubgraphFork>>,
         subgraph_metrics: &Arc<SubgraphInstanceMetrics>,
+        instrument: bool,
     ) -> Result<BlockState<C>, MappingError> {
         self.process_trigger_in_hosts(
             logger,
@@ -104,6 +105,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
             causality_region,
             debug_fork,
             subgraph_metrics,
+            instrument,
         )
         .await
     }
@@ -119,6 +121,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
         causality_region: &str,
         debug_fork: &Option<Arc<dyn SubgraphFork>>,
         subgraph_metrics: &Arc<SubgraphInstanceMetrics>,
+        instrument: bool,
     ) -> Result<BlockState<C>, MappingError> {
         self.trigger_processor
             .process_trigger(
@@ -131,6 +134,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
                 causality_region,
                 debug_fork,
                 subgraph_metrics,
+                instrument,
             )
             .await
     }

--- a/core/src/subgraph/inputs.rs
+++ b/core/src/subgraph/inputs.rs
@@ -28,4 +28,8 @@ pub struct IndexingInputs<C: Blockchain> {
 
     // Correspondence between data source or template position in the manifest and name.
     pub manifest_idx_and_name: Vec<(u32, String)>,
+
+    /// Whether to instrument trigger processing and log additional,
+    /// possibly expensive and noisy, information
+    pub instrument: bool,
 }

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -403,6 +403,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
         let causality_region_seq =
             CausalityRegionSeq::from_current(store.causality_region_curr_val().await?);
 
+        let instrument = self.subgraph_store.instrument(&deployment)?;
         let instance = super::context::instance::SubgraphInstance::from_manifest(
             &logger,
             manifest,
@@ -427,6 +428,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             manifest_idx_and_name,
             poi_version,
             network,
+            instrument,
         };
 
         // The subgraph state tracks the state of the subgraph instance over time

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -325,6 +325,7 @@ where
                         &causality_region,
                         &self.inputs.debug_fork,
                         &self.metrics.subgraph,
+                        self.inputs.instrument,
                     )
                     .await
                     .map_err(|e| {
@@ -504,6 +505,7 @@ where
                     causality_region,
                     &self.inputs.debug_fork,
                     &self.metrics.subgraph,
+                    self.inputs.instrument,
                 )
                 .await
                 .map_err(move |mut e| {
@@ -666,6 +668,7 @@ where
                     causality_region,
                     &self.inputs.debug_fork,
                     &self.metrics.subgraph,
+                    self.inputs.instrument,
                 )
                 .await
                 .map_err(move |err| {

--- a/core/src/subgraph/trigger_processor.rs
+++ b/core/src/subgraph/trigger_processor.rs
@@ -30,6 +30,7 @@ where
         causality_region: &str,
         debug_fork: &Option<Arc<dyn SubgraphFork>>,
         subgraph_metrics: &Arc<SubgraphInstanceMetrics>,
+        instrument: bool,
     ) -> Result<BlockState<C>, MappingError> {
         let error_count = state.deterministic_errors.len();
 
@@ -71,6 +72,7 @@ where
                     state,
                     proof_of_indexing.cheap_clone(),
                     debug_fork,
+                    instrument,
                 )
                 .await?;
             let elapsed = start.elapsed().as_secs_f64();

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -169,6 +169,11 @@ pub trait SubgraphStore: Send + Sync + 'static {
         hash: &DeploymentHash,
         raw_yaml: String,
     ) -> Result<(), StoreError>;
+
+    /// Return `true` if the `instrument` flag for the deployment is set.
+    /// When this flag is set, indexing of the deployment should log
+    /// additional diagnostic information
+    fn instrument(&self, deployment: &DeploymentLocator) -> Result<bool, StoreError>;
 }
 
 pub trait ReadStore: Send + Sync + 'static {

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -63,6 +63,7 @@ pub trait RuntimeHost<C: Blockchain>: Send + Sync + 'static {
         state: BlockState<C>,
         proof_of_indexing: SharedProofOfIndexing,
         debug_fork: &Option<Arc<dyn SubgraphFork>>,
+        instrument: bool,
     ) -> Result<BlockState<C>, MappingError>;
 
     /// Block number in which this host was created.

--- a/graph/src/components/trigger_processor.rs
+++ b/graph/src/components/trigger_processor.rs
@@ -27,5 +27,6 @@ where
         causality_region: &str,
         debug_fork: &Option<Arc<dyn SubgraphFork>>,
         subgraph_metrics: &Arc<SubgraphInstanceMetrics>,
+        instrument: bool,
     ) -> Result<BlockState<C>, MappingError>;
 }

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -116,6 +116,7 @@ pub fn mock_context(
         host_fns: Arc::new(Vec::new()),
         debug_fork: None,
         mapping_logger: Logger::root(slog::Discard, o!()),
+        instrument: false,
     }
 }
 

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -159,6 +159,7 @@ where
         block_ptr: BlockPtr,
         proof_of_indexing: SharedProofOfIndexing,
         debug_fork: &Option<Arc<dyn SubgraphFork>>,
+        instrument: bool,
     ) -> Result<BlockState<C>, MappingError> {
         let handler = trigger.handler_name().to_string();
 
@@ -186,6 +187,7 @@ where
                     host_fns: self.host_fns.cheap_clone(),
                     debug_fork: debug_fork.cheap_clone(),
                     mapping_logger: Logger::new(&logger, o!("component" => "UserMapping")),
+                    instrument,
                 },
                 trigger,
                 result_sender,
@@ -240,6 +242,7 @@ impl<C: Blockchain> RuntimeHostTrait<C> for RuntimeHost<C> {
         state: BlockState<C>,
         proof_of_indexing: SharedProofOfIndexing,
         debug_fork: &Option<Arc<dyn SubgraphFork>>,
+        instrument: bool,
     ) -> Result<BlockState<C>, MappingError> {
         self.send_mapping_request(
             logger,
@@ -248,6 +251,7 @@ impl<C: Blockchain> RuntimeHostTrait<C> for RuntimeHost<C> {
             block_ptr,
             proof_of_indexing,
             debug_fork,
+            instrument,
         )
         .await
     }

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -126,6 +126,8 @@ pub struct MappingContext<C: Blockchain> {
     pub debug_fork: Option<Arc<dyn SubgraphFork>>,
     /// Logger for messages coming from mappings
     pub mapping_logger: Logger,
+    /// Whether to log details about host fn execution
+    pub instrument: bool,
 }
 
 impl<C: Blockchain> MappingContext<C> {
@@ -139,6 +141,7 @@ impl<C: Blockchain> MappingContext<C> {
             host_fns: self.host_fns.cheap_clone(),
             debug_fork: self.debug_fork.cheap_clone(),
             mapping_logger: Logger::new(&self.logger, o!("component" => "UserMapping")),
+            instrument: self.instrument,
         }
     }
 }

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -925,9 +925,15 @@ impl<C: Blockchain> WasmInstanceContext<C> {
         let stopwatch = &self.host_metrics.stopwatch;
         stopwatch.start_section("host_export_store_set__wasm_instance_context_store_set");
 
-        let entity = asc_get(self, entity_ptr, gas)?;
-        let id = asc_get(self, id_ptr, gas)?;
+        let entity: String = asc_get(self, entity_ptr, gas)?;
+        let id: String = asc_get(self, id_ptr, gas)?;
         let data = asc_get(self, data_ptr, gas)?;
+
+        if self.ctx.instrument {
+            debug!(self.ctx.logger, "store_set";
+                    "type" => &entity,
+                    "id" => &id);
+        }
 
         self.ctx.host_exports.store_set(
             &self.ctx.logger,
@@ -950,8 +956,13 @@ impl<C: Blockchain> WasmInstanceContext<C> {
         entity_ptr: AscPtr<AscString>,
         id_ptr: AscPtr<AscString>,
     ) -> Result<(), HostExportError> {
-        let entity = asc_get(self, entity_ptr, gas)?;
-        let id = asc_get(self, id_ptr, gas)?;
+        let entity: String = asc_get(self, entity_ptr, gas)?;
+        let id: String = asc_get(self, id_ptr, gas)?;
+        if self.ctx.instrument {
+            debug!(self.ctx.logger, "store_remove";
+                    "type" => &entity,
+                    "id" => &id);
+        }
         self.ctx.host_exports.store_remove(
             &self.ctx.logger,
             &mut self.ctx.state,
@@ -982,7 +993,12 @@ impl<C: Blockchain> WasmInstanceContext<C> {
             id.clone(),
             gas,
         )?;
-
+        if self.ctx.instrument {
+            debug!(self.ctx.logger, "store_get";
+                    "type" => &entity_type,
+                    "id" => &id,
+                    "found" => entity_option.is_some());
+        }
         let ret = match entity_option {
             Some(entity) => {
                 let _section = self

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -80,6 +80,7 @@ pub(crate) struct SubgraphInfo {
     pub(crate) description: Option<String>,
     pub(crate) repository: Option<String>,
     pub(crate) poi_version: ProofOfIndexingVersion,
+    pub(crate) instrument: bool,
 }
 
 pub struct StoreInner {
@@ -589,6 +590,7 @@ impl DeploymentStore {
             description: manifest_info.description,
             repository: manifest_info.repository,
             poi_version,
+            instrument: manifest_info.instrument,
         };
 
         // Insert the schema into the cache.

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1416,4 +1416,12 @@ impl SubgraphStoreTrait for SubgraphStore {
         let (store, site) = self.store(hash)?;
         store.set_manifest_raw_yaml(site, raw_yaml).await
     }
+
+    fn instrument(&self, deployment: &DeploymentLocator) -> Result<bool, StoreError> {
+        let site = self.find_site(deployment.id.into())?;
+        let store = self.for_site(&site)?;
+
+        let info = store.subgraph_info(&site)?;
+        Ok(info.instrument)
+    }
 }


### PR DESCRIPTION
These changes make it so that an individual deployment can be set to log all store interactions to help diagnose problems with the deployment.

Right now, this is turned on by manipulating the database directly; if it turns out to be useful, we should add a `graphman` command to turn this on.