### PR TITLE
fix(store): Fix rewinding of dynamic data sources

### DIFF
--- a/store/postgres/src/dynds/mod.rs
+++ b/store/postgres/src/dynds/mod.rs
@@ -36,13 +36,13 @@ pub(crate) fn insert(
     }
 }
 
-pub(crate) fn revert(
+pub(crate) fn revert_to(
     conn: &PgConnection,
     site: &Site,
     block: BlockNumber,
 ) -> Result<(), StoreError> {
     match site.schema_version.private_data_sources() {
-        true => DataSourcesTable::new(site.namespace.clone()).revert(conn, block),
+        true => DataSourcesTable::new(site.namespace.clone()).revert_to(conn, block),
         false => shared::revert(conn, &site.deployment, block),
     }
 }

--- a/store/postgres/src/dynds/private.rs
+++ b/store/postgres/src/dynds/private.rs
@@ -190,11 +190,15 @@ impl DataSourcesTable {
         Ok(inserted_total)
     }
 
-    pub(crate) fn revert(&self, conn: &PgConnection, block: BlockNumber) -> Result<(), StoreError> {
+    pub(crate) fn revert_to(
+        &self,
+        conn: &PgConnection,
+        block: BlockNumber,
+    ) -> Result<(), StoreError> {
         // Use `@>` to leverage the gist index.
         // This assumes all ranges are of the form [x, +inf).
         let query = format!(
-            "delete from {} where block_range @> $1 and lower(block_range) = $1",
+            "delete from {} where block_range @> $1 and lower(block_range) >= $1",
             self.qname
         );
         sql_query(query).bind::<Integer, _>(block).execute(conn)?;

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -946,7 +946,7 @@ impl Layout {
         site: &Site,
         block: BlockNumber,
     ) -> Result<(), StoreError> {
-        crate::dynds::revert(conn, site, block)?;
+        crate::dynds::revert_to(conn, site, block)?;
         crate::deployment::revert_subgraph_errors(conn, &site.deployment, block)?;
 
         Ok(())


### PR DESCRIPTION
The `fn revert` was correct if blocks are reverted one by one, as in typical subgraph operation. But on a `graphman rewind` to block `N` it would fail to remove data sources created past block `N`.