### PR TITLE
[Feature] Include blockhash and number in eth_call debug logs

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1192,7 +1192,9 @@ impl EthereumAdapterTrait for EthereumAdapter {
 
         debug!(logger, "eth_call";
             "address" => hex::encode(call.address),
-            "data" => hex::encode(&call_data)
+            "data" => hex::encode(&call_data),
+            "block_hash" => call.block_ptr.hash_hex(),
+            "block_number" => call.block_ptr.block_number()
         );
 
         // Check if we have it cached, if not do the call and cache.


### PR DESCRIPTION
This closes issue #4698
Example of new debug logs:
```
DEBG eth_call, block_number: 16498903, block_hash: edabdef6666290010449e023eeb28b523dea6c46235bdd8b2d46ce689478697d, data: 70a0823100000000000000000000000038a8e16951352bab0cfd8872b881cd6bfdab25c8, address: dac17f958d2ee523a2206206994597c13d831ec7, sgd: 47, subgraph_id: QmUGnnNmiB3rTi1AFY4XKZWQ1z8kxKK6p1nFXL6wyyUo2r, component: SubgraphInstanceManager
```
Bloch hash does not have 0x at the start as all log entries that I saw in this repo had the same format 
