### PR TITLE
don't fail ingestor on net_version changed from zero

### DIFF
--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -7,7 +7,7 @@ use std::{
 use graph::{
     blockchain::ChainIdentifier,
     components::store::BlockStore as BlockStoreTrait,
-    prelude::{error, BlockNumber, BlockPtr, Logger, ENV_VARS},
+    prelude::{error, warn, BlockNumber, BlockPtr, Logger, ENV_VARS},
 };
 use graph::{constraint_violation, prelude::CheapClone};
 use graph::{
@@ -241,13 +241,21 @@ impl BlockStore {
                 return false;
             }
             if chain.net_version != ident.net_version {
-                error!(logger,
+                if chain.net_version == "0" {
+                    warn!(logger,
+                        "the net version for chain {} has changed from 0 to {} since the last time we ran, ignoring difference because 0 means UNSET and firehose does not provide it",
+                        chain.name,
+                        ident.net_version,
+                        )
+                } else {
+                    error!(logger,
                         "the net version for chain {} has changed from {} to {} since the last time we ran",
                         chain.name,
                         chain.net_version,
                         ident.net_version
                     );
-                return false;
+                    return false;
+                }
             }
             if chain.genesis_block != ident.genesis_block_hash.hash_hex() {
                 error!(logger,


### PR DESCRIPTION
If a chain was first set up using firehose and we then try to switch to an RPC provider, we get an error on a failing safety check for net_version.

Before this fix:
```
Jun 13 09:37:26.175 ERRO the net version for chain mainnet has changed from 0 to 1 since the last time we ran, component: BlockStore
Jun 13 09:37:26.186 INFO Creating LoadManager in disabled mode, component: LoadManager
Jun 13 09:37:26.187 ERRO Failed to create block ingestor Not starting block ingestor (chain is defective), network_name mainnet, network_name: mainnet
```

After this fix:
```Jun 13 11:11:03.201 WARN the net version for chain mainnet has changed from 0 to 1 since the last time we ran, ignoring difference because 0 means UNSET and firehose does not provide it, component: BlockStore```
