### PR TITLE
Make `Bytes` `id` in substreams roundtrip-safe

### DIFF
--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -219,13 +219,8 @@ where
                             }
                         }
                     };
-                    let key = EntityKey {
-                        entity_type: entity_type.clone(),
-                        entity_id: entity_id.clone().into(),
-                        causality_region: CausalityRegion::ONCHAIN, // Substreams don't currently support offchain data
-                    };
-                    let mut data: HashMap<Word, Value> = HashMap::from_iter(vec![]);
 
+                    let mut data: HashMap<Word, Value> = HashMap::from_iter(vec![]);
                     for field in entity_change.fields.iter() {
                         let new_value: &codec::value::Typed = match &field.new_value {
                             Some(codec::Value {
@@ -236,7 +231,7 @@ where
 
                         let value: Value = decode_value(new_value)?;
                         *data
-                            .entry(Word::from(field.name.clone()))
+                            .entry(Word::from(field.name.as_str()))
                             .or_insert(Value::Null) = value;
                     }
 
@@ -251,6 +246,12 @@ where
                         causality_region,
                         logger,
                     );
+
+                    let key = EntityKey {
+                        entity_type: entity_type,
+                        entity_id: Word::from(entity_id),
+                        causality_region: CausalityRegion::ONCHAIN, // Substreams don't currently support offchain data
+                    };
 
                     let id = state.entity_cache.schema.id_value(&key)?;
                     data.insert(Word::from("id"), id);

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -172,6 +172,13 @@ impl ValueType {
     }
 }
 
+/// The types that can be used for the `id` of an entity
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum IdType {
+    String,
+    Bytes,
+}
+
 // Note: Do not modify fields without also making a backward compatible change to the StableHash impl (below)
 /// An attribute value is represented as an enum with variants for all supported value types.
 #[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -559,9 +559,15 @@ impl Layout {
                 entity_id: entity_data.id(),
                 causality_region: CausalityRegion::from_entity(&entity_data),
             };
-            let overwrite = entities.insert(key, entity_data).is_some();
-            if overwrite {
-                return Err(constraint_violation!("duplicate entity in result set"));
+            if entities.contains_key(&key) {
+                return Err(constraint_violation!(
+                    "duplicate entity {}[{}] in result set, block = {}",
+                    key.entity_type,
+                    key.entity_id,
+                    block
+                ));
+            } else {
+                entities.insert(key, entity_data);
             }
         }
         Ok(entities)


### PR DESCRIPTION
There was confusion in the substreams code whether the `id` when represented as a string in the `EntityKey` should start with `0x` or not, causing issue #4661 

This PR addresses that in a fairly hacky way; the right fix, #4663, will be much more involved and have ripple effects throughout the codebase; we should still do it though.