### PR TITLE
Undeprecate ens_name_by_hash

### DIFF
--- a/graph/src/runtime/gas/costs.rs
+++ b/graph/src/runtime/gas/costs.rs
@@ -53,6 +53,8 @@ pub const BIG_MATH_GAS_OP: GasOp = GasOp {
 // Allow up to 100,000 data sources to be created
 pub const CREATE_DATA_SOURCE: Gas = Gas(CONST_MAX_GAS_PER_HANDLER / 100_000);
 
+pub const ENS_NAME_BY_HASH: Gas = Gas(DEFAULT_BASE_COST);
+
 pub const LOG_OP: GasOp = GasOp {
     // Allow up to 100,000 logs
     base_cost: CONST_MAX_GAS_PER_HANDLER / 100_000,

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -737,7 +737,12 @@ impl<C: Blockchain> HostExports<C> {
         Ok(())
     }
 
-    pub(crate) fn ens_name_by_hash(&self, hash: &str) -> Result<Option<String>, anyhow::Error> {
+    pub(crate) fn ens_name_by_hash(
+        &self,
+        hash: &str,
+        gas: &GasCounter,
+    ) -> Result<Option<String>, anyhow::Error> {
+        gas.consume_host_fn(gas::ENS_NAME_BY_HASH)?;
         Ok(self.ens_lookup.find_name(hash)?)
     }
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -1852,16 +1852,8 @@ impl<C: Blockchain> WasmInstanceContext<C> {
         gas: &GasCounter,
         hash_ptr: AscPtr<AscString>,
     ) -> Result<AscPtr<AscString>, HostExportError> {
-        // Not enabled on the network, no gas consumed.
-        // This is unrelated to IPFS, but piggyback on the config to disallow it on the network.
-        if !self.experimental_features.allow_non_deterministic_ipfs {
-            return Err(HostExportError::Deterministic(anyhow!(
-                "`ens_name_by_hash` is deprecated"
-            )));
-        }
-
         let hash: String = asc_get(self, hash_ptr, gas)?;
-        let name = self.ctx.host_exports.ens_name_by_hash(&hash)?;
+        let name = self.ctx.host_exports.ens_name_by_hash(&hash, gas)?;
         if name.is_none() && self.ctx.host_exports.is_ens_data_empty()? {
             return Err(anyhow!(
                 "Missing ENS data: see https://github.com/graphprotocol/ens-rainbow"


### PR DESCRIPTION
This is expected to be used in the network. We will still error if the table is not populated, but will no longer gate on setting any env var.