### PR TITLE
add a retry(5) when refetch_firehose_block fails

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -300,10 +300,19 @@ where
                 );
 
                 let block: Arc<C::Block> = if self.inputs.chain.is_refetch_block_required() {
+                    let cur = firehose_cursor.clone();
+                    let log = logger.cheap_clone();
+                    let chain = self.inputs.chain.cheap_clone();
                     Arc::new(
-                        self.inputs
-                            .chain
-                            .refetch_firehose_block(&logger, firehose_cursor.clone())
+                        retry("refetch firehose block after dynamic datasource was added", &logger)
+                            .limit(5)
+                            .no_timeout()
+                            .run(move || {
+                                let cur = cur.clone();
+                                let log = log.cheap_clone();
+                                let chain = chain.cheap_clone();
+                                async move { chain.refetch_firehose_block(&log, cur).await }
+                            })
                             .await?,
                     )
                 } else {

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -304,16 +304,19 @@ where
                     let log = logger.cheap_clone();
                     let chain = self.inputs.chain.cheap_clone();
                     Arc::new(
-                        retry("refetch firehose block after dynamic datasource was added", &logger)
-                            .limit(5)
-                            .no_timeout()
-                            .run(move || {
-                                let cur = cur.clone();
-                                let log = log.cheap_clone();
-                                let chain = chain.cheap_clone();
-                                async move { chain.refetch_firehose_block(&log, cur).await }
-                            })
-                            .await?,
+                        retry(
+                            "refetch firehose block after dynamic datasource was added",
+                            &logger,
+                        )
+                        .limit(5)
+                        .no_timeout()
+                        .run(move || {
+                            let cur = cur.clone();
+                            let log = log.cheap_clone();
+                            let chain = chain.cheap_clone();
+                            async move { chain.refetch_firehose_block(&log, cur).await }
+                        })
+                        .await?,
                     )
                 } else {
                     block.cheap_clone()


### PR DESCRIPTION
* `refetch_firehose_block` is called when using filters and a dynamic datasource is added.
* If it fails, the whole subgraph fails and retries after 2 minutes
* This downtime is out of proportions with a single "failed http fetch", so a few retries make sense.