### PR TITLE
Add subgraph-specific settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,6 +1580,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_plain",
+ "serde_regex",
  "serde_yaml",
  "slog",
  "slog-async",
@@ -1594,6 +1595,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tokio-stream",
+ "toml 0.7.4",
  "tonic",
  "tonic-build",
  "url",
@@ -1791,10 +1793,8 @@ dependencies = [
  "lazy_static",
  "prometheus",
  "serde",
- "serde_regex",
  "shellexpand",
  "termcolor",
- "toml 0.7.1",
  "url",
 ]
 
@@ -2908,15 +2908,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
-name = "nom8"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3975,9 +3966,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
 ]
@@ -4716,9 +4707,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772c1426ab886e7362aedf4abc9c0d1348a979517efedfc25862944d10137af0"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -4728,24 +4719,24 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.1"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a238ee2e6ede22fb95350acc78e21dc40da00bb66c0334bde83de4ed89424e"
+checksum = "92d964908cec0d030b812013af25a0e57fddfadb1e066ecc6681d86253129d4f"
 dependencies = [
  "indexmap",
- "nom8",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -5742,6 +5733,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -33,6 +33,7 @@ semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.126", features = ["rc"] }
 serde_derive = "1.0.125"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
+serde_regex = "1.1.0"
 serde_yaml = "0.9.21"
 slog = { version = "2.7.0", features = ["release_max_level_trace", "max_level_trace"] }
 stable-hash_legacy = { version = "0.3.3", package = "stable-hash" }
@@ -47,6 +48,7 @@ tiny-keccak = "1.5.0"
 tokio = { version = "1.28.1", features = ["time", "sync", "macros", "test-util", "rt-multi-thread", "parking_lot"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tokio-retry = "0.3.0"
+toml = "0.7.4"
 url = "2.3.1"
 prometheus = "0.13.3"
 priority-queue = "0.7.0"

--- a/graph/src/components/subgraph/mod.rs
+++ b/graph/src/components/subgraph/mod.rs
@@ -4,6 +4,7 @@ mod instance_manager;
 mod proof_of_indexing;
 mod provider;
 mod registrar;
+mod settings;
 
 pub use crate::prelude::Entity;
 
@@ -16,3 +17,4 @@ pub use self::proof_of_indexing::{
 };
 pub use self::provider::SubgraphAssignmentProvider;
 pub use self::registrar::{SubgraphRegistrar, SubgraphVersionSwitchingMode};
+pub use self::settings::{Setting, Settings};

--- a/graph/src/components/subgraph/settings.rs
+++ b/graph/src/components/subgraph/settings.rs
@@ -1,0 +1,94 @@
+//! Facilities for dealing with subgraph-specific settings
+use std::fs::read_to_string;
+
+use crate::{
+    anyhow,
+    prelude::{regex::Regex, SubgraphName},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum Predicate {
+    #[serde(alias = "name", with = "serde_regex")]
+    Name(Regex),
+}
+
+impl Predicate {
+    fn matches(&self, name: &SubgraphName) -> bool {
+        match self {
+            Predicate::Name(rx) => rx.is_match(name.as_str()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Setting {
+    #[serde(alias = "match")]
+    pred: Predicate,
+    pub history_blocks: i32,
+}
+
+impl Setting {
+    fn matches(&self, name: &SubgraphName) -> bool {
+        self.pred.matches(name)
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct Settings {
+    #[serde(alias = "setting")]
+    settings: Vec<Setting>,
+}
+
+impl Settings {
+    pub fn from_file(path: &str) -> Result<Self, anyhow::Error> {
+        Self::from_str(&read_to_string(path)?)
+    }
+
+    pub fn from_str(toml: &str) -> Result<Self, anyhow::Error> {
+        toml::from_str::<Self>(toml).map_err(anyhow::Error::from)
+    }
+
+    pub fn for_name(&self, name: &SubgraphName) -> Option<&Setting> {
+        self.settings.iter().find(|setting| setting.matches(name))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Predicate, Settings};
+
+    #[test]
+    fn parses_correctly() {
+        let content = r#"
+        [[setting]]
+        match = { name = ".*" }
+        history_blocks = 10000
+
+        [[setting]]
+        match = { name = "xxxxx" }
+        history_blocks = 10000
+
+        [[setting]]
+        match = { name = ".*!$" }
+        history_blocks = 10000
+        "#;
+
+        let section = Settings::from_str(content).unwrap();
+        assert_eq!(section.settings.len(), 3);
+
+        let rule1 = match &section.settings[0].pred {
+            Predicate::Name(name) => name,
+        };
+        assert_eq!(rule1.as_str(), ".*");
+
+        let rule2 = match &section.settings[1].pred {
+            Predicate::Name(name) => name,
+        };
+        assert_eq!(rule2.as_str(), "xxxxx");
+        let rule1 = match &section.settings[2].pred {
+            Predicate::Name(name) => name,
+        };
+        assert_eq!(rule1.as_str(), ".*!$");
+    }
+}

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -172,6 +172,9 @@ pub struct EnvVars {
     /// Set by the environment variable `ETHEREUM_REORG_THRESHOLD`. The default
     /// value is 250 blocks.
     pub reorg_threshold: BlockNumber,
+    /// Set by the env var `GRAPH_EXPERIMENTAL_SUBGRAPH_SETTINGS` which should point
+    /// to a file with subgraph-specific settings
+    pub subgraph_settings: Option<String>,
 }
 
 impl EnvVars {
@@ -229,6 +232,7 @@ impl EnvVars {
             external_ws_base_url: inner.external_ws_base_url,
             static_filters_threshold: inner.static_filters_threshold,
             reorg_threshold: inner.reorg_threshold,
+            subgraph_settings: inner.subgraph_settings,
         })
     }
 
@@ -347,6 +351,8 @@ struct Inner {
     // JSON-RPC specific.
     #[envconfig(from = "ETHEREUM_REORG_THRESHOLD", default = "250")]
     reorg_threshold: BlockNumber,
+    #[envconfig(from = "GRAPH_EXPERIMENTAL_SUBGRAPH_SETTINGS")]
+    subgraph_settings: Option<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -89,6 +89,7 @@ pub mod prelude {
     pub use serde;
     pub use serde_derive::{Deserialize, Serialize};
     pub use serde_json;
+    pub use serde_regex;
     pub use serde_yaml;
     pub use slog::{self, crit, debug, error, info, o, trace, warn, Logger};
     pub use std::convert::TryFrom;
@@ -100,6 +101,7 @@ pub mod prelude {
     pub use thiserror;
     pub use tiny_keccak;
     pub use tokio;
+    pub use toml;
     pub use tonic;
     pub use web3;
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -36,8 +36,6 @@ graph-server-websocket = { path = "../server/websocket" }
 graph-server-metrics = { path = "../server/metrics" }
 graph-store-postgres = { path = "../store/postgres" }
 serde = { version = "1.0.126", features = ["derive", "rc"] }
-serde_regex = "1.1.0"
-toml = "0.7.1"
 shellexpand = "3.1.0"
 termcolor = "1.2.0"
 diesel = "1.4.8"

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -383,6 +383,15 @@ pub enum ConfigCommand {
         features: String,
         network: String,
     },
+    /// Show subgraph-specific settings
+    ///
+    /// GRAPH_EXPERIMENTAL_SUBGRAPH_SETTINGS can add a file that contains
+    /// subgraph-specific settings. This command determines which settings
+    /// would apply when a subgraph <name> is deployed and prints the result
+    Setting {
+        /// The subgraph name for which to print settings
+        name: String,
+    },
 }
 
 #[derive(Clone, Debug, Subcommand)]
@@ -1079,6 +1088,7 @@ async fn main() -> anyhow::Result<()> {
                     commands::config::provider(logger, &ctx.config, registry, features, network)
                         .await
                 }
+                Setting { name } => commands::config::setting(&name),
             }
         }
         Remove { name } => commands::remove::run(ctx.subgraph_store(), &name),

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -10,7 +10,7 @@ use graph::{
             de::{self, value, SeqAccess, Visitor},
             Deserialize, Deserializer, Serialize,
         },
-        serde_json, Logger, NodeId, StoreError,
+        serde_json, serde_regex, toml, Logger, NodeId, StoreError,
     },
 };
 use graph_chain_ethereum::{self as ethereum, NodeCapabilities};
@@ -1155,7 +1155,7 @@ mod tests {
     use graph::blockchain::BlockchainKind;
     use graph::firehose::SubgraphLimit;
     use graph::prelude::regex::Regex;
-    use graph::prelude::NodeId;
+    use graph::prelude::{toml, NodeId};
     use http::{HeaderMap, HeaderValue};
     use std::collections::BTreeSet;
     use std::fs::read_to_string;
@@ -1460,7 +1460,7 @@ mod tests {
                 details = { type = "firehose", url = "http://localhost:9000" }
                 match = [
                   { name = "some_node_.*", limit = 10 },
-                  { name = "other_node_.*", limit = 0 } ] 
+                  { name = "other_node_.*", limit = 0 } ]
             "#,
         )
         .unwrap();
@@ -1498,7 +1498,7 @@ mod tests {
                 details = { type = "substreams", url = "http://localhost:9000" }
                 match = [
                   { name = "some_node_.*", limit = 101 },
-                  { name = "other_node_.*", limit = 0 } ] 
+                  { name = "other_node_.*", limit = 0 } ]
             "#,
         )
         .unwrap();
@@ -1536,7 +1536,7 @@ mod tests {
                 details = { type = "substreams", url = "http://localhost:9000" }
                 match = [
                   { name = "some_node_.*", limit = 10 },
-                  { name = "other_node_.*", limit = 0 } ] 
+                  { name = "other_node_.*", limit = 0 } ]
             "#,
         )
         .unwrap();
@@ -1574,7 +1574,7 @@ mod tests {
                 details = { type = "substreams", url = "http://localhost:9000" }
                 match = [
                   { name = "some_node_.*", limit = 101 },
-                  { name = "other_node_.*", limit = 0 } ] 
+                  { name = "other_node_.*", limit = 0 } ]
             "#,
         )
         .unwrap();

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -17,6 +17,7 @@ use graph::blockchain::client::ChainClient;
 use graph::blockchain::{BlockchainKind, BlockchainMap};
 use graph::cheap_clone::CheapClone;
 use graph::components::store::{BlockStore as _, DeploymentLocator};
+use graph::components::subgraph::Settings;
 use graph::endpoint::EndpointMetrics;
 use graph::env::EnvVars;
 use graph::firehose::FirehoseEndpoints;
@@ -198,6 +199,7 @@ pub async fn run(
         blockchain_map,
         node_id.clone(),
         SubgraphVersionSwitchingMode::Instant,
+        Arc::new(Settings::default()),
     ));
 
     let (name, hash) = if subgraph.contains(':') {

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -973,7 +973,7 @@ mod data {
                     use public::eth_call_meta as meta;
 
                     cache::table
-                        .find(id.as_ref())
+                        .find::<&[u8]>(id.as_ref())
                         .inner_join(meta::table)
                         .select((
                             cache::return_value,
@@ -1101,7 +1101,7 @@ mod data {
                 Storage::Shared => {
                     use public::eth_call_meta as meta;
 
-                    update(meta::table.find(contract_address.as_ref()))
+                    update(meta::table.find::<&[u8]>(contract_address.as_ref()))
                         .set(meta::accessed_at.eq(sql("CURRENT_DATE")))
                         .execute(conn)
                 }

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -18,6 +18,7 @@ use graph::blockchain::{
 use graph::cheap_clone::CheapClone;
 use graph::components::metrics::MetricsRegistry;
 use graph::components::store::{BlockStore, DeploymentLocator};
+use graph::components::subgraph::Settings;
 use graph::data::graphql::effort::LoadManager;
 use graph::data::query::{Query, QueryTarget};
 use graph::data::subgraph::schema::{SubgraphError, SubgraphHealth};
@@ -408,6 +409,7 @@ pub async fn setup<C: Blockchain>(
         blockchain_map.clone(),
         node_id.clone(),
         SubgraphVersionSwitchingMode::Instant,
+        Arc::new(Settings::default()),
     ));
 
     SubgraphRegistrar::create_subgraph(subgraph_registrar.as_ref(), subgraph_name.clone())


### PR DESCRIPTION
This PR achieves a very similar result as #4622 but with a few important differences:

* rule evaluation is predictable as rules are always evaluated in the order in which they are listed in the settings file
* the command `graphman config check` will check the settings file for validity if one is set in the environment
* the command `graphman config setting <name>` will print what setting will be used when deploying a new subgraph `name`

The syntax of the file is also slightly different to streamline it a bit:
```toml
[[setting]]
match = { name = "foo/.*" }
history_blocks = 100

[[setting]]
match = { name = ".*/bar" }
history_blocks = 200
```