### PR TITLE
Automatically refresh materialized views

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- the materialized views in the `info` schema (`table_sizes`, `subgraph_sizes`, and `chain_sizes`) that provide information about the size of various database objects are now automatically refreshed every 6 hours. [#4461](https://github.com/graphprotocol/graph-node/pull/4461)
+
+
 ## v0.30.0
 
 ### Database locale change
@@ -87,7 +90,7 @@ Dependency upgrades:
 
   - `Qmccst5mbV5a6vT6VvJMLPKMAA1VRgT6NGbxkLL8eDRsE7`
   - `Qmd9nZKCH8UZU1pBzk7G8ECJr3jX3a2vAf3vowuTwFvrQg`
- 
+
   Here's an example [manifest](https://ipfs.io/ipfs/Qmd9nZKCH8UZU1pBzk7G8ECJr3jX3a2vAf3vowuTwFvrQg), taking a look at the data sources of name `ERC721` and `CryptoKitties`, both listen to the `Transfer(...)` event. Considering a block where there's only one occurence of this event, `graph-node` would duplicate it and call `handleTransfer` twice. Now this is fixed and it will be called only once per event/call that happened on chain.
 
   In the case you're indexing one of the impacted subgraphs, you should first upgrade the `graph-node` version, then rewind the affected subgraphs to the smallest `startBlock` of their subgraph manifest. To achieve that the `graphman rewind` CLI command can be used.
@@ -95,7 +98,7 @@ Dependency upgrades:
   See [#4055](https://github.com/graphprotocol/graph-node/pull/4055) for more information.
 
 * This release fixes another determinism bug that affects a handful of subgraphs. The bug affects all subgraphs which have an `apiVersion` **older than** 0.0.5 using call handlers. While call handlers prior to 0.0.5 should be triggered by both failed and successful transactions, in some cases failed transactions would not trigger the handlers. This resulted in nondeterministic behavior. With this version of `graph-node`, call handlers with an `apiVersion` older than 0.0.5 will always be triggered by both successful and failed transactions. Behavior for `apiVersion` 0.0.5 onward is not affected.
-  
+
   The affected subgraphs are:
 
   - `QmNY7gDNXHECV8SXoEY7hbfg4BX1aDMxTBDiFuG4huaSGA`

--- a/store/postgres/src/jobs.rs
+++ b/store/postgres/src/jobs.rs
@@ -20,25 +20,28 @@ pub fn register(
     primary_pool: ConnectionPool,
     registry: Arc<dyn MetricsRegistryTrait>,
 ) {
+    const ONE_MINUTE: Duration = Duration::from_secs(60);
+    const ONE_HOUR: Duration = Duration::from_secs(60 * 60);
+
     runner.register(
         Arc::new(VacuumDeploymentsJob::new(store.subgraph_store())),
-        Duration::from_secs(60),
+        ONE_MINUTE,
     );
 
     runner.register(
         Arc::new(NotificationQueueUsage::new(primary_pool, registry)),
-        Duration::from_secs(60),
+        ONE_MINUTE,
     );
 
     runner.register(
         Arc::new(MirrorPrimary::new(store.subgraph_store())),
-        Duration::from_secs(15 * 60),
+        15 * ONE_MINUTE,
     );
 
     // Remove unused deployments every 2 hours
     runner.register(
         Arc::new(UnusedJob::new(store.subgraph_store())),
-        Duration::from_secs(2 * 60 * 60),
+        2 * ONE_HOUR,
     )
 }
 

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1029,6 +1029,15 @@ impl SubgraphStoreInner {
         .await;
     }
 
+    pub async fn refresh_materialized_views(&self, logger: &Logger) {
+        join_all(
+            self.stores
+                .values()
+                .map(|store| store.refresh_materialized_views(logger)),
+        )
+        .await;
+    }
+
     pub fn analyze(
         &self,
         deployment: &DeploymentLocator,


### PR DESCRIPTION
We have some materialized views that contain information about the size of various things in the database. So far, they had to be refreshed manually and could therefore fall out of sync by a lot.

With this change, they get refreshed automatically every 6 hours. For very large databases, a refresh takes a little over a minute.