### PR TITLE
Revert most of PR 4827

### DIFF
--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -461,7 +461,7 @@ pub enum ParentLink {
     /// The parent stores the id of one child. The ith entry in the
     /// vector contains the id of the child of the parent with id
     /// `EntityWindow.ids[i]`
-    Scalar(Vec<Option<String>>),
+    Scalar(Vec<String>),
 }
 
 /// How many children a parent can have when the child stores

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -74,8 +74,6 @@ pub enum QueryExecutionError {
     InvalidSubgraphManifest,
     ResultTooBig(usize, usize),
     DeploymentNotFound(String),
-    IdMissing,
-    IdNotString,
 }
 
 impl QueryExecutionError {
@@ -132,9 +130,7 @@ impl QueryExecutionError {
             | InvalidSubgraphManifest
             | ValidationError(_, _)
             | ResultTooBig(_, _)
-            | DeploymentNotFound(_)
-            | IdMissing
-            | IdNotString => false,
+            | DeploymentNotFound(_) => false,
         }
     }
 }
@@ -278,9 +274,7 @@ impl fmt::Display for QueryExecutionError {
             SubgraphManifestResolveError(e) => write!(f, "failed to resolve subgraph manifest: {}", e),
             InvalidSubgraphManifest => write!(f, "invalid subgraph manifest file"),
             ResultTooBig(actual, limit) => write!(f, "the result size of {} is larger than the allowed limit of {}", actual, limit),
-            DeploymentNotFound(id_or_name) => write!(f, "deployment `{}` does not exist", id_or_name),
-            IdMissing => write!(f, "Entity is missing an `id` attribute"),
-            IdNotString => write!(f, "Entity is missing an `id` attribute")
+            DeploymentNotFound(id_or_name) => write!(f, "deployment `{}` does not exist", id_or_name)
         }
     }
 }

--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -109,10 +109,6 @@ pub struct EnvVarsStore {
     /// is 10_000 which corresponds to 10MB. Setting this to 0 disables
     /// write batching.
     pub write_batch_size: usize,
-    /// Disable the optimization that skips certain child queries for
-    /// entities. Only as a safety valve. Remove after 2023-09-30 if the
-    /// optimization has not caused any issues
-    pub disable_child_optimization: bool,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -154,7 +150,6 @@ impl From<InnerStore> for EnvVarsStore {
             history_slack_factor: x.history_slack_factor.0,
             write_batch_duration: Duration::from_secs(x.write_batch_duration_in_secs),
             write_batch_size: x.write_batch_size * 1_000,
-            disable_child_optimization: x.disable_child_optimization.0,
         }
     }
 }
@@ -208,8 +203,6 @@ pub struct InnerStore {
     write_batch_duration_in_secs: u64,
     #[envconfig(from = "GRAPH_STORE_WRITE_BATCH_SIZE", default = "10000")]
     write_batch_size: usize,
-    #[envconfig(from = "GRAPH_STORE_DISABLE_CHILD_OPTIMIZATION", default = "false")]
-    disable_child_optimization: EnvVarBoolean,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -730,11 +730,7 @@ fn fetch(
         // See if we can short-circuit query execution and just reuse what
         // we already have in memory. We could do this probably even with
         // multiple windows, but this covers the most common case.
-        if !ENV_VARS.store.disable_child_optimization
-            && windows.len() == 1
-            && windows[0].link.has_child_ids()
-            && selects_id_only(field, &query)
-        {
+        if windows.len() == 1 && windows[0].link.has_child_ids() && selects_id_only(field, &query) {
             let mut windows = windows;
             // unwrap: we checked that len is 1
             let window = windows.pop().unwrap();

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2102,13 +2102,7 @@ enum ParentIds {
 impl ParentIds {
     fn new(link: ParentLink) -> Self {
         match link {
-            ParentLink::Scalar(child_ids) => {
-                // Remove `None` child ids; query generation doesn't require
-                // that parent and child ids are in strict 1:1
-                // correspondence
-                let child_ids = child_ids.into_iter().filter_map(|c| c).collect();
-                ParentIds::Scalar(child_ids)
-            }
+            ParentLink::Scalar(child_ids) => ParentIds::Scalar(child_ids),
             ParentLink::List(child_ids) => {
                 // Postgres will only accept child_ids, which is a Vec<Vec<String>>
                 // if all Vec<String> are the same length. We therefore pad

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -555,7 +555,7 @@ fn query() {
             ids: vec![CHILD1.to_owned(), CHILD2.to_owned()],
             link: EntityLink::Parent(
                 THING.clone(),
-                ParentLink::Scalar(vec![Some(ROOT.to_owned()), Some(ROOT.to_owned())]),
+                ParentLink::Scalar(vec![ROOT.to_owned(), ROOT.to_owned()]),
             ),
             column_names: AttributeNames::All,
         }]);


### PR DESCRIPTION
Because of how we store relationships between entities (see [here](https://github.com/graphprotocol/graph-node/issues/4261#issuecomment-1714711768) for background) we actually can't optimize child queries away.

This PR reverts most of #4827. It only keeps changes that are simple quality-of-life improvements without any functional implication, namely c31a1f09, 8a08a738, and 13de37c5