### PR TITLE
Make `SubstreamsBlockIngestor` start at chain's head if no cursor already exist

### DIFF
--- a/chain/substreams/src/block_ingestor.rs
+++ b/chain/substreams/src/block_ingestor.rs
@@ -144,7 +144,7 @@ impl BlockIngestor for SubstreamsBlockIngestor {
                 mapper.cheap_clone(),
                 package.modules.clone(),
                 "map_blocks".to_string(),
-                vec![],
+                vec![-1],
                 vec![],
                 self.logger.cheap_clone(),
                 self.metrics.cheap_clone(),


### PR DESCRIPTION
Fixes #4942

