### PR TITLE
use expose instead of ports

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   graph-node:
     image: graphprotocol/graph-node
-    ports:
+    expose:
       - '8000:8000'
       - '8001:8001'
       - '8020:8020'
@@ -23,13 +23,13 @@ services:
       GRAPH_LOG: info
   ipfs:
     image: ipfs/go-ipfs:v0.10.0
-    ports:
+    expose:
       - '5001:5001'
     volumes:
       - ./data/ipfs:/data/ipfs
   postgres:
     image: postgres
-    ports:
+    expose:
       - '5432:5432'
     command:
       [


### PR DESCRIPTION
This PR updates the docker compose file for graph node to expose ports on the bridge network and not the host network for docker.