### PR TITLE
De-`Arc` `IpfsClient`

### DIFF
--- a/core/src/link_resolver.rs
+++ b/core/src/link_resolver.rs
@@ -49,13 +49,13 @@ fn retry_policy<I: Send + Sync>(
 /// case multiple clients respond in a timely manner. In addition, we may make
 /// good use of the stat returned.
 async fn select_fastest_client_with_stat(
-    clients: Arc<Vec<Arc<IpfsClient>>>,
+    clients: Arc<Vec<IpfsClient>>,
     logger: Logger,
     api: StatApi,
     path: String,
     timeout: Duration,
     do_retry: bool,
-) -> Result<(u64, Arc<IpfsClient>), Error> {
+) -> Result<(u64, IpfsClient), Error> {
     let mut err: Option<Error> = None;
 
     let mut stats: FuturesUnordered<_> = clients
@@ -108,7 +108,7 @@ fn restrict_file_size(path: &str, size: u64, max_file_bytes: usize) -> Result<()
 
 #[derive(Clone)]
 pub struct LinkResolver {
-    clients: Arc<Vec<Arc<IpfsClient>>>,
+    clients: Arc<Vec<IpfsClient>>,
     cache: Arc<Mutex<LruCache<String, Vec<u8>>>>,
     timeout: Duration,
     retry: bool,
@@ -118,7 +118,7 @@ pub struct LinkResolver {
 impl LinkResolver {
     pub fn new(clients: Vec<IpfsClient>, env_vars: Arc<EnvVars>) -> Self {
         Self {
-            clients: Arc::new(clients.into_iter().map(Arc::new).collect()),
+            clients: Arc::new(clients.into_iter().collect()),
             cache: Arc::new(Mutex::new(LruCache::with_capacity(
                 env_vars.mappings.max_ipfs_cache_size as usize,
             ))),

--- a/graph/src/cheap_clone.rs
+++ b/graph/src/cheap_clone.rs
@@ -28,6 +28,7 @@ impl<T: ?Sized + CheapClone> CheapClone for Box<T> {}
 impl<T: ?Sized + CheapClone> CheapClone for std::pin::Pin<T> {}
 impl<T: CheapClone> CheapClone for Option<T> {}
 impl CheapClone for Logger {}
+impl CheapClone for reqwest::Client {}
 
 // Pool is implemented as a newtype over Arc,
 // So it is CheapClone.

--- a/graph/src/cheap_clone.rs
+++ b/graph/src/cheap_clone.rs
@@ -28,6 +28,7 @@ impl<T: ?Sized + CheapClone> CheapClone for Box<T> {}
 impl<T: ?Sized + CheapClone> CheapClone for std::pin::Pin<T> {}
 impl<T: CheapClone> CheapClone for Option<T> {}
 impl CheapClone for Logger {}
+// reqwest::Client uses Arc internally, so it is CheapClone.
 impl CheapClone for reqwest::Client {}
 
 // Pool is implemented as a newtype over Arc,

--- a/graph/src/ipfs_client.rs
+++ b/graph/src/ipfs_client.rs
@@ -110,6 +110,8 @@ pub struct AddResponse {
 #[derive(Clone)]
 pub struct IpfsClient {
     base: Arc<Uri>,
+    // reqwest::Client doesn't need to be `Arc` because it has one internally
+    // already.
     client: reqwest::Client,
 }
 

--- a/graph/src/ipfs_client.rs
+++ b/graph/src/ipfs_client.rs
@@ -110,7 +110,7 @@ pub struct AddResponse {
 #[derive(Clone)]
 pub struct IpfsClient {
     base: Arc<Uri>,
-    client: Arc<reqwest::Client>,
+    client: reqwest::Client,
 }
 
 impl CheapClone for IpfsClient {
@@ -125,14 +125,14 @@ impl CheapClone for IpfsClient {
 impl IpfsClient {
     pub fn new(base: &str) -> Result<Self, Error> {
         Ok(IpfsClient {
-            client: Arc::new(reqwest::Client::new()),
+            client: reqwest::Client::new(),
             base: Arc::new(Uri::from_str(base)?),
         })
     }
 
     pub fn localhost() -> Self {
         IpfsClient {
-            client: Arc::new(reqwest::Client::new()),
+            client: reqwest::Client::new(),
             base: Arc::new(Uri::from_str("http://localhost:5001").unwrap()),
         }
     }


### PR DESCRIPTION
- `IpfsClient` is already `CheapClone`, so we don't need to wrap it in an `Arc` to pass is around.
- `reqwest::Client` already uses an `Arc` internally (this is not an implementation detail, but something documented and intended), so we don't need to wrap it in an `Arc`,
- Many `CheapClone` implementations can and should use the default implementation of `CheapClone::cheap_clone`, because they don't need custom behavior.