### PR TITLE
Retry block_pointer_from_number on deploy

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -722,7 +722,7 @@ impl<C: Blockchain> SubgraphManifest<C> {
             features,
             spec_version,
             data_source_kinds: data_source_kinds.into_iter().collect_vec(),
-            network: network,
+            network,
         }
     }
 

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -53,6 +53,7 @@ pub use semver;
 pub use slog;
 pub use stable_hash_legacy;
 pub use tokio;
+pub use tokio_retry;
 pub use tokio_stream;
 pub use url;
 


### PR DESCRIPTION
Add retry to avoid a single failure while making the call prevent the subsgraph from being deployed Add warning for failed attempts

Closes https://github.com/graphprotocol/graph-node/issues/4724
