### PR TITLE
Restricted Substreams accepted types, updated to latest `substreams-sink-entity-changes` model

### DIFF
--- a/chain/substreams/proto/codec.proto
+++ b/chain/substreams/proto/codec.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 
-package substreams.entity.v1;
+package sf.substreams.sink.entity.v1;
+
+option go_package = "github.com/streamingfast/substreams-sink-entity-changes/pb/sf/substreams/sink/entity/v1;pbentity";
 
 message EntityChanges {
   repeated EntityChange entity_changes = 5;
@@ -9,12 +11,14 @@ message EntityChanges {
 message EntityChange {
   string entity = 1;
   string id = 2;
+  // Deprecated, this is not used within `graph-node`.
   uint64 ordinal = 3;
   enum Operation {
-    UNSET = 0;    // Protobuf default should not be used, this is used so that the consume can ensure that the value was actually specified
-    CREATE = 1;
-    UPDATE = 2;
-    DELETE = 3;
+    OPERATION_UNSPECIFIED = 0;    // Protobuf default should not be used, this is used so that the consume can ensure that the value was actually specified
+    OPERATION_CREATE = 1;
+    OPERATION_UPDATE = 2;
+    OPERATION_DELETE = 3;
+    OPERATION_FINAL = 4;
   }
   Operation operation = 4;
   repeated Field fields = 5;
@@ -26,7 +30,7 @@ message Value {
     string bigdecimal = 2;
     string bigint = 3;
     string string = 4;
-    bytes bytes = 5;
+    string bytes = 5;
     bool bool = 6;
 
     //reserved 7 to 9;  // For future types
@@ -42,5 +46,6 @@ message Array {
 message Field {
   string name = 1;
   optional Value new_value = 3;
+  // Deprecated, this is not used within `graph-node`.
   optional Value old_value = 5;
 }

--- a/chain/substreams/src/codec.rs
+++ b/chain/substreams/src/codec.rs
@@ -1,5 +1,5 @@
 #[rustfmt::skip]
-#[path = "protobuf/substreams.entity.v1.rs"]
+#[path = "protobuf/sf.substreams.sink.entity.v1.rs"]
 mod pbsubstreamsentity;
 
 pub use pbsubstreamsentity::*;

--- a/chain/substreams/src/protobuf/sf.substreams.sink.entity.v1.rs
+++ b/chain/substreams/src/protobuf/sf.substreams.sink.entity.v1.rs
@@ -11,6 +11,7 @@ pub struct EntityChange {
     pub entity: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub id: ::prost::alloc::string::String,
+    /// Deprecated, this is not used within `graph-node`.
     #[prost(uint64, tag = "3")]
     pub ordinal: u64,
     #[prost(enumeration = "entity_change::Operation", tag = "4")]
@@ -34,10 +35,11 @@ pub mod entity_change {
     #[repr(i32)]
     pub enum Operation {
         /// Protobuf default should not be used, this is used so that the consume can ensure that the value was actually specified
-        Unset = 0,
+        Unspecified = 0,
         Create = 1,
         Update = 2,
         Delete = 3,
+        Final = 4,
     }
     impl Operation {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -46,19 +48,21 @@ pub mod entity_change {
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
-                Operation::Unset => "UNSET",
-                Operation::Create => "CREATE",
-                Operation::Update => "UPDATE",
-                Operation::Delete => "DELETE",
+                Operation::Unspecified => "OPERATION_UNSPECIFIED",
+                Operation::Create => "OPERATION_CREATE",
+                Operation::Update => "OPERATION_UPDATE",
+                Operation::Delete => "OPERATION_DELETE",
+                Operation::Final => "OPERATION_FINAL",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
         pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
             match value {
-                "UNSET" => Some(Self::Unset),
-                "CREATE" => Some(Self::Create),
-                "UPDATE" => Some(Self::Update),
-                "DELETE" => Some(Self::Delete),
+                "OPERATION_UNSPECIFIED" => Some(Self::Unspecified),
+                "OPERATION_CREATE" => Some(Self::Create),
+                "OPERATION_UPDATE" => Some(Self::Update),
+                "OPERATION_DELETE" => Some(Self::Delete),
+                "OPERATION_FINAL" => Some(Self::Final),
                 _ => None,
             }
         }
@@ -83,8 +87,8 @@ pub mod value {
         Bigint(::prost::alloc::string::String),
         #[prost(string, tag = "4")]
         String(::prost::alloc::string::String),
-        #[prost(bytes, tag = "5")]
-        Bytes(::prost::alloc::vec::Vec<u8>),
+        #[prost(string, tag = "5")]
+        Bytes(::prost::alloc::string::String),
         #[prost(bool, tag = "6")]
         Bool(bool),
         #[prost(message, tag = "10")]
@@ -104,6 +108,7 @@ pub struct Field {
     pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "3")]
     pub new_value: ::core::option::Option<Value>,
+    /// Deprecated, this is not used within `graph-node`.
     #[prost(message, optional, tag = "5")]
     pub old_value: ::core::option::Option<Value>,
 }

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -191,10 +191,10 @@ where
     ) -> Result<BlockState<Chain>, MappingError> {
         for entity_change in block.changes.entity_changes.iter() {
             match entity_change.operation() {
-                Operation::Unset => {
+                Operation::Unspecified => {
                     // Potentially an issue with the server side or
                     // we are running an outdated version. In either case we should abort.
-                    return Err(MappingError::Unknown(anyhow!("Detected UNSET entity operation, either a server error or there's a new type of operation and we're running an outdated protobuf")));
+                    return Err(MappingError::Unknown(anyhow!("Detected UNSPECIFIED entity operation, either a server error or there's a new type of operation and we're running an outdated protobuf")));
                 }
                 Operation::Create | Operation::Update => {
                     let schema = state.entity_cache.schema.as_ref();
@@ -279,6 +279,9 @@ where
                         causality_region,
                         logger,
                     )
+                }
+                Operation::Final => {
+                    // Ignored, nothing to perform in this case
                 }
             }
         }

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -346,6 +346,10 @@ pub enum SubstreamsError {
     #[error("received gRPC block payload cannot be decoded: {0}")]
     DecodingError(#[from] prost::DecodeError),
 
+    /// We received a message for a type we don't support (the argument is the message)
+    #[error("{0}")]
+    InvalidTypeUrl(String),
+
     /// Some unknown error occurred
     #[error("unknown error")]
     UnknownError(#[from] anyhow::Error),


### PR DESCRIPTION
The Substreams handler should restrict its output to know message urls. Trying to decode an invalid url should be a fatal error. The only 2 acceptable types for now are `type.googleapis.com/sf.substreams.entity.v1.EntityChanges` (renamed to next accepted package) and `type.googleapis.com/sf.substreams.sink.entity.v1.EntityChanges`. The package id recently changed to be `sf.substreams.sink.entity.v1`, it has the same binary layout (and will remain the same through `v1` model), so it's not a problem accepting both.

This also brings in latest `substreams-entity-change` proto definition.

On the fatal error handling, I did something so that the stream can returns a "fatal error" and stop the block stream. This seems weirdly handled in the consuming side. First, it logs a message that error is non-fatal. But the code seems to continue on error but then the subgraph is stopped and nothing happens anymore. I'm pretty sure this is invalid and the subgraph should switch to determinisic error state but it does not seems to be the case (but I could be wrong).

What I see:

```
Jun 29 15:16:03.819 ERRO Mapping message to BlockStreamEvent failed: Invalid message type url, got type.googleapis.com/sf.sink.entity.v1.EntityChanges but accepting only type.googleapis.com/sf.substreams.entity.v1.EntityChanges, type.googleapis.com/sf.substreams.sink.entity.v1.EntityChanges, provider: substreams, deployment: QmejrrfbjjM4RTcZBFq3LuWBcsXtRcnFzvHA4doWaQBCbu, sgd: 6, subgraph_id: QmejrrfbjjM4RTcZBFq3LuWBcsXtRcnFzvHA4doWaQBCbu, component: SubstreamsBlockStream
Jun 29 15:16:03.819 DEBG Block stream produced a non-fatal error, error: Mapping message to BlockStreamEvent failed, sgd: 6, subgraph_id: QmejrrfbjjM4RTcZBFq3LuWBcsXtRcnFzvHA4doWaQBCbu, component: SubgraphInstanceManager
Jun 29 15:16:03.819 INFO Stopping subgraph, sgd: 6, subgraph_id: QmejrrfbjjM4RTcZBFq3LuWBcsXtRcnFzvHA4doWaQBCbu, component: SubgraphInstanceManager
<Nothing more after that until I Ctrl-C>
```

Which is handled https://github.com/graphprotocol/graph-node/blob/6637691999961ad4909470e0c53a12915427cc88/core/src/subgraph/runner.rs#L1026-L1043 but as you can see, the code says `Ok(Action::Continue)` but `Stopping subgraph` is called somewhere after that. Also the log says non-fatal error but don't do nothing, so either the handling needs to retry or the log needs to change.
