### PR TITLE
CONTRIBUTING.md: Updating deprecated rustfmt-preview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Install development helpers:
 
 ```sh
 cargo install cargo-watch
-rustup component add rustfmt-preview
+rustup component add rustfmt
 ```
 
 Set environment variables:


### PR DESCRIPTION
Rust has deprecated the `rustfmt-preview` with the `rustfmt` component. `rustup` understands that `rustfmt-preview` is now just `rustfmt` and checks for that instead, but we could still just update this to the new command.

> Second, this is a preview, as it says in the name. rustfmt is not at 1.0 yet, and some stuff is being tweaked, and bugs are being fixed. Once rustfmt hits 1.0, we'll be releasing a rustfmt component and deprecating rustfmt-preview.

https://blog.rust-lang.org/2018/02/15/Rust-1.24.html