### PR TITLE
Add jitter to `ExponentialBackoff`

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -60,9 +60,10 @@ where
                 should_try_unfail_non_deterministic: true,
                 synced: false,
                 skip_ptr_updates_timer: Instant::now(),
-                backoff: ExponentialBackoff::new(
+                backoff: ExponentialBackoff::with_jitter(
                     (MINUTE * 2).min(env_vars.subgraph_error_retry_ceil),
                     env_vars.subgraph_error_retry_ceil,
+                    env_vars.subgraph_error_retry_jitter,
                 ),
                 entity_lfu_cache: LfuCache::new(),
             },

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -135,6 +135,11 @@ pub struct EnvVars {
     /// Set by the environment variable `GRAPH_SUBGRAPH_ERROR_RETRY_CEIL_SECS`
     /// (expressed in seconds). The default value is 1800s (30 minutes).
     pub subgraph_error_retry_ceil: Duration,
+    /// Jitter factor for the backoff retry of non-deterministic errors.
+    ///
+    /// Set by the environment variable `GRAPH_SUBGRAPH_ERROR_RETRY_JITTER`
+    /// (clamped between 0.0 and 1.0). The default value is 0.2.
+    pub subgraph_error_retry_jitter: f64,
     /// Experimental feature.
     ///
     /// Set by the flag `GRAPH_ENABLE_SELECT_BY_SPECIFIC_ATTRIBUTES`. Off by
@@ -210,6 +215,7 @@ impl EnvVars {
             subgraph_max_data_sources: inner.subgraph_max_data_sources.0,
             disable_fail_fast: inner.disable_fail_fast.0,
             subgraph_error_retry_ceil: Duration::from_secs(inner.subgraph_error_retry_ceil_in_secs),
+            subgraph_error_retry_jitter: inner.subgraph_error_retry_jitter,
             enable_select_by_specific_attributes: inner.enable_select_by_specific_attributes.0,
             log_trigger_data: inner.log_trigger_data.0,
             explorer_ttl: Duration::from_secs(inner.explorer_ttl_in_secs),
@@ -315,6 +321,8 @@ struct Inner {
     disable_fail_fast: EnvVarBoolean,
     #[envconfig(from = "GRAPH_SUBGRAPH_ERROR_RETRY_CEIL_SECS", default = "1800")]
     subgraph_error_retry_ceil_in_secs: u64,
+    #[envconfig(from = "GRAPH_SUBGRAPH_ERROR_RETRY_JITTER", default = "0.2")]
+    subgraph_error_retry_jitter: f64,
     #[envconfig(from = "GRAPH_ENABLE_SELECT_BY_SPECIFIC_ATTRIBUTES", default = "false")]
     enable_select_by_specific_attributes: EnvVarBoolean,
     #[envconfig(from = "GRAPH_LOG_TRIGGER_DATA", default = "false")]

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -133,7 +133,7 @@ pub struct EnvVars {
     /// Ceiling for the backoff retry of non-deterministic errors.
     ///
     /// Set by the environment variable `GRAPH_SUBGRAPH_ERROR_RETRY_CEIL_SECS`
-    /// (expressed in seconds). The default value is 1800s (30 minutes).
+    /// (expressed in seconds). The default value is 3600s (60 minutes).
     pub subgraph_error_retry_ceil: Duration,
     /// Jitter factor for the backoff retry of non-deterministic errors.
     ///
@@ -319,7 +319,7 @@ struct Inner {
     subgraph_max_data_sources: NoUnderscores<usize>,
     #[envconfig(from = "GRAPH_DISABLE_FAIL_FAST", default = "false")]
     disable_fail_fast: EnvVarBoolean,
-    #[envconfig(from = "GRAPH_SUBGRAPH_ERROR_RETRY_CEIL_SECS", default = "1800")]
+    #[envconfig(from = "GRAPH_SUBGRAPH_ERROR_RETRY_CEIL_SECS", default = "3600")]
     subgraph_error_retry_ceil_in_secs: u64,
     #[envconfig(from = "GRAPH_SUBGRAPH_ERROR_RETRY_JITTER", default = "0.2")]
     subgraph_error_retry_jitter: f64,


### PR DESCRIPTION
Implements #4474

Used by `SubgraphRunner` with default value = 0.2