### PR TITLE
graph-chain-ethereum: Avoid adapters with errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,6 +1655,7 @@ dependencies = [
  "test-store",
  "tiny-keccak 1.5.0",
  "tonic-build",
+ "uuid",
 ]
 
 [[package]]

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -27,6 +27,7 @@ graph-runtime-derive = { path = "../../runtime/derive" }
 [dev-dependencies]
 test-store = { path = "../../store/test-store" }
 base64 = "0.20.0"
+uuid = { version = "1.3.0", features = ["v4"] }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -828,8 +828,6 @@ impl SubgraphEthRpcMetrics {
 /// or a remote node over RPC.
 #[async_trait]
 pub trait EthereumAdapter: Send + Sync + 'static {
-    fn url_hostname(&self) -> &str;
-
     /// The `provider.label` from the adapter's configuration
     fn provider(&self) -> &str;
 

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -837,10 +837,6 @@ impl EthereumAdapter {
 
 #[async_trait]
 impl EthereumAdapterTrait for EthereumAdapter {
-    fn url_hostname(&self) -> &str {
-        &self.url.host_str().unwrap()
-    }
-
     fn provider(&self) -> &str {
         &self.provider
     }
@@ -1419,7 +1415,7 @@ pub(crate) async fn blocks_with_triggers(
             None => {
                 warn!(logger,
                       "Ethereum endpoint is behind";
-                      "url" => eth.url_hostname()
+                      "url" => eth.provider()
                 );
                 bail!("Block {} not found in the chain", to)
             }

--- a/chain/ethereum/src/network.rs
+++ b/chain/ethereum/src/network.rs
@@ -39,8 +39,7 @@ impl EthereumNetworkAdapter {
     }
 
     pub fn current_error_count(&self) -> u64 {
-        self.endpoint_metrics
-            .get_count(&self.adapter.url.as_str().into())
+        self.endpoint_metrics.get_count(&self.provider().into())
     }
     pub fn provider(&self) -> &str {
         self.adapter.provider()

--- a/chain/ethereum/src/network.rs
+++ b/chain/ethereum/src/network.rs
@@ -1,7 +1,9 @@
-use anyhow::{anyhow, bail, Context};
+use anyhow::{anyhow, bail};
 use graph::cheap_clone::CheapClone;
-use graph::firehose::SubgraphLimit;
-use graph::prelude::rand::{self, seq::IteratorRandom};
+use graph::endpoint::EndpointMetrics;
+use graph::firehose::{AvailableCapacity, SubgraphLimit};
+use graph::prelude::rand::seq::IteratorRandom;
+use graph::prelude::rand::{self, Rng};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -13,10 +15,13 @@ use crate::adapter::EthereumAdapter as _;
 use crate::capabilities::NodeCapabilities;
 use crate::EthereumAdapter;
 
+pub const DEFAULT_ADAPTER_ERROR_RETEST_PERCENT: f64 = 0.2;
+
 #[derive(Debug, Clone)]
 pub struct EthereumNetworkAdapter {
+    endpoint_metrics: Arc<EndpointMetrics>,
     pub capabilities: NodeCapabilities,
-    adapter: Arc<EthereumAdapter>,
+    pub adapter: Arc<EthereumAdapter>,
     /// The maximum number of times this adapter can be used. We use the
     /// strong_count on `adapter` to determine whether the adapter is above
     /// that limit. That's a somewhat imprecise but convenient way to
@@ -28,15 +33,43 @@ impl EthereumNetworkAdapter {
     fn is_call_only(&self) -> bool {
         self.adapter.is_call_only()
     }
+
+    pub fn get_capacity(&self) -> AvailableCapacity {
+        self.limit.get_capacity(Arc::strong_count(&self.adapter))
+    }
+
+    pub fn current_error_count(&self) -> u64 {
+        self.endpoint_metrics
+            .get_count(&self.adapter.url.as_str().into())
+    }
+    pub fn provider(&self) -> &str {
+        self.adapter.provider()
+    }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct EthereumNetworkAdapters {
     pub adapters: Vec<EthereumNetworkAdapter>,
-    pub call_only_adapters: Vec<EthereumNetworkAdapter>,
+    call_only_adapters: Vec<EthereumNetworkAdapter>,
+    // Percentage of request that should be used to retest errored adapters.
+    retest_percent: f64,
+}
+
+impl Default for EthereumNetworkAdapters {
+    fn default() -> Self {
+        Self::new(None)
+    }
 }
 
 impl EthereumNetworkAdapters {
+    pub fn new(retest_percent: Option<f64>) -> Self {
+        Self {
+            adapters: vec![],
+            call_only_adapters: vec![],
+            retest_percent: retest_percent.unwrap_or(DEFAULT_ADAPTER_ERROR_RETEST_PERCENT),
+        }
+    }
+
     pub fn push_adapter(&mut self, adapter: EthereumNetworkAdapter) {
         if adapter.is_call_only() {
             self.call_only_adapters.push(adapter);
@@ -47,7 +80,7 @@ impl EthereumNetworkAdapters {
     pub fn all_cheapest_with(
         &self,
         required_capabilities: &NodeCapabilities,
-    ) -> impl Iterator<Item = Arc<EthereumAdapter>> + '_ {
+    ) -> impl Iterator<Item = &EthereumNetworkAdapter> + '_ {
         let cheapest_sufficient_capability = self
             .adapters
             .iter()
@@ -57,27 +90,38 @@ impl EthereumNetworkAdapters {
         self.adapters
             .iter()
             .filter(move |adapter| Some(&adapter.capabilities) == cheapest_sufficient_capability)
-            .filter(|adapter| {
-                adapter
-                    .limit
-                    .has_capacity(Arc::strong_count(&adapter.adapter))
-            })
-            .map(|adapter| adapter.adapter.cheap_clone())
+            .filter(|adapter| adapter.get_capacity() > AvailableCapacity::Unavailable)
     }
 
     pub fn cheapest_with(
         &self,
         required_capabilities: &NodeCapabilities,
     ) -> Result<Arc<EthereumAdapter>, Error> {
-        // Select randomly from the cheapest adapters that have sufficent capabilities.
-        self.all_cheapest_with(required_capabilities)
-            .choose(&mut rand::thread_rng())
-            .with_context(|| {
-                anyhow!(
-                    "A matching Ethereum network with {:?} was not found.",
-                    required_capabilities
-                )
-            })
+        let retest_rng: f64 = (&mut rand::thread_rng()).gen();
+        let cheapest = self
+            .all_cheapest_with(required_capabilities)
+            .choose_multiple(&mut rand::thread_rng(), 3);
+        let cheapest = cheapest.iter();
+
+        // If request falls below the retest threshold, use this request to try and
+        // reset the failed adapter. If a request succeeds the adapter will be more
+        // likely to be selected afterwards.
+        if retest_rng < self.retest_percent {
+            cheapest.max_by_key(|adapter| adapter.current_error_count())
+        } else {
+            // The assumption here is that most RPC endpoints will not have limits
+            // which makes the check for low/high available capacity less relevant.
+            // So we essentially assume if it had available capacity when calling
+            // `all_cheapest_with` then it prolly maintains that state and so we
+            // just select whichever adapter is working better according to
+            // the number of errors.
+            cheapest.min_by_key(|adapter| adapter.current_error_count())
+        }
+        .map(|adapter| adapter.adapter.clone())
+        .ok_or(anyhow!(
+            "A matching Ethereum network with {:?} was not found.",
+            required_capabilities
+        ))
     }
 
     pub fn cheapest(&self) -> Option<Arc<EthereumAdapter>> {
@@ -138,13 +182,15 @@ impl EthereumNetworkAdapters {
 
 #[derive(Clone)]
 pub struct EthereumNetworks {
+    pub metrics: Arc<EndpointMetrics>,
     pub networks: HashMap<String, EthereumNetworkAdapters>,
 }
 
 impl EthereumNetworks {
-    pub fn new() -> EthereumNetworks {
+    pub fn new(metrics: Arc<EndpointMetrics>) -> EthereumNetworks {
         EthereumNetworks {
             networks: HashMap::new(),
+            metrics,
         }
     }
 
@@ -161,6 +207,7 @@ impl EthereumNetworks {
             capabilities,
             adapter,
             limit,
+            endpoint_metrics: self.metrics.cheap_clone(),
         });
     }
 
@@ -219,13 +266,20 @@ impl EthereumNetworks {
 
 #[cfg(test)]
 mod tests {
-    use graph::{firehose::SubgraphLimit, prelude::MetricsRegistry, tokio, url::Url};
+    use graph::{
+        endpoint::{EndpointMetrics, Host},
+        firehose::SubgraphLimit,
+        prelude::MetricsRegistry,
+        slog::{o, Discard, Logger},
+        tokio,
+        url::Url,
+    };
     use http::HeaderMap;
     use std::sync::Arc;
 
     use crate::{EthereumAdapter, EthereumNetworks, ProviderEthRpcMetrics, Transport};
 
-    use super::NodeCapabilities;
+    use super::{EthereumNetworkAdapter, EthereumNetworkAdapters, NodeCapabilities};
 
     #[test]
     fn ethereum_capabilities_comparison() {
@@ -284,11 +338,15 @@ mod tests {
 
     #[tokio::test]
     async fn adapter_selector_selects_eth_call() {
+        let metrics = Arc::new(EndpointMetrics::mock());
         let chain = "mainnet".to_string();
         let logger = graph::log::logger(true);
-        let mock_registry: Arc<MetricsRegistry> = Arc::new(MetricsRegistry::mock());
-        let transport =
-            Transport::new_rpc(Url::parse("http://127.0.0.1").unwrap(), HeaderMap::new());
+        let mock_registry = Arc::new(MetricsRegistry::mock());
+        let transport = Transport::new_rpc(
+            Url::parse("http://127.0.0.1").unwrap(),
+            HeaderMap::new(),
+            metrics.clone(),
+        );
         let provider_metrics = Arc::new(ProviderEthRpcMetrics::new(mock_registry.clone()));
 
         let eth_call_adapter = Arc::new(
@@ -318,7 +376,7 @@ mod tests {
         );
 
         let mut adapters = {
-            let mut ethereum_networks = EthereumNetworks::new();
+            let mut ethereum_networks = EthereumNetworks::new(metrics);
             ethereum_networks.insert(
                 chain.clone(),
                 NodeCapabilities {
@@ -387,11 +445,15 @@ mod tests {
 
     #[tokio::test]
     async fn adapter_selector_unlimited() {
+        let metrics = Arc::new(EndpointMetrics::mock());
         let chain = "mainnet".to_string();
         let logger = graph::log::logger(true);
-        let mock_registry: Arc<MetricsRegistry> = Arc::new(MetricsRegistry::mock());
-        let transport =
-            Transport::new_rpc(Url::parse("http://127.0.0.1").unwrap(), HeaderMap::new());
+        let mock_registry = Arc::new(MetricsRegistry::mock());
+        let transport = Transport::new_rpc(
+            Url::parse("http://127.0.0.1").unwrap(),
+            HeaderMap::new(),
+            metrics.clone(),
+        );
         let provider_metrics = Arc::new(ProviderEthRpcMetrics::new(mock_registry.clone()));
 
         let eth_call_adapter = Arc::new(
@@ -421,7 +483,7 @@ mod tests {
         );
 
         let adapters = {
-            let mut ethereum_networks = EthereumNetworks::new();
+            let mut ethereum_networks = EthereumNetworks::new(metrics);
             ethereum_networks.insert(
                 chain.clone(),
                 NodeCapabilities {
@@ -455,11 +517,15 @@ mod tests {
 
     #[tokio::test]
     async fn adapter_selector_disable_call_only_fallback() {
+        let metrics = Arc::new(EndpointMetrics::mock());
         let chain = "mainnet".to_string();
         let logger = graph::log::logger(true);
-        let mock_registry: Arc<MetricsRegistry> = Arc::new(MetricsRegistry::mock());
-        let transport =
-            Transport::new_rpc(Url::parse("http://127.0.0.1").unwrap(), HeaderMap::new());
+        let mock_registry = Arc::new(MetricsRegistry::mock());
+        let transport = Transport::new_rpc(
+            Url::parse("http://127.0.0.1").unwrap(),
+            HeaderMap::new(),
+            metrics.clone(),
+        );
         let provider_metrics = Arc::new(ProviderEthRpcMetrics::new(mock_registry.clone()));
 
         let eth_call_adapter = Arc::new(
@@ -489,7 +555,7 @@ mod tests {
         );
 
         let adapters = {
-            let mut ethereum_networks = EthereumNetworks::new();
+            let mut ethereum_networks = EthereumNetworks::new(metrics);
             ethereum_networks.insert(
                 chain.clone(),
                 NodeCapabilities {
@@ -521,11 +587,15 @@ mod tests {
 
     #[tokio::test]
     async fn adapter_selector_no_call_only_fallback() {
+        let metrics = Arc::new(EndpointMetrics::mock());
         let chain = "mainnet".to_string();
         let logger = graph::log::logger(true);
-        let mock_registry: Arc<MetricsRegistry> = Arc::new(MetricsRegistry::mock());
-        let transport =
-            Transport::new_rpc(Url::parse("http://127.0.0.1").unwrap(), HeaderMap::new());
+        let mock_registry = Arc::new(MetricsRegistry::mock());
+        let transport = Transport::new_rpc(
+            Url::parse("http://127.0.0.1").unwrap(),
+            HeaderMap::new(),
+            metrics.clone(),
+        );
         let provider_metrics = Arc::new(ProviderEthRpcMetrics::new(mock_registry.clone()));
 
         let eth_adapter = Arc::new(
@@ -542,7 +612,7 @@ mod tests {
         );
 
         let adapters = {
-            let mut ethereum_networks = EthereumNetworks::new();
+            let mut ethereum_networks = EthereumNetworks::new(metrics);
             ethereum_networks.insert(
                 chain.clone(),
                 NodeCapabilities {
@@ -560,5 +630,234 @@ mod tests {
             adapters.call_or_cheapest(None).unwrap().is_call_only(),
             false
         );
+    }
+
+    #[tokio::test]
+    async fn eth_adapter_selection_multiple_adapters() {
+        let logger = Logger::root(Discard, o!());
+        let unavailable_host = "http://127.0.0.1/unavailable";
+        let error_host = "http://127.0.0.1/error";
+        let no_error_host = "http://127.0.0.1/no_error";
+
+        let metrics = Arc::new(EndpointMetrics::new(
+            logger,
+            &[unavailable_host, error_host, no_error_host],
+        ));
+        let logger = graph::log::logger(true);
+        let mock_registry = Arc::new(MetricsRegistry::mock());
+        let provider_metrics = Arc::new(ProviderEthRpcMetrics::new(mock_registry.clone()));
+
+        let adapters = vec![
+            fake_adapter(
+                &logger,
+                &unavailable_host.into(),
+                &provider_metrics,
+                &metrics,
+                false,
+            )
+            .await,
+            fake_adapter(
+                &logger,
+                &error_host.into(),
+                &provider_metrics,
+                &metrics,
+                false,
+            )
+            .await,
+            fake_adapter(
+                &logger,
+                &no_error_host.into(),
+                &provider_metrics,
+                &metrics,
+                false,
+            )
+            .await,
+        ];
+
+        // Set errors
+        metrics.failure(&error_host.into());
+
+        let mut no_retest_adapters = EthereumNetworkAdapters::new(Some(0f64));
+        let mut always_retest_adapters = EthereumNetworkAdapters::new(Some(1f64));
+        adapters.iter().cloned().for_each(|adapter| {
+            let limit = if adapter.url.as_str() == unavailable_host {
+                SubgraphLimit::Disabled
+            } else {
+                SubgraphLimit::Unlimited
+            };
+
+            no_retest_adapters.adapters.push(EthereumNetworkAdapter {
+                endpoint_metrics: metrics.clone(),
+                capabilities: NodeCapabilities {
+                    archive: true,
+                    traces: false,
+                },
+                adapter: adapter.clone(),
+                limit: limit.clone(),
+            });
+            always_retest_adapters
+                .adapters
+                .push(EthereumNetworkAdapter {
+                    endpoint_metrics: metrics.clone(),
+                    capabilities: NodeCapabilities {
+                        archive: true,
+                        traces: false,
+                    },
+                    adapter,
+                    limit,
+                });
+        });
+
+        assert_eq!(
+            no_retest_adapters
+                .cheapest_with(&NodeCapabilities {
+                    archive: true,
+                    traces: false,
+                })
+                .unwrap()
+                .url
+                .as_str(),
+            no_error_host
+        );
+        assert_eq!(
+            always_retest_adapters
+                .cheapest_with(&NodeCapabilities {
+                    archive: true,
+                    traces: false,
+                })
+                .unwrap()
+                .url
+                .as_str(),
+            error_host
+        );
+    }
+
+    #[tokio::test]
+    async fn eth_adapter_selection_single_adapter() {
+        let logger = Logger::root(Discard, o!());
+        let unavailable_host = "http://127.0.0.1/";
+        let error_host = "http://127.0.0.1/error";
+        let no_error_host = "http://127.0.0.1/no_error";
+
+        let metrics = Arc::new(EndpointMetrics::new(
+            logger,
+            &[unavailable_host, error_host, no_error_host],
+        ));
+        let logger = graph::log::logger(true);
+        let mock_registry = Arc::new(MetricsRegistry::mock());
+        let provider_metrics = Arc::new(ProviderEthRpcMetrics::new(mock_registry.clone()));
+
+        // Set errors
+        metrics.failure(&error_host.into());
+
+        let mut no_retest_adapters = EthereumNetworkAdapters::new(Some(0f64));
+        no_retest_adapters.adapters.push(EthereumNetworkAdapter {
+            endpoint_metrics: metrics.clone(),
+            capabilities: NodeCapabilities {
+                archive: true,
+                traces: false,
+            },
+            adapter: fake_adapter(
+                &logger,
+                &error_host.into(),
+                &provider_metrics,
+                &metrics,
+                false,
+            )
+            .await,
+            limit: SubgraphLimit::Unlimited,
+        });
+        assert_eq!(
+            no_retest_adapters
+                .cheapest_with(&NodeCapabilities {
+                    archive: true,
+                    traces: false,
+                })
+                .unwrap()
+                .url
+                .as_str(),
+            error_host
+        );
+
+        let mut always_retest_adapters = EthereumNetworkAdapters::new(Some(1f64));
+        always_retest_adapters
+            .adapters
+            .push(EthereumNetworkAdapter {
+                endpoint_metrics: metrics.clone(),
+                capabilities: NodeCapabilities {
+                    archive: true,
+                    traces: false,
+                },
+                adapter: fake_adapter(
+                    &logger,
+                    &no_error_host.into(),
+                    &provider_metrics,
+                    &metrics,
+                    false,
+                )
+                .await,
+                limit: SubgraphLimit::Unlimited,
+            });
+        assert_eq!(
+            always_retest_adapters
+                .cheapest_with(&NodeCapabilities {
+                    archive: true,
+                    traces: false,
+                })
+                .unwrap()
+                .url
+                .as_str(),
+            no_error_host
+        );
+
+        let mut no_available_adapter = EthereumNetworkAdapters::default();
+        no_available_adapter.adapters.push(EthereumNetworkAdapter {
+            endpoint_metrics: metrics.clone(),
+            capabilities: NodeCapabilities {
+                archive: true,
+                traces: false,
+            },
+            adapter: fake_adapter(
+                &logger,
+                &no_error_host.into(),
+                &provider_metrics,
+                &metrics,
+                false,
+            )
+            .await,
+            limit: SubgraphLimit::Disabled,
+        });
+        let res = no_available_adapter.cheapest_with(&NodeCapabilities {
+            archive: true,
+            traces: false,
+        });
+        assert!(res.is_err(), "{:?}", res);
+    }
+
+    async fn fake_adapter(
+        logger: &Logger,
+        host: &Host,
+        provider_metrics: &Arc<ProviderEthRpcMetrics>,
+        endpoint_metrics: &Arc<EndpointMetrics>,
+        call_only: bool,
+    ) -> Arc<EthereumAdapter> {
+        let transport = Transport::new_rpc(
+            Url::parse(&host.to_string()).unwrap(),
+            HeaderMap::new(),
+            endpoint_metrics.clone(),
+        );
+
+        Arc::new(
+            EthereumAdapter::new(
+                logger.clone(),
+                String::new(),
+                &host,
+                transport.clone(),
+                provider_metrics.clone(),
+                true,
+                call_only,
+            )
+            .await,
+        )
     }
 }

--- a/chain/ethereum/src/transport.rs
+++ b/chain/ethereum/src/transport.rs
@@ -1,3 +1,4 @@
+use graph::endpoint::{EndpointMetrics, Host};
 use jsonrpc_core::types::Call;
 use jsonrpc_core::Value;
 
@@ -11,7 +12,11 @@ use std::future::Future;
 /// Abstraction over the different web3 transports.
 #[derive(Clone, Debug)]
 pub enum Transport {
-    RPC(http::Http),
+    RPC {
+        client: http::Http,
+        metrics: Arc<EndpointMetrics>,
+        host: Host,
+    },
     IPC(ipc::Ipc),
     WS(ws::WebSocket),
 }
@@ -38,22 +43,32 @@ impl Transport {
     ///
     /// Note: JSON-RPC over HTTP doesn't always support subscribing to new
     /// blocks (one such example is Infura's HTTP endpoint).
-    pub fn new_rpc(rpc: Url, headers: ::http::HeaderMap) -> Self {
+    pub fn new_rpc(rpc: Url, headers: ::http::HeaderMap, metrics: Arc<EndpointMetrics>) -> Self {
         // Unwrap: This only fails if something is wrong with the system's TLS config.
         let client = reqwest::Client::builder()
             .default_headers(headers)
             .build()
             .unwrap();
-        Transport::RPC(http::Http::with_client(client, rpc))
+
+        let host = rpc.to_string();
+        Transport::RPC {
+            client: http::Http::with_client(client, rpc),
+            metrics,
+            host: host.into(),
+        }
     }
 }
 
 impl web3::Transport for Transport {
-    type Out = Box<dyn Future<Output = Result<Value, web3::error::Error>> + Send + Unpin>;
+    type Out = Pin<Box<dyn Future<Output = Result<Value, web3::error::Error>> + Send + 'static>>;
 
     fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {
         match self {
-            Transport::RPC(http) => http.prepare(method, params),
+            Transport::RPC {
+                client,
+                metrics: _,
+                host: _,
+            } => client.prepare(method, params),
             Transport::IPC(ipc) => ipc.prepare(method, params),
             Transport::WS(ws) => ws.prepare(method, params),
         }
@@ -61,9 +76,29 @@ impl web3::Transport for Transport {
 
     fn send(&self, id: RequestId, request: Call) -> Self::Out {
         match self {
-            Transport::RPC(http) => Box::new(http.send(id, request)),
-            Transport::IPC(ipc) => Box::new(ipc.send(id, request)),
-            Transport::WS(ws) => Box::new(ws.send(id, request)),
+            Transport::RPC {
+                client,
+                metrics,
+                host,
+            } => {
+                let metrics = metrics.cheap_clone();
+                let client = client.clone();
+                let host = host.clone();
+                let out = async move {
+                    let host = host.clone();
+                    let out = client.send(id, request).await;
+                    match out {
+                        Ok(_) => metrics.success(&host),
+                        Err(_) => metrics.failure(&host),
+                    }
+
+                    out
+                };
+
+                Box::pin(out)
+            }
+            Transport::IPC(ipc) => Box::pin(ipc.send(id, request)),
+            Transport::WS(ws) => Box::pin(ws.send(id, request)),
         }
     }
 }
@@ -80,7 +115,11 @@ impl web3::BatchTransport for Transport {
         T: IntoIterator<Item = (RequestId, Call)>,
     {
         match self {
-            Transport::RPC(http) => Box::new(http.send_batch(requests)),
+            Transport::RPC {
+                client,
+                metrics: _,
+                host: _,
+            } => Box::new(client.send_batch(requests)),
             Transport::IPC(ipc) => Box::new(ipc.send_batch(requests)),
             Transport::WS(ws) => Box::new(ws.send_batch(requests)),
         }

--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -182,7 +182,7 @@ where
             };
 
             let logger = self.logger.new(
-                o!("provider" => endpoint.provider.clone(), "network_name"=> self.network_name()),
+                o!("provider" => endpoint.provider.to_string(), "network_name"=> self.network_name()),
             );
 
             info!(

--- a/graph/src/blockchain/firehose_block_stream.rs
+++ b/graph/src/blockchain/firehose_block_stream.rs
@@ -217,7 +217,7 @@ fn stream_blocks<C: Blockchain, F: FirehoseMapper<C>>(
     try_stream! {
         loop {
             let endpoint = client.firehose_endpoint()?;
-            let logger = logger.new(o!("deployment" => deployment.clone(), "provider" => endpoint.provider.clone()));
+            let logger = logger.new(o!("deployment" => deployment.clone(), "provider" => endpoint.provider.to_string()));
 
             info!(
                 &logger,

--- a/graph/src/blockchain/substreams_block_stream.rs
+++ b/graph/src/blockchain/substreams_block_stream.rs
@@ -135,7 +135,7 @@ where
         let manifest_end_block_num = end_blocks.into_iter().min().unwrap_or(0);
 
         let metrics =
-            SubstreamsBlockStreamMetrics::new(registry, deployment, endpoint.provider.clone());
+            SubstreamsBlockStreamMetrics::new(registry, deployment, endpoint.provider.to_string());
 
         SubstreamsBlockStream {
             stream: Box::pin(stream_blocks(

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 use config::PoolSize;
 use git_testament::{git_testament, render_testament};
 use graph::bail;
+use graph::endpoint::EndpointMetrics;
 use graph::log::logger_with_levels;
 use graph::prelude::{MetricsRegistry, BLOCK_NUMBER_MAX};
 use graph::{data::graphql::effort::LoadManager, prelude::chrono, prometheus::Registry};
@@ -897,7 +898,8 @@ impl Context {
     async fn ethereum_networks(&self) -> anyhow::Result<EthereumNetworks> {
         let logger = self.logger.clone();
         let registry = self.metrics_registry();
-        create_all_ethereum_networks(logger, registry, &self.config).await
+        let metrics = Arc::new(EndpointMetrics::mock());
+        create_all_ethereum_networks(logger, registry, &self.config, metrics).await
     }
 
     fn chain_store(self, chain_name: &str) -> anyhow::Result<Arc<ChainStore>> {

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -471,7 +471,6 @@ pub async fn create_ethereum_networks_for_chain(
                 graph_chain_ethereum::EthereumAdapter::new(
                     logger,
                     provider.label.clone(),
-                    &web3.url,
                     transport,
                     eth_rpc_metrics.clone(),
                     supports_eip_1898,

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -130,11 +130,13 @@ pub fn create_substreams_networks(
                     .entry(chain.protocol)
                     .or_insert_with(FirehoseNetworks::new);
 
-                for i in 0..firehose.conn_pool_size {
+                for _ in 0..firehose.conn_pool_size {
                     parsed_networks.insert(
                         name.to_string(),
                         Arc::new(FirehoseEndpoint::new(
-                            &format!("{}-{}", provider.label, i),
+                            // This label needs to be the original label so that the metrics
+                            // can be deduped.
+                            &provider.label,
                             &firehose.url,
                             firehose.token.clone(),
                             firehose.filters_enabled(),
@@ -184,11 +186,13 @@ pub fn create_firehose_networks(
                 // eg: pool_size = 3 and sg_limit 2 will result in 3 separate instances
                 // of FirehoseEndpoint and each of those instance can be used in 2 different
                 // SubgraphInstances.
-                for i in 0..firehose.conn_pool_size {
+                for _ in 0..firehose.conn_pool_size {
                     parsed_networks.insert(
                         name.to_string(),
                         Arc::new(FirehoseEndpoint::new(
-                            &format!("{}-{}", provider.label, i),
+                            // This label needs to be the original label so that the metrics
+                            // can be deduped.
+                            &provider.label,
                             &firehose.url,
                             firehose.token.clone(),
                             firehose.filters_enabled(),
@@ -310,7 +314,7 @@ where
                 let logger = logger.new(o!("provider" => endpoint.provider.to_string()));
                 info!(
                     logger, "Connecting to Firehose to get chain identifier";
-                    "provider" => &endpoint.provider,
+                    "provider" => &endpoint.provider.to_string(),
                 );
                 match tokio::time::timeout(
                     NET_VERSION_WAIT_TIME,
@@ -333,7 +337,7 @@ where
                         info!(
                             logger,
                             "Connected to Firehose";
-                            "provider" => &endpoint.provider,
+                            "provider" => &endpoint.provider.to_string(),
                             "genesis_block" => format_args!("{}", &ptr),
                         );
 

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -421,14 +421,14 @@ impl ChainSection {
         Ok(Self { ingestor, chains })
     }
 
-    pub fn provider_urls(&self) -> Vec<String> {
+    pub fn providers(&self) -> Vec<String> {
         self.chains
             .values()
             .flat_map(|chain| {
                 chain
                     .providers
                     .iter()
-                    .map(|p| p.url())
+                    .map(|p| p.label.clone())
                     .collect::<Vec<String>>()
             })
             .collect()
@@ -552,24 +552,6 @@ fn btree_map_to_http_headers(kvs: BTreeMap<String, String>) -> HeaderMap {
 pub struct Provider {
     pub label: String,
     pub details: ProviderDetails,
-}
-
-impl Provider {
-    /// url returns the necessary information to uniquely identify adapters.
-    /// for firehose this is the url (multiple adapter are generated from a single config)
-    /// rpc this is the provider label
-    pub fn url(&self) -> String {
-        let url = match &self.details {
-            ProviderDetails::Substreams(firehose) | ProviderDetails::Firehose(firehose) => {
-                firehose.url.clone()
-            }
-            ProviderDetails::Web3(_) | ProviderDetails::Web3Call(_) => self.label.clone(),
-        };
-
-        // parsing and printing here normalizes the urls so we don't have
-        // mismatches later on.
-        url.parse::<Url>().expect("failed to parse url").to_string()
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -230,7 +230,7 @@ async fn main() {
 
     let endpoint_metrics = Arc::new(EndpointMetrics::new(
         logger.clone(),
-        &config.chains.provider_urls(),
+        &config.chains.providers(),
         metrics_registry.cheap_clone(),
     ));
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -237,11 +237,16 @@ async fn main() {
     // Ethereum clients; query nodes ignore all ethereum clients and never
     // connect to them directly
     let eth_networks = if query_only {
-        EthereumNetworks::new()
+        EthereumNetworks::new(endpoint_metrics.cheap_clone())
     } else {
-        create_all_ethereum_networks(logger.clone(), metrics_registry.clone(), &config)
-            .await
-            .expect("Failed to parse Ethereum networks")
+        create_all_ethereum_networks(
+            logger.clone(),
+            metrics_registry.clone(),
+            &config,
+            endpoint_metrics.cheap_clone(),
+        )
+        .await
+        .expect("Failed to parse Ethereum networks")
     };
 
     let mut firehose_networks_by_kind = if query_only {

--- a/node/src/manager/commands/config.rs
+++ b/node/src/manager/commands/config.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use graph::{
     anyhow::bail,
+    endpoint::EndpointMetrics,
     itertools::Itertools,
     prelude::{
         anyhow::{anyhow, Error},
@@ -9,7 +10,7 @@ use graph::{
     },
     slog::Logger,
 };
-use graph_chain_ethereum::{EthereumAdapterTrait, NodeCapabilities, ProviderEthRpcMetrics};
+use graph_chain_ethereum::{NodeCapabilities, ProviderEthRpcMetrics};
 use graph_store_postgres::DeploymentPlacer;
 
 use crate::{chain::create_ethereum_networks_for_chain, config::Config};
@@ -119,10 +120,12 @@ pub async fn provider(
         Ok(caps)
     }
 
+    let metrics = Arc::new(EndpointMetrics::mock());
     let caps = caps_from_features(features)?;
     let eth_rpc_metrics = Arc::new(ProviderEthRpcMetrics::new(registry));
     let networks =
-        create_ethereum_networks_for_chain(&logger, eth_rpc_metrics, config, &network).await?;
+        create_ethereum_networks_for_chain(&logger, eth_rpc_metrics, config, &network, metrics)
+            .await?;
     let adapters = networks
         .networks
         .get(&network)

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -83,10 +83,15 @@ pub async fn run(
     let link_resolver = Arc::new(LinkResolver::new(ipfs_clients, env_vars.cheap_clone()));
 
     let eth_rpc_metrics = Arc::new(ProviderEthRpcMetrics::new(metrics_registry.clone()));
-    let eth_networks =
-        create_ethereum_networks_for_chain(&logger, eth_rpc_metrics, &config, &network_name)
-            .await
-            .expect("Failed to parse Ethereum networks");
+    let eth_networks = create_ethereum_networks_for_chain(
+        &logger,
+        eth_rpc_metrics,
+        &config,
+        &network_name,
+        endpoint_metrics.cheap_clone(),
+    )
+    .await
+    .expect("Failed to parse Ethereum networks");
     let firehose_networks_by_kind =
         create_firehose_networks(logger.clone(), &config, endpoint_metrics);
     let firehose_networks = firehose_networks_by_kind.get(&BlockchainKind::Ethereum);

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -74,7 +74,7 @@ pub async fn run(
 
     let endpoint_metrics = Arc::new(EndpointMetrics::new(
         logger.clone(),
-        &config.chains.provider_urls(),
+        &config.chains.providers(),
         metrics_registry.cheap_clone(),
     ));
 


### PR DESCRIPTION
- Wire EndpointMetrics for rpc endpoints
- Use a percentage of traffic to retest errored adapters