### PR TITLE
Write changes in batches during syncing

### DIFF
--- a/core/src/subgraph/inputs.rs
+++ b/core/src/subgraph/inputs.rs
@@ -26,9 +26,6 @@ pub struct IndexingInputs<C: Blockchain> {
     pub poi_version: ProofOfIndexingVersion,
     pub network: String,
 
-    // Correspondence between data source or template position in the manifest and name.
-    pub manifest_idx_and_name: Vec<(u32, String)>,
-
     /// Whether to instrument trigger processing and log additional,
     /// possibly expensive and noisy, information
     pub instrument: bool,
@@ -50,7 +47,6 @@ impl<C: Blockchain> IndexingInputs<C> {
             static_filters,
             poi_version,
             network,
-            manifest_idx_and_name,
             instrument,
         } = self;
         IndexingInputs {
@@ -67,7 +63,6 @@ impl<C: Blockchain> IndexingInputs<C> {
             static_filters: *static_filters,
             poi_version: *poi_version,
             network: network.clone(),
-            manifest_idx_and_name: manifest_idx_and_name.clone(),
             instrument: *instrument,
         }
     }

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -474,7 +474,6 @@ where
                 &self.metrics.host.stopwatch,
                 persisted_data_sources,
                 deterministic_errors,
-                self.inputs.manifest_idx_and_name.clone(),
                 processed_data_sources,
             )
             .await

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -238,3 +238,9 @@ those.
   to 0.5 for the `REBUILD_THRESHOLD` and 0.05 for the `DELETE_THRESHOLD`;
   they must be between 0 and 1, and `REBUILD_THRESHOLD` must be bigger than
   `DELETE_THRESHOLD`.
+- `GRAPH_STORE_WRITE_BATCH_DURATION`: how long to accumulate changes during
+  syncing into a batch before a write has to happen in seconds. The default
+  is 300s. Setting this to 0 disables write batching.
+- `GRAPH_STORE_WRITE_BATCH_SIZE`: how many changes to accumulate during
+  syncing in kilobytes before a write has to happen. The default is 10_000
+  which corresponds to 10MB. Setting this to 0 disables write batching.

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -139,10 +139,14 @@ pub trait SubgraphStore: Send + Sync + 'static {
     /// assumptions about the in-memory state of writing has been made; in
     /// particular, no assumptions about whether previous writes have
     /// actually been committed or not.
+    ///
+    /// The `manifest_idx_and_name` lists the correspondence between data
+    /// source or template position in the manifest and name.
     async fn writable(
         self: Arc<Self>,
         logger: Logger,
         deployment: DeploymentId,
+        manifest_idx_and_name: Arc<Vec<(u32, String)>>,
     ) -> Result<Arc<dyn WritableStore>, StoreError>;
 
     /// Initiate a graceful shutdown of the writable that a previous call to
@@ -292,7 +296,6 @@ pub trait WritableStore: ReadStore + DeploymentCursorTracker {
         stopwatch: &StopwatchMetrics,
         data_sources: Vec<StoredDynamicDataSource>,
         deterministic_errors: Vec<SubgraphError>,
-        manifest_idx_and_name: Vec<(u32, String)>,
         offchain_to_remove: Vec<StoredDynamicDataSource>,
     ) -> Result<(), StoreError>;
 

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -5,65 +5,118 @@ use crate::{
     blockchain::{block_stream::FirehoseCursor, BlockPtr},
     cheap_clone::CheapClone,
     components::subgraph::Entity,
-    data::subgraph::schema::SubgraphError,
+    data::{subgraph::schema::SubgraphError, value::Word},
+    data_source::CausalityRegion,
     prelude::DeploymentHash,
 };
 
 use super::{
-    BlockNumber, EntityKey, EntityModification, EntityType, StoreEvent, StoredDynamicDataSource,
+    BlockNumber, EntityKey, EntityModification, EntityType, StoreError, StoreEvent,
+    StoredDynamicDataSource,
 };
 
-/// Trait for something that has a block number associated with it
-pub trait BlockTagged {
-    fn block(&self) -> BlockNumber;
-}
-
+/// A data structure similar to `EntityModification`, but tagged with a
+/// block. We might eventually replace `EntityModification` with this, but
+/// until the dust settles, we'll keep them separate.
+///
+/// This is geared towards how we persist entity changes: there are only
+/// ever two operations we perform on them, clamping the range of an
+/// existing entity version, and writing a new entity version.
 #[derive(Debug)]
-/// The data for a write operation; a write operation is either an insert of
-/// a new entity or the overwriting of an existing entity.
-/// A helper for objects that are tagged with a block number
-pub struct EntityWrite {
-    pub key: EntityKey,
-    pub data: Entity,
-    pub block: BlockNumber,
+pub enum EntityMod {
+    /// Insert the entity
+    Insert {
+        key: EntityKey,
+        data: Entity,
+        block: BlockNumber,
+    },
+    /// Update the entity by overwriting it
+    Overwrite {
+        key: EntityKey,
+        data: Entity,
+        block: BlockNumber,
+    },
+    /// Remove the entity
+    Remove { key: EntityKey, block: BlockNumber },
 }
 
-impl EntityWrite {
-    pub fn new(key: EntityKey, data: Entity, block: BlockNumber) -> Self {
-        Self { key, data, block }
+impl EntityMod {
+    fn new(m: EntityModification, block: BlockNumber) -> Self {
+        match m {
+            EntityModification::Insert { key, data } => Self::Insert { key, data, block },
+            EntityModification::Overwrite { key, data } => Self::Overwrite { key, data, block },
+            EntityModification::Remove { key } => Self::Remove { key, block },
+        }
     }
-}
 
-impl BlockTagged for EntityWrite {
+    #[cfg(debug_assertions)]
+    pub fn new_test(m: EntityModification, block: BlockNumber) -> Self {
+        Self::new(m, block)
+    }
+
+    pub fn id(&self) -> &Word {
+        match self {
+            EntityMod::Insert { key, .. }
+            | EntityMod::Overwrite { key, .. }
+            | EntityMod::Remove { key, .. } => &key.entity_id,
+        }
+    }
+
     fn block(&self) -> BlockNumber {
-        self.block
+        match self {
+            EntityMod::Insert { block, .. }
+            | EntityMod::Overwrite { block, .. }
+            | EntityMod::Remove { block, .. } => *block,
+        }
     }
-}
 
-pub struct EntityRef {
-    pub key: EntityKey,
-    pub block: BlockNumber,
-}
-
-impl EntityRef {
-    pub fn new(key: EntityKey, block: BlockNumber) -> Self {
-        Self { key, block }
+    /// Return `true` if `self` requires a write operation, i.e.,insert of a
+    /// new row, for either a new or an existing entity
+    fn is_write(&self) -> bool {
+        match self {
+            EntityMod::Insert { .. } | EntityMod::Overwrite { .. } => true,
+            EntityMod::Remove { .. } => false,
+        }
     }
-}
 
-impl BlockTagged for EntityRef {
-    fn block(&self) -> BlockNumber {
-        self.block
+    /// Return the details of the write if `self` is a write operation for a
+    /// new or an existing entity
+    fn as_write(&self) -> Option<(&Word, &Entity, CausalityRegion, BlockNumber)> {
+        match self {
+            EntityMod::Insert { key, data, block } | EntityMod::Overwrite { key, data, block } => {
+                Some((&key.entity_id, data, key.causality_region, *block))
+            }
+            EntityMod::Remove { .. } => None,
+        }
+    }
+
+    /// Return `true` if `self` requires clamping of an existing version
+    fn is_clamp(&self) -> bool {
+        match self {
+            EntityMod::Insert { .. } => false,
+            EntityMod::Overwrite { .. } | EntityMod::Remove { .. } => true,
+        }
+    }
+
+    fn key(&self) -> &EntityKey {
+        match self {
+            EntityMod::Insert { key, .. }
+            | EntityMod::Overwrite { key, .. }
+            | EntityMod::Remove { key, .. } => key,
+        }
     }
 }
 
 /// A list of entity changes grouped by the entity type
-pub struct RowGroup<R> {
+#[derive(Debug)]
+pub struct RowGroup {
     pub entity_type: EntityType,
-    pub rows: Vec<R>,
+    /// All changes for this entity type, ordered by block; i.e., if `i < j`
+    /// then `rows[i].block() <= rows[j].block()`
+    pub rows: Vec<EntityMod>,
 }
 
-impl<R> RowGroup<R> {
+impl RowGroup {
     pub fn new(entity_type: EntityType) -> Self {
         Self {
             entity_type,
@@ -71,45 +124,93 @@ impl<R> RowGroup<R> {
         }
     }
 
-    pub fn push(&mut self, row: R) {
-        self.rows.push(row)
+    pub fn push(&mut self, emod: EntityModification, block: BlockNumber) -> Result<(), StoreError> {
+        debug_assert!(self
+            .rows
+            .last()
+            .map(|emod| emod.block() <= block)
+            .unwrap_or(true));
+        let row = EntityMod::new(emod, block);
+        self.rows.push(row);
+        Ok(())
     }
 
     fn row_count(&self) -> usize {
         self.rows.len()
     }
-}
 
-impl<R: BlockTagged> RowGroup<R> {
-    pub fn runs(&self) -> impl Iterator<Item = (BlockNumber, &[R])> {
-        RunIterator::new(self)
+    /// Iterate over all changes that need clamping of the block range of an
+    /// existing entity version
+    pub fn clamps_by_block(&self) -> impl Iterator<Item = (BlockNumber, &[EntityMod])> {
+        ClampsByBlockIterator::new(self)
+    }
+
+    /// Iterate over all changes that require writing a new entity version
+    pub fn writes(&self) -> impl Iterator<Item = &EntityMod> {
+        self.rows.iter().filter(|row| row.is_write())
+    }
+
+    /// Return an iterator over all writes in chunks. The returned
+    /// `WriteChunker` is an iterator that produces `WriteChunk`s, which are
+    /// the iterators over the writes. Each `WriteChunk` has `chunk_size`
+    /// elements, except for the last one which might have fewer
+    pub fn write_chunks<'a>(&'a self, chunk_size: usize) -> WriteChunker<'a> {
+        WriteChunker::new(self, chunk_size)
+    }
+
+    pub fn has_clamps(&self) -> bool {
+        self.rows.iter().any(|row| row.is_clamp())
+    }
+
+    pub fn last_op(&self, key: &EntityKey) -> Option<EntityOp<'_>> {
+        self.rows
+            .iter()
+            .rfind(|emod| emod.key() == key)
+            .map(EntityOp::from)
+    }
+
+    pub fn effective_ops(&self) -> impl Iterator<Item = EntityOp<'_>> {
+        let mut seen = HashSet::new();
+        self.rows
+            .iter()
+            .rev()
+            .filter(move |emod| seen.insert(emod.id()))
+            .map(EntityOp::from)
     }
 }
 
-struct RunIterator<'a, R> {
+struct ClampsByBlockIterator<'a> {
     position: usize,
-    rows: &'a [R],
+    rows: &'a [EntityMod],
 }
 
-impl<'a, R> RunIterator<'a, R> {
-    fn new(group: &'a RowGroup<R>) -> Self {
-        RunIterator {
+impl<'a> ClampsByBlockIterator<'a> {
+    fn new(group: &'a RowGroup) -> Self {
+        ClampsByBlockIterator {
             position: 0,
             rows: &group.rows,
         }
     }
 }
 
-impl<'a, R: BlockTagged> Iterator for RunIterator<'a, R> {
-    type Item = (BlockNumber, &'a [R]);
+impl<'a> Iterator for ClampsByBlockIterator<'a> {
+    type Item = (BlockNumber, &'a [EntityMod]);
 
     fn next(&mut self) -> Option<Self::Item> {
+        // Make sure we start on a clamp
+        while self.position < self.rows.len() && !self.rows[self.position].is_clamp() {
+            self.position += 1;
+        }
         if self.position >= self.rows.len() {
             return None;
         }
         let block = self.rows[self.position].block();
         let mut next = self.position;
-        while next < self.rows.len() && self.rows[next].block() == block {
+        // Collect consecutive clamps
+        while next < self.rows.len()
+            && self.rows[next].block() == block
+            && self.rows[next].is_clamp()
+        {
             next += 1;
         }
         let res = Some((block, &self.rows[self.position..next]));
@@ -119,31 +220,24 @@ impl<'a, R: BlockTagged> Iterator for RunIterator<'a, R> {
 }
 
 /// A list of entity changes with one group per entity type
-pub struct Sheet<R> {
-    pub groups: Vec<RowGroup<R>>,
+pub struct Sheet {
+    pub groups: Vec<RowGroup>,
 }
 
-impl<R> Sheet<R> {
+impl Sheet {
     fn new() -> Self {
         Self { groups: Vec::new() }
     }
 
-    fn group(&self, entity_type: &EntityType) -> Option<&RowGroup<R>> {
+    fn group(&self, entity_type: &EntityType) -> Option<&RowGroup> {
         self.groups
             .iter()
             .find(|group| &group.entity_type == entity_type)
     }
 
-    /// Return a mutable reference to an existing group.
-    fn group_mut(&mut self, entity_type: &EntityType) -> Option<&mut RowGroup<R>> {
-        self.groups
-            .iter_mut()
-            .find(|group| &group.entity_type == entity_type)
-    }
-
     /// Return a mutable reference to an existing group, or create a new one
     /// if there isn't one yet and return a reference to that
-    fn group_entry(&mut self, entity_type: &EntityType) -> &mut RowGroup<R> {
+    fn group_entry(&mut self, entity_type: &EntityType) -> &mut RowGroup {
         let pos = self
             .groups
             .iter()
@@ -183,8 +277,24 @@ impl<E> BlockEntries<E> {
 pub type DataSources = BlockEntries<Vec<StoredDynamicDataSource>>;
 
 pub enum EntityOp<'a> {
-    Write(&'a Entity),
-    Remove,
+    Write {
+        key: &'a EntityKey,
+        entity: &'a Entity,
+    },
+    Remove {
+        key: &'a EntityKey,
+    },
+}
+
+impl<'a> From<&'a EntityMod> for EntityOp<'a> {
+    fn from(emod: &'a EntityMod) -> Self {
+        match emod {
+            EntityMod::Insert { data, key, .. } | EntityMod::Overwrite { data, key, .. } => {
+                EntityOp::Write { key, entity: data }
+            }
+            EntityMod::Remove { key, .. } => EntityOp::Remove { key },
+        }
+    }
 }
 
 /// A write batch. This data structure encapsulates all the things that need
@@ -196,12 +306,7 @@ pub struct Batch {
     pub block_ptr: BlockPtr,
     /// The firehose cursor corresponding to `block_ptr`
     pub firehose_cursor: FirehoseCursor,
-    /// New entities that need to be inserted
-    pub inserts: Sheet<EntityWrite>,
-    /// Existing entities that need to be modified
-    pub overwrites: Sheet<EntityWrite>,
-    /// Existing entities that need to be removed
-    pub removes: Sheet<EntityRef>,
+    mods: Sheet,
     /// New data sources
     pub data_sources: DataSources,
     pub deterministic_errors: Vec<SubgraphError>,
@@ -212,113 +317,59 @@ impl Batch {
     pub fn new(
         block_ptr: BlockPtr,
         firehose_cursor: FirehoseCursor,
-        mods: Vec<EntityModification>,
+        mut raw_mods: Vec<EntityModification>,
         data_sources: Vec<StoredDynamicDataSource>,
         deterministic_errors: Vec<SubgraphError>,
         offchain_to_remove: Vec<StoredDynamicDataSource>,
-    ) -> Self {
+    ) -> Result<Self, StoreError> {
         let block = block_ptr.number;
 
-        let mut inserts = Sheet::new();
-        let mut overwrites = Sheet::new();
-        let mut removes = Sheet::new();
+        // Sort the modifications such that writes and clamps are
+        // consecutive. It's not needed for correctness but helps with some
+        // of the iterations, especially when we iterate with
+        // `clamps_by_block` so we get only one run for each block
+        raw_mods.sort_unstable_by_key(|emod| match emod {
+            EntityModification::Insert { .. } => 2,
+            EntityModification::Overwrite { .. } => 1,
+            EntityModification::Remove { .. } => 0,
+        });
 
-        for m in mods {
-            match m {
-                EntityModification::Insert { key, data } => {
-                    let row = EntityWrite::new(key, data, block);
-                    inserts.group_entry(&row.key.entity_type).push(row);
-                }
-                EntityModification::Overwrite { key, data } => {
-                    let row = EntityWrite::new(key, data, block);
-                    overwrites.group_entry(&row.key.entity_type).push(row);
-                }
-                EntityModification::Remove { key } => {
-                    let row = EntityRef::new(key, block);
-                    removes.group_entry(&row.key.entity_type).push(row)
-                }
-            }
+        let mut mods = Sheet::new();
+
+        for m in raw_mods {
+            mods.group_entry(&m.entity_ref().entity_type)
+                .push(m, block)?;
         }
 
         let data_sources = DataSources::new(block_ptr.cheap_clone(), data_sources);
         let offchain_to_remove = DataSources::new(block_ptr.cheap_clone(), offchain_to_remove);
-        Self {
+        Ok(Self {
             block_ptr,
             firehose_cursor,
-            inserts,
-            overwrites,
-            removes,
+            mods,
             data_sources,
             deterministic_errors,
             offchain_to_remove,
-        }
+        })
     }
 
     pub fn entity_count(&self) -> usize {
-        self.inserts.entity_count() + self.overwrites.entity_count() + self.removes.entity_count()
+        self.mods.entity_count()
     }
 
     /// Find out whether the latest operation for the entity with type
     /// `entity_type` and `id` is going to write that entity, i.e., insert
     /// or overwrite it, or if it is going to remove it. If no change will
     /// be made to the entity, return `None`
-    pub fn last_op(&self, entity_type: &EntityType, id: &str) -> Option<EntityOp<'_>> {
-        // Check if we are inserting or overwriting the entity
-        if let Some((_, entity)) = self
-            .writes(entity_type)
-            .find(|(_, entity)| entity.id() == id)
-        {
-            return Some(EntityOp::Write(entity));
-        }
-        self.removes(entity_type)
-            .find(|eref| eref.key.entity_id.as_str() == id)
-            .map(|_| EntityOp::Remove)
+    pub fn last_op(&self, key: &EntityKey) -> Option<EntityOp<'_>> {
+        self.mods.group(&key.entity_type)?.last_op(key)
     }
 
-    /// Iterate over all entities that have a pending write
-    pub fn writes(&self, entity_type: &EntityType) -> impl Iterator<Item = (&EntityKey, &Entity)> {
-        self.inserts
+    pub fn effective_ops(&self, entity_type: &EntityType) -> impl Iterator<Item = EntityOp> {
+        self.mods
             .group(entity_type)
+            .map(|group| group.effective_ops())
             .into_iter()
-            .map(|ew| &ew.rows)
-            .flatten()
-            .chain(
-                self.overwrites
-                    .group(entity_type)
-                    .into_iter()
-                    .map(|ew| &ew.rows)
-                    .flatten(),
-            )
-            .map(|ew| (&ew.key, &ew.data))
-    }
-
-    /// Iterate over all entities that have a pending write, allowing for
-    /// mutation of the entity
-    pub fn writes_mut(
-        &mut self,
-        entity_type: &EntityType,
-    ) -> impl Iterator<Item = (&EntityKey, &mut Entity)> {
-        self.inserts
-            .group_mut(entity_type)
-            .into_iter()
-            .map(|rg| &mut rg.rows)
-            .flatten()
-            .chain(
-                self.overwrites
-                    .group_mut(entity_type)
-                    .into_iter()
-                    .map(|rg| &mut rg.rows)
-                    .flatten(),
-            )
-            .map(|ew| (&ew.key, &mut ew.data))
-    }
-
-    /// Iterate over all entity deletions/removals
-    pub fn removes(&self, entity_type: &EntityType) -> impl Iterator<Item = &EntityRef> {
-        self.removes
-            .group(entity_type)
-            .into_iter()
-            .map(|rg| &rg.rows)
             .flatten()
     }
 
@@ -340,33 +391,128 @@ impl Batch {
     /// Generate a store event for all the changes that this batch makes
     pub fn store_event(&self, deployment: &DeploymentHash) -> StoreEvent {
         let entity_types = HashSet::from_iter(
-            self.inserts
+            self.mods
                 .groups
                 .iter()
-                .chain(self.overwrites.groups.iter())
                 .map(|group| group.entity_type.clone()),
         );
         StoreEvent::from_types(deployment, entity_types)
+    }
+
+    pub fn groups<'a>(&'a self) -> impl Iterator<Item = &'a RowGroup> {
+        self.mods.groups.iter()
+    }
+}
+
+pub struct WriteChunker<'a> {
+    group: &'a RowGroup,
+    chunk_size: usize,
+    position: usize,
+}
+
+impl<'a> WriteChunker<'a> {
+    fn new(group: &'a RowGroup, chunk_size: usize) -> Self {
+        Self {
+            group,
+            chunk_size,
+            position: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for WriteChunker<'a> {
+    type Item = WriteChunk<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Produce a chunk according to the current `self.position`
+        let res = if self.position < self.group.rows.len() {
+            Some(WriteChunk {
+                group: self.group,
+                chunk_size: self.chunk_size,
+                position: self.position,
+            })
+        } else {
+            None
+        };
+
+        // Advance `self.position` to the start of the next chunk
+        let mut count = 0;
+        while count < self.chunk_size && self.position < self.group.rows.len() {
+            if self.group.rows[self.position].is_write() {
+                count += 1;
+            }
+            self.position += 1;
+        }
+
+        res
+    }
+}
+
+#[derive(Debug)]
+pub struct WriteChunk<'a> {
+    group: &'a RowGroup,
+    chunk_size: usize,
+    position: usize,
+}
+
+impl<'a> WriteChunk<'a> {
+    pub fn is_empty(&'a self) -> bool {
+        self.iter().next().is_none()
+    }
+
+    pub fn iter(&self) -> WriteChunkIter<'a> {
+        WriteChunkIter {
+            group: self.group,
+            chunk_size: self.chunk_size,
+            position: self.position,
+            count: 0,
+        }
+    }
+}
+
+impl<'a> IntoIterator for &WriteChunk<'a> {
+    type Item = (&'a Word, &'a Entity, CausalityRegion, BlockNumber);
+
+    type IntoIter = WriteChunkIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        WriteChunkIter {
+            group: self.group,
+            chunk_size: self.chunk_size,
+            position: self.position,
+            count: 0,
+        }
+    }
+}
+
+pub struct WriteChunkIter<'a> {
+    group: &'a RowGroup,
+    chunk_size: usize,
+    position: usize,
+    count: usize,
+}
+
+impl<'a> Iterator for WriteChunkIter<'a> {
+    type Item = (&'a Word, &'a Entity, CausalityRegion, BlockNumber);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.count < self.chunk_size && self.position < self.group.rows.len() {
+            let insert = self.group.rows[self.position].as_write();
+            self.position += 1;
+            if insert.is_some() {
+                self.count += 1;
+                return insert;
+            }
+        }
+        return None;
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::components::store::{BlockNumber, EntityType};
+    use crate::components::store::{write::EntityMod, BlockNumber, EntityKey, EntityType};
 
-    use super::{BlockTagged, RowGroup};
-
-    #[derive(Debug)]
-    struct Entry {
-        value: usize,
-        block: BlockNumber,
-    }
-
-    impl BlockTagged for Entry {
-        fn block(&self) -> BlockNumber {
-            self.block
-        }
-    }
+    use super::RowGroup;
 
     #[track_caller]
     fn check_runs(values: &[usize], blocks: &[BlockNumber], exp: &[(BlockNumber, &[usize])]) {
@@ -375,8 +521,8 @@ mod test {
         let rows = values
             .iter()
             .zip(blocks.iter())
-            .map(|(value, block)| Entry {
-                value: *value,
+            .map(|(value, block)| EntityMod::Remove {
+                key: EntityKey::data("RowGroup".to_string(), value.to_string()),
                 block: *block,
             })
             .collect();
@@ -385,11 +531,14 @@ mod test {
             rows,
         };
         let act = group
-            .runs()
+            .clamps_by_block()
             .map(|(block, entries)| {
                 (
                     block,
-                    entries.iter().map(|entry| entry.value).collect::<Vec<_>>(),
+                    entries
+                        .iter()
+                        .map(|entry| entry.id().parse().unwrap())
+                        .collect::<Vec<_>>(),
                 )
             })
             .collect::<Vec<_>>();

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -491,6 +491,8 @@ impl<'a> From<&'a EntityMod> for EntityOp<'a> {
 pub struct Batch {
     /// The last block for which this batch contains changes
     pub block_ptr: BlockPtr,
+    /// The first block for which this batch contains changes
+    pub first_block: BlockNumber,
     /// The firehose cursor corresponding to `block_ptr`
     pub firehose_cursor: FirehoseCursor,
     mods: Sheet,
@@ -530,8 +532,10 @@ impl Batch {
 
         let data_sources = DataSources::new(block_ptr.cheap_clone(), data_sources);
         let offchain_to_remove = DataSources::new(block_ptr.cheap_clone(), offchain_to_remove);
+        let first_block = block_ptr.number;
         Ok(Self {
             block_ptr,
+            first_block,
             firehose_cursor,
             mods,
             data_sources,

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -98,6 +98,13 @@ impl EntityMod {
         }
     }
 
+    pub fn creates_entity(&self) -> bool {
+        match self {
+            EntityMod::Insert { .. } => true,
+            EntityMod::Overwrite { .. } | EntityMod::Remove { .. } => false,
+        }
+    }
+
     fn key(&self) -> &EntityKey {
         match self {
             EntityMod::Insert { key, .. }

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -224,7 +224,7 @@ pub struct RowGroup {
     /// All changes for this entity type, ordered by block; i.e., if `i < j`
     /// then `rows[i].block() <= rows[j].block()`. Several methods on this
     /// struct rely on the fact that this ordering is observed.
-    pub rows: Vec<EntityMod>,
+    rows: Vec<EntityMod>,
 }
 
 impl RowGroup {
@@ -353,6 +353,10 @@ impl RowGroup {
         }
 
         Ok(())
+    }
+
+    pub fn ids(&self) -> impl Iterator<Item = &str> {
+        self.rows.iter().map(|emod| emod.id().as_str())
     }
 }
 

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -9,6 +9,7 @@ use crate::{
     data::{subgraph::schema::SubgraphError, value::Word},
     data_source::CausalityRegion,
     prelude::DeploymentHash,
+    util::cache_weight::CacheWeight,
 };
 
 use super::{
@@ -610,6 +611,35 @@ impl Batch {
 
     pub fn groups<'a>(&'a self) -> impl Iterator<Item = &'a RowGroup> {
         self.mods.groups.iter()
+    }
+}
+
+impl CacheWeight for Batch {
+    fn indirect_weight(&self) -> usize {
+        self.mods.indirect_weight()
+    }
+}
+
+impl CacheWeight for Sheet {
+    fn indirect_weight(&self) -> usize {
+        self.groups.indirect_weight()
+    }
+}
+
+impl CacheWeight for RowGroup {
+    fn indirect_weight(&self) -> usize {
+        self.rows.indirect_weight()
+    }
+}
+
+impl CacheWeight for EntityMod {
+    fn indirect_weight(&self) -> usize {
+        match self {
+            EntityMod::Insert { key, data, .. } | EntityMod::Overwrite { key, data, .. } => {
+                key.indirect_weight() + data.indirect_weight()
+            }
+            EntityMod::Remove { key, .. } => key.indirect_weight(),
+        }
     }
 }
 

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -1,0 +1,283 @@
+//! Data structures and helpers for writing subgraph changes to the store
+use std::collections::HashSet;
+
+use crate::{
+    blockchain::{block_stream::FirehoseCursor, BlockPtr},
+    cheap_clone::CheapClone,
+    components::subgraph::Entity,
+    data::subgraph::schema::SubgraphError,
+    prelude::DeploymentHash,
+};
+
+use super::{
+    BlockNumber, EntityKey, EntityModification, EntityType, StoreEvent, StoredDynamicDataSource,
+};
+
+/// The data for a write operation; a write operation is either an insert of
+/// a new entity or the overwriting of an existing entity.
+#[derive(Debug)]
+pub struct EntityWrite {
+    pub key: EntityKey,
+    pub data: Entity,
+    pub block: BlockNumber,
+}
+
+impl EntityWrite {
+    pub fn new(key: EntityKey, data: Entity, block: BlockNumber) -> Self {
+        Self { key, data, block }
+    }
+}
+
+/// A list of entity changes grouped by the entity type
+pub struct RowGroup<R> {
+    pub entity_type: EntityType,
+    pub rows: Vec<R>,
+}
+
+impl<R> RowGroup<R> {
+    pub fn new(entity_type: EntityType) -> Self {
+        Self {
+            entity_type,
+            rows: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, row: R) {
+        self.rows.push(row)
+    }
+
+    fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+}
+
+/// A list of entity changes with one group per entity type
+pub struct Sheet<R> {
+    pub groups: Vec<RowGroup<R>>,
+}
+
+impl<R> Sheet<R> {
+    fn new() -> Self {
+        Self { groups: Vec::new() }
+    }
+
+    fn group(&self, entity_type: &EntityType) -> Option<&RowGroup<R>> {
+        self.groups
+            .iter()
+            .find(|group| &group.entity_type == entity_type)
+    }
+
+    /// Return a mutable reference to an existing group.
+    fn group_mut(&mut self, entity_type: &EntityType) -> Option<&mut RowGroup<R>> {
+        self.groups
+            .iter_mut()
+            .find(|group| &group.entity_type == entity_type)
+    }
+
+    /// Return a mutable reference to an existing group, or create a new one
+    /// if there isn't one yet and return a reference to that
+    fn group_entry(&mut self, entity_type: &EntityType) -> &mut RowGroup<R> {
+        let pos = self
+            .groups
+            .iter()
+            .position(|group| &group.entity_type == entity_type);
+        match pos {
+            Some(pos) => &mut self.groups[pos],
+            None => {
+                self.groups.push(RowGroup::new(entity_type.clone()));
+                // unwrap: we just pushed an entry
+                self.groups.last_mut().unwrap()
+            }
+        }
+    }
+
+    fn entity_count(&self) -> usize {
+        self.groups.iter().map(|group| group.row_count()).sum()
+    }
+}
+
+// Arbitrary data grouped by block
+pub struct BlockEntries<E> {
+    pub entries: Vec<(BlockPtr, E)>,
+}
+
+impl<E> BlockEntries<E> {
+    fn new(ptr: BlockPtr, entries: E) -> Self {
+        BlockEntries {
+            entries: vec![(ptr, entries)],
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+pub type DataSources = BlockEntries<Vec<StoredDynamicDataSource>>;
+
+pub enum EntityOp<'a> {
+    Write(&'a Entity),
+    Remove,
+}
+
+/// A write batch. This data structure encapsulates all the things that need
+/// to be changed to persist the output of mappings up to a certain block.
+/// For now, a batch will only contain changes for a single block, but will
+/// eventually contain data for multiple blocks.
+pub struct Batch {
+    /// The last block for which this batch contains changes
+    pub block_ptr: BlockPtr,
+    /// The firehose cursor corresponding to `block_ptr`
+    pub firehose_cursor: FirehoseCursor,
+    /// New entities that need to be inserted
+    pub inserts: Sheet<EntityWrite>,
+    /// Existing entities that need to be modified
+    pub overwrites: Sheet<EntityWrite>,
+    /// Existing entities that need to be removed
+    pub removes: Sheet<EntityKey>,
+    /// New data sources
+    pub data_sources: DataSources,
+    pub deterministic_errors: Vec<SubgraphError>,
+    pub offchain_to_remove: DataSources,
+}
+
+impl Batch {
+    pub fn new(
+        block_ptr: BlockPtr,
+        firehose_cursor: FirehoseCursor,
+        mods: Vec<EntityModification>,
+        data_sources: Vec<StoredDynamicDataSource>,
+        deterministic_errors: Vec<SubgraphError>,
+        offchain_to_remove: Vec<StoredDynamicDataSource>,
+    ) -> Self {
+        let block = block_ptr.number;
+
+        let mut inserts = Sheet::new();
+        let mut overwrites = Sheet::new();
+        let mut removes = Sheet::new();
+
+        for m in mods {
+            match m {
+                EntityModification::Insert { key, data } => {
+                    let row = EntityWrite::new(key, data, block);
+                    inserts.group_entry(&row.key.entity_type).push(row);
+                }
+                EntityModification::Overwrite { key, data } => {
+                    let row = EntityWrite::new(key, data, block);
+                    overwrites.group_entry(&row.key.entity_type).push(row);
+                }
+                EntityModification::Remove { key } => {
+                    removes.group_entry(&key.entity_type).push(key)
+                }
+            }
+        }
+
+        let data_sources = DataSources::new(block_ptr.cheap_clone(), data_sources);
+        let offchain_to_remove = DataSources::new(block_ptr.cheap_clone(), offchain_to_remove);
+        Self {
+            block_ptr,
+            firehose_cursor,
+            inserts,
+            overwrites,
+            removes,
+            data_sources,
+            deterministic_errors,
+            offchain_to_remove,
+        }
+    }
+
+    pub fn entity_count(&self) -> usize {
+        self.inserts.entity_count() + self.overwrites.entity_count() + self.removes.entity_count()
+    }
+
+    /// Find out whether the latest operation for the entity with type
+    /// `entity_type` and `id` is going to write that entity, i.e., insert
+    /// or overwrite it, or if it is going to remove it. If no change will
+    /// be made to the entity, return `None`
+    pub fn last_op(&self, entity_type: &EntityType, id: &str) -> Option<EntityOp<'_>> {
+        // Check if we are inserting or overwriting the entity
+        if let Some((_, entity)) = self
+            .writes(entity_type)
+            .find(|(_, entity)| entity.id() == id)
+        {
+            return Some(EntityOp::Write(entity));
+        }
+        self.removes(entity_type)
+            .find(|key| key.entity_id.as_str() == id)
+            .map(|_| EntityOp::Remove)
+    }
+
+    /// Iterate over all entities that have a pending write
+    pub fn writes(&self, entity_type: &EntityType) -> impl Iterator<Item = (&EntityKey, &Entity)> {
+        self.inserts
+            .group(entity_type)
+            .into_iter()
+            .map(|ew| &ew.rows)
+            .flatten()
+            .chain(
+                self.overwrites
+                    .group(entity_type)
+                    .into_iter()
+                    .map(|ew| &ew.rows)
+                    .flatten(),
+            )
+            .map(|ew| (&ew.key, &ew.data))
+    }
+
+    /// Iterate over all entities that have a pending write, allowing for
+    /// mutation of the entity
+    pub fn writes_mut(
+        &mut self,
+        entity_type: &EntityType,
+    ) -> impl Iterator<Item = (&EntityKey, &mut Entity)> {
+        self.inserts
+            .group_mut(entity_type)
+            .into_iter()
+            .map(|rg| &mut rg.rows)
+            .flatten()
+            .chain(
+                self.overwrites
+                    .group_mut(entity_type)
+                    .into_iter()
+                    .map(|rg| &mut rg.rows)
+                    .flatten(),
+            )
+            .map(|ew| (&ew.key, &mut ew.data))
+    }
+
+    /// Iterate over all entity deletions/removals
+    pub fn removes(&self, entity_type: &EntityType) -> impl Iterator<Item = &EntityKey> {
+        self.removes
+            .group(entity_type)
+            .into_iter()
+            .map(|rg| &rg.rows)
+            .flatten()
+    }
+
+    pub fn new_data_sources(&self) -> impl Iterator<Item = &StoredDynamicDataSource> {
+        self.data_sources
+            .entries
+            .iter()
+            .map(|(_, ds)| ds)
+            .flatten()
+            .filter(|ds| {
+                !self
+                    .offchain_to_remove
+                    .entries
+                    .iter()
+                    .any(|(_, entries)| entries.contains(ds))
+            })
+    }
+
+    /// Generate a store event for all the changes that this batch makes
+    pub fn store_event(&self, deployment: &DeploymentHash) -> StoreEvent {
+        let entity_types = HashSet::from_iter(
+            self.inserts
+                .groups
+                .iter()
+                .chain(self.overwrites.groups.iter())
+                .map(|group| group.entity_type.clone()),
+        );
+        StoreEvent::from_types(deployment, entity_types)
+    }
+}

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -188,6 +188,8 @@ pub enum Value {
     BigInt(scalar::BigInt),
 }
 
+pub const NULL: Value = Value::Null;
+
 impl stable_hash_legacy::StableHash for Value {
     fn stable_hash<H: stable_hash_legacy::StableHasher>(
         &self,

--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -98,6 +98,17 @@ pub struct EnvVarsStore {
     /// blocks) than its history limit. The default value is 1.2 and the
     /// value must be at least 1.01
     pub history_slack_factor: f64,
+    /// How long to accumulate changes into a batch before a write has to
+    /// happen. Set by the environment variable
+    /// `GRAPH_STORE_WRITE_BATCH_DURATION` in seconds. The default is 300s.
+    /// Setting this to 0 disables write batching.
+    pub write_batch_duration: Duration,
+    /// How many changes to accumulate in bytes before a write has to
+    /// happen. Set by the environment variable
+    /// `GRAPH_STORE_WRITE_BATCH_SIZE`, which is in kilobytes. The default
+    /// is 10_000 which corresponds to 10MB. Setting this to 0 disables
+    /// write batching.
+    pub write_batch_size: usize,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -137,6 +148,8 @@ impl From<InnerStore> for EnvVarsStore {
             rebuild_threshold: x.rebuild_threshold.0,
             delete_threshold: x.delete_threshold.0,
             history_slack_factor: x.history_slack_factor.0,
+            write_batch_duration: Duration::from_secs(x.write_batch_duration_in_secs),
+            write_batch_size: x.write_batch_size * 1_000,
         }
     }
 }
@@ -186,6 +199,10 @@ pub struct InnerStore {
     delete_threshold: ZeroToOneF64,
     #[envconfig(from = "GRAPH_STORE_HISTORY_SLACK_FACTOR", default = "1.2")]
     history_slack_factor: HistorySlackF64,
+    #[envconfig(from = "GRAPH_STORE_WRITE_BATCH_DURATION", default = "300")]
+    write_batch_duration_in_secs: u64,
+    #[envconfig(from = "GRAPH_STORE_WRITE_BATCH_SIZE", default = "10000")]
+    write_batch_size: usize,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -109,7 +109,12 @@ pub fn mock_context(
             api_version,
         )),
         state: BlockState::new(
-            futures03::executor::block_on(store.writable(LOGGER.clone(), deployment.id)).unwrap(),
+            futures03::executor::block_on(store.writable(
+                LOGGER.clone(),
+                deployment.id,
+                Arc::new(Vec::new()),
+            ))
+            .unwrap(),
             Default::default(),
         ),
         proof_of_indexing: None,

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -974,7 +974,10 @@ async fn test_entity_store(api_version: Version) {
     load_and_set_user_name(&mut module, "steve", "Steve-O");
 
     // We need to empty the cache for the next test
-    let writable = store.writable(LOGGER.clone(), deployment.id).await.unwrap();
+    let writable = store
+        .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
+        .await
+        .unwrap();
     let cache = std::mem::replace(
         &mut module.instance_ctx_mut().ctx.state.entity_cache,
         EntityCache::new(Arc::new(writable.clone())),

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -53,16 +53,6 @@ lazy_static! {
 #[derive(Clone, Debug)]
 pub struct BlockRange(Bound<BlockNumber>, Bound<BlockNumber>);
 
-// Doing this properly by implementing Clone for Bound is currently
-// a nightly-only feature, so we need to work around that
-fn clone_bound(bound: Bound<&BlockNumber>) -> Bound<BlockNumber> {
-    match bound {
-        Bound::Included(nr) => Bound::Included(*nr),
-        Bound::Excluded(nr) => Bound::Excluded(*nr),
-        Bound::Unbounded => Bound::Unbounded,
-    }
-}
-
 pub(crate) fn first_block_in_range(
     bound: &(Bound<BlockNumber>, Bound<BlockNumber>),
 ) -> Option<BlockNumber> {
@@ -87,10 +77,13 @@ pub(crate) fn block_number(block_ptr: &BlockPtr) -> BlockNumber {
 
 impl From<RangeFrom<BlockNumber>> for BlockRange {
     fn from(range: RangeFrom<BlockNumber>) -> BlockRange {
-        BlockRange(
-            clone_bound(range.start_bound()),
-            clone_bound(range.end_bound()),
-        )
+        BlockRange(range.start_bound().cloned(), range.end_bound().cloned())
+    }
+}
+
+impl From<std::ops::Range<BlockNumber>> for BlockRange {
+    fn from(range: std::ops::Range<BlockNumber>) -> BlockRange {
+        BlockRange(Bound::Included(range.start), Bound::Excluded(range.end))
     }
 }
 

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -235,18 +235,6 @@ impl<'a> BlockRangeColumn<'a> {
         }
     }
 
-    /// Output the literal value of the block range `[block,..)`, mostly for
-    /// generating an insert statement containing the block range column
-    pub fn literal_range_current(&self, out: &mut AstPass<Pg>) -> QueryResult<()> {
-        match self {
-            BlockRangeColumn::Mutable { block, .. } => {
-                let block_range: BlockRange = (*block..).into();
-                out.push_bind_param::<Range<Integer>, _>(&block_range)
-            }
-            BlockRangeColumn::Immutable { block, .. } => out.push_bind_param::<Integer, _>(block),
-        }
-    }
-
     /// Output an expression that matches rows that are the latest version
     /// of their entity
     pub fn latest(&self, out: &mut AstPass<Pg>) {

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -816,18 +816,21 @@ pub fn update_deployment_status(
         .map_err(StoreError::from)
 }
 
-/// Insert the errors and check if the subgraph needs to be set as unhealthy.
+/// Insert the errors and check if the subgraph needs to be set as
+/// unhealthy. The `latest_block` is only used to check whether the subgraph
+/// is healthy as of that block; errors are inserted according to the
+/// `block_ptr` they contain
 pub(crate) fn insert_subgraph_errors(
     conn: &PgConnection,
     id: &DeploymentHash,
     deterministic_errors: &[SubgraphError],
-    block: BlockNumber,
+    latest_block: BlockNumber,
 ) -> Result<(), StoreError> {
     for error in deterministic_errors {
         insert_subgraph_error(conn, error)?;
     }
 
-    check_health(conn, id, block)
+    check_health(conn, id, latest_block)
 }
 
 #[cfg(debug_assertions)]

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -337,7 +337,7 @@ impl DeploymentStore {
         // Overwrites:
         for group in &overwrites.groups {
             // we do not update the count since the number of entities remains the same
-            self.overwrite_entities(group, conn, layout, ptr, stopwatch)?;
+            self.overwrite_entities(group, conn, layout, stopwatch)?;
         }
 
         // Removals
@@ -370,7 +370,6 @@ impl DeploymentStore {
         group: &'a RowGroup<EntityWrite>,
         conn: &PgConnection,
         layout: &'a Layout,
-        ptr: &BlockPtr,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
         let section = stopwatch.start_section("check_interface_entity_uniqueness");
@@ -381,7 +380,7 @@ impl DeploymentStore {
         section.end();
 
         let _section = stopwatch.start_section("apply_entity_modifications_update");
-        layout.update(conn, group, block_number(ptr), stopwatch)
+        layout.update(conn, group, stopwatch)
     }
 
     fn remove_entities(

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -331,7 +331,7 @@ impl DeploymentStore {
         // Apply modification groups.
         // Inserts:
         for group in &inserts.groups {
-            count += self.insert_entities(group, conn, layout, ptr, stopwatch)? as i32
+            count += self.insert_entities(group, conn, layout, stopwatch)? as i32
         }
 
         // Overwrites:
@@ -352,7 +352,6 @@ impl DeploymentStore {
         group: &'a RowGroup<EntityWrite>,
         conn: &PgConnection,
         layout: &'a Layout,
-        ptr: &BlockPtr,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
         let section = stopwatch.start_section("check_interface_entity_uniqueness");
@@ -363,7 +362,7 @@ impl DeploymentStore {
         section.end();
 
         let _section = stopwatch.start_section("apply_entity_modifications_insert");
-        layout.insert(conn, group, block_number(ptr), stopwatch)
+        layout.insert(conn, group, stopwatch)
     }
 
     fn overwrite_entities<'a>(

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -5,7 +5,7 @@ use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use graph::anyhow::Context;
 use graph::blockchain::block_stream::FirehoseCursor;
-use graph::components::store::write::{EntityWrite, RowGroup, Sheet};
+use graph::components::store::write::{EntityRef, EntityWrite, RowGroup, Sheet};
 use graph::components::store::{
     Batch, DerivedEntityQuery, EntityKey, EntityType, PrunePhase, PruneReporter, PruneRequest,
     PruningStrategy, StoredDynamicDataSource, VersionStats,
@@ -45,7 +45,7 @@ use graph::prelude::{
 use graph::schema::{ApiSchema, InputSchema};
 use web3::types::Address;
 
-use crate::block_range::{block_number, BLOCK_COLUMN, BLOCK_RANGE_COLUMN};
+use crate::block_range::{BLOCK_COLUMN, BLOCK_RANGE_COLUMN};
 use crate::deployment::{self, OnSync};
 use crate::detail::ErrorDetail;
 use crate::dynds::DataSourcesTable;
@@ -322,8 +322,7 @@ impl DeploymentStore {
         layout: &Layout,
         inserts: &Sheet<EntityWrite>,
         overwrites: &Sheet<EntityWrite>,
-        removes: &Sheet<EntityKey>,
-        ptr: &BlockPtr,
+        removes: &Sheet<EntityRef>,
         stopwatch: &StopwatchMetrics,
     ) -> Result<i32, StoreError> {
         let mut count = 0;
@@ -342,7 +341,7 @@ impl DeploymentStore {
 
         // Removals
         for group in &removes.groups {
-            count -= self.remove_entities(group, conn, layout, ptr, stopwatch)? as i32;
+            count -= self.remove_entities(group, conn, layout, stopwatch)? as i32;
         }
         Ok(count)
     }
@@ -385,14 +384,13 @@ impl DeploymentStore {
 
     fn remove_entities(
         &self,
-        group: &RowGroup<EntityKey>,
+        group: &RowGroup<EntityRef>,
         conn: &PgConnection,
         layout: &Layout,
-        ptr: &BlockPtr,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
         let _section = stopwatch.start_section("apply_entity_modifications_delete");
-        layout.delete(conn, group, block_number(ptr), stopwatch)
+        layout.delete(conn, group, stopwatch)
     }
 
     /// Execute a closure with a connection to the database.
@@ -1142,7 +1140,6 @@ impl DeploymentStore {
                     &batch.inserts,
                     &batch.overwrites,
                     &batch.removes,
-                    &batch.block_ptr,
                     stopwatch,
                 )?;
                 section.end();

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -5,7 +5,7 @@ use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use graph::anyhow::Context;
 use graph::blockchain::block_stream::FirehoseCursor;
-use graph::components::store::write::{EntityRef, EntityWrite, RowGroup, Sheet};
+use graph::components::store::write::RowGroup;
 use graph::components::store::{
     Batch, DerivedEntityQuery, EntityKey, EntityType, PrunePhase, PruneReporter, PruneRequest,
     PruningStrategy, StoredDynamicDataSource, VersionStats,
@@ -13,6 +13,7 @@ use graph::components::store::{
 use graph::components::versions::VERSIONS;
 use graph::data::query::Trace;
 use graph::data::subgraph::{status, SPEC_VERSION_0_0_6};
+use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
 use graph::prelude::futures03::FutureExt;
 use graph::prelude::{
@@ -272,7 +273,8 @@ impl DeploymentStore {
         &self,
         conn: &PgConnection,
         layout: &Layout,
-        key: &EntityKey,
+        entity_type: &EntityType,
+        entity_id: &Word,
     ) -> Result<(), StoreError> {
         // Collect all types that share an interface implementation with this
         // entity type, and make sure there are no conflicting IDs.
@@ -291,24 +293,24 @@ impl DeploymentStore {
             .expect("API schema should be present")
             .clone();
         let types_for_interface = schema.types_for_interface();
-        let entity_type = key.entity_type.to_string();
+        let entity_type_str = entity_type.to_string();
         let types_with_shared_interface = Vec::from_iter(
             schema
-                .interfaces_for_type(&key.entity_type)
+                .interfaces_for_type(entity_type)
                 .into_iter()
                 .flatten()
                 .flat_map(|interface| &types_for_interface[&EntityType::from(interface)])
                 .map(EntityType::from)
-                .filter(|type_name| type_name != &key.entity_type),
+                .filter(|type_name| type_name != entity_type),
         );
 
         if !types_with_shared_interface.is_empty() {
             if let Some(conflicting_entity) =
-                layout.conflicting_entity(conn, &key.entity_id, types_with_shared_interface)?
+                layout.conflicting_entity(conn, entity_id, types_with_shared_interface)?
             {
                 return Err(StoreError::ConflictingId(
-                    entity_type,
-                    key.entity_id.to_string(),
+                    entity_type_str,
+                    entity_id.to_string(),
                     conflicting_entity,
                 ));
             }
@@ -316,47 +318,36 @@ impl DeploymentStore {
         Ok(())
     }
 
-    fn apply_entity_modifications(
+    fn apply_entity_modifications<'a>(
         &self,
         conn: &PgConnection,
         layout: &Layout,
-        inserts: &Sheet<EntityWrite>,
-        overwrites: &Sheet<EntityWrite>,
-        removes: &Sheet<EntityRef>,
+        groups: impl Iterator<Item = &'a RowGroup>,
         stopwatch: &StopwatchMetrics,
     ) -> Result<i32, StoreError> {
         let mut count = 0;
 
-        // Apply modification groups.
-        // Inserts:
-        for group in &inserts.groups {
+        for group in groups {
+            if group.has_clamps() {
+                count -= self.remove_entities(group, conn, layout, stopwatch)? as i32;
+            }
             count += self.insert_entities(group, conn, layout, stopwatch)? as i32
         }
 
-        // Overwrites:
-        for group in &overwrites.groups {
-            // we do not update the count since the number of entities remains the same
-            self.overwrite_entities(group, conn, layout, stopwatch)?;
-        }
-
-        // Removals
-        for group in &removes.groups {
-            count -= self.remove_entities(group, conn, layout, stopwatch)? as i32;
-        }
         Ok(count)
     }
 
     fn insert_entities<'a>(
         &'a self,
-        group: &'a RowGroup<EntityWrite>,
+        group: &'a RowGroup,
         conn: &PgConnection,
         layout: &'a Layout,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
         let section = stopwatch.start_section("check_interface_entity_uniqueness");
-        for row in group.rows.iter() {
+        for row in group.writes() {
             // WARNING: This will potentially execute 2 queries for each entity key.
-            self.check_interface_entity_uniqueness(conn, layout, &row.key)?;
+            self.check_interface_entity_uniqueness(conn, layout, &group.entity_type, &row.id())?;
         }
         section.end();
 
@@ -364,27 +355,9 @@ impl DeploymentStore {
         layout.insert(conn, group, stopwatch)
     }
 
-    fn overwrite_entities<'a>(
-        &'a self,
-        group: &'a RowGroup<EntityWrite>,
-        conn: &PgConnection,
-        layout: &'a Layout,
-        stopwatch: &StopwatchMetrics,
-    ) -> Result<usize, StoreError> {
-        let section = stopwatch.start_section("check_interface_entity_uniqueness");
-        for row in group.rows.iter() {
-            // WARNING: This will potentially execute 2 queries for each entity key.
-            self.check_interface_entity_uniqueness(conn, layout, &row.key)?;
-        }
-        section.end();
-
-        let _section = stopwatch.start_section("apply_entity_modifications_update");
-        layout.update(conn, group, stopwatch)
-    }
-
     fn remove_entities(
         &self,
-        group: &RowGroup<EntityRef>,
+        group: &RowGroup,
         conn: &PgConnection,
         layout: &Layout,
         stopwatch: &StopwatchMetrics,
@@ -1137,9 +1110,7 @@ impl DeploymentStore {
                 let count = self.apply_entity_modifications(
                     &conn,
                     layout.as_ref(),
-                    &batch.inserts,
-                    &batch.overwrites,
-                    &batch.removes,
+                    batch.groups(),
                     stopwatch,
                 )?;
                 section.end();

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1144,13 +1144,7 @@ impl DeploymentStore {
                 )?;
                 section.end();
 
-                dynds::insert(
-                    &conn,
-                    &site,
-                    &batch.data_sources,
-                    &batch.block_ptr,
-                    manifest_idx_and_name,
-                )?;
+                dynds::insert(&conn, &site, &batch.data_sources, manifest_idx_and_name)?;
 
                 dynds::update_offchain_status(&conn, &site, &batch.offchain_to_remove)?;
 

--- a/store/postgres/src/dynds/mod.rs
+++ b/store/postgres/src/dynds/mod.rs
@@ -6,7 +6,6 @@ pub(crate) use private::DataSourcesTable;
 use crate::primary::Site;
 use diesel::PgConnection;
 use graph::{
-    blockchain::BlockPtr,
     components::store::{write, StoredDynamicDataSource},
     constraint_violation,
     data_source::CausalityRegion,
@@ -29,18 +28,11 @@ pub(crate) fn insert(
     conn: &PgConnection,
     site: &Site,
     data_sources: &write::DataSources,
-    block_ptr: &BlockPtr,
     manifest_idx_and_name: &[(u32, String)],
 ) -> Result<usize, StoreError> {
     match site.schema_version.private_data_sources() {
         true => DataSourcesTable::new(site.namespace.clone()).insert(conn, data_sources),
-        false => shared::insert(
-            conn,
-            &site.deployment,
-            data_sources,
-            block_ptr,
-            manifest_idx_and_name,
-        ),
+        false => shared::insert(conn, &site.deployment, data_sources, manifest_idx_and_name),
     }
 }
 

--- a/store/postgres/src/dynds/shared.rs
+++ b/store/postgres/src/dynds/shared.rs
@@ -14,8 +14,7 @@ use graph::{
     constraint_violation,
     data_source::CausalityRegion,
     prelude::{
-        bigdecimal::ToPrimitive, serde_json, BigDecimal, BlockNumber, BlockPtr, DeploymentHash,
-        StoreError,
+        bigdecimal::ToPrimitive, serde_json, BigDecimal, BlockNumber, DeploymentHash, StoreError,
     },
 };
 
@@ -104,7 +103,6 @@ pub(super) fn insert(
     conn: &PgConnection,
     deployment: &DeploymentHash,
     data_sources: &write::DataSources,
-    block_ptr: &BlockPtr,
     manifest_idx_and_name: &[(u32, String)],
 ) -> Result<usize, StoreError> {
     use dynamic_ethereum_contract_data_source as decds;
@@ -117,7 +115,7 @@ pub(super) fn insert(
     let dds: Vec<_> = data_sources
         .entries
         .iter()
-        .map(|(_, dds)| {
+        .map(|(block_ptr, dds)| {
             dds.iter().map(|ds| {
                 let StoredDynamicDataSource {
                     manifest_idx: _,

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -847,6 +847,11 @@ impl Layout {
         group: &RowGroup,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
+        if !group.has_clamps() {
+            // Nothing to do
+            return Ok(0);
+        }
+
         let table = self.table_for_entity(&group.entity_type)?;
         if table.immutable {
             return Err(constraint_violation!(

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -24,6 +24,7 @@ use diesel::types::{FromSql, ToSql};
 use diesel::{connection::SimpleConnection, Connection};
 use diesel::{debug_query, OptionalExtension, PgConnection, RunQueryDsl};
 use graph::cheap_clone::CheapClone;
+use graph::components::store::write::{EntityWrite, RowGroup};
 use graph::constraint_violation;
 use graph::data::graphql::TypeExt as _;
 use graph::data::query::Trace;
@@ -33,6 +34,7 @@ use graph::prelude::{q, s, EntityQuery, StopwatchMetrics, ENV_VARS};
 use graph::schema::{FulltextConfig, FulltextDefinition, InputSchema, SCHEMA_TYPE_NAME};
 use graph::slog::warn;
 use inflector::Inflector;
+use itertools::Itertools;
 use lazy_static::lazy_static;
 use std::borrow::Borrow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -651,19 +653,18 @@ impl Layout {
     pub fn insert<'a>(
         &'a self,
         conn: &PgConnection,
-        entity_type: &'a EntityType,
-        entities: &'a [(&'a EntityKey, &'a Entity)],
+        group: &'a RowGroup<EntityWrite>,
         block: BlockNumber,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
-        let table = self.table_for_entity(entity_type)?;
+        let table = self.table_for_entity(&group.entity_type)?;
         let _section = stopwatch.start_section("insert_modification_insert_query");
         let mut count = 0;
 
         // We insert the entities in chunks to make sure each operation does
         // not exceed the maximum number of bindings allowed in queries
         let chunk_size = InsertQuery::chunk_size(table);
-        for chunk in entities.chunks(chunk_size) {
+        for chunk in group.rows.chunks(chunk_size) {
             count += InsertQuery::new(table, chunk, block)?
                 .get_results(conn)
                 .map(|ids| ids.len())?
@@ -799,28 +800,29 @@ impl Layout {
     pub fn update<'a>(
         &'a self,
         conn: &PgConnection,
-        entity_type: &'a EntityType,
-        entities: &'a [(&'a EntityKey, &'a Entity)],
+        group: &'a RowGroup<EntityWrite>,
         block: BlockNumber,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
-        let table = self.table_for_entity(entity_type)?;
+        let table = self.table_for_entity(&group.entity_type)?;
         if table.immutable {
-            let ids = entities
+            let ids = group
+                .rows
                 .iter()
-                .map(|(key, _)| key.entity_id.as_str())
+                .map(|row| row.key.entity_id.as_str())
                 .collect::<Vec<_>>()
                 .join(", ");
             return Err(constraint_violation!(
                 "entities of type `{}` can not be updated since they are immutable. Entity ids are [{}]",
-                entity_type,
+                group.entity_type,
                 ids
             ));
         }
 
-        let entity_keys: Vec<&str> = entities
+        let entity_keys: Vec<&str> = group
+            .rows
             .iter()
-            .map(|(key, _)| key.entity_id.as_str())
+            .map(|row| row.key.entity_id.as_str())
             .collect();
 
         let section = stopwatch.start_section("update_modification_clamp_range_query");
@@ -833,7 +835,7 @@ impl Layout {
         // We insert the entities in chunks to make sure each operation does
         // not exceed the maximum number of bindings allowed in queries
         let chunk_size = InsertQuery::chunk_size(table);
-        for chunk in entities.chunks(chunk_size) {
+        for chunk in group.rows.chunks(chunk_size) {
             count += InsertQuery::new(table, chunk, block)?.execute(conn)?;
         }
         Ok(count)
@@ -842,22 +844,26 @@ impl Layout {
     pub fn delete(
         &self,
         conn: &PgConnection,
-        entity_type: &EntityType,
-        entity_ids: &[&str],
+        group: &RowGroup<EntityKey>,
         block: BlockNumber,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
-        let table = self.table_for_entity(entity_type)?;
+        let table = self.table_for_entity(&group.entity_type)?;
         if table.immutable {
             return Err(constraint_violation!(
                 "entities of type `{}` can not be deleted since they are immutable. Entity ids are [{}]",
-                entity_type, entity_ids.join(", ")
+                table.object, group.rows.iter().map(|key| &key.entity_id).join(", ")
             ));
         }
 
         let _section = stopwatch.start_section("delete_modification_clamp_range_query");
         let mut count = 0;
-        for chunk in entity_ids.chunks(DELETE_OPERATION_CHUNK_SIZE) {
+        let ids: Vec<_> = group
+            .rows
+            .iter()
+            .map(|key| key.entity_id.as_str())
+            .collect();
+        for chunk in ids.chunks(DELETE_OPERATION_CHUNK_SIZE) {
             count += ClampRangeQuery::new(table, chunk, block)?.execute(conn)?
         }
         Ok(count)

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -24,7 +24,7 @@ use diesel::types::{FromSql, ToSql};
 use diesel::{connection::SimpleConnection, Connection};
 use diesel::{debug_query, OptionalExtension, PgConnection, RunQueryDsl};
 use graph::cheap_clone::CheapClone;
-use graph::components::store::write::{EntityRef, EntityWrite, RowGroup};
+use graph::components::store::write::RowGroup;
 use graph::constraint_violation;
 use graph::data::graphql::TypeExt as _;
 use graph::data::query::Trace;
@@ -653,7 +653,7 @@ impl Layout {
     pub fn insert<'a>(
         &'a self,
         conn: &PgConnection,
-        group: &'a RowGroup<EntityWrite>,
+        group: &'a RowGroup,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
         let table = self.table_for_entity(&group.entity_type)?;
@@ -663,10 +663,13 @@ impl Layout {
         // We insert the entities in chunks to make sure each operation does
         // not exceed the maximum number of bindings allowed in queries
         let chunk_size = InsertQuery::chunk_size(table);
-        for chunk in group.rows.chunks(chunk_size) {
-            count += InsertQuery::new(table, chunk)?
-                .get_results(conn)
-                .map(|ids| ids.len())?
+        for chunk in group.write_chunks(chunk_size) {
+            // Empty chunks would lead to invalid SQL
+            if !chunk.is_empty() {
+                count += InsertQuery::new(table, &chunk)?
+                    .get_results(conn)
+                    .map(|ids| ids.len())?
+            }
         }
         Ok(count)
     }
@@ -799,15 +802,15 @@ impl Layout {
     pub fn update<'a>(
         &'a self,
         conn: &PgConnection,
-        group: &'a RowGroup<EntityWrite>,
+        group: &'a RowGroup,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
         let table = self.table_for_entity(&group.entity_type)?;
-        if table.immutable {
+        if table.immutable && group.has_clamps() {
             let ids = group
                 .rows
                 .iter()
-                .map(|row| row.key.entity_id.as_str())
+                .map(|row| row.id().as_str())
                 .collect::<Vec<_>>()
                 .join(", ");
             return Err(constraint_violation!(
@@ -818,9 +821,8 @@ impl Layout {
         }
 
         let section = stopwatch.start_section("update_modification_clamp_range_query");
-        for (block, rows) in group.runs() {
-            let entity_keys: Vec<&str> =
-                rows.iter().map(|row| row.key.entity_id.as_str()).collect();
+        for (block, rows) in group.clamps_by_block() {
+            let entity_keys: Vec<&str> = rows.iter().map(|row| row.id().as_str()).collect();
 
             ClampRangeQuery::new(table, &entity_keys, block)?.execute(conn)?;
         }
@@ -832,8 +834,8 @@ impl Layout {
         // We insert the entities in chunks to make sure each operation does
         // not exceed the maximum number of bindings allowed in queries
         let chunk_size = InsertQuery::chunk_size(table);
-        for chunk in group.rows.chunks(chunk_size) {
-            count += InsertQuery::new(table, chunk)?.execute(conn)?;
+        for chunk in group.write_chunks(chunk_size) {
+            count += InsertQuery::new(table, &chunk)?.execute(conn)?;
         }
 
         Ok(count)
@@ -842,24 +844,21 @@ impl Layout {
     pub fn delete(
         &self,
         conn: &PgConnection,
-        group: &RowGroup<EntityRef>,
+        group: &RowGroup,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
         let table = self.table_for_entity(&group.entity_type)?;
         if table.immutable {
             return Err(constraint_violation!(
                 "entities of type `{}` can not be deleted since they are immutable. Entity ids are [{}]",
-                table.object, group.rows.iter().map(|eref| &eref.key.entity_id).join(", ")
+                table.object, group.rows.iter().map(|eref| eref.id()).join(", ")
             ));
         }
 
         let _section = stopwatch.start_section("delete_modification_clamp_range_query");
         let mut count = 0;
-        for (block, rows) in group.runs() {
-            let ids: Vec<_> = rows
-                .iter()
-                .map(|eref| eref.key.entity_id.as_str())
-                .collect();
+        for (block, rows) in group.clamps_by_block() {
+            let ids: Vec<_> = rows.iter().map(|eref| eref.id().as_str()).collect();
             for chunk in ids.chunks(DELETE_OPERATION_CHUNK_SIZE) {
                 count += ClampRangeQuery::new(table, chunk, block)?.execute(conn)?
             }

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -807,12 +807,7 @@ impl Layout {
     ) -> Result<usize, StoreError> {
         let table = self.table_for_entity(&group.entity_type)?;
         if table.immutable && group.has_clamps() {
-            let ids = group
-                .rows
-                .iter()
-                .map(|row| row.id().as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
+            let ids = group.ids().collect::<Vec<_>>().join(", ");
             return Err(constraint_violation!(
                 "entities of type `{}` can not be updated since they are immutable. Entity ids are [{}]",
                 group.entity_type,
@@ -856,7 +851,7 @@ impl Layout {
         if table.immutable {
             return Err(constraint_violation!(
                 "entities of type `{}` can not be deleted since they are immutable. Entity ids are [{}]",
-                table.object, group.rows.iter().map(|eref| eref.id()).join(", ")
+                table.object, group.ids().join(", ")
             ));
         }
 

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -654,7 +654,6 @@ impl Layout {
         &'a self,
         conn: &PgConnection,
         group: &'a RowGroup<EntityWrite>,
-        block: BlockNumber,
         stopwatch: &StopwatchMetrics,
     ) -> Result<usize, StoreError> {
         let table = self.table_for_entity(&group.entity_type)?;
@@ -665,7 +664,7 @@ impl Layout {
         // not exceed the maximum number of bindings allowed in queries
         let chunk_size = InsertQuery::chunk_size(table);
         for chunk in group.rows.chunks(chunk_size) {
-            count += InsertQuery::new(table, chunk, block)?
+            count += InsertQuery::new(table, chunk)?
                 .get_results(conn)
                 .map(|ids| ids.len())?
         }
@@ -836,7 +835,7 @@ impl Layout {
         // not exceed the maximum number of bindings allowed in queries
         let chunk_size = InsertQuery::chunk_size(table);
         for chunk in group.rows.chunks(chunk_size) {
-            count += InsertQuery::new(table, chunk, block)?.execute(conn)?;
+            count += InsertQuery::new(table, chunk)?.execute(conn)?;
         }
         Ok(count)
     }

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1329,6 +1329,7 @@ impl SubgraphStoreTrait for SubgraphStore {
         self: Arc<Self>,
         logger: Logger,
         deployment: graph::components::store::DeploymentId,
+        manifest_idx_and_name: Arc<Vec<(u32, String)>>,
     ) -> Result<Arc<dyn store::WritableStore>, StoreError> {
         let deployment = deployment.into();
         // We cache writables to make sure calls to this method are
@@ -1352,7 +1353,14 @@ impl SubgraphStoreTrait for SubgraphStore {
         .unwrap()?; // Propagate panics, there shouldn't be any.
 
         let writable = Arc::new(
-            WritableStore::new(self.as_ref().clone(), logger, site, self.registry.clone()).await?,
+            WritableStore::new(
+                self.as_ref().clone(),
+                logger,
+                site,
+                manifest_idx_and_name,
+                self.registry.clone(),
+            )
+            .await?,
         );
         self.writables
             .lock()

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -808,8 +808,8 @@ impl Queue {
                                     }
                                 }
                             }
-                            for key in batch.removes(&derived_query.entity_type) {
-                                map.insert(key.clone(), None);
+                            for eref in batch.removes(&derived_query.entity_type) {
+                                map.insert(eref.key.clone(), None);
                             }
                         }
                     }

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -728,8 +728,10 @@ impl Queue {
     ///   1. The subgraph is not synced
     ///   2. The newest request (back of the queue) is not already being
     ///      processed by the writing thread
-    ///   3. The newest write request is not older than `MAX_BATCH_TIME`
-    ///   4. The newest write request is not bigger than `MAX_BATCH_WEIGHT`
+    ///   3. The newest write request is not older than
+    ///      `GRAPH_STORE_WRITE_BATCH_DURATION`
+    ///   4. The newest write request is not bigger than
+    ///      `GRAPH_STORE_WRITE_BATCH_SIZE`
     ///
     /// In all other cases, we queue a new write request.
     ///
@@ -739,10 +741,10 @@ impl Queue {
     /// nothing has to ever wait for the database, and the gains from
     /// batching would not be noticable.
     async fn push_write(&self, batch: Batch) -> Result<(), StoreError> {
-        const MAX_BATCH_TIME: Duration = Duration::from_secs(30);
-        const MAX_BATCH_WEIGHT: usize = 10_000 * 1000;
-
-        let batch = if !self.batch_writes.load(Ordering::SeqCst) {
+        let batch = if ENV_VARS.store.write_batch_size == 0
+            || ENV_VARS.store.write_batch_duration.is_zero()
+            || !self.batch_writes.load(Ordering::SeqCst)
+        {
             Some(batch)
         } else {
             self.queue.map_newest(move |newest| {
@@ -768,7 +770,7 @@ impl Queue {
                         queued,
                         ..
                     } => {
-                        if queued.elapsed() < MAX_BATCH_TIME {
+                        if queued.elapsed() < ENV_VARS.store.write_batch_duration {
                             // We are being very defensive here: if anything
                             // is holding the lock on the batch, do not
                             // modify it. We create a new request instead of
@@ -777,7 +779,7 @@ impl Queue {
                             // probably be fine to wait for the lock.
                             match existing.try_write() {
                                 Ok(mut existing) => {
-                                    if existing.weight() < MAX_BATCH_WEIGHT {
+                                    if existing.weight() < ENV_VARS.store.write_batch_size {
                                         existing.append(batch).map(|()| None)
                                     } else {
                                         Ok(Some(batch))

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -129,7 +129,6 @@ impl WritableStore for MockStore {
         _: &StopwatchMetrics,
         _: Vec<StoredDynamicDataSource>,
         _: Vec<SubgraphError>,
-        _: Vec<(u32, String)>,
         _: Vec<StoredDynamicDataSource>,
     ) -> Result<(), StoreError> {
         unimplemented!()
@@ -384,7 +383,7 @@ where
         let deployment = insert_test_data(subgraph_store.clone()).await;
         let writable = store
             .subgraph_store()
-            .writable(LOGGER.clone(), deployment.id)
+            .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
             .await
             .expect("we can get a writable store");
 

--- a/store/test-store/tests/postgres/graft.rs
+++ b/store/test-store/tests/postgres/graft.rs
@@ -121,7 +121,7 @@ where
 
         store
             .cheap_clone()
-            .writable(LOGGER.clone(), deployment.id)
+            .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
             .await
             .unwrap()
             .flush()
@@ -326,7 +326,9 @@ async fn check_graft(
         .await
         .unwrap();
 
-    let writable = store.writable(LOGGER.clone(), deployment.id).await?;
+    let writable = store
+        .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
+        .await?;
     writable
         .revert_block_operations(BLOCKS[1].clone(), FirehoseCursor::None)
         .await
@@ -438,7 +440,7 @@ fn copy() {
 
             store
                 .cheap_clone()
-                .writable(LOGGER.clone(), deployment.id)
+                .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
                 .await?
                 .start_subgraph_deployment(&LOGGER)
                 .await?;
@@ -467,7 +469,10 @@ fn on_sync() {
                     on_sync,
                 )?;
 
-                let writable = store.cheap_clone().writable(LOGGER.clone(), dst.id).await?;
+                let writable = store
+                    .cheap_clone()
+                    .writable(LOGGER.clone(), dst.id, Arc::new(Vec::new()))
+                    .await?;
 
                 writable.start_subgraph_deployment(&LOGGER).await?;
                 writable.deployment_synced()?;
@@ -513,7 +518,10 @@ fn on_sync() {
                 OnSync::Replace,
             )?;
 
-            let writable = store.cheap_clone().writable(LOGGER.clone(), dst.id).await?;
+            let writable = store
+                .cheap_clone()
+                .writable(LOGGER.clone(), dst.id, Arc::new(Vec::new()))
+                .await?;
 
             // Perform the copy
             writable.start_subgraph_deployment(&LOGGER).await?;

--- a/store/test-store/tests/postgres/relational.rs
+++ b/store/test-store/tests/postgres/relational.rs
@@ -34,7 +34,7 @@ use graph_store_postgres::{
 
 use test_store::*;
 
-use crate::postgres::relational_bytes::{row_group, row_group_key};
+use crate::postgres::relational_bytes::{row_group, row_group_ref};
 
 const THINGS_GQL: &str = r#"
     type _Schema_ @fulltext(
@@ -745,9 +745,9 @@ fn delete() {
         let key = EntityKey::data("Scalar".to_owned(), "no such entity".to_owned());
         let entity_type = EntityType::from("Scalar");
         let mut entity_keys = vec![key];
-        let group = row_group_key(&entity_type, 1, entity_keys.clone());
+        let group = row_group_ref(&entity_type, 1, entity_keys.clone());
         let count = layout
-            .delete(conn, &group, 1, &MOCK_STOPWATCH)
+            .delete(conn, &group, &MOCK_STOPWATCH)
             .expect("Failed to delete");
         assert_eq!(0, count);
         assert_eq!(2, count_scalar_entities(conn, layout));
@@ -758,9 +758,9 @@ fn delete() {
             .map(|key| key.entity_id = Word::from("two"))
             .expect("Failed to update key");
 
-        let group = row_group_key(&entity_type, 1, entity_keys);
+        let group = row_group_ref(&entity_type, 1, entity_keys);
         let count = layout
-            .delete(conn, &group, 1, &MOCK_STOPWATCH)
+            .delete(conn, &group, &MOCK_STOPWATCH)
             .expect("Failed to delete");
         assert_eq!(1, count);
         assert_eq!(1, count_scalar_entities(conn, layout));
@@ -786,9 +786,9 @@ fn insert_many_and_delete_many() {
             .into_iter()
             .map(|key| EntityKey::data(entity_type.as_str(), key))
             .collect();
-        let group = row_group_key(&entity_type, 1, entity_keys);
+        let group = row_group_ref(&entity_type, 1, entity_keys);
         let num_removed = layout
-            .delete(conn, &group, 1, &MOCK_STOPWATCH)
+            .delete(conn, &group, &MOCK_STOPWATCH)
             .expect("Failed to delete");
         assert_eq!(2, num_removed);
         assert_eq!(1, count_scalar_entities(conn, layout));

--- a/store/test-store/tests/postgres/relational.rs
+++ b/store/test-store/tests/postgres/relational.rs
@@ -236,9 +236,7 @@ fn insert_entity_at(
         entity_type, entities_with_keys
     );
     let group = row_group(&entity_type, block, entities_with_keys_owned.clone());
-    let inserted = layout
-        .insert(conn, &group, block, &MOCK_STOPWATCH)
-        .expect(&errmsg);
+    let inserted = layout.insert(conn, &group, &MOCK_STOPWATCH).expect(&errmsg);
     assert_eq!(inserted, entities_with_keys_owned.len());
 }
 

--- a/store/test-store/tests/postgres/relational.rs
+++ b/store/test-store/tests/postgres/relational.rs
@@ -269,9 +269,7 @@ fn update_entity_at(
         entity_type, entities_with_keys
     );
     let group = row_group(&entity_type, block, entities_with_keys_owned.clone());
-    let updated = layout
-        .update(conn, &group, block, &MOCK_STOPWATCH)
-        .expect(&errmsg);
+    let updated = layout.update(conn, &group, &MOCK_STOPWATCH).expect(&errmsg);
     assert_eq!(updated, entities_with_keys_owned.len());
 }
 
@@ -579,7 +577,7 @@ fn update() {
         let entities = vec![(key, entity.clone())];
         let group = row_group(&entity_type, 0, entities);
         layout
-            .update(conn, &group, 0, &MOCK_STOPWATCH)
+            .update(conn, &group, &MOCK_STOPWATCH)
             .expect("Failed to update");
 
         let actual = layout
@@ -634,7 +632,7 @@ fn update_many() {
         let entities: Vec<_> = keys.into_iter().zip(entities_vec.into_iter()).collect();
         let group = row_group(&entity_type, 0, entities);
         layout
-            .update(conn, &group, 0, &MOCK_STOPWATCH)
+            .update(conn, &group, &MOCK_STOPWATCH)
             .expect("Failed to update");
 
         // check updates took effect
@@ -703,7 +701,7 @@ fn serialize_bigdecimal() {
             let entities = vec![(key, entity.clone())];
             let group = row_group(&entity_type, 0, entities);
             layout
-                .update(conn, &group, 0, &MOCK_STOPWATCH)
+                .update(conn, &group, &MOCK_STOPWATCH)
                 .expect("Failed to update");
 
             let actual = layout

--- a/store/test-store/tests/postgres/relational.rs
+++ b/store/test-store/tests/postgres/relational.rs
@@ -15,7 +15,6 @@ use graph_store_postgres::layout_for_tests::LayoutCache;
 use graph_store_postgres::layout_for_tests::SqlName;
 use hex_literal::hex;
 use lazy_static::lazy_static;
-use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::panic;
 use std::str::FromStr;
@@ -224,9 +223,9 @@ fn insert_entity_at(
             (key, entity)
         })
         .collect::<Vec<(EntityKey, Entity)>>();
-    let mut entities_with_keys: Vec<_> = entities_with_keys_owned
+    let entities_with_keys: Vec<_> = entities_with_keys_owned
         .iter()
-        .map(|(key, entity)| (key, Cow::from(entity)))
+        .map(|(key, entity)| (key, entity))
         .collect();
     let entity_type = EntityType::from(entity_type);
     let errmsg = format!(
@@ -237,7 +236,7 @@ fn insert_entity_at(
         .insert(
             conn,
             &entity_type,
-            &mut entities_with_keys,
+            &entities_with_keys,
             block,
             &MOCK_STOPWATCH,
         )
@@ -263,9 +262,9 @@ fn update_entity_at(
             (key, entity)
         })
         .collect();
-    let mut entities_with_keys: Vec<_> = entities_with_keys_owned
+    let entities_with_keys: Vec<_> = entities_with_keys_owned
         .iter()
-        .map(|(key, entity)| (key, Cow::from(entity)))
+        .map(|(key, entity)| (key, entity))
         .collect();
 
     let entity_type = EntityType::from(entity_type);
@@ -278,7 +277,7 @@ fn update_entity_at(
         .update(
             conn,
             &entity_type,
-            &mut entities_with_keys,
+            &entities_with_keys,
             block,
             &MOCK_STOPWATCH,
         )
@@ -587,9 +586,9 @@ fn update() {
         let key = EntityKey::data("Scalar".to_owned(), entity.id());
 
         let entity_type = EntityType::from("Scalar");
-        let mut entities = vec![(&key, Cow::from(&entity))];
+        let entities = vec![(&key, &entity)];
         layout
-            .update(conn, &entity_type, &mut entities, 0, &MOCK_STOPWATCH)
+            .update(conn, &entity_type, &entities, 0, &MOCK_STOPWATCH)
             .expect("Failed to update");
 
         let actual = layout
@@ -641,13 +640,10 @@ fn update_many() {
             .collect();
 
         let entities_vec = vec![one, two, three];
-        let mut entities: Vec<(&EntityKey, Cow<'_, Entity>)> = keys
-            .iter()
-            .zip(entities_vec.iter().map(Cow::Borrowed))
-            .collect();
+        let entities: Vec<(&EntityKey, &Entity)> = keys.iter().zip(entities_vec.iter()).collect();
 
         layout
-            .update(conn, &entity_type, &mut entities, 0, &MOCK_STOPWATCH)
+            .update(conn, &entity_type, &entities, 0, &MOCK_STOPWATCH)
             .expect("Failed to update");
 
         // check updates took effect
@@ -713,15 +709,9 @@ fn serialize_bigdecimal() {
 
             let key = EntityKey::data("Scalar".to_owned(), entity.id());
             let entity_type = EntityType::from("Scalar");
-            let mut entities = vec![(&key, Cow::Borrowed(&entity))];
+            let entities = vec![(&key, &entity)];
             layout
-                .update(
-                    conn,
-                    &entity_type,
-                    entities.as_mut_slice(),
-                    0,
-                    &MOCK_STOPWATCH,
-                )
+                .update(conn, &entity_type, &entities, 0, &MOCK_STOPWATCH)
                 .expect("Failed to update");
 
             let actual = layout

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -110,9 +110,7 @@ fn insert_entity(conn: &PgConnection, layout: &Layout, entity_type: &str, entity
     let entities = vec![(key.clone(), entity)];
     let group = row_group(&entity_type, 0, entities);
     let errmsg = format!("Failed to insert entity {}[{}]", entity_type, key.entity_id);
-    layout
-        .insert(conn, &group, 0, &MOCK_STOPWATCH)
-        .expect(&errmsg);
+    layout.insert(conn, &group, &MOCK_STOPWATCH).expect(&errmsg);
 }
 
 fn insert_thing(conn: &PgConnection, layout: &Layout, id: &str, name: &str) {

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -323,7 +323,7 @@ fn update() {
         let entities = vec![(key, entity.clone())];
         let group = row_group(&entity_type, 1, entities);
         layout
-            .update(conn, &group, 1, &MOCK_STOPWATCH)
+            .update(conn, &group, &MOCK_STOPWATCH)
             .expect("Failed to update");
 
         let actual = layout

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -10,7 +10,6 @@ use graph::prelude::{EntityQuery, MetricsRegistry};
 use graph::schema::InputSchema;
 use hex_literal::hex;
 use lazy_static::lazy_static;
-use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::str::FromStr;
 use std::{collections::BTreeMap, sync::Arc};
@@ -83,16 +82,10 @@ fn insert_entity(conn: &PgConnection, layout: &Layout, entity_type: &str, entity
     let key = EntityKey::data(entity_type.to_owned(), entity.id());
 
     let entity_type = EntityType::from(entity_type);
-    let mut entities = vec![(&key, Cow::from(&entity))];
+    let entities = vec![(&key, &entity)];
     let errmsg = format!("Failed to insert entity {}[{}]", entity_type, key.entity_id);
     layout
-        .insert(
-            conn,
-            &entity_type,
-            entities.as_mut_slice(),
-            0,
-            &MOCK_STOPWATCH,
-        )
+        .insert(conn, &entity_type, &entities, 0, &MOCK_STOPWATCH)
         .expect(&errmsg);
 }
 
@@ -303,9 +296,9 @@ fn update() {
 
         let entity_id = entity.id();
         let entity_type = key.entity_type.clone();
-        let mut entities = vec![(&key, Cow::from(&entity))];
+        let entities = vec![(&key, &entity)];
         layout
-            .update(conn, &entity_type, &mut entities, 1, &MOCK_STOPWATCH)
+            .update(conn, &entity_type, &entities, 1, &MOCK_STOPWATCH)
             .expect("Failed to update");
 
         let actual = layout

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -141,7 +141,7 @@ where
         let deployment = insert_test_data(subgraph_store.clone()).await;
         let writable = store
             .subgraph_store()
-            .writable(LOGGER.clone(), deployment.id)
+            .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
             .await
             .expect("we can get a writable store");
 
@@ -1530,7 +1530,6 @@ fn handle_large_string_with_index() {
                 Vec::new(),
                 Vec::new(),
                 Vec::new(),
-                Vec::new(),
             )
             .await
             .expect("Failed to insert large text");
@@ -1621,7 +1620,6 @@ fn handle_large_bytea_with_index() {
                     make_insert_op(TWO, &other_bytea, &schema),
                 ],
                 &stopwatch_metrics,
-                Vec::new(),
                 Vec::new(),
                 Vec::new(),
                 Vec::new(),

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -1286,7 +1286,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             ),
             ("2".to_owned(), entity! { schema => id: "2", name: "Tessa" }),
         ];
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             TEST_BLOCK_1_PTR.clone(),
@@ -1314,7 +1314,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
         };
 
         // Commit update & delete ops
-        transact_entity_operations(
+        transact_and_wait(
             &store.subgraph_store(),
             &deployment,
             TEST_BLOCK_2_PTR.clone(),

--- a/store/test-store/tests/postgres/subgraph.rs
+++ b/store/test-store/tests/postgres/subgraph.rs
@@ -55,7 +55,7 @@ fn get_version_info(store: &Store, subgraph_name: &str) -> VersionInfo {
 async fn latest_block(store: &Store, deployment_id: DeploymentId) -> BlockPtr {
     store
         .subgraph_store()
-        .writable(LOGGER.clone(), deployment_id)
+        .writable(LOGGER.clone(), deployment_id, Arc::new(Vec::new()))
         .await
         .expect("can get writable")
         .block_ptr()
@@ -176,10 +176,14 @@ fn create_subgraph() {
     }
 
     fn deployment_synced(store: &Arc<SubgraphStore>, deployment: &DeploymentLocator) {
-        futures03::executor::block_on(store.cheap_clone().writable(LOGGER.clone(), deployment.id))
-            .expect("can get writable")
-            .deployment_synced()
-            .unwrap();
+        futures03::executor::block_on(store.cheap_clone().writable(
+            LOGGER.clone(),
+            deployment.id,
+            Arc::new(Vec::new()),
+        ))
+        .expect("can get writable")
+        .deployment_synced()
+        .unwrap();
     }
 
     // Test VersionSwitchingMode::Instant
@@ -416,7 +420,7 @@ fn status() {
 
         store
             .subgraph_store()
-            .writable(LOGGER.clone(), deployment.id)
+            .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
             .await
             .expect("can get writable")
             .fail_subgraph(error)
@@ -576,7 +580,7 @@ fn fatal_vs_non_fatal() {
 
         store
             .subgraph_store()
-            .writable(LOGGER.clone(), deployment.id)
+            .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
             .await
             .expect("can get writable")
             .fail_subgraph(error())
@@ -670,7 +674,7 @@ fn fail_unfail_deterministic_error() {
 
         let writable = store
             .subgraph_store()
-            .writable(LOGGER.clone(), deployment.id)
+            .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
             .await
             .expect("can get writable");
 
@@ -762,7 +766,7 @@ fn fail_unfail_deterministic_error_noop() {
 
         let writable = store
             .subgraph_store()
-            .writable(LOGGER.clone(), deployment.id)
+            .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
             .await
             .expect("can get writable");
 
@@ -889,7 +893,7 @@ fn fail_unfail_non_deterministic_error() {
 
         let writable = store
             .subgraph_store()
-            .writable(LOGGER.clone(), deployment.id)
+            .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
             .await
             .expect("can get writable");
 
@@ -989,7 +993,7 @@ fn fail_unfail_non_deterministic_error_noop() {
 
         let writable = store
             .subgraph_store()
-            .writable(LOGGER.clone(), deployment.id)
+            .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
             .await
             .expect("can get writable");
 

--- a/store/test-store/tests/postgres/writable.rs
+++ b/store/test-store/tests/postgres/writable.rs
@@ -87,7 +87,7 @@ where
         let deployment = insert_test_data(subgraph_store.clone()).await;
         let writable = store
             .subgraph_store()
-            .writable(LOGGER.clone(), deployment.id)
+            .writable(LOGGER.clone(), deployment.id, Arc::new(Vec::new()))
             .await
             .expect("we can get a writable store");
 

--- a/tests/tests/runner_tests.rs
+++ b/tests/tests/runner_tests.rs
@@ -196,7 +196,7 @@ async fn file_data_sources() {
 
     let store = ctx.store.cheap_clone();
     let writable = store
-        .writable(ctx.logger.clone(), ctx.deployment.id)
+        .writable(ctx.logger.clone(), ctx.deployment.id, Arc::new(Vec::new()))
         .await
         .unwrap();
     let datasources = writable.load_dynamic_data_sources(vec![]).await.unwrap();
@@ -218,7 +218,7 @@ async fn file_data_sources() {
     let writable = ctx
         .store
         .clone()
-        .writable(ctx.logger.clone(), ctx.deployment.id)
+        .writable(ctx.logger.clone(), ctx.deployment.id, Arc::new(Vec::new()))
         .await
         .unwrap();
     let data_sources = writable.load_dynamic_data_sources(vec![]).await.unwrap();


### PR DESCRIPTION
With this PR, when a subgraph syncs, changes are accumulated into batches for a while (5 minutes by default) or until they reach a certain size (10MB) This should considerably speed up syncing of subgraphs whose speed is limited by the database. Batching only kicks in when the write queue has more than one entry - it turns out that holding writes for a while is pretty tricky, but for subgraphs where the bottleneck is the database, this should not matter.

Most of this PR is concerned with restructuring the code around writing entities so that those changes can be captured in a new data structure `graph::components::store::write::Batch` to which more changes can then be added.

Note that this PR sits on top of #4572 and we'll need to merge that first before merging this.