### PR TITLE
fix(runtime): improve error message for timeouts

### DIFF
--- a/runtime/test/src/test/abi.rs
+++ b/runtime/test/src/test/abi.rs
@@ -1,10 +1,6 @@
 use graph::prelude::{ethabi::Token, web3::types::U256};
-use graph_runtime_wasm::{
-    asc_abi::class::{
-        ArrayBuffer, AscAddress, AscEnum, AscEnumArray, EthereumValueKind, StoreValueKind,
-        TypedArray,
-    },
-    TRAP_TIMEOUT,
+use graph_runtime_wasm::asc_abi::class::{
+    ArrayBuffer, AscAddress, AscEnum, AscEnumArray, EthereumValueKind, StoreValueKind, TypedArray,
 };
 
 use super::*;
@@ -23,7 +19,10 @@ async fn test_unbounded_loop(api_version: Version) {
     .await
     .0;
     let res: Result<(), _> = module.get_func("loop").typed().unwrap().call(());
-    assert!(res.unwrap_err().to_string().contains(TRAP_TIMEOUT));
+    assert_eq!(
+        res.unwrap_err().to_string().lines().next().unwrap(),
+        "wasm trap: interrupt"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/runtime/wasm/src/lib.rs
+++ b/runtime/wasm/src/lib.rs
@@ -21,6 +21,3 @@ pub use host::RuntimeHostBuilder;
 pub use host_exports::HostExports;
 pub use mapping::{MappingContext, ValidModule};
 pub use module::{ExperimentalFeatures, WasmInstance};
-
-#[cfg(debug_assertions)]
-pub use module::TRAP_TIMEOUT;


### PR DESCRIPTION
After https://github.com/graphprotocol/graph-node/pull/4475, a timeout trap might be hidden in a host function error. And those timeouts wouldn't get a nice error message. This hopefully addresses that by detecting timeouts anywhere in the anyhow error chain.