### PR TITLE
store: Do not create GIN indexes for numeric arrays

### DIFF
--- a/store/postgres/src/relational/ddl_tests.rs
+++ b/store/postgres/src/relational/ddl_tests.rs
@@ -378,9 +378,9 @@ create table "sgd0815"."song" (
 create index brin_song
     on "sgd0815"."song"
  using brin(block$, vid);
-create index attr_2_1_song_title
+create index attr_2_0_song_title
     on "sgd0815"."song" using btree(left("title", 256));
-create index attr_2_2_song_written_by
+create index attr_2_1_song_written_by
     on "sgd0815"."song" using btree("written_by", block$);
 
 create table "sgd0815"."song_stat" (


### PR DESCRIPTION
GIN indexes are pretty expensive to build and maintain. For fields of types like `[BigInt!]!` or `[BigDecimal!]!`, they also don't help much since [they only support](https://www.postgresql.org/docs/current/gin-builtin-opclasses.html) looking for exact values, which is very unlikely to happen in a query, and even less unlikely to be the filter that the query planner would use.