### PR TITLE
Avoid redundant child queries

### DIFF
--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -410,10 +410,23 @@ pub struct EntityRange {
 }
 
 impl EntityRange {
+    /// The default value for `first` that we use when the user doesn't
+    /// specify one
+    pub const FIRST: u32 = 100;
+
     /// Query for the first `n` entities.
     pub fn first(n: u32) -> Self {
         Self {
             first: Some(n),
+            skip: 0,
+        }
+    }
+}
+
+impl std::default::Default for EntityRange {
+    fn default() -> Self {
+        Self {
+            first: Some(Self::FIRST),
             skip: 0,
         }
     }
@@ -591,7 +604,7 @@ impl EntityQuery {
             collection,
             filter: None,
             order: EntityOrder::Default,
-            range: EntityRange::first(100),
+            range: EntityRange::default(),
             logger: None,
             query_id: None,
             trace: false,

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -30,7 +30,7 @@ use crate::blockchain::Block;
 use crate::components::store::write::EntityModification;
 use crate::data::store::scalar::Bytes;
 use crate::data::store::*;
-use crate::data::value::Word;
+use crate::data::value::{Object, Word};
 use crate::data_source::CausalityRegion;
 use crate::schema::InputSchema;
 use crate::util::intern;
@@ -481,6 +481,84 @@ pub enum EntityLink {
     Direct(WindowAttribute, ChildMultiplicity),
     /// Join with the parents table to get at the parent id
     Parent(EntityType, ParentLink),
+}
+
+impl EntityLink {
+    /// Return a list of objects that have only the `id`, parent id, and
+    /// typename set using the child ids from `self` when `self` is
+    /// `Parent`. If `self` is `Direct`, return `None`
+    ///
+    /// The list that is returned is sorted and truncated to `first` many
+    /// entries.
+    ///
+    /// This makes it possible to avoid running a query when all that is
+    /// needed is the `id` of the children
+    pub fn to_basic_objects(self, parents: &Vec<String>, first: usize) -> Option<Vec<Object>> {
+        use crate::data::value::Value as V;
+
+        fn basic_object(entity_type: &EntityType, parent: &str, child: String) -> Object {
+            let mut obj = Vec::new();
+            obj.push((ID.clone(), V::String(child)));
+            obj.push((Word::from("__typename"), V::String(entity_type.to_string())));
+            obj.push((PARENT_ID.clone(), V::String(parent.to_string())));
+            Object::from_iter(obj)
+        }
+
+        fn basic_objects(
+            entity_type: &EntityType,
+            parent: &str,
+            children: Vec<String>,
+        ) -> Vec<Object> {
+            children
+                .into_iter()
+                .map(|child| basic_object(entity_type, parent, child))
+                .collect()
+        }
+
+        fn obj_key<'a>(obj: &'a Object) -> Option<(&'a str, &'a str)> {
+            match (obj.get(&*PARENT_ID), obj.get(ID.as_str())) {
+                (Some(V::String(p)), Some(V::String(id))) => Some((p, id)),
+                _ => None,
+            }
+        }
+
+        fn obj_cmp(a: &Object, b: &Object) -> std::cmp::Ordering {
+            obj_key(a).cmp(&obj_key(b))
+        }
+
+        match self {
+            EntityLink::Direct(_, _) => return None,
+            EntityLink::Parent(entity_type, link) => {
+                let mut objects = Vec::new();
+                match link {
+                    ParentLink::List(ids) => {
+                        for (parent, children) in parents.iter().zip(ids) {
+                            objects.extend(basic_objects(&entity_type, parent, children));
+                        }
+                    }
+                    ParentLink::Scalar(ids) => {
+                        for (parent, child) in parents.iter().zip(ids) {
+                            if let Some(child) = child {
+                                objects.push(basic_object(&entity_type, parent, child));
+                            }
+                        }
+                    }
+                }
+                // Sort the objects by parent id and child id just as
+                // running a query would
+                objects.sort_by(obj_cmp);
+                objects.truncate(first);
+                Some(objects)
+            }
+        }
+    }
+
+    pub fn has_child_ids(&self) -> bool {
+        match self {
+            EntityLink::Direct(_, _) => false,
+            EntityLink::Parent(_, _) => true,
+        }
+    }
 }
 
 /// Window results of an `EntityQuery` query along the parent's id:

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -461,7 +461,7 @@ pub enum ParentLink {
     /// The parent stores the id of one child. The ith entry in the
     /// vector contains the id of the child of the parent with id
     /// `EntityWindow.ids[i]`
-    Scalar(Vec<String>),
+    Scalar(Vec<Option<String>>),
 }
 
 /// How many children a parent can have when the child stores

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -74,6 +74,8 @@ pub enum QueryExecutionError {
     InvalidSubgraphManifest,
     ResultTooBig(usize, usize),
     DeploymentNotFound(String),
+    IdMissing,
+    IdNotString,
 }
 
 impl QueryExecutionError {
@@ -130,7 +132,9 @@ impl QueryExecutionError {
             | InvalidSubgraphManifest
             | ValidationError(_, _)
             | ResultTooBig(_, _)
-            | DeploymentNotFound(_) => false,
+            | DeploymentNotFound(_)
+            | IdMissing
+            | IdNotString => false,
         }
     }
 }
@@ -274,7 +278,9 @@ impl fmt::Display for QueryExecutionError {
             SubgraphManifestResolveError(e) => write!(f, "failed to resolve subgraph manifest: {}", e),
             InvalidSubgraphManifest => write!(f, "invalid subgraph manifest file"),
             ResultTooBig(actual, limit) => write!(f, "the result size of {} is larger than the allowed limit of {}", actual, limit),
-            DeploymentNotFound(id_or_name) => write!(f, "deployment `{}` does not exist", id_or_name)
+            DeploymentNotFound(id_or_name) => write!(f, "deployment `{}` does not exist", id_or_name),
+            IdMissing => write!(f, "Entity is missing an `id` attribute"),
+            IdNotString => write!(f, "Entity is missing an `id` attribute")
         }
     }
 }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -634,6 +634,9 @@ where
 lazy_static! {
     /// The name of the id attribute, `"id"`
     pub static ref ID: Word = Word::from("id");
+    /// The name of the parent_id attribute that we inject into query
+    /// results
+    pub static ref PARENT_ID: Word = Word::from("g$parent_id");
 }
 
 /// An entity is represented as a map of attribute names to values.

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -275,11 +275,18 @@ impl CacheWeight for Object {
 
 impl std::fmt::Debug for Object {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        f.debug_map()
+            .entries(self.0.into_iter().map(|e| {
+                (
+                    e.key.as_ref().map(|w| w.as_str()).unwrap_or("---"),
+                    &e.value,
+                )
+            }))
+            .finish()
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub enum Value {
     Int(i64),
     Float(f64),
@@ -503,6 +510,21 @@ impl From<Value> for q::Value {
                 }
                 q::Value::Object(rmap)
             }
+        }
+    }
+}
+
+impl std::fmt::Debug for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Value::Int(i) => f.debug_tuple("Int").field(i).finish(),
+            Value::Float(n) => f.debug_tuple("Float").field(n).finish(),
+            Value::String(s) => write!(f, "{s:?}"),
+            Value::Boolean(b) => write!(f, "{b}"),
+            Value::Null => write!(f, "null"),
+            Value::Enum(e) => write!(f, "{e}"),
+            Value::List(l) => f.debug_list().entries(l).finish(),
+            Value::Object(o) => write!(f, "{o:?}"),
         }
     }
 }

--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -109,6 +109,10 @@ pub struct EnvVarsStore {
     /// is 10_000 which corresponds to 10MB. Setting this to 0 disables
     /// write batching.
     pub write_batch_size: usize,
+    /// Disable the optimization that skips certain child queries for
+    /// entities. Only as a safety valve. Remove after 2023-09-30 if the
+    /// optimization has not caused any issues
+    pub disable_child_optimization: bool,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -150,6 +154,7 @@ impl From<InnerStore> for EnvVarsStore {
             history_slack_factor: x.history_slack_factor.0,
             write_batch_duration: Duration::from_secs(x.write_batch_duration_in_secs),
             write_batch_size: x.write_batch_size * 1_000,
+            disable_child_optimization: x.disable_child_optimization.0,
         }
     }
 }
@@ -203,6 +208,8 @@ pub struct InnerStore {
     write_batch_duration_in_secs: u64,
     #[envconfig(from = "GRAPH_STORE_WRITE_BATCH_SIZE", default = "10000")]
     write_batch_size: usize,
+    #[envconfig(from = "GRAPH_STORE_DISABLE_CHILD_OPTIMIZATION", default = "false")]
+    disable_child_optimization: EnvVarBoolean,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/graphql/src/execution/query.rs
+++ b/graphql/src/execution/query.rs
@@ -16,8 +16,8 @@ use graph::data::graphql::{ext::TypeExt, ObjectOrInterface};
 use graph::data::query::QueryExecutionError;
 use graph::data::query::{Query as GraphDataQuery, QueryVariables};
 use graph::prelude::{
-    info, o, q, r, s, warn, BlockNumber, CheapClone, DeploymentHash, GraphQLMetrics, Logger,
-    TryFromValue, ENV_VARS,
+    info, o, q, r, s, warn, BlockNumber, CheapClone, DeploymentHash, EntityRange, GraphQLMetrics,
+    Logger, TryFromValue, ENV_VARS,
 };
 use graph::schema::ast::{self as sast};
 use graph::schema::ErrorPolicy;
@@ -560,7 +560,7 @@ impl<'s> RawQuery<'s> {
                                 q::Value::Int(n) => Some(n.as_i64()? as u64),
                                 _ => None,
                             })
-                            .unwrap_or(100);
+                            .unwrap_or(EntityRange::FIRST as u64);
                         max_entities
                             .checked_add(
                                 max_entities.checked_mul(field_complexity).ok_or(Overflow)?,

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -4,6 +4,7 @@
 use anyhow::{anyhow, Error};
 use graph::constraint_violation;
 use graph::data::query::Trace;
+use graph::data::store::PARENT_ID;
 use graph::data::value::{Object, Word};
 use graph::prelude::{r, CacheWeight, CheapClone};
 use graph::slog::warn;
@@ -401,7 +402,7 @@ impl<'a> Join<'a> {
         let mut grouped: BTreeMap<&str, Vec<Rc<Node>>> = BTreeMap::default();
         for child in children.iter() {
             match child
-                .get("g$parent_id")
+                .get(&*PARENT_ID)
                 .expect("the query that produces 'child' ensures there is always a g$parent_id")
             {
                 r::Value::String(key) => grouped.entry(key).or_default().push(child.clone()),

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -1,12 +1,11 @@
 //! Run a GraphQL query and fetch all the entitied needed to build the
 //! final result
 
-use anyhow::{anyhow, Error};
 use graph::constraint_violation;
 use graph::data::query::Trace;
-use graph::data::store::PARENT_ID;
+use graph::data::store::{ID, PARENT_ID};
 use graph::data::value::{Object, Word};
-use graph::prelude::{r, CacheWeight, CheapClone};
+use graph::prelude::{r, CacheWeight, CheapClone, EntityQuery, EntityRange};
 use graph::slog::warn;
 use graph::util::cache_weight;
 use std::collections::BTreeMap;
@@ -171,11 +170,11 @@ impl ValueExt for r::Value {
 }
 
 impl Node {
-    fn id(&self) -> Result<String, Error> {
+    fn id(&self) -> Result<String, QueryExecutionError> {
         match self.get("id") {
-            None => Err(anyhow!("Entity is missing an `id` attribute")),
+            None => Err(QueryExecutionError::IdMissing),
             Some(r::Value::String(s)) => Ok(s.clone()),
-            _ => Err(anyhow!("Entity has non-string `id` attribute")),
+            _ => Err(QueryExecutionError::IdNotString),
         }
     }
 
@@ -658,6 +657,30 @@ fn execute_field(
     .map_err(|e| vec![e])
 }
 
+/// Check whether `field` only selects the `id` of its children and whether
+/// it is safe to skip running `query` if we have all child ids in memory
+/// already.
+fn selects_id_only(field: &a::Field, query: &EntityQuery) -> bool {
+    if query.filter.is_some() || query.range.skip != 0 {
+        return false;
+    }
+    match &query.order {
+        EntityOrder::Ascending(attr, _) => {
+            if attr != ID.as_str() {
+                return false;
+            }
+        }
+        _ => {
+            return false;
+        }
+    }
+    field
+        .selection_set
+        .single_field()
+        .map(|field| field.name.as_str() == ID.as_str())
+        .unwrap_or(false)
+}
+
 /// Query child entities for `parents` from the store. The `join` indicates
 /// in which child field to look for the parent's id/join field. When
 /// `is_single` is `true`, there is at most one child per parent.
@@ -703,6 +726,23 @@ fn fetch(
         let windows = join.windows(parents, multiplicity, &query.collection);
         if windows.is_empty() {
             return Ok((vec![], Trace::None));
+        }
+        // See if we can short-circuit query execution and just reuse what
+        // we already have in memory. We could do this probably even with
+        // multiple windows, but this covers the most common case.
+        if windows.len() == 1 && windows[0].link.has_child_ids() && selects_id_only(field, &query) {
+            let mut windows = windows;
+            // unwrap: we checked that len is 1
+            let window = windows.pop().unwrap();
+            let parent_ids = parents
+                .iter()
+                .map(|parent| parent.id())
+                .collect::<Result<_, _>>()
+                .map_err(QueryExecutionError::from)?;
+            // unwrap: we checked in the if condition that the window has child ids
+            let first = query.range.first.unwrap_or(EntityRange::FIRST) as usize;
+            let objs = window.link.to_basic_objects(&parent_ids, first).unwrap();
+            return Ok((objs.into_iter().map(Node::from).collect(), Trace::None));
         }
         query.collection = EntityCollection::Window(windows);
     }

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -295,10 +295,12 @@ impl<'a> JoinCond<'a> {
                         // those and the parent ids
                         let (ids, child_ids): (Vec<_>, Vec<_>) = parents_by_id
                             .into_iter()
-                            .filter_map(|(id, node)| {
-                                node.get(child_field)
-                                    .and_then(|value| value.as_str())
-                                    .map(|child_id| (id, child_id.to_owned()))
+                            .map(|(id, node)| {
+                                (
+                                    id,
+                                    node.get(child_field)
+                                        .and_then(|value| value.as_str().map(|s| s.to_string())),
+                                )
                             })
                             .unzip();
 
@@ -310,25 +312,28 @@ impl<'a> JoinCond<'a> {
                         // parent ids
                         let (ids, child_ids): (Vec<_>, Vec<_>) = parents_by_id
                             .into_iter()
-                            .filter_map(|(id, node)| {
-                                node.get(child_field)
-                                    .and_then(|value| match value {
-                                        r::Value::List(values) => {
-                                            let values: Vec<_> = values
-                                                .iter()
-                                                .filter_map(|value| {
-                                                    value.as_str().map(|value| value.to_owned())
-                                                })
-                                                .collect();
-                                            if values.is_empty() {
-                                                None
-                                            } else {
-                                                Some(values)
+                            .map(|(id, node)| {
+                                (
+                                    id,
+                                    node.get(child_field)
+                                        .and_then(|value| match value {
+                                            r::Value::List(values) => {
+                                                let values: Vec<_> = values
+                                                    .iter()
+                                                    .filter_map(|value| {
+                                                        value.as_str().map(|value| value.to_owned())
+                                                    })
+                                                    .collect();
+                                                if values.is_empty() {
+                                                    None
+                                                } else {
+                                                    Some(values)
+                                                }
                                             }
-                                        }
-                                        _ => None,
-                                    })
-                                    .map(|child_ids| (id, child_ids))
+                                            _ => None,
+                                        })
+                                        .unwrap_or(Vec::new()),
+                                )
                             })
                             .unzip();
                         (ids, ParentLink::List(child_ids))

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -730,7 +730,11 @@ fn fetch(
         // See if we can short-circuit query execution and just reuse what
         // we already have in memory. We could do this probably even with
         // multiple windows, but this covers the most common case.
-        if windows.len() == 1 && windows[0].link.has_child_ids() && selects_id_only(field, &query) {
+        if !ENV_VARS.store.disable_child_optimization
+            && windows.len() == 1
+            && windows[0].link.has_child_ids()
+            && selects_id_only(field, &query)
+        {
             let mut windows = windows;
             // unwrap: we checked that len is 1
             let window = windows.pop().unwrap();

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2102,7 +2102,13 @@ enum ParentIds {
 impl ParentIds {
     fn new(link: ParentLink) -> Self {
         match link {
-            ParentLink::Scalar(child_ids) => ParentIds::Scalar(child_ids),
+            ParentLink::Scalar(child_ids) => {
+                // Remove `None` child ids; query generation doesn't require
+                // that parent and child ids are in strict 1:1
+                // correspondence
+                let child_ids = child_ids.into_iter().filter_map(|c| c).collect();
+                ParentIds::Scalar(child_ids)
+            }
             ParentLink::List(child_ids) => {
                 // Postgres will only accept child_ids, which is a Vec<Vec<String>>
                 // if all Vec<String> are the same length. We therefore pad

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -3,6 +3,7 @@ use graph::components::store::{
     DeploymentCursorTracker, DerivedEntityQuery, EntityKey, EntityType, GetScope,
     LoadRelatedRequest, ReadStore, StoredDynamicDataSource, WritableStore,
 };
+use graph::data::store::PARENT_ID;
 use graph::data::subgraph::schema::{DeploymentCreate, SubgraphError, SubgraphHealth};
 use graph::data_source::CausalityRegion;
 use graph::schema::InputSchema;
@@ -741,7 +742,7 @@ fn no_internal_keys() {
         #[track_caller]
         fn check(entity: &Entity) {
             assert_eq!(None, entity.get("__typename"));
-            assert_eq!(None, entity.get("g$parent_id"));
+            assert_eq!(None, entity.get(&*PARENT_ID));
         }
         let key = EntityKey::data(WALLET.to_owned(), "1".to_owned());
 

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -555,7 +555,7 @@ fn query() {
             ids: vec![CHILD1.to_owned(), CHILD2.to_owned()],
             link: EntityLink::Parent(
                 THING.clone(),
-                ParentLink::Scalar(vec![ROOT.to_owned(), ROOT.to_owned()]),
+                ParentLink::Scalar(vec![Some(ROOT.to_owned()), Some(ROOT.to_owned())]),
             ),
             column_names: AttributeNames::All,
         }]);


### PR DESCRIPTION
If a query only needs to get the `id` of children, and we already have them  in memory, do not run a query to fetch them again. Instead, construct the appropriate objects in memory.
    
Fixes https://github.com/graphprotocol/graph-node/issues/4261