### PR TITLE
Handle `EntityType` and entity ids more clearly and safely

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -106,7 +106,7 @@ impl BlockStreamBuilder<Chain> for EthereumStreamBuilder {
     async fn build_substreams(
         &self,
         _chain: &Chain,
-        _schema: Arc<InputSchema>,
+        _schema: InputSchema,
         _deployment: DeploymentLocator,
         _block_cursor: FirehoseCursor,
         _subgraph_current_block: Option<BlockPtr>,

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -44,7 +44,7 @@ impl BlockStreamBuilder<Chain> for NearStreamBuilder {
     async fn build_substreams(
         &self,
         _chain: &Chain,
-        _schema: Arc<InputSchema>,
+        _schema: InputSchema,
         _deployment: DeploymentLocator,
         _block_cursor: FirehoseCursor,
         _subgraph_current_block: Option<BlockPtr>,

--- a/chain/substreams/src/block_stream.rs
+++ b/chain/substreams/src/block_stream.rs
@@ -34,7 +34,7 @@ impl BlockStreamBuilderTrait<Chain> for BlockStreamBuilder {
     async fn build_substreams(
         &self,
         chain: &Chain,
-        schema: Arc<InputSchema>,
+        schema: InputSchema,
         deployment: DeploymentLocator,
         block_cursor: FirehoseCursor,
         subgraph_current_block: Option<BlockPtr>,

--- a/chain/substreams/src/chain.rs
+++ b/chain/substreams/src/chain.rs
@@ -5,9 +5,10 @@ use graph::blockchain::client::ChainClient;
 use graph::blockchain::{
     BasicBlockchainBuilder, BlockIngestor, EmptyNodeCapabilities, NoopRuntimeAdapter,
 };
-use graph::components::store::{DeploymentCursorTracker, EntityKey};
+use graph::components::store::DeploymentCursorTracker;
 use graph::firehose::FirehoseEndpoints;
 use graph::prelude::{BlockHash, CheapClone, Entity, LoggerFactory, MetricsRegistry};
+use graph::schema::EntityKey;
 use graph::{
     blockchain::{
         self,

--- a/chain/substreams/src/mapper.rs
+++ b/chain/substreams/src/mapper.rs
@@ -152,9 +152,9 @@ fn parse_changes(
             }
         };
         // Substreams don't currently support offchain data
-        let key = entity_type.key_in(Word::from(entity_id), CausalityRegion::ONCHAIN);
+        let key = entity_type.parse_key_in(Word::from(entity_id), CausalityRegion::ONCHAIN)?;
 
-        let id = key.id_value()?;
+        let id = key.id_value();
         parsed_data.insert(Word::from("id"), id);
 
         let changes = match entity_change.operation() {

--- a/chain/substreams/src/mapper.rs
+++ b/chain/substreams/src/mapper.rs
@@ -7,7 +7,7 @@ use crate::{codec, Block, Chain, EntityChanges, ParsedChanges, TriggerData};
 use graph::blockchain::block_stream::{
     BlockStreamEvent, BlockWithTriggers, FirehoseCursor, SubstreamsError, SubstreamsMapper,
 };
-use graph::components::store::{EntityKey, EntityType};
+use graph::components::store::EntityKey;
 use graph::data::store::scalar::Bytes;
 use graph::data::store::IdType;
 use graph::data::value::Word;
@@ -131,7 +131,7 @@ fn parse_changes(
     let mut parsed_changes = vec![];
     for entity_change in changes.entity_changes.iter() {
         let mut parsed_data: HashMap<Word, Value> = HashMap::default();
-        let entity_type = EntityType::new(entity_change.entity.to_string());
+        let entity_type = schema.entity_type(&entity_change.entity)?;
 
         // Make sure that the `entity_id` gets set to a value
         // that is safe for roundtrips through the database. In

--- a/chain/substreams/src/mapper.rs
+++ b/chain/substreams/src/mapper.rs
@@ -154,7 +154,7 @@ fn parse_changes(
         // Substreams don't currently support offchain data
         let key = entity_type.key_in(Word::from(entity_id), CausalityRegion::ONCHAIN);
 
-        let id = schema.id_value(&key)?;
+        let id = key.id_value()?;
         parsed_data.insert(Word::from("id"), id);
 
         let changes = match entity_change.operation() {

--- a/chain/substreams/src/mapper.rs
+++ b/chain/substreams/src/mapper.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use crate::codec::entity_change;
 use crate::{codec, Block, Chain, EntityChanges, ParsedChanges, TriggerData};
@@ -26,7 +25,7 @@ use prost::Message;
 // the store. If schema is None then only the original block is passed. This None should only
 // be used for block ingestion where entity content is empty and gets discarded.
 pub struct Mapper {
-    pub schema: Option<Arc<InputSchema>>,
+    pub schema: Option<InputSchema>,
 }
 
 #[async_trait]
@@ -126,7 +125,7 @@ impl SubstreamsMapper<Chain> for Mapper {
 
 fn parse_changes(
     changes: &EntityChanges,
-    schema: &Arc<InputSchema>,
+    schema: &InputSchema,
 ) -> anyhow::Result<Vec<ParsedChanges>> {
     let mut parsed_changes = vec![];
     for entity_change in changes.entity_changes.iter() {

--- a/chain/substreams/src/mapper.rs
+++ b/chain/substreams/src/mapper.rs
@@ -6,14 +6,13 @@ use crate::{codec, Block, Chain, EntityChanges, ParsedChanges, TriggerData};
 use graph::blockchain::block_stream::{
     BlockStreamEvent, BlockWithTriggers, FirehoseCursor, SubstreamsError, SubstreamsMapper,
 };
-use graph::components::store::EntityKey;
 use graph::data::store::scalar::Bytes;
 use graph::data::store::IdType;
 use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
 use graph::prelude::BigDecimal;
 use graph::prelude::{async_trait, BigInt, BlockHash, BlockNumber, BlockPtr, Logger, Value};
-use graph::schema::InputSchema;
+use graph::schema::{EntityKey, InputSchema};
 use graph::slog::o;
 use graph::substreams::Clock;
 use graph::substreams_rpc::response::Message as SubstreamsMessage;

--- a/chain/substreams/src/mapper.rs
+++ b/chain/substreams/src/mapper.rs
@@ -142,7 +142,7 @@ fn parse_changes(
         // Needless to say, this is a very ugly hack, and the
         // real fix is what's described in [this
         // issue](https://github.com/graphprotocol/graph-node/issues/4663)
-        let entity_id: String = match schema.id_type(&entity_type)? {
+        let entity_id: String = match entity_type.id_type()? {
             IdType::String => entity_change.id.clone(),
             IdType::Bytes => {
                 if entity_change.id.starts_with("0x") {

--- a/chain/substreams/src/mapper.rs
+++ b/chain/substreams/src/mapper.rs
@@ -12,7 +12,7 @@ use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
 use graph::prelude::BigDecimal;
 use graph::prelude::{async_trait, BigInt, BlockHash, BlockNumber, BlockPtr, Logger, Value};
-use graph::schema::{EntityKey, InputSchema};
+use graph::schema::InputSchema;
 use graph::slog::o;
 use graph::substreams::Clock;
 use graph::substreams_rpc::response::Message as SubstreamsMessage;
@@ -151,11 +151,9 @@ fn parse_changes(
                 }
             }
         };
-        let key = EntityKey {
-            entity_type,
-            entity_id: Word::from(entity_id),
-            causality_region: CausalityRegion::ONCHAIN, // Substreams don't currently support offchain data
-        };
+        // Substreams don't currently support offchain data
+        let key = entity_type.key_in(Word::from(entity_id), CausalityRegion::ONCHAIN);
+
         let id = schema.id_value(&key)?;
         parsed_data.insert(Word::from("id"), id);
 

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -195,7 +195,7 @@ where
                         proof_of_indexing,
                         &ProofOfIndexingEvent::SetEntity {
                             entity_type: key.entity_type.as_str(),
-                            id: &key.entity_id,
+                            id: &key.entity_id.to_string(),
                             data: &entity,
                         },
                         causality_region,
@@ -213,11 +213,11 @@ where
                         proof_of_indexing,
                         &ProofOfIndexingEvent::RemoveEntity {
                             entity_type: entity_type.as_str(),
-                            id: id.as_str(),
+                            id: &id.to_string(),
                         },
                         causality_region,
                         logger,
-                    )
+                    );
                 }
             }
         }

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -6,9 +6,7 @@ use crate::subgraph::stream::new_block_stream;
 use atomic_refcell::AtomicRefCell;
 use graph::blockchain::block_stream::{BlockStreamEvent, BlockWithTriggers, FirehoseCursor};
 use graph::blockchain::{Block, Blockchain, DataSource as _, TriggerFilter as _};
-use graph::components::store::{
-    EmptyStore, EntityKey, GetScope, ReadStore, StoredDynamicDataSource,
-};
+use graph::components::store::{EmptyStore, GetScope, ReadStore, StoredDynamicDataSource};
 use graph::components::{
     store::ModificationsAndCache,
     subgraph::{MappingError, PoICausalityRegion, ProofOfIndexing, SharedProofOfIndexing},
@@ -23,6 +21,7 @@ use graph::data_source::{
 };
 use graph::env::EnvVars;
 use graph::prelude::*;
+use graph::schema::EntityKey;
 use graph::util::{backoff::ExponentialBackoff, lfu_cache::LfuCache};
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -1095,17 +1095,15 @@ async fn update_proof_of_indexing(
 
     for (causality_region, stream) in proof_of_indexing.drain() {
         // Create the special POI entity key specific to this causality_region
-        let entity_key = EntityKey {
-            entity_type: entity_cache.schema.poi_type().clone(),
-
-            // There are two things called causality regions here, one is the causality region for
-            // the poi which is a string and the PoI entity id. The other is the data source
-            // causality region to which the PoI belongs as an entity. Currently offchain events do
-            // not affect PoI so it is assumed to be `ONCHAIN`.
-            // See also: poi-ignores-offchain
-            entity_id: causality_region.into(),
-            causality_region: CausalityRegion::ONCHAIN,
-        };
+        // There are two things called causality regions here, one is the causality region for
+        // the poi which is a string and the PoI entity id. The other is the data source
+        // causality region to which the PoI belongs as an entity. Currently offchain events do
+        // not affect PoI so it is assumed to be `ONCHAIN`.
+        // See also: poi-ignores-offchain
+        let entity_key = entity_cache
+            .schema
+            .poi_type()
+            .key_in(causality_region, CausalityRegion::ONCHAIN);
 
         // Grab the current digest attribute on this entity
         let poi_digest = entity_cache.schema.poi_digest().clone();

--- a/core/src/subgraph/state.rs
+++ b/core/src/subgraph/state.rs
@@ -1,6 +1,6 @@
 use graph::{
-    components::store::EntityKey,
     prelude::Entity,
+    schema::EntityKey,
     util::{backoff::ExponentialBackoff, lfu_cache::LfuCache},
 };
 use std::time::Instant;

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -124,7 +124,7 @@ pub trait BlockStreamBuilder<C: Blockchain>: Send + Sync {
     async fn build_substreams(
         &self,
         chain: &C,
-        schema: Arc<InputSchema>,
+        schema: InputSchema,
         deployment: DeploymentLocator,
         block_cursor: FirehoseCursor,
         subgraph_current_block: Option<BlockPtr>,

--- a/graph/src/components/server/index_node.rs
+++ b/graph/src/components/server/index_node.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use futures::prelude::*;
 
 use crate::{prelude::BlockNumber, schema::InputSchema};
@@ -15,7 +13,7 @@ pub struct VersionInfo {
     pub failed: bool,
     pub description: Option<String>,
     pub repository: Option<String>,
-    pub schema: Arc<InputSchema>,
+    pub schema: InputSchema,
     pub network: String,
 }
 

--- a/graph/src/components/store/entity_cache.rs
+++ b/graph/src/components/store/entity_cache.rs
@@ -13,7 +13,7 @@ use crate::schema::InputSchema;
 use crate::util::intern::Error as InternError;
 use crate::util::lfu_cache::{EvictStats, LfuCache};
 
-use super::{BlockNumber, DerivedEntityQuery, EntityType, LoadRelatedRequest, StoreError};
+use super::{BlockNumber, DerivedEntityQuery, LoadRelatedRequest, StoreError};
 
 /// The scope in which the `EntityCache` should perform a `get` operation
 pub enum GetScope {
@@ -204,7 +204,7 @@ impl EntityCache {
         let (base_type, field, id_is_bytes) = self.schema.get_field_related(eref)?;
 
         let query = DerivedEntityQuery {
-            entity_type: EntityType::new(base_type.to_string()),
+            entity_type: self.schema.entity_type(base_type)?,
             entity_field: field.name.clone().into(),
             value: eref.entity_id.clone(),
             causality_region: eref.causality_region,

--- a/graph/src/components/store/entity_cache.rs
+++ b/graph/src/components/store/entity_cache.rs
@@ -412,7 +412,7 @@ impl EntityCache {
         // is wrong and the store already has a version of the entity from a
         // previous block, the attempt to insert will trigger a constraint
         // violation in the database, ensuring correctness
-        let missing = missing.filter(|key| !self.schema.is_immutable(&key.entity_type));
+        let missing = missing.filter(|key| !key.entity_type.is_immutable());
 
         for (entity_key, entity) in self.store.get_many(missing.cloned().collect())? {
             self.current.insert(entity_key, Some(entity));

--- a/graph/src/components/store/entity_cache.rs
+++ b/graph/src/components/store/entity_cache.rs
@@ -201,14 +201,13 @@ impl EntityCache {
         &mut self,
         eref: &LoadRelatedRequest,
     ) -> Result<Vec<Entity>, anyhow::Error> {
-        let (base_type, field, id_is_bytes) = self.schema.get_field_related(eref)?;
+        let (base_type, field) = self.schema.get_field_related(eref)?;
 
         let query = DerivedEntityQuery {
             entity_type: self.schema.entity_type(base_type)?,
             entity_field: field.name.clone().into(),
             value: eref.entity_id.clone(),
             causality_region: eref.causality_region,
-            id_is_bytes,
         };
 
         let mut entity_map = self.store.get_derived(&query)?;

--- a/graph/src/components/store/entity_cache.rs
+++ b/graph/src/components/store/entity_cache.rs
@@ -86,7 +86,7 @@ pub struct EntityCache {
     /// The store is only used to read entities.
     pub store: Arc<dyn s::ReadStore>,
 
-    pub schema: Arc<InputSchema>,
+    pub schema: InputSchema,
 }
 
 impl Debug for EntityCache {

--- a/graph/src/components/store/entity_cache.rs
+++ b/graph/src/components/store/entity_cache.rs
@@ -6,10 +6,10 @@ use std::sync::Arc;
 
 use crate::cheap_clone::CheapClone;
 use crate::components::store::write::EntityModification;
-use crate::components::store::{self as s, Entity, EntityKey, EntityOperation};
+use crate::components::store::{self as s, Entity, EntityOperation};
 use crate::data::store::{EntityValidationError, IntoEntityIterator};
 use crate::prelude::ENV_VARS;
-use crate::schema::InputSchema;
+use crate::schema::{EntityKey, InputSchema};
 use crate::util::intern::Error as InternError;
 use crate::util::lfu_cache::{EvictStats, LfuCache};
 

--- a/graph/src/components/store/err.rs
+++ b/graph/src/components/store/err.rs
@@ -1,7 +1,7 @@
-use super::{BlockNumber, DeploymentHash, DeploymentSchemaVersion};
-use crate::data::store::EntityValidationError;
+use super::{BlockNumber, DeploymentSchemaVersion};
 use crate::prelude::QueryExecutionError;
 use crate::util::intern::Error as InternError;
+use crate::{data::store::EntityValidationError, prelude::DeploymentHash};
 
 use anyhow::{anyhow, Error};
 use diesel::result::Error as DieselError;

--- a/graph/src/components/store/err.rs
+++ b/graph/src/components/store/err.rs
@@ -75,10 +75,10 @@ pub enum StoreError {
 #[macro_export]
 macro_rules! constraint_violation {
     ($msg:expr) => {{
-        StoreError::ConstraintViolation(format!("{}", $msg))
+        $crate::prelude::StoreError::ConstraintViolation(format!("{}", $msg))
     }};
     ($fmt:expr, $($arg:tt)*) => {{
-        StoreError::ConstraintViolation(format!($fmt, $($arg)*))
+        $crate::prelude::StoreError::ConstraintViolation(format!($fmt, $($arg)*))
     }}
 }
 

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1073,11 +1073,11 @@ impl fmt::Display for DeploymentSchemaVersion {
 
 /// A `ReadStore` that is always empty.
 pub struct EmptyStore {
-    schema: Arc<InputSchema>,
+    schema: InputSchema,
 }
 
 impl EmptyStore {
-    pub fn new(schema: Arc<InputSchema>) -> Self {
+    pub fn new(schema: InputSchema) -> Self {
         EmptyStore { schema }
     }
 }
@@ -1098,7 +1098,7 @@ impl ReadStore for EmptyStore {
         Ok(BTreeMap::new())
     }
 
-    fn input_schema(&self) -> Arc<InputSchema> {
+    fn input_schema(&self) -> InputSchema {
         self.schema.cheap_clone()
     }
 }

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -36,8 +36,7 @@ use crate::data::value::Word;
 use crate::data_source::CausalityRegion;
 use crate::env::ENV_VARS;
 use crate::prelude::{Attribute, DeploymentHash, SubscriptionFilter, ValueType};
-use crate::schema::{EntityType, InputSchema};
-use crate::util::intern;
+use crate::schema::{EntityKey, EntityType, InputSchema};
 use crate::util::stats::MovingStats;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -53,39 +52,6 @@ impl EntityFilterDerivative {
     }
 }
 
-/// Key by which an individual entity in the store can be accessed. Stores
-/// only the entity type and id. The deployment must be known from context.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EntityKey {
-    /// Name of the entity type.
-    pub entity_type: EntityType,
-
-    /// ID of the individual entity.
-    pub entity_id: Word,
-
-    /// This is the causality region of the data source that created the entity.
-    ///
-    /// In the case of an entity lookup, this is the causality region of the data source that is
-    /// doing the lookup. So if the entity exists but was created on a different causality region,
-    /// the lookup will return empty.
-    pub causality_region: CausalityRegion,
-}
-
-impl EntityKey {
-    pub fn unknown_attribute(&self, err: intern::Error) -> StoreError {
-        StoreError::UnknownAttribute(self.entity_type.to_string(), err.not_interned())
-    }
-}
-
-impl std::fmt::Debug for EntityKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "EntityKey({}[{}], cr={})",
-            self.entity_type, self.entity_id, self.causality_region
-        )
-    }
-}
 #[derive(Debug, Clone)]
 pub struct LoadRelatedRequest {
     /// Name of the entity type.
@@ -135,27 +101,6 @@ impl DerivedEntityQuery {
                     _ => false,
                 })
                 .unwrap_or(false)
-    }
-}
-
-impl EntityKey {
-    // For use in tests only
-    #[cfg(debug_assertions)]
-    pub fn onchain(entity_type: &EntityType, entity_id: impl Into<String>) -> Self {
-        Self {
-            entity_type: entity_type.clone(),
-            entity_id: entity_id.into().into(),
-            causality_region: CausalityRegion::ONCHAIN,
-        }
-    }
-
-    pub fn from(id: &String, load_related_request: &LoadRelatedRequest) -> Self {
-        let clone = load_related_request.clone();
-        Self {
-            entity_id: id.clone().into(),
-            entity_type: clone.entity_type,
-            causality_region: clone.causality_region,
-        }
     }
 }
 

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -17,7 +17,6 @@ pub use write::Batch;
 
 use futures::stream::poll_fn;
 use futures::{Async, Poll, Stream};
-use graphql_parser::schema as s;
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 use std::collections::btree_map::Entry;
@@ -38,7 +37,7 @@ use crate::data::store::Value;
 use crate::data::value::Word;
 use crate::data_source::CausalityRegion;
 use crate::env::ENV_VARS;
-use crate::prelude::{Attribute, DeploymentHash, SubscriptionFilter, ValueType};
+use crate::prelude::{s, Attribute, DeploymentHash, SubscriptionFilter, ValueType};
 use crate::schema::InputSchema;
 use crate::util::intern;
 use crate::util::stats::MovingStats;
@@ -75,14 +74,14 @@ impl fmt::Display for EntityType {
     }
 }
 
-impl<'a> From<&s::ObjectType<'a, String>> for EntityType {
-    fn from(object_type: &s::ObjectType<'a, String>) -> Self {
+impl<'a> From<&s::ObjectType> for EntityType {
+    fn from(object_type: &s::ObjectType) -> Self {
         EntityType::new(object_type.name.clone())
     }
 }
 
-impl<'a> From<&s::InterfaceType<'a, String>> for EntityType {
-    fn from(interface_type: &s::InterfaceType<'a, String>) -> Self {
+impl<'a> From<&s::InterfaceType> for EntityType {
+    fn from(interface_type: &s::InterfaceType) -> Self {
         EntityType::new(interface_type.name.clone())
     }
 }

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -137,7 +137,7 @@ pub trait SubgraphStore: Send + Sync + 'static {
     ) -> Result<Vec<EntityOperation>, StoreError>;
 
     /// Return the GraphQL schema supplied by the user
-    fn input_schema(&self, subgraph_id: &DeploymentHash) -> Result<Arc<InputSchema>, StoreError>;
+    fn input_schema(&self, subgraph_id: &DeploymentHash) -> Result<InputSchema, StoreError>;
 
     /// Return a bool represeting whether there is a pending graft for the subgraph
     fn graft_pending(&self, id: &DeploymentHash) -> Result<bool, StoreError>;
@@ -225,7 +225,7 @@ pub trait ReadStore: Send + Sync + 'static {
         query_derived: &DerivedEntityQuery,
     ) -> Result<BTreeMap<EntityKey, Entity>, StoreError>;
 
-    fn input_schema(&self) -> Arc<InputSchema>;
+    fn input_schema(&self) -> InputSchema;
 }
 
 // This silly impl is needed until https://github.com/rust-lang/rust/issues/65991 is stable.
@@ -248,13 +248,13 @@ impl<T: ?Sized + ReadStore> ReadStore for Arc<T> {
         (**self).get_derived(entity_derived)
     }
 
-    fn input_schema(&self) -> Arc<InputSchema> {
+    fn input_schema(&self) -> InputSchema {
         (**self).input_schema()
     }
 }
 
 pub trait DeploymentCursorTracker: Sync + Send + 'static {
-    fn input_schema(&self) -> Arc<InputSchema>;
+    fn input_schema(&self) -> InputSchema;
 
     /// Get a pointer to the most recently processed block in the subgraph.
     fn block_ptr(&self) -> Option<BlockPtr>;
@@ -274,7 +274,7 @@ impl<T: ?Sized + DeploymentCursorTracker> DeploymentCursorTracker for Arc<T> {
         (**self).firehose_cursor()
     }
 
-    fn input_schema(&self) -> Arc<InputSchema> {
+    fn input_schema(&self) -> InputSchema {
         (**self).input_schema()
     }
 }
@@ -564,7 +564,7 @@ pub trait QueryStore: Send + Sync {
 
     fn api_schema(&self) -> Result<Arc<ApiSchema>, QueryExecutionError>;
 
-    fn input_schema(&self) -> Result<Arc<InputSchema>, QueryExecutionError>;
+    fn input_schema(&self) -> Result<InputSchema, QueryExecutionError>;
 
     fn network_name(&self) -> &str;
 

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -10,8 +10,8 @@ use crate::components::subgraph::SubgraphVersionSwitchingMode;
 use crate::components::transaction_receipt;
 use crate::components::versions::ApiVersion;
 use crate::data::query::Trace;
+use crate::data::store::QueryObject;
 use crate::data::subgraph::{status, DeploymentFeatures};
-use crate::data::value::Object;
 use crate::data::{query::QueryTarget, subgraph::schema::*};
 use crate::prelude::{DeploymentState, NodeId, QueryExecutionError, SubgraphName};
 use crate::schema::{ApiSchema, InputSchema};
@@ -537,7 +537,7 @@ pub trait QueryStore: Send + Sync {
     fn find_query_values(
         &self,
         query: EntityQuery,
-    ) -> Result<(Vec<Object>, Trace), QueryExecutionError>;
+    ) -> Result<(Vec<QueryObject>, Trace), QueryExecutionError>;
 
     async fn is_deployment_synced(&self) -> Result<bool, Error>;
 

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -1,14 +1,19 @@
+use anyhow::Error;
+use async_trait::async_trait;
 use web3::types::{Address, H256};
 
 use super::*;
 use crate::blockchain::block_stream::FirehoseCursor;
+use crate::components::metrics::stopwatch::StopwatchMetrics;
 use crate::components::server::index_node::VersionInfo;
+use crate::components::subgraph::SubgraphVersionSwitchingMode;
 use crate::components::transaction_receipt;
 use crate::components::versions::ApiVersion;
 use crate::data::query::Trace;
 use crate::data::subgraph::{status, DeploymentFeatures};
 use crate::data::value::Object;
 use crate::data::{query::QueryTarget, subgraph::schema::*};
+use crate::prelude::{DeploymentState, NodeId, QueryExecutionError, SubgraphName};
 use crate::schema::{ApiSchema, InputSchema};
 
 pub trait SubscriptionManager: Send + Sync + 'static {

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -564,6 +564,8 @@ pub trait QueryStore: Send + Sync {
 
     fn api_schema(&self) -> Result<Arc<ApiSchema>, QueryExecutionError>;
 
+    fn input_schema(&self) -> Result<Arc<InputSchema>, QueryExecutionError>;
+
     fn network_name(&self) -> &str;
 
     /// A permit should be acquired before starting query execution.

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -1,5 +1,5 @@
 //! Data structures and helpers for writing subgraph changes to the store
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
 
 use crate::{
     blockchain::{block_stream::FirehoseCursor, BlockPtr},
@@ -524,12 +524,12 @@ impl<'a> Iterator for ClampsByBlockIterator<'a> {
 /// A list of entity changes with one group per entity type
 #[derive(Debug)]
 pub struct RowGroups {
-    schema: Arc<InputSchema>,
+    schema: InputSchema,
     pub groups: Vec<RowGroup>,
 }
 
 impl RowGroups {
-    fn new(schema: Arc<InputSchema>) -> Self {
+    fn new(schema: InputSchema) -> Self {
         Self {
             schema,
             groups: Vec::new(),
@@ -633,7 +633,7 @@ pub struct Batch {
 
 impl Batch {
     pub fn new(
-        schema: Arc<InputSchema>,
+        schema: InputSchema,
         block_ptr: BlockPtr,
         firehose_cursor: FirehoseCursor,
         mut raw_mods: Vec<EntityModification>,

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -897,8 +897,7 @@ impl<'a> Iterator for WriteChunkIter<'a> {
 mod test {
     use crate::{
         components::store::{
-            write::EntityModification, write::EntityOp, BlockNumber, EntityKey, EntityType,
-            StoreError,
+            write::EntityModification, write::EntityOp, BlockNumber, EntityType, StoreError,
         },
         entity,
         prelude::DeploymentHash,
@@ -916,7 +915,7 @@ mod test {
             .iter()
             .zip(blocks.iter())
             .map(|(value, block)| EntityModification::Remove {
-                key: EntityKey::onchain(&*ROW_GROUP_TYPE, value.to_string()),
+                key: ROW_GROUP_TYPE.key(value.to_string()),
                 block: *block,
             })
             .collect();
@@ -989,7 +988,7 @@ mod test {
             use Mod::*;
 
             let value = value.clone();
-            let key = EntityKey::onchain(&*THING_TYPE, "one");
+            let key = THING_TYPE.key("one");
             match value {
                 Ins(block) => EntityModification::Insert {
                     key,
@@ -1093,7 +1092,7 @@ mod test {
     fn last_op() {
         #[track_caller]
         fn is_remove(group: &RowGroup, at: BlockNumber) {
-            let key = EntityKey::onchain(&*THING_TYPE, "one");
+            let key = THING_TYPE.key("one");
             let op = group.last_op(&key, at).unwrap();
 
             assert!(
@@ -1105,7 +1104,7 @@ mod test {
         }
         #[track_caller]
         fn is_write(group: &RowGroup, at: BlockNumber) {
-            let key = EntityKey::onchain(&*THING_TYPE, "one");
+            let key = THING_TYPE.key("one");
             let op = group.last_op(&key, at).unwrap();
 
             assert!(
@@ -1118,7 +1117,7 @@ mod test {
 
         use Mod::*;
 
-        let key = EntityKey::onchain(&*THING_TYPE, "one");
+        let key = THING_TYPE.key("one");
 
         // This will result in two mods int the group:
         //   [ InsC(1,2), InsC(2,3) ]

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -1,9 +1,10 @@
 use crate::{
     blockchain::Blockchain,
-    components::store::{EntityKey, ReadStore, StoredDynamicDataSource},
+    components::store::{ReadStore, StoredDynamicDataSource},
     data::subgraph::schema::SubgraphError,
     data_source::DataSourceTemplate,
     prelude::*,
+    schema::EntityKey,
     util::lfu_cache::LfuCache,
 };
 

--- a/graph/src/components/subgraph/proof_of_indexing/mod.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/mod.rs
@@ -36,6 +36,7 @@ pub type SharedProofOfIndexing = Option<Arc<AtomicRefCell<ProofOfIndexing>>>;
 mod tests {
     use super::*;
     use crate::{
+        data::store::Id,
         prelude::{BlockPtr, DeploymentHash, Value},
         schema::InputSchema,
     };
@@ -71,7 +72,7 @@ mod tests {
             // pretty foolproof so that the actual usage will also match.
 
             // Create a database which stores intermediate PoIs
-            let mut db = HashMap::<String, Vec<u8>>::new();
+            let mut db = HashMap::<Id, Vec<u8>>::new();
 
             let mut block_count = 1;
             for causality_region in case.data.causality_regions.values() {

--- a/graph/src/data/graphql/object_or_interface.rs
+++ b/graph/src/data/graphql/object_or_interface.rs
@@ -1,5 +1,5 @@
-use crate::schema::Schema;
-use crate::{components::store::EntityType, prelude::s};
+use crate::prelude::s;
+use crate::schema::{EntityType, Schema};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};

--- a/graph/src/data/graphql/object_or_interface.rs
+++ b/graph/src/data/graphql/object_or_interface.rs
@@ -63,15 +63,6 @@ impl<'a> From<&'a s::InterfaceType> for ObjectOrInterface<'a> {
     }
 }
 
-impl<'a> From<ObjectOrInterface<'a>> for EntityType {
-    fn from(ooi: ObjectOrInterface) -> Self {
-        match ooi {
-            ObjectOrInterface::Object(ty) => EntityType::from(ty),
-            ObjectOrInterface::Interface(ty) => EntityType::from(ty),
-        }
-    }
-}
-
 impl<'a> ObjectOrInterface<'a> {
     pub fn is_object(self) -> bool {
         match self {

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -322,6 +322,12 @@ impl From<SubgraphManifestResolveError> for QueryExecutionError {
     }
 }
 
+impl From<anyhow::Error> for QueryExecutionError {
+    fn from(e: anyhow::Error) -> Self {
+        QueryExecutionError::Panic(e.to_string())
+    }
+}
+
 /// Error caused while processing a [Query](struct.Query.html) request.
 #[derive(Clone, Debug)]
 pub enum QueryError {

--- a/graph/src/data/store/id.rs
+++ b/graph/src/data/store/id.rs
@@ -1,17 +1,48 @@
 //! Types and helpers to deal with entity IDs which support a subset of the
 //! types that more general values support
 use anyhow::{anyhow, Error};
+use stable_hash::{StableHash, StableHasher};
+use std::convert::TryFrom;
+use std::fmt;
 
 use crate::{
     data::graphql::{ObjectTypeExt, TypeExt},
     prelude::s,
 };
 
+use crate::{
+    components::store::StoreError,
+    constraint_violation,
+    data::value::Word,
+    prelude::{CacheWeight, QueryExecutionError},
+    runtime::gas::{Gas, GasSizeOf},
+    schema::EntityType,
+};
+
+use super::{scalar, Value};
+
 /// The types that can be used for the `id` of an entity
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum IdType {
     String,
     Bytes,
+}
+
+impl IdType {
+    /// Parse the given string into an ID of this type
+    pub fn parse(&self, s: Word) -> Result<Id, Error> {
+        match self {
+            IdType::String => Ok(Id::String(s)),
+            IdType::Bytes => Ok(Id::Bytes(s.parse()?)),
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            IdType::String => "String",
+            IdType::Bytes => "Bytes",
+        }
+    }
 }
 
 impl<'a> TryFrom<&s::ObjectType> for IdType {
@@ -23,13 +54,337 @@ impl<'a> TryFrom<&s::ObjectType> for IdType {
         match base_type {
             "ID" | "String" => Ok(IdType::String),
             "Bytes" => Ok(IdType::Bytes),
-            s => {
-                return Err(anyhow!(
-                    "Entity type {} uses illegal type {} for id column",
-                    obj_type.name,
-                    s
-                ))
+            s => Err(anyhow!(
+                "Entity type {} uses illegal type {} for id column",
+                obj_type.name,
+                s
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for IdType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Values for the ids of entities
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Id {
+    String(Word),
+    Bytes(scalar::Bytes),
+}
+
+impl Id {
+    pub fn id_type(&self) -> IdType {
+        match self {
+            Id::String(_) => IdType::String,
+            Id::Bytes(_) => IdType::Bytes,
+        }
+    }
+}
+
+impl std::hash::Hash for Id {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        core::mem::discriminant(self).hash(state);
+        match self {
+            Id::String(s) => s.hash(state),
+            Id::Bytes(b) => b.hash(state),
+        }
+    }
+}
+
+impl PartialEq<Value> for Id {
+    fn eq(&self, other: &Value) -> bool {
+        match (self, other) {
+            (Id::String(s), Value::String(v)) => s.as_str() == v.as_str(),
+            (Id::Bytes(s), Value::Bytes(v)) => s == v,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<Id> for Value {
+    fn eq(&self, other: &Id) -> bool {
+        other.eq(self)
+    }
+}
+
+impl TryFrom<Value> for Id {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::String(s) => Ok(Id::String(Word::from(s))),
+            Value::Bytes(b) => Ok(Id::Bytes(b)),
+            _ => Err(anyhow!(
+                "expected string or bytes for id but found {:?}",
+                value
+            )),
+        }
+    }
+}
+
+impl From<Id> for Value {
+    fn from(value: Id) -> Self {
+        match value {
+            Id::String(s) => Value::String(s.into()),
+            Id::Bytes(b) => Value::Bytes(b),
+        }
+    }
+}
+
+impl std::fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Id::String(s) => write!(f, "{}", s),
+            Id::Bytes(b) => write!(f, "{}", b),
+        }
+    }
+}
+
+impl CacheWeight for Id {
+    fn indirect_weight(&self) -> usize {
+        match self {
+            Id::String(s) => s.indirect_weight(),
+            Id::Bytes(b) => b.indirect_weight(),
+        }
+    }
+}
+
+impl GasSizeOf for Id {
+    fn gas_size_of(&self) -> Gas {
+        match self {
+            Id::String(s) => s.gas_size_of(),
+            Id::Bytes(b) => b.gas_size_of(),
+        }
+    }
+}
+
+impl StableHash for Id {
+    fn stable_hash<H: StableHasher>(&self, field_address: H::Addr, state: &mut H) {
+        match self {
+            Id::String(s) => stable_hash::StableHash::stable_hash(s, field_address, state),
+            Id::Bytes(b) => {
+                // We have to convert here to a string `0xdeadbeef` for
+                // backwards compatibility. It would be nice to avoid that
+                // allocation and just use the bytes directly, but that will
+                // break PoI compatibility
+                stable_hash::StableHash::stable_hash(&b.to_string(), field_address, state)
             }
+        }
+    }
+}
+
+impl stable_hash_legacy::StableHash for Id {
+    fn stable_hash<H: stable_hash_legacy::StableHasher>(
+        &self,
+        sequence_number: H::Seq,
+        state: &mut H,
+    ) {
+        match self {
+            Id::String(s) => stable_hash_legacy::StableHash::stable_hash(s, sequence_number, state),
+            Id::Bytes(b) => {
+                stable_hash_legacy::StableHash::stable_hash(&b.to_string(), sequence_number, state)
+            }
+        }
+    }
+}
+
+/// A value that contains a reference to the underlying data for an entity
+/// ID. This is used to avoid cloning the ID when it is not necessary.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum IdRef<'a> {
+    String(&'a str),
+    Bytes(&'a [u8]),
+}
+
+impl std::fmt::Display for IdRef<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IdRef::String(s) => write!(f, "{}", s),
+            IdRef::Bytes(b) => write!(f, "0x{}", hex::encode(b)),
+        }
+    }
+}
+
+impl<'a> IdRef<'a> {
+    pub fn to_value(self) -> Id {
+        match self {
+            IdRef::String(s) => Id::String(Word::from(s.to_owned())),
+            IdRef::Bytes(b) => Id::Bytes(scalar::Bytes::from(b)),
+        }
+    }
+}
+
+/// A homogeneous list of entity ids, i.e., all ids in the list are of the
+/// same `IdType`
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IdList {
+    String(Vec<Word>),
+    Bytes(Vec<scalar::Bytes>),
+}
+
+impl IdList {
+    pub fn new(typ: IdType) -> Self {
+        match typ {
+            IdType::String => IdList::String(Vec::new()),
+            IdType::Bytes => IdList::Bytes(Vec::new()),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            IdList::String(ids) => ids.len(),
+            IdList::Bytes(ids) => ids.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Turn a list of ids into an `IdList` and check that they are all the
+    /// same type
+    pub fn try_from_iter<I: Iterator<Item = Id>>(
+        entity_type: &EntityType,
+        mut iter: I,
+    ) -> Result<Self, QueryExecutionError> {
+        let id_type = entity_type.id_type()?;
+        match id_type {
+            IdType::String => {
+                let ids: Vec<Word> = iter.try_fold(vec![], |mut ids, id| match id {
+                    Id::String(id) => {
+                        ids.push(id);
+                        Ok(ids)
+                    }
+                    Id::Bytes(id) => Err(constraint_violation!(
+                        "expected string id, got bytes: {}",
+                        id,
+                    )),
+                })?;
+                Ok(IdList::String(ids))
+            }
+            IdType::Bytes => {
+                let ids: Vec<scalar::Bytes> = iter.try_fold(vec![], |mut ids, id| match id {
+                    Id::String(id) => Err(constraint_violation!(
+                        "expected bytes id, got string: {}",
+                        id,
+                    )),
+                    Id::Bytes(id) => {
+                        ids.push(id);
+                        Ok(ids)
+                    }
+                })?;
+                Ok(IdList::Bytes(ids))
+            }
+        }
+    }
+
+    /// Turn a list of references to ids into an `IdList` and check that
+    /// they are all the same type. Note that this method clones all the ids
+    /// and `try_from_iter` is therefore preferrable
+    pub fn try_from_iter_ref<'a, I: Iterator<Item = IdRef<'a>>>(
+        mut iter: I,
+    ) -> Result<Self, QueryExecutionError> {
+        let first = match iter.next() {
+            Some(id) => id,
+            None => return Ok(IdList::String(Vec::new())),
+        };
+        match first {
+            IdRef::String(s) => {
+                let ids: Vec<_> = iter.try_fold(vec![Word::from(s)], |mut ids, id| match id {
+                    IdRef::String(id) => {
+                        ids.push(Word::from(id));
+                        Ok(ids)
+                    }
+                    IdRef::Bytes(id) => Err(constraint_violation!(
+                        "expected string id, got bytes: 0x{}",
+                        hex::encode(id),
+                    )),
+                })?;
+                Ok(IdList::String(ids))
+            }
+            IdRef::Bytes(b) => {
+                let ids: Vec<_> =
+                    iter.try_fold(vec![scalar::Bytes::from(b)], |mut ids, id| match id {
+                        IdRef::String(id) => Err(constraint_violation!(
+                            "expected bytes id, got string: {}",
+                            id,
+                        )),
+                        IdRef::Bytes(id) => {
+                            ids.push(scalar::Bytes::from(id));
+                            Ok(ids)
+                        }
+                    })?;
+                Ok(IdList::Bytes(ids))
+            }
+        }
+    }
+
+    pub fn index(&self, index: usize) -> IdRef<'_> {
+        match self {
+            IdList::String(ids) => IdRef::String(&ids[index]),
+            IdList::Bytes(ids) => IdRef::Bytes(ids[index].as_slice()),
+        }
+    }
+
+    pub fn first(&self) -> Option<IdRef<'_>> {
+        if self.len() > 0 {
+            Some(self.index(0))
+        } else {
+            None
+        }
+    }
+
+    pub fn iter(&self) -> Box<dyn Iterator<Item = IdRef<'_>> + '_> {
+        match self {
+            IdList::String(ids) => Box::new(ids.iter().map(|id| IdRef::String(id))),
+            IdList::Bytes(ids) => Box::new(ids.iter().map(|id| IdRef::Bytes(id))),
+        }
+    }
+
+    pub fn as_unique(self) -> Self {
+        match self {
+            IdList::String(mut ids) => {
+                ids.sort_unstable();
+                ids.dedup();
+                IdList::String(ids)
+            }
+            IdList::Bytes(mut ids) => {
+                ids.sort_unstable_by(|id1, id2| id1.as_slice().cmp(id2.as_slice()));
+                ids.dedup();
+                IdList::Bytes(ids)
+            }
+        }
+    }
+
+    pub fn push(&mut self, entity_id: Id) -> Result<(), StoreError> {
+        match (self, entity_id) {
+            (IdList::String(ids), Id::String(id)) => {
+                ids.push(id);
+                Ok(())
+            }
+            (IdList::Bytes(ids), Id::Bytes(id)) => {
+                ids.push(id);
+                Ok(())
+            }
+            (IdList::String(_), Id::Bytes(b)) => Err(constraint_violation!(
+                "expected id of type string, but got Bytes[{}]",
+                b
+            )),
+            (IdList::Bytes(_), Id::String(s)) => Err(constraint_violation!(
+                "expected id of type bytes, but got String[{}]",
+                s
+            )),
+        }
+    }
+
+    pub fn as_ids(self) -> Vec<Id> {
+        match self {
+            IdList::String(ids) => ids.into_iter().map(Id::String).collect(),
+            IdList::Bytes(ids) => ids.into_iter().map(Id::Bytes).collect(),
         }
     }
 }

--- a/graph/src/data/store/id.rs
+++ b/graph/src/data/store/id.rs
@@ -19,7 +19,7 @@ use crate::{
     schema::EntityType,
 };
 
-use super::{scalar, Value};
+use super::{scalar, Value, ID};
 
 /// The types that can be used for the `id` of an entity
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -49,7 +49,7 @@ impl<'a> TryFrom<&s::ObjectType> for IdType {
     type Error = Error;
 
     fn try_from(obj_type: &s::ObjectType) -> Result<Self, Self::Error> {
-        let base_type = obj_type.field("id").unwrap().field_type.get_base_type();
+        let base_type = obj_type.field(&*ID).unwrap().field_type.get_base_type();
 
         match base_type {
             "ID" | "String" => Ok(IdType::String),

--- a/graph/src/data/store/id.rs
+++ b/graph/src/data/store/id.rs
@@ -1,0 +1,35 @@
+//! Types and helpers to deal with entity IDs which support a subset of the
+//! types that more general values support
+use anyhow::{anyhow, Error};
+
+use crate::{
+    data::graphql::{ObjectTypeExt, TypeExt},
+    prelude::s,
+};
+
+/// The types that can be used for the `id` of an entity
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum IdType {
+    String,
+    Bytes,
+}
+
+impl<'a> TryFrom<&s::ObjectType> for IdType {
+    type Error = Error;
+
+    fn try_from(obj_type: &s::ObjectType) -> Result<Self, Self::Error> {
+        let base_type = obj_type.field("id").unwrap().field_type.get_base_type();
+
+        match base_type {
+            "ID" | "String" => Ok(IdType::String),
+            "Bytes" => Ok(IdType::Bytes),
+            s => {
+                return Err(anyhow!(
+                    "Entity type {} uses illegal type {} for id column",
+                    obj_type.name,
+                    s
+                ))
+            }
+        }
+    }
+}

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -931,7 +931,7 @@ impl Entity {
         for field in self.0.atoms() {
             if !schema.has_field(&key.entity_type, field) {
                 return Err(EntityValidationError::FieldsNotDefined {
-                    entity: key.entity_type.clone().into_string(),
+                    entity: key.entity_type.to_string(),
                 });
             }
         }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -28,7 +28,7 @@ use super::{
 
 /// Handling of entity ids
 mod id;
-pub use id::IdType;
+pub use id::{Id, IdList, IdRef, IdType};
 
 /// Custom scalars in GraphQL.
 pub mod scalar;
@@ -806,12 +806,8 @@ impl Entity {
     /// string. If it is `Bytes`, return it as a hex string with a `0x`
     /// prefix. If the ID is not set or anything but a `String` or `Bytes`,
     /// return an error
-    pub fn id(&self) -> Word {
-        match self.get("id") {
-            Some(Value::String(s)) => Word::from(s.clone()),
-            Some(Value::Bytes(b)) => Word::from(b.to_string()),
-            None | Some(_) => unreachable!("we checked the id when constructing this entity"),
-        }
+    pub fn id(&self) -> Id {
+        Id::try_from(self.get("id").unwrap().clone()).expect("the id is set to a valid value")
     }
 
     /// Merges an entity update `update` into this entity.
@@ -1047,7 +1043,7 @@ impl std::fmt::Debug for Entity {
 /// possibly a pointer to its parent if the query that constructed it is one
 /// that depends on parents
 pub struct QueryObject {
-    pub parent: Option<r::Value>,
+    pub parent: Option<Id>,
     pub entity: r::Object,
 }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -26,6 +26,10 @@ use super::{
     value::Word,
 };
 
+/// Handling of entity ids
+mod id;
+pub use id::IdType;
+
 /// Custom scalars in GraphQL.
 pub mod scalar;
 
@@ -172,33 +176,6 @@ impl ValueType {
     /// Return `true` if `s` is the name of a builtin scalar type
     pub fn is_scalar(s: &str) -> bool {
         Self::from_str(s).is_ok()
-    }
-}
-
-/// The types that can be used for the `id` of an entity
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub enum IdType {
-    String,
-    Bytes,
-}
-
-impl<'a> TryFrom<&s::ObjectType> for IdType {
-    type Error = Error;
-
-    fn try_from(obj_type: &s::ObjectType) -> Result<Self, Self::Error> {
-        let base_type = obj_type.field("id").unwrap().field_type.get_base_type();
-
-        match base_type {
-            "ID" | "String" => Ok(IdType::String),
-            "Bytes" => Ok(IdType::Bytes),
-            s => {
-                return Err(anyhow!(
-                    "Entity type {} uses illegal type {} for id column",
-                    obj_type.name,
-                    s
-                ))
-            }
-        }
     }
 }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1099,6 +1099,7 @@ fn entity_validation() {
         static ref SUBGRAPH: DeploymentHash = DeploymentHash::new("doesntmatter").unwrap();
         static ref SCHEMA: InputSchema =
             InputSchema::parse(DOCUMENT, SUBGRAPH.clone()).expect("Failed to parse test schema");
+        static ref THING_TYPE: EntityType = SCHEMA.entity_type("Thing").unwrap();
     }
 
     fn make_thing(name: &str) -> Entity {
@@ -1107,7 +1108,7 @@ fn entity_validation() {
 
     fn check(thing: Entity, errmsg: &str) {
         let id = thing.id();
-        let key = EntityKey::data("Thing".to_owned(), id.clone());
+        let key = EntityKey::onchain(&*THING_TYPE, id.clone());
 
         let err = thing.validate(&SCHEMA, &key);
         if errmsg.is_empty() {

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -654,9 +654,6 @@ where
 lazy_static! {
     /// The name of the id attribute, `"id"`
     pub static ref ID: Word = Word::from("id");
-    /// The name of the parent_id attribute that we inject into query
-    /// results
-    pub static ref PARENT_ID: Word = Word::from("g$parent_id");
 }
 
 /// An entity is represented as a map of attribute names to values.
@@ -1065,6 +1062,21 @@ impl std::fmt::Debug for Entity {
             ds.field(k, v);
         }
         ds.finish()
+    }
+}
+
+/// An object that is returned from a query. It's a an `r::Value` which
+/// carries the attributes of the object (`__typename`, `id` etc.) and
+/// possibly a pointer to its parent if the query that constructed it is one
+/// that depends on parents
+pub struct QueryObject {
+    pub parent: Option<r::Value>,
+    pub entity: r::Object,
+}
+
+impl CacheWeight for QueryObject {
+    fn indirect_weight(&self) -> usize {
+        self.parent.indirect_weight() + self.entity.indirect_weight()
     }
 }
 

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -182,6 +182,26 @@ pub enum IdType {
     Bytes,
 }
 
+impl TryFrom<&s::ObjectType> for IdType {
+    type Error = Error;
+
+    fn try_from(obj_type: &s::ObjectType) -> Result<Self, Self::Error> {
+        let base_type = obj_type.field("id").unwrap().field_type.get_base_type();
+
+        match base_type {
+            "ID" | "String" => Ok(IdType::String),
+            "Bytes" => Ok(IdType::Bytes),
+            s => {
+                return Err(anyhow!(
+                    "Entity type {} uses illegal type {} for id column",
+                    obj_type.name,
+                    s
+                ))
+            }
+        }
+    }
+}
+
 // Note: Do not modify fields without also making a backward compatible change to the StableHash impl (below)
 /// An attribute value is represented as an enum with variants for all supported value types.
 #[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -929,7 +929,7 @@ impl Entity {
         })?;
 
         for field in self.0.atoms() {
-            if !schema.has_field(&key.entity_type, field) {
+            if !key.entity_type.has_field(field) {
                 return Err(EntityValidationError::FieldsNotDefined {
                     entity: key.entity_type.to_string(),
                 });

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -55,7 +55,7 @@ impl SubscriptionFilter {
                     entity_type,
                     ..
                 },
-            ) => subgraph_id == eid && entity_type == etype,
+            ) => subgraph_id == eid && entity_type == etype.as_str(),
             (Self::Assignment, EntityChange::Assignment { .. }) => true,
             _ => false,
         }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -22,7 +22,7 @@ use strum_macros::IntoStaticStr;
 use thiserror::Error;
 
 use super::{
-    graphql::{ext::DirectiveFinder, TypeExt as _},
+    graphql::{ext::DirectiveFinder, ObjectOrInterface, TypeExt as _},
     value::Word,
 };
 
@@ -182,7 +182,7 @@ pub enum IdType {
     Bytes,
 }
 
-impl TryFrom<&s::ObjectType> for IdType {
+impl<'a> TryFrom<&s::ObjectType> for IdType {
     type Error = Error;
 
     fn try_from(obj_type: &s::ObjectType) -> Result<Self, Self::Error> {

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -921,7 +921,7 @@ impl Entity {
             return Ok(());
         }
 
-        let object_type = schema.find_object_type(&key.entity_type).ok_or_else(|| {
+        let object_type = key.entity_type.object_type().ok_or_else(|| {
             EntityValidationError::UnknownEntityType {
                 entity: key.entity_type.to_string(),
                 id: key.entity_id.to_string(),

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,9 +1,9 @@
 use crate::{
-    components::store::{DeploymentLocator, EntityKey},
+    components::store::DeploymentLocator,
     data::graphql::ObjectTypeExt,
     prelude::{lazy_static, q, r, s, CacheWeight, QueryExecutionError},
     runtime::gas::{Gas, GasSizeOf},
-    schema::{EntityType, InputSchema},
+    schema::{EntityKey, EntityType, InputSchema},
     util::intern::{self, AtomPool},
     util::intern::{Error as InternError, NullValue, Object},
 };

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -867,7 +867,7 @@ impl Entity {
                 s::Type::NamedType(name) => ValueType::from_str(name).unwrap_or_else(|_| {
                     match schema.get_named_type(name) {
                         Some(t::Object(obj_type)) => {
-                            let id = obj_type.field("id").expect("all object types have an id");
+                            let id = obj_type.field(&*ID).expect("all object types have an id");
                             scalar_value_type(schema, &id.field_type)
                         }
                         Some(t::Interface(intf)) => {
@@ -887,7 +887,7 @@ impl Entity {
                                 }
                                 Some(obj_type) => {
                                     let id =
-                                        obj_type.field("id").expect("all object types have an id");
+                                        obj_type.field(&*ID).expect("all object types have an id");
                                     scalar_value_type(schema, &id.field_type)
                                 }
                             }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1108,7 +1108,7 @@ fn entity_validation() {
 
     fn check(thing: Entity, errmsg: &str) {
         let id = thing.id();
-        let key = EntityKey::onchain(&*THING_TYPE, id.clone());
+        let key = THING_TYPE.key(id.clone());
 
         let err = thing.validate(&SCHEMA, &key);
         if errmsg.is_empty() {

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,9 +1,9 @@
 use crate::{
-    components::store::{DeploymentLocator, EntityKey, EntityType},
+    components::store::{DeploymentLocator, EntityKey},
     data::graphql::ObjectTypeExt,
     prelude::{lazy_static, q, r, s, CacheWeight, QueryExecutionError},
     runtime::gas::{Gas, GasSizeOf},
-    schema::InputSchema,
+    schema::{EntityType, InputSchema},
     util::intern::{self, AtomPool},
     util::intern::{Error as InternError, NullValue, Object},
 };

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -22,7 +22,7 @@ use strum_macros::IntoStaticStr;
 use thiserror::Error;
 
 use super::{
-    graphql::{ext::DirectiveFinder, ObjectOrInterface, TypeExt as _},
+    graphql::{ext::DirectiveFinder, TypeExt as _},
     value::Word,
 };
 

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -589,7 +589,7 @@ impl GasSizeOf for BigInt {
 }
 
 /// A byte array that's serialized as a hex string prefixed by `0x`.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Bytes(Box<[u8]>);
 
 impl Deref for Bytes {
@@ -675,6 +675,15 @@ impl<const N: usize> From<[u8; N]> for Bytes {
 impl From<Vec<u8>> for Bytes {
     fn from(vec: Vec<u8>) -> Self {
         Bytes(vec.into())
+    }
+}
+
+impl ToSql<diesel::sql_types::Binary, diesel::pg::Pg> for Bytes {
+    fn to_sql<W: Write>(
+        &self,
+        out: &mut diesel::serialize::Output<W, diesel::pg::Pg>,
+    ) -> diesel::serialize::Result {
+        <_ as ToSql<diesel::sql_types::Binary, _>>::to_sql(self.as_slice(), out)
     }
 }
 

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -9,12 +9,13 @@ use std::str::FromStr;
 use std::{fmt, fmt::Display};
 
 use super::DeploymentHash;
+use crate::blockchain::Blockchain;
 use crate::data::graphql::TryFromValue;
 use crate::data::store::Value;
 use crate::data::subgraph::SubgraphManifest;
 use crate::prelude::*;
+use crate::schema::EntityType;
 use crate::util::stable_hash_glue::impl_stable_hash;
-use crate::{blockchain::Blockchain, components::store::EntityType};
 
 pub const POI_TABLE: &str = "poi2$";
 

--- a/graph/src/data/subgraph/schema.rs
+++ b/graph/src/data/subgraph/schema.rs
@@ -2,7 +2,6 @@
 
 use anyhow::{anyhow, bail, Error};
 use hex;
-use lazy_static::lazy_static;
 use rand::rngs::OsRng;
 use rand::Rng;
 use std::collections::BTreeSet;
@@ -13,17 +12,11 @@ use super::DeploymentHash;
 use crate::data::graphql::TryFromValue;
 use crate::data::store::Value;
 use crate::data::subgraph::SubgraphManifest;
-use crate::data::value::Word;
 use crate::prelude::*;
 use crate::util::stable_hash_glue::impl_stable_hash;
 use crate::{blockchain::Blockchain, components::store::EntityType};
 
 pub const POI_TABLE: &str = "poi2$";
-lazy_static! {
-    pub static ref POI_OBJECT: EntityType = EntityType::new("Poi$".to_string());
-    /// The name of the digest attribute of POI entities
-    pub static ref POI_DIGEST: Word = Word::from("digest");
-}
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -1,9 +1,14 @@
 use crate::prelude::{q, s, CacheWeight};
 use crate::runtime::gas::{Gas, GasSizeOf, SaturatingInto};
+use diesel::pg::Pg;
+use diesel::serialize::{self, Output};
+use diesel::sql_types::Text;
+use diesel::types::ToSql;
 use serde::ser::{SerializeMap, SerializeSeq, Serializer};
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
+use std::io::Write;
 use std::iter::FromIterator;
 
 /// An immutable string that is more memory-efficient since it only has an
@@ -65,6 +70,12 @@ impl<'de> serde::Deserialize<'de> for Word {
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer).map(Into::into)
+    }
+}
+
+impl ToSql<Text, Pg> for Word {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+        <str as ToSql<Text, Pg>>::to_sql(&self.0, out)
     }
 }
 

--- a/graph/src/data_source/mod.rs
+++ b/graph/src/data_source/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     data_source::offchain::OFFCHAIN_KINDS,
     prelude::{CheapClone as _, DataSourceContext},
-    schema::EntityType,
+    schema::{EntityType, InputSchema},
 };
 use anyhow::Error;
 use semver::Version;
@@ -342,6 +342,7 @@ impl<C: Blockchain> UnresolvedDataSourceTemplate<C> {
     pub async fn resolve(
         self,
         resolver: &Arc<dyn LinkResolver>,
+        schema: &InputSchema,
         logger: &Logger,
         manifest_idx: u32,
     ) -> Result<DataSourceTemplate<C>, Error> {
@@ -351,7 +352,7 @@ impl<C: Blockchain> UnresolvedDataSourceTemplate<C> {
                 .await
                 .map(DataSourceTemplate::Onchain),
             Self::Offchain(ds) => ds
-                .resolve(resolver, logger, manifest_idx)
+                .resolve(resolver, logger, manifest_idx, schema)
                 .await
                 .map(DataSourceTemplate::Offchain),
         }

--- a/graph/src/data_source/mod.rs
+++ b/graph/src/data_source/mod.rs
@@ -13,10 +13,11 @@ use crate::{
     },
     components::{
         link_resolver::LinkResolver,
-        store::{BlockNumber, EntityType, StoredDynamicDataSource},
+        store::{BlockNumber, StoredDynamicDataSource},
     },
     data_source::offchain::OFFCHAIN_KINDS,
     prelude::{CheapClone as _, DataSourceContext},
+    schema::EntityType,
 };
 use anyhow::Error;
 use semver::Version;

--- a/graph/src/data_source/offchain.rs
+++ b/graph/src/data_source/offchain.rs
@@ -3,13 +3,14 @@ use crate::{
     blockchain::{BlockPtr, Blockchain},
     components::{
         link_resolver::LinkResolver,
-        store::{BlockNumber, EntityType, StoredDynamicDataSource},
+        store::{BlockNumber, StoredDynamicDataSource},
         subgraph::DataSourceTemplateInfo,
     },
     data::{store::scalar::Bytes, subgraph::SPEC_VERSION_0_0_7, value::Word},
     data_source,
     ipfs_client::CidFile,
     prelude::{DataSourceContext, Link},
+    schema::EntityType,
 };
 use anyhow::{anyhow, Context, Error};
 use itertools::Itertools;

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -207,6 +207,6 @@ pub mod prelude {
     });
 
     pub mod r {
-        pub use crate::data::value::Value;
+        pub use crate::data::value::{Object, Value};
     }
 }

--- a/graph/src/runtime/gas/size_of.rs
+++ b/graph/src/runtime/gas/size_of.rs
@@ -1,8 +1,9 @@
 //! Various implementations of GasSizeOf;
 
 use crate::{
-    components::store::{EntityKey, EntityType, LoadRelatedRequest},
+    components::store::{EntityKey, LoadRelatedRequest},
     data::store::{scalar::Bytes, Value},
+    schema::EntityType,
 };
 
 use super::{Gas, GasSizeOf, SaturatingInto as _};

--- a/graph/src/runtime/gas/size_of.rs
+++ b/graph/src/runtime/gas/size_of.rs
@@ -1,9 +1,9 @@
 //! Various implementations of GasSizeOf;
 
 use crate::{
-    components::store::{EntityKey, LoadRelatedRequest},
+    components::store::LoadRelatedRequest,
     data::store::{scalar::Bytes, Value},
-    schema::EntityType,
+    schema::{EntityKey, EntityType},
 };
 
 use super::{Gas, GasSizeOf, SaturatingInto as _};

--- a/graph/src/schema/api.rs
+++ b/graph/src/schema/api.rs
@@ -93,7 +93,7 @@ impl ApiSchema {
     /// In addition, the API schema has an introspection schema mixed into
     /// `api_schema`. In particular, the `Query` type has fields called
     /// `__schema` and `__type`
-    pub fn from_api_schema(mut api_schema: Schema) -> Result<Self, anyhow::Error> {
+    pub(crate) fn from_api_schema(mut api_schema: Schema) -> Result<Self, anyhow::Error> {
         add_introspection_schema(&mut api_schema.document);
 
         let query_type = api_schema
@@ -121,6 +121,14 @@ impl ApiSchema {
             subscription_type,
             object_types,
         })
+    }
+
+    /// Create an API Schema that can be used to execute GraphQL queries.
+    /// This method is only meant for schemas that are not derived from a
+    /// subgraph schema, like the schema for the index-node server. Use
+    /// `InputSchema::api_schema` to get an API schema for a subgraph
+    pub fn from_graphql_schema(schema: Schema) -> Result<Self, anyhow::Error> {
+        Self::from_api_schema(schema)
     }
 
     pub fn document(&self) -> &s::Document {

--- a/graph/src/schema/api.rs
+++ b/graph/src/schema/api.rs
@@ -5,7 +5,6 @@ use graphql_parser::{schema::TypeDefinition, Pos};
 use inflector::Inflector;
 use lazy_static::lazy_static;
 
-use crate::components::store::EntityType;
 use crate::data::graphql::{ObjectOrInterface, ObjectTypeExt};
 use crate::schema::{ast, META_FIELD_NAME, META_FIELD_TYPE};
 
@@ -136,12 +135,12 @@ impl ApiSchema {
         &self.schema
     }
 
-    pub fn types_for_interface(&self) -> &BTreeMap<EntityType, Vec<ObjectType>> {
+    pub fn types_for_interface(&self) -> &BTreeMap<String, Vec<ObjectType>> {
         &self.schema.types_for_interface
     }
 
     /// Returns `None` if the type implements no interfaces.
-    pub fn interfaces_for_type(&self, type_name: &EntityType) -> Option<&Vec<InterfaceType>> {
+    pub fn interfaces_for_type(&self, type_name: &str) -> Option<&Vec<InterfaceType>> {
         self.schema.interfaces_for_type(type_name)
     }
 

--- a/graph/src/schema/ast.rs
+++ b/graph/src/schema/ast.rs
@@ -405,11 +405,10 @@ pub fn is_list(field_type: &s::Type) -> bool {
 
 #[test]
 fn entity_validation() {
-    use crate::components::store::EntityKey;
     use crate::data::store;
     use crate::entity;
     use crate::prelude::{DeploymentHash, Entity};
-    use crate::schema::{EntityType, InputSchema};
+    use crate::schema::{EntityKey, EntityType, InputSchema};
 
     const DOCUMENT: &str = "
     enum Color { red, yellow, blue }

--- a/graph/src/schema/ast.rs
+++ b/graph/src/schema/ast.rs
@@ -406,11 +406,10 @@ pub fn is_list(field_type: &s::Type) -> bool {
 #[test]
 fn entity_validation() {
     use crate::components::store::EntityKey;
-    use crate::components::store::EntityType;
     use crate::data::store;
     use crate::entity;
     use crate::prelude::{DeploymentHash, Entity};
-    use crate::schema::InputSchema;
+    use crate::schema::{EntityType, InputSchema};
 
     const DOCUMENT: &str = "
     enum Color { red, yellow, blue }

--- a/graph/src/schema/ast.rs
+++ b/graph/src/schema/ast.rs
@@ -408,7 +408,7 @@ fn entity_validation() {
     use crate::data::store;
     use crate::entity;
     use crate::prelude::{DeploymentHash, Entity};
-    use crate::schema::{EntityKey, EntityType, InputSchema};
+    use crate::schema::{EntityType, InputSchema};
 
     const DOCUMENT: &str = "
     enum Color { red, yellow, blue }
@@ -440,7 +440,7 @@ fn entity_validation() {
 
     fn check(thing: Entity, errmsg: &str) {
         let id = thing.id();
-        let key = EntityKey::onchain(&*THING_TYPE, id.clone());
+        let key = THING_TYPE.key(id.clone());
 
         let err = thing.validate(&SCHEMA, &key);
         if errmsg.is_empty() {

--- a/graph/src/schema/ast.rs
+++ b/graph/src/schema/ast.rs
@@ -406,6 +406,7 @@ pub fn is_list(field_type: &s::Type) -> bool {
 #[test]
 fn entity_validation() {
     use crate::components::store::EntityKey;
+    use crate::components::store::EntityType;
     use crate::data::store;
     use crate::entity;
     use crate::prelude::{DeploymentHash, Entity};
@@ -432,6 +433,7 @@ fn entity_validation() {
     lazy_static! {
         static ref SUBGRAPH: DeploymentHash = DeploymentHash::new("doesntmatter").unwrap();
         static ref SCHEMA: InputSchema = InputSchema::raw(DOCUMENT, "doesntmatter");
+        static ref THING_TYPE: EntityType = SCHEMA.entity_type("Thing").unwrap();
     }
 
     fn make_thing(name: &str) -> Entity {
@@ -440,7 +442,7 @@ fn entity_validation() {
 
     fn check(thing: Entity, errmsg: &str) {
         let id = thing.id();
-        let key = EntityKey::data("Thing".to_owned(), id.clone());
+        let key = EntityKey::onchain(&*THING_TYPE, id.clone());
 
         let err = thing.validate(&SCHEMA, &key);
         if errmsg.is_empty() {

--- a/graph/src/schema/entity_key.rs
+++ b/graph/src/schema/entity_key.rs
@@ -1,10 +1,7 @@
 use std::fmt;
 
-use anyhow::Error;
-
 use crate::components::store::StoreError;
-use crate::data::store::Value;
-use crate::data::value::Word;
+use crate::data::store::{Id, Value};
 use crate::data_source::CausalityRegion;
 use crate::schema::EntityType;
 use crate::util::intern;
@@ -17,7 +14,7 @@ pub struct EntityKey {
     pub entity_type: EntityType,
 
     /// ID of the individual entity.
-    pub entity_id: Word,
+    pub entity_id: Id,
 
     /// This is the causality region of the data source that created the entity.
     ///
@@ -38,7 +35,7 @@ impl EntityKey {
 impl EntityKey {
     pub(in crate::schema) fn new(
         entity_type: EntityType,
-        entity_id: Word,
+        entity_id: Id,
         causality_region: CausalityRegion,
     ) -> Self {
         Self {
@@ -49,8 +46,8 @@ impl EntityKey {
         }
     }
 
-    pub fn id_value(&self) -> Result<Value, Error> {
-        self.entity_type.id_value(self.entity_id.clone())
+    pub fn id_value(&self) -> Value {
+        Value::from(self.entity_id.clone())
     }
 }
 

--- a/graph/src/schema/entity_key.rs
+++ b/graph/src/schema/entity_key.rs
@@ -22,6 +22,8 @@ pub struct EntityKey {
     /// doing the lookup. So if the entity exists but was created on a different causality region,
     /// the lookup will return empty.
     pub causality_region: CausalityRegion,
+
+    _force_use_of_new: (),
 }
 
 impl EntityKey {
@@ -40,16 +42,17 @@ impl EntityKey {
             entity_type,
             entity_id,
             causality_region,
+            _force_use_of_new: (),
         }
     }
 
     pub fn from(id: &String, load_related_request: &LoadRelatedRequest) -> Self {
         let clone = load_related_request.clone();
-        Self {
-            entity_id: id.clone().into(),
-            entity_type: clone.entity_type,
-            causality_region: clone.causality_region,
-        }
+        Self::new(
+            clone.entity_type,
+            Word::from(id.as_str()),
+            clone.causality_region,
+        )
     }
 }
 

--- a/graph/src/schema/entity_key.rs
+++ b/graph/src/schema/entity_key.rs
@@ -1,0 +1,62 @@
+use std::fmt;
+
+use crate::components::store::{LoadRelatedRequest, StoreError};
+use crate::data::value::Word;
+use crate::data_source::CausalityRegion;
+use crate::schema::EntityType;
+use crate::util::intern;
+
+/// Key by which an individual entity in the store can be accessed. Stores
+/// only the entity type and id. The deployment must be known from context.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EntityKey {
+    /// Name of the entity type.
+    pub entity_type: EntityType,
+
+    /// ID of the individual entity.
+    pub entity_id: Word,
+
+    /// This is the causality region of the data source that created the entity.
+    ///
+    /// In the case of an entity lookup, this is the causality region of the data source that is
+    /// doing the lookup. So if the entity exists but was created on a different causality region,
+    /// the lookup will return empty.
+    pub causality_region: CausalityRegion,
+}
+
+impl EntityKey {
+    pub fn unknown_attribute(&self, err: intern::Error) -> StoreError {
+        StoreError::UnknownAttribute(self.entity_type.to_string(), err.not_interned())
+    }
+}
+
+impl EntityKey {
+    // For use in tests only
+    #[cfg(debug_assertions)]
+    pub fn onchain(entity_type: &EntityType, entity_id: impl Into<String>) -> Self {
+        Self {
+            entity_type: entity_type.clone(),
+            entity_id: entity_id.into().into(),
+            causality_region: CausalityRegion::ONCHAIN,
+        }
+    }
+
+    pub fn from(id: &String, load_related_request: &LoadRelatedRequest) -> Self {
+        let clone = load_related_request.clone();
+        Self {
+            entity_id: id.clone().into(),
+            entity_type: clone.entity_type,
+            causality_region: clone.causality_region,
+        }
+    }
+}
+
+impl std::fmt::Debug for EntityKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "EntityKey({}[{}], cr={})",
+            self.entity_type, self.entity_id, self.causality_region
+        )
+    }
+}

--- a/graph/src/schema/entity_key.rs
+++ b/graph/src/schema/entity_key.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use anyhow::Error;
 
-use crate::components::store::{LoadRelatedRequest, StoreError};
+use crate::components::store::StoreError;
 use crate::data::store::Value;
 use crate::data::value::Word;
 use crate::data_source::CausalityRegion;
@@ -47,15 +47,6 @@ impl EntityKey {
             causality_region,
             _force_use_of_new: (),
         }
-    }
-
-    pub fn from(id: &String, load_related_request: &LoadRelatedRequest) -> Self {
-        let clone = load_related_request.clone();
-        Self::new(
-            clone.entity_type,
-            Word::from(id.as_str()),
-            clone.causality_region,
-        )
     }
 
     pub fn id_value(&self) -> Result<Value, Error> {

--- a/graph/src/schema/entity_key.rs
+++ b/graph/src/schema/entity_key.rs
@@ -1,6 +1,9 @@
 use std::fmt;
 
+use anyhow::Error;
+
 use crate::components::store::{LoadRelatedRequest, StoreError};
+use crate::data::store::Value;
 use crate::data::value::Word;
 use crate::data_source::CausalityRegion;
 use crate::schema::EntityType;
@@ -53,6 +56,10 @@ impl EntityKey {
             Word::from(id.as_str()),
             clone.causality_region,
         )
+    }
+
+    pub fn id_value(&self) -> Result<Value, Error> {
+        self.entity_type.id_value(self.entity_id.clone())
     }
 }
 

--- a/graph/src/schema/entity_key.rs
+++ b/graph/src/schema/entity_key.rs
@@ -31,13 +31,15 @@ impl EntityKey {
 }
 
 impl EntityKey {
-    // For use in tests only
-    #[cfg(debug_assertions)]
-    pub fn onchain(entity_type: &EntityType, entity_id: impl Into<String>) -> Self {
+    pub(in crate::schema) fn new(
+        entity_type: EntityType,
+        entity_id: Word,
+        causality_region: CausalityRegion,
+    ) -> Self {
         Self {
-            entity_type: entity_type.clone(),
-            entity_id: entity_id.into().into(),
-            causality_region: CausalityRegion::ONCHAIN,
+            entity_type,
+            entity_id,
+            causality_region,
         }
     }
 

--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Borrow, fmt, sync::Arc};
 
-use anyhow::{bail, Context, Error};
+use anyhow::{Context, Error};
 use serde::Serialize;
 
 use crate::{
@@ -27,18 +27,8 @@ pub struct EntityType {
 }
 
 impl EntityType {
-    /// Construct a new entity type. Ideally, this is only called when
-    /// `entity_type` either comes from the GraphQL schema, or from
-    /// the database from fields that are known to contain a valid entity type
-    // This method is only meant to be used in `InputSchema`; all external
-    // constructions of an `EntityType` need to go through that struct
-    pub(in crate::schema) fn new(schema: InputSchema, name: &str) -> Result<Self, Error> {
-        let atom = match schema.pool().lookup(name) {
-            Some(atom) => atom,
-            None => bail!("entity type `{name}` is not interned"),
-        };
-
-        Ok(EntityType { schema, atom })
+    pub(in crate::schema) fn new(schema: InputSchema, atom: Atom) -> Self {
+        EntityType { schema, atom }
     }
 
     pub fn as_str(&self) -> &str {

--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -5,12 +5,13 @@ use serde::Serialize;
 
 use crate::{
     cheap_clone::CheapClone,
-    data::{graphql::ObjectOrInterface, store::IdType},
+    data::{graphql::ObjectOrInterface, store::IdType, value::Word},
+    data_source::causality_region::CausalityRegion,
     prelude::s,
     util::intern::Atom,
 };
 
-use super::{input_schema::POI_OBJECT, InputSchema};
+use super::{input_schema::POI_OBJECT, EntityKey, InputSchema};
 
 /// The type name of an entity. This is the string that is used in the
 /// subgraph's GraphQL schema as `type NAME @entity { .. }`
@@ -58,6 +59,16 @@ impl EntityType {
 
     pub fn id_type(&self) -> Result<IdType, Error> {
         self.schema.id_type(self)
+    }
+
+    /// Create a key from this type for an onchain entity
+    pub fn key(&self, id: impl Into<Word>) -> EntityKey {
+        self.key_in(id, CausalityRegion::ONCHAIN)
+    }
+
+    /// Create a key from this type for an entity in the given causality region
+    pub fn key_in(&self, id: impl Into<Word>, causality_region: CausalityRegion) -> EntityKey {
+        EntityKey::new(self.cheap_clone(), id.into(), causality_region)
     }
 
     fn same_pool(&self, other: &EntityType) -> bool {

--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -59,7 +59,7 @@ impl EntityType {
     }
 
     pub fn id_type(&self) -> Result<IdType, Error> {
-        self.schema.id_type(self)
+        self.schema.id_type(self.atom)
     }
 
     pub fn object_type(&self) -> Option<&s::ObjectType> {
@@ -82,7 +82,7 @@ impl EntityType {
         let id = id.into();
         let id_type = self
             .schema
-            .id_type(self)
+            .id_type(self.atom)
             .with_context(|| format!("error determining id_type for {}[{}]", self.as_str(), id))?;
         match id_type {
             IdType::String => Ok(Value::String(id.to_string())),

--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -62,6 +62,10 @@ impl EntityType {
         self.schema.id_type(self)
     }
 
+    pub fn object_type(&self) -> Option<&s::ObjectType> {
+        self.schema.find_object_type(self)
+    }
+
     /// Create a key from this type for an onchain entity
     pub fn key(&self, id: impl Into<Word>) -> EntityKey {
         self.key_in(id, CausalityRegion::ONCHAIN)

--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -4,7 +4,10 @@ use anyhow::{bail, Error};
 use serde::Serialize;
 
 use crate::{
-    cheap_clone::CheapClone, data::graphql::ObjectOrInterface, prelude::s, util::intern::Atom,
+    cheap_clone::CheapClone,
+    data::{graphql::ObjectOrInterface, store::IdType},
+    prelude::s,
+    util::intern::Atom,
 };
 
 use super::{input_schema::POI_OBJECT, InputSchema};
@@ -43,6 +46,18 @@ impl EntityType {
 
     pub fn is_poi(&self) -> bool {
         self.as_str() == POI_OBJECT
+    }
+
+    pub fn has_field(&self, field: Atom) -> bool {
+        self.schema.has_field(self.atom, field)
+    }
+
+    pub fn is_immutable(&self) -> bool {
+        self.schema.is_immutable(self.atom)
+    }
+
+    pub fn id_type(&self) -> Result<IdType, Error> {
+        self.schema.id_type(self)
     }
 
     fn same_pool(&self, other: &EntityType) -> bool {

--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Borrow, fmt, sync::Arc};
 
 use anyhow::{bail, Error};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::{
     cheap_clone::CheapClone,
@@ -12,7 +12,7 @@ use crate::{
 
 /// The type name of an entity. This is the string that is used in the
 /// subgraph's GraphQL schema as `type NAME @entity { .. }`
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EntityType(Word);
 
 impl EntityType {

--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -1,0 +1,97 @@
+use std::{borrow::Borrow, fmt, sync::Arc};
+
+use anyhow::{bail, Error};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    cheap_clone::CheapClone,
+    data::{graphql::ObjectOrInterface, value::Word},
+    prelude::s,
+    util::intern::AtomPool,
+};
+
+/// The type name of an entity. This is the string that is used in the
+/// subgraph's GraphQL schema as `type NAME @entity { .. }`
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EntityType(Word);
+
+impl EntityType {
+    /// Construct a new entity type. Ideally, this is only called when
+    /// `entity_type` either comes from the GraphQL schema, or from
+    /// the database from fields that are known to contain a valid entity type
+    pub(crate) fn new(pool: &Arc<AtomPool>, entity_type: &str) -> Result<Self, Error> {
+        match pool.lookup(entity_type) {
+            Some(_) => Ok(EntityType(Word::from(entity_type))),
+            None => bail!("entity type `{}` is not interned", entity_type),
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn into_string(self) -> String {
+        self.0.to_string()
+    }
+
+    pub fn is_poi(&self) -> bool {
+        self.0.as_str() == "Poi$"
+    }
+}
+
+impl fmt::Display for EntityType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Borrow<str> for EntityType {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl CheapClone for EntityType {}
+
+impl std::fmt::Debug for EntityType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "EntityType({})", self.0)
+    }
+}
+
+pub trait AsEntityTypeName {
+    fn name(&self) -> &str;
+}
+
+impl AsEntityTypeName for &str {
+    fn name(&self) -> &str {
+        self
+    }
+}
+
+impl AsEntityTypeName for &String {
+    fn name(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsEntityTypeName for &s::ObjectType {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl AsEntityTypeName for &s::InterfaceType {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl AsEntityTypeName for ObjectOrInterface<'_> {
+    fn name(&self) -> &str {
+        match self {
+            ObjectOrInterface::Object(object) => &object.name,
+            ObjectOrInterface::Interface(interface) => &interface.name,
+        }
+    }
+}

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -31,6 +31,9 @@ const POI_DIGEST: &str = "digest";
 /// with writing a subgraph should use this struct. Code that deals with
 /// querying subgraphs will instead want to use an `ApiSchema` which can be
 /// generated with the `api_schema` method on `InputSchema`
+///
+/// There's no need to put this into an `Arc`, since `InputSchema` already
+/// does that internally and is `CheapClone`
 #[derive(Clone, Debug, PartialEq)]
 pub struct InputSchema {
     inner: Arc<Inner>,

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -245,7 +245,10 @@ impl InputSchema {
         }
     }
 
-    pub fn id_type(&self, entity_type: &EntityType) -> Result<store::IdType, Error> {
+    pub(in crate::schema) fn id_type(
+        &self,
+        entity_type: &EntityType,
+    ) -> Result<store::IdType, Error> {
         let base_type = self
             .inner
             .schema
@@ -283,9 +286,8 @@ impl InputSchema {
         }
     }
 
-    pub fn is_immutable(&self, entity_type: &EntityType) -> bool {
-        let atom = self.inner.pool.lookup(entity_type.as_str()).unwrap();
-        self.inner.immutable_types.contains(&atom)
+    pub(in crate::schema) fn is_immutable(&self, entity_type: Atom) -> bool {
+        self.inner.immutable_types.contains(&entity_type)
     }
 
     pub fn get_named_type(&self, name: &str) -> Option<&s::TypeDefinition> {
@@ -391,11 +393,10 @@ impl InputSchema {
         Entity::try_make(self.inner.pool.clone(), iter)
     }
 
-    pub fn has_field(&self, entity_type: &EntityType, field: Atom) -> bool {
-        let atom = self.inner.pool.lookup(entity_type.as_str()).unwrap();
+    pub(in crate::schema) fn has_field(&self, entity_type: Atom, field: Atom) -> bool {
         self.inner
             .field_names
-            .get(&atom)
+            .get(&entity_type)
             .map(|fields| fields.contains(&field))
             .unwrap_or(false)
     }

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -223,34 +223,7 @@ impl InputSchema {
     ///
     /// When asked to load the related entities from "Account" in the field "wallets"
     /// This function will return the type "Wallet" with the field "account"
-    pub fn get_field_related(
-        &self,
-        key: &LoadRelatedRequest,
-    ) -> Result<(&str, &s::Field, bool), Error> {
-        let id_field = self
-            .inner
-            .schema
-            .document
-            .get_object_type_definition(key.entity_type.as_str())
-            .ok_or_else(|| {
-                anyhow!(
-                    "Entity {}[{}]: unknown entity type `{}`",
-                    key.entity_type,
-                    key.entity_id,
-                    key.entity_type,
-                )
-            })?
-            .field("id")
-            .ok_or_else(|| {
-                anyhow!(
-                    "Entity {}[{}]: unknown field `{}`",
-                    key.entity_type,
-                    key.entity_id,
-                    key.entity_field,
-                )
-            })?;
-
-        let id_is_bytes = id_field.field_type.get_base_type() == "Bytes";
+    pub fn get_field_related(&self, key: &LoadRelatedRequest) -> Result<(&str, &s::Field), Error> {
         let field = self
             .inner
             .schema
@@ -301,7 +274,7 @@ impl InputSchema {
                     )
                 })?;
 
-            Ok((base_type, field, id_is_bytes))
+            Ok((base_type, field))
         } else {
             Err(anyhow!(
                 "Entity {}[{}]: field `{}` is not derived",

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -286,10 +286,7 @@ impl InputSchema {
     }
 
     pub fn types_for_interface(&self, intf: &s::InterfaceType) -> Option<&Vec<s::ObjectType>> {
-        self.inner
-            .schema
-            .types_for_interface
-            .get(&EntityType::new(intf.name.clone()))
+        self.inner.schema.types_for_interface.get(&intf.name)
     }
 
     pub fn find_object_type(&self, entity_type: &EntityType) -> Option<&s::ObjectType> {
@@ -313,7 +310,7 @@ impl InputSchema {
         self.inner.schema.document.get_object_type_definitions()
     }
 
-    pub fn interface_types(&self) -> &BTreeMap<EntityType, Vec<s::ObjectType>> {
+    pub fn interface_types(&self) -> &BTreeMap<String, Vec<s::ObjectType>> {
         &self.inner.schema.types_for_interface
     }
 

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -287,7 +287,10 @@ impl InputSchema {
         self.inner.schema.interfaces_for_type(type_name)
     }
 
-    pub fn find_object_type(&self, entity_type: &EntityType) -> Option<&s::ObjectType> {
+    pub(in crate::schema) fn find_object_type(
+        &self,
+        entity_type: &EntityType,
+    ) -> Option<&s::ObjectType> {
         self.inner
             .schema
             .document

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -1,17 +1,14 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Error};
+use anyhow::{anyhow, Error};
 use store::Entity;
 
 use crate::cheap_clone::CheapClone;
 use crate::components::store::LoadRelatedRequest;
 use crate::data::graphql::ext::DirectiveFinder;
 use crate::data::graphql::{DirectiveExt, DocumentExt, ObjectTypeExt, TypeExt, ValueExt};
-use crate::data::store::{
-    self, scalar, EntityValidationError, IntoEntityIterator, TryIntoEntityIterator,
-};
+use crate::data::store::{self, EntityValidationError, IntoEntityIterator, TryIntoEntityIterator};
 use crate::data::value::Word;
 use crate::prelude::q::Value;
 use crate::prelude::{s, DeploymentHash};
@@ -19,7 +16,7 @@ use crate::schema::api_schema;
 use crate::util::intern::{Atom, AtomPool};
 
 use super::fulltext::FulltextDefinition;
-use super::{ApiSchema, AsEntityTypeName, EntityKey, EntityType, Schema, SchemaValidationError};
+use super::{ApiSchema, AsEntityTypeName, EntityType, Schema, SchemaValidationError};
 
 /// The name of the PoI entity type
 pub(crate) const POI_OBJECT: &str = "Poi$";
@@ -270,19 +267,6 @@ impl InputSchema {
                     s
                 ))
             }
-        }
-    }
-
-    /// Construct a value for the entity type's id attribute
-    pub fn id_value(&self, key: &EntityKey) -> Result<store::Value, Error> {
-        let id_type = self
-            .id_type(&key.entity_type)
-            .with_context(|| format!("error determining id_type for {:?}", key))?;
-        match id_type {
-            store::IdType::String => Ok(store::Value::String(key.entity_id.to_string())),
-            store::IdType::Bytes => Ok(store::Value::Bytes(scalar::Bytes::from_str(
-                &key.entity_id,
-            )?)),
         }
     }
 

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Context, Error};
 use store::Entity;
 
 use crate::cheap_clone::CheapClone;
-use crate::components::store::{AsEntityTypeName, EntityKey, EntityType, LoadRelatedRequest};
+use crate::components::store::{EntityKey, LoadRelatedRequest};
 use crate::data::graphql::ext::DirectiveFinder;
 use crate::data::graphql::{DirectiveExt, DocumentExt, ObjectTypeExt, TypeExt, ValueExt};
 use crate::data::store::{
@@ -19,7 +19,7 @@ use crate::schema::api_schema;
 use crate::util::intern::{Atom, AtomPool};
 
 use super::fulltext::FulltextDefinition;
-use super::{ApiSchema, Schema, SchemaValidationError};
+use super::{ApiSchema, AsEntityTypeName, EntityType, Schema, SchemaValidationError};
 
 /// The name of the PoI entity type
 const POI_OBJECT: &str = "Poi$";

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -22,7 +22,7 @@ use super::fulltext::FulltextDefinition;
 use super::{ApiSchema, AsEntityTypeName, EntityType, Schema, SchemaValidationError};
 
 /// The name of the PoI entity type
-const POI_OBJECT: &str = "Poi$";
+pub(crate) const POI_OBJECT: &str = "Poi$";
 /// The name of the digest attribute of POI entities
 const POI_DIGEST: &str = "digest";
 
@@ -401,18 +401,16 @@ impl InputSchema {
     }
 
     pub fn poi_type(&self) -> EntityType {
-        EntityType::new(&self.inner.pool, POI_OBJECT).unwrap()
+        // unwrap: we make sure to put POI_OBJECT into the pool
+        EntityType::new(self.cheap_clone(), POI_OBJECT).unwrap()
     }
 
     pub fn poi_digest(&self) -> Word {
         Word::from(POI_DIGEST)
     }
 
-    pub fn atom(&self, s: &str) -> Option<Atom> {
-        self.inner.pool.lookup(s)
-    }
-
-    pub fn pool(&self) -> &Arc<AtomPool> {
+    // A helper for the `EntityType` constructor
+    pub(in crate::schema) fn pool(&self) -> &Arc<AtomPool> {
         &self.inner.pool
     }
 
@@ -421,7 +419,7 @@ impl InputSchema {
     /// of `named` is based on user input. If `named` is an internal object,
     /// like a `ObjectType`, it is safe to unwrap the result
     pub fn entity_type<N: AsEntityTypeName>(&self, named: N) -> Result<EntityType, Error> {
-        EntityType::new(&self.inner.pool, named.name())
+        EntityType::new(self.cheap_clone(), named.name())
     }
 }
 

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Context, Error};
 use store::Entity;
 
 use crate::cheap_clone::CheapClone;
-use crate::components::store::{EntityKey, LoadRelatedRequest};
+use crate::components::store::LoadRelatedRequest;
 use crate::data::graphql::ext::DirectiveFinder;
 use crate::data::graphql::{DirectiveExt, DocumentExt, ObjectTypeExt, TypeExt, ValueExt};
 use crate::data::store::{
@@ -19,7 +19,7 @@ use crate::schema::api_schema;
 use crate::util::intern::{Atom, AtomPool};
 
 use super::fulltext::FulltextDefinition;
-use super::{ApiSchema, AsEntityTypeName, EntityType, Schema, SchemaValidationError};
+use super::{ApiSchema, AsEntityTypeName, EntityKey, EntityType, Schema, SchemaValidationError};
 
 /// The name of the PoI entity type
 pub(crate) const POI_OBJECT: &str = "Poi$";

--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -27,6 +27,7 @@ mod api;
 /// Utilities for working with GraphQL schema ASTs.
 pub mod ast;
 
+mod entity_key;
 mod entity_type;
 mod fulltext;
 mod input_schema;
@@ -34,6 +35,7 @@ mod input_schema;
 pub use api::{api_schema, is_introspection_field, APISchemaError, INTROSPECTION_QUERY_TYPE};
 
 pub use api::{ApiSchema, ErrorPolicy};
+pub use entity_key::EntityKey;
 pub use entity_type::{AsEntityTypeName, EntityType};
 pub use fulltext::{FulltextAlgorithm, FulltextConfig, FulltextDefinition, FulltextLanguage};
 pub use input_schema::InputSchema;

--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -27,12 +27,14 @@ mod api;
 /// Utilities for working with GraphQL schema ASTs.
 pub mod ast;
 
+mod entity_type;
 mod fulltext;
 mod input_schema;
 
 pub use api::{api_schema, is_introspection_field, APISchemaError, INTROSPECTION_QUERY_TYPE};
 
 pub use api::{ApiSchema, ErrorPolicy};
+pub use entity_type::{AsEntityTypeName, EntityType};
 pub use fulltext::{FulltextAlgorithm, FulltextConfig, FulltextDefinition, FulltextLanguage};
 pub use input_schema::InputSchema;
 

--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -1,6 +1,6 @@
 use crate::data::graphql::ext::{DirectiveExt, DirectiveFinder, DocumentExt, TypeExt, ValueExt};
 use crate::data::graphql::ObjectTypeExt;
-use crate::data::store::ValueType;
+use crate::data::store::{ValueType, ID};
 use crate::data::subgraph::DeploymentHash;
 use crate::prelude::{
     anyhow,
@@ -786,7 +786,7 @@ impl Schema {
             let id_types: HashSet<&str> = HashSet::from_iter(
                 obj_types
                     .iter()
-                    .filter_map(|obj_type| obj_type.field("id"))
+                    .filter_map(|obj_type| obj_type.field(&*ID))
                     .map(|f| f.field_type.get_base_type())
                     .map(|name| if name == "ID" { "String" } else { name }),
             );

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -1,8 +1,7 @@
 use crate::{
-    components::store::EntityKey,
     data::value::Word,
     prelude::{q, BigDecimal, BigInt, Value},
-    schema::EntityType,
+    schema::{EntityKey, EntityType},
 };
 use std::{
     collections::{BTreeMap, HashMap},

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -1,7 +1,8 @@
 use crate::{
-    components::store::{EntityKey, EntityType},
+    components::store::EntityKey,
     data::value::Word,
     prelude::{q, BigDecimal, BigInt, Value},
+    schema::EntityType,
 };
 use std::{
     collections::{BTreeMap, HashMap},

--- a/graph/src/util/intern.rs
+++ b/graph/src/util/intern.rs
@@ -24,7 +24,10 @@ type AtomInt = u16;
 
 /// An atom in a pool. To look up the underlying string, surrounding code
 /// needs to know the pool for it.
-#[derive(Eq, Hash, PartialEq, Clone, Copy, Debug)]
+///
+/// The ordering for atoms is based on their integer value, and has no
+/// connection to how the strings they represent would be ordered
+#[derive(Eq, Hash, PartialEq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub struct Atom(AtomInt);
 
 /// An atom and the underlying pool. A `FatAtom` can be used in place of a

--- a/graph/src/util/intern.rs
+++ b/graph/src/util/intern.rs
@@ -137,6 +137,16 @@ impl AtomPool {
     }
 }
 
+impl<S: AsRef<str>> FromIterator<S> for AtomPool {
+    fn from_iter<I: IntoIterator<Item = S>>(iter: I) -> Self {
+        let mut pool = AtomPool::new();
+        for s in iter {
+            pool.intern(s.as_ref());
+        }
+        pool
+    }
+}
+
 /// A marker for an empty entry in an `Object`
 const TOMBSTONE_KEY: Atom = Atom(AtomInt::MAX);
 

--- a/graphql/src/execution/ast.rs
+++ b/graphql/src/execution/ast.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 
 use graph::{
-    components::store::EntityType,
     data::graphql::ObjectOrInterface,
     prelude::{anyhow, q, r, s, QueryExecutionError, ValueMap},
     schema::{ast::ObjectType, ApiSchema},
@@ -351,7 +350,7 @@ pub(crate) fn resolve_object_types(
         .ok_or_else(|| QueryExecutionError::AbstractTypeError(name.to_string()))?
     {
         s::TypeDefinition::Interface(intf) => {
-            for obj_ty in &schema.types_for_interface()[&EntityType::new(intf.name.to_string())] {
+            for obj_ty in &schema.types_for_interface()[&intf.name] {
                 let obj_ty = schema.object_type(obj_ty);
                 set.insert(obj_ty.into());
             }

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -196,7 +196,7 @@ fn object_interfaces(
 ) -> r::Value {
     r::Value::List(
         schema
-            .interfaces_for_type(&object_type.into())
+            .interfaces_for_type(&object_type.name)
             .unwrap_or(&vec![])
             .iter()
             .map(|typedef| interface_type_object(schema, type_objects, typedef))

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -13,8 +13,8 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::time::Instant;
 
-use graph::schema::{ast as sast, InputSchema};
-use graph::{components::store::EntityType, data::graphql::*};
+use graph::data::graphql::*;
+use graph::schema::{ast as sast, EntityType, InputSchema};
 use graph::{
     data::graphql::ext::DirectiveFinder,
     prelude::{

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -1,15 +1,17 @@
 //! Run a GraphQL query and fetch all the entitied needed to build the
 //! final result
 
-use anyhow::{anyhow, Error};
 use graph::constraint_violation;
 use graph::data::query::Trace;
+use graph::data::store::Id;
+use graph::data::store::IdList;
+use graph::data::store::IdType;
 use graph::data::store::QueryObject;
 use graph::data::value::{Object, Word};
 use graph::prelude::{r, CacheWeight, CheapClone};
 use graph::slog::warn;
 use graph::util::cache_weight;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 use std::time::Instant;
 
@@ -19,8 +21,8 @@ use graph::{
     data::graphql::ext::DirectiveFinder,
     prelude::{
         s, AttributeNames, ChildMultiplicity, EntityCollection, EntityFilter, EntityLink,
-        EntityOrder, EntityWindow, ParentLink, QueryExecutionError, StoreError,
-        Value as StoreValue, WindowAttribute, ENV_VARS,
+        EntityOrder, EntityWindow, ParentLink, QueryExecutionError, Value as StoreValue,
+        WindowAttribute, ENV_VARS,
     },
 };
 
@@ -41,7 +43,7 @@ struct Node {
     /// the keys and values of the `children` map, but not of the map itself
     children_weight: usize,
 
-    parent: Option<r::Value>,
+    parent: Option<Id>,
 
     entity: Object,
     /// We are using an `Rc` here for two reasons: it allows us to defer
@@ -163,6 +165,7 @@ impl From<Node> for r::Value {
 
 trait ValueExt {
     fn as_str(&self) -> Option<&str>;
+    fn as_id(&self, id_type: IdType) -> Option<Id>;
 }
 
 impl ValueExt for r::Value {
@@ -172,14 +175,25 @@ impl ValueExt for r::Value {
             _ => None,
         }
     }
+
+    fn as_id(&self, id_type: IdType) -> Option<Id> {
+        match self {
+            r::Value::String(s) => id_type.parse(Word::from(s.as_str())).ok(),
+            _ => None,
+        }
+    }
 }
 
 impl Node {
-    fn id(&self) -> Result<String, Error> {
+    fn id(&self, schema: &InputSchema) -> Result<Id, QueryExecutionError> {
+        let entity_type = schema.entity_type(self.typename())?;
         match self.get("id") {
-            None => Err(anyhow!("Entity is missing an `id` attribute")),
-            Some(r::Value::String(s)) => Ok(s.clone()),
-            _ => Err(anyhow!("Entity has non-string `id` attribute")),
+            None => Err(QueryExecutionError::IdMissing),
+            Some(r::Value::String(s)) => {
+                let id = entity_type.parse_id(s.as_str())?;
+                Ok(id)
+            }
+            _ => Err(QueryExecutionError::IdNotString),
         }
     }
 
@@ -282,38 +296,45 @@ impl<'a> JoinCond<'a> {
 
     fn entity_link(
         &self,
-        parents_by_id: Vec<(String, &Node)>,
+        parents_by_id: Vec<(Id, &Node)>,
         multiplicity: ChildMultiplicity,
-    ) -> (Vec<String>, EntityLink) {
+    ) -> Result<(IdList, EntityLink), QueryExecutionError> {
         match &self.relation {
             JoinRelation::Direct(field) => {
                 // we only need the parent ids
-                let ids = parents_by_id.into_iter().map(|(id, _)| id).collect();
-                (
+                let ids = IdList::try_from_iter(
+                    &self.parent_type,
+                    parents_by_id.into_iter().map(|(id, _)| id),
+                )?;
+                Ok((
                     ids,
                     EntityLink::Direct(field.window_attribute(), multiplicity),
-                )
+                ))
             }
             JoinRelation::Derived(field) => {
                 let (ids, parent_link) = match field {
                     JoinField::Scalar(child_field) => {
                         // child_field contains a String id of the child; extract
                         // those and the parent ids
+                        let id_type = self.child_type.id_type().unwrap();
                         let (ids, child_ids): (Vec<_>, Vec<_>) = parents_by_id
                             .into_iter()
                             .filter_map(|(id, node)| {
                                 node.get(child_field)
-                                    .and_then(|value| value.as_str())
+                                    .and_then(|value| value.as_id(id_type))
                                     .map(|child_id| (id, child_id.to_owned()))
                             })
                             .unzip();
-
+                        let ids = IdList::try_from_iter(&self.parent_type, ids.into_iter())?;
+                        let child_ids =
+                            IdList::try_from_iter(&self.child_type, child_ids.into_iter())?;
                         (ids, ParentLink::Scalar(child_ids))
                     }
                     JoinField::List(child_field) => {
                         // child_field stores a list of child ids; extract them,
                         // turn them into a list of strings and combine with the
                         // parent ids
+                        let id_type = self.child_type.id_type().unwrap();
                         let (ids, child_ids): (Vec<_>, Vec<_>) = parents_by_id
                             .into_iter()
                             .filter_map(|(id, node)| {
@@ -322,9 +343,7 @@ impl<'a> JoinCond<'a> {
                                         r::Value::List(values) => {
                                             let values: Vec<_> = values
                                                 .iter()
-                                                .filter_map(|value| {
-                                                    value.as_str().map(|value| value.to_owned())
-                                                })
+                                                .filter_map(|value| value.as_id(id_type))
                                                 .collect();
                                             if values.is_empty() {
                                                 None
@@ -337,13 +356,18 @@ impl<'a> JoinCond<'a> {
                                     .map(|child_ids| (id, child_ids))
                             })
                             .unzip();
+                        let ids = IdList::try_from_iter(&self.parent_type, ids.into_iter())?;
+                        let child_ids = child_ids
+                            .into_iter()
+                            .map(|ids| IdList::try_from_iter(&self.child_type, ids.into_iter()))
+                            .collect::<Result<Vec<_>, _>>()?;
                         (ids, ParentLink::List(child_ids))
                     }
                 };
-                (
+                Ok((
                     ids,
                     EntityLink::Parent(self.parent_type.clone(), parent_link),
-                )
+                ))
             }
         }
     }
@@ -380,24 +404,25 @@ impl<'a> Join<'a> {
 
     fn windows(
         &self,
+        schema: &InputSchema,
         parents: &[&mut Node],
         multiplicity: ChildMultiplicity,
         previous_collection: &EntityCollection,
-    ) -> Vec<EntityWindow> {
+    ) -> Result<Vec<EntityWindow>, QueryExecutionError> {
         let mut windows = vec![];
         let column_names_map = previous_collection.entity_types_and_column_names();
         for cond in &self.conds {
             let mut parents_by_id = parents
                 .iter()
                 .filter(|parent| parent.typename() == cond.parent_type.as_str())
-                .filter_map(|parent| parent.id().ok().map(|id| (id, &**parent)))
+                .filter_map(|parent| parent.id(schema).ok().map(|id| (id, &**parent)))
                 .collect::<Vec<_>>();
 
             if !parents_by_id.is_empty() {
                 parents_by_id.sort_unstable_by(|(id1, _), (id2, _)| id1.cmp(id2));
                 parents_by_id.dedup_by(|(id1, _), (id2, _)| id1 == id2);
 
-                let (ids, link) = cond.entity_link(parents_by_id, multiplicity);
+                let (ids, link) = cond.entity_link(parents_by_id, multiplicity)?;
                 let child_type: EntityType = cond.child_type.clone();
                 let column_names = match column_names_map.get(&child_type) {
                     Some(column_names) => column_names.clone(),
@@ -411,7 +436,7 @@ impl<'a> Join<'a> {
                 });
             }
         }
-        windows
+        Ok(windows)
     }
 }
 
@@ -450,6 +475,7 @@ impl<'a> MaybeJoin<'a> {
 /// If `parents` only has one entry, add all children to that one parent. In
 /// particular, this is what happens for toplevel queries.
 fn add_children(
+    schema: &InputSchema,
     parents: &mut [&mut Node],
     children: Vec<Node>,
     response_key: &str,
@@ -466,19 +492,19 @@ fn add_children(
     // children to their parent. This relies on the fact that interfaces
     // make sure that id's are distinct across all implementations of the
     // interface.
-    let mut grouped: BTreeMap<&str, Vec<Rc<Node>>> = BTreeMap::default();
+    let mut grouped: HashMap<&Id, Vec<Rc<Node>>> = HashMap::default();
     for child in children.iter() {
         let parent = child.parent.as_ref().ok_or_else(|| {
             QueryExecutionError::Panic(format!(
                 "child {}[{}] is missing a parent id",
                 child.typename(),
-                child.id().unwrap_or_else(|_| "<no id>".to_owned())
+                child
+                    .id(schema)
+                    .map(|id| id.to_string())
+                    .unwrap_or_else(|_| "<no id>".to_owned())
             ))
         })?;
-        match parent {
-            r::Value::String(key) => grouped.entry(key).or_default().push(child.clone()),
-            _ => unreachable!("the parent_id returned by the query is always a string"),
-        }
+        grouped.entry(parent).or_default().push(child.clone());
     }
 
     // Add appropriate children using grouped map
@@ -490,7 +516,10 @@ fn add_children(
         // interface level and in nested object type conditions. The values for the interface
         // query are always joined first, and may then be overwritten by the merged selection
         // set under the object type condition. See also: e0d6da3e-60cf-41a5-b83c-b60a7a766d4a
-        let values = parent.id().ok().and_then(|id| grouped.get(&*id).cloned());
+        let values = parent
+            .id(schema)
+            .ok()
+            .and_then(|id| grouped.get(&id).cloned());
         parent.set_children(response_key.to_owned(), values.unwrap_or_default());
     }
 
@@ -649,7 +678,12 @@ fn execute_selection_set<'a>(
                         &field.selection_set,
                     ) {
                         Ok((children, trace)) => {
-                            add_children(&mut parents, children, field.response_key())?;
+                            add_children(
+                                &input_schema,
+                                &mut parents,
+                                children,
+                                field.response_key(),
+                            )?;
                             let weight =
                                 parents.iter().map(|parent| parent.weight()).sum::<usize>();
                             check_result_size(ctx, weight)?;
@@ -723,7 +757,7 @@ fn fetch(
         selected_attrs,
         &super::query::SchemaPair {
             api: ctx.query.schema.clone(),
-            input: input_schema,
+            input: input_schema.cheap_clone(),
         },
     )?;
     query.trace = ctx.trace;
@@ -746,7 +780,7 @@ fn fetch(
     if let MaybeJoin::Nested(join) = join {
         // For anything but the root node, restrict the children we select
         // by the parent list
-        let windows = join.windows(parents, multiplicity, &query.collection);
+        let windows = join.windows(&input_schema, parents, multiplicity, &query.collection)?;
         if windows.is_empty() {
             return Ok((vec![], Trace::None));
         }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -7,7 +7,7 @@ use graph::data::value::Object;
 use graph::data::value::Value as DataValue;
 use graph::prelude::*;
 use graph::schema::ast::{self as sast, FilterOp};
-use graph::schema::ApiSchema;
+use graph::schema::{ApiSchema, InputSchema};
 use graph::{components::store::EntityType, data::graphql::ObjectOrInterface};
 
 use crate::execution::ast as a;
@@ -18,6 +18,11 @@ use super::prefetch::SelectedAttributes;
 enum OrderDirection {
     Ascending,
     Descending,
+}
+
+pub(crate) struct SchemaPair {
+    pub api: Arc<ApiSchema>,
+    pub input: Arc<InputSchema>,
 }
 
 /// Builds a EntityQuery from GraphQL arguments.
@@ -31,19 +36,21 @@ pub(crate) fn build_query<'a>(
     max_first: u32,
     max_skip: u32,
     mut column_names: SelectedAttributes,
-    schema: &ApiSchema,
+    schema: &SchemaPair,
 ) -> Result<EntityQuery, QueryExecutionError> {
     let entity = entity.into();
     let entity_types = EntityCollection::All(match &entity {
         ObjectOrInterface::Object(object) => {
             let selected_columns = column_names.get(object);
-            vec![((*object).into(), selected_columns)]
+            let entity_type = schema.input.entity_type(*object).unwrap();
+            vec![(entity_type, selected_columns)]
         }
         ObjectOrInterface::Interface(interface) => types_for_interface[&interface.name]
             .iter()
             .map(|o| {
                 let selected_columns = column_names.get(o);
-                (o.into(), selected_columns)
+                let entity_type = schema.input.entity_type(o).unwrap();
+                (entity_type, selected_columns)
             })
             .collect(),
     });
@@ -172,7 +179,7 @@ fn build_range(
 fn build_filter(
     entity: ObjectOrInterface,
     field: &a::Field,
-    schema: &ApiSchema,
+    schema: &SchemaPair,
 ) -> Result<Option<EntityFilter>, QueryExecutionError> {
     let where_filter = match field.argument_value("where") {
         Some(r::Value::Object(object)) => match build_filter_from_object(entity, object, schema) {
@@ -268,7 +275,7 @@ fn build_entity_filter(
 /// Iterate over the list and generate an EntityFilter from it
 fn build_list_filter_from_value(
     entity: ObjectOrInterface,
-    schema: &ApiSchema,
+    schema: &SchemaPair,
     value: &r::Value,
 ) -> Result<Vec<EntityFilter>, QueryExecutionError> {
     // We have object like this
@@ -293,10 +300,10 @@ fn build_list_filter_from_value(
 }
 
 /// build a filter which has list of nested filters
-fn build_list_filter_from_object(
+fn build_list_filter_from_object<'a>(
     entity: ObjectOrInterface,
     object: &Object,
-    schema: &ApiSchema,
+    schema: &SchemaPair,
 ) -> Result<Vec<EntityFilter>, QueryExecutionError> {
     Ok(object
         .iter()
@@ -309,10 +316,10 @@ fn build_list_filter_from_object(
 }
 
 /// Parses a GraphQL input object into an EntityFilter, if present.
-fn build_filter_from_object(
+fn build_filter_from_object<'a>(
     entity: ObjectOrInterface,
     object: &Object,
-    schema: &ApiSchema,
+    schema: &SchemaPair,
 ) -> Result<Vec<EntityFilter>, QueryExecutionError> {
     object
         .iter()
@@ -389,15 +396,17 @@ fn build_child_filter_from_object(
     entity: ObjectOrInterface,
     field_name: String,
     object: &Object,
-    schema: &ApiSchema,
+    schema: &SchemaPair,
 ) -> Result<EntityFilter, QueryExecutionError> {
     let field = entity
         .field(&field_name)
         .ok_or(QueryExecutionError::InvalidFilterError)?;
     let type_name = &field.field_type.get_base_type();
     let child_entity = schema
+        .api
         .object_or_interface(type_name)
         .ok_or(QueryExecutionError::InvalidFilterError)?;
+    let child_entity_type = schema.input.entity_type(child_entity)?;
     let filter = Box::new(EntityFilter::And(build_filter_from_object(
         child_entity,
         object,
@@ -415,25 +424,27 @@ fn build_child_filter_from_object(
     if child_entity.is_interface() {
         Ok(EntityFilter::Or(
             child_entity
-                .object_types(schema.schema())
+                .object_types(schema.api.schema())
                 .ok_or(QueryExecutionError::AbstractTypeError(
                     "Interface is not implemented by any types".to_string(),
                 ))?
                 .iter()
                 .map(|object_type| {
-                    EntityFilter::Child(Child {
-                        attr: attr.clone(),
-                        entity_type: EntityType::new(object_type.name.to_string()),
-                        filter: filter.clone(),
-                        derived,
+                    schema.input.entity_type(*object_type).map(|entity_type| {
+                        EntityFilter::Child(Child {
+                            attr: attr.clone(),
+                            entity_type,
+                            filter: filter.clone(),
+                            derived,
+                        })
                     })
                 })
-                .collect(),
+                .collect::<Result<_, _>>()?,
         ))
     } else if entity.is_interface() {
         Ok(EntityFilter::Or(
             entity
-                .object_types(schema.schema())
+                .object_types(schema.api.schema())
                 .ok_or(QueryExecutionError::AbstractTypeError(
                     "Interface is not implemented by any types".to_string(),
                 ))?
@@ -456,7 +467,7 @@ fn build_child_filter_from_object(
 
                     Ok(EntityFilter::Child(Child {
                         attr,
-                        entity_type: EntityType::new(child_entity.name().to_string()),
+                        entity_type: child_entity_type.clone(),
                         filter: filter.clone(),
                         derived,
                     }))
@@ -466,7 +477,7 @@ fn build_child_filter_from_object(
     } else {
         Ok(EntityFilter::Child(Child {
             attr,
-            entity_type: EntityType::new(type_name.to_string()),
+            entity_type: schema.input.entity_type(*type_name)?,
             filter,
             derived,
         }))
@@ -543,7 +554,7 @@ enum OrderByChild {
 fn build_order_by(
     entity: ObjectOrInterface,
     field: &a::Field,
-    schema: &ApiSchema,
+    schema: &SchemaPair,
 ) -> Result<Option<(String, ValueType, Option<OrderByChild>)>, QueryExecutionError> {
     match field.argument_value("orderBy") {
         Some(r::Value::Enum(name)) => match parse_order_by(name)? {
@@ -574,12 +585,13 @@ fn build_order_by(
                         })?
                     }
                     ObjectOrInterface::Interface(_) => {
-                        let object_types = schema.types_for_interface().get(entity.name()).ok_or(
-                            QueryExecutionError::EntityFieldError(
-                                entity.name().to_owned(),
-                                parent_field_name.clone(),
-                            ),
-                        )?;
+                        let object_types =
+                            schema.api.types_for_interface().get(entity.name()).ok_or(
+                                QueryExecutionError::EntityFieldError(
+                                    entity.name().to_owned(),
+                                    parent_field_name.clone(),
+                                ),
+                            )?;
 
                         if let Some(first_entity) = object_types.first() {
                             sast::get_field(first_entity, parent_field_name.as_str()).ok_or_else(
@@ -602,6 +614,7 @@ fn build_order_by(
                 let base_type = field.field_type.get_base_type();
 
                 let child_entity = schema
+                    .api
                     .object_or_interface(base_type)
                     .ok_or_else(|| QueryExecutionError::NamedTypeError(base_type.into()))?;
                 let child_field = sast::get_field(child_entity, child_field_name.as_str())
@@ -627,23 +640,24 @@ fn build_order_by(
 
                 let child = match child_entity {
                     ObjectOrInterface::Object(_) => OrderByChild::Object(ObjectOrderDetails {
-                        entity_type: EntityType::new(base_type.into()),
+                        entity_type: schema.input.entity_type(base_type)?,
                         join_attribute,
                         derived,
                     }),
                     ObjectOrInterface::Interface(interface) => {
                         let entity_types = schema
+                            .api
                             .types_for_interface()
                             .get(&interface.name)
                             .map(|object_types| {
                                 object_types
                                     .iter()
-                                    .map(|object_type| EntityType::new(object_type.name.clone()))
-                                    .collect::<Vec<EntityType>>()
+                                    .map(|object_type| schema.input.entity_type(object_type))
+                                    .collect::<Result<Vec<EntityType>, _>>()
                             })
                             .ok_or(QueryExecutionError::AbstractTypeError(
                                 "Interface not implemented by any object type".to_string(),
-                            ))?;
+                            ))??;
                         OrderByChild::Interface(InterfaceOrderDetails {
                             entity_types,
                             join_attribute,
@@ -720,6 +734,7 @@ pub fn parse_subgraph_id<'a>(
 
 /// Recursively collects entities involved in a query field as `(subgraph ID, name)` tuples.
 pub(crate) fn collect_entities_from_query_field(
+    input_schema: &InputSchema,
     schema: &ApiSchema,
     object_type: sast::ObjectType,
     field: &a::Field,
@@ -761,16 +776,20 @@ pub(crate) fn collect_entities_from_query_field(
         }
     }
 
-    Ok(entities
+    entities
         .into_iter()
-        .map(|(id, entity_type)| SubscriptionFilter::Entities(id, EntityType::new(entity_type)))
-        .collect())
+        .map(|(id, entity_type)| {
+            input_schema
+                .entity_type(&entity_type)
+                .map(|entity_type| SubscriptionFilter::Entities(id, entity_type))
+        })
+        .collect::<Result<_, _>>()
+        .map_err(Into::into)
 }
 
 #[cfg(test)]
 mod tests {
     use graph::{
-        components::store::EntityType,
         data::value::Object,
         prelude::{
             r, AttributeNames, DeploymentHash, EntityCollection, EntityFilter, EntityRange, Value,
@@ -780,12 +799,12 @@ mod tests {
             s::{self, Directive, Field, InputValue, ObjectType, Type, Value as SchemaValue},
             EntityOrder,
         },
-        schema::{ApiSchema, Schema},
+        schema::{ApiSchema, InputSchema, Schema},
     };
     use graphql_parser::Pos;
     use std::{collections::BTreeMap, iter::FromIterator, sync::Arc};
 
-    use super::{a, build_query};
+    use super::{a, build_query, SchemaPair};
 
     fn default_object() -> ObjectType {
         let subgraph_id_argument = (
@@ -825,7 +844,7 @@ mod tests {
         ObjectType {
             position: Default::default(),
             description: None,
-            name: String::new(),
+            name: "DefaultObject".to_string(),
             implements_interfaces: vec![],
             directives: vec![subgraph_id_directive],
             fields: vec![name_field, email_field],
@@ -880,28 +899,42 @@ mod tests {
         field
     }
 
-    fn build_schema(raw_schema: &str) -> ApiSchema {
-        let document = graphql_parser::parse_schema(raw_schema)
+    fn build_default_schema() -> SchemaPair {
+        // These schemas are somewhat nonsensical and just good enough to
+        // run the tests. The `API_SCHEMA` does not look like anything that
+        // would be generated from the `INPUT_SCHEMA`
+        const API_SCHEMA: &str = r#"
+        type Query {
+            aField(first: Int, skip: Int): [SomeType]
+        }
+
+        type SomeType @entity {
+            id: ID!
+            name: String!
+        }
+    "#;
+        const INPUT_SCHEMA: &str = r#"
+        type Entity1 @entity { id: ID! }
+        type Entity2 @entity { id: ID! }
+        type DefaultObject @entity {
+            id: ID!
+            name: String
+            email: String
+        }
+    "#;
+
+        let id = DeploymentHash::new("id").unwrap();
+        let input_schema = InputSchema::parse(INPUT_SCHEMA, id.clone()).unwrap();
+        let api_schema = graphql_parser::parse_schema(API_SCHEMA)
             .expect("Failed to parse raw schema")
             .into_static();
+        let api_schema = Schema::new(id, api_schema).unwrap();
+        let api_schema = ApiSchema::from_graphql_schema(api_schema).unwrap();
 
-        let schema = Schema::new(DeploymentHash::new("id").unwrap(), document).unwrap();
-        ApiSchema::from_api_schema(schema).expect("Failed to build schema")
-    }
-
-    fn build_default_schema() -> ApiSchema {
-        build_schema(
-            r#"
-                type Query {
-                    aField(first: Int, skip: Int): [SomeType]
-                }
-
-                type SomeType @entity {
-                    id: ID!
-                    name: String!
-                }
-            "#,
-        )
+        SchemaPair {
+            input: Arc::new(input_schema),
+            api: Arc::new(api_schema),
+        }
     }
 
     #[test]
@@ -916,11 +949,14 @@ mod tests {
                 std::u32::MAX,
                 std::u32::MAX,
                 Default::default(),
-                &schema
+                &schema,
             )
             .unwrap()
             .collection,
-            EntityCollection::All(vec![(EntityType::from("Entity1"), AttributeNames::All)])
+            EntityCollection::All(vec![(
+                schema.input.entity_type("Entity1").unwrap(),
+                AttributeNames::All
+            )])
         );
         assert_eq!(
             build_query(
@@ -935,7 +971,10 @@ mod tests {
             )
             .unwrap()
             .collection,
-            EntityCollection::All(vec![(EntityType::from("Entity2"), AttributeNames::All)])
+            EntityCollection::All(vec![(
+                schema.input.entity_type("Entity2").unwrap(),
+                AttributeNames::All
+            )])
         );
     }
 
@@ -1010,7 +1049,7 @@ mod tests {
                 std::u32::MAX,
                 std::u32::MAX,
                 Default::default(),
-                &schema
+                &schema,
             )
             .unwrap()
             .order,
@@ -1094,7 +1133,7 @@ mod tests {
                 std::u32::MAX,
                 std::u32::MAX,
                 Default::default(),
-                &schema,
+                &schema
             )
             .unwrap()
             .order,

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -2,13 +2,13 @@ use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::mem::discriminant;
 
 use graph::data::graphql::ext::DirectiveFinder;
+use graph::data::graphql::ObjectOrInterface;
 use graph::data::graphql::TypeExt as _;
 use graph::data::value::Object;
 use graph::data::value::Value as DataValue;
 use graph::prelude::*;
 use graph::schema::ast::{self as sast, FilterOp};
-use graph::schema::{ApiSchema, InputSchema};
-use graph::{components::store::EntityType, data::graphql::ObjectOrInterface};
+use graph::schema::{ApiSchema, EntityType, InputSchema};
 
 use crate::execution::ast as a;
 

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -22,7 +22,7 @@ enum OrderDirection {
 
 pub(crate) struct SchemaPair {
     pub api: Arc<ApiSchema>,
-    pub input: Arc<InputSchema>,
+    pub input: InputSchema,
 }
 
 /// Builds a EntityQuery from GraphQL arguments.
@@ -932,7 +932,7 @@ mod tests {
         let api_schema = ApiSchema::from_graphql_schema(api_schema).unwrap();
 
         SchemaPair {
-            input: Arc::new(input_schema),
+            input: input_schema,
             api: Arc::new(api_schema),
         }
     }

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -359,7 +359,9 @@ impl Resolver for StoreResolver {
     ) -> result::Result<UnitStream, QueryExecutionError> {
         // Collect all entities involved in the query field
         let object_type = schema.object_type(object_type).into();
-        let entities = collect_entities_from_query_field(schema, object_type, field)?;
+        let input_schema = self.store.input_schema()?;
+        let entities =
+            collect_entities_from_query_field(&input_schema, schema, object_type, field)?;
 
         // Subscribe to the store and return the entity change stream
         Ok(self.subscription_manager.subscribe_no_payload(entities))

--- a/node/src/manager/commands/listen.rs
+++ b/node/src/manager/commands/listen.rs
@@ -4,9 +4,9 @@ use std::{collections::BTreeSet, io::Write};
 
 use futures::compat::Future01CompatExt;
 use graph::prelude::DeploymentHash;
-use graph::schema::InputSchema;
+use graph::schema::{EntityType, InputSchema};
 use graph::{
-    components::store::{EntityType, SubscriptionManager as _},
+    components::store::SubscriptionManager as _,
     prelude::{serde_json, Error, Stream, SubscriptionFilter},
 };
 use graph_store_postgres::connection_pool::ConnectionPool;

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -5,7 +5,7 @@ use graph::prelude::web3::types::U256;
 use graph::runtime::gas::GasCounter;
 use graph::runtime::{AscIndexId, AscType, HostExportError};
 use graph::runtime::{AscPtr, ToAscObj};
-use graph::schema::{EntityType, InputSchema};
+use graph::schema::{EntityKey, EntityType, InputSchema};
 use graph::{components::store::*, ipfs_client::IpfsClient};
 use graph::{entity, prelude::*};
 use graph_chain_ethereum::{Chain, DataSource};

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -5,7 +5,7 @@ use graph::prelude::web3::types::U256;
 use graph::runtime::gas::GasCounter;
 use graph::runtime::{AscIndexId, AscType, HostExportError};
 use graph::runtime::{AscPtr, ToAscObj};
-use graph::schema::InputSchema;
+use graph::schema::{EntityType, InputSchema};
 use graph::{components::store::*, ipfs_client::IpfsClient};
 use graph::{entity, prelude::*};
 use graph_chain_ethereum::{Chain, DataSource};

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -436,9 +436,10 @@ fn make_thing(id: &str, value: &str) -> (String, EntityModification) {
     const DOCUMENT: &str = " type Thing @entity { id: String!, value: String!, extra: String }";
     lazy_static! {
         static ref SCHEMA: InputSchema = InputSchema::raw(DOCUMENT, "doesntmatter");
+        static ref THING_TYPE: EntityType = SCHEMA.entity_type("Thing").unwrap();
     }
     let data = entity! { SCHEMA => id: id, value: value, extra: USER_DATA };
-    let key = EntityKey::data("Thing".to_string(), id);
+    let key = EntityKey::onchain(&*THING_TYPE, id);
     (
         format!("{{ \"id\": \"{}\", \"value\": \"{}\"}}", id, value),
         EntityModification::insert(key, data, 0),
@@ -963,7 +964,7 @@ async fn test_entity_store(api_version: Version) {
 
     let alex = entity! { schema => id: "alex", name: "Alex" };
     let steve = entity! { schema => id: "steve", name: "Steve" };
-    let user_type = EntityType::from("User");
+    let user_type = schema.entity_type("User").unwrap();
     test_store::insert_entities(
         &deployment,
         vec![(user_type.clone(), alex), (user_type, steve)],
@@ -1407,7 +1408,7 @@ async fn test_store_set_invalid_fields() {
         id: ID!,
         name: String
     }
-    
+
     type Binary @entity {
         id: Bytes!,
         test: String,

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -5,7 +5,7 @@ use graph::prelude::web3::types::U256;
 use graph::runtime::gas::GasCounter;
 use graph::runtime::{AscIndexId, AscType, HostExportError};
 use graph::runtime::{AscPtr, ToAscObj};
-use graph::schema::{EntityKey, EntityType, InputSchema};
+use graph::schema::{EntityType, InputSchema};
 use graph::{components::store::*, ipfs_client::IpfsClient};
 use graph::{entity, prelude::*};
 use graph_chain_ethereum::{Chain, DataSource};
@@ -439,7 +439,7 @@ fn make_thing(id: &str, value: &str) -> (String, EntityModification) {
         static ref THING_TYPE: EntityType = SCHEMA.entity_type("Thing").unwrap();
     }
     let data = entity! { SCHEMA => id: id, value: value, extra: USER_DATA };
-    let key = EntityKey::onchain(&*THING_TYPE, id);
+    let key = THING_TYPE.key(id);
     (
         format!("{{ \"id\": \"{}\", \"value\": \"{}\"}}", id, value),
         EntityModification::insert(key, data, 0),

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -177,11 +177,7 @@ impl<C: Blockchain> HostExports<C> {
         }
 
         let entity_type = state.entity_cache.schema.entity_type(&entity_type)?;
-        let key = EntityKey {
-            entity_type,
-            entity_id: entity_id.into(),
-            causality_region: self.data_source_causality_region,
-        };
+        let key = entity_type.key_in(entity_id, self.data_source_causality_region);
         self.check_entity_type_access(&key.entity_type)?;
 
         gas.consume_host_fn(gas::STORE_SET.with_args(complexity::Linear, (&key, &data)))?;
@@ -242,11 +238,7 @@ impl<C: Blockchain> HostExports<C> {
             logger,
         );
         let entity_type = state.entity_cache.schema.entity_type(&entity_type)?;
-        let key = EntityKey {
-            entity_type,
-            entity_id: entity_id.into(),
-            causality_region: self.data_source_causality_region,
-        };
+        let key = entity_type.key_in(entity_id, self.data_source_causality_region);
         self.check_entity_type_access(&key.entity_type)?;
 
         gas.consume_host_fn(gas::STORE_REMOVE.with_args(complexity::Size, &key))?;
@@ -265,11 +257,7 @@ impl<C: Blockchain> HostExports<C> {
         scope: GetScope,
     ) -> Result<Option<Cow<'a, Entity>>, anyhow::Error> {
         let entity_type = state.entity_cache.schema.entity_type(&entity_type)?;
-        let store_key = EntityKey {
-            entity_type,
-            entity_id: entity_id.into(),
-            causality_region: self.data_source_causality_region,
-        };
+        let store_key = entity_type.key_in(entity_id, self.data_source_causality_region);
         self.check_entity_type_access(&store_key.entity_type)?;
 
         let result = state.entity_cache.get(&store_key, scope)?;

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -191,7 +191,7 @@ impl<C: Blockchain> HostExports<C> {
                 // The validation will catch the type mismatch
             }
             None => {
-                let value = state.entity_cache.schema.id_value(&key)?;
+                let value = key.entity_type.id_value(key.entity_id.clone())?;
                 data.insert(store::ID.clone(), value);
             }
         }

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -6,14 +6,15 @@ use std::time::{Duration, Instant};
 
 use graph::data::value::Word;
 
+use graph::schema::EntityType;
 use never::Never;
 use semver::Version;
 use wasmtime::Trap;
 use web3::types::H160;
 
 use graph::blockchain::Blockchain;
+use graph::components::store::EntityKey;
 use graph::components::store::{EnsLookup, GetScope, LoadRelatedRequest};
-use graph::components::store::{EntityKey, EntityType};
 use graph::components::subgraph::{
     PoICausalityRegion, ProofOfIndexingEvent, SharedProofOfIndexing,
 };

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -6,14 +6,13 @@ use std::time::{Duration, Instant};
 
 use graph::data::value::Word;
 
-use graph::schema::EntityType;
+use graph::schema::{EntityKey, EntityType};
 use never::Never;
 use semver::Version;
 use wasmtime::Trap;
 use web3::types::H160;
 
 use graph::blockchain::Blockchain;
-use graph::components::store::EntityKey;
 use graph::components::store::{EnsLookup, GetScope, LoadRelatedRequest};
 use graph::components::subgraph::{
     PoICausalityRegion, ProofOfIndexingEvent, SharedProofOfIndexing,

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -176,8 +176,9 @@ impl<C: Blockchain> HostExports<C> {
             }
         }
 
+        let entity_type = state.entity_cache.schema.entity_type(&entity_type)?;
         let key = EntityKey {
-            entity_type: EntityType::new(entity_type),
+            entity_type,
             entity_id: entity_id.into(),
             causality_region: self.data_source_causality_region,
         };
@@ -240,8 +241,9 @@ impl<C: Blockchain> HostExports<C> {
             &self.poi_causality_region,
             logger,
         );
+        let entity_type = state.entity_cache.schema.entity_type(&entity_type)?;
         let key = EntityKey {
-            entity_type: EntityType::new(entity_type),
+            entity_type,
             entity_id: entity_id.into(),
             causality_region: self.data_source_causality_region,
         };
@@ -262,8 +264,9 @@ impl<C: Blockchain> HostExports<C> {
         gas: &GasCounter,
         scope: GetScope,
     ) -> Result<Option<Cow<'a, Entity>>, anyhow::Error> {
+        let entity_type = state.entity_cache.schema.entity_type(&entity_type)?;
         let store_key = EntityKey {
-            entity_type: EntityType::new(entity_type),
+            entity_type,
             entity_id: entity_id.into(),
             causality_region: self.data_source_causality_region,
         };
@@ -287,8 +290,9 @@ impl<C: Blockchain> HostExports<C> {
         entity_field: String,
         gas: &GasCounter,
     ) -> Result<Vec<Entity>, anyhow::Error> {
+        let entity_type = state.entity_cache.schema.entity_type(&entity_type)?;
         let store_key = LoadRelatedRequest {
-            entity_type: EntityType::new(entity_type),
+            entity_type,
             entity_id: entity_id.into(),
             entity_field: entity_field.into(),
             causality_region: self.data_source_causality_region,

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -2,11 +2,12 @@ use std::collections::BTreeMap;
 use std::convert::TryInto;
 
 use graph::data::query::Trace;
+use graph::schema::EntityType;
 use web3::types::Address;
 
 use git_testament::{git_testament, CommitKind};
 use graph::blockchain::{Blockchain, BlockchainKind, BlockchainMap};
-use graph::components::store::{BlockPtrForNumber, BlockStore, EntityType, Store};
+use graph::components::store::{BlockPtrForNumber, BlockStore, Store};
 use graph::components::versions::VERSIONS;
 use graph::data::graphql::{object, IntoValue, ObjectOrInterface, ValueMap};
 use graph::data::subgraph::status;

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::convert::TryInto;
 
 use graph::data::query::Trace;
+use graph::data::store::Id;
 use graph::schema::EntityType;
 use web3::types::Address;
 
@@ -11,7 +12,7 @@ use graph::components::store::{BlockPtrForNumber, BlockStore, Store};
 use graph::components::versions::VERSIONS;
 use graph::data::graphql::{object, IntoValue, ObjectOrInterface, ValueMap};
 use graph::data::subgraph::status;
-use graph::data::value::{Object, Word};
+use graph::data::value::Object;
 use graph::prelude::*;
 use graph_graphql::prelude::{a, ExecutionContext, Resolver};
 
@@ -589,7 +590,7 @@ fn entity_changes_to_graphql(entity_changes: Vec<EntityOperation>) -> r::Value {
 
     // First, we isolate updates and deletions with the same entity type.
     let mut updates: BTreeMap<EntityType, Vec<Entity>> = BTreeMap::new();
-    let mut deletions: BTreeMap<EntityType, Vec<Word>> = BTreeMap::new();
+    let mut deletions: BTreeMap<EntityType, Vec<Id>> = BTreeMap::new();
 
     for change in entity_changes {
         match change {

--- a/server/index-node/src/schema.rs
+++ b/server/index-node/src/schema.rs
@@ -8,7 +8,7 @@ lazy_static! {
         let raw_schema = include_str!("./schema.graphql");
         let document = graphql_parser::parse_schema(raw_schema).unwrap();
         Arc::new(
-            ApiSchema::from_api_schema(
+            ApiSchema::from_graphql_schema(
                 Schema::new(DeploymentHash::new("indexnode").unwrap(), document).unwrap(),
             )
             .unwrap(),

--- a/store/postgres/src/catalog.rs
+++ b/store/postgres/src/catalog.rs
@@ -6,9 +6,9 @@ use diesel::{
     sql_types::{Array, Double, Nullable, Text},
     ExpressionMethods, QueryDsl,
 };
-use graph::components::store::EntityType;
 use graph::components::store::VersionStats;
 use graph::prelude::BlockNumber;
+use graph::schema::EntityType;
 use itertools::Itertools;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Write;

--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -32,9 +32,9 @@ use diesel::{
     RunQueryDsl,
 };
 use graph::{
-    components::store::EntityType,
     constraint_violation,
     prelude::{info, o, warn, BlockNumber, BlockPtr, Logger, StoreError, ENV_VARS},
+    schema::EntityType,
 };
 
 use crate::{

--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -485,7 +485,7 @@ impl TableState {
             .into_iter()
             .map(
                 |(id, entity_type, current_vid, target_vid, size, duration_ms)| {
-                    let entity_type = EntityType::new(entity_type);
+                    let entity_type = src_layout.input_schema.entity_type(&entity_type)?;
                     let src =
                         resolve_entity(src_layout, "source", &entity_type, dst_layout.site.id, id);
                     let dst = resolve_entity(

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -13,14 +13,9 @@ use diesel::{
     sql_query,
     sql_types::{Nullable, Text},
 };
-use graph::{blockchain::block_stream::FirehoseCursor, data::subgraph::schema::SubgraphError};
 use graph::{
-    components::store::EntityType,
-    prelude::{
-        anyhow, bigdecimal::ToPrimitive, hex, web3::types::H256, BigDecimal, BlockNumber, BlockPtr,
-        DeploymentHash, DeploymentState, StoreError,
-    },
-    schema::InputSchema,
+    blockchain::block_stream::FirehoseCursor, data::subgraph::schema::SubgraphError,
+    schema::EntityType,
 };
 use graph::{
     data::subgraph::{
@@ -28,6 +23,13 @@ use graph::{
         SubgraphFeature,
     },
     util::backoff::ExponentialBackoff,
+};
+use graph::{
+    prelude::{
+        anyhow, bigdecimal::ToPrimitive, hex, web3::types::H256, BigDecimal, BlockNumber, BlockPtr,
+        DeploymentHash, DeploymentState, StoreError,
+    },
+    schema::InputSchema,
 };
 use stable_hash_legacy::crypto::SetHasher;
 use std::{collections::BTreeSet, convert::TryFrom, ops::Bound, time::Duration};

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -919,8 +919,11 @@ pub(crate) fn entities_with_causality_region(
         .get_result::<Vec<String>>(conn)
         .map_err(|e| e.into())
         .map(|ents| {
+            // It is possible to have entity types in
+            // `entities_with_causality_region` that are not mentioned in
+            // the schema.
             ents.into_iter()
-                .map(|ent| schema.entity_type(&ent).unwrap())
+                .filter_map(|ent| schema.entity_type(&ent).ok())
                 .collect()
         })
 }

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -298,10 +298,10 @@ impl DeploymentStore {
         let entity_type_str = entity_type.to_string();
         let types_with_shared_interface = Vec::from_iter(
             schema
-                .interfaces_for_type(entity_type)
+                .interfaces_for_type(entity_type.as_str())
                 .into_iter()
                 .flatten()
-                .flat_map(|interface| &types_for_interface[&EntityType::from(interface)])
+                .flat_map(|interface| &types_for_interface[&interface.name])
                 .map(EntityType::from)
                 .filter(|type_name| type_name != entity_type),
         );

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -7,8 +7,8 @@ use graph::anyhow::Context;
 use graph::blockchain::block_stream::FirehoseCursor;
 use graph::components::store::write::RowGroup;
 use graph::components::store::{
-    Batch, DerivedEntityQuery, EntityKey, EntityType, PrunePhase, PruneReporter, PruneRequest,
-    PruningStrategy, StoredDynamicDataSource, VersionStats,
+    Batch, DerivedEntityQuery, EntityKey, PrunePhase, PruneReporter, PruneRequest, PruningStrategy,
+    StoredDynamicDataSource, VersionStats,
 };
 use graph::components::versions::VERSIONS;
 use graph::data::query::Trace;
@@ -43,7 +43,7 @@ use graph::prelude::{
     DeploymentHash, DeploymentState, Entity, EntityQuery, Error, Logger, QueryExecutionError,
     StopwatchMetrics, StoreError, StoreEvent, UnfailOutcome, Value, ENV_VARS,
 };
-use graph::schema::{ApiSchema, InputSchema};
+use graph::schema::{ApiSchema, EntityType, InputSchema};
 use web3::types::Address;
 
 use crate::block_range::{BLOCK_COLUMN, BLOCK_RANGE_COLUMN};

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -76,7 +76,7 @@ pub enum ReplicaId {
 #[derive(Clone)]
 pub(crate) struct SubgraphInfo {
     /// The schema as supplied by the user
-    pub(crate) input: Arc<InputSchema>,
+    pub(crate) input: InputSchema,
     /// The schema we derive from `input` with `graphql::schema::api::api_schema`
     pub(crate) api: HashMap<ApiVersion, Arc<ApiSchema>>,
     /// The block number at which this subgraph was grafted onto
@@ -511,7 +511,7 @@ impl DeploymentStore {
         };
 
         let info = SubgraphInfo {
-            input: Arc::new(manifest_info.input_schema),
+            input: manifest_info.input_schema,
             api,
             graft_block,
             debug_fork,

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -7,7 +7,7 @@ use graph::anyhow::Context;
 use graph::blockchain::block_stream::FirehoseCursor;
 use graph::components::store::write::RowGroup;
 use graph::components::store::{
-    Batch, DerivedEntityQuery, EntityKey, PrunePhase, PruneReporter, PruneRequest, PruningStrategy,
+    Batch, DerivedEntityQuery, PrunePhase, PruneReporter, PruneRequest, PruningStrategy,
     StoredDynamicDataSource, VersionStats,
 };
 use graph::components::versions::VERSIONS;
@@ -43,7 +43,7 @@ use graph::prelude::{
     DeploymentHash, DeploymentState, Entity, EntityQuery, Error, Logger, QueryExecutionError,
     StopwatchMetrics, StoreError, StoreEvent, UnfailOutcome, Value, ENV_VARS,
 };
-use graph::schema::{ApiSchema, EntityType, InputSchema};
+use graph::schema::{ApiSchema, EntityKey, EntityType, InputSchema};
 use web3::types::Address;
 
 use crate::block_range::{BLOCK_COLUMN, BLOCK_RANGE_COLUMN};

--- a/store/postgres/src/fork.rs
+++ b/store/postgres/src/fork.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
-    sync::{Arc, Mutex},
+    sync::Mutex,
 };
 
 use graph::{
@@ -41,7 +41,7 @@ struct Variables {
 pub(crate) struct SubgraphFork {
     client: reqwest::Client,
     endpoint: Url,
-    schema: Arc<InputSchema>,
+    schema: InputSchema,
     fetched_ids: Mutex<HashSet<String>>,
     logger: Logger,
 }
@@ -91,7 +91,7 @@ impl SubgraphFork {
     pub(crate) fn new(
         base: Url,
         id: DeploymentHash,
-        schema: Arc<InputSchema>,
+        schema: InputSchema,
         logger: Logger,
     ) -> Result<Self, StoreError> {
         Ok(Self {
@@ -249,8 +249,8 @@ mod tests {
         DeploymentHash::new("test").unwrap()
     }
 
-    fn test_schema() -> Arc<InputSchema> {
-        let schema = InputSchema::new(
+    fn test_schema() -> InputSchema {
+        InputSchema::new(
             DeploymentHash::new("test").unwrap(),
             parse_schema::<String>(
                 r#"type Gravatar @entity {
@@ -262,8 +262,7 @@ mod tests {
             )
             .unwrap(),
         )
-        .unwrap();
-        Arc::new(schema)
+        .unwrap()
     }
 
     fn test_logger() -> Logger {

--- a/store/postgres/src/fork.rs
+++ b/store/postgres/src/fork.rs
@@ -6,7 +6,7 @@ use std::{
 
 use graph::{
     block_on,
-    components::store::{EntityType, SubgraphFork as SubgraphForkTrait},
+    components::store::SubgraphFork as SubgraphForkTrait,
     data::graphql::ext::DirectiveFinder,
     prelude::{
         info,
@@ -130,7 +130,7 @@ impl SubgraphFork {
     }
 
     fn get_fields_of(&self, entity_type: &str) -> Result<&Vec<Field>, StoreError> {
-        let entity_type = EntityType::new(entity_type.to_string());
+        let entity_type = self.schema.entity_type(entity_type)?;
         let entity: Option<&ObjectType> = self.schema.find_object_type(&entity_type);
 
         if entity.is_none() {

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -120,7 +120,7 @@ impl QueryStoreTrait for QueryStore {
         Ok(info.api.get(&self.api_version).unwrap().clone())
     }
 
-    fn input_schema(&self) -> Result<Arc<InputSchema>, QueryExecutionError> {
+    fn input_schema(&self) -> Result<InputSchema, QueryExecutionError> {
         let info = self.store.subgraph_info(&self.site)?;
         Ok(info.input)
     }

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -1,7 +1,7 @@
 use crate::deployment_store::{DeploymentStore, ReplicaId};
 use graph::components::store::{DeploymentId, QueryStore as QueryStoreTrait};
 use graph::data::query::Trace;
-use graph::data::value::Object;
+use graph::data::store::QueryObject;
 use graph::prelude::*;
 use graph::schema::{ApiSchema, InputSchema};
 
@@ -38,7 +38,7 @@ impl QueryStoreTrait for QueryStore {
     fn find_query_values(
         &self,
         query: EntityQuery,
-    ) -> Result<(Vec<Object>, Trace), graph::prelude::QueryExecutionError> {
+    ) -> Result<(Vec<QueryObject>, Trace), graph::prelude::QueryExecutionError> {
         assert_eq!(&self.site.deployment, &query.subgraph_id);
         let conn = self
             .store

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -3,7 +3,7 @@ use graph::components::store::{DeploymentId, QueryStore as QueryStoreTrait};
 use graph::data::query::Trace;
 use graph::data::value::Object;
 use graph::prelude::*;
-use graph::schema::ApiSchema;
+use graph::schema::{ApiSchema, InputSchema};
 
 use crate::primary::Site;
 
@@ -118,6 +118,11 @@ impl QueryStoreTrait for QueryStore {
     fn api_schema(&self) -> Result<Arc<ApiSchema>, QueryExecutionError> {
         let info = self.store.subgraph_info(&self.site)?;
         Ok(info.api.get(&self.api_version).unwrap().clone())
+    }
+
+    fn input_schema(&self) -> Result<Arc<InputSchema>, QueryExecutionError> {
+        let info = self.store.subgraph_info(&self.site)?;
+        Ok(info.input)
     }
 
     fn network_name(&self) -> &str {

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -437,7 +437,7 @@ impl Layout {
     }
 
     pub fn supports_proof_of_indexing(&self) -> bool {
-        self.tables.contains_key(self.input_schema.poi_type())
+        self.tables.contains_key(&self.input_schema.poi_type())
     }
 
     pub fn create_relational_schema(

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -32,7 +32,7 @@ use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
 use graph::prelude::{q, s, EntityQuery, StopwatchMetrics, ENV_VARS};
 use graph::schema::{
-    EntityType, FulltextConfig, FulltextDefinition, InputSchema, SCHEMA_TYPE_NAME,
+    EntityKey, EntityType, FulltextConfig, FulltextDefinition, InputSchema, SCHEMA_TYPE_NAME,
 };
 use graph::slog::warn;
 use inflector::Inflector;
@@ -54,7 +54,7 @@ use crate::{
         FilterQuery, FindManyQuery, FindQuery, InsertQuery, RevertClampQuery, RevertRemoveQuery,
     },
 };
-use graph::components::store::{DerivedEntityQuery, EntityKey};
+use graph::components::store::DerivedEntityQuery;
 use graph::data::graphql::ext::{DirectiveFinder, ObjectTypeExt};
 use graph::data::store::BYTES_SCALAR;
 use graph::data::subgraph::schema::POI_TABLE;

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -31,7 +31,9 @@ use graph::data::query::Trace;
 use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
 use graph::prelude::{q, s, EntityQuery, StopwatchMetrics, ENV_VARS};
-use graph::schema::{FulltextConfig, FulltextDefinition, InputSchema, SCHEMA_TYPE_NAME};
+use graph::schema::{
+    EntityType, FulltextConfig, FulltextDefinition, InputSchema, SCHEMA_TYPE_NAME,
+};
 use graph::slog::warn;
 use inflector::Inflector;
 use itertools::Itertools;
@@ -52,7 +54,7 @@ use crate::{
         FilterQuery, FindManyQuery, FindQuery, InsertQuery, RevertClampQuery, RevertRemoveQuery,
     },
 };
-use graph::components::store::{DerivedEntityQuery, EntityKey, EntityType};
+use graph::components::store::{DerivedEntityQuery, EntityKey};
 use graph::data::graphql::ext::{DirectiveFinder, ObjectTypeExt};
 use graph::data::store::BYTES_SCALAR;
 use graph::data::subgraph::schema::POI_TABLE;

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -312,7 +312,7 @@ impl Layout {
                         // they have a String `id` field
                         // see also: id-type-for-unimplemented-interfaces
                         let id_type = types.iter().next().cloned().unwrap_or(IdType::String);
-                        Ok((interface.clone(), id_type))
+                        Ok((EntityType::from(interface.as_str()), id_type))
                     }
                 })
         });

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -931,13 +931,13 @@ impl Layout {
                 .filter(|id| !unclamped.contains(id))
                 .map(|_| EntityChange::Data {
                     subgraph_id: self.site.deployment.clone(),
-                    entity_type: table.object.clone(),
+                    entity_type: table.object.to_string(),
                 });
             changes.extend(deleted);
             // EntityChange for versions that we just updated or inserted
             let set = unclamped.into_iter().map(|_| EntityChange::Data {
                 subgraph_id: self.site.deployment.clone(),
-                entity_type: table.object.clone(),
+                entity_type: table.object.to_string(),
             });
             changes.extend(set);
         }

--- a/store/postgres/src/relational/query_tests.rs
+++ b/store/postgres/src/relational/query_tests.rs
@@ -2,7 +2,6 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use diesel::{debug_query, pg::Pg};
 use graph::{
-    components::store::EntityType,
     prelude::{r, serde_json as json, DeploymentHash, EntityFilter},
     schema::InputSchema,
 };
@@ -49,7 +48,7 @@ fn filter_contains(filter: EntityFilter, sql: &str) {
     }";
     let layout = test_layout(SCHEMA);
     let table = layout
-        .table_for_entity(&EntityType::new("Thing".to_string()))
+        .table_for_entity(&layout.input_schema.entity_type("Thing").unwrap())
         .unwrap();
     let filter = QueryFilter::new(&filter, table.as_ref(), &layout, Default::default()).unwrap();
     let query = debug_query::<Pg, _>(&filter);

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -475,25 +475,24 @@ impl EntityData {
                 let parent_id = map
                     .remove(PARENT_ID)
                     .and_then(|json| {
-                        if T::WITH_INTERNAL_KEYS {
-                            match &parent_type {
-                                None => {
-                                    // A query that does not have parents
-                                    // somehow returned parent ids. We have no
-                                    // idea how to deserialize that
-                                    Some(Err(graph::constraint_violation!(
-                                        "query unexpectedly produces parent ids"
-                                    )))
-                                }
-                                Some(parent_type) => Some(
-                                    parent_type
-                                        .id_type()
-                                        .map_err(StoreError::from)
-                                        .and_then(|id_type| id_type.parse_id(json)),
-                                ),
+                        if !T::WITH_INTERNAL_KEYS {
+                            return None;
+                        }
+                        match &parent_type {
+                            None => {
+                                // A query that does not have parents
+                                // somehow returned parent ids. We have no
+                                // idea how to deserialize that
+                                Some(Err(graph::constraint_violation!(
+                                    "query unexpectedly produces parent ids"
+                                )))
                             }
-                        } else {
-                            None
+                            Some(parent_type) => Some(
+                                parent_type
+                                    .id_type()
+                                    .map_err(StoreError::from)
+                                    .and_then(|id_type| id_type.parse_id(json)),
+                            ),
                         }
                     })
                     .transpose()?;

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -22,11 +22,8 @@ use graph::prelude::{
     EntityFilter, EntityLink, EntityOrder, EntityOrderByChild, EntityOrderByChildInfo, EntityRange,
     EntityWindow, ParentLink, QueryExecutionError, StoreError, Value, ENV_VARS,
 };
-use graph::schema::{FulltextAlgorithm, InputSchema};
-use graph::{
-    components::store::{AttributeNames, EntityType},
-    data::store::scalar,
-};
+use graph::schema::{EntityType, FulltextAlgorithm, InputSchema};
+use graph::{components::store::AttributeNames, data::store::scalar};
 use inflector::Inflector;
 use itertools::Itertools;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -486,8 +486,8 @@ pub struct EntityDeletion {
 }
 
 impl EntityDeletion {
-    pub fn entity_type(&self) -> EntityType {
-        EntityType::new(self.entity.clone())
+    pub fn entity_type(&self, schema: &InputSchema) -> EntityType {
+        schema.entity_type(&self.entity).unwrap()
     }
 
     pub fn id(&self) -> &str {
@@ -513,8 +513,8 @@ pub struct EntityData {
 }
 
 impl EntityData {
-    pub fn entity_type(&self) -> EntityType {
-        EntityType::new(self.entity.clone())
+    pub fn entity_type(&self, schema: &InputSchema) -> EntityType {
+        schema.entity_type(&self.entity).unwrap()
     }
 
     /// Map the `EntityData` using the schema information in `Layout`
@@ -523,7 +523,7 @@ impl EntityData {
         layout: &Layout,
         parent_type: Option<&ColumnType>,
     ) -> Result<T, StoreError> {
-        let entity_type = EntityType::new(self.entity.clone());
+        let entity_type = layout.input_schema.entity_type(&self.entity)?;
         let table = layout.table_for_entity(&entity_type)?;
 
         use serde_json::Value as j;

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -13,7 +13,7 @@ use diesel::sql_types::{Array, BigInt, Binary, Bool, Int8, Integer, Jsonb, Range
 use diesel::Connection;
 
 use graph::components::store::write::WriteChunk;
-use graph::components::store::{DerivedEntityQuery, EntityKey};
+use graph::components::store::DerivedEntityQuery;
 use graph::data::store::{NULL, PARENT_ID};
 use graph::data::value::{Object, Word};
 use graph::data_source::CausalityRegion;
@@ -22,7 +22,7 @@ use graph::prelude::{
     EntityFilter, EntityLink, EntityOrder, EntityOrderByChild, EntityOrderByChildInfo, EntityRange,
     EntityWindow, ParentLink, QueryExecutionError, StoreError, Value, ENV_VARS,
 };
-use graph::schema::{EntityType, FulltextAlgorithm, InputSchema};
+use graph::schema::{EntityKey, EntityType, FulltextAlgorithm, InputSchema};
 use graph::{components::store::AttributeNames, data::store::scalar};
 use inflector::Inflector;
 use itertools::Itertools;

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1370,7 +1370,7 @@ impl SubgraphStoreTrait for SubgraphStore {
         Ok(changes)
     }
 
-    fn input_schema(&self, id: &DeploymentHash) -> Result<Arc<InputSchema>, StoreError> {
+    fn input_schema(&self, id: &DeploymentHash) -> Result<InputSchema, StoreError> {
         let (store, site) = self.store(id)?;
         let info = store.subgraph_info(&site)?;
         Ok(info.input)

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -622,7 +622,7 @@ impl SubgraphStoreInner {
                 node
             )));
         }
-        let deployment = src_store.load_deployment(src.as_ref())?;
+        let deployment = src_store.load_deployment(src.clone())?;
         if deployment.failed {
             return Err(StoreError::Unknown(anyhow!(
                 "can not copy deployment {} because it has failed",
@@ -1186,8 +1186,8 @@ impl SubgraphStoreInner {
         store.set_history_blocks(&site, history_blocks, reorg_threshold)
     }
 
-    pub fn load_deployment(&self, site: &Site) -> Result<SubgraphDeploymentEntity, StoreError> {
-        let src_store = self.for_site(site)?;
+    pub fn load_deployment(&self, site: Arc<Site>) -> Result<SubgraphDeploymentEntity, StoreError> {
+        let src_store = self.for_site(&site)?;
         src_store.load_deployment(site)
     }
 
@@ -1197,7 +1197,7 @@ impl SubgraphStoreInner {
     ) -> Result<SubgraphDeploymentEntity, StoreError> {
         let site = self.find_site(id)?;
         let src_store = self.for_site(&site)?;
-        src_store.load_deployment(&site)
+        src_store.load_deployment(site)
     }
 }
 

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -79,7 +79,7 @@ struct SyncStore {
     store: WritableSubgraphStore,
     writable: Arc<DeploymentStore>,
     site: Arc<Site>,
-    input_schema: Arc<InputSchema>,
+    input_schema: InputSchema,
     manifest_idx_and_name: Arc<Vec<(u32, String)>>,
 }
 
@@ -369,8 +369,8 @@ impl SyncStore {
         .await
     }
 
-    fn input_schema(&self) -> Arc<InputSchema> {
-        self.input_schema.clone()
+    fn input_schema(&self) -> InputSchema {
+        self.input_schema.cheap_clone()
     }
 }
 
@@ -1444,7 +1444,7 @@ impl ReadStore for WritableStore {
         self.writer.get_derived(key)
     }
 
-    fn input_schema(&self) -> Arc<InputSchema> {
+    fn input_schema(&self) -> InputSchema {
         self.store.input_schema()
     }
 }
@@ -1458,7 +1458,7 @@ impl DeploymentCursorTracker for WritableStore {
         self.block_cursor.lock().unwrap().clone()
     }
 
-    fn input_schema(&self) -> Arc<InputSchema> {
+    fn input_schema(&self) -> InputSchema {
         self.store.input_schema()
     }
 }

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -19,7 +19,7 @@ use graph::prelude::{
     BlockNumber, CacheWeight, Entity, MetricsRegistry, SubgraphDeploymentEntity,
     SubgraphStore as _, BLOCK_NUMBER_MAX,
 };
-use graph::schema::InputSchema;
+use graph::schema::{EntityType, InputSchema};
 use graph::slog::{info, warn};
 use graph::tokio::select;
 use graph::tokio::sync::Notify;
@@ -27,7 +27,7 @@ use graph::tokio::task::JoinHandle;
 use graph::util::bounded_queue::BoundedQueue;
 use graph::{
     cheap_clone::CheapClone,
-    components::store::{self, write::EntityOp, EntityType, WritableStore as WritableStoreTrait},
+    components::store::{self, write::EntityOp, WritableStore as WritableStoreTrait},
     data::subgraph::schema::SubgraphError,
     prelude::{
         BlockPtr, DeploymentHash, EntityModification, Error, Logger, StopwatchMetrics, StoreError,

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -1537,7 +1537,6 @@ impl WritableStoreTrait for WritableStore {
         is_non_fatal_errors_active: bool,
     ) -> Result<(), StoreError> {
         let batch = Batch::new(
-            self.store.input_schema.cheap_clone(),
             block_ptr_to.clone(),
             firehose_cursor.clone(),
             mods,

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -7,9 +7,7 @@ use std::time::{Duration, Instant};
 use std::{collections::BTreeMap, sync::Arc};
 
 use graph::blockchain::block_stream::FirehoseCursor;
-use graph::components::store::{
-    Batch, DeploymentCursorTracker, DerivedEntityQuery, EntityKey, ReadStore,
-};
+use graph::components::store::{Batch, DeploymentCursorTracker, DerivedEntityQuery, ReadStore};
 use graph::constraint_violation;
 use graph::data::store::scalar::Bytes;
 use graph::data::store::Value;
@@ -19,7 +17,7 @@ use graph::prelude::{
     BlockNumber, CacheWeight, Entity, MetricsRegistry, SubgraphDeploymentEntity,
     SubgraphStore as _, BLOCK_NUMBER_MAX,
 };
-use graph::schema::{EntityType, InputSchema};
+use graph::schema::{EntityKey, EntityType, InputSchema};
 use graph::slog::{info, warn};
 use graph::tokio::select;
 use graph::tokio::sync::Notify;

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -62,7 +62,7 @@ impl WritableSubgraphStore {
         self.0.layout(id)
     }
 
-    fn load_deployment(&self, site: &Site) -> Result<SubgraphDeploymentEntity, StoreError> {
+    fn load_deployment(&self, site: Arc<Site>) -> Result<SubgraphDeploymentEntity, StoreError> {
         self.0.load_deployment(site)
     }
 
@@ -139,7 +139,7 @@ impl SyncStore {
             let graft_base = match self.writable.graft_pending(&self.site.deployment)? {
                 Some((base_id, base_ptr)) => {
                     let src = self.store.layout(&base_id)?;
-                    let deployment_entity = self.store.load_deployment(&src.site)?;
+                    let deployment_entity = self.store.load_deployment(src.site.clone())?;
                     Some((src, base_ptr, deployment_entity))
                 }
                 None => None,

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -9,14 +9,14 @@ use graph::data_source::CausalityRegion;
 use graph::data_source::DataSource;
 use graph::log;
 use graph::prelude::{QueryStoreManager as _, SubgraphStore as _, *};
+use graph::schema::EntityKey;
 use graph::schema::EntityType;
 use graph::schema::InputSchema;
 use graph::semver::Version;
 use graph::{
     blockchain::block_stream::FirehoseCursor, blockchain::ChainIdentifier,
-    components::store::DeploymentLocator, components::store::EntityKey,
-    components::store::StatusStore, components::store::StoredDynamicDataSource,
-    data::subgraph::status, prelude::NodeId,
+    components::store::DeploymentLocator, components::store::StatusStore,
+    components::store::StoredDynamicDataSource, data::subgraph::status, prelude::NodeId,
 };
 use graph_graphql::prelude::{
     execute_query, Query as PreparedQuery, QueryExecutionOptions, StoreResolver,

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -9,13 +9,14 @@ use graph::data_source::CausalityRegion;
 use graph::data_source::DataSource;
 use graph::log;
 use graph::prelude::{QueryStoreManager as _, SubgraphStore as _, *};
+use graph::schema::EntityType;
 use graph::schema::InputSchema;
 use graph::semver::Version;
 use graph::{
     blockchain::block_stream::FirehoseCursor, blockchain::ChainIdentifier,
     components::store::DeploymentLocator, components::store::EntityKey,
-    components::store::EntityType, components::store::StatusStore,
-    components::store::StoredDynamicDataSource, data::subgraph::status, prelude::NodeId,
+    components::store::StatusStore, components::store::StoredDynamicDataSource,
+    data::subgraph::status, prelude::NodeId,
 };
 use graph_graphql::prelude::{
     execute_query, Query as PreparedQuery, QueryExecutionOptions, StoreResolver,

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -5,11 +5,9 @@ use graph::data::query::QueryResults;
 use graph::data::query::QueryTarget;
 use graph::data::subgraph::schema::{DeploymentCreate, SubgraphError};
 use graph::data::subgraph::SubgraphFeature;
-use graph::data_source::CausalityRegion;
 use graph::data_source::DataSource;
 use graph::log;
 use graph::prelude::{QueryStoreManager as _, SubgraphStore as _, *};
-use graph::schema::EntityKey;
 use graph::schema::EntityType;
 use graph::schema::InputSchema;
 use graph::semver::Version;
@@ -414,11 +412,7 @@ pub async fn insert_entities(
     let insert_ops = entities
         .into_iter()
         .map(|(entity_type, data)| EntityOperation::Set {
-            key: EntityKey {
-                entity_type,
-                entity_id: data.get("id").unwrap().clone().as_string().unwrap().into(),
-                causality_region: CausalityRegion::ONCHAIN,
-            },
+            key: entity_type.key(data.id()),
             data,
         });
 

--- a/store/test-store/tests/chain/ethereum/manifest.rs
+++ b/store/test-store/tests/chain/ethereum/manifest.rs
@@ -24,7 +24,10 @@ use graph::semver::Version;
 use graph_chain_ethereum::{BlockHandlerFilter, Chain, NodeCapabilities};
 use test_store::LOGGER;
 
-const GQL_SCHEMA: &str = "type Thing @entity { id: ID! }";
+const GQL_SCHEMA: &str = r#"
+  type Thing @entity { id: ID! }
+  type TestEntity @entity { id: ID! }
+"#;
 const GQL_SCHEMA_FULLTEXT: &str = include_str!("full-text.graphql");
 const MAPPING_WITH_IPFS_FUNC_WASM: &[u8] = include_bytes!("ipfs-on-ethereum-contracts.wasm");
 const ABI: &str = "[{\"type\":\"function\", \"inputs\": [{\"name\": \"i\",\"type\": \"uint256\"}],\"name\":\"get\",\"outputs\": [{\"type\": \"address\",\"name\": \"o\"}]}]";

--- a/store/test-store/tests/chain/ethereum/manifest.rs
+++ b/store/test-store/tests/chain/ethereum/manifest.rs
@@ -16,10 +16,7 @@ use graph::prelude::{
 };
 use graph::{
     blockchain::NodeCapabilities as _,
-    components::{
-        link_resolver::{JsonValueStream, LinkResolver as LinkResolverTrait},
-        store::EntityType,
-    },
+    components::link_resolver::{JsonValueStream, LinkResolver as LinkResolverTrait},
     data::subgraph::SubgraphFeature,
 };
 
@@ -211,9 +208,12 @@ specVersion: 0.0.2
 
         // Adds an example entity.
         let thing = entity! { schema => id: "datthing" };
-        test_store::insert_entities(&deployment, vec![(EntityType::from("Thing"), thing)])
-            .await
-            .unwrap();
+        test_store::insert_entities(
+            &deployment,
+            vec![(schema.entity_type("Thing").unwrap(), thing)],
+        )
+        .await
+        .unwrap();
 
         let error = SubgraphError {
             subgraph_id: deployment.hash.clone(),
@@ -308,9 +308,12 @@ specVersion: 0.0.2
         );
 
         let thing = entity! { schema => id: "datthing" };
-        test_store::insert_entities(&deployment, vec![(EntityType::from("Thing"), thing)])
-            .await
-            .unwrap();
+        test_store::insert_entities(
+            &deployment,
+            vec![(schema.entity_type("Thing").unwrap(), thing)],
+        )
+        .await
+        .unwrap();
 
         // Validation against subgraph that has not reached the graft point fails
         let unvalidated = resolve_unvalidated(YAML).await;

--- a/store/test-store/tests/core/interfaces.rs
+++ b/store/test-store/tests/core/interfaces.rs
@@ -1298,6 +1298,10 @@ async fn mixed_mutability() {
 
 #[tokio::test]
 async fn derived_interface_bytes() {
+    fn b(s: &str) -> Value {
+        Value::Bytes(s.parse().unwrap())
+    }
+
     let subgraph_id = "DerivedInterfaceBytes";
     let document = r#" type Pool {
         id: Bytes!,
@@ -1322,9 +1326,9 @@ async fn derived_interface_bytes() {
     let query = "query { pools { trades { id } } }";
 
     let entities = vec![
-        ("Pool", entity! { schema =>  id: "0xf001" }),
-        ("Sell", entity! { schema =>  id: "0xc0", pool: "0xf001"}),
-        ("Buy", entity! { schema =>  id: "0xb0", pool: "0xf001"}),
+        ("Pool", entity! { schema =>  id: b("0xf001") }),
+        ("Sell", entity! { schema =>  id: b("0xc0"), pool: "0xf001"}),
+        ("Buy", entity! { schema =>  id: b("0xb0"), pool: "0xf001"}),
     ];
 
     let res = insert_and_query(subgraph_id, document, entities, query)

--- a/store/test-store/tests/core/interfaces.rs
+++ b/store/test-store/tests/core/interfaces.rs
@@ -4,7 +4,7 @@ use graph::entity;
 use graph::schema::InputSchema;
 use pretty_assertions::assert_eq;
 
-use graph::{components::store::EntityType, data::graphql::object};
+use graph::data::graphql::object;
 use graph::{data::query::QueryTarget, prelude::*};
 use test_store::*;
 
@@ -17,10 +17,10 @@ async fn insert_and_query(
 ) -> Result<QueryResult, StoreError> {
     let subgraph_id = DeploymentHash::new(subgraph_id).unwrap();
     let deployment = create_test_subgraph(&subgraph_id, schema).await;
-
+    let schema = InputSchema::parse(schema, subgraph_id.clone()).unwrap();
     let entities = entities
         .into_iter()
-        .map(|(entity_type, data)| (EntityType::new(entity_type.to_owned()), data))
+        .map(|(entity_type, data)| (schema.entity_type(entity_type).unwrap(), data))
         .collect();
 
     insert_entities(&deployment, entities).await?;

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -1,12 +1,12 @@
 use graph::blockchain::block_stream::FirehoseCursor;
 use graph::components::store::{
-    DeploymentCursorTracker, DerivedEntityQuery, EntityKey, EntityType, GetScope,
-    LoadRelatedRequest, ReadStore, StoredDynamicDataSource, WritableStore,
+    DeploymentCursorTracker, DerivedEntityQuery, EntityKey, GetScope, LoadRelatedRequest,
+    ReadStore, StoredDynamicDataSource, WritableStore,
 };
 use graph::data::store::PARENT_ID;
 use graph::data::subgraph::schema::{DeploymentCreate, SubgraphError, SubgraphHealth};
 use graph::data_source::CausalityRegion;
-use graph::schema::InputSchema;
+use graph::schema::{EntityType, InputSchema};
 use graph::{
     components::store::{DeploymentId, DeploymentLocator},
     prelude::{DeploymentHash, Entity, EntityCache, EntityModification, Value},

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -1,12 +1,12 @@
 use graph::blockchain::block_stream::FirehoseCursor;
 use graph::components::store::{
-    DeploymentCursorTracker, DerivedEntityQuery, EntityKey, GetScope, LoadRelatedRequest,
-    ReadStore, StoredDynamicDataSource, WritableStore,
+    DeploymentCursorTracker, DerivedEntityQuery, GetScope, LoadRelatedRequest, ReadStore,
+    StoredDynamicDataSource, WritableStore,
 };
 use graph::data::store::PARENT_ID;
 use graph::data::subgraph::schema::{DeploymentCreate, SubgraphError, SubgraphHealth};
 use graph::data_source::CausalityRegion;
-use graph::schema::{EntityType, InputSchema};
+use graph::schema::{EntityKey, EntityType, InputSchema};
 use graph::{
     components::store::{DeploymentId, DeploymentLocator},
     prelude::{DeploymentHash, Entity, EntityCache, EntityModification, Value},

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -29,9 +29,8 @@ lazy_static! {
     static ref SUBGRAPH_ID: DeploymentHash = DeploymentHash::new("entity_cache").unwrap();
     static ref DEPLOYMENT: DeploymentLocator =
         DeploymentLocator::new(DeploymentId::new(-12), SUBGRAPH_ID.clone());
-    static ref SCHEMA: Arc<InputSchema> = Arc::new(
-        InputSchema::parse(
-            "
+    static ref SCHEMA: InputSchema = InputSchema::parse(
+        "
             type Band @entity {
                 id: ID!
                 name: String!
@@ -39,10 +38,9 @@ lazy_static! {
                 label: String
             }
             ",
-            SUBGRAPH_ID.clone(),
-        )
-        .expect("Test schema invalid")
-    );
+        SUBGRAPH_ID.clone(),
+    )
+    .expect("Test schema invalid");
 }
 
 struct MockStore {
@@ -74,7 +72,7 @@ impl ReadStore for MockStore {
         Ok(self.get_many_res.clone())
     }
 
-    fn input_schema(&self) -> Arc<InputSchema> {
+    fn input_schema(&self) -> InputSchema {
         SCHEMA.clone()
     }
 }
@@ -87,7 +85,7 @@ impl DeploymentCursorTracker for MockStore {
         unimplemented!()
     }
 
-    fn input_schema(&self) -> Arc<InputSchema> {
+    fn input_schema(&self) -> InputSchema {
         todo!()
     }
 }

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -458,7 +458,7 @@ fn create_account_entity(id: &str, name: &str, email: &str, age: i32) -> EntityO
         entity! { LOAD_RELATED_SUBGRAPH => id: id, name: name, email: email, age: age };
 
     EntityOperation::Set {
-        key: EntityKey::onchain(&*ACCOUNT_TYPE, id),
+        key: ACCOUNT_TYPE.key(id),
         data: test_entity,
     }
 }
@@ -469,7 +469,7 @@ fn create_wallet_entity(id: &str, account_id: &str, balance: i32) -> Entity {
 fn create_wallet_operation(id: &str, account_id: &str, balance: i32) -> EntityOperation {
     let test_wallet = create_wallet_entity(id, account_id, balance);
     EntityOperation::Set {
-        key: EntityKey::onchain(&*WALLET_TYPE, id),
+        key: WALLET_TYPE.key(id),
         data: test_wallet,
     }
 }
@@ -634,7 +634,7 @@ fn check_for_insert_async_not_related() {
 fn check_for_update_async_related() {
     run_store_test(|mut cache, store, deployment, writable| async move {
         let account_id = "1";
-        let entity_key = EntityKey::onchain(&*WALLET_TYPE, "1");
+        let entity_key = WALLET_TYPE.key("1");
         let wallet_entity_update = create_wallet_operation("1", account_id, 79_i32);
 
         let new_data = match wallet_entity_update {
@@ -671,7 +671,7 @@ fn check_for_update_async_related() {
 fn check_for_delete_async_related() {
     run_store_test(|mut cache, store, deployment, _writable| async move {
         let account_id = "1";
-        let del_key = EntityKey::onchain(&*WALLET_TYPE, "1");
+        let del_key = WALLET_TYPE.key("1");
         // delete wallet
         transact_entity_operations(
             &store,
@@ -701,12 +701,12 @@ fn check_for_delete_async_related() {
 fn scoped_get() {
     run_store_test(|mut cache, _store, _deployment, _writable| async move {
         // Key for an existing entity that is in the store
-        let key1 = EntityKey::onchain(&*WALLET_TYPE, "1");
+        let key1 = WALLET_TYPE.key("1");
         let wallet1 = create_wallet_entity("1", "1", 67);
 
         // Create a new entity that is not in the store
         let wallet5 = create_wallet_entity("5", "5", 100);
-        let key5 = EntityKey::onchain(&*WALLET_TYPE, "5");
+        let key5 = WALLET_TYPE.key("5");
         cache.set(key5.clone(), wallet5.clone()).unwrap();
 
         // For the new entity, we can retrieve it with either scope
@@ -748,7 +748,7 @@ fn no_internal_keys() {
             assert_eq!(None, entity.get("__typename"));
             assert_eq!(None, entity.get(&*PARENT_ID));
         }
-        let key = EntityKey::onchain(&*WALLET_TYPE, "1");
+        let key = WALLET_TYPE.key("1");
 
         let wallet = writable.get(&key).unwrap().unwrap();
         check(&wallet);

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -179,11 +179,7 @@ impl WritableStore for MockStore {
 }
 
 fn make_band_key(id: &'static str) -> EntityKey {
-    EntityKey {
-        entity_type: SCHEMA.entity_type("Band").unwrap(),
-        entity_id: id.into(),
-        causality_region: CausalityRegion::ONCHAIN,
-    }
+    SCHEMA.entity_type("Band").unwrap().key(id)
 }
 
 fn sort_by_entity_key(mut mods: Vec<EntityModification>) -> Vec<EntityModification> {
@@ -231,11 +227,7 @@ fn insert_modifications() {
 fn entity_version_map(entity_type: &str, entities: Vec<Entity>) -> BTreeMap<EntityKey, Entity> {
     let mut map = BTreeMap::new();
     for entity in entities {
-        let key = EntityKey {
-            entity_type: SCHEMA.entity_type(entity_type).unwrap(),
-            entity_id: entity.id().into(),
-            causality_region: CausalityRegion::ONCHAIN,
-        };
+        let key = SCHEMA.entity_type(entity_type).unwrap().key(entity.id());
         map.insert(key, entity);
     }
     map

--- a/store/test-store/tests/graphql/introspection.rs
+++ b/store/test-store/tests/graphql/introspection.rs
@@ -570,7 +570,7 @@ async fn introspection_query(schema: Schema, query: &str) -> QueryResult {
         trace: false,
     };
 
-    let schema = Arc::new(ApiSchema::from_api_schema(schema).unwrap());
+    let schema = Arc::new(ApiSchema::from_graphql_schema(schema).unwrap());
     let result =
         match PreparedQuery::new(&logger, schema, None, query, None, 100, graphql_metrics()) {
             Ok(query) => {

--- a/store/test-store/tests/graphql/query.rs
+++ b/store/test-store/tests/graphql/query.rs
@@ -433,6 +433,7 @@ async fn insert_test_entities(
             vec![
                 entity! { is => id: "rl2",  title: "Rock",           songs: vec![s[2]] },
                 entity! { is => id: "rl3",  title: "Cheesy",         songs: vec![s[1]] },
+                entity! { is => id: "rl4",  title: "Silence",        songs: Vec::<graph::prelude::Value>::new() },
             ],
         ),
     ];
@@ -2796,4 +2797,24 @@ fn can_compare_id() {
             assert_eq!(data, exp, "check {} for {:?} ids", cond, id_type);
         })
     }
+}
+
+#[test]
+fn empty_type_c() {
+    // Single `rl4` has no songs. Make sure our SQL query generation does
+    // not cause a syntax error
+    const QUERY: &str = "
+    query {
+        single(id: \"rl4\") {
+            songs { id }
+        }
+    }";
+
+    run_query(QUERY, |result, _| {
+        let exp = object! {
+            single: object! { songs: Vec::<r::Value>::new() }
+        };
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    })
 }

--- a/store/test-store/tests/graphql/query.rs
+++ b/store/test-store/tests/graphql/query.rs
@@ -1,8 +1,7 @@
-use graph::components::store::EntityKey;
 use graph::data::subgraph::schema::DeploymentCreate;
 use graph::entity;
 use graph::prelude::SubscriptionResult;
-use graph::schema::InputSchema;
+use graph::schema::{EntityKey, InputSchema};
 use graphql_parser::Pos;
 use std::iter::FromIterator;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/store/test-store/tests/graphql/query.rs
+++ b/store/test-store/tests/graphql/query.rs
@@ -1,7 +1,7 @@
 use graph::data::subgraph::schema::DeploymentCreate;
 use graph::entity;
 use graph::prelude::SubscriptionResult;
-use graph::schema::{EntityKey, InputSchema};
+use graph::schema::InputSchema;
 use graphql_parser::Pos;
 use std::iter::FromIterator;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -306,7 +306,7 @@ async fn insert_test_entities(
             .map(|(typename, entities)| {
                 let entity_type = schema.entity_type(typename).unwrap();
                 entities.into_iter().map(move |data| EntityOperation::Set {
-                    key: EntityKey::onchain(&entity_type, data.id()),
+                    key: entity_type.key(data.id()),
                     data,
                 })
             })

--- a/store/test-store/tests/postgres/graft.rs
+++ b/store/test-store/tests/postgres/graft.rs
@@ -1,14 +1,14 @@
 use graph::blockchain::block_stream::FirehoseCursor;
 use graph::data::value::Word;
-use graph::schema::InputSchema;
+use graph::schema::{EntityType, InputSchema};
 use graph_store_postgres::command_support::OnSync;
 use lazy_static::lazy_static;
 use std::{marker::PhantomData, str::FromStr};
 use test_store::*;
 
 use graph::components::store::{
-    DeploymentLocator, EntityKey, EntityOrder, EntityQuery, EntityType, PruneReporter,
-    PruneRequest, PruningStrategy, VersionStats,
+    DeploymentLocator, EntityKey, EntityOrder, EntityQuery, PruneReporter, PruneRequest,
+    PruningStrategy, VersionStats,
 };
 use graph::data::store::scalar;
 use graph::data::subgraph::schema::*;

--- a/store/test-store/tests/postgres/graft.rs
+++ b/store/test-store/tests/postgres/graft.rs
@@ -1,6 +1,6 @@
 use graph::blockchain::block_stream::FirehoseCursor;
 use graph::data::value::Word;
-use graph::schema::{EntityKey, EntityType, InputSchema};
+use graph::schema::{EntityType, InputSchema};
 use graph_store_postgres::command_support::OnSync;
 use lazy_static::lazy_static;
 use std::{marker::PhantomData, str::FromStr};
@@ -258,7 +258,7 @@ fn create_test_entity(
 
     let entity_type = TEST_SUBGRAPH_SCHEMA.entity_type(entity_type).unwrap();
     EntityOperation::Set {
-        key: EntityKey::onchain(&entity_type, id),
+        key: entity_type.key(id),
         data: test_entity,
     }
 }
@@ -322,7 +322,7 @@ async fn check_graft(
     // Make our own entries for block 2
     shaq.set("email", "shaq@gmail.com").unwrap();
     let op = EntityOperation::Set {
-        key: EntityKey::onchain(&*USER_TYPE, "3"),
+        key: USER_TYPE.key("3"),
         data: shaq,
     };
     transact_and_wait(&store, &deployment, BLOCKS[2].clone(), vec![op])

--- a/store/test-store/tests/postgres/graft.rs
+++ b/store/test-store/tests/postgres/graft.rs
@@ -1,14 +1,14 @@
 use graph::blockchain::block_stream::FirehoseCursor;
 use graph::data::value::Word;
-use graph::schema::{EntityType, InputSchema};
+use graph::schema::{EntityKey, EntityType, InputSchema};
 use graph_store_postgres::command_support::OnSync;
 use lazy_static::lazy_static;
 use std::{marker::PhantomData, str::FromStr};
 use test_store::*;
 
 use graph::components::store::{
-    DeploymentLocator, EntityKey, EntityOrder, EntityQuery, PruneReporter, PruneRequest,
-    PruningStrategy, VersionStats,
+    DeploymentLocator, EntityOrder, EntityQuery, PruneReporter, PruneRequest, PruningStrategy,
+    VersionStats,
 };
 use graph::data::store::scalar;
 use graph::data::subgraph::schema::*;

--- a/store/test-store/tests/postgres/relational.rs
+++ b/store/test-store/tests/postgres/relational.rs
@@ -210,9 +210,15 @@ lazy_static! {
             id: "one",
         }
     };
-    static ref SCALAR: EntityType = EntityType::from("Scalar");
-    static ref NO_ENTITY: EntityType = EntityType::from("NoEntity");
-    static ref NULLABLE_STRINGS: EntityType = EntityType::from("NullableStrings");
+    static ref SCALAR_TYPE: EntityType = THINGS_SCHEMA.entity_type("Scalar").unwrap();
+    static ref USER_TYPE: EntityType = THINGS_SCHEMA.entity_type("User").unwrap();
+    static ref DOG_TYPE: EntityType = THINGS_SCHEMA.entity_type("Dog").unwrap();
+    static ref CAT_TYPE: EntityType = THINGS_SCHEMA.entity_type("Cat").unwrap();
+    static ref FERRET_TYPE: EntityType = THINGS_SCHEMA.entity_type("Ferret").unwrap();
+    static ref MINK_TYPE: EntityType = THINGS_SCHEMA.entity_type("Mink").unwrap();
+    static ref CHAIR_TYPE: EntityType = THINGS_SCHEMA.entity_type("Chair").unwrap();
+    static ref NULLABLE_STRINGS_TYPE: EntityType =
+        THINGS_SCHEMA.entity_type("NullableStrings").unwrap();
     static ref MOCK_STOPWATCH: StopwatchMetrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
         THINGS_SUBGRAPH_ID.clone(),
@@ -231,14 +237,14 @@ fn remove_schema(conn: &PgConnection) {
 fn insert_entity_at(
     conn: &PgConnection,
     layout: &Layout,
-    entity_type: &str,
+    entity_type: &EntityType,
     mut entities: Vec<Entity>,
     block: BlockNumber,
 ) {
     let entities_with_keys_owned = entities
         .drain(..)
         .map(|entity| {
-            let key = EntityKey::data(entity_type.to_owned(), entity.id());
+            let key = EntityKey::onchain(entity_type, entity.id());
             (key, entity)
         })
         .collect::<Vec<(EntityKey, Entity)>>();
@@ -246,7 +252,6 @@ fn insert_entity_at(
         .iter()
         .map(|(key, entity)| (key, entity))
         .collect();
-    let entity_type = EntityType::from(entity_type);
     let errmsg = format!(
         "Failed to insert entities {}[{:?}]",
         entity_type, entities_with_keys
@@ -259,21 +264,26 @@ fn insert_entity_at(
     );
 }
 
-fn insert_entity(conn: &PgConnection, layout: &Layout, entity_type: &str, entities: Vec<Entity>) {
+fn insert_entity(
+    conn: &PgConnection,
+    layout: &Layout,
+    entity_type: &EntityType,
+    entities: Vec<Entity>,
+) {
     insert_entity_at(conn, layout, entity_type, entities, 0);
 }
 
 fn update_entity_at(
     conn: &PgConnection,
     layout: &Layout,
-    entity_type: &str,
+    entity_type: &EntityType,
     mut entities: Vec<Entity>,
     block: BlockNumber,
 ) {
     let entities_with_keys_owned: Vec<(EntityKey, Entity)> = entities
         .drain(..)
         .map(|entity| {
-            let key = EntityKey::data(entity_type.to_owned(), entity.id());
+            let key = EntityKey::onchain(entity_type, entity.id());
             (key, entity)
         })
         .collect();
@@ -282,7 +292,6 @@ fn update_entity_at(
         .map(|(key, entity)| (key, entity))
         .collect();
 
-    let entity_type = EntityType::from(entity_type);
     let errmsg = format!(
         "Failed to insert entities {}[{:?}]",
         entity_type, entities_with_keys
@@ -296,7 +305,7 @@ fn insert_user_entity(
     conn: &PgConnection,
     layout: &Layout,
     id: &str,
-    entity_type: &str,
+    entity_type: &EntityType,
     name: &str,
     email: &str,
     age: i32,
@@ -362,7 +371,7 @@ fn insert_users(conn: &PgConnection, layout: &Layout) {
         conn,
         layout,
         "1",
-        "User",
+        &*USER_TYPE,
         "Johnton",
         "tonofjohn@email.com",
         67_i32,
@@ -377,7 +386,7 @@ fn insert_users(conn: &PgConnection, layout: &Layout) {
         conn,
         layout,
         "2",
-        "User",
+        &*USER_TYPE,
         "Cindini",
         "dinici@email.com",
         43_i32,
@@ -392,7 +401,7 @@ fn insert_users(conn: &PgConnection, layout: &Layout) {
         conn,
         layout,
         "3",
-        "User",
+        &*USER_TYPE,
         "Shaqueeena",
         "teeko@email.com",
         28_i32,
@@ -409,7 +418,7 @@ fn update_user_entity(
     conn: &PgConnection,
     layout: &Layout,
     id: &str,
-    entity_type: &str,
+    entity_type: &EntityType,
     name: &str,
     email: &str,
     age: i32,
@@ -438,7 +447,7 @@ fn update_user_entity(
 fn insert_pet(
     conn: &PgConnection,
     layout: &Layout,
-    entity_type: &str,
+    entity_type: &EntityType,
     id: &str,
     name: &str,
     block: BlockNumber,
@@ -451,8 +460,8 @@ fn insert_pet(
 }
 
 fn insert_pets(conn: &PgConnection, layout: &Layout) {
-    insert_pet(conn, layout, "Dog", "pluto", "Pluto", 0);
-    insert_pet(conn, layout, "Cat", "garfield", "Garfield", 0);
+    insert_pet(conn, layout, &*DOG_TYPE, "pluto", "Pluto", 0);
+    insert_pet(conn, layout, &*CAT_TYPE, "garfield", "Garfield", 0);
 }
 
 fn create_schema(conn: &PgConnection) -> Layout {
@@ -527,13 +536,13 @@ where
 #[test]
 fn find() {
     run_test(|conn, layout| {
-        insert_entity(conn, layout, "Scalar", vec![SCALAR_ENTITY.clone()]);
+        insert_entity(conn, layout, &*SCALAR_TYPE, vec![SCALAR_ENTITY.clone()]);
 
         // Happy path: find existing entity
         let entity = layout
             .find(
                 conn,
-                &EntityKey::data(SCALAR.as_str(), "one"),
+                &EntityKey::onchain(&*SCALAR_TYPE, "one"),
                 BLOCK_NUMBER_MAX,
             )
             .expect("Failed to read Scalar[one]")
@@ -544,25 +553,11 @@ fn find() {
         let entity = layout
             .find(
                 conn,
-                &EntityKey::data(SCALAR.as_str(), "noone"),
+                &EntityKey::onchain(&*SCALAR_TYPE, "noone"),
                 BLOCK_NUMBER_MAX,
             )
             .expect("Failed to read Scalar[noone]");
         assert!(entity.is_none());
-
-        // Find for non-existing entity type
-        let err = layout.find(
-            conn,
-            &EntityKey::data(NO_ENTITY.as_str(), "one"),
-            BLOCK_NUMBER_MAX,
-        );
-        match err {
-            Err(e) => assert_eq!("unknown table 'NoEntity'", e.to_string()),
-            _ => {
-                println!("{:?}", err);
-                assert!(false)
-            }
-        }
     });
 }
 
@@ -572,7 +567,7 @@ fn insert_null_fulltext_fields() {
         insert_entity(
             conn,
             layout,
-            "NullableStrings",
+            &*NULLABLE_STRINGS_TYPE,
             vec![EMPTY_NULLABLESTRINGS_ENTITY.clone()],
         );
 
@@ -580,7 +575,7 @@ fn insert_null_fulltext_fields() {
         let entity = layout
             .find(
                 conn,
-                &EntityKey::data(NULLABLE_STRINGS.as_str(), "one"),
+                &EntityKey::onchain(&*NULLABLE_STRINGS_TYPE, "one"),
                 BLOCK_NUMBER_MAX,
             )
             .expect("Failed to read NullableStrings[one]")
@@ -592,16 +587,16 @@ fn insert_null_fulltext_fields() {
 #[test]
 fn update() {
     run_test(|conn, layout| {
-        insert_entity(conn, layout, "Scalar", vec![SCALAR_ENTITY.clone()]);
+        insert_entity(conn, layout, &*SCALAR_TYPE, vec![SCALAR_ENTITY.clone()]);
 
         // Update with overwrite
         let mut entity = SCALAR_ENTITY.clone();
         entity.set("string", "updated").unwrap();
         entity.remove("strings");
         entity.set("bool", Value::Null).unwrap();
-        let key = EntityKey::data("Scalar".to_owned(), entity.id());
+        let key = EntityKey::onchain(&*SCALAR_TYPE, entity.id());
 
-        let entity_type = EntityType::from("Scalar");
+        let entity_type = layout.input_schema.entity_type("Scalar").unwrap();
         let entities = vec![(key, entity.clone())];
         let group = row_group_update(&entity_type, 0, entities);
         layout
@@ -611,7 +606,7 @@ fn update() {
         let actual = layout
             .find(
                 conn,
-                &EntityKey::data(SCALAR.as_str(), "one"),
+                &EntityKey::onchain(&*SCALAR_TYPE, "one"),
                 BLOCK_NUMBER_MAX,
             )
             .expect("Failed to read Scalar[one]")
@@ -631,7 +626,7 @@ fn update_many() {
         insert_entity(
             conn,
             layout,
-            "Scalar",
+            &*SCALAR_TYPE,
             vec![one.clone(), two.clone(), three.clone()],
         );
 
@@ -650,10 +645,10 @@ fn update_many() {
         three.set("color", "red").unwrap();
 
         // generate keys
-        let entity_type = EntityType::from("Scalar");
+        let entity_type = layout.input_schema.entity_type("Scalar").unwrap();
         let keys: Vec<EntityKey> = ["one", "two", "three"]
             .iter()
-            .map(|id| EntityKey::data("Scalar".to_owned(), String::from(*id)))
+            .map(|id| EntityKey::onchain(&*SCALAR_TYPE, *id))
             .collect();
 
         let entities_vec = vec![one, two, three];
@@ -670,7 +665,7 @@ fn update_many() {
                 layout
                     .find(
                         conn,
-                        &EntityKey::data(SCALAR.as_str(), id),
+                        &EntityKey::onchain(&*SCALAR_TYPE, id),
                         BLOCK_NUMBER_MAX,
                     )
                     .unwrap_or_else(|_| panic!("Failed to read Scalar[{}]", id))
@@ -715,7 +710,7 @@ fn update_many() {
 #[test]
 fn serialize_bigdecimal() {
     run_test(|conn, layout| {
-        insert_entity(conn, layout, "Scalar", vec![SCALAR_ENTITY.clone()]);
+        insert_entity(conn, layout, &*SCALAR_TYPE, vec![SCALAR_ENTITY.clone()]);
 
         // Update with overwrite
         let mut entity = SCALAR_ENTITY.clone();
@@ -724,8 +719,8 @@ fn serialize_bigdecimal() {
             let d = BigDecimal::from_str(d).unwrap();
             entity.set("bigDecimal", d).unwrap();
 
-            let key = EntityKey::data("Scalar".to_owned(), entity.id());
-            let entity_type = EntityType::from("Scalar");
+            let key = EntityKey::onchain(&*SCALAR_TYPE, entity.id());
+            let entity_type = layout.input_schema.entity_type("Scalar").unwrap();
             let entities = vec![(key, entity.clone())];
             let group = row_group_update(&entity_type, 0, entities);
             layout
@@ -735,7 +730,7 @@ fn serialize_bigdecimal() {
             let actual = layout
                 .find(
                     conn,
-                    &EntityKey::data(SCALAR.as_str(), "one"),
+                    &EntityKey::onchain(&*SCALAR_TYPE, "one"),
                     BLOCK_NUMBER_MAX,
                 )
                 .expect("Failed to read Scalar[one]")
@@ -750,7 +745,7 @@ fn count_scalar_entities(conn: &PgConnection, layout: &Layout) -> usize {
         EntityFilter::Equal("bool".into(), true.into()),
         EntityFilter::Equal("bool".into(), false.into()),
     ]);
-    let collection = EntityCollection::All(vec![(SCALAR.to_owned(), AttributeNames::All)]);
+    let collection = EntityCollection::All(vec![(SCALAR_TYPE.to_owned(), AttributeNames::All)]);
     let mut query = EntityQuery::new(layout.site.deployment.clone(), BLOCK_NUMBER_MAX, collection)
         .filter(filter);
     query.range.first = None;
@@ -764,14 +759,14 @@ fn count_scalar_entities(conn: &PgConnection, layout: &Layout) -> usize {
 #[test]
 fn delete() {
     run_test(|conn, layout| {
-        insert_entity(conn, layout, "Scalar", vec![SCALAR_ENTITY.clone()]);
+        insert_entity(conn, layout, &*SCALAR_TYPE, vec![SCALAR_ENTITY.clone()]);
         let mut two = SCALAR_ENTITY.clone();
         two.set("id", "two").unwrap();
-        insert_entity(conn, layout, "Scalar", vec![two]);
+        insert_entity(conn, layout, &*SCALAR_TYPE, vec![two]);
 
         // Delete where nothing is getting deleted
-        let key = EntityKey::data("Scalar".to_owned(), "no such entity".to_owned());
-        let entity_type = EntityType::from("Scalar");
+        let key = EntityKey::onchain(&*SCALAR_TYPE, "no such entity");
+        let entity_type = layout.input_schema.entity_type("Scalar").unwrap();
         let mut entity_keys = vec![key];
         let group = row_group_delete(&entity_type, 1, entity_keys.clone());
         let count = layout
@@ -803,18 +798,17 @@ fn insert_many_and_delete_many() {
         two.set("id", "two").unwrap();
         let mut three = SCALAR_ENTITY.clone();
         three.set("id", "three").unwrap();
-        insert_entity(conn, layout, "Scalar", vec![one, two, three]);
+        insert_entity(conn, layout, &*SCALAR_TYPE, vec![one, two, three]);
 
         // confidence test: there should be 3 scalar entities in store right now
         assert_eq!(3, count_scalar_entities(conn, layout));
 
         // Delete entities with ids equal to "two" and "three"
-        let entity_type = EntityType::from("Scalar");
         let entity_keys: Vec<_> = vec!["two", "three"]
             .into_iter()
-            .map(|key| EntityKey::data(entity_type.as_str(), key))
+            .map(|key| EntityKey::onchain(&*SCALAR_TYPE, key))
             .collect();
-        let group = row_group_delete(&entity_type, 1, entity_keys);
+        let group = row_group_delete(&*SCALAR_TYPE, 1, entity_keys);
         let num_removed = layout
             .delete(conn, &group, &MOCK_STOPWATCH)
             .expect("Failed to delete");
@@ -878,30 +872,25 @@ fn conflicting_entity() {
     // `id` is the id of an entity to create, `cat`, `dog`, and `ferret` are
     // the names of the types for which to check entity uniqueness
     fn check(conn: &PgConnection, layout: &Layout, id: Value, cat: &str, dog: &str, ferret: &str) {
-        let cat = EntityType::from(cat);
-        let dog = EntityType::from(dog);
-        let ferret = EntityType::from(ferret);
+        let conflicting = |types: Vec<&EntityType>| {
+            let types = types.into_iter().cloned().collect();
+            layout.conflicting_entity(conn, &id.to_string(), types)
+        };
+
+        let cat_type = layout.input_schema.entity_type(cat).unwrap();
+        let dog_type = layout.input_schema.entity_type(dog).unwrap();
+        let ferret_type = layout.input_schema.entity_type(ferret).unwrap();
 
         let fred = entity! { layout.input_schema => id: id.clone(), name: id.clone() };
-        insert_entity(conn, layout, cat.as_str(), vec![fred]);
+        insert_entity(conn, layout, &cat_type, vec![fred]);
 
         // If we wanted to create Fred the dog, which is forbidden, we'd run this:
-        let conflict = layout
-            .conflicting_entity(conn, &id.to_string(), vec![cat.clone(), ferret.clone()])
-            .unwrap();
+        let conflict = conflicting(vec![&cat_type, &ferret_type]).unwrap();
         assert_eq!(Some(cat.to_string()), conflict);
 
         // If we wanted to manipulate Fred the cat, which is ok, we'd run:
-        let conflict = layout
-            .conflicting_entity(conn, &id.to_string(), vec![dog.clone(), ferret.clone()])
-            .unwrap();
+        let conflict = conflicting(vec![&dog_type, &ferret_type]).unwrap();
         assert_eq!(None, conflict);
-
-        // Chairs are not pets
-        let chair = EntityType::from("Chair");
-        let result = layout.conflicting_entity(conn, &id.to_string(), vec![dog, ferret, chair]);
-        assert!(result.is_err());
-        assert_eq!("unknown table 'Chair'", result.err().unwrap().to_string());
     }
 
     run_test(|conn, layout| {
@@ -924,15 +913,15 @@ fn revert_block() {
                 name: name
             };
             if block == 0 {
-                insert_entity_at(conn, layout, "Cat", vec![fred], block);
+                insert_entity_at(conn, layout, &*CAT_TYPE, vec![fred], block);
             } else {
-                update_entity_at(conn, layout, "Cat", vec![fred], block);
+                update_entity_at(conn, layout, &*CAT_TYPE, vec![fred], block);
             }
         };
 
         let assert_fred = |name: &str| {
             let fred = layout
-                .find(conn, &EntityKey::data("Cat", id), BLOCK_NUMBER_MAX)
+                .find(conn, &EntityKey::onchain(&*CAT_TYPE, id), BLOCK_NUMBER_MAX)
                 .unwrap()
                 .expect("there's a fred");
             assert_eq!(name, fred.get("name").unwrap().as_str().unwrap())
@@ -962,14 +951,13 @@ fn revert_block() {
                     id: id,
                     order: block,
                 };
-                insert_entity_at(conn, layout, "Mink", vec![marty], block);
+                insert_entity_at(conn, layout, &*MINK_TYPE, vec![marty], block);
             }
         };
 
         let assert_marties = |max_block, except: Vec<BlockNumber>| {
             let id = DeploymentHash::new("QmXW3qvxV7zXnwRntpj7yoK8HZVtaraZ67uMqaLRvXdxha").unwrap();
-            let collection =
-                EntityCollection::All(vec![(EntityType::from("Mink"), AttributeNames::All)]);
+            let collection = EntityCollection::All(vec![(MINK_TYPE.clone(), AttributeNames::All)]);
             let filter = EntityFilter::StartsWith("id".to_string(), Value::from("marty"));
             let query = EntityQuery::new(id, BLOCK_NUMBER_MAX, collection)
                 .filter(filter)
@@ -1029,7 +1017,7 @@ impl<'a> QueryChecker<'a> {
             conn,
             layout,
             "1",
-            "User",
+            &*USER_TYPE,
             "Jono",
             "achangedemail@email.com",
             67_i32,
@@ -1077,21 +1065,21 @@ impl<'a> QueryChecker<'a> {
     }
 }
 
-fn query(entity_types: Vec<&str>) -> EntityQuery {
+fn query(entity_types: &[&EntityType]) -> EntityQuery {
     EntityQuery::new(
         THINGS_SUBGRAPH_ID.clone(),
         BLOCK_NUMBER_MAX,
         EntityCollection::All(
             entity_types
                 .into_iter()
-                .map(|entity_type| (EntityType::from(entity_type), AttributeNames::All))
+                .map(|entity_type| ((*entity_type).clone(), AttributeNames::All))
                 .collect(),
         ),
     )
 }
 
 fn user_query() -> EntityQuery {
-    query(vec!["User"])
+    query(&vec![&*USER_TYPE])
 }
 
 trait EasyOrder {
@@ -1138,7 +1126,7 @@ fn check_block_finds() {
             conn,
             layout,
             "1",
-            "User",
+            &*USER_TYPE,
             "Johnton",
             "tonofjohn@email.com",
             67_i32,
@@ -1173,30 +1161,19 @@ fn check_block_finds() {
 fn check_find() {
     run_test(move |conn, layout| {
         // find with interfaces
+        let types = vec![&*CAT_TYPE, &*DOG_TYPE];
         let checker = QueryChecker::new(conn, layout)
-            .check(vec!["garfield", "pluto"], query(vec!["Cat", "Dog"]))
-            .check(
-                vec!["pluto", "garfield"],
-                query(vec!["Cat", "Dog"]).desc("name"),
-            )
+            .check(vec!["garfield", "pluto"], query(&types))
+            .check(vec!["pluto", "garfield"], query(&types).desc("name"))
             .check(
                 vec!["garfield"],
-                query(vec!["Cat", "Dog"])
+                query(&types)
                     .filter(EntityFilter::StartsWith("name".into(), Value::from("Gar")))
                     .desc("name"),
             )
-            .check(
-                vec!["pluto", "garfield"],
-                query(vec!["Cat", "Dog"]).desc("id"),
-            )
-            .check(
-                vec!["garfield", "pluto"],
-                query(vec!["Cat", "Dog"]).asc("id"),
-            )
-            .check(
-                vec!["garfield", "pluto"],
-                query(vec!["Cat", "Dog"]).unordered(),
-            );
+            .check(vec!["pluto", "garfield"], query(&types).desc("id"))
+            .check(vec!["garfield", "pluto"], query(&types).asc("id"))
+            .check(vec!["garfield", "pluto"], query(&types).unordered());
 
         // fulltext
         let checker = checker
@@ -1698,10 +1675,10 @@ struct FilterChecker<'a> {
 impl<'a> FilterChecker<'a> {
     fn new(conn: &'a PgConnection, layout: &'a Layout) -> Self {
         let (a1, a2, a2b, a3) = ferrets();
-        insert_pet(conn, layout, "Ferret", "a1", &a1, 0);
-        insert_pet(conn, layout, "Ferret", "a2", &a2, 0);
-        insert_pet(conn, layout, "Ferret", "a2b", &a2b, 0);
-        insert_pet(conn, layout, "Ferret", "a3", &a3, 0);
+        insert_pet(conn, layout, &*FERRET_TYPE, "a1", &a1, 0);
+        insert_pet(conn, layout, &*FERRET_TYPE, "a2", &a2, 0);
+        insert_pet(conn, layout, &*FERRET_TYPE, "a2b", &a2b, 0);
+        insert_pet(conn, layout, &*FERRET_TYPE, "a3", &a3, 0);
 
         Self { conn, layout }
     }
@@ -1710,7 +1687,7 @@ impl<'a> FilterChecker<'a> {
         let expected_entity_ids: Vec<String> =
             expected_entity_ids.into_iter().map(str::to_owned).collect();
 
-        let query = query(vec!["Ferret"]).filter(filter).asc("id");
+        let query = query(&vec![&*FERRET_TYPE]).filter(filter).asc("id");
 
         let entities = self
             .layout
@@ -1842,7 +1819,7 @@ fn check_filters() {
         update_entity_at(
             conn,
             layout,
-            "Ferret",
+            &*FERRET_TYPE,
             vec![entity! { layout.input_schema =>
               id: "a1",
               name: "Test"

--- a/store/test-store/tests/postgres/relational.rs
+++ b/store/test-store/tests/postgres/relational.rs
@@ -1,7 +1,6 @@
 //! Test mapping of GraphQL schema to a relational schema
 use diesel::connection::SimpleConnection as _;
 use diesel::pg::PgConnection;
-use graph::components::store::EntityKey;
 use graph::data::store::scalar;
 use graph::data::value::Word;
 use graph::entity;
@@ -10,7 +9,7 @@ use graph::prelude::{
     EntityOrder, EntityQuery, Logger, StopwatchMetrics, Value, ValueType, BLOCK_NUMBER_MAX,
 };
 use graph::prelude::{BlockNumber, MetricsRegistry};
-use graph::schema::{EntityType, InputSchema};
+use graph::schema::{EntityKey, EntityType, InputSchema};
 use graph_store_postgres::layout_for_tests::set_account_like;
 use graph_store_postgres::layout_for_tests::LayoutCache;
 use graph_store_postgres::layout_for_tests::SqlName;

--- a/store/test-store/tests/postgres/relational.rs
+++ b/store/test-store/tests/postgres/relational.rs
@@ -10,7 +10,7 @@ use graph::prelude::{
     EntityOrder, EntityQuery, Logger, StopwatchMetrics, Value, ValueType, BLOCK_NUMBER_MAX,
 };
 use graph::prelude::{BlockNumber, MetricsRegistry};
-use graph::schema::InputSchema;
+use graph::schema::{EntityType, InputSchema};
 use graph_store_postgres::layout_for_tests::set_account_like;
 use graph_store_postgres::layout_for_tests::LayoutCache;
 use graph_store_postgres::layout_for_tests::SqlName;
@@ -24,7 +24,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use graph::{
-    components::store::{AttributeNames, EntityType},
+    components::store::AttributeNames,
     data::store::scalar::{BigDecimal, BigInt, Bytes},
 };
 use graph_store_postgres::{

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -8,21 +8,18 @@ use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
 use graph::entity;
 use graph::prelude::{BlockNumber, EntityModification, EntityQuery, MetricsRegistry, StoreError};
-use graph::schema::InputSchema;
+use graph::schema::{EntityType, InputSchema};
 use hex_literal::hex;
 use lazy_static::lazy_static;
 use std::collections::BTreeSet;
 use std::str::FromStr;
 use std::{collections::BTreeMap, sync::Arc};
 
+use graph::data::store::scalar::{BigDecimal, BigInt};
 use graph::prelude::{
     o, slog, web3::types::H256, AttributeNames, ChildMultiplicity, DeploymentHash, Entity,
     EntityCollection, EntityLink, EntityWindow, Logger, ParentLink, StopwatchMetrics,
     WindowAttribute, BLOCK_NUMBER_MAX,
-};
-use graph::{
-    components::store::EntityType,
-    data::store::scalar::{BigDecimal, BigInt},
 };
 use graph_store_postgres::{
     layout_for_tests::make_dummy_site,

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -298,16 +298,8 @@ fn find_many() {
             .expect("Failed to read many things");
         assert_eq!(2, entities.len());
 
-        let id_key = EntityKey {
-            entity_id: ID.into(),
-            entity_type: THING_TYPE.clone(),
-            causality_region: CausalityRegion::ONCHAIN,
-        };
-        let id2_key = EntityKey {
-            entity_id: ID2.into(),
-            entity_type: THING_TYPE.clone(),
-            causality_region: CausalityRegion::ONCHAIN,
-        };
+        let id_key = THING_TYPE.key(ID);
+        let id2_key = THING_TYPE.key(ID2);
         assert!(entities.contains_key(&id_key), "Missing ID");
         assert!(entities.contains_key(&id2_key), "Missing ID2");
     });

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -2,13 +2,12 @@
 use diesel::connection::SimpleConnection as _;
 use diesel::pg::PgConnection;
 use graph::components::store::write::RowGroup;
-use graph::components::store::EntityKey;
 use graph::data::store::scalar;
 use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
 use graph::entity;
 use graph::prelude::{BlockNumber, EntityModification, EntityQuery, MetricsRegistry, StoreError};
-use graph::schema::{EntityType, InputSchema};
+use graph::schema::{EntityKey, EntityType, InputSchema};
 use hex_literal::hex;
 use lazy_static::lazy_static;
 use std::collections::BTreeSet;

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -899,7 +899,7 @@ fn find() {
 fn make_entity_change(entity_type: &EntityType) -> EntityChange {
     EntityChange::Data {
         subgraph_id: TEST_SUBGRAPH_ID.clone(),
-        entity_type: entity_type.to_owned(),
+        entity_type: entity_type.to_string(),
     }
 }
 
@@ -1234,7 +1234,7 @@ fn revert_block_with_dynamic_data_source_operations() {
             changes: HashSet::from_iter(
                 vec![EntityChange::Data {
                     subgraph_id: DeploymentHash::new("testsubgraph").unwrap(),
-                    entity_type: USER_TYPE.to_owned(),
+                    entity_type: USER_TYPE.to_string(),
                 }]
                 .into_iter(),
             ),
@@ -1330,21 +1330,21 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             StoreEvent::new(vec![
                 EntityChange::Data {
                     subgraph_id: subgraph_id.clone(),
-                    entity_type: USER_TYPE.clone(),
+                    entity_type: USER_TYPE.to_string(),
                 },
                 EntityChange::Data {
                     subgraph_id: subgraph_id.clone(),
-                    entity_type: USER_TYPE.clone(),
+                    entity_type: USER_TYPE.to_string(),
                 },
             ]),
             StoreEvent::new(vec![
                 EntityChange::Data {
                     subgraph_id: subgraph_id.clone(),
-                    entity_type: USER_TYPE.clone(),
+                    entity_type: USER_TYPE.to_string(),
                 },
                 EntityChange::Data {
                     subgraph_id: subgraph_id.clone(),
-                    entity_type: USER_TYPE.clone(),
+                    entity_type: USER_TYPE.to_string(),
                 },
             ]),
         ];

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -2,7 +2,7 @@ use graph::blockchain::block_stream::FirehoseCursor;
 use graph::data::graphql::ext::TypeDefinitionExt;
 use graph::data::query::QueryTarget;
 use graph::data::subgraph::schema::DeploymentCreate;
-use graph::schema::{EntityType, InputSchema};
+use graph::schema::{EntityKey, EntityType, InputSchema};
 use graph_chain_ethereum::{Mapping, MappingABI};
 use hex_literal::hex;
 use lazy_static::lazy_static;
@@ -11,7 +11,7 @@ use std::{collections::HashSet, sync::Mutex};
 use std::{marker::PhantomData, str::FromStr};
 use test_store::*;
 
-use graph::components::store::{DeploymentLocator, EntityKey, ReadStore, WritableStore};
+use graph::components::store::{DeploymentLocator, ReadStore, WritableStore};
 use graph::data::subgraph::*;
 use graph::{
     blockchain::DataSource,

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -2,7 +2,7 @@ use graph::blockchain::block_stream::FirehoseCursor;
 use graph::data::graphql::ext::TypeDefinitionExt;
 use graph::data::query::QueryTarget;
 use graph::data::subgraph::schema::DeploymentCreate;
-use graph::schema::InputSchema;
+use graph::schema::{EntityType, InputSchema};
 use graph_chain_ethereum::{Mapping, MappingABI};
 use hex_literal::hex;
 use lazy_static::lazy_static;
@@ -16,7 +16,7 @@ use graph::data::subgraph::*;
 use graph::{
     blockchain::DataSource,
     components::store::{
-        BlockStore as _, EntityFilter, EntityOrder, EntityQuery, EntityType, StatusStore,
+        BlockStore as _, EntityFilter, EntityOrder, EntityQuery, StatusStore,
         SubscriptionManager as _,
     },
     prelude::ethabi::Contract,

--- a/store/test-store/tests/postgres/writable.rs
+++ b/store/test-store/tests/postgres/writable.rs
@@ -107,7 +107,7 @@ fn block_pointer(number: u8) -> BlockPtr {
 }
 
 fn count_key(id: &str) -> EntityKey {
-    COUNTER_TYPE.key(id)
+    COUNTER_TYPE.parse_key(id).unwrap()
 }
 
 async fn insert_count(store: &Arc<DieselSubgraphStore>, deployment: &DeploymentLocator, count: u8) {
@@ -198,7 +198,6 @@ fn count_get_derived(writable: &dyn WritableStore) -> i32 {
         entity_type: key.entity_type.clone(),
         entity_field: Word::from("id"),
         value: key.entity_id.clone(),
-        id_is_bytes: false,
         causality_region: CausalityRegion::ONCHAIN,
     };
     let map = writable.get_derived(&query).unwrap();

--- a/store/test-store/tests/postgres/writable.rs
+++ b/store/test-store/tests/postgres/writable.rs
@@ -2,15 +2,13 @@ use graph::blockchain::block_stream::FirehoseCursor;
 use graph::data::subgraph::schema::DeploymentCreate;
 use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
-use graph::schema::InputSchema;
+use graph::schema::{EntityType, InputSchema};
 use lazy_static::lazy_static;
 use std::collections::BTreeSet;
 use std::marker::PhantomData;
 use test_store::*;
 
-use graph::components::store::{
-    DeploymentLocator, DerivedEntityQuery, EntityKey, EntityType, WritableStore,
-};
+use graph::components::store::{DeploymentLocator, DerivedEntityQuery, EntityKey, WritableStore};
 use graph::data::subgraph::*;
 use graph::semver::Version;
 use graph::{entity, prelude::*};

--- a/store/test-store/tests/postgres/writable.rs
+++ b/store/test-store/tests/postgres/writable.rs
@@ -2,13 +2,13 @@ use graph::blockchain::block_stream::FirehoseCursor;
 use graph::data::subgraph::schema::DeploymentCreate;
 use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
-use graph::schema::{EntityType, InputSchema};
+use graph::schema::{EntityKey, EntityType, InputSchema};
 use lazy_static::lazy_static;
 use std::collections::BTreeSet;
 use std::marker::PhantomData;
 use test_store::*;
 
-use graph::components::store::{DeploymentLocator, DerivedEntityQuery, EntityKey, WritableStore};
+use graph::components::store::{DeploymentLocator, DerivedEntityQuery, WritableStore};
 use graph::data::subgraph::*;
 use graph::semver::Version;
 use graph::{entity, prelude::*};

--- a/store/test-store/tests/postgres/writable.rs
+++ b/store/test-store/tests/postgres/writable.rs
@@ -8,7 +8,9 @@ use std::collections::BTreeSet;
 use std::marker::PhantomData;
 use test_store::*;
 
-use graph::components::store::{DeploymentLocator, DerivedEntityQuery, EntityKey, WritableStore};
+use graph::components::store::{
+    DeploymentLocator, DerivedEntityQuery, EntityKey, EntityType, WritableStore,
+};
 use graph::data::subgraph::*;
 use graph::semver::Version;
 use graph::{entity, prelude::*};
@@ -32,6 +34,7 @@ lazy_static! {
     static ref TEST_SUBGRAPH_SCHEMA: InputSchema =
         InputSchema::parse(SCHEMA_GQL, TEST_SUBGRAPH_ID.clone())
             .expect("Failed to parse user schema");
+    static ref COUNTER_TYPE: EntityType = TEST_SUBGRAPH_SCHEMA.entity_type(COUNTER).unwrap();
 }
 
 /// Inserts test data into the store.
@@ -106,7 +109,7 @@ fn block_pointer(number: u8) -> BlockPtr {
 }
 
 fn count_key(id: &str) -> EntityKey {
-    EntityKey::data(COUNTER.to_owned(), id.to_owned())
+    EntityKey::onchain(&*COUNTER_TYPE, id)
 }
 
 async fn insert_count(store: &Arc<DieselSubgraphStore>, deployment: &DeploymentLocator, count: u8) {

--- a/store/test-store/tests/postgres/writable.rs
+++ b/store/test-store/tests/postgres/writable.rs
@@ -107,7 +107,7 @@ fn block_pointer(number: u8) -> BlockPtr {
 }
 
 fn count_key(id: &str) -> EntityKey {
-    EntityKey::onchain(&*COUNTER_TYPE, id)
+    COUNTER_TYPE.key(id)
 }
 
 async fn insert_count(store: &Arc<DieselSubgraphStore>, deployment: &DeploymentLocator, count: u8) {

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -584,7 +584,7 @@ impl<C: Blockchain> BlockStreamBuilder<C> for MutexBlockStreamBuilder<C> {
     async fn build_substreams(
         &self,
         _chain: &C,
-        _schema: Arc<InputSchema>,
+        _schema: InputSchema,
         _deployment: DeploymentLocator,
         _block_cursor: FirehoseCursor,
         _subgraph_current_block: Option<BlockPtr>,
@@ -623,7 +623,7 @@ where
     async fn build_substreams(
         &self,
         _chain: &C,
-        _schema: Arc<InputSchema>,
+        _schema: InputSchema,
         _deployment: DeploymentLocator,
         _block_cursor: FirehoseCursor,
         _subgraph_current_block: Option<BlockPtr>,


### PR DESCRIPTION
We used to treat both `EntityType` and ids as just strings, which lead to situations where it was very unclear what either of them meant and how it had to be converted. In addition, we had to do lots of lookups for ancillary information against things like the `InputSchema` which made code harder to follow than it has to be. It also has caused hard-to-spot bugs in the past, especially around conversion of strings to bytes and vice versa.

With these changes, entity types and ids are converted into a better internal representation at the point where we take them in from the outside (mappings, substreams, database) with checks that what we take in actually makes sense.

The `EntityType` is now properly checked against the `InputSchema` when it is first constructed, and can be used to look up ancillary information like the type of the `id` field directly without needing to have an `InputSchema` around.

Similarly, the `Id` type now wraps entity ids and carries type information with it making it much less likely that code changes get confused about the actual type they need to deal with.

A lot of the commits in this PR are pretty boring (my apologies to the reviewer), and either just moving methods around or slightly changing method signatures. None of them should cause a functional change.