### PR TITLE
Cache only correct eth_call data

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1303,14 +1303,21 @@ impl EthereumAdapterTrait for EthereumAdapter {
                         .map(move |result| {
                             // Don't block handler execution on writing to the cache.
                             let for_cache = result.0.clone();
-                            let _ = graph::spawn_blocking_allow_panic(move || {
-                                cache
-                                    .set_call(call.address, &call_data, call.block_ptr, &for_cache)
-                                    .map_err(|e| {
-                                        error!(logger, "call cache set error";
-                                                   "error" => e.to_string())
-                                    })
-                            });
+                            if !result.0.is_empty() {
+                                let _ = graph::spawn_blocking_allow_panic(move || {
+                                    cache
+                                        .set_call(
+                                            call.address,
+                                            &call_data,
+                                            call.block_ptr,
+                                            &for_cache,
+                                        )
+                                        .map_err(|e| {
+                                            error!(logger, "call cache set error";
+                                                       "error" => e.to_string())
+                                        })
+                                });
+                            }
                             result.0
                         }),
                     )


### PR DESCRIPTION
This PR closes https://github.com/graphprotocol/graph-node/issues/4756 
It changes caching logic to cache only correct and decodable eth_calls to prevent cache from providing faulty data
