### PR TITLE
set id field downstream when making entity change

### DIFF
--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -20,7 +20,6 @@ use graph_runtime_wasm::module::ToAscPtr;
 use lazy_static::__Deref;
 
 use crate::codec;
-use crate::codec::value::Typed;
 use crate::{codec::entity_change::Operation, Block, Chain, NoopDataSourceTemplate};
 
 #[derive(Eq, PartialEq, PartialOrd, Ord, Debug)]
@@ -220,7 +219,7 @@ where
 
                     data.insert(
                         Word::from("id"),
-                        decode_value(&Typed::String(entity_id)).unwrap(),
+                        decode_value(&codec::value::Typed::String(entity_id)).unwrap(),
                     );
 
                     let entity = state.entity_cache.make_entity(data)?;

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -20,6 +20,7 @@ use graph_runtime_wasm::module::ToAscPtr;
 use lazy_static::__Deref;
 
 use crate::codec;
+use crate::codec::value::Typed;
 use crate::{codec::entity_change::Operation, Block, Chain, NoopDataSourceTemplate};
 
 #[derive(Eq, PartialEq, PartialOrd, Ord, Debug)]
@@ -215,6 +216,11 @@ where
                         },
                         causality_region,
                         logger,
+                    );
+
+                    data.insert(
+                        Word::from("id"),
+                        decode_value(&Typed::String(entity_id)).unwrap(),
                     );
 
                     let entity = state.entity_cache.make_entity(data)?;

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -217,10 +217,7 @@ where
                         logger,
                     );
 
-                    data.insert(
-                        Word::from("id"),
-                        decode_value(&codec::value::Typed::String(entity_id)).unwrap(),
-                    );
+                    data.insert(Word::from("id"), Value::from(&entity_id));
 
                     let entity = state.entity_cache.make_entity(data)?;
                     state.entity_cache.set(key, entity)?;


### PR DESCRIPTION
With recent changes done to the make entity, we have to send a create with the "id" field AND all the update entity changes also need to contain a "id" field change.