### PR TITLE
node: Add perf config file support

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,6 @@ mod subgraph;
 
 pub use crate::link_resolver::LinkResolver;
 pub use crate::subgraph::{
-    SubgraphAssignmentProvider, SubgraphInstanceManager, SubgraphRegistrar, SubgraphRunner,
-    SubgraphTriggerProcessor,
+    SubgraphAssignmentProvider, SubgraphInstanceManager, SubgraphPerfConfig, SubgraphPerfRules,
+    SubgraphRegistrar, SubgraphRunner, SubgraphTriggerProcessor,
 };

--- a/core/src/subgraph/config.rs
+++ b/core/src/subgraph/config.rs
@@ -1,0 +1,26 @@
+use graph::prelude::{regex::Regex, SubgraphName};
+
+#[derive(Default, Debug)]
+pub struct SubgraphPerfRules {
+    pub rules: Vec<(Regex, SubgraphPerfConfig)>,
+}
+
+impl SubgraphPerfRules {
+    pub fn config_for_name(&self, name: &SubgraphName) -> Option<SubgraphPerfConfig> {
+        self.rules.iter().find_map(|(regex, config)| {
+            if regex.is_match(name.as_str()) {
+                Some(config.clone())
+            } else {
+                None
+            }
+        })
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+// TODO: Remove clone and use Arc or something on the RulesStructure
+// Make this struct combinable by setting relevant priority per field,
+// eg prefer shorter history_blocks etc
+pub struct SubgraphPerfConfig {
+    pub history_blocks: i32,
+}

--- a/core/src/subgraph/mod.rs
+++ b/core/src/subgraph/mod.rs
@@ -1,3 +1,4 @@
+mod config;
 mod context;
 mod error;
 mod inputs;
@@ -10,6 +11,7 @@ mod state;
 mod stream;
 mod trigger_processor;
 
+pub use self::config::*;
 pub use self::instance_manager::SubgraphInstanceManager;
 pub use self::provider::SubgraphAssignmentProvider;
 pub use self::registrar::SubgraphRegistrar;

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -172,6 +172,9 @@ pub struct EnvVars {
     /// Set by the environment variable `ETHEREUM_REORG_THRESHOLD`. The default
     /// value is 250 blocks.
     pub reorg_threshold: BlockNumber,
+    /// Set by the env var `GRAPH_EXPERIMENTAL_PERFORMANCE_CFG_FILE` which should point
+    /// the performance configuration file.
+    pub performance_config_file: Option<String>,
 }
 
 impl EnvVars {
@@ -229,6 +232,7 @@ impl EnvVars {
             external_ws_base_url: inner.external_ws_base_url,
             static_filters_threshold: inner.static_filters_threshold,
             reorg_threshold: inner.reorg_threshold,
+            performance_config_file: inner.performance_config_file,
         })
     }
 
@@ -347,6 +351,8 @@ struct Inner {
     // JSON-RPC specific.
     #[envconfig(from = "ETHEREUM_REORG_THRESHOLD", default = "250")]
     reorg_threshold: BlockNumber,
+    #[envconfig(from = "GRAPH_EXPERIMENTAL_PERFORMANCE_CFG_FILE")]
+    performance_config_file: Option<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,6 +8,7 @@ extern crate diesel;
 pub mod chain;
 pub mod config;
 pub mod opt;
+pub mod perf_config;
 pub mod store_builder;
 
 pub mod manager;

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -30,7 +30,7 @@ use graph_chain_ethereum as ethereum;
 use graph_core::polling_monitor::ipfs_service;
 use graph_core::{
     LinkResolver, SubgraphAssignmentProvider as IpfsSubgraphAssignmentProvider,
-    SubgraphInstanceManager, SubgraphRegistrar as IpfsSubgraphRegistrar,
+    SubgraphInstanceManager, SubgraphPerfRules, SubgraphRegistrar as IpfsSubgraphRegistrar,
 };
 
 fn locate(store: &dyn SubgraphStore, hash: &str) -> Result<DeploymentLocator, anyhow::Error> {
@@ -198,6 +198,7 @@ pub async fn run(
         blockchain_map,
         node_id.clone(),
         SubgraphVersionSwitchingMode::Instant,
+        Arc::new(SubgraphPerfRules::default()),
     ));
 
     let (name, hash) = if subgraph.contains(':') {

--- a/node/src/perf_config.rs
+++ b/node/src/perf_config.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+
+use graph::{anyhow, prelude::regex::Regex};
+use graph_core::{SubgraphPerfConfig, SubgraphPerfRules};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SubgraphConfigSection {
+    rules: HashMap<String, SubgraphConfigRule>,
+}
+
+impl TryInto<SubgraphPerfRules> for SubgraphConfigSection {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<SubgraphPerfRules, Self::Error> {
+        self.rules
+            .into_values()
+            .map(|x| {
+                let key = match x.match_rule {
+                    MatchSelection::SubgraphName { name } => Regex::new(&name),
+                };
+
+                key.map(|k| (k, x.actions.into()))
+                    .map_err(anyhow::Error::from)
+            })
+            .collect::<anyhow::Result<Vec<(Regex, SubgraphPerfConfig)>>>()
+            .map(|rules| SubgraphPerfRules { rules })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SubgraphConfigRule {
+    #[serde(alias = "match")]
+    match_rule: MatchSelection,
+    actions: SubgraphConfigDetails,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct SubgraphConfigDetails {
+    history_blocks: i32,
+}
+
+impl Into<SubgraphPerfConfig> for SubgraphConfigDetails {
+    fn into(self) -> SubgraphPerfConfig {
+        let Self { history_blocks } = self;
+
+        SubgraphPerfConfig { history_blocks }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MatchSelection {
+    SubgraphName { name: String },
+}
+
+#[cfg(test)]
+mod test {
+    use crate::perf_config::MatchSelection;
+
+    #[test]
+    fn parses_correctly() {
+        let content = r#"
+        [rules]
+
+        [rules.name] 
+        match = { type = "subgraph_name", name = ".*" } 
+        actions = { history_blocks = 10000 } 
+
+        [rules.name2]
+        match = { type = "subgraph_name", name = "xxxxx" } 
+        actions = { history_blocks = 10000 } 
+
+        [rules.name3] 
+        match = { type = "subgraph_name", name = ".*!$" } 
+        actions = { history_blocks = 10000 } 
+        "#;
+
+        let section = toml::from_str::<super::SubgraphConfigSection>(content).unwrap();
+        assert_eq!(section.rules.len(), 3);
+
+        let rule1 = match section.rules.get("name").unwrap().match_rule {
+            MatchSelection::SubgraphName { ref name } => name,
+        };
+        assert_eq!(rule1, ".*");
+
+        let rule2 = match section.rules.get("name2").unwrap().match_rule {
+            MatchSelection::SubgraphName { ref name } => name,
+        };
+        assert_eq!(rule2, "xxxxx");
+        let rule1 = match section.rules.get("name3").unwrap().match_rule {
+            MatchSelection::SubgraphName { ref name } => name,
+        };
+        assert_eq!(rule1, ".*!$");
+    }
+}

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -408,6 +408,7 @@ pub async fn setup<C: Blockchain>(
         blockchain_map.clone(),
         node_id.clone(),
         SubgraphVersionSwitchingMode::Instant,
+        Arc::new(graph_core::SubgraphPerfRules::default()),
     ));
 
     SubgraphRegistrar::create_subgraph(subgraph_registrar.as_ref(), subgraph_name.clone())


### PR DESCRIPTION
First iteration of https://github.com/graphprotocol/graph-node/issues/4325's implementation. 

Some unsolved issues in MVP:
- Rules are read in random order 
- If multiple rules apply to the same subgraph one of them is selected
- No tool to check how the rules apply to existing subgraphs. 
- Currently history_blocks cannot be replaced via config, only applied to new deployments
