### PR TITLE
Track per query connection and permit wait times

### DIFF
--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -531,6 +531,11 @@ pub trait EthereumCallCache: Send + Sync + 'static {
     ) -> Result<(), Error>;
 }
 
+pub struct QueryPermit {
+    pub permit: tokio::sync::OwnedSemaphorePermit,
+    pub wait: Duration,
+}
+
 /// Store operations used when serving queries for a specific deployment
 #[async_trait]
 pub trait QueryStore: Send + Sync {
@@ -569,7 +574,7 @@ pub trait QueryStore: Send + Sync {
     fn network_name(&self) -> &str;
 
     /// A permit should be acquired before starting query execution.
-    async fn query_permit(&self) -> Result<tokio::sync::OwnedSemaphorePermit, StoreError>;
+    async fn query_permit(&self) -> Result<QueryPermit, StoreError>;
 
     /// Report the name of the shard in which the subgraph is stored. This
     /// should only be used for reporting and monitoring
@@ -584,7 +589,7 @@ pub trait QueryStore: Send + Sync {
 #[async_trait]
 pub trait StatusStore: Send + Sync + 'static {
     /// A permit should be acquired before starting query execution.
-    async fn query_permit(&self) -> Result<tokio::sync::OwnedSemaphorePermit, StoreError>;
+    async fn query_permit(&self) -> Result<QueryPermit, StoreError>;
 
     fn status(&self, filter: status::Filter) -> Result<Vec<status::Info>, StoreError>;
 

--- a/graph/src/data/query/trace.rs
+++ b/graph/src/data/query/trace.rs
@@ -17,12 +17,14 @@ pub enum Trace {
         block: BlockNumber,
         elapsed: Mutex<Duration>,
         conn_wait: Duration,
+        permit_wait: Duration,
         children: Vec<(String, Trace)>,
     },
     Query {
         query: String,
         elapsed: Duration,
         conn_wait: Duration,
+        permit_wait: Duration,
         entity_count: usize,
         children: Vec<(String, Trace)>,
     },
@@ -50,6 +52,7 @@ impl Trace {
                 block,
                 elapsed: Mutex::new(Duration::from_millis(0)),
                 conn_wait: Duration::from_millis(0),
+                permit_wait: Duration::from_millis(0),
                 children: Vec::new(),
             }
         } else {
@@ -69,6 +72,7 @@ impl Trace {
             query: query.to_string(),
             elapsed,
             conn_wait: Duration::from_millis(0),
+            permit_wait: Duration::from_millis(0),
             entity_count,
             children: Vec::new(),
         }
@@ -103,6 +107,15 @@ impl Trace {
             Trace::Root { conn_wait, .. } | Trace::Query { conn_wait, .. } => *conn_wait += time,
         }
     }
+
+    pub fn permit_wait(&mut self, time: Duration) {
+        match self {
+            Trace::None => { /* nothing to do  */ }
+            Trace::Root { permit_wait, .. } | Trace::Query { permit_wait, .. } => {
+                *permit_wait += time
+            }
+        }
+    }
 }
 
 impl Serialize for Trace {
@@ -119,6 +132,7 @@ impl Serialize for Trace {
                 block,
                 elapsed,
                 conn_wait,
+                permit_wait,
                 children,
             } => {
                 let mut map = ser.serialize_map(Some(children.len() + 2))?;
@@ -133,12 +147,14 @@ impl Serialize for Trace {
                     map.serialize_entry(child, trace)?;
                 }
                 map.serialize_entry("conn_wait_ms", &conn_wait.as_millis())?;
+                map.serialize_entry("permit_wait_ms", &permit_wait.as_millis())?;
                 map.end()
             }
             Trace::Query {
                 query,
                 elapsed,
                 conn_wait,
+                permit_wait,
                 entity_count,
                 children,
             } => {
@@ -146,6 +162,7 @@ impl Serialize for Trace {
                 map.serialize_entry("query", query)?;
                 map.serialize_entry("elapsed_ms", &elapsed.as_millis())?;
                 map.serialize_entry("conn_wait_ms", &conn_wait.as_millis())?;
+                map.serialize_entry("permit_wait_ms", &permit_wait.as_millis())?;
                 map.serialize_entry("entity_count", entity_count)?;
                 for (child, trace) in children {
                     map.serialize_entry(child, trace)?;

--- a/graph/src/data/query/trace.rs
+++ b/graph/src/data/query/trace.rs
@@ -16,13 +16,14 @@ pub enum Trace {
         query_id: String,
         block: BlockNumber,
         elapsed: Mutex<Duration>,
+        conn_wait: Duration,
         children: Vec<(String, Trace)>,
     },
     Query {
         query: String,
         elapsed: Duration,
+        conn_wait: Duration,
         entity_count: usize,
-
         children: Vec<(String, Trace)>,
     },
 }
@@ -48,6 +49,7 @@ impl Trace {
                 query_id: query_id.to_string(),
                 block,
                 elapsed: Mutex::new(Duration::from_millis(0)),
+                conn_wait: Duration::from_millis(0),
                 children: Vec::new(),
             }
         } else {
@@ -66,6 +68,7 @@ impl Trace {
         Trace::Query {
             query: query.to_string(),
             elapsed,
+            conn_wait: Duration::from_millis(0),
             entity_count,
             children: Vec::new(),
         }
@@ -93,6 +96,13 @@ impl Trace {
             Trace::Root { .. } | Trace::Query { .. } => false,
         }
     }
+
+    pub fn conn_wait(&mut self, time: Duration) {
+        match self {
+            Trace::None => { /* nothing to do  */ }
+            Trace::Root { conn_wait, .. } | Trace::Query { conn_wait, .. } => *conn_wait += time,
+        }
+    }
 }
 
 impl Serialize for Trace {
@@ -108,6 +118,7 @@ impl Serialize for Trace {
                 query_id,
                 block,
                 elapsed,
+                conn_wait,
                 children,
             } => {
                 let mut map = ser.serialize_map(Some(children.len() + 2))?;
@@ -121,17 +132,20 @@ impl Serialize for Trace {
                 for (child, trace) in children {
                     map.serialize_entry(child, trace)?;
                 }
+                map.serialize_entry("conn_wait_ms", &conn_wait.as_millis())?;
                 map.end()
             }
             Trace::Query {
                 query,
                 elapsed,
+                conn_wait,
                 entity_count,
                 children,
             } => {
                 let mut map = ser.serialize_map(Some(children.len() + 3))?;
                 map.serialize_entry("query", query)?;
                 map.serialize_entry("elapsed_ms", &elapsed.as_millis())?;
+                map.serialize_entry("conn_wait_ms", &conn_wait.as_millis())?;
                 map.serialize_entry("entity_count", entity_count)?;
                 for (child, trace) in children {
                     map.serialize_entry(child, trace)?;

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -375,6 +375,9 @@ pub(crate) async fn execute_root_selection_set<R: Resolver>(
             // Unwrap: In practice should never fail, but if it does we will catch the panic.
             execute_ctx.resolver.post_process(&mut query_res).unwrap();
             query_res.deployment = Some(execute_ctx.query.schema.id().clone());
+            if let Ok(qp) = _permit {
+                query_res.trace.permit_wait(qp.wait);
+            }
             Arc::new(query_res)
         })
         .await

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
-use graph::components::store::UnitStream;
+use graph::components::store::{QueryPermit, UnitStream};
 use graph::data::query::{CacheStatus, Trace};
-use graph::prelude::{async_trait, s, tokio, Error, QueryExecutionError};
+use graph::prelude::{async_trait, s, Error, QueryExecutionError};
 use graph::schema::ApiSchema;
 use graph::{
     data::graphql::ObjectOrInterface,
@@ -18,7 +18,7 @@ use super::Query;
 pub trait Resolver: Sized + Send + Sync + 'static {
     const CACHEABLE: bool;
 
-    async fn query_permit(&self) -> Result<tokio::sync::OwnedSemaphorePermit, QueryExecutionError>;
+    async fn query_permit(&self) -> Result<QueryPermit, QueryExecutionError>;
 
     /// Prepare for executing a query by prefetching as much data as possible
     fn prefetch(

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -1,3 +1,4 @@
+use graph::components::store::QueryPermit;
 use graph::data::graphql::ext::{FieldExt, TypeDefinitionExt};
 use graph::data::query::Trace;
 use graphql_parser::Pos;
@@ -359,7 +360,7 @@ impl Resolver for IntrospectionResolver {
     // see `fn as_introspection_context`, so this value is irrelevant.
     const CACHEABLE: bool = false;
 
-    async fn query_permit(&self) -> Result<tokio::sync::OwnedSemaphorePermit, QueryExecutionError> {
+    async fn query_permit(&self) -> Result<QueryPermit, QueryExecutionError> {
         unreachable!()
     }
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::result;
 use std::sync::Arc;
 
-use graph::components::store::{SubscriptionManager, UnitStream};
+use graph::components::store::{QueryPermit, SubscriptionManager, UnitStream};
 use graph::data::graphql::load_manager::LoadManager;
 use graph::data::graphql::{object, ObjectOrInterface};
 use graph::data::query::{CacheStatus, Trace};
@@ -283,7 +283,7 @@ impl StoreResolver {
 impl Resolver for StoreResolver {
     const CACHEABLE: bool = true;
 
-    async fn query_permit(&self) -> Result<tokio::sync::OwnedSemaphorePermit, QueryExecutionError> {
+    async fn query_permit(&self) -> Result<QueryPermit, QueryExecutionError> {
         self.store.query_permit().await.map_err(Into::into)
     }
 

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -8,7 +8,7 @@ use web3::types::Address;
 
 use git_testament::{git_testament, CommitKind};
 use graph::blockchain::{Blockchain, BlockchainKind, BlockchainMap};
-use graph::components::store::{BlockPtrForNumber, BlockStore, Store};
+use graph::components::store::{BlockPtrForNumber, BlockStore, QueryPermit, Store};
 use graph::components::versions::VERSIONS;
 use graph::data::graphql::{object, IntoValue, ObjectOrInterface, ValueMap};
 use graph::data::subgraph::{status, DeploymentFeatures};
@@ -797,7 +797,7 @@ fn entity_changes_to_graphql(entity_changes: Vec<EntityOperation>) -> r::Value {
 impl<S: Store> Resolver for IndexNodeResolver<S> {
     const CACHEABLE: bool = false;
 
-    async fn query_permit(&self) -> Result<tokio::sync::OwnedSemaphorePermit, QueryExecutionError> {
+    async fn query_permit(&self) -> Result<QueryPermit, QueryExecutionError> {
         self.store.query_permit().await.map_err(Into::into)
     }
 

--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -6,14 +6,11 @@ use std::{
 
 use graph::{
     blockchain::ChainIdentifier,
-    components::store::BlockStore as BlockStoreTrait,
+    components::store::{BlockStore as BlockStoreTrait, QueryPermit},
     prelude::{error, info, warn, BlockNumber, BlockPtr, Logger, ENV_VARS},
 };
 use graph::{constraint_violation, prelude::CheapClone};
-use graph::{
-    prelude::{tokio, StoreError},
-    util::timed_cache::TimedCache,
-};
+use graph::{prelude::StoreError, util::timed_cache::TimedCache};
 
 use crate::{
     chain_head_listener::ChainHeadUpdateSender, chain_store::ChainStoreMetrics,
@@ -313,7 +310,7 @@ impl BlockStore {
         Ok(block_store)
     }
 
-    pub(crate) async fn query_permit_primary(&self) -> tokio::sync::OwnedSemaphorePermit {
+    pub(crate) async fn query_permit_primary(&self) -> QueryPermit {
         self.mirror
             .primary()
             .query_permit()

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -8,7 +8,7 @@ use graph::blockchain::block_stream::FirehoseCursor;
 use graph::components::store::write::RowGroup;
 use graph::components::store::{
     Batch, DerivedEntityQuery, PrunePhase, PruneReporter, PruneRequest, PruningStrategy,
-    StoredDynamicDataSource, VersionStats,
+    QueryPermit, StoredDynamicDataSource, VersionStats,
 };
 use graph::components::versions::VERSIONS;
 use graph::data::query::Trace;
@@ -17,7 +17,7 @@ use graph::data::subgraph::{status, SPEC_VERSION_0_0_6};
 use graph::data_source::CausalityRegion;
 use graph::prelude::futures03::FutureExt;
 use graph::prelude::{
-    tokio, ApiVersion, CancelHandle, CancelToken, CancelableError, EntityOperation, PoolWaitStats,
+    ApiVersion, CancelHandle, CancelToken, CancelableError, EntityOperation, PoolWaitStats,
     SubgraphDeploymentEntity,
 };
 use graph::semver::Version;
@@ -427,10 +427,7 @@ impl DeploymentStore {
         Ok(conn)
     }
 
-    pub(crate) async fn query_permit(
-        &self,
-        replica: ReplicaId,
-    ) -> Result<tokio::sync::OwnedSemaphorePermit, StoreError> {
+    pub(crate) async fn query_permit(&self, replica: ReplicaId) -> Result<QueryPermit, StoreError> {
         let pool = match replica {
             ReplicaId::Main => &self.pool,
             ReplicaId::ReadOnly(idx) => &self.read_only_pools[idx],

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use crate::deployment_store::{DeploymentStore, ReplicaId};
-use graph::components::store::{DeploymentId, QueryStore as QueryStoreTrait};
+use graph::components::store::{DeploymentId, QueryPermit, QueryStore as QueryStoreTrait};
 use graph::data::query::Trace;
 use graph::data::store::QueryObject;
 use graph::prelude::*;
@@ -138,7 +138,7 @@ impl QueryStoreTrait for QueryStore {
         &self.site.network
     }
 
-    async fn query_permit(&self) -> Result<tokio::sync::OwnedSemaphorePermit, StoreError> {
+    async fn query_permit(&self) -> Result<QueryPermit, StoreError> {
         self.store.query_permit(self.replica_id).await
     }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -5,15 +5,15 @@ use graph::{
     components::{
         server::index_node::VersionInfo,
         store::{
-            BlockPtrForNumber, BlockStore as BlockStoreTrait, QueryStoreManager, StatusStore,
-            Store as StoreTrait,
+            BlockPtrForNumber, BlockStore as BlockStoreTrait, QueryPermit, QueryStoreManager,
+            StatusStore, Store as StoreTrait,
         },
     },
     constraint_violation,
     data::subgraph::status,
     prelude::{
-        tokio, web3::types::Address, BlockNumber, BlockPtr, CheapClone, DeploymentHash,
-        PartialBlockPtr, QueryExecutionError, StoreError,
+        web3::types::Address, BlockNumber, BlockPtr, CheapClone, DeploymentHash, PartialBlockPtr,
+        QueryExecutionError, StoreError,
     },
 };
 
@@ -168,7 +168,7 @@ impl StatusStore for Store {
             .await
     }
 
-    async fn query_permit(&self) -> Result<tokio::sync::OwnedSemaphorePermit, StoreError> {
+    async fn query_permit(&self) -> Result<QueryPermit, StoreError> {
         // Status queries go to the primary shard.
         Ok(self.block_store.query_permit_primary().await)
     }

--- a/store/test-store/tests/graphql/introspection.rs
+++ b/store/test-store/tests/graphql/introspection.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
+use std::time::Duration;
 
+use graph::components::store::QueryPermit;
 use graph::data::graphql::{object, object_value, ObjectOrInterface};
 use graph::data::query::Trace;
 use graph::prelude::{
@@ -49,11 +51,15 @@ impl Resolver for MockResolver {
         Ok(r::Value::Null)
     }
 
-    async fn query_permit(&self) -> Result<tokio::sync::OwnedSemaphorePermit, QueryExecutionError> {
-        Ok(Arc::new(tokio::sync::Semaphore::new(1))
+    async fn query_permit(&self) -> Result<QueryPermit, QueryExecutionError> {
+        let permit = Arc::new(tokio::sync::Semaphore::new(1))
             .acquire_owned()
             .await
-            .unwrap())
+            .unwrap();
+        Ok(QueryPermit {
+            permit,
+            wait: Duration::from_secs(0),
+        })
     }
 }
 


### PR DESCRIPTION
There are other places during query execution where we might be waiting for connections, but this at least records the times for getting the actual data.