### PR TITLE
Update rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.68.0"
+channel = "1.68"
 profile = "default"


### PR DESCRIPTION
I think we are safe to use any version within the `1.xx` release train.

Maybe due to a local setup problem, I had this error when trying `cargo check` after pulling latest `master` branch:

```bash
$ cargo check
error: the 'cargo' binary, normally provided by the 'cargo' component, is not applicable to the '1.68.0-aarch64-apple-darwin' toolchain
```

I tried `rustup update` but didn't change anything. Changing `rust-toolchain.toml` to use `1.68` fixed it.

Maybe a side effect of "changing" which Rust version to use (?). Anyway, I think it's quite safe to not force the usage of a particular minor version.

