### PR TITLE
Upgrade to Rust 1.68.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,5 +2,8 @@
 # Warnings create a lot of noise, we only print errors.
 check-clippy = "clippy --no-deps -- --allow warnings"
 
+# Can be safely removed once Cargo's sparse protocol (see
+# https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol)
+# becomes the default.
 [registries.crates-io]
 protocol = "sparse"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
 [alias]
 # Warnings create a lot of noise, we only print errors.
 check-clippy = "clippy --no-deps -- --allow warnings"
+
+[registries.crates-io]
+protocol = "sparse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,6 @@ name = "graph-node"
 version = "0.30.0"
 dependencies = [
  "clap",
- "crossbeam-channel",
  "diesel",
  "env_logger 0.9.3",
  "futures 0.3.16",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,7 +20,6 @@ graphql-parser = "0.4.0"
 futures = { version = "0.3.1", features = ["compat"] }
 lazy_static = "1.2.0"
 url = "2.3.1"
-crossbeam-channel = "0.5.7"
 graph = { path = "../graph" }
 graph-core = { path = "../core" }
 graph-chain-arweave = { path = "../chain/arweave" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.66.0"
+channel = "1.68.0"
 profile = "default"


### PR DESCRIPTION
- Rust 1.67 replaces `std::sync::mpsc` with the `crossbeam-channel` implementation, improving performance.
- Rust 1.68 introduces Cargo's new "sparse indexing protocol", which TL;DR reduces download times to https://crates.io and is especially useful for CI. It's not yet the default option, so I turned it on in our `.cargo/config.toml`.

I'm also removing `crossbeam-channel` and replacing it with `std::sync::mpsc`, since now they are effectively the same thing.