### PR TITLE
Use GitHub issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,0 @@
-**Do you want to request a *feature* or report a *bug*?**
-
-**What is the current behavior?**
-
-**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem.**
-
-**What is the expected behavior?**

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Use this issue template if something is not working the way it should be.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: bug-report
+    attributes:
+      label: Bug report
+      description: Please provide a detailed overview of the expected behavior, and what happens instead. The more details, the better. You can use Markdown.
+      render: Markdown
+  - type: textarea
+    id: graph-node-logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output (either graph-node or hosted service logs). This will be automatically formatted into code, so no need for backticks. Leave black if it doesn't apply.
+      render: Shell
+  - type: markdown
+    attributes:
+      value: Does this bug affect a specific subgraph deployment? If not, leave the following blank.
+  - type: input
+    attributes:
+      label: IPFS hash
+      placeholder: e.g. QmST8VZnjHrwhrW5gTyaiWJDhVcx6TooRv85B49zG7ziLH
+    validations:
+      required: false
+  - type: input
+    attributes:
+      label: Subgraph name or link to explorer
+      placeholder: e.g. https://thegraph.com/explorer/subgraphs/3nXfK3RbFrj6mhkGdoKRowEEti2WvmUdxmz73tben6Mb?view=Overview&chain=mainnet
+    validations:
+      required: false
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Some information to help us out
+      options:
+        - label: Tick this box if this bug is caused by a regression found in the latest release.
+        - label: Tick this box if this bug is specific to the hosted service.
+        - label: I have searched the issue tracker to make sure this issue is not a duplicate.
+          required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: OS information
+      description: What OS are you running? Leave blank if it doesn't apply.
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Other (please specify in your bug report)

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: To request or discuss new features.
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: bug-report
+    attributes:
+      label: Description
+      description: Please provide a detailed overview of the desired feature or improvement, along with any examples or useful information. You can use Markdown.
+      render: Markdown
+  - type: textarea
+    id: blockers
+    attributes:
+      label: Are you aware of any blockers that must be resolved before implementing this feature? If so, which? Link to any relevant GitHub issues.
+      render: Markdown
+    validations:
+      required: false
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Some information to help us out
+      options:
+        - label: Tick this box if you plan on implementing this feature yourself.
+        - label: I have searched the issue tracker to make sure this issue is not a duplicate.
+          required: true


### PR DESCRIPTION
This PR removes the current GitHub issue template and replaces it with two [issue forms](https://github.blog/changelog/2021-06-23-issues-forms-beta-for-public-repositories/). One issue form is for bug reports, while the other is for feature requests. The goal would be to get more structured information out of our GitHub issues. Users still have the freedom to select a blank template if they don't wish to use any of the two premade templates.

I have deployed this feature in my personal fork of `graph-node`, here: https://github.com/neysofu/graph-node/issues/new/choose. Feel free to try it out.