### PR TITLE
feat: initial Starknet support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
 
 [[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint 0.4.4",
+ "num-traits",
+ "paste",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint 0.4.4",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std",
+ "digest 0.10.7",
+ "num-bigint 0.4.4",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,7 +251,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.1",
+ "itoa",
  "matchit",
  "memchr",
  "mime",
@@ -297,6 +361,7 @@ dependencies = [
  "num-bigint 0.4.4",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -437,7 +502,7 @@ checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
 dependencies = [
  "serde",
  "serde_repr",
- "serde_with",
+ "serde_with 3.3.0",
 ]
 
 [[package]]
@@ -860,6 +925,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
+dependencies = [
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +963,41 @@ checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -920,6 +1031,17 @@ name = "defer"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "647605a6345d5e89c3950a36a638c56478af9b414c55c6f2477c73b115f9acde"
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
 
 [[package]]
 name = "derive_more"
@@ -1023,6 +1145,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1443,13 +1566,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1659,6 +1784,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "graph-chain-starknet"
+version = "0.32.0"
+dependencies = [
+ "graph",
+ "graph-runtime-derive",
+ "graph-runtime-wasm",
+ "hex",
+ "prost",
+ "prost-types",
+ "serde",
+ "starknet-core",
+ "tonic-build",
+]
+
+[[package]]
 name = "graph-chain-substreams"
 version = "0.32.0"
 dependencies = [
@@ -1701,6 +1841,7 @@ dependencies = [
  "graph-chain-cosmos",
  "graph-chain-ethereum",
  "graph-chain-near",
+ "graph-chain-starknet",
  "graph-chain-substreams",
  "graph-runtime-wasm",
  "ipfs-api",
@@ -1749,6 +1890,7 @@ dependencies = [
  "graph-chain-cosmos",
  "graph-chain-ethereum",
  "graph-chain-near",
+ "graph-chain-starknet",
  "graph-chain-substreams",
  "graph-core",
  "graph-graphql",
@@ -1848,6 +1990,7 @@ dependencies = [
  "graph-chain-cosmos",
  "graph-chain-ethereum",
  "graph-chain-near",
+ "graph-chain-starknet",
  "graph-graphql",
  "graphql-parser",
  "http",
@@ -2068,6 +2211,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-literal"
@@ -2092,6 +2238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,7 +2254,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa",
 ]
 
 [[package]]
@@ -2161,7 +2316,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.1",
+ "itoa",
  "pin-project-lite",
  "socket2 0.4.9",
  "tokio",
@@ -2261,6 +2416,12 @@ dependencies = [
  "rand",
  "static_assertions",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2466,12 +2627,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
-
-[[package]]
-name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
@@ -2594,9 +2749,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.0"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+dependencies = [
+ "cpufeatures 0.2.2",
+]
 
 [[package]]
 name = "lazy_static"
@@ -2769,7 +2927,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.45.0",
 ]
 
@@ -2912,9 +3070,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -3224,7 +3382,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
- "hmac",
+ "hmac 0.10.1",
  "md-5",
  "memchr",
  "rand",
@@ -3669,6 +3827,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3915,11 +4083,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
- "itoa 0.4.7",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_json_pythonic"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62212da9872ca2a0cad0093191ee33753eddff9266cbbc1b4a602d13a3a768db"
+dependencies = [
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3970,9 +4149,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
 ]
 
 [[package]]
@@ -3992,13 +4186,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with_macros"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
  "indexmap 1.9.3",
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
@@ -4054,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.1"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -4240,6 +4446,78 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "starknet-core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b796a32a7400f7d85e95d3900b5cee7a392b2adbf7ad16093ed45ec6f8d85de6"
+dependencies = [
+ "base64 0.21.0",
+ "flate2",
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_json_pythonic",
+ "serde_with 2.3.3",
+ "sha3",
+ "starknet-crypto",
+ "starknet-ff",
+]
+
+[[package]]
+name = "starknet-crypto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbb308033b5c60c5677645f7ba3b012b4e3e81f773480d27fb5f342d50621e6"
+dependencies = [
+ "crypto-bigint",
+ "hex",
+ "hmac 0.12.1",
+ "num-bigint 0.4.4",
+ "num-integer",
+ "num-traits",
+ "rfc6979",
+ "sha2 0.10.7",
+ "starknet-crypto-codegen",
+ "starknet-curve",
+ "starknet-ff",
+ "zeroize",
+]
+
+[[package]]
+name = "starknet-crypto-codegen"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
+dependencies = [
+ "starknet-curve",
+ "starknet-ff",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "starknet-curve"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68a0d87ae56572abf83ddbfd44259a7c90dbeeee1629a1ffe223e7f9a8f3052"
+dependencies = [
+ "starknet-ff",
+]
+
+[[package]]
+name = "starknet-ff"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2cb1d9c0a50380cddab99cb202c6bfb3332728a2769bd0ca2ee80b0b390dd4"
+dependencies = [
+ "ark-ff",
+ "bigdecimal 0.3.1",
+ "crypto-bigint",
+ "getrandom",
+ "hex",
+ "serde",
+]
 
 [[package]]
 name = "static_assertions"
@@ -4525,7 +4803,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "serde",
  "time-core",
  "time-macros",
@@ -5188,12 +5466,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -5838,6 +6110,26 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
 dependencies = [
  "serde",
  "serde_repr",
- "serde_with 3.3.0",
+ "serde_with",
 ]
 
 [[package]]
@@ -930,9 +930,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
- "generic-array",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -963,41 +961,6 @@ checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
  "generic-array",
  "subtle",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.32",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.32",
 ]
 
 [[package]]
@@ -1145,7 +1108,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1794,7 +1756,8 @@ dependencies = [
  "prost",
  "prost-types",
  "serde",
- "starknet-core",
+ "sha3",
+ "starknet-ff",
  "tonic-build",
 ]
 
@@ -2238,15 +2201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,12 +2370,6 @@ dependencies = [
  "rand",
  "static_assertions",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3382,7 +3330,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
- "hmac 0.10.1",
+ "hmac",
  "md-5",
  "memchr",
  "rand",
@@ -3827,16 +3775,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4093,17 +4031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json_pythonic"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62212da9872ca2a0cad0093191ee33753eddff9266cbbc1b4a602d13a3a768db"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_plain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4156,21 +4083,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "hex",
- "serde",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
@@ -4183,18 +4095,6 @@ dependencies = [
  "serde",
  "serde_json",
  "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.32",
 ]
 
 [[package]]
@@ -4446,64 +4346,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "starknet-core"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b796a32a7400f7d85e95d3900b5cee7a392b2adbf7ad16093ed45ec6f8d85de6"
-dependencies = [
- "base64 0.21.0",
- "flate2",
- "hex",
- "serde",
- "serde_json",
- "serde_json_pythonic",
- "serde_with 2.3.3",
- "sha3",
- "starknet-crypto",
- "starknet-ff",
-]
-
-[[package]]
-name = "starknet-crypto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dbb308033b5c60c5677645f7ba3b012b4e3e81f773480d27fb5f342d50621e6"
-dependencies = [
- "crypto-bigint",
- "hex",
- "hmac 0.12.1",
- "num-bigint 0.4.4",
- "num-integer",
- "num-traits",
- "rfc6979",
- "sha2 0.10.7",
- "starknet-crypto-codegen",
- "starknet-curve",
- "starknet-ff",
- "zeroize",
-]
-
-[[package]]
-name = "starknet-crypto-codegen"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
-dependencies = [
- "starknet-curve",
- "starknet-ff",
- "syn 2.0.32",
-]
-
-[[package]]
-name = "starknet-curve"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68a0d87ae56572abf83ddbfd44259a7c90dbeeee1629a1ffe223e7f9a8f3052"
-dependencies = [
- "starknet-ff",
-]
 
 [[package]]
 name = "starknet-ff"

--- a/chain/starknet/Cargo.toml
+++ b/chain/starknet/Cargo.toml
@@ -12,7 +12,8 @@ hex = { version = "0.4.3", features = ["serde"] }
 prost = { workspace = true }
 prost-types = { workspace = true }
 serde = "1.0"
-starknet-core = "0.6.0"
+sha3 = "0.10.8"
+starknet-ff = "0.3.4"
 
 graph-runtime-wasm = { path = "../../runtime/wasm" }
 graph-runtime-derive = { path = "../../runtime/derive" }

--- a/chain/starknet/Cargo.toml
+++ b/chain/starknet/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "graph-chain-starknet"
+version.workspace = true
+edition.workspace = true
+
+[build-dependencies]
+tonic-build = { workspace = true }
+
+[dependencies]
+graph = { path = "../../graph" }
+hex = { version = "0.4.3", features = ["serde"] }
+prost = { workspace = true }
+prost-types = { workspace = true }
+serde = "1.0"
+starknet-core = "0.6.0"
+
+graph-runtime-wasm = { path = "../../runtime/wasm" }
+graph-runtime-derive = { path = "../../runtime/derive" }

--- a/chain/starknet/build.rs
+++ b/chain/starknet/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    println!("cargo:rerun-if-changed=proto");
+    tonic_build::configure()
+        .out_dir("src/protobuf")
+        .compile(&["proto/starknet.proto"], &["proto"])
+        .expect("Failed to compile Firehose StarkNet proto(s)");
+}

--- a/chain/starknet/proto/starknet.proto
+++ b/chain/starknet/proto/starknet.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package zklend.starknet.type.v1;
+
+option go_package = "github.com/starknet-graph/firehose-starknet/types/pb/zklend/starknet/type/v1;pbacme";
+
+// This file only contains the bare minimum types for the POC. It's far from a complete
+// representation of a StarkNet network's history as required by the Firehose protocol. As a result,
+// any future changes to this schema would require a full re-sync of the StarkNet node.
+
+message Block {
+  uint64 height = 1;
+  bytes hash = 2;
+  bytes prevHash = 3;
+  uint64 timestamp = 4;
+  repeated Transaction transactions = 5;
+}
+
+message Transaction {
+  TransactionType type = 1;
+  bytes hash = 2;
+  repeated Event events = 3;
+}
+
+enum TransactionType {
+  DEPLOY = 0;
+  INVOKE_FUNCTION = 1;
+  DECLARE = 2;
+  L1_HANDLER = 3;
+  DEPLOY_ACCOUNT = 4;
+}
+
+message Event {
+  bytes fromAddr = 1;
+  repeated bytes keys = 2;
+  repeated bytes data = 3;
+}

--- a/chain/starknet/src/adapter.rs
+++ b/chain/starknet/src/adapter.rs
@@ -1,0 +1,32 @@
+use graph::blockchain::{EmptyNodeCapabilities, TriggerFilter as TriggerFilterTrait};
+
+use crate::{
+    data_source::{DataSource, DataSourceTemplate},
+    Chain,
+};
+
+// Currently `TriggerFilter` is useless, as it doesn't really filter anything from the block
+// stream, and the complete stream is always consumed, regardless of what the subgraph is indexing.
+// This is very bad for indexing performance and must be implemented for it to be considered
+// production-ready.
+// TODO: implement trigger filter for much better performance
+#[derive(Default, Clone)]
+pub struct TriggerFilter;
+
+impl TriggerFilterTrait<Chain> for TriggerFilter {
+    #[allow(unused)]
+    fn extend_with_template(&mut self, data_source: impl Iterator<Item = DataSourceTemplate>) {
+        todo!()
+    }
+
+    #[allow(unused)]
+    fn extend<'a>(&mut self, data_sources: impl Iterator<Item = &'a DataSource> + Clone) {}
+
+    fn node_capabilities(&self) -> EmptyNodeCapabilities<Chain> {
+        todo!()
+    }
+
+    fn to_firehose_filter(self) -> Vec<prost_types::Any> {
+        todo!()
+    }
+}

--- a/chain/starknet/src/adapter.rs
+++ b/chain/starknet/src/adapter.rs
@@ -5,11 +5,6 @@ use crate::{
     Chain,
 };
 
-// Currently `TriggerFilter` is useless, as it doesn't really filter anything from the block
-// stream, and the complete stream is always consumed, regardless of what the subgraph is indexing.
-// This is very bad for indexing performance and must be implemented for it to be considered
-// production-ready.
-// TODO: implement trigger filter for much better performance
 #[derive(Default, Clone)]
 pub struct TriggerFilter;
 

--- a/chain/starknet/src/chain.rs
+++ b/chain/starknet/src/chain.rs
@@ -1,0 +1,439 @@
+use graph::{
+    anyhow::Result,
+    blockchain::{
+        block_stream::{
+            BlockStream, BlockStreamBuilder, BlockStreamEvent, BlockWithTriggers, FirehoseCursor,
+            FirehoseError, FirehoseMapper as FirehoseMapperTrait,
+            TriggersAdapter as TriggersAdapterTrait,
+        },
+        client::ChainClient,
+        firehose_block_ingestor::FirehoseBlockIngestor,
+        firehose_block_stream::FirehoseBlockStream,
+        BasicBlockchainBuilder, Block, BlockIngestor, BlockPtr, Blockchain, BlockchainBuilder,
+        BlockchainKind, EmptyNodeCapabilities, IngestorError, NoopRuntimeAdapter,
+        RuntimeAdapter as RuntimeAdapterTrait,
+    },
+    cheap_clone::CheapClone,
+    components::store::{DeploymentCursorTracker, DeploymentLocator},
+    data::subgraph::UnifiedMappingApiVersion,
+    env::EnvVars,
+    firehose::{self, FirehoseEndpoint, ForkStep},
+    prelude::{
+        async_trait, BlockHash, BlockNumber, ChainStore, Error, Logger, LoggerFactory,
+        MetricsRegistry, TryFutureExt,
+    },
+    schema::InputSchema,
+    slog::o,
+};
+use prost::Message;
+use std::sync::Arc;
+
+use crate::{
+    adapter::TriggerFilter,
+    codec,
+    data_source::{
+        DataSource, DataSourceTemplate, UnresolvedDataSource, UnresolvedDataSourceTemplate,
+    },
+    trigger::{StarknetBlockTrigger, StarknetEventTrigger, StarknetTrigger},
+};
+
+pub struct Chain {
+    logger_factory: LoggerFactory,
+    name: String,
+    client: Arc<ChainClient<Self>>,
+    chain_store: Arc<dyn ChainStore>,
+    metrics_registry: Arc<MetricsRegistry>,
+    block_stream_builder: Arc<dyn BlockStreamBuilder<Self>>,
+}
+
+pub struct StarknetStreamBuilder;
+
+pub struct FirehoseMapper {
+    adapter: Arc<dyn TriggersAdapterTrait<Chain>>,
+    filter: Arc<TriggerFilter>,
+}
+
+pub struct TriggersAdapter;
+
+// impl Chain {
+//     pub fn new(
+//         logger_factory: LoggerFactory,
+//         name: String,
+//         registry: Arc<dyn MetricsRegistry>,
+//         firehose_endpoints: FirehoseEndpoints,
+//         chain_store: Arc<dyn ChainStore>,
+//         block_stream_builder: Arc<dyn BlockStreamBuilder<Self>>,
+// ) -> Self {
+impl BlockchainBuilder<Chain> for BasicBlockchainBuilder {
+    fn build(self, _config: &Arc<EnvVars>) -> Chain {
+        Chain {
+            logger_factory: self.logger_factory,
+            name: self.name,
+            chain_store: self.chain_store,
+            client: Arc::new(ChainClient::new_firehose(self.firehose_endpoints)),
+            metrics_registry: self.metrics_registry,
+            block_stream_builder: Arc::new(StarknetStreamBuilder {}),
+        }
+    }
+}
+
+impl std::fmt::Debug for Chain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "chain: starknet")
+    }
+}
+
+#[async_trait]
+impl Blockchain for Chain {
+    const KIND: BlockchainKind = BlockchainKind::Starknet;
+
+    type Client = ();
+    type Block = codec::Block;
+    type DataSource = DataSource;
+    type UnresolvedDataSource = UnresolvedDataSource;
+
+    type DataSourceTemplate = DataSourceTemplate;
+    type UnresolvedDataSourceTemplate = UnresolvedDataSourceTemplate;
+
+    type TriggerData = crate::trigger::StarknetTrigger;
+
+    type MappingTrigger = crate::trigger::StarknetTrigger;
+
+    type TriggerFilter = crate::adapter::TriggerFilter;
+
+    type NodeCapabilities = EmptyNodeCapabilities<Self>;
+
+    fn triggers_adapter(
+        &self,
+        _log: &DeploymentLocator,
+        _capabilities: &Self::NodeCapabilities,
+        _unified_api_version: UnifiedMappingApiVersion,
+    ) -> Result<Arc<dyn TriggersAdapterTrait<Self>>, Error> {
+        Ok(Arc::new(TriggersAdapter))
+    }
+
+    async fn new_block_stream(
+        &self,
+        deployment: DeploymentLocator,
+        store: impl DeploymentCursorTracker,
+        start_blocks: Vec<BlockNumber>,
+        filter: Arc<Self::TriggerFilter>,
+        unified_api_version: UnifiedMappingApiVersion,
+    ) -> Result<Box<dyn BlockStream<Self>>, Error> {
+        self.block_stream_builder
+            .build_firehose(
+                self,
+                deployment,
+                store.firehose_cursor(),
+                start_blocks,
+                store.block_ptr(),
+                filter,
+                unified_api_version,
+            )
+            .await
+    }
+
+    fn is_refetch_block_required(&self) -> bool {
+        false
+    }
+
+    async fn refetch_firehose_block(
+        &self,
+        _logger: &Logger,
+        _cursor: FirehoseCursor,
+    ) -> Result<codec::Block, Error> {
+        unimplemented!("This chain does not support Dynamic Data Sources. is_refetch_block_required always returns false, this shouldn't be called.")
+    }
+
+    fn chain_store(&self) -> Arc<dyn ChainStore> {
+        self.chain_store.clone()
+    }
+
+    async fn block_pointer_from_number(
+        &self,
+        logger: &Logger,
+        number: BlockNumber,
+    ) -> Result<BlockPtr, IngestorError> {
+        let firehose_endpoint = self.client.firehose_endpoint()?;
+
+        firehose_endpoint
+            .block_ptr_for_number::<codec::Block>(logger, number)
+            .map_err(Into::into)
+            .await
+    }
+
+    fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapterTrait<Self>> {
+        Arc::new(NoopRuntimeAdapter::default())
+    }
+
+    fn chain_client(&self) -> Arc<ChainClient<Self>> {
+        self.client.clone()
+    }
+
+    fn block_ingestor(&self) -> Result<Box<dyn BlockIngestor>> {
+        let ingestor = FirehoseBlockIngestor::<crate::Block, Self>::new(
+            self.chain_store.cheap_clone(),
+            self.chain_client(),
+            self.logger_factory
+                .component_logger("StarknetFirehoseBlockIngestor", None),
+            self.name.clone(),
+        );
+        Ok(Box::new(ingestor))
+    }
+}
+
+#[async_trait]
+impl BlockStreamBuilder<Chain> for StarknetStreamBuilder {
+    async fn build_substreams(
+        &self,
+        _chain: &Chain,
+        _schema: InputSchema,
+        _deployment: DeploymentLocator,
+        _block_cursor: FirehoseCursor,
+        _subgraph_current_block: Option<BlockPtr>,
+        _filter: Arc<<Chain as Blockchain>::TriggerFilter>,
+    ) -> Result<Box<dyn BlockStream<Chain>>> {
+        unimplemented!()
+    }
+
+    async fn build_firehose(
+        &self,
+        chain: &Chain,
+        deployment: DeploymentLocator,
+        block_cursor: FirehoseCursor,
+        start_blocks: Vec<BlockNumber>,
+        subgraph_current_block: Option<BlockPtr>,
+        filter: Arc<TriggerFilter>,
+        unified_api_version: UnifiedMappingApiVersion,
+    ) -> Result<Box<dyn BlockStream<Chain>>> {
+        let adapter = chain
+            .triggers_adapter(
+                &deployment,
+                &EmptyNodeCapabilities::default(),
+                unified_api_version,
+            )
+            .unwrap_or_else(|_| panic!("no adapter for network {}", chain.name));
+
+        let logger = chain
+            .logger_factory
+            .subgraph_logger(&deployment)
+            .new(o!("component" => "FirehoseBlockStream"));
+
+        let firehose_mapper = Arc::new(FirehoseMapper { adapter, filter });
+
+        Ok(Box::new(FirehoseBlockStream::new(
+            deployment.hash,
+            chain.chain_client(),
+            subgraph_current_block,
+            block_cursor,
+            firehose_mapper,
+            start_blocks,
+            logger,
+            chain.metrics_registry.clone(),
+        )))
+    }
+
+    async fn build_polling(
+        &self,
+        _chain: &Chain,
+        _deployment: DeploymentLocator,
+        _start_blocks: Vec<BlockNumber>,
+        _subgraph_current_block: Option<BlockPtr>,
+        _filter: Arc<TriggerFilter>,
+        _unified_api_version: UnifiedMappingApiVersion,
+    ) -> Result<Box<dyn BlockStream<Chain>>> {
+        panic!("StarkNet does not support polling block stream")
+    }
+}
+
+#[async_trait]
+impl FirehoseMapperTrait<Chain> for FirehoseMapper {
+    fn trigger_filter(&self) -> &TriggerFilter {
+        self.filter.as_ref()
+    }
+
+    async fn to_block_stream_event(
+        &self,
+        logger: &Logger,
+        response: &firehose::Response,
+    ) -> Result<BlockStreamEvent<Chain>, FirehoseError> {
+        let step = ForkStep::from_i32(response.step).unwrap_or_else(|| {
+            panic!(
+                "unknown step i32 value {}, maybe you forgot update & re-regenerate the protobuf definitions?",
+                response.step
+            )
+        });
+
+        let any_block = response
+            .block
+            .as_ref()
+            .expect("block payload information should always be present");
+
+        // Right now, this is done in all cases but in reality, with how the BlockStreamEvent::Revert
+        // is defined right now, only block hash and block number is necessary. However, this information
+        // is not part of the actual bstream::BlockResponseV2 payload. As such, we need to decode the full
+        // block which is useless.
+        //
+        // Check about adding basic information about the block in the bstream::BlockResponseV2 or maybe
+        // define a slimmed down stuct that would decode only a few fields and ignore all the rest.
+        let block = codec::Block::decode(any_block.value.as_ref())?;
+
+        use ForkStep::*;
+        match step {
+            StepNew => Ok(BlockStreamEvent::ProcessBlock(
+                self.adapter
+                    .triggers_in_block(logger, block, &self.filter)
+                    .await?,
+                FirehoseCursor::from(response.cursor.clone()),
+            )),
+
+            StepUndo => {
+                let parent_ptr = block
+                    .parent_ptr()
+                    .expect("Genesis block should never be reverted");
+
+                Ok(BlockStreamEvent::Revert(
+                    parent_ptr,
+                    FirehoseCursor::from(response.cursor.clone()),
+                ))
+            }
+
+            StepFinal => {
+                panic!("irreversible step is not handled and should not be requested in the Firehose request")
+            }
+
+            StepUnset => {
+                panic!("unknown step should not happen in the Firehose response")
+            }
+        }
+    }
+
+    /// Returns the [BlockPtr] value for this given block number. This is the block pointer
+    /// of the longuest according to Firehose view of the blockchain state.
+    ///
+    /// This is a thin wrapper around [FirehoseEndpoint#block_ptr_for_number] to make
+    /// it chain agnostic and callable from chain agnostic [FirehoseBlockStream].
+    async fn block_ptr_for_number(
+        &self,
+        logger: &Logger,
+        endpoint: &Arc<FirehoseEndpoint>,
+        number: BlockNumber,
+    ) -> Result<BlockPtr, Error> {
+        endpoint
+            .block_ptr_for_number::<codec::Block>(logger, number)
+            .await
+    }
+
+    /// Returns the closest final block ptr to the block ptr received.
+    /// On probablitics chain like Ethereum, final is determined by
+    /// the confirmations threshold configured for the Firehose stack (currently
+    /// hard-coded to 200).
+    ///
+    /// On some other chain like NEAR, the actual final block number is determined
+    /// from the block itself since it contains information about which block number
+    /// is final against the current block.
+    ///
+    /// To take an example, assuming we are on Ethereum, the final block pointer
+    /// for block #10212 would be the determined final block #10012 (10212 - 200 = 10012).
+    async fn final_block_ptr_for(
+        &self,
+        logger: &Logger,
+        endpoint: &Arc<FirehoseEndpoint>,
+        block: &codec::Block,
+    ) -> Result<BlockPtr, Error> {
+        // Firehose for Starknet has an hard-coded confirmations for finality sets to 100 block
+        // behind the current block. The magic value 100 here comes from this hard-coded Firehose
+        // value.
+        let final_block_number = match block.number() {
+            x if x >= 100 => x - 100,
+            _ => 0,
+        };
+
+        self.block_ptr_for_number(logger, endpoint, final_block_number)
+            .await
+    }
+}
+
+#[async_trait]
+impl TriggersAdapterTrait<Chain> for TriggersAdapter {
+    // Return the block that is `offset` blocks before the block pointed to
+    // by `ptr` from the local cache. An offset of 0 means the block itself,
+    // an offset of 1 means the block's parent etc. If the block is not in
+    // the local cache, return `None`
+    async fn ancestor_block(
+        &self,
+        _ptr: BlockPtr,
+        _offset: BlockNumber,
+    ) -> Result<Option<codec::Block>, Error> {
+        panic!("Should never be called since FirehoseBlockStream cannot resolve it")
+    }
+
+    // Returns a sequence of blocks in increasing order of block number.
+    // Each block will include all of its triggers that match the given `filter`.
+    // The sequence may omit blocks that contain no triggers,
+    // but all returned blocks must part of a same chain starting at `chain_base`.
+    // At least one block will be returned, even if it contains no triggers.
+    // `step_size` is the suggested number blocks to be scanned.
+    async fn scan_triggers(
+        &self,
+        _from: BlockNumber,
+        _to: BlockNumber,
+        _filter: &crate::adapter::TriggerFilter,
+    ) -> Result<Vec<BlockWithTriggers<Chain>>, Error> {
+        panic!("Should never be called since not used by FirehoseBlockStream")
+    }
+
+    // Used for reprocessing blocks when creating a data source.
+    #[allow(unused)]
+    async fn triggers_in_block(
+        &self,
+        logger: &Logger,
+        block: codec::Block,
+        filter: &crate::adapter::TriggerFilter,
+    ) -> Result<BlockWithTriggers<Chain>, Error> {
+        // We can't do any filtering here as `TriggerFilter` is useless.
+        // TODO: implement trigger filtering once `TriggerFilter` actually does something.
+
+        let shared_block = Arc::new(block.clone());
+
+        let mut triggers: Vec<_> = shared_block
+            .transactions
+            .iter()
+            .flat_map(|transaction| -> Vec<StarknetTrigger> {
+                transaction
+                    .events
+                    .iter()
+                    .map(|event| {
+                        StarknetTrigger::Event(StarknetEventTrigger {
+                            event: Arc::new(event.clone()),
+                            block: shared_block.clone(),
+                            transaction: Arc::new(transaction.clone()),
+                        })
+                    })
+                    .collect()
+            })
+            .collect();
+
+        triggers.push(StarknetTrigger::Block(StarknetBlockTrigger {
+            block: shared_block,
+        }));
+
+        Ok(BlockWithTriggers::new(block, triggers, logger))
+    }
+
+    /// Return `true` if the block with the given hash and number is on the
+    /// main chain, i.e., the chain going back from the current chain head.
+    async fn is_on_main_chain(&self, _ptr: BlockPtr) -> Result<bool, Error> {
+        panic!("Should never be called since not used by FirehoseBlockStream")
+    }
+
+    /// Get pointer to parent of `block`. This is called when reverting `block`.
+    async fn parent_ptr(&self, block: &BlockPtr) -> Result<Option<BlockPtr>, Error> {
+        // Panics if `block` is genesis.
+        // But that's ok since this is only called when reverting `block`.
+        Ok(Some(BlockPtr {
+            hash: BlockHash::from(vec![0xff; 32]),
+            number: block.number.saturating_sub(1),
+        }))
+    }
+}

--- a/chain/starknet/src/codec.rs
+++ b/chain/starknet/src/codec.rs
@@ -1,0 +1,32 @@
+#[allow(clippy::all)]
+#[rustfmt::skip]
+#[path = "protobuf/zklend.starknet.r#type.v1.rs"]
+pub mod pbcodec;
+
+use graph::blockchain::{Block as BlockchainBlock, BlockHash, BlockPtr};
+
+pub use pbcodec::*;
+
+impl BlockchainBlock for Block {
+    fn number(&self) -> i32 {
+        self.height as i32
+    }
+
+    fn ptr(&self) -> BlockPtr {
+        BlockPtr {
+            hash: BlockHash(self.hash.clone().into_boxed_slice()),
+            number: self.height as i32,
+        }
+    }
+
+    fn parent_ptr(&self) -> Option<BlockPtr> {
+        if self.height == 0 {
+            None
+        } else {
+            Some(BlockPtr {
+                hash: BlockHash(self.prev_hash.clone().into_boxed_slice()),
+                number: (self.height - 1) as i32,
+            })
+        }
+    }
+}

--- a/chain/starknet/src/codec.rs
+++ b/chain/starknet/src/codec.rs
@@ -1,7 +1,6 @@
-#[allow(clippy::all)]
 #[rustfmt::skip]
 #[path = "protobuf/zklend.starknet.r#type.v1.rs"]
-pub mod pbcodec;
+mod pbcodec;
 
 use graph::blockchain::{Block as BlockchainBlock, BlockHash, BlockPtr};
 

--- a/chain/starknet/src/data_source.rs
+++ b/chain/starknet/src/data_source.rs
@@ -1,0 +1,320 @@
+use graph::{
+    anyhow::{anyhow, Error},
+    blockchain::{self, Block as BlockchainBlock, TriggerWithHandler},
+    components::{link_resolver::LinkResolver, store::StoredDynamicDataSource},
+    data::subgraph::DataSourceContext,
+    prelude::{async_trait, BlockNumber, DataSourceTemplateInfo, Deserialize, Link, Logger},
+    semver,
+};
+use starknet_core::{types::FieldElement, utils::get_selector_from_name};
+use std::{collections::HashSet, sync::Arc};
+
+use crate::{
+    chain::Chain,
+    codec,
+    trigger::{StarknetEventTrigger, StarknetTrigger},
+};
+
+const BLOCK_HANDLER_KIND: &str = "block";
+const EVENT_HANDLER_KIND: &str = "event";
+
+#[derive(Clone)]
+pub struct DataSource {
+    pub kind: String,
+    pub network: String,
+    pub name: String,
+    pub source: Source,
+    pub mapping: Mapping,
+}
+
+#[derive(Clone)]
+pub struct Mapping {
+    pub block_handlers: Vec<MappingBlockHandler>,
+    pub event_handlers: Vec<MappingEventHandler>,
+    pub runtime: Arc<Vec<u8>>,
+}
+
+#[derive(Deserialize)]
+pub struct UnresolvedDataSource {
+    pub kind: String,
+    pub network: String,
+    pub name: String,
+    pub source: Source,
+    pub mapping: UnresolvedMapping,
+}
+
+#[derive(Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Source {
+    pub start_block: BlockNumber,
+    #[serde(default, deserialize_with = "deserialize_address")]
+    pub address: Option<FieldElement>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnresolvedMapping {
+    #[serde(default)]
+    pub block_handlers: Vec<MappingBlockHandler>,
+    #[serde(default)]
+    pub event_handlers: Vec<UnresolvedMappingEventHandler>,
+    pub file: Link,
+}
+
+#[derive(Clone, PartialEq, Eq, Deserialize)]
+pub struct MappingBlockHandler {
+    pub handler: String,
+}
+
+#[derive(Clone, PartialEq, Eq, Deserialize)]
+pub struct MappingEventHandler {
+    pub handler: String,
+    pub event_selector: FieldElement,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct UnresolvedMappingEventHandler {
+    pub handler: String,
+    pub event: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DataSourceTemplate;
+
+#[derive(Clone, Default, Deserialize)]
+pub struct UnresolvedDataSourceTemplate;
+
+impl blockchain::DataSource<Chain> for DataSource {
+    fn from_template_info(_template_info: DataSourceTemplateInfo<Chain>) -> Result<Self, Error> {
+        Err(anyhow!("StarkNet subgraphs do not support templates"))
+    }
+
+    fn address(&self) -> Option<&[u8]> {
+        None
+    }
+
+    fn start_block(&self) -> BlockNumber {
+        self.source.start_block
+    }
+
+    fn handler_kinds(&self) -> HashSet<&str> {
+        let mut kinds = HashSet::new();
+
+        let Mapping {
+            block_handlers,
+            event_handlers,
+            ..
+        } = &self.mapping;
+
+        if !block_handlers.is_empty() {
+            kinds.insert(BLOCK_HANDLER_KIND);
+        }
+        if !event_handlers.is_empty() {
+            kinds.insert(EVENT_HANDLER_KIND);
+        }
+
+        kinds
+    }
+
+    fn match_and_decode(
+        &self,
+        trigger: &StarknetTrigger,
+        block: &Arc<codec::Block>,
+        _logger: &Logger,
+    ) -> Result<Option<TriggerWithHandler<Chain>>, Error> {
+        if self.start_block() > block.number() {
+            return Ok(None);
+        }
+
+        let handler = match trigger {
+            StarknetTrigger::Block(_) => match self.mapping.block_handlers.first() {
+                Some(handler) => handler.handler.clone(),
+                None => return Ok(None),
+            },
+            StarknetTrigger::Event(event) => match self.handler_for_event(event) {
+                Some(handler) => handler.handler,
+                None => return Ok(None),
+            },
+        };
+
+        Ok(Some(TriggerWithHandler::<Chain>::new(
+            trigger.clone(),
+            handler,
+            block.ptr(),
+        )))
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    fn network(&self) -> Option<&str> {
+        Some(&self.network)
+    }
+
+    fn context(&self) -> Arc<Option<DataSourceContext>> {
+        Arc::new(None)
+    }
+
+    fn creation_block(&self) -> Option<BlockNumber> {
+        None
+    }
+
+    fn is_duplicate_of(&self, other: &Self) -> bool {
+        let DataSource {
+            kind,
+            network,
+            name,
+            source,
+            mapping,
+        } = self;
+
+        kind == &other.kind
+            && network == &other.network
+            && name == &other.name
+            && source == &other.source
+            && mapping.event_handlers == other.mapping.event_handlers
+            && mapping.block_handlers == other.mapping.block_handlers
+    }
+
+    fn as_stored_dynamic_data_source(&self) -> StoredDynamicDataSource {
+        // FIXME (Starknet): Implement me!
+        todo!()
+    }
+
+    fn from_stored_dynamic_data_source(
+        _template: &DataSourceTemplate,
+        _stored: StoredDynamicDataSource,
+    ) -> Result<Self, Error> {
+        // FIXME (Starknet): Implement me correctly
+        todo!()
+    }
+
+    fn validate(&self) -> Vec<Error> {
+        Default::default()
+    }
+
+    fn api_version(&self) -> semver::Version {
+        semver::Version::new(0, 0, 5)
+    }
+
+    fn runtime(&self) -> Option<Arc<Vec<u8>>> {
+        Some(self.mapping.runtime.clone())
+    }
+}
+
+impl DataSource {
+    /// Returns event trigger if an event.key matches the handler.key and optionally
+    /// if event.fromAddr matches the source address. Note this only supports the default
+    /// Starknet behavior of one key per event.
+    fn handler_for_event(&self, event: &StarknetEventTrigger) -> Option<MappingEventHandler> {
+        let event_key = FieldElement::from_byte_slice_be(event.event.keys.first()?).ok()?;
+
+        // Always deocding first here seems fine as we expect most sources to define an address
+        // filter anyways. Alternatively we can use lazy init here, which seems unnecessary.
+        let event_from_addr = FieldElement::from_byte_slice_be(&event.event.from_addr).ok()?;
+
+        return self
+            .mapping
+            .event_handlers
+            .iter()
+            .find(|handler| {
+                // No need to compare address if selector doesn't match
+                if handler.event_selector != event_key {
+                    return false;
+                }
+
+                match &self.source.address {
+                    Some(addr_filter) => addr_filter == &event_from_addr,
+                    None => true,
+                }
+            })
+            .cloned();
+    }
+}
+
+#[async_trait]
+impl blockchain::UnresolvedDataSource<Chain> for UnresolvedDataSource {
+    async fn resolve(
+        self,
+        resolver: &Arc<dyn LinkResolver>,
+        logger: &Logger,
+        _manifest_idx: u32,
+    ) -> Result<DataSource, Error> {
+        let module_bytes = resolver.cat(logger, &self.mapping.file).await?;
+
+        Ok(DataSource {
+            kind: self.kind,
+            network: self.network,
+            name: self.name,
+            source: self.source,
+            mapping: Mapping {
+                block_handlers: self.mapping.block_handlers,
+                event_handlers: self
+                    .mapping
+                    .event_handlers
+                    .into_iter()
+                    .map(|handler| {
+                        Ok(MappingEventHandler {
+                            handler: handler.handler,
+                            event_selector: get_selector_from_name(&handler.event)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, Error>>()?,
+                runtime: Arc::new(module_bytes),
+            },
+        })
+    }
+}
+
+// Starknet data source templates are not supported at the moment. This should be implemented for
+// the Starknet support to be considered production ready.
+// TODO: support Starknet data source template
+impl blockchain::DataSourceTemplate<Chain> for DataSourceTemplate {
+    fn api_version(&self) -> semver::Version {
+        todo!()
+    }
+
+    fn runtime(&self) -> Option<Arc<Vec<u8>>> {
+        todo!()
+    }
+
+    fn name(&self) -> &str {
+        todo!()
+    }
+
+    fn manifest_idx(&self) -> u32 {
+        todo!()
+    }
+
+    fn kind(&self) -> &str {
+        todo!()
+    }
+}
+
+// Starknet data source templates are not supported at the moment. This should be implemented for
+// the Starknet support to be considered production ready.
+// TODO: support Starknet data source template
+#[async_trait]
+impl blockchain::UnresolvedDataSourceTemplate<Chain> for UnresolvedDataSourceTemplate {
+    #[allow(unused)]
+    async fn resolve(
+        self,
+        resolver: &Arc<dyn LinkResolver>,
+        logger: &Logger,
+        manifest_idx: u32,
+    ) -> Result<DataSourceTemplate, Error> {
+        todo!()
+    }
+}
+
+fn deserialize_address<'de, D>(deserializer: D) -> Result<Option<FieldElement>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    Ok(Some(serde::Deserialize::deserialize(deserializer)?))
+}

--- a/chain/starknet/src/lib.rs
+++ b/chain/starknet/src/lib.rs
@@ -1,0 +1,9 @@
+mod adapter;
+mod chain;
+pub mod codec;
+mod data_source;
+mod runtime;
+mod trigger;
+
+pub use crate::chain::{Chain, StarknetStreamBuilder};
+pub use codec::Block;

--- a/chain/starknet/src/protobuf/zklend.starknet.r#type.v1.rs
+++ b/chain/starknet/src/protobuf/zklend.starknet.r#type.v1.rs
@@ -1,0 +1,69 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Block {
+    #[prost(uint64, tag = "1")]
+    pub height: u64,
+    #[prost(bytes = "vec", tag = "2")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub prev_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag = "4")]
+    pub timestamp: u64,
+    #[prost(message, repeated, tag = "5")]
+    pub transactions: ::prost::alloc::vec::Vec<Transaction>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Transaction {
+    #[prost(enumeration = "TransactionType", tag = "1")]
+    pub r#type: i32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, repeated, tag = "3")]
+    pub events: ::prost::alloc::vec::Vec<Event>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Event {
+    #[prost(bytes = "vec", tag = "1")]
+    pub from_addr: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub keys: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "vec", repeated, tag = "3")]
+    pub data: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum TransactionType {
+    Deploy = 0,
+    InvokeFunction = 1,
+    Declare = 2,
+    L1Handler = 3,
+    DeployAccount = 4,
+}
+impl TransactionType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            TransactionType::Deploy => "DEPLOY",
+            TransactionType::InvokeFunction => "INVOKE_FUNCTION",
+            TransactionType::Declare => "DECLARE",
+            TransactionType::L1Handler => "L1_HANDLER",
+            TransactionType::DeployAccount => "DEPLOY_ACCOUNT",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "DEPLOY" => Some(Self::Deploy),
+            "INVOKE_FUNCTION" => Some(Self::InvokeFunction),
+            "DECLARE" => Some(Self::Declare),
+            "L1_HANDLER" => Some(Self::L1Handler),
+            "DEPLOY_ACCOUNT" => Some(Self::DeployAccount),
+            _ => None,
+        }
+    }
+}

--- a/chain/starknet/src/runtime/abi.rs
+++ b/chain/starknet/src/runtime/abi.rs
@@ -1,0 +1,106 @@
+use graph::{
+    prelude::BigInt,
+    runtime::{asc_new, gas::GasCounter, AscHeap, HostExportError, ToAscObj},
+};
+use graph_runtime_wasm::asc_abi::class::{Array, AscEnum, EnumPayload};
+
+use crate::{
+    codec,
+    trigger::{StarknetBlockTrigger, StarknetEventTrigger},
+};
+
+pub(crate) use super::generated::*;
+
+impl ToAscObj<AscBlock> for codec::Block {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+        gas: &GasCounter,
+    ) -> Result<AscBlock, HostExportError> {
+        Ok(AscBlock {
+            number: asc_new(heap, &BigInt::from(self.height), gas)?,
+            hash: asc_new(heap, self.hash.as_slice(), gas)?,
+            prev_hash: asc_new(heap, self.prev_hash.as_slice(), gas)?,
+            timestamp: asc_new(heap, &BigInt::from(self.timestamp), gas)?,
+        })
+    }
+}
+
+impl ToAscObj<AscTransaction> for codec::Transaction {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+        gas: &GasCounter,
+    ) -> Result<AscTransaction, HostExportError> {
+        Ok(AscTransaction {
+            r#type: asc_new(
+                heap,
+                &codec::TransactionType::from_i32(self.r#type)
+                    .expect("invalid TransactionType value"),
+                gas,
+            )?,
+            hash: asc_new(heap, self.hash.as_slice(), gas)?,
+        })
+    }
+}
+
+impl ToAscObj<AscTransactionTypeEnum> for codec::TransactionType {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        _heap: &mut H,
+        _gas: &GasCounter,
+    ) -> Result<AscTransactionTypeEnum, HostExportError> {
+        Ok(AscTransactionTypeEnum(AscEnum {
+            kind: match self {
+                codec::TransactionType::Deploy => AscTransactionType::Deploy,
+                codec::TransactionType::InvokeFunction => AscTransactionType::InvokeFunction,
+                codec::TransactionType::Declare => AscTransactionType::Declare,
+                codec::TransactionType::L1Handler => AscTransactionType::L1Handler,
+                codec::TransactionType::DeployAccount => AscTransactionType::DeployAccount,
+            },
+            _padding: 0,
+            payload: EnumPayload(0),
+        }))
+    }
+}
+
+impl ToAscObj<AscBytesArray> for Vec<Vec<u8>> {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+        gas: &GasCounter,
+    ) -> Result<AscBytesArray, HostExportError> {
+        let content: Result<Vec<_>, _> = self
+            .iter()
+            .map(|x| asc_new(heap, x.as_slice(), gas))
+            .collect();
+
+        Ok(AscBytesArray(Array::new(&content?, heap, gas)?))
+    }
+}
+
+impl ToAscObj<AscBlock> for StarknetBlockTrigger {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+        gas: &GasCounter,
+    ) -> Result<AscBlock, HostExportError> {
+        self.block.to_asc_obj(heap, gas)
+    }
+}
+
+impl ToAscObj<AscEvent> for StarknetEventTrigger {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+        gas: &GasCounter,
+    ) -> Result<AscEvent, HostExportError> {
+        Ok(AscEvent {
+            from_addr: asc_new(heap, self.event.from_addr.as_slice(), gas)?,
+            keys: asc_new(heap, &self.event.keys, gas)?,
+            data: asc_new(heap, &self.event.data, gas)?,
+            block: asc_new(heap, self.block.as_ref(), gas)?,
+            transaction: asc_new(heap, self.transaction.as_ref(), gas)?,
+        })
+    }
+}

--- a/chain/starknet/src/runtime/generated.rs
+++ b/chain/starknet/src/runtime/generated.rs
@@ -1,0 +1,100 @@
+use graph::runtime::{
+    AscIndexId, AscPtr, AscType, AscValue, DeterministicHostError, IndexForAscTypeId,
+};
+use graph::semver::Version;
+use graph_runtime_derive::AscType;
+use graph_runtime_wasm::asc_abi::class::{Array, AscBigInt, AscEnum, Uint8Array};
+
+pub struct AscBytesArray(pub(crate) Array<AscPtr<Uint8Array>>);
+
+impl AscType for AscBytesArray {
+    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+        self.0.to_asc_bytes()
+    }
+
+    fn from_asc_bytes(
+        asc_obj: &[u8],
+        api_version: &Version,
+    ) -> Result<Self, DeterministicHostError> {
+        Ok(Self(Array::from_asc_bytes(asc_obj, api_version)?))
+    }
+}
+
+impl AscIndexId for AscBytesArray {
+    const INDEX_ASC_TYPE_ID: IndexForAscTypeId = IndexForAscTypeId::StarknetArrayBytes;
+}
+
+pub struct AscTransactionTypeEnum(pub(crate) AscEnum<AscTransactionType>);
+
+impl AscType for AscTransactionTypeEnum {
+    fn to_asc_bytes(&self) -> Result<Vec<u8>, DeterministicHostError> {
+        self.0.to_asc_bytes()
+    }
+
+    fn from_asc_bytes(
+        asc_obj: &[u8],
+        api_version: &Version,
+    ) -> Result<Self, DeterministicHostError> {
+        Ok(Self(AscEnum::from_asc_bytes(asc_obj, api_version)?))
+    }
+}
+
+impl AscIndexId for AscTransactionTypeEnum {
+    const INDEX_ASC_TYPE_ID: IndexForAscTypeId = IndexForAscTypeId::StarknetTransactionTypeEnum;
+}
+
+#[repr(C)]
+#[derive(AscType)]
+pub(crate) struct AscBlock {
+    pub number: AscPtr<AscBigInt>,
+    pub hash: AscPtr<Uint8Array>,
+    pub prev_hash: AscPtr<Uint8Array>,
+    pub timestamp: AscPtr<AscBigInt>,
+}
+
+impl AscIndexId for AscBlock {
+    const INDEX_ASC_TYPE_ID: IndexForAscTypeId = IndexForAscTypeId::StarknetBlock;
+}
+
+#[repr(C)]
+#[derive(AscType)]
+pub(crate) struct AscTransaction {
+    pub r#type: AscPtr<AscTransactionTypeEnum>,
+    pub hash: AscPtr<Uint8Array>,
+}
+
+impl AscIndexId for AscTransaction {
+    const INDEX_ASC_TYPE_ID: IndexForAscTypeId = IndexForAscTypeId::StarknetTransaction;
+}
+
+#[repr(u32)]
+#[derive(AscType, Copy, Clone)]
+pub(crate) enum AscTransactionType {
+    Deploy,
+    InvokeFunction,
+    Declare,
+    L1Handler,
+    DeployAccount,
+}
+
+impl AscValue for AscTransactionType {}
+
+impl Default for AscTransactionType {
+    fn default() -> Self {
+        Self::Deploy
+    }
+}
+
+#[repr(C)]
+#[derive(AscType)]
+pub(crate) struct AscEvent {
+    pub from_addr: AscPtr<Uint8Array>,
+    pub keys: AscPtr<AscBytesArray>,
+    pub data: AscPtr<AscBytesArray>,
+    pub block: AscPtr<AscBlock>,
+    pub transaction: AscPtr<AscTransaction>,
+}
+
+impl AscIndexId for AscEvent {
+    const INDEX_ASC_TYPE_ID: IndexForAscTypeId = IndexForAscTypeId::StarknetEvent;
+}

--- a/chain/starknet/src/runtime/mod.rs
+++ b/chain/starknet/src/runtime/mod.rs
@@ -1,0 +1,3 @@
+pub mod abi;
+
+mod generated;

--- a/chain/starknet/src/trigger.rs
+++ b/chain/starknet/src/trigger.rs
@@ -1,0 +1,118 @@
+use graph::{
+    blockchain::{MappingTriggerTrait, TriggerData},
+    runtime::{asc_new, gas::GasCounter, AscPtr, HostExportError},
+};
+use graph_runtime_wasm::module::ToAscPtr;
+use starknet_core::types::FieldElement;
+use std::{cmp::Ordering, sync::Arc};
+
+use crate::codec;
+
+#[derive(Debug, Clone)]
+pub enum StarknetTrigger {
+    Block(StarknetBlockTrigger),
+    Event(StarknetEventTrigger),
+}
+
+#[derive(Debug, Clone)]
+pub struct StarknetBlockTrigger {
+    pub(crate) block: Arc<codec::Block>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StarknetEventTrigger {
+    pub(crate) event: Arc<codec::Event>,
+    pub(crate) block: Arc<codec::Block>,
+    pub(crate) transaction: Arc<codec::Transaction>,
+}
+
+impl PartialEq for StarknetTrigger {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Block(l), Self::Block(r)) => l.block == r.block,
+            (Self::Event(l), Self::Event(r)) => {
+                // Without event index we can't really tell if they're the same
+                // TODO: implement add event index to trigger data
+                l.block.hash == r.block.hash
+                    && l.transaction.hash == r.transaction.hash
+                    && l.event == r.event
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for StarknetTrigger {}
+
+impl PartialOrd for StarknetTrigger {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for StarknetTrigger {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::Block(l), Self::Block(r)) => l.block.height.cmp(&r.block.height),
+
+            // Block triggers always come last
+            (Self::Block(..), _) => Ordering::Greater,
+            (_, Self::Block(..)) => Ordering::Less,
+
+            // Keep the order when comparing two event triggers
+            // TODO: compare block hash, tx index, and event index
+            (Self::Event(..), Self::Event(..)) => Ordering::Equal,
+        }
+    }
+}
+
+impl TriggerData for StarknetTrigger {
+    fn error_context(&self) -> String {
+        match self {
+            Self::Block(block) => format!("block #{}", block.block.height),
+            Self::Event(event) => {
+                format!(
+                    "event from {}",
+                    match FieldElement::from_byte_slice_be(&event.event.from_addr) {
+                        Ok(from_addr) => format!("{from_addr:#x}"),
+                        Err(_) => "[unable to parse source address]".into(),
+                    }
+                )
+            }
+        }
+    }
+
+    fn address_match(&self) -> Option<&[u8]> {
+        None
+    }
+}
+
+impl ToAscPtr for StarknetTrigger {
+    fn to_asc_ptr<H: graph::runtime::AscHeap>(
+        self,
+        heap: &mut H,
+        gas: &GasCounter,
+    ) -> Result<AscPtr<()>, HostExportError> {
+        Ok(match self {
+            StarknetTrigger::Block(block) => asc_new(heap, &block, gas)?.erase(),
+            StarknetTrigger::Event(event) => asc_new(heap, &event, gas)?.erase(),
+        })
+    }
+}
+
+impl MappingTriggerTrait for StarknetTrigger {
+    fn error_context(&self) -> String {
+        match self {
+            Self::Block(block) => format!("block #{}", block.block.height),
+            Self::Event(event) => {
+                format!(
+                    "event from {}",
+                    match FieldElement::from_byte_slice_be(&event.event.from_addr) {
+                        Ok(from_addr) => format!("{from_addr:#x}"),
+                        Err(_) => "[unable to parse source address]".into(),
+                    }
+                )
+            }
+        }
+    }
+}

--- a/chain/starknet/src/trigger.rs
+++ b/chain/starknet/src/trigger.rs
@@ -3,7 +3,7 @@ use graph::{
     runtime::{asc_new, gas::GasCounter, AscPtr, HostExportError},
 };
 use graph_runtime_wasm::module::ToAscPtr;
-use starknet_core::types::FieldElement;
+use starknet_ff::FieldElement;
 use std::{cmp::Ordering, sync::Arc};
 
 use crate::codec;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ graph-chain-ethereum = { path = "../chain/ethereum" }
 graph-chain-near = { path = "../chain/near" }
 graph-chain-cosmos = { path = "../chain/cosmos" }
 graph-chain-substreams = { path = "../chain/substreams" }
+graph-chain-starknet = { path = "../chain/starknet" }
 lazy_static = "1.2.0"
 lru_time_cache = "0.11"
 semver = "1.0.18"

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -119,6 +119,20 @@ impl<S: SubgraphStore> SubgraphInstanceManagerTrait for SubgraphInstanceManager<
 
                     self.start_subgraph_inner(logger, loc, runner).await
                 }
+                BlockchainKind::Starknet => {
+                    let runner = instance_manager
+                        .build_subgraph_runner::<graph_chain_starknet::Chain>(
+                            logger.clone(),
+                            self.env_vars.cheap_clone(),
+                            loc.clone(),
+                            manifest,
+                            stop_block,
+                            Box::new(SubgraphTriggerProcessor {}),
+                        )
+                        .await?;
+
+                    self.start_subgraph_inner(logger, loc, runner).await
+                }
             }
         };
 

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -406,6 +406,24 @@ where
                 )
                 .await?
             }
+            BlockchainKind::Starknet => {
+                create_subgraph_version::<graph_chain_starknet::Chain, _>(
+                    &logger,
+                    self.store.clone(),
+                    self.chains.cheap_clone(),
+                    name.clone(),
+                    hash.cheap_clone(),
+                    start_block_override,
+                    graft_block_override,
+                    raw,
+                    node_id,
+                    debug_fork,
+                    self.version_switching_mode,
+                    &self.resolver,
+                    history_blocks,
+                )
+                .await?
+            }
         };
 
         debug!(

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -396,7 +396,6 @@ pub enum BlockchainKind {
 
     Substreams,
 
-    /// StarkNet chains
     Starknet,
 }
 

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -395,6 +395,9 @@ pub enum BlockchainKind {
     Cosmos,
 
     Substreams,
+
+    /// StarkNet chains
+    Starknet,
 }
 
 impl fmt::Display for BlockchainKind {
@@ -405,6 +408,7 @@ impl fmt::Display for BlockchainKind {
             BlockchainKind::Near => "near",
             BlockchainKind::Cosmos => "cosmos",
             BlockchainKind::Substreams => "substreams",
+            BlockchainKind::Starknet => "starknet",
         };
         write!(f, "{}", value)
     }
@@ -420,6 +424,7 @@ impl FromStr for BlockchainKind {
             "near" => Ok(BlockchainKind::Near),
             "cosmos" => Ok(BlockchainKind::Cosmos),
             "substreams" => Ok(BlockchainKind::Substreams),
+            "starknet" => Ok(BlockchainKind::Starknet),
             _ => Err(anyhow!("unknown blockchain kind {}", s)),
         }
     }

--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -355,7 +355,20 @@ pub enum IndexForAscTypeId {
     // ...
     // LastArweaveType = 3499,
 
-    // Reserved discriminant space for a future blockchain type IDs: [3,500, 4,499]
+    // StarkNet types
+    StarknetBlock = 3500,
+    StarknetTransaction = 3501,
+    StarknetTransactionTypeEnum = 3502,
+    StarknetEvent = 3503,
+    StarknetArrayBytes = 3504,
+    // Continue to add more StarkNet type IDs here.
+    // e.g.:
+    // NextStarknetType = 3505,
+    // AnotherStarknetType = 3506,
+    // ...
+    // LastStarknetType = 4499,
+
+    // Reserved discriminant space for a future blockchain type IDs: [4,500, 5,499]
     //
     // Generated with the following shell script:
     //

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -27,6 +27,7 @@ graph-chain-ethereum = { path = "../chain/ethereum" }
 graph-chain-near = { path = "../chain/near" }
 graph-chain-cosmos = { path = "../chain/cosmos" }
 graph-chain-substreams = { path = "../chain/substreams" }
+graph-chain-starknet = { path = "../chain/starknet" }
 graph-graphql = { path = "../graphql" }
 graph-runtime-wasm = { path = "../runtime/wasm" }
 graph-server-http = { path = "../server/http" }

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -13,6 +13,7 @@ graph-chain-arweave = { path = "../../chain/arweave" }
 graph-chain-ethereum = { path = "../../chain/ethereum" }
 graph-chain-near = { path = "../../chain/near" }
 graph-chain-cosmos = { path = "../../chain/cosmos" }
+graph-chain-starknet = { path = "../../chain/starknet" }
 graphql-parser = "0.4.0"
 http = "0.2"
 hyper = "0.14"

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -552,6 +552,7 @@ impl<S: Store> IndexNodeResolver<S> {
         try_resolve_for_chain!(graph_chain_arweave::Chain);
         try_resolve_for_chain!(graph_chain_cosmos::Chain);
         try_resolve_for_chain!(graph_chain_near::Chain);
+        try_resolve_for_chain!(graph_chain_starknet::Chain);
 
         // If you're adding support for a new chain and this `match` clause just
         // gave you a compiler error, then this message is for you! You need to
@@ -563,7 +564,8 @@ impl<S: Store> IndexNodeResolver<S> {
             | BlockchainKind::Arweave
             | BlockchainKind::Ethereum
             | BlockchainKind::Cosmos
-            | BlockchainKind::Near => (),
+            | BlockchainKind::Near
+            | BlockchainKind::Starknet => (),
         }
 
         // The given network does not exist.


### PR DESCRIPTION
This PR brings initial support for Starknet into `graph-node`. The implementation comes from [starknet-graph](https://github.com/starknet-graph), and has been used in production by the [zkLend](https://zklend.com/) team for around a year. That said, the support enabled by this PR is not production ready:

- Trigger filter is not implemented, and `graph-node` would always consume the entire Firehose block stream and build all possible triggers. No benchmark has been done yet, but this should hurt performance pretty bad.
- Data source templates are not supported. This hasn't been tested yet, but technically `graph-node` would panic if someone deploys a subgraph with Starknet data source templates defined.
- Substream support has not been added (will take inspiration from #4887).

Nevertheless, this PR is submitted here first to kickstart the integration process. Let's bring `graph-node`'s amazing indexing capabilities to Starknet!