### PR TITLE
Avoid `writer poisoned` errors

### DIFF
--- a/core/src/subgraph/inputs.rs
+++ b/core/src/subgraph/inputs.rs
@@ -33,3 +33,42 @@ pub struct IndexingInputs<C: Blockchain> {
     /// possibly expensive and noisy, information
     pub instrument: bool,
 }
+
+impl<C: Blockchain> IndexingInputs<C> {
+    pub fn with_store(&self, store: Arc<dyn WritableStore>) -> Self {
+        let IndexingInputs {
+            deployment,
+            features,
+            start_blocks,
+            stop_block,
+            store: _,
+            debug_fork,
+            triggers_adapter,
+            chain,
+            templates,
+            unified_api_version,
+            static_filters,
+            poi_version,
+            network,
+            manifest_idx_and_name,
+            instrument,
+        } = self;
+        IndexingInputs {
+            deployment: deployment.clone(),
+            features: features.clone(),
+            start_blocks: start_blocks.clone(),
+            stop_block: stop_block.clone(),
+            store,
+            debug_fork: debug_fork.clone(),
+            triggers_adapter: triggers_adapter.clone(),
+            chain: chain.clone(),
+            templates: templates.clone(),
+            unified_api_version: unified_api_version.clone(),
+            static_filters: *static_filters,
+            poi_version: *poi_version,
+            network: network.clone(),
+            manifest_idx_and_name: manifest_idx_and_name.clone(),
+            instrument: *instrument,
+        }
+    }
+}

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -179,7 +179,19 @@ where
                         self.inputs.store.flush().await?;
                         return Ok(self);
                     }
-                    Action::Restart => break,
+                    Action::Restart => {
+                        // Restart the store to clear any errors that it
+                        // might have encountered and use that from now on
+                        let store = self.inputs.store.cheap_clone();
+                        let store = store.restart().await?;
+                        self.inputs = Arc::new(self.inputs.with_store(store));
+                        // Also clear the entity cache since we might have
+                        // entries in there that never made it to the
+                        // database
+                        self.state.entity_lfu_cache = LfuCache::new();
+                        self.state.synced = self.inputs.store.is_deployment_synced().await?;
+                        break;
+                    }
                 };
             }
         }

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -105,8 +105,8 @@ where
         self.run_inner(break_on_restart).await
     }
 
-    pub async fn run(self) -> Result<Self, Error> {
-        self.run_inner(false).await
+    pub async fn run(self) -> Result<(), Error> {
+        self.run_inner(false).await.map(|_| ())
     }
 
     async fn run_inner(mut self, break_on_restart: bool) -> Result<Self, Error> {

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -331,10 +331,11 @@ pub trait WritableStore: ReadStore + DeploymentCursorTracker {
     /// contain unprocessed write requests that will be discarded by this
     /// call.
     ///
-    /// After this call, `self` should not be used anymore, as it will
-    /// continue to produce errors for any write requests, and instead, the
-    /// returned `WritableStore` should be used.
-    async fn restart(self: Arc<Self>) -> Result<Arc<dyn WritableStore>, StoreError>;
+    /// This call returns `None` if a restart was not needed because `self`
+    /// had no errors. If it returns `Some`, `self` should not be used
+    /// anymore, as it will continue to produce errors for any write
+    /// requests, and instead, the returned `WritableStore` should be used.
+    async fn restart(self: Arc<Self>) -> Result<Option<Arc<dyn WritableStore>>, StoreError>;
 }
 
 #[async_trait]

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -324,6 +324,17 @@ pub trait WritableStore: ReadStore + DeploymentCursorTracker {
 
     /// Wait for the background writer to finish processing its queue
     async fn flush(&self) -> Result<(), StoreError>;
+
+    /// Restart the `WritableStore`. This will clear any errors that have
+    /// been encountered. Code that calls this must not make any assumptions
+    /// about what has been written already, as the write queue might
+    /// contain unprocessed write requests that will be discarded by this
+    /// call.
+    ///
+    /// After this call, `self` should not be used anymore, as it will
+    /// continue to produce errors for any write requests, and instead, the
+    /// returned `WritableStore` should be used.
+    async fn restart(self: Arc<Self>) -> Result<Arc<dyn WritableStore>, StoreError>;
 }
 
 #[async_trait]

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -961,6 +961,8 @@ impl Writer {
         match self {
             Writer::Sync(_) => Ok(()),
             Writer::Async { join_handle, queue } => {
+                // If there was an error, report that instead of a naked 'writer not running'
+                queue.check_err()?;
                 if join_handle.is_finished() {
                     Err(constraint_violation!(
                         "Subgraph writer for {} is not running",

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -170,7 +170,7 @@ impl WritableStore for MockStore {
         unimplemented!()
     }
 
-    async fn restart(self: Arc<Self>) -> Result<Arc<dyn WritableStore>, StoreError> {
+    async fn restart(self: Arc<Self>) -> Result<Option<Arc<dyn WritableStore>>, StoreError> {
         unimplemented!()
     }
 }

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -169,6 +169,10 @@ impl WritableStore for MockStore {
     async fn causality_region_curr_val(&self) -> Result<Option<CausalityRegion>, StoreError> {
         unimplemented!()
     }
+
+    async fn restart(self: Arc<Self>) -> Result<Arc<dyn WritableStore>, StoreError> {
+        unimplemented!()
+    }
 }
 
 fn make_band_key(id: &'static str) -> EntityKey {

--- a/store/test-store/tests/postgres/writable.rs
+++ b/store/test-store/tests/postgres/writable.rs
@@ -192,7 +192,7 @@ fn restart() {
 
         // We now have a poisoned store. Restarting it gives us a new store
         // that works again
-        let writable = writable.restart().await.unwrap();
+        let writable = writable.restart().await.unwrap().unwrap();
         writable.flush().await.unwrap();
 
         // Retry our write with correct data


### PR DESCRIPTION
If a subgraph encountered an error, it would get restarted with some backoff. If that error was caused by some store interaction, the `WritableStore` would remain in poisoned state and refuse to process any more writes.

This PR changes that so that the `WritableStore` is restarted when a subgraph is restarted, clearing the error. That requires that we clear any internal state that is based on assumptions of what has been written so far. I am not entirely sure that the changes in `core/src/subgraph/runner.rs` is enough to do that, and would appreciate a thorough review of what other state might have to be cleared.