### PR TITLE
Small improvements for batch writes

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -452,7 +452,7 @@ where
         // If a deterministic error has happened, make the PoI to be the only entity that'll be stored.
         if has_errors && !is_non_fatal_errors_active {
             let is_poi_entity =
-                |entity_mod: &EntityModification| entity_mod.entity_ref().entity_type.is_poi();
+                |entity_mod: &EntityModification| entity_mod.key().entity_type.is_poi();
             mods.retain(is_poi_entity);
             // Confidence check
             assert!(

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -403,7 +403,7 @@ where
             evict_stats,
         } = block_state
             .entity_cache
-            .as_modifications()
+            .as_modifications(block.number())
             .map_err(|e| BlockProcessingError::Unknown(e.into()))?;
         section.end();
 
@@ -738,7 +738,12 @@ where
                 return Err(anyhow!("{}", err.to_string()));
             }
 
-            mods.extend(block_state.entity_cache.as_modifications()?.modifications);
+            mods.extend(
+                block_state
+                    .entity_cache
+                    .as_modifications(block.number())?
+                    .modifications,
+            );
             processed_data_sources.extend(block_state.processed_data_sources);
         }
 

--- a/graph/src/components/store/entity_cache.rs
+++ b/graph/src/components/store/entity_cache.rs
@@ -5,6 +5,7 @@ use std::fmt::{self, Debug};
 use std::sync::Arc;
 
 use crate::cheap_clone::CheapClone;
+use crate::components::store::write::EntityModification;
 use crate::components::store::{self as s, Entity, EntityKey, EntityOp, EntityOperation};
 use crate::data::store::IntoEntityIterator;
 use crate::prelude::ENV_VARS;
@@ -279,7 +280,7 @@ impl EntityCache {
 
         let mut mods = Vec::new();
         for (key, update) in self.updates {
-            use s::EntityModification::*;
+            use EntityModification::*;
 
             let current = self.current.remove(&key).and_then(|entity| entity);
             let modification = match (current, update) {

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -725,7 +725,7 @@ impl StoreEvent {
             .map(|op| {
                 use self::EntityModification::*;
                 match op {
-                    Insert { key, .. } | Overwrite { key, .. } | Remove { key } => {
+                    Insert { key, .. } | Overwrite { key, .. } | Remove { key, .. } => {
                         EntityChange::for_data(subgraph_id.clone(), key.clone())
                     }
                 }
@@ -1008,18 +1008,50 @@ pub type PoolWaitStats = Arc<RwLock<MovingStats>>;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EntityModification {
     /// Insert the entity
-    Insert { key: EntityKey, data: Entity },
+    Insert {
+        key: EntityKey,
+        data: Entity,
+        block: BlockNumber,
+        end: Option<BlockNumber>,
+    },
     /// Update the entity by overwriting it
-    Overwrite { key: EntityKey, data: Entity },
+    Overwrite {
+        key: EntityKey,
+        data: Entity,
+        block: BlockNumber,
+        end: Option<BlockNumber>,
+    },
     /// Remove the entity
-    Remove { key: EntityKey },
+    Remove { key: EntityKey, block: BlockNumber },
 }
 
 impl EntityModification {
+    pub fn insert(key: EntityKey, data: Entity, block: BlockNumber) -> Self {
+        EntityModification::Insert {
+            key,
+            data,
+            block,
+            end: None,
+        }
+    }
+
+    pub fn overwrite(key: EntityKey, data: Entity, block: BlockNumber) -> Self {
+        EntityModification::Overwrite {
+            key,
+            data,
+            block,
+            end: None,
+        }
+    }
+
+    pub fn remove(key: EntityKey, block: BlockNumber) -> Self {
+        EntityModification::Remove { key, block }
+    }
+
     pub fn entity_ref(&self) -> &EntityKey {
         use EntityModification::*;
         match self {
-            Insert { key, .. } | Overwrite { key, .. } | Remove { key } => key,
+            Insert { key, .. } | Overwrite { key, .. } | Remove { key, .. } => key,
         }
     }
 

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -289,21 +289,6 @@ impl EntityModification {
             Insert { key, .. } | Overwrite { key, .. } | Remove { key, .. } => key,
         }
     }
-
-    pub fn entity(&self) -> Option<&Entity> {
-        match self {
-            EntityModification::Insert { data, .. }
-            | EntityModification::Overwrite { data, .. } => Some(data),
-            EntityModification::Remove { .. } => None,
-        }
-    }
-
-    pub fn is_remove(&self) -> bool {
-        match self {
-            EntityModification::Remove { .. } => true,
-            _ => false,
-        }
-    }
 }
 
 /// A list of entity changes grouped by the entity type

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -101,27 +101,37 @@ impl<'a> TryFrom<&'a EntityMod> for EntityWrite<'a> {
 }
 
 impl EntityMod {
-    fn new(m: EntityModification, block: BlockNumber) -> Self {
+    fn new(m: EntityModification) -> Self {
         match m {
-            EntityModification::Insert { key, data } => Self::Insert {
+            EntityModification::Insert {
                 key,
                 data,
                 block,
-                end: None,
-            },
-            EntityModification::Overwrite { key, data } => Self::Overwrite {
+                end,
+            } => Self::Insert {
                 key,
                 data,
                 block,
-                end: None,
+                end,
             },
-            EntityModification::Remove { key } => Self::Remove { key, block },
+            EntityModification::Overwrite {
+                key,
+                data,
+                block,
+                end,
+            } => Self::Overwrite {
+                key,
+                data,
+                block,
+                end,
+            },
+            EntityModification::Remove { key, block } => Self::Remove { key, block },
         }
     }
 
     #[cfg(debug_assertions)]
-    pub fn new_test(m: EntityModification, block: BlockNumber) -> Self {
-        Self::new(m, block)
+    pub fn new_test(m: EntityModification) -> Self {
+        Self::new(m)
     }
 
     pub fn id(&self) -> &Word {
@@ -321,7 +331,7 @@ impl RowGroup {
             ));
         }
 
-        let row = EntityMod::new(emod, block);
+        let row = EntityMod::new(emod);
         self.append_row(row)
     }
 

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -468,6 +468,7 @@ impl RowGroup {
             ));
         }
 
+        self.rows.reserve(group.rows.len());
         for row in group.rows {
             self.append_row(row)?;
         }

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -283,7 +283,7 @@ impl EntityModification {
         EntityModification::Remove { key, block }
     }
 
-    pub fn entity_ref(&self) -> &EntityKey {
+    pub fn key(&self) -> &EntityKey {
         use EntityModification::*;
         match self {
             Insert { key, .. } | Overwrite { key, .. } | Remove { key, .. } => key,
@@ -649,8 +649,7 @@ impl Batch {
         let mut mods = RowGroups::new();
 
         for m in raw_mods {
-            mods.group_entry(&m.entity_ref().entity_type)
-                .push(m, block)?;
+            mods.group_entry(&m.key().entity_type).push(m, block)?;
         }
 
         let data_sources = DataSources::new(block_ptr.cheap_clone(), data_sources);

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -124,13 +124,13 @@ pub mod prelude {
     pub use crate::components::server::query::GraphQLServer;
     pub use crate::components::server::subscription::SubscriptionServer;
     pub use crate::components::store::{
-        AttributeNames, BlockNumber, CachedEthereumCall, ChainStore, Child, ChildMultiplicity,
-        EntityCache, EntityChange, EntityChangeOperation, EntityCollection, EntityFilter,
-        EntityLink, EntityModification, EntityOperation, EntityOrder, EntityOrderByChild,
-        EntityOrderByChildInfo, EntityQuery, EntityRange, EntityWindow, EthereumCallCache,
-        ParentLink, PartialBlockPtr, PoolWaitStats, QueryStore, QueryStoreManager, StoreError,
-        StoreEvent, StoreEventStream, StoreEventStreamBox, SubgraphStore, UnfailOutcome,
-        WindowAttribute, BLOCK_NUMBER_MAX,
+        write::EntityModification, AttributeNames, BlockNumber, CachedEthereumCall, ChainStore,
+        Child, ChildMultiplicity, EntityCache, EntityChange, EntityChangeOperation,
+        EntityCollection, EntityFilter, EntityLink, EntityOperation, EntityOrder,
+        EntityOrderByChild, EntityOrderByChildInfo, EntityQuery, EntityRange, EntityWindow,
+        EthereumCallCache, ParentLink, PartialBlockPtr, PoolWaitStats, QueryStore,
+        QueryStoreManager, StoreError, StoreEvent, StoreEventStream, StoreEventStreamBox,
+        SubgraphStore, UnfailOutcome, WindowAttribute, BLOCK_NUMBER_MAX,
     };
     pub use crate::components::subgraph::{
         BlockState, DataSourceTemplateInfo, HostMetrics, RuntimeHost, RuntimeHostBuilder,

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -489,12 +489,7 @@ async fn run_ipfs_map(
             .modifications;
 
         // Bring the modifications into a predictable order (by entity_id)
-        mods.sort_by(|a, b| {
-            a.entity_ref()
-                .entity_id
-                .partial_cmp(&b.entity_ref().entity_id)
-                .unwrap()
-        });
+        mods.sort_by(|a, b| a.key().entity_id.partial_cmp(&b.key().entity_id).unwrap());
         Ok(mods)
     })
     .join()

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -441,7 +441,7 @@ fn make_thing(id: &str, value: &str) -> (String, EntityModification) {
     let key = EntityKey::data("Thing".to_string(), id);
     (
         format!("{{ \"id\": \"{}\", \"value\": \"{}\"}}", id, value),
-        EntityModification::Insert { key, data },
+        EntityModification::insert(key, data, 0),
     )
 }
 
@@ -485,7 +485,7 @@ async fn run_ipfs_map(
             .ctx
             .state
             .entity_cache
-            .as_modifications()?
+            .as_modifications(0)?
             .modifications;
 
         // Bring the modifications into a predictable order (by entity_id)
@@ -1017,7 +1017,7 @@ async fn test_entity_store(api_version: Version) {
         &mut module.instance_ctx_mut().ctx.state.entity_cache,
         EntityCache::new(Arc::new(writable.clone())),
     );
-    let mut mods = cache.as_modifications().unwrap().modifications;
+    let mut mods = cache.as_modifications(0).unwrap().modifications;
     assert_eq!(1, mods.len());
     match mods.pop().unwrap() {
         EntityModification::Overwrite { data, .. } => {
@@ -1038,7 +1038,7 @@ async fn test_entity_store(api_version: Version) {
         .ctx
         .state
         .entity_cache
-        .as_modifications()
+        .as_modifications(0)
         .unwrap()
         .modifications;
     assert_eq!(1, mods.len());

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -1497,6 +1497,7 @@ impl WritableStoreTrait for WritableStore {
         processed_data_sources: Vec<StoredDynamicDataSource>,
     ) -> Result<(), StoreError> {
         let batch = Batch::new(
+            self.store.input_schema.cheap_clone(),
             block_ptr_to.clone(),
             firehose_cursor.clone(),
             mods,

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -290,7 +290,7 @@ pub async fn transact_entities_and_dynamic_data_sources(
     let mut entity_cache = EntityCache::new(Arc::new(store.clone()));
     entity_cache.append(ops);
     let mods = entity_cache
-        .as_modifications()
+        .as_modifications(block_ptr_to.number)
         .expect("failed to convert to modifications")
         .modifications;
     let metrics_registry = Arc::new(MetricsRegistry::mock());

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -183,7 +183,7 @@ fn make_band_key(id: &'static str) -> EntityKey {
 }
 
 fn sort_by_entity_key(mut mods: Vec<EntityModification>) -> Vec<EntityModification> {
-    mods.sort_by_key(|m| m.entity_ref().clone());
+    mods.sort_by_key(|m| m.key().clone());
     mods
 }
 

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -191,7 +191,7 @@ fn sort_by_entity_key(mut mods: Vec<EntityModification>) -> Vec<EntityModificati
 async fn empty_cache_modifications() {
     let store = Arc::new(MockStore::new(BTreeMap::new()));
     let cache = EntityCache::new(store);
-    let result = cache.as_modifications();
+    let result = cache.as_modifications(0);
     assert_eq!(result.unwrap().modifications, vec![]);
 }
 
@@ -214,18 +214,12 @@ fn insert_modifications() {
         .set(sigurros_key.clone(), sigurros_data.clone())
         .unwrap();
 
-    let result = cache.as_modifications();
+    let result = cache.as_modifications(0);
     assert_eq!(
         sort_by_entity_key(result.unwrap().modifications),
         sort_by_entity_key(vec![
-            EntityModification::Insert {
-                key: mogwai_key,
-                data: mogwai_data,
-            },
-            EntityModification::Insert {
-                key: sigurros_key,
-                data: sigurros_data,
-            }
+            EntityModification::insert(mogwai_key, mogwai_data, 0),
+            EntityModification::insert(sigurros_key, sigurros_data, 0)
         ])
     );
 }
@@ -268,18 +262,12 @@ fn overwrite_modifications() {
         .set(sigurros_key.clone(), sigurros_data.clone())
         .unwrap();
 
-    let result = cache.as_modifications();
+    let result = cache.as_modifications(0);
     assert_eq!(
         sort_by_entity_key(result.unwrap().modifications),
         sort_by_entity_key(vec![
-            EntityModification::Overwrite {
-                key: mogwai_key,
-                data: mogwai_data,
-            },
-            EntityModification::Overwrite {
-                key: sigurros_key,
-                data: sigurros_data,
-            }
+            EntityModification::overwrite(mogwai_key, mogwai_data, 0),
+            EntityModification::overwrite(sigurros_key, sigurros_data, 0)
         ])
     );
 }
@@ -311,13 +299,14 @@ fn consecutive_modifications() {
 
     // We expect a single overwrite modification for the above that leaves "id"
     // and "name" untouched, sets "founded" and removes the "label" field.
-    let result = cache.as_modifications();
+    let result = cache.as_modifications(0);
     assert_eq!(
         sort_by_entity_key(result.unwrap().modifications),
-        sort_by_entity_key(vec![EntityModification::Overwrite {
-            key: update_key,
-            data: entity! { SCHEMA => id: "mogwai", name: "Mogwai", founded: 1995 }
-        }])
+        sort_by_entity_key(vec![EntityModification::overwrite(
+            update_key,
+            entity! { SCHEMA => id: "mogwai", name: "Mogwai", founded: 1995 },
+            0
+        )])
     );
 }
 

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -87,7 +87,7 @@ pub fn row_group_update(
     let mut group = RowGroup::new(entity_type.clone());
     for (key, data) in data {
         group
-            .push(EntityModification::Overwrite { key, data }, block)
+            .push(EntityModification::overwrite(key, data, block), block)
             .unwrap();
     }
     group
@@ -101,7 +101,7 @@ pub fn row_group_insert(
     let mut group = RowGroup::new(entity_type.clone());
     for (key, data) in data {
         group
-            .push(EntityModification::Insert { key, data }, block)
+            .push(EntityModification::insert(key, data, block), block)
             .unwrap();
     }
     group
@@ -115,7 +115,7 @@ pub fn row_group_delete(
     let mut group = RowGroup::new(entity_type.clone());
     for key in data {
         group
-            .push(EntityModification::Remove { key }, block)
+            .push(EntityModification::remove(key, block), block)
             .unwrap();
     }
     group

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -84,7 +84,7 @@ pub fn row_group_update(
     block: BlockNumber,
     data: impl IntoIterator<Item = (EntityKey, Entity)>,
 ) -> RowGroup {
-    let mut group = RowGroup::new(entity_type.clone());
+    let mut group = RowGroup::new(entity_type.clone(), false);
     for (key, data) in data {
         group
             .push(EntityModification::overwrite(key, data, block), block)
@@ -98,7 +98,7 @@ pub fn row_group_insert(
     block: BlockNumber,
     data: impl IntoIterator<Item = (EntityKey, Entity)>,
 ) -> RowGroup {
-    let mut group = RowGroup::new(entity_type.clone());
+    let mut group = RowGroup::new(entity_type.clone(), false);
     for (key, data) in data {
         group
             .push(EntityModification::insert(key, data, block), block)
@@ -112,7 +112,7 @@ pub fn row_group_delete(
     block: BlockNumber,
     data: impl IntoIterator<Item = EntityKey>,
 ) -> RowGroup {
-    let mut group = RowGroup::new(entity_type.clone());
+    let mut group = RowGroup::new(entity_type.clone(), false);
     for key in data {
         group
             .push(EntityModification::remove(key, block), block)

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -1492,12 +1492,17 @@ fn handle_large_string_with_index() {
     const ONE: &str = "large_string_one";
     const TWO: &str = "large_string_two";
 
-    fn make_insert_op(id: &str, name: &str, schema: &InputSchema) -> EntityModification {
+    fn make_insert_op(
+        id: &str,
+        name: &str,
+        schema: &InputSchema,
+        block: BlockNumber,
+    ) -> EntityModification {
         let data = entity! { schema => id: id, name: name };
 
         let key = EntityKey::data(USER.to_owned(), id.to_owned());
 
-        EntityModification::Insert { key, data }
+        EntityModification::insert(key, data, block)
     }
 
     run_test(|store, writable, deployment| async move {
@@ -1518,13 +1523,14 @@ fn handle_large_string_with_index() {
             metrics_registry.clone(),
         );
 
+        let block = TEST_BLOCK_3_PTR.number;
         writable
             .transact_block_operations(
                 TEST_BLOCK_3_PTR.clone(),
                 FirehoseCursor::None,
                 vec![
-                    make_insert_op(ONE, &long_text, &schema),
-                    make_insert_op(TWO, &other_text, &schema),
+                    make_insert_op(ONE, &long_text, &schema, block),
+                    make_insert_op(TWO, &other_text, &schema, block),
                 ],
                 &stopwatch_metrics,
                 Vec::new(),
@@ -1580,12 +1586,17 @@ fn handle_large_bytea_with_index() {
     const ONE: &str = "large_string_one";
     const TWO: &str = "large_string_two";
 
-    fn make_insert_op(id: &str, name: &[u8], schema: &InputSchema) -> EntityModification {
+    fn make_insert_op(
+        id: &str,
+        name: &[u8],
+        schema: &InputSchema,
+        block: BlockNumber,
+    ) -> EntityModification {
         let data = entity! { schema => id: id, bin_name: scalar::Bytes::from(name) };
 
         let key = EntityKey::data(USER.to_owned(), id.to_owned());
 
-        EntityModification::Insert { key, data }
+        EntityModification::insert(key, data, block)
     }
 
     run_test(|store, writable, deployment| async move {
@@ -1611,13 +1622,14 @@ fn handle_large_bytea_with_index() {
             metrics_registry.clone(),
         );
 
+        let block = TEST_BLOCK_3_PTR.number;
         writable
             .transact_block_operations(
                 TEST_BLOCK_3_PTR.clone(),
                 FirehoseCursor::None,
                 vec![
-                    make_insert_op(ONE, &long_bytea, &schema),
-                    make_insert_op(TWO, &other_bytea, &schema),
+                    make_insert_op(ONE, &long_bytea, &schema, block),
+                    make_insert_op(TWO, &other_bytea, &schema, block),
                 ],
                 &stopwatch_metrics,
                 Vec::new(),


### PR DESCRIPTION
These changes mostly clean up a little bit of code around batched writes:

* we have two structs, `EntityMod` and `EntityModification` that are almost identical. Change that so we only have one
* for immutable entities, there's no point in searching for a previous change as there can't be one