### PR TITLE
Detect timeouts in asc_type_id

### DIFF
--- a/chain/arweave/src/runtime/abi.rs
+++ b/chain/arweave/src/runtime/abi.rs
@@ -1,7 +1,7 @@
 use crate::codec;
 use crate::trigger::TransactionWithBlockPtr;
 use graph::runtime::gas::GasCounter;
-use graph::runtime::{asc_new, AscHeap, AscPtr, DeterministicHostError, ToAscObj};
+use graph::runtime::{asc_new, AscHeap, AscPtr, HostExportError, ToAscObj};
 use graph_runtime_wasm::asc_abi::class::{Array, Uint8Array};
 
 pub(crate) use super::generated::*;
@@ -11,7 +11,7 @@ impl ToAscObj<AscTag> for codec::Tag {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscTag, DeterministicHostError> {
+    ) -> Result<AscTag, HostExportError> {
         Ok(AscTag {
             name: asc_new(heap, self.name.as_slice(), gas)?,
             value: asc_new(heap, self.value.as_slice(), gas)?,
@@ -24,7 +24,7 @@ impl ToAscObj<AscTransactionArray> for Vec<Vec<u8>> {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscTransactionArray, DeterministicHostError> {
+    ) -> Result<AscTransactionArray, HostExportError> {
         let content = self
             .iter()
             .map(|x| asc_new(heap, x.as_slice(), gas))
@@ -38,7 +38,7 @@ impl ToAscObj<AscTagArray> for Vec<codec::Tag> {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscTagArray, DeterministicHostError> {
+    ) -> Result<AscTagArray, HostExportError> {
         let content = self
             .iter()
             .map(|x| asc_new(heap, x, gas))
@@ -52,7 +52,7 @@ impl ToAscObj<AscProofOfAccess> for codec::ProofOfAccess {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscProofOfAccess, DeterministicHostError> {
+    ) -> Result<AscProofOfAccess, HostExportError> {
         Ok(AscProofOfAccess {
             option: asc_new(heap, &self.option, gas)?,
             tx_path: asc_new(heap, self.tx_path.as_slice(), gas)?,
@@ -67,7 +67,7 @@ impl ToAscObj<AscTransaction> for codec::Transaction {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscTransaction, DeterministicHostError> {
+    ) -> Result<AscTransaction, HostExportError> {
         Ok(AscTransaction {
             format: self.format,
             id: asc_new(heap, self.id.as_slice(), gas)?,
@@ -108,7 +108,7 @@ impl ToAscObj<AscBlock> for codec::Block {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscBlock, DeterministicHostError> {
+    ) -> Result<AscBlock, HostExportError> {
         Ok(AscBlock {
             indep_hash: asc_new(heap, self.indep_hash.as_slice(), gas)?,
             nonce: asc_new(heap, self.nonce.as_slice(), gas)?,
@@ -182,7 +182,7 @@ impl ToAscObj<AscTransactionWithBlockPtr> for TransactionWithBlockPtr {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscTransactionWithBlockPtr, DeterministicHostError> {
+    ) -> Result<AscTransactionWithBlockPtr, HostExportError> {
         Ok(AscTransactionWithBlockPtr {
             tx: asc_new(heap, &self.tx.as_ref(), gas)?,
             block: asc_new(heap, self.block.as_ref(), gas)?,

--- a/chain/arweave/src/trigger.rs
+++ b/chain/arweave/src/trigger.rs
@@ -7,7 +7,7 @@ use graph::runtime::asc_new;
 use graph::runtime::gas::GasCounter;
 use graph::runtime::AscHeap;
 use graph::runtime::AscPtr;
-use graph::runtime::DeterministicHostError;
+use graph::runtime::HostExportError;
 use graph_runtime_wasm::module::ToAscPtr;
 use std::{cmp::Ordering, sync::Arc};
 
@@ -38,7 +38,7 @@ impl ToAscPtr for ArweaveTrigger {
         self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscPtr<()>, DeterministicHostError> {
+    ) -> Result<AscPtr<()>, HostExportError> {
         Ok(match self {
             ArweaveTrigger::Block(block) => asc_new(heap, block.as_ref(), gas)?.erase(),
             ArweaveTrigger::Transaction(tx) => asc_new(heap, tx.as_ref(), gas)?.erase(),

--- a/chain/cosmos/src/runtime/abi.rs
+++ b/chain/cosmos/src/runtime/abi.rs
@@ -1,4 +1,5 @@
 use crate::protobuf::*;
+use graph::runtime::HostExportError;
 pub use graph::semver::Version;
 
 pub use graph::runtime::{
@@ -16,7 +17,7 @@ impl ToAscObj<AscBytesArray> for Vec<Vec<u8>> {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscBytesArray, DeterministicHostError> {
+    ) -> Result<AscBytesArray, HostExportError> {
         let content: Result<Vec<_>, _> = self
             .iter()
             .map(|x| asc_new(heap, &graph_runtime_wasm::asc_abi::class::Bytes(x), gas))
@@ -52,7 +53,7 @@ impl ToAscObj<AscAny> for prost_types::Any {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscAny, DeterministicHostError> {
+    ) -> Result<AscAny, HostExportError> {
         Ok(AscAny {
             type_url: asc_new(heap, &self.type_url, gas)?,
             value: asc_new(
@@ -71,7 +72,7 @@ impl ToAscObj<AscAnyArray> for Vec<prost_types::Any> {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscAnyArray, DeterministicHostError> {
+    ) -> Result<AscAnyArray, HostExportError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
 
         Ok(AscAnyArray(Array::new(&content?, heap, gas)?))

--- a/chain/cosmos/src/trigger.rs
+++ b/chain/cosmos/src/trigger.rs
@@ -3,7 +3,8 @@ use std::{cmp::Ordering, sync::Arc};
 use graph::blockchain::{Block, BlockHash, TriggerData};
 use graph::cheap_clone::CheapClone;
 use graph::prelude::{BlockNumber, Error};
-use graph::runtime::{asc_new, gas::GasCounter, AscHeap, AscPtr, DeterministicHostError};
+use graph::runtime::HostExportError;
+use graph::runtime::{asc_new, gas::GasCounter, AscHeap, AscPtr};
 use graph_runtime_wasm::module::ToAscPtr;
 
 use crate::codec;
@@ -42,7 +43,7 @@ impl ToAscPtr for CosmosTrigger {
         self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscPtr<()>, DeterministicHostError> {
+    ) -> Result<AscPtr<()>, HostExportError> {
         Ok(match self {
             CosmosTrigger::Block(block) => asc_new(heap, block.as_ref(), gas)?.erase(),
             CosmosTrigger::Event { event_data, .. } => {

--- a/chain/ethereum/src/runtime/abi.rs
+++ b/chain/ethereum/src/runtime/abi.rs
@@ -10,7 +10,7 @@ use graph::{
     },
     runtime::{
         asc_get, asc_new, gas::GasCounter, AscHeap, AscIndexId, AscPtr, AscType,
-        DeterministicHostError, FromAscObj, IndexForAscTypeId, ToAscObj,
+        DeterministicHostError, FromAscObj, HostExportError, IndexForAscTypeId, ToAscObj,
     },
 };
 use graph_runtime_derive::AscType;
@@ -42,7 +42,7 @@ impl ToAscObj<AscLogParamArray> for Vec<ethabi::LogParam> {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscLogParamArray, DeterministicHostError> {
+    ) -> Result<AscLogParamArray, HostExportError> {
         let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
         let content = content?;
         Ok(AscLogParamArray(Array::new(&content, heap, gas)?))
@@ -73,7 +73,7 @@ impl ToAscObj<AscTopicArray> for Vec<H256> {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscTopicArray, DeterministicHostError> {
+    ) -> Result<AscTopicArray, HostExportError> {
         let topics = self
             .iter()
             .map(|topic| asc_new(heap, topic, gas))
@@ -106,7 +106,7 @@ impl ToAscObj<AscLogArray> for Vec<Log> {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscLogArray, DeterministicHostError> {
+    ) -> Result<AscLogArray, HostExportError> {
         let logs = self
             .iter()
             .map(|log| asc_new(heap, &log, gas))
@@ -416,7 +416,7 @@ impl ToAscObj<AscEthereumBlock> for EthereumBlockData {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscEthereumBlock, DeterministicHostError> {
+    ) -> Result<AscEthereumBlock, HostExportError> {
         Ok(AscEthereumBlock {
             hash: asc_new(heap, &self.hash, gas)?,
             parent_hash: asc_new(heap, &self.parent_hash, gas)?,
@@ -448,7 +448,7 @@ impl ToAscObj<AscEthereumBlock_0_0_6> for EthereumBlockData {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscEthereumBlock_0_0_6, DeterministicHostError> {
+    ) -> Result<AscEthereumBlock_0_0_6, HostExportError> {
         Ok(AscEthereumBlock_0_0_6 {
             hash: asc_new(heap, &self.hash, gas)?,
             parent_hash: asc_new(heap, &self.parent_hash, gas)?,
@@ -484,7 +484,7 @@ impl ToAscObj<AscEthereumTransaction_0_0_1> for EthereumTransactionData {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscEthereumTransaction_0_0_1, DeterministicHostError> {
+    ) -> Result<AscEthereumTransaction_0_0_1, HostExportError> {
         Ok(AscEthereumTransaction_0_0_1 {
             hash: asc_new(heap, &self.hash, gas)?,
             index: asc_new(heap, &BigInt::from(self.index), gas)?,
@@ -505,7 +505,7 @@ impl ToAscObj<AscEthereumTransaction_0_0_2> for EthereumTransactionData {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscEthereumTransaction_0_0_2, DeterministicHostError> {
+    ) -> Result<AscEthereumTransaction_0_0_2, HostExportError> {
         Ok(AscEthereumTransaction_0_0_2 {
             hash: asc_new(heap, &self.hash, gas)?,
             index: asc_new(heap, &BigInt::from(self.index), gas)?,
@@ -527,7 +527,7 @@ impl ToAscObj<AscEthereumTransaction_0_0_6> for EthereumTransactionData {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscEthereumTransaction_0_0_6, DeterministicHostError> {
+    ) -> Result<AscEthereumTransaction_0_0_6, HostExportError> {
         Ok(AscEthereumTransaction_0_0_6 {
             hash: asc_new(heap, &self.hash, gas)?,
             index: asc_new(heap, &BigInt::from(self.index), gas)?,
@@ -556,7 +556,7 @@ where
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscEthereumEvent<T, B>, DeterministicHostError> {
+    ) -> Result<AscEthereumEvent<T, B>, HostExportError> {
         Ok(AscEthereumEvent {
             address: asc_new(heap, &self.address, gas)?,
             log_index: asc_new(heap, &BigInt::from_unsigned_u256(&self.log_index), gas)?,
@@ -589,7 +589,7 @@ where
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscEthereumEvent_0_0_7<T, B>, DeterministicHostError> {
+    ) -> Result<AscEthereumEvent_0_0_7<T, B>, HostExportError> {
         let (event_data, optional_receipt) = self;
         let AscEthereumEvent {
             address,
@@ -623,7 +623,7 @@ impl ToAscObj<AscEthereumLog> for Log {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscEthereumLog, DeterministicHostError> {
+    ) -> Result<AscEthereumLog, HostExportError> {
         Ok(AscEthereumLog {
             address: asc_new(heap, &self.address, gas)?,
             topics: asc_new(heap, &self.topics, gas)?,
@@ -670,7 +670,7 @@ impl ToAscObj<AscEthereumTransactionReceipt> for &TransactionReceipt {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscEthereumTransactionReceipt, DeterministicHostError> {
+    ) -> Result<AscEthereumTransactionReceipt, HostExportError> {
         Ok(AscEthereumTransactionReceipt {
             transaction_hash: asc_new(heap, &self.transaction_hash, gas)?,
             transaction_index: asc_new(heap, &BigInt::from(self.transaction_index), gas)?,
@@ -714,7 +714,7 @@ impl ToAscObj<AscEthereumCall> for EthereumCallData {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscEthereumCall, DeterministicHostError> {
+    ) -> Result<AscEthereumCall, HostExportError> {
         Ok(AscEthereumCall {
             address: asc_new(heap, &self.to, gas)?,
             block: asc_new(heap, &self.block, gas)?,
@@ -734,7 +734,7 @@ impl ToAscObj<AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_2, AscEthereumBlo
         gas: &GasCounter,
     ) -> Result<
         AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_2, AscEthereumBlock>,
-        DeterministicHostError,
+        HostExportError,
     > {
         Ok(AscEthereumCall_0_0_3 {
             to: asc_new(heap, &self.to, gas)?,
@@ -756,7 +756,7 @@ impl ToAscObj<AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_6, AscEthereumBlo
         gas: &GasCounter,
     ) -> Result<
         AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_6, AscEthereumBlock_0_0_6>,
-        DeterministicHostError,
+        HostExportError,
     > {
         Ok(AscEthereumCall_0_0_3 {
             to: asc_new(heap, &self.to, gas)?,
@@ -774,7 +774,7 @@ impl ToAscObj<AscLogParam> for ethabi::LogParam {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscLogParam, DeterministicHostError> {
+    ) -> Result<AscLogParam, HostExportError> {
         Ok(AscLogParam {
             name: asc_new(heap, self.name.as_str(), gas)?,
             value: asc_new(heap, &self.value, gas)?,

--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -21,7 +21,7 @@ use graph::runtime::asc_new;
 use graph::runtime::gas::GasCounter;
 use graph::runtime::AscHeap;
 use graph::runtime::AscPtr;
-use graph::runtime::DeterministicHostError;
+use graph::runtime::HostExportError;
 use graph::semver::Version;
 use graph_runtime_wasm::module::ToAscPtr;
 use std::convert::TryFrom;
@@ -116,7 +116,7 @@ impl ToAscPtr for MappingTrigger {
         self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscPtr<()>, DeterministicHostError> {
+    ) -> Result<AscPtr<()>, HostExportError> {
         Ok(match self {
             MappingTrigger::Log {
                 block,

--- a/chain/near/src/trigger.rs
+++ b/chain/near/src/trigger.rs
@@ -4,7 +4,8 @@ use graph::cheap_clone::CheapClone;
 use graph::prelude::hex;
 use graph::prelude::web3::types::H256;
 use graph::prelude::BlockNumber;
-use graph::runtime::{asc_new, gas::GasCounter, AscHeap, AscPtr, DeterministicHostError};
+use graph::runtime::HostExportError;
+use graph::runtime::{asc_new, gas::GasCounter, AscHeap, AscPtr};
 use graph_runtime_wasm::module::ToAscPtr;
 use std::{cmp::Ordering, sync::Arc};
 
@@ -40,7 +41,7 @@ impl ToAscPtr for NearTrigger {
         self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscPtr<()>, DeterministicHostError> {
+    ) -> Result<AscPtr<()>, HostExportError> {
         Ok(match self {
             NearTrigger::Block(block) => asc_new(heap, block.as_ref(), gas)?.erase(),
             NearTrigger::Receipt(receipt) => asc_new(heap, receipt.as_ref(), gas)?.erase(),
@@ -150,7 +151,7 @@ mod tests {
         anyhow::anyhow,
         data::subgraph::API_VERSION_0_0_5,
         prelude::{hex, BigInt},
-        runtime::gas::GasCounter,
+        runtime::{gas::GasCounter, DeterministicHostError, HostExportError},
         util::mem::init_slice,
     };
 
@@ -495,7 +496,7 @@ mod tests {
         fn asc_type_id(
             &mut self,
             type_id_index: graph::runtime::IndexForAscTypeId,
-        ) -> Result<u32, DeterministicHostError> {
+        ) -> Result<u32, HostExportError> {
             // Not totally clear what is the purpose of this method, why not a default implementation here?
             Ok(type_id_index as u32)
         }

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -38,7 +38,7 @@ impl ToAscPtr for TriggerData {
         self,
         _heap: &mut H,
         _gas: &graph::runtime::gas::GasCounter,
-    ) -> Result<graph::runtime::AscPtr<()>, graph::runtime::DeterministicHostError> {
+    ) -> Result<graph::runtime::AscPtr<()>, graph::runtime::HostExportError> {
         unimplemented!()
     }
 }

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -11,8 +11,8 @@ use crate::data_source::{
     DataSource, DataSourceTemplate, MappingTrigger, TriggerData, TriggerWithHandler,
 };
 use crate::prelude::*;
+use crate::runtime::HostExportError;
 use crate::{blockchain::Blockchain, components::subgraph::SharedProofOfIndexing};
-use crate::{components::metrics::HistogramVec, runtime::DeterministicHostError};
 
 #[derive(Debug)]
 pub enum MappingError {
@@ -27,9 +27,14 @@ impl From<anyhow::Error> for MappingError {
     }
 }
 
-impl From<DeterministicHostError> for MappingError {
-    fn from(value: DeterministicHostError) -> MappingError {
-        MappingError::Unknown(value.inner())
+impl From<HostExportError> for MappingError {
+    fn from(value: HostExportError) -> MappingError {
+        match value {
+            HostExportError::PossibleReorg(e) => MappingError::PossibleReorg(e.into()),
+            HostExportError::Deterministic(e) | HostExportError::Unknown(e) => {
+                MappingError::Unknown(e.into())
+            }
+        }
     }
 }
 

--- a/graph/src/runtime/asc_ptr.rs
+++ b/graph/src/runtime/asc_ptr.rs
@@ -1,5 +1,5 @@
 use super::gas::GasCounter;
-use super::{padding_to_16, DeterministicHostError};
+use super::{padding_to_16, DeterministicHostError, HostExportError};
 
 use super::{AscHeap, AscIndexId, AscType, IndexForAscTypeId};
 use semver::Version;
@@ -86,7 +86,7 @@ impl<C: AscType> AscPtr<C> {
         asc_obj: C,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<AscPtr<C>, DeterministicHostError>
+    ) -> Result<AscPtr<C>, HostExportError>
     where
         C: AscIndexId,
     {
@@ -143,7 +143,7 @@ impl<C: AscType> AscPtr<C> {
         type_id_index: IndexForAscTypeId,
         content_length: usize,
         full_length: usize,
-    ) -> Result<Vec<u8>, DeterministicHostError> {
+    ) -> Result<Vec<u8>, HostExportError> {
         let mut header: Vec<u8> = Vec::with_capacity(20);
 
         let gc_info: [u8; 4] = (0u32).to_le_bytes();

--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -385,7 +385,7 @@ impl ToAscObj<u32> for IndexForAscTypeId {
         &self,
         _heap: &mut H,
         _gas: &GasCounter,
-    ) -> Result<u32, DeterministicHostError> {
+    ) -> Result<u32, HostExportError> {
         Ok(*self as u32)
     }
 }

--- a/runtime/derive/src/generate_array_type.rs
+++ b/runtime/derive/src/generate_array_type.rs
@@ -50,7 +50,7 @@ pub fn generate_array_type(metadata: TokenStream, input: TokenStream) -> TokenSt
                 &self,
                 heap: &mut H,
                 gas: &graph::runtime::gas::GasCounter,
-            ) -> Result<#asc_name_array, graph::runtime::DeterministicHostError> {
+            ) -> Result<#asc_name_array, graph::runtime::HostExportError> {
                 let content: Result<Vec<_>, _> = self.iter().map(|x| graph::runtime::asc_new(heap, x, gas)).collect();
 
                 Ok(#asc_name_array(graph_runtime_wasm::asc_abi::class::Array::new(&content?, heap, gas)?))

--- a/runtime/derive/src/generate_from_rust_type.rs
+++ b/runtime/derive/src/generate_from_rust_type.rs
@@ -56,7 +56,7 @@ pub fn generate_from_rust_type(metadata: TokenStream, input: TokenStream) -> Tok
 
         quote! {
             let #fld_name = self.#fld_name.as_ref()
-                .ok_or_else(||  graph::runtime::DeterministicHostError::from(anyhow::anyhow!("{} missing {}", #type_nm, #fld_nm)))?;
+                .ok_or_else(||  graph::runtime::HostExportError::from(graph::runtime::DeterministicHostError::from(anyhow::anyhow!("{} missing {}", #type_nm, #fld_nm))))?;
             }
     });
 
@@ -148,7 +148,7 @@ pub fn generate_from_rust_type(metadata: TokenStream, input: TokenStream) -> Tok
                     &self,
                     heap: &mut H,
                     gas: &graph::runtime::gas::GasCounter,
-                ) -> Result<#asc_name, graph::runtime::DeterministicHostError> {
+                ) -> Result<#asc_name, graph::runtime::HostExportError> {
 
                     #(#enum_validation)*
 

--- a/runtime/test/src/test_padding.rs
+++ b/runtime/test/src/test_padding.rs
@@ -109,6 +109,7 @@ pub mod data {
             IndexForAscTypeId::UnitTestNetworkUnitTestTypeBool;
     }
 
+    use graph::runtime::HostExportError;
     pub use graph::runtime::{
         asc_new, gas::GasCounter, AscHeap, AscIndexId, AscPtr, AscType, AscValue,
         DeterministicHostError, IndexForAscTypeId, ToAscObj,
@@ -119,7 +120,7 @@ pub mod data {
             &self,
             heap: &mut H,
             gas: &GasCounter,
-        ) -> Result<AscBad, DeterministicHostError> {
+        ) -> Result<AscBad, HostExportError> {
             Ok(AscBad {
                 nonce: self.nonce,
                 str_suff: asc_new(heap, &self.str_suff, gas)?,
@@ -178,7 +179,7 @@ pub mod data {
             &self,
             heap: &mut H,
             gas: &GasCounter,
-        ) -> Result<AscBadFixed, DeterministicHostError> {
+        ) -> Result<AscBadFixed, HostExportError> {
             Ok(AscBadFixed {
                 nonce: self.nonce,
                 str_suff: asc_new(heap, &self.str_suff, gas)?,

--- a/runtime/wasm/src/asc_abi/class.rs
+++ b/runtime/wasm/src/asc_abi/class.rs
@@ -4,7 +4,8 @@ use semver::Version;
 use graph::{
     data::store,
     runtime::{
-        gas::GasCounter, AscHeap, AscIndexId, AscType, AscValue, IndexForAscTypeId, ToAscObj,
+        gas::GasCounter, AscHeap, AscIndexId, AscType, AscValue, HostExportError,
+        IndexForAscTypeId, ToAscObj,
     },
 };
 use graph::{prelude::serde_json, runtime::DeterministicHostError};
@@ -92,7 +93,7 @@ impl<T: AscValue> TypedArray<T> {
         content: &[T],
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<Self, DeterministicHostError> {
+    ) -> Result<Self, HostExportError> {
         match heap.api_version() {
             version if version <= Version::new(0, 0, 4) => Ok(Self::ApiVersion0_0_4(
                 v0_0_4::TypedArray::new(content, heap, gas)?,
@@ -147,7 +148,7 @@ impl ToAscObj<Uint8Array> for Bytes<'_> {
         &self,
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<Uint8Array, DeterministicHostError> {
+    ) -> Result<Uint8Array, HostExportError> {
         self.0.to_asc_obj(heap, gas)
     }
 }
@@ -272,7 +273,7 @@ impl<T: AscValue> Array<T> {
         content: &[T],
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<Self, DeterministicHostError> {
+    ) -> Result<Self, HostExportError> {
         match heap.api_version() {
             version if version <= Version::new(0, 0, 4) => Ok(Self::ApiVersion0_0_4(
                 v0_0_4::Array::new(content, heap, gas)?,

--- a/runtime/wasm/src/asc_abi/v0_0_4.rs
+++ b/runtime/wasm/src/asc_abi/v0_0_4.rs
@@ -6,7 +6,7 @@ use std::mem::{size_of, size_of_val};
 use anyhow::anyhow;
 use semver::Version;
 
-use graph::runtime::{AscHeap, AscPtr, AscType, AscValue, DeterministicHostError};
+use graph::runtime::{AscHeap, AscPtr, AscType, AscValue, DeterministicHostError, HostExportError};
 use graph_runtime_derive::AscType;
 
 use crate::asc_abi::class;
@@ -153,7 +153,7 @@ impl<T: AscValue> TypedArray<T> {
         content: &[T],
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<Self, DeterministicHostError> {
+    ) -> Result<Self, HostExportError> {
         let buffer = class::ArrayBuffer::new(content, heap.api_version())?;
         let buffer_byte_length = if let class::ArrayBuffer::ApiVersion0_0_4(ref a) = buffer {
             a.byte_length
@@ -307,7 +307,7 @@ impl<T: AscValue> Array<T> {
         content: &[T],
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<Self, DeterministicHostError> {
+    ) -> Result<Self, HostExportError> {
         let arr_buffer = class::ArrayBuffer::new(content, heap.api_version())?;
         let arr_buffer_ptr = AscPtr::alloc_obj(arr_buffer, heap, gas)?;
         Ok(Array {

--- a/runtime/wasm/src/asc_abi/v0_0_5.rs
+++ b/runtime/wasm/src/asc_abi/v0_0_5.rs
@@ -5,7 +5,9 @@ use anyhow::anyhow;
 use semver::Version;
 
 use graph::runtime::gas::GasCounter;
-use graph::runtime::{AscHeap, AscPtr, AscType, AscValue, DeterministicHostError, HEADER_SIZE};
+use graph::runtime::{
+    AscHeap, AscPtr, AscType, AscValue, DeterministicHostError, HostExportError, HEADER_SIZE,
+};
 use graph_runtime_derive::AscType;
 
 use crate::asc_abi::class;
@@ -116,7 +118,7 @@ impl<T: AscValue> TypedArray<T> {
         content: &[T],
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<Self, DeterministicHostError> {
+    ) -> Result<Self, HostExportError> {
         let buffer = class::ArrayBuffer::new(content, heap.api_version())?;
         let byte_length = content.len() as u32;
         let ptr = AscPtr::alloc_obj(buffer, heap, gas)?;
@@ -266,7 +268,7 @@ impl<T: AscValue> Array<T> {
         content: &[T],
         heap: &mut H,
         gas: &GasCounter,
-    ) -> Result<Self, DeterministicHostError> {
+    ) -> Result<Self, HostExportError> {
         let arr_buffer = class::ArrayBuffer::new(content, heap.api_version())?;
         let buffer = AscPtr::alloc_obj(arr_buffer, heap, gas)?;
         let buffer_data_length = buffer.read_len(heap, gas)?;

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -601,7 +601,7 @@ impl<C: Blockchain> HostExports<C> {
         x: BigDecimal,
         y: BigDecimal,
         gas: &GasCounter,
-    ) -> Result<bool, DeterministicHostError> {
+    ) -> Result<bool, HostExportError> {
         gas.consume_host_fn(gas::BIG_MATH_GAS_OP.with_args(complexity::Min, (&x, &y)))?;
         Ok(x == y)
     }

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -219,7 +219,11 @@ impl<C: Blockchain> WasmInstance<C> {
 
         // This `match` will return early if there was a non-deterministic trap.
         let deterministic_error: Option<Error> = match func.call(arg.wasm_ptr()) {
-            Ok(()) => None,
+            Ok(()) => {
+                assert!(self.instance_ctx().possible_reorg == false);
+                assert!(self.instance_ctx().deterministic_host_trap == false);
+                None
+            }
             Err(trap) if self.instance_ctx().possible_reorg => {
                 self.instance_ctx_mut().ctx.state.exit_handler();
                 return Err(MappingError::PossibleReorg(trap.into()));


### PR DESCRIPTION
Fixes https://github.com/graphprotocol/graph-node/issues/3576.

When a timeout happened when calling `asc_type_id` this was incorrectly classified as a deterministic error. And these timeouts where happening frequently in the wild. Fixing this required correctly classifying wasm traps returned by `asc_type_id`. The second commit is the actual fix, most of the diff is from all the signatures that needed to change.