### PR TITLE
Fix Markdown rendering in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -12,7 +12,6 @@ body:
     attributes:
       label: Bug report
       description: Please provide a detailed overview of the expected behavior, and what happens instead. The more details, the better. You can use Markdown.
-      render: Markdown
   - type: textarea
     id: graph-node-logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -4,16 +4,14 @@ title: "[Feature] "
 labels: ["enhancement"]
 body:
   - type: textarea
-    id: bug-report
+    id: feature-description
     attributes:
       label: Description
       description: Please provide a detailed overview of the desired feature or improvement, along with any examples or useful information. You can use Markdown.
-      render: Markdown
   - type: textarea
     id: blockers
     attributes:
       label: Are you aware of any blockers that must be resolved before implementing this feature? If so, which? Link to any relevant GitHub issues.
-      render: Markdown
     validations:
       required: false
   - type: checkboxes


### PR DESCRIPTION
The rendering of bug and feature descriptions with the new issue templates doesn't use Markdown (everything is monospace). This PR fixes it. I tested it on my fork of `graph-node`, see https://github.com/neysofu/graph-node/issues/75.