### PR TITLE
perf: Avoid cloning cached entities

### DIFF
--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -691,6 +691,12 @@ impl Entity {
         v
     }
 
+    pub fn sorted_ref(&self) -> Vec<(&str, &Value)> {
+        let mut v: Vec<_> = self.0.iter().collect();
+        v.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+        v
+    }
+
     fn check_id(&self) -> Result<(), Error> {
         match self.get("id") {
             None => Err(anyhow!(

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -15,6 +15,7 @@ use graph_runtime_wasm::{
 };
 
 use semver::Version;
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 use test_store::{LOGGER, STORE};
@@ -1305,7 +1306,7 @@ async fn test_store_set_id() {
             &mut self,
             entity_type: &str,
             id: &str,
-        ) -> Result<Option<Entity>, anyhow::Error> {
+        ) -> Result<Option<Cow<Entity>>, anyhow::Error> {
             let user_id = String::from(id);
             self.host_exports.store_get(
                 &mut self.ctx.state,

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -340,6 +340,18 @@ impl ToAscObj<AscEntity> for Vec<(Word, store::Value)> {
     }
 }
 
+impl ToAscObj<AscEntity> for Vec<(&str, &store::Value)> {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+        gas: &GasCounter,
+    ) -> Result<AscEntity, HostExportError> {
+        Ok(AscTypedMap {
+            entries: asc_new(heap, self.as_slice(), gas)?,
+        })
+    }
+}
+
 impl ToAscObj<Array<AscPtr<AscEntity>>> for Vec<Vec<(Word, store::Value)>> {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,

--- a/runtime/wasm/src/to_from/mod.rs
+++ b/runtime/wasm/src/to_from/mod.rs
@@ -65,6 +65,19 @@ impl ToAscObj<AscString> for str {
     }
 }
 
+impl ToAscObj<AscString> for &str {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+        _gas: &GasCounter,
+    ) -> Result<AscString, HostExportError> {
+        Ok(AscString::new(
+            &self.encode_utf16().collect::<Vec<_>>(),
+            heap.api_version(),
+        )?)
+    }
+}
+
 impl ToAscObj<AscString> for String {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -717,16 +717,16 @@ fn scoped_get() {
 
         // For the new entity, we can retrieve it with either scope
         let act5 = cache.get(&key5, GetScope::InBlock).unwrap();
-        assert_eq!(Some(&wallet5), act5.as_ref());
+        assert_eq!(Some(&wallet5), act5.as_ref().map(|e| e.as_ref()));
         let act5 = cache.get(&key5, GetScope::Store).unwrap();
-        assert_eq!(Some(&wallet5), act5.as_ref());
+        assert_eq!(Some(&wallet5), act5.as_ref().map(|e| e.as_ref()));
 
         // For an entity in the store, we can not get it `InBlock` but with
         // `Store`
         let act1 = cache.get(&key1, GetScope::InBlock).unwrap();
         assert_eq!(None, act1);
         let act1 = cache.get(&key1, GetScope::Store).unwrap();
-        assert_eq!(Some(&wallet1), act1.as_ref());
+        assert_eq!(Some(&wallet1), act1.as_ref().map(|e| e.as_ref()));
         // Even after reading from the store, the entity is not visible with
         // `InBlock`
         let act1 = cache.get(&key1, GetScope::InBlock).unwrap();
@@ -736,9 +736,9 @@ fn scoped_get() {
         wallet1.set("balance", 70).unwrap();
         cache.set(key1.clone(), wallet1.clone()).unwrap();
         let act1 = cache.get(&key1, GetScope::InBlock).unwrap();
-        assert_eq!(Some(&wallet1), act1.as_ref());
+        assert_eq!(Some(&wallet1), act1.as_ref().map(|e| e.as_ref()));
         let act1 = cache.get(&key1, GetScope::Store).unwrap();
-        assert_eq!(Some(&wallet1), act1.as_ref());
+        assert_eq!(Some(&wallet1), act1.as_ref().map(|e| e.as_ref()));
     })
 }
 


### PR DESCRIPTION
This should be a measurable performance improvement. And the lifetime adjustments surprisingly didn't cause much trouble. The only case where a clone is still required is if the entity needs to be mutated by applying pending updates, so we use a `Cow` to handle that. The entity sorting step is also faster now, because it no longer requires cloning the entity keys, rather we just sort the interned values.

