### PR TITLE
fix(graphman): Increase default sleep after stopping sg

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -182,7 +182,7 @@ pub enum Command {
         #[clap(
             long,
             short,
-            default_value = "10",
+            default_value = "20",
             parse(try_from_str = parse_duration_in_secs)
         )]
         sleep: Duration,

--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -121,7 +121,10 @@ pub async fn run(
     if paused {
         // There's no good way to tell that a subgraph has in fact stopped
         // indexing. We sleep and hope for the best.
-        println!("\nWaiting 10s to make sure pausing was processed");
+        println!(
+            "\nWaiting {}s to make sure pausing was processed",
+            sleep.as_secs()
+        );
         thread::sleep(sleep);
     }
 


### PR DESCRIPTION
We've seen data get corrupted, possibly because this sleep wasn't enough for the subgraph to stop.