### PR TITLE
core, graph, runtime: Add store.get_in_block

### DIFF
--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -2,7 +2,7 @@ mod entity_cache;
 mod err;
 mod traits;
 
-pub use entity_cache::{EntityCache, ModificationsAndCache};
+pub use entity_cache::{EntityCache, GetScope, ModificationsAndCache};
 
 use diesel::types::{FromSql, ToSql};
 pub use err::StoreError;

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -9,7 +9,7 @@ use wasmtime::Trap;
 use web3::types::H160;
 
 use graph::blockchain::Blockchain;
-use graph::components::store::{EnsLookup, LoadRelatedRequest};
+use graph::components::store::{EnsLookup, GetScope, LoadRelatedRequest};
 use graph::components::store::{EntityKey, EntityType};
 use graph::components::subgraph::{
     PoICausalityRegion, ProofOfIndexingEvent, SharedProofOfIndexing,
@@ -225,6 +225,7 @@ impl<C: Blockchain> HostExports<C> {
         entity_type: String,
         entity_id: String,
         gas: &GasCounter,
+        scope: GetScope,
     ) -> Result<Option<Entity>, anyhow::Error> {
         let store_key = EntityKey {
             entity_type: EntityType::new(entity_type),
@@ -233,7 +234,7 @@ impl<C: Blockchain> HostExports<C> {
         };
         self.check_entity_type_access(&store_key.entity_type)?;
 
-        let result = state.entity_cache.get(&store_key)?;
+        let result = state.entity_cache.get(&store_key, scope)?;
         gas.consume_host_fn(gas::STORE_GET.with_args(complexity::Linear, (&store_key, &result)))?;
 
         Ok(result)


### PR DESCRIPTION
This adds a new host fn `get_in_block` that will only look for entities that have been created or updated in the current block. This can improve indexing performance quite a bit if it is known that a certain entity has to have been created in the same block.

A typical situation for this is that one handler creates a `Transaction` from some on-chain event, and a later handler wants to access this transaction if it exists. In the case where the transaction does not exist, a normal `store.get` will have to go to the database just to find out that the entity does not exist; if the subgraph author already knows that the entity must have been created in the same block, using `store.get_in_block` avoids this database roundtrip. For some subgraphs, these missed lookups can contribute significantly to the indexing time.