### PR TITLE
graph, test-store: Small improvements

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -218,6 +218,12 @@ impl SubgraphName {
         Ok(SubgraphName(s))
     }
 
+    /// Tests are allowed to create arbitrary subgraph names
+    #[cfg(debug_assertions)]
+    pub fn new_unchecked(s: impl Into<String>) -> Self {
+        SubgraphName(s.into())
+    }
+
     pub fn as_str(&self) -> &str {
         self.0.as_str()
     }


### PR DESCRIPTION
* Do not arbitrarily truncate subgraph names to 32 characters; that can lead to strange surprises when the names of two test subgraphs only differ after the 32nd character
* Use a more direct method to get rid of test subgraphs. Using `record_unused_deployments` is a bit too roundabout for tests, and can lead to not deleting a subgraph if a previous run recorded the subgraph as unused, but didn't delete it

