### PR TITLE
graph, graphql: Expand which fields we optimize away

### DIFF
--- a/graph/src/data/query/trace.rs
+++ b/graph/src/data/query/trace.rs
@@ -79,8 +79,7 @@ impl Trace {
             (Self::Query { children, .. }, Self::Query { .. }) => {
                 children.push((name.to_string(), trace))
             }
-            (Self::None, Self::None) | (Self::Root { .. }, Self::None) => { /* tracing is turned off */
-            }
+            (_, Self::None) => { /* ignore, we didn't record any work */ }
             (s, t) => {
                 unreachable!("can not add child self: {:#?} trace: {:#?}", s, t)
             }

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -659,12 +659,15 @@ fn selects_id_only(field: &a::Field, query: &EntityQuery) -> bool {
     if query.filter.is_some() || query.range.skip != 0 {
         return false;
     }
+    // We can only skip the query if it orders by id or no ordering is
+    // specified
     match &query.order {
         EntityOrder::Ascending(attr, _) => {
             if attr != ID.as_str() {
                 return false;
             }
         }
+        EntityOrder::Default | EntityOrder::Unordered => {}
         _ => {
             return false;
         }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2102,13 +2102,7 @@ enum ParentIds {
 impl ParentIds {
     fn new(link: ParentLink) -> Self {
         match link {
-            ParentLink::Scalar(child_ids) => {
-                // Remove `None` child ids; query generation doesn't require
-                // that parent and child ids are in strict 1:1
-                // correspondence
-                let child_ids = child_ids.into_iter().filter_map(|c| c).collect();
-                ParentIds::Scalar(child_ids)
-            }
+            ParentLink::Scalar(child_ids) => ParentIds::Scalar(child_ids),
             ParentLink::List(child_ids) => {
                 // Postgres will only accept child_ids, which is a Vec<Vec<String>>
                 // if all Vec<String> are the same length. We therefore pad

--- a/store/test-store/tests/graphql/query.rs
+++ b/store/test-store/tests/graphql/query.rs
@@ -440,6 +440,7 @@ async fn insert_test_entities(
         vec![
             entity! { is => id: "m3", name: "Tom", mainBand: "b2", bands: vec!["b1", "b2"], favoriteCount: 5 },
             entity! { is => id: "m4", name: "Valerie", bands: Vec::<String>::new(), favoriteCount: 20 },
+            entity! { is => id: "m5", name: "Paul", mainBand: "b2", bands: vec!["b2"], favoriteCount: 2 },
         ],
     )];
     let entities1 = insert_ops(entities1);
@@ -664,7 +665,8 @@ fn can_query_one_to_one_relationship() {
                 object! { name: "John", mainBand: object! { name: "The Musicians" }, favoriteCount: "10" },
                 object! { name: "Lisa", mainBand: object! { name: "The Musicians" }, favoriteCount: "100" },
                 object! { name: "Tom",  mainBand: object! { name: "The Amateurs" }, favoriteCount: "5" },
-                object! { name: "Valerie", mainBand: r::Value::Null, favoriteCount: "20" }
+                object! { name: "Valerie", mainBand: r::Value::Null, favoriteCount: "20" },
+                object! { name: "Paul", mainBand: object! { name: "The Amateurs" }, favoriteCount: "2" }
             ],
             songStats: vec![
                 object! {
@@ -723,6 +725,9 @@ fn can_query_one_to_many_relationships_in_both_directions() {
                 object! {
                     name: "Valerie", writtenSongs: Vec::<String>::new()
                 },
+                object! {
+                    name: "Paul", writtenSongs: Vec::<String>::new()
+                },
             ]
         };
 
@@ -761,15 +766,16 @@ fn can_query_many_to_many_relationship() {
 
         let the_amateurs = object! {
             name: "The Amateurs",
-            members: members(vec![ "John", "Tom" ])
+            members: members(vec![ "John", "Tom", "Paul" ])
         };
 
         let exp = object! {
             musicians: vec![
                 object! { name: "John", bands: vec![ the_musicians.clone(), the_amateurs.clone() ]},
                 object! { name: "Lisa", bands: vec![ the_musicians.clone() ] },
-                object! { name: "Tom", bands: vec![ the_musicians, the_amateurs ] },
-                object! { name: "Valerie", bands: Vec::<String>::new() }
+                object! { name: "Tom", bands: vec![ the_musicians, the_amateurs.clone() ] },
+                object! { name: "Valerie", bands: Vec::<String>::new() },
+                object! { name: "Paul", bands: vec![ the_amateurs ] }
             ]
         };
 
@@ -851,10 +857,12 @@ fn can_query_with_sorting_by_child_entity() {
                 object! { name: "Valerie", mainBand: r::Value::Null },
                 object! { name: "Lisa", mainBand: object! { name: "The Musicians" } },
                 object! { name: "John", mainBand: object! { name: "The Musicians" } },
+                object! { name: "Paul",  mainBand: object! { name: "The Amateurs"} },
                 object! { name: "Tom",  mainBand: object! { name: "The Amateurs"} },
                 ],
             asc: vec![
                 object! { name: "Tom",  mainBand: object! { name: "The Amateurs"} },
+                object! { name: "Paul",  mainBand: object! { name: "The Amateurs"} },
                 object! { name: "John", mainBand: object! { name: "The Musicians" } },
                 object! { name: "Lisa", mainBand: object! { name: "The Musicians" } },
                 object! { name: "Valerie", mainBand: r::Value::Null },
@@ -1162,7 +1170,8 @@ fn can_query_with_child_filter_on_list_type_field() {
         let exp = object! {
             musicians: vec![
                 object! { name: "John", bands: vec![ the_musicians.clone(), the_amateurs.clone() ]},
-                object! { name: "Tom", bands: vec![ the_musicians, the_amateurs ] },
+                object! { name: "Tom", bands: vec![ the_musicians, the_amateurs.clone() ] },
+                object! { name: "Paul", bands: vec![ the_amateurs ] },
             ]
         };
 
@@ -1207,7 +1216,8 @@ fn can_query_with_child_filter_on_named_type_field() {
     run_query(QUERY, |result, _| {
         let exp = object! {
             musicians: vec![
-                object! { name: "Tom", mainBand: object! { id: "b2"} }
+                object! { name: "Tom", mainBand: object! { id: "b2"} },
+                object! { name: "Paul", mainBand: object! { id: "b2"} }
             ]
         };
 
@@ -1558,7 +1568,7 @@ fn skip_directive_works_with_query_variables() {
 
     run_query((QUERY, object! { skip: true }), |result, _| {
         // Assert that only names are returned
-        let musicians: Vec<_> = ["John", "Lisa", "Tom", "Valerie"]
+        let musicians: Vec<_> = ["John", "Lisa", "Tom", "Valerie", "Paul"]
             .into_iter()
             .map(|name| object! { name: name })
             .collect();
@@ -1574,7 +1584,8 @@ fn skip_directive_works_with_query_variables() {
                 object! { id: "m1", name: "John" },
                 object! { id: "m2", name: "Lisa"},
                 object! { id: "m3", name: "Tom" },
-                object! { id: "m4", name: "Valerie" }
+                object! { id: "m4", name: "Valerie" },
+                object! { id: "m5", name: "Paul" }
             ]
         };
         let data = extract_data!(result).unwrap();
@@ -1600,7 +1611,8 @@ fn include_directive_works_with_query_variables() {
                 object! { id: "m1", name: "John" },
                 object! { id: "m2", name: "Lisa"},
                 object! { id: "m3", name: "Tom" },
-                object! { id: "m4", name: "Valerie" }
+                object! { id: "m4", name: "Valerie" },
+                object! { id: "m5", name: "Paul" }
             ]
         };
         let data = extract_data!(result).unwrap();
@@ -1609,7 +1621,7 @@ fn include_directive_works_with_query_variables() {
 
     run_query((QUERY, object! { include: false }), |result, _| {
         // Assert that only names are returned
-        let musicians: Vec<_> = ["John", "Lisa", "Tom", "Valerie"]
+        let musicians: Vec<_> = ["John", "Lisa", "Tom", "Valerie", "Paul"]
             .into_iter()
             .map(|name| object! { name: name })
             .collect();
@@ -1801,7 +1813,7 @@ fn skip_is_nullable() {
 ";
 
     run_query(QUERY, |result, _| {
-        let musicians: Vec<_> = ["John", "Lisa", "Tom", "Valerie"]
+        let musicians: Vec<_> = ["John", "Lisa", "Tom", "Valerie", "Paul"]
             .into_iter()
             .map(|name| object! { name: name })
             .collect();
@@ -1822,7 +1834,7 @@ fn first_is_nullable() {
 ";
 
     run_query(QUERY, |result, _| {
-        let musicians: Vec<_> = ["John", "Lisa", "Tom", "Valerie"]
+        let musicians: Vec<_> = ["John", "Lisa", "Tom", "Valerie", "Paul"]
             .into_iter()
             .map(|name| object! { name: name })
             .collect();
@@ -1880,7 +1892,7 @@ fn ambiguous_derived_from_result() {
 }
 
 #[test]
-fn can_filter_by_relationship_fields() {
+fn c_by_relationship_fields() {
     const QUERY: &str = "
     query {
         musicians(orderBy: id, where: { mainBand: \"b2\" }) {
@@ -1899,7 +1911,8 @@ fn can_filter_by_relationship_fields() {
 
         let exp = object! {
             musicians: vec![
-                object! { id: "m3", name: "Tom", mainBand: object! { id: "b2"} }
+                object! { id: "m3", name: "Tom", mainBand: object! { id: "b2"} },
+                object! { id: "m5", name: "Paul", mainBand: object! { id: "b2"} }
             ],
             bands: vec![
                 object! {
@@ -2013,6 +2026,10 @@ fn can_use_nested_filter() {
                 object! {
                     name: "Valerie",
                     bands: Vec::<r::Value>::new(),
+                },
+                object! {
+                    name: "Paul",
+                    bands: vec![ object! { id: "b2" }]
                 }
             ]
         };
@@ -2035,7 +2052,7 @@ fn ignores_invalid_field_arguments() {
             // Without validations
             Ok(Some(r::Value::Object(obj))) => match obj.get("musicians").unwrap() {
                 r::Value::List(lst) => {
-                    assert_eq!(4, lst.len());
+                    assert_eq!(5, lst.len());
                 }
                 _ => panic!("expected a list of values"),
             },
@@ -2141,6 +2158,7 @@ fn missing_variable() {
                 object! { id: "m2" },
                 object! { id: "m3" },
                 object! { id: "m4" },
+                object! { id: "m5" },
             ]
         };
 
@@ -2171,6 +2189,7 @@ fn missing_variable() {
                 object! { id: "m2" },
                 object! { id: "m3" },
                 object! { id: "m4" },
+                object! { id: "m5" },
             ]
         };
 
@@ -2269,10 +2288,14 @@ fn query_at_block() {
 
     musicians_at("number: 7000", Err(BLOCK_NOT_INDEXED), "n7000");
     musicians_at("number: 0", Ok(vec!["m1", "m2"]), "n0");
-    musicians_at("number: 1", Ok(vec!["m1", "m2", "m3", "m4"]), "n1");
+    musicians_at("number: 1", Ok(vec!["m1", "m2", "m3", "m4", "m5"]), "n1");
 
     musicians_at(&hash(&GENESIS_BLOCK), Ok(vec!["m1", "m2"]), "h0");
-    musicians_at(&hash(&BLOCK_ONE), Ok(vec!["m1", "m2", "m3", "m4"]), "h1");
+    musicians_at(
+        &hash(&BLOCK_ONE),
+        Ok(vec!["m1", "m2", "m3", "m4", "m5"]),
+        "h1",
+    );
     musicians_at(&hash(&BLOCK_TWO), Err(BLOCK_NOT_INDEXED2), "h2");
     musicians_at(&hash(&BLOCK_THREE), Err(BLOCK_HASH_NOT_FOUND), "h3");
 }
@@ -2315,14 +2338,14 @@ fn query_at_block_with_vars() {
 
     musicians_at_nr(7000, Err(BLOCK_NOT_INDEXED), "n7000");
     musicians_at_nr(0, Ok(vec!["m1", "m2"]), "n0");
-    musicians_at_nr(1, Ok(vec!["m1", "m2", "m3", "m4"]), "n1");
+    musicians_at_nr(1, Ok(vec!["m1", "m2", "m3", "m4", "m5"]), "n1");
 
     musicians_at_nr_gte(7000, Err(BLOCK_NOT_INDEXED), "ngte7000");
-    musicians_at_nr_gte(0, Ok(vec!["m1", "m2", "m3", "m4"]), "ngte0");
-    musicians_at_nr_gte(1, Ok(vec!["m1", "m2", "m3", "m4"]), "ngte1");
+    musicians_at_nr_gte(0, Ok(vec!["m1", "m2", "m3", "m4", "m5"]), "ngte0");
+    musicians_at_nr_gte(1, Ok(vec!["m1", "m2", "m3", "m4", "m5"]), "ngte1");
 
     musicians_at_hash(&GENESIS_BLOCK, Ok(vec!["m1", "m2"]), "h0");
-    musicians_at_hash(&BLOCK_ONE, Ok(vec!["m1", "m2", "m3", "m4"]), "h1");
+    musicians_at_hash(&BLOCK_ONE, Ok(vec!["m1", "m2", "m3", "m4", "m5"]), "h1");
     musicians_at_hash(&BLOCK_TWO, Err(BLOCK_NOT_INDEXED2), "h2");
     musicians_at_hash(&BLOCK_THREE, Err(BLOCK_HASH_NOT_FOUND), "h3");
 }
@@ -2685,6 +2708,7 @@ fn can_query_with_or_and_filter() {
             musicians: vec![
                 object! { name: "John", id: "m1" },
                 object! { name: "Tom", id: "m3" },
+                object! { name: "Paul", id: "m5" },
             ],
         };
         let data = extract_data!(result).unwrap();
@@ -2710,6 +2734,7 @@ fn can_query_with_or_explicit_and_filter() {
             musicians: vec![
                 object! { name: "John", id: "m1" },
                 object! { name: "Tom", id: "m3" },
+                object! { name: "Paul", id: "m5" },
             ],
         };
         let data = extract_data!(result).unwrap();
@@ -2793,4 +2818,82 @@ fn can_compare_id() {
             assert_eq!(data, exp, "check {} for {:?} ids", cond, id_type);
         })
     }
+}
+
+/// Check that if we have entities where a related entity is null, followed
+/// by one where it is not null that the children are joined correctly to
+/// their respective parent
+#[test]
+fn children_are_joined_correctly() {
+    // In this query, the `mainBand` and `bands` can be optimized away so
+    // that we test that code path
+    const QUERY1: &str = "
+    query {
+        musicians {
+          id
+          mainBand { id }
+          bands { id }
+        }
+      }
+    ";
+
+    run_query(QUERY1, |result, _| {
+        fn b1() -> r::Value {
+            object! { id: "b1" }
+        }
+        fn b2() -> r::Value {
+            object! { id: "b2" }
+        }
+        let null = r::Value::Null;
+        let none = Vec::<r::Value>::new();
+
+        let exp = object! {
+            musicians: vec![
+                object! { id: "m1", mainBand: b1(), bands: vec![ b1(), b2() ] },
+                object! { id: "m2", mainBand: b1(), bands: vec![ b1() ] },
+                object! { id: "m3", mainBand: b2(), bands: vec![ b1(), b2() ] },
+                object! { id: "m4", mainBand: null, bands: none },
+                object! { id: "m5", mainBand: b2(), bands: vec![ b2() ] },
+            ],
+        };
+
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    });
+
+    // In this query, we need to fetch the `mainBand` and `bands` from the
+    // database
+    const QUERY2: &str = "
+    query {
+        musicians {
+          id
+          mainBand { id name }
+          bands { id name }
+        }
+      }
+    ";
+
+    run_query(QUERY2, |result, _| {
+        fn b1() -> r::Value {
+            object! { id: "b1", name: "The Musicians" }
+        }
+        fn b2() -> r::Value {
+            object! { id: "b2", name: "The Amateurs" }
+        }
+        let null = r::Value::Null;
+        let none = Vec::<r::Value>::new();
+
+        let exp = object! {
+            musicians: vec![
+                object! { id: "m1", mainBand: b1(), bands: vec![ b1(), b2() ] },
+                object! { id: "m2", mainBand: b1(), bands: vec![ b1() ]  },
+                object! { id: "m3", mainBand: b2(), bands: vec![ b1(), b2() ]  },
+                object! { id: "m4", mainBand: null, bands: none },
+                object! { id: "m5", mainBand: b2(), bands: vec![ b2() ]  },
+            ],
+        };
+
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    });
 }

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -555,7 +555,7 @@ fn query() {
             ids: vec![CHILD1.to_owned(), CHILD2.to_owned()],
             link: EntityLink::Parent(
                 THING.clone(),
-                ParentLink::Scalar(vec![Some(ROOT.to_owned()), Some(ROOT.to_owned())]),
+                ParentLink::Scalar(vec![ROOT.to_owned(), ROOT.to_owned()]),
             ),
             column_names: AttributeNames::All,
         }]);


### PR DESCRIPTION
This is a follow-on to https://github.com/graphprotocol/graph-node/pull/4827 to cover the important case where no ordering is specified (for example, for single-value child fields)

