### PR TITLE
Optimize match and decode, turn on static filters

### DIFF
--- a/chain/arweave/src/trigger.rs
+++ b/chain/arweave/src/trigger.rs
@@ -128,6 +128,10 @@ impl TriggerData for ArweaveTrigger {
             }
         }
     }
+
+    fn address_match(&self) -> Option<&[u8]> {
+        None
+    }
 }
 
 pub struct TransactionWithBlockPtr {

--- a/chain/cosmos/src/trigger.rs
+++ b/chain/cosmos/src/trigger.rs
@@ -259,6 +259,10 @@ impl TriggerData for CosmosTrigger {
             }
         }
     }
+
+    fn address_match(&self) -> Option<&[u8]> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -504,20 +504,13 @@ impl DataSource {
     }
 
     fn matches_trigger_address(&self, trigger: &EthereumTrigger) -> bool {
-        let ds_address = match self.address {
-            Some(addr) => addr,
-
+        let Some(ds_address) = self.address else {
             // 'wildcard' data sources match any trigger address.
-            None => return true,
+            return true
         };
 
-        let trigger_address = match trigger {
-            EthereumTrigger::Block(_, EthereumBlockTriggerType::WithCallTo(address)) => address,
-            EthereumTrigger::Call(call) => &call.to,
-            EthereumTrigger::Log(log, _) => &log.address,
-
-            // Unfiltered block triggers match any data source address.
-            EthereumTrigger::Block(_, EthereumBlockTriggerType::Every) => return true,
+        let Some(trigger_address) = trigger.address() else {
+             return true
         };
 
         ds_address == *trigger_address

--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -266,6 +266,20 @@ impl EthereumTrigger {
             EthereumTrigger::Log(log, _) => log.block_hash.unwrap(),
         }
     }
+
+    /// `None` means the trigger matches any address.
+    pub fn address(&self) -> Option<&Address> {
+        match self {
+            EthereumTrigger::Block(_, EthereumBlockTriggerType::WithCallTo(address)) => {
+                Some(address)
+            }
+            EthereumTrigger::Call(call) => Some(&call.to),
+            EthereumTrigger::Log(log, _) => Some(&log.address),
+
+            // Unfiltered block triggers match any data source address.
+            EthereumTrigger::Block(_, EthereumBlockTriggerType::Every) => None,
+        }
+    }
 }
 
 impl Ord for EthereumTrigger {
@@ -331,6 +345,10 @@ impl TriggerData for EthereumTrigger {
             ),
             None => String::new(),
         }
+    }
+
+    fn address_match(&self) -> Option<&[u8]> {
+        self.address().map(|address| address.as_bytes())
     }
 }
 

--- a/chain/near/src/trigger.rs
+++ b/chain/near/src/trigger.rs
@@ -132,6 +132,10 @@ impl TriggerData for NearTrigger {
             }
         }
     }
+
+    fn address_match(&self) -> Option<&[u8]> {
+        None
+    }
 }
 
 pub struct ReceiptWithOutcome {

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -30,6 +30,10 @@ impl blockchain::TriggerData for TriggerData {
     fn error_context(&self) -> String {
         "Failed to process substreams block".to_string()
     }
+
+    fn address_match(&self) -> Option<&[u8]> {
+        None
+    }
 }
 
 impl ToAscPtr for TriggerData {
@@ -164,7 +168,7 @@ where
     async fn process_trigger(
         &self,
         logger: &Logger,
-        _hosts: &[Arc<T::Host>],
+        _: Box<dyn Iterator<Item = &T::Host> + Send + '_>,
         block: &Arc<Block>,
         _trigger: &data_source::TriggerData<Chain>,
         mut state: BlockState<Chain>,

--- a/core/src/subgraph/context.rs
+++ b/core/src/subgraph/context.rs
@@ -97,7 +97,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
     ) -> Result<BlockState<C>, MappingError> {
         self.process_trigger_in_hosts(
             logger,
-            self.instance.hosts(),
+            self.instance.hosts_for_trigger(trigger),
             block,
             trigger,
             state,
@@ -113,7 +113,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
     pub async fn process_trigger_in_hosts(
         &self,
         logger: &Logger,
-        hosts: &[Arc<T::Host>],
+        hosts: Box<dyn Iterator<Item = &T::Host> + Send + '_>,
         block: &Arc<C::Block>,
         trigger: &TriggerData<C>,
         state: BlockState<C>,

--- a/core/src/subgraph/context/instance.rs
+++ b/core/src/subgraph/context/instance.rs
@@ -7,7 +7,7 @@ use graph::{
     },
     prelude::*,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use super::OffchainMonitor;
 
@@ -18,16 +18,8 @@ pub struct SubgraphInstance<C: Blockchain, T: RuntimeHostBuilder<C>> {
     templates: Arc<Vec<DataSourceTemplate<C>>>,
     host_metrics: Arc<HostMetrics>,
 
-    /// Runtime hosts, one for each data source mapping.
-    ///
-    /// The runtime hosts are created and added in the same order the
-    /// data sources appear in the subgraph manifest. Incoming block
-    /// stream events are processed by the mappings in this same order.
-    hosts: Vec<Arc<T::Host>>,
-
-    /// Addresses of `hosts`, in a set for fast lookup. This may contain false positives, that is,
-    /// addresses which are not in `hosts`. So technically it's a superset of the `host` addresses.
-    host_addresses: HashSet<Box<[u8]>>,
+    /// The hosts represent the data sources in the subgraph. There is one host per data source.
+    hosts: Hosts<C, T>,
 
     /// Maps the hash of a module to a channel to the thread in which the module is instantiated.
     module_cache: HashMap<[u8; 32], Sender<T::Req>>,
@@ -57,8 +49,7 @@ where
             host_builder,
             subgraph_id,
             network,
-            hosts: Vec::new(),
-            host_addresses: HashSet::new(),
+            hosts: Hosts::new(),
             module_cache: HashMap::new(),
             templates,
             host_metrics,
@@ -117,10 +108,6 @@ where
             }
         };
 
-        if let Some(address) = data_source.address() {
-            self.host_addresses.insert(address.into());
-        }
-
         self.host_builder.build(
             self.network.clone(),
             self.subgraph_id.clone(),
@@ -158,7 +145,7 @@ where
 
         let host = Arc::new(self.new_host(logger.clone(), data_source, &module_bytes)?);
 
-        Ok(if self.hosts.contains(&host) {
+        Ok(if self.hosts.hosts().contains(&host) {
             None
         } else {
             self.hosts.push(host.clone());
@@ -190,6 +177,7 @@ where
         }
 
         self.hosts
+            .hosts()
             .iter()
             .filter(|host| matches!(host.done_at(), Some(done_at) if done_at >= reverted_block))
             .map(|host| {
@@ -214,29 +202,13 @@ where
         }
     }
 
-    /// Returns all hosts which match the trigger, but may also return false positives. This is a
-    /// performance optimization to reduce the number of calls to `match_and_decode`.
+    /// Returns all hosts which match the trigger's address.
+    /// This is a performance optimization to reduce the number of calls to `match_and_decode`.
     pub fn hosts_for_trigger(
         &self,
         trigger: &TriggerData<C>,
     ) -> Box<dyn Iterator<Item = &T::Host> + Send + '_> {
-        // If the trigger has no address, it has opted out of this optimization and might match any host.
-        let Some(address) = trigger.address_match() else {
-            return Box::new(self.hosts.iter().map(|host| host.as_ref()));
-        };
-
-        Box::new(
-            self.hosts
-                .iter()
-                .filter(move |host| match host.data_source().address() {
-                    // A host with an address may only match triggers with the same address.
-                    Some(host_address) => host_address == address,
-
-                    // A host with no address may match a trigger regardless of the trigger's address.
-                    None => true,
-                })
-                .map(|host| host.as_ref()),
-        )
+        self.hosts.iter_by_address(trigger.address_match())
     }
 
     pub(super) fn causality_region_next_value(&mut self) -> CausalityRegion {
@@ -245,6 +217,106 @@ where
 
     #[cfg(debug_assertions)]
     pub fn hosts(&self) -> &[Arc<T::Host>] {
+        &self.hosts.hosts()
+    }
+}
+
+/// Runtime hosts, one for each data source mapping.
+///
+/// The runtime hosts are created and added to the vec in the same order the data sources appear in
+/// the subgraph manifest. Incoming block stream events are processed by the mappings in this same
+/// order.
+///
+/// This structure also maintains a partition of the hosts by address, for faster trigger matching.
+/// This partition uses the host's index in the main vec, to maintain the correct ordering.
+struct Hosts<C: Blockchain, T: RuntimeHostBuilder<C>> {
+    hosts: Vec<Arc<T::Host>>,
+
+    // The `usize` is the index of the host in `hosts`.
+    hosts_by_address: HashMap<Box<[u8]>, Vec<usize>>,
+    hosts_without_address: Vec<usize>,
+}
+
+impl<C: Blockchain, T: RuntimeHostBuilder<C>> Hosts<C, T> {
+    fn new() -> Self {
+        Self {
+            hosts: Vec::new(),
+            hosts_by_address: HashMap::new(),
+            hosts_without_address: Vec::new(),
+        }
+    }
+
+    fn hosts(&self) -> &[Arc<T::Host>] {
         &self.hosts
+    }
+
+    fn last(&self) -> Option<&Arc<T::Host>> {
+        self.hosts.last()
+    }
+
+    fn len(&self) -> usize {
+        self.hosts.len()
+    }
+
+    fn push(&mut self, host: Arc<T::Host>) {
+        self.hosts.push(host.cheap_clone());
+        let idx = self.hosts.len() - 1;
+        let address = host.data_source().address();
+        match address {
+            Some(address) => {
+                self.hosts_by_address
+                    .entry(address.into())
+                    .or_default()
+                    .push(idx);
+            }
+            None => {
+                self.hosts_without_address.push(idx);
+            }
+        }
+    }
+
+    fn pop(&mut self) {
+        let Some(host) = self.hosts.pop() else { return };
+        let address = host.data_source().address();
+        match address {
+            Some(address) => {
+                // Unwrap and assert: The same host we just popped must be the last one in `hosts_by_address`.
+                let hosts = self.hosts_by_address.get_mut(address.as_slice()).unwrap();
+                let idx = hosts.pop().unwrap();
+                assert_eq!(idx, self.hosts.len());
+            }
+            None => {
+                // Unwrap and assert: The same host we just popped must be the last one in `hosts_without_address`.
+                let idx = self.hosts_without_address.pop().unwrap();
+                assert_eq!(idx, self.hosts.len());
+            }
+        }
+    }
+
+    /// Returns an iterator over all hosts that match the given address, in the order they were inserted in `hosts`.
+    /// Note that this always includes the hosts without an address, since they match all addresses.
+    /// If no address is provided, returns an iterator over all hosts.
+    fn iter_by_address(
+        &self,
+        address: Option<Vec<u8>>,
+    ) -> Box<dyn Iterator<Item = &T::Host> + Send + '_> {
+        let Some(address) = address else {
+            return Box::new(self.hosts.iter().map(|host| host.as_ref()));
+        };
+
+        let mut matching_hosts: Vec<usize> = self
+            .hosts_by_address
+            .get(address.as_slice())
+            .into_iter()
+            .flatten() // Flatten non-existing `address` into empty.
+            .copied()
+            .chain(self.hosts_without_address.iter().copied())
+            .collect();
+        matching_hosts.sort();
+        Box::new(
+            matching_hosts
+                .into_iter()
+                .map(move |idx| self.hosts[idx].as_ref()),
+        )
     }
 }

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -343,7 +343,7 @@ where
                         .ctx
                         .process_trigger_in_hosts(
                             &logger,
-                            &runtime_hosts,
+                            Box::new(runtime_hosts.iter().map(|host| host.as_ref())),
                             &block,
                             &TriggerData::Onchain(trigger),
                             block_state,

--- a/core/src/subgraph/trigger_processor.rs
+++ b/core/src/subgraph/trigger_processor.rs
@@ -19,10 +19,10 @@ where
     C: Blockchain,
     T: RuntimeHostBuilder<C>,
 {
-    async fn process_trigger(
-        &self,
+    async fn process_trigger<'a>(
+        &'a self,
         logger: &Logger,
-        hosts: &[Arc<T::Host>],
+        hosts: Box<dyn Iterator<Item = &T::Host> + Send + 'a>,
         block: &Arc<C::Block>,
         trigger: &TriggerData<C>,
         mut state: BlockState<C>,

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -219,6 +219,10 @@ impl TriggerData for MockTriggerData {
     fn error_context(&self) -> String {
         todo!()
     }
+
+    fn address_match(&self) -> Option<&[u8]> {
+        None
+    }
 }
 
 #[derive(Debug)]

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -333,6 +333,14 @@ pub trait TriggerData {
     /// If there is an error when processing this trigger, this will called to add relevant context.
     /// For example an useful return is: `"block #<N> (<hash>), transaction <tx_hash>".
     fn error_context(&self) -> String;
+
+    /// If this trigger can only possibly match data sources with a specific address, then it can be
+    /// returned here for improved trigger matching performance, which helps subgraphs with many
+    /// data sources. But this optimization is not required, so returning `None` is always correct.
+    ///
+    /// When this does return `Some`, make sure that the `DataSource::address` of matching data
+    /// sources is equal to the addresssed returned here.
+    fn address_match(&self) -> Option<&[u8]>;
 }
 
 pub struct HostFnCtx<'a> {

--- a/graph/src/components/trigger_processor.rs
+++ b/graph/src/components/trigger_processor.rs
@@ -16,10 +16,10 @@ where
     C: Blockchain,
     T: RuntimeHostBuilder<C>,
 {
-    async fn process_trigger(
-        &self,
+    async fn process_trigger<'a>(
+        &'a self,
         logger: &Logger,
-        hosts: &[Arc<T::Host>],
+        hosts: Box<dyn Iterator<Item = &T::Host> + Send + 'a>,
         block: &Arc<C::Block>,
         trigger: &TriggerData<C>,
         mut state: BlockState<C>,

--- a/graph/src/data_source/mod.rs
+++ b/graph/src/data_source/mod.rs
@@ -407,6 +407,13 @@ impl<C: Blockchain> TriggerData<C> {
             Self::Offchain(trigger) => format!("{:?}", trigger.source),
         }
     }
+
+    pub fn address_match(&self) -> Option<Vec<u8>> {
+        match self {
+            Self::Onchain(trigger) => trigger.address_match().map(|address| address.to_owned()),
+            Self::Offchain(trigger) => trigger.source.address(),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/graph/src/data_source/offchain.rs
+++ b/graph/src/data_source/offchain.rs
@@ -198,12 +198,8 @@ impl DataSource {
         })
     }
 
-    /// The concept of an address may or not make sense for an offchain data source, but this is
-    /// used as the value to be returned to mappings from the `dataSource.address()` host function.
     pub fn address(&self) -> Option<Vec<u8>> {
-        match self.source {
-            Source::Ipfs(ref cid) => Some(cid.to_bytes()),
-        }
+        self.source.address()
     }
 
     pub(super) fn is_duplicate_of(&self, b: &DataSource) -> bool {
@@ -239,6 +235,20 @@ impl DataSource {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Source {
     Ipfs(CidFile),
+}
+
+impl Source {
+    /// The concept of an address may or not make sense for an offchain data source, but graph node
+    /// will use this in a few places where some sort of not necessarily unique id is useful:
+    /// 1. This is used as the value to be returned to mappings from the `dataSource.address()` host
+    ///    function, so changing this is a breaking change.
+    /// 2. This is used to match with triggers with hosts in `fn hosts_for_trigger`, so make sure
+    ///    the `source` of the data source is equal the `source` of the `TriggerData`.
+    pub fn address(&self) -> Option<Vec<u8>> {
+        match self {
+            Source::Ipfs(ref cid) => Some(cid.to_bytes()),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -342,8 +342,7 @@ struct Inner {
     external_http_base_url: Option<String>,
     #[envconfig(from = "EXTERNAL_WS_BASE_URL")]
     external_ws_base_url: Option<String>,
-    // Setting this to be unrealistically high so it doesn't get triggered.
-    #[envconfig(from = "GRAPH_STATIC_FILTERS_THRESHOLD", default = "100000000")]
+    #[envconfig(from = "GRAPH_STATIC_FILTERS_THRESHOLD", default = "10000")]
     static_filters_threshold: usize,
     // JSON-RPC specific.
     #[envconfig(from = "ETHEREUM_REORG_THRESHOLD", default = "250")]


### PR DESCRIPTION
We saw great effect from static filters on uniswap, stabilizing the firehose connection and the overall throughput of the subgraph. But they do cause a large number of false positive triggers to be received, resulting in a lot of time being spent by `fn match_and_decode` to discard those false positives.

Right now the total number of calls to `match_and_decode` would be: `n_triggers * n_data_sources`. This PR optimizes trigger matching by introducing a hash set of addresses to filter out triggers which are certain not to match any data sources, and this requires only a hash operation for each trigger.

The second commit turns on static filters for any subgraph with more than 10k data sources, under the assumption that with this optimization static filters will be an improvement for most subgraphs.