### PR TITLE
graph: fix substreams `startBlock` selection

### DIFF
--- a/chain/substreams/src/data_source.rs
+++ b/chain/substreams/src/data_source.rs
@@ -277,7 +277,6 @@ mod test {
 
     use crate::{DataSource, Mapping, UnresolvedDataSource, UnresolvedMapping, SUBSTREAMS_KIND};
 
-
     #[test]
     fn parse_data_source() {
         let ds: UnresolvedDataSource = serde_yaml::from_str(TEMPLATE_DATA_SOURCE).unwrap();

--- a/chain/substreams/src/data_source.rs
+++ b/chain/substreams/src/data_source.rs
@@ -280,6 +280,8 @@ mod test {
         components::link_resolver::LinkResolver,
         prelude::{async_trait, serde_yaml, JsonValueStream, Link},
         slog::{o, Discard, Logger},
+        substreams::module::{Kind, KindMap, KindStore},
+        substreams::{Module, Modules, Package},
     };
     use prost::Message;
 
@@ -354,20 +356,47 @@ mod test {
         );
     }
 
-    fn gen_package() -> graph::substreams::Package {
-        graph::substreams::Package {
+    fn gen_package() -> Package {
+        Package {
             proto_files: vec![],
             version: 0,
-            modules: Some(graph::substreams::Modules {
-                modules: vec![graph::substreams::Module {
-                    name: "output".into(),
-                    initial_block: 123,
-                    binary_entrypoint: "entry".into(),
-                    binary_index: 0,
-                    kind: None,
-                    inputs: vec![],
-                    output: None,
-                }],
+            modules: Some(Modules {
+                modules: vec![
+                    Module {
+                        name: "output".into(),
+                        initial_block: 123,
+                        binary_entrypoint: "output".into(),
+                        binary_index: 0,
+                        kind: Some(Kind::KindMap(KindMap {
+                            output_type: "proto".into(),
+                        })),
+                        inputs: vec![],
+                        output: None,
+                    },
+                    Module {
+                        name: "store_mod".into(),
+                        initial_block: 0,
+                        binary_entrypoint: "store_mod".into(),
+                        binary_index: 0,
+                        kind: Some(Kind::KindStore(KindStore {
+                            update_policy: 1,
+                            value_type: "proto1".into(),
+                        })),
+                        inputs: vec![],
+                        output: None,
+                    },
+                    Module {
+                        name: "map_mod".into(),
+                        initial_block: 123456,
+                        binary_entrypoint: "other2".into(),
+                        binary_index: 0,
+                        kind: Some(Kind::KindMap(KindMap {
+                            output_type: "proto2".into(),
+                        })),
+                        inputs: vec![],
+                        output: None,
+                    },
+                ],
                 binaries: vec![],
             }),
             module_meta: vec![],

--- a/chain/substreams/src/data_source.rs
+++ b/chain/substreams/src/data_source.rs
@@ -172,9 +172,14 @@ impl blockchain::UnresolvedDataSource<Chain> for UnresolvedDataSource {
 
         let package = graph::substreams::Package::decode(content.as_ref())?;
 
-        let initial_block: Option<u64> = match package.modules {
-            Some(ref modules) => modules.modules.iter().map(|x| x.initial_block).min(),
+        let module = match package.modules {
+            Some(ref modules) => modules.modules.iter().find(|module| module.name == self.source.package.module_name),
             None => None,
+        };
+
+        let initial_block: Option<u64> = match module {
+            Some(module) => Some(module.initial_block),
+            None => return Err(anyhow!("Substreams module {} does not exist", self.source.package.module_name)),
         };
 
         let initial_block: Option<i32> = initial_block

--- a/chain/substreams/src/data_source.rs
+++ b/chain/substreams/src/data_source.rs
@@ -173,13 +173,21 @@ impl blockchain::UnresolvedDataSource<Chain> for UnresolvedDataSource {
         let package = graph::substreams::Package::decode(content.as_ref())?;
 
         let module = match package.modules {
-            Some(ref modules) => modules.modules.iter().find(|module| module.name == self.source.package.module_name),
+            Some(ref modules) => modules
+                .modules
+                .iter()
+                .find(|module| module.name == self.source.package.module_name),
             None => None,
         };
 
         let initial_block: Option<u64> = match module {
             Some(module) => Some(module.initial_block),
-            None => return Err(anyhow!("Substreams module {} does not exist", self.source.package.module_name)),
+            None => {
+                return Err(anyhow!(
+                    "Substreams module {} does not exist",
+                    self.source.package.module_name
+                ))
+            }
         };
 
         let initial_block: Option<i32> = initial_block

--- a/chain/substreams/src/data_source.rs
+++ b/chain/substreams/src/data_source.rs
@@ -181,7 +181,15 @@ impl blockchain::UnresolvedDataSource<Chain> for UnresolvedDataSource {
         };
 
         let initial_block: Option<u64> = match module {
-            Some(module) => Some(module.initial_block),
+            Some(module) => match &module.kind {
+                Some(graph::substreams::module::Kind::KindMap(_)) => Some(module.initial_block),
+                _ => {
+                    return Err(anyhow!(
+                        "Substreams module {} must be of 'map' kind",
+                        module.name
+                    ))
+                }
+            },
             None => {
                 return Err(anyhow!(
                     "Substreams module {} does not exist",

--- a/graph/src/blockchain/substreams_block_stream.rs
+++ b/graph/src/blockchain/substreams_block_stream.rs
@@ -6,7 +6,7 @@ use crate::firehose::FirehoseEndpoint;
 use crate::prelude::*;
 use crate::substreams::response::Message;
 use crate::substreams::ForkStep::{StepNew, StepUndo};
-use crate::substreams::{Modules, Request, Response, module_progress};
+use crate::substreams::{Modules, Request, Response};
 use crate::util::backoff::ExponentialBackoff;
 use async_stream::try_stream;
 use futures03::{Stream, StreamExt};
@@ -313,76 +313,11 @@ async fn process_substreams_response<C: Blockchain, F: SubstreamsMapper<C>>(
                 None => Ok(None),
             }
         }
-        Some(Message::Progress(modules_progress)) => {
-            for module_progress in modules_progress.modules.iter() {
-                match module_progress.r#type.clone() {
-                    Some(module_progress::Type::ProcessedRanges(processed_range)) => {
-                        for processed_range in processed_range.processed_ranges.iter() {
-                            if processed_range.end_block % 1000 == 0 {
-                                debug!(
-                                    logger,
-                                    "Range progress for module: {}, Range: {}-{}",
-                                    module_progress.name,
-                                    processed_range.start_block,
-                                    processed_range.end_block
-                                );
-                            }
-                        }
-                    }
-                    Some(module_progress::Type::InitialState(initial_state)) => {
-                        debug!(
-                            &logger,
-                            "State progress for module: {}, InitialState: {:?}",
-                            module_progress.name,
-                            initial_state
-                        );
-                    }
-                    Some(module_progress::Type::ProcessedBytes(processed_bytes)) => {
-                        debug!(
-                            &logger,
-                            "Bytes progress for module: {}, ProcessedBytes: {:?}",
-                            module_progress.name,
-                            processed_bytes
-                        );
-                    }
-                    Some(module_progress::Type::Failed(failed)) => {
-                        error!(
-                            &logger,
-                            "ModuleProgress failed. Reason: {}. Logs: {:?}. Logs truncated: {}",
-                            failed.reason,
-                            failed.logs,
-                            failed.logs_truncated,
-                        );
-                    }
-                    None => {
-                        warn!(&logger, "Received an empty ModuleProgress");
-                    }
-                }
-            }
-            Ok(None)
-        }
-        Some(Message::Session(session_init)) => {
-            debug!(&logger, "Session trace_id: {}", session_init.trace_id,);
-            Ok(None)
-        }
-        Some(Message::SnapshotData(snapshort_data)) => {
-            debug!(
-                &logger,
-                "SnapshotData for module {}: keys: {}/{}",
-                snapshort_data.module_name,
-                snapshort_data.sent_keys,
-                snapshort_data.total_keys,
-            );
-            Ok(None)
-        }
-        Some(Message::SnapshotComplete(snapshort_data)) => {
-            debug!(&logger, "SnapshotComplete cursor {}", snapshort_data.cursor,);
-            Ok(None)
-        }
         None => {
             warn!(&logger, "Got None on substream message");
             Ok(None)
-        } // _ => Ok(None),
+        }
+        _ => Ok(None),
     }
 }
 


### PR DESCRIPTION
This fixes #4449 by choosing `initial_block` of the module provided in the manifest.

It also verifies that module name provided in the subgraph manifest exists in the substreams manifest and if not, `graph deploy` errors out rather than letting it deploy and then unsuccessfully retry RPC requests to the substreams endpoint.

