### PR TITLE
Add MappingTrigger.error_context()  to error logs

### DIFF
--- a/chain/arweave/src/trigger.rs
+++ b/chain/arweave/src/trigger.rs
@@ -1,4 +1,5 @@
 use graph::blockchain::Block;
+use graph::blockchain::MappingTriggerTrait;
 use graph::blockchain::TriggerData;
 use graph::cheap_clone::CheapClone;
 use graph::prelude::web3::types::H256;
@@ -87,6 +88,22 @@ impl ArweaveTrigger {
             ArweaveTrigger::Transaction(tx) => tx.block.ptr().hash_as_h256(),
         }
     }
+
+    fn error_context(&self) -> std::string::String {
+        match self {
+            ArweaveTrigger::Block(..) => {
+                format!("Block #{} ({})", self.block_number(), self.block_hash())
+            }
+            ArweaveTrigger::Transaction(tx) => {
+                format!(
+                    "Tx #{}, block #{}({})",
+                    base64_url::encode(&tx.tx.id),
+                    self.block_number(),
+                    self.block_hash()
+                )
+            }
+        }
+    }
 }
 
 impl Ord for ArweaveTrigger {
@@ -113,20 +130,14 @@ impl PartialOrd for ArweaveTrigger {
 }
 
 impl TriggerData for ArweaveTrigger {
-    fn error_context(&self) -> std::string::String {
-        match self {
-            ArweaveTrigger::Block(..) => {
-                format!("Block #{} ({})", self.block_number(), self.block_hash())
-            }
-            ArweaveTrigger::Transaction(tx) => {
-                format!(
-                    "Tx #{}, block #{}({})",
-                    base64_url::encode(&tx.tx.id),
-                    self.block_number(),
-                    self.block_hash()
-                )
-            }
-        }
+    fn error_context(&self) -> String {
+        self.error_context()
+    }
+}
+
+impl MappingTriggerTrait for ArweaveTrigger {
+    fn error_context(&self) -> String {
+        self.error_context()
     }
 }
 

--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -1,3 +1,4 @@
+use graph::blockchain::MappingTriggerTrait;
 use graph::blockchain::TriggerData;
 use graph::data::subgraph::API_VERSION_0_0_2;
 use graph::data::subgraph::API_VERSION_0_0_6;
@@ -59,6 +60,21 @@ pub enum MappingTrigger {
     Block {
         block: Arc<LightEthereumBlock>,
     },
+}
+
+impl MappingTriggerTrait for MappingTrigger {
+    fn error_context(&self) -> std::string::String {
+        let transaction_id = match self {
+            MappingTrigger::Log { log, .. } => log.transaction_hash,
+            MappingTrigger::Call { call, .. } => call.transaction_hash,
+            MappingTrigger::Block { .. } => None,
+        };
+
+        match transaction_id {
+            Some(tx_hash) => format!("transaction {:x}", tx_hash),
+            None => String::new(),
+        }
+    }
 }
 
 // Logging the block is too verbose, so this strips the block from the trigger for Debug.

--- a/chain/near/src/trigger.rs
+++ b/chain/near/src/trigger.rs
@@ -1,4 +1,5 @@
 use graph::blockchain::Block;
+use graph::blockchain::MappingTriggerTrait;
 use graph::blockchain::TriggerData;
 use graph::cheap_clone::CheapClone;
 use graph::prelude::hex;
@@ -91,6 +92,22 @@ impl NearTrigger {
             NearTrigger::Receipt(receipt) => receipt.block.ptr().hash_as_h256(),
         }
     }
+
+    fn error_context(&self) -> std::string::String {
+        match self {
+            NearTrigger::Block(..) => {
+                format!("Block #{} ({})", self.block_number(), self.block_hash())
+            }
+            NearTrigger::Receipt(receipt) => {
+                format!(
+                    "receipt id {}, block #{} ({})",
+                    hex::encode(&receipt.receipt.receipt_id.as_ref().unwrap().bytes),
+                    self.block_number(),
+                    self.block_hash()
+                )
+            }
+        }
+    }
 }
 
 impl Ord for NearTrigger {
@@ -117,20 +134,14 @@ impl PartialOrd for NearTrigger {
 }
 
 impl TriggerData for NearTrigger {
-    fn error_context(&self) -> std::string::String {
-        match self {
-            NearTrigger::Block(..) => {
-                format!("Block #{} ({})", self.block_number(), self.block_hash())
-            }
-            NearTrigger::Receipt(receipt) => {
-                format!(
-                    "receipt id {}, block #{} ({})",
-                    hex::encode(&receipt.receipt.receipt_id.as_ref().unwrap().bytes),
-                    self.block_number(),
-                    self.block_hash()
-                )
-            }
-        }
+    fn error_context(&self) -> String {
+        self.error_context()
+    }
+}
+
+impl MappingTriggerTrait for NearTrigger {
+    fn error_context(&self) -> String {
+        self.error_context()
     }
 }
 

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -2,7 +2,9 @@ use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use anyhow::Error;
 use graph::{
-    blockchain::{self, block_stream::BlockWithTriggers, BlockPtr, EmptyNodeCapabilities},
+    blockchain::{
+        self, block_stream::BlockWithTriggers, BlockPtr, EmptyNodeCapabilities, MappingTriggerTrait,
+    },
     components::{
         store::{DeploymentLocator, EntityKey, EntityType, SubgraphFork},
         subgraph::{MappingError, ProofOfIndexingEvent, SharedProofOfIndexing},
@@ -24,6 +26,12 @@ use crate::{codec::entity_change::Operation, Block, Chain, NoopDataSourceTemplat
 
 #[derive(Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub struct TriggerData {}
+
+impl MappingTriggerTrait for TriggerData {
+    fn error_context(&self) -> String {
+        "Failed to process substreams block".to_string()
+    }
+}
 
 impl blockchain::TriggerData for TriggerData {
     // TODO(filipe): Can this be improved with some data from the block?

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -14,7 +14,8 @@ use std::{convert::TryFrom, sync::Arc};
 use super::{
     block_stream::{self, BlockStream, FirehoseCursor},
     client::ChainClient,
-    BlockIngestor, EmptyNodeCapabilities, HostFn, IngestorError, TriggerWithHandler,
+    BlockIngestor, EmptyNodeCapabilities, HostFn, IngestorError, MappingTriggerTrait,
+    TriggerWithHandler,
 };
 
 use super::{
@@ -224,6 +225,11 @@ impl TriggerData for MockTriggerData {
 #[derive(Debug)]
 pub struct MockMappingTrigger {}
 
+impl MappingTriggerTrait for MockMappingTrigger {
+    fn error_context(&self) -> String {
+        todo!()
+    }
+}
 #[derive(Clone, Default)]
 pub struct MockTriggerFilter;
 

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -167,7 +167,7 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
 
     /// Decoded trigger ready to be processed by the mapping.
     /// New implementations should have this be the same as `TriggerData`.
-    type MappingTrigger: Send + Sync + Debug;
+    type MappingTrigger: MappingTriggerTrait + Send + Sync + Debug;
 
     /// Trigger filter used as input to the triggers adapter.
     type TriggerFilter: TriggerFilter<Self>;
@@ -330,6 +330,12 @@ pub trait UnresolvedDataSource<C: Blockchain>:
 }
 
 pub trait TriggerData {
+    /// If there is an error when processing this trigger, this will called to add relevant context.
+    /// For example an useful return is: `"block #<N> (<hash>), transaction <tx_hash>".
+    fn error_context(&self) -> String;
+}
+
+pub trait MappingTriggerTrait {
     /// If there is an error when processing this trigger, this will called to add relevant context.
     /// For example an useful return is: `"block #<N> (<hash>), transaction <tx_hash>".
     fn error_context(&self) -> String;

--- a/graph/src/data_source/mod.rs
+++ b/graph/src/data_source/mod.rs
@@ -8,8 +8,8 @@ mod tests;
 
 use crate::{
     blockchain::{
-        BlockPtr, Blockchain, DataSource as _, DataSourceTemplate as _, TriggerData as _,
-        UnresolvedDataSource as _, UnresolvedDataSourceTemplate as _,
+        BlockPtr, Blockchain, DataSource as _, DataSourceTemplate as _, MappingTriggerTrait,
+        TriggerData as _, UnresolvedDataSource as _, UnresolvedDataSourceTemplate as _,
     },
     components::{
         link_resolver::LinkResolver,
@@ -413,6 +413,15 @@ impl<C: Blockchain> TriggerData<C> {
 pub enum MappingTrigger<C: Blockchain> {
     Onchain(C::MappingTrigger),
     Offchain(offchain::TriggerData),
+}
+
+impl<C: Blockchain> MappingTrigger<C> {
+    pub fn error_context(&self) -> String {
+        match self {
+            Self::Onchain(trigger) => trigger.error_context(),
+            Self::Offchain(trigger) => format!("{:?}", trigger.source),
+        }
+    }
 }
 
 macro_rules! clone_data_source {

--- a/graph/src/data_source/mod.rs
+++ b/graph/src/data_source/mod.rs
@@ -416,10 +416,10 @@ pub enum MappingTrigger<C: Blockchain> {
 }
 
 impl<C: Blockchain> MappingTrigger<C> {
-    pub fn error_context(&self) -> String {
+    pub fn error_context(&self) -> Option<String> {
         match self {
-            Self::Onchain(trigger) => trigger.error_context(),
-            Self::Offchain(trigger) => format!("{:?}", trigger.source),
+            Self::Onchain(trigger) => Some(trigger.error_context()),
+            Self::Offchain(_) => None, // TODO: Add error context for offchain triggers
         }
     }
 }

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -240,7 +240,7 @@ impl<C: Blockchain> WasmInstance<C> {
         handler: &str,
         arg: AscPtr<T>,
         logging_extras: Arc<dyn SendSyncRefUnwindSafeKV>,
-        error_context: String,
+        error_context: Option<String>,
     ) -> Result<(BlockState<C>, Gas), MappingError> {
         let func = self
             .instance
@@ -290,7 +290,10 @@ impl<C: Blockchain> WasmInstance<C> {
         };
 
         if let Some(deterministic_error) = deterministic_error {
-            let deterministic_error = deterministic_error.context(error_context);
+            let deterministic_error = match error_context {
+                Some(error_context) => deterministic_error.context(error_context),
+                None => deterministic_error,
+            };
             let message = format!("{:#}", deterministic_error).replace('\n', "\t");
 
             // Log the error and restore the updates snapshot, effectively reverting the handler.

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -290,8 +290,8 @@ impl<C: Blockchain> WasmInstance<C> {
         };
 
         if let Some(deterministic_error) = deterministic_error {
-            let message =
-                format!("{:#}, {}", deterministic_error, error_context).replace('\n', "\t");
+            let deterministic_error = deterministic_error.context(error_context);
+            let message = format!("{:#}", deterministic_error).replace('\n', "\t");
 
             // Log the error and restore the updates snapshot, effectively reverting the handler.
             error!(&self.instance_ctx().ctx.logger,


### PR DESCRIPTION
Closes #4437 , Closes #3694

This PR allows details like transaction hash to be added to an `error_context()` method on `MappingTrigger`  which can then be logged or returned with `SubgraphError`