### PR TITLE
Reduce CI flakiness: disable TCP checksum offloading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     env:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
     steps:
+      - name: Tune GitHub hosted runner to reduce flakiness
+        # https://github.com/smorimoto/tune-github-hosted-runner-network/blob/main/action.yml
+        run: sudo ethtool -K eth0 tx off rx off
       - name: Checkout sources
         uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
@@ -75,6 +78,9 @@ jobs:
     env:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
     steps:
+      - name: Tune GitHub hosted runner to reduce flakiness
+        # https://github.com/smorimoto/tune-github-hosted-runner-network/blob/main/action.yml
+        run: sudo ethtool -K eth0 tx off rx off
       - name: Checkout sources
         uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
@@ -98,6 +104,9 @@ jobs:
     env:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
     steps:
+      - name: Tune GitHub hosted runner to reduce flakiness
+        # https://github.com/smorimoto/tune-github-hosted-runner-network/blob/main/action.yml
+        run: sudo ethtool -K eth0 tx off rx off
       - name: Checkout sources
         uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
We're not the only ones experiencing flaky networking on Github Actions hosted runners: https://github.com/actions/runner-images/issues/1187

Someone suggested disabling TCP checksum offloading as a possible solution as hosted runners' implementation may be buggy. Performance impact should be minimal and error rates go down significantly.