### PR TITLE
fix(graphql): change CDN to JS Deliver for GraphiQL

### DIFF
--- a/server/http/assets/index.html
+++ b/server/http/assets/index.html
@@ -5,7 +5,7 @@
     <title>The GraphiQL</title>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@graphql-yoga/graphiql@4.1.1/dist/style.css"
+      href="https://cdn.jsdelivr.net/npm/@graphql-yoga/graphiql@4.2.0/dist/style.css"
     />
     <link
       rel="icon"
@@ -16,10 +16,8 @@
   <body id="body" class="no-focus-outline">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"></script>
     <script type="module">
-      import { renderYogaGraphiQL } from "https://unpkg.com/@graphql-yoga/graphiql@4.1.1/dist/yoga-graphiql.es.js";
+      import { renderYogaGraphiQL } from "https://cdn.jsdelivr.net/npm/@graphql-yoga/graphiql@4.2.0/+esm";
 
       const endpoint = window.location.pathname.substring(
         0,

--- a/server/http/assets/index.html
+++ b/server/http/assets/index.html
@@ -6,17 +6,19 @@
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@graphql-yoga/graphiql@4.2.0/dist/style.css"
+      crossorigin
     />
     <link
       rel="icon"
       type="image/png"
       href="https://storage.googleapis.com/graph-web/favicon.png"
+      crossorigin
     />
   </head>
   <body id="body" class="no-focus-outline">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script type="module">
+    <script type="module" crossorigin>
       import { renderYogaGraphiQL } from "https://cdn.jsdelivr.net/npm/@graphql-yoga/graphiql@4.2.0/+esm";
 
       const endpoint = window.location.pathname.substring(


### PR DESCRIPTION
https://unpkg.com seems to have some [weird CORS issues](https://github.com/mjackson/unpkg/issues/174) so swapping to JS Deliver

<img width="883" alt="CleanShot 2023-10-26 at 11 45 12" src="https://github.com/graphprotocol/graph-node/assets/44710980/be3f2aca-11fd-47b9-996e-71afa1444284">
