### PR TITLE
Add rootless Docker container support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,9 +97,9 @@ EXPOSE 8020
 EXPOSE 8030
 
 RUN apt-get update \
-    && apt-get install -y libpq-dev ca-certificates netcat \
+    && apt-get install -y libpq-dev ca-certificates netcat whois \
     && useradd -m graphuser \
-    && echo "graphuser:graphuser" | chpasswd
+    && echo "graphuser:$(mkpasswd -m sha-512 -s somesalt4325)" | chpasswd
 
 ADD docker/wait_for docker/start /usr/local/bin/
 COPY --from=graph-node-build /usr/local/bin/graph-node /usr/local/bin/graphman /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,9 +97,8 @@ EXPOSE 8020
 EXPOSE 8030
 
 RUN apt-get update \
-    && apt-get install -y libpq-dev ca-certificates netcat whois \
-    && useradd -m graphuser \
-    && echo "graphuser:$(mkpasswd -m sha-512 -s somesalt4325)" | chpasswd
+    && apt-get install -y libpq-dev ca-certificates netcat \
+    && useradd -m graphuser
 
 ADD docker/wait_for docker/start /usr/local/bin/
 COPY --from=graph-node-build /usr/local/bin/graph-node /usr/local/bin/graphman /usr/local/bin/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   graph-node:
     image: graphprotocol/graph-node
+    user: "1000:1000"
     ports:
       - '8000:8000'
       - '8001:8001'


### PR DESCRIPTION
By default the container will run as root

This will force the container, in prod, to run as rootless user, (default user is 1000)

feel free to change the name of the user as needed

Please further test, this has worked for me for over a year but please have others test to ensure the execution is unaffected by permissions