### PR TITLE
fix(graphql): include introspection fields in error

### DIFF
--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -31,9 +31,12 @@ pub use fulltext::{FulltextAlgorithm, FulltextConfig, FulltextDefinition, Fullte
 pub use input_schema::InputSchema;
 
 pub const SCHEMA_TYPE_NAME: &str = "_Schema_";
+pub const INTROSPECTION_SCHEMA_FIELD_NAME: &str = "__schema";
 
 pub const META_FIELD_TYPE: &str = "_Meta_";
 pub const META_FIELD_NAME: &str = "_meta";
+
+pub const INTROSPECTION_TYPE_FIELD_NAME: &str = "__type";
 
 pub const BLOCK_FIELD_TYPE: &str = "_Block_";
 

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -385,33 +385,31 @@ impl Resolver for StoreResolver {
                 let mut data = result.take_data();
 
                 // Only keep the _meta, __schema and __type fields from the data
-                let meta_fields = data
-                    .as_mut()
-                    .and_then(|d| {
-                        let meta_field = d.remove("_meta");
-                        let schema_field = d.remove("__schema");
-                        let type_field = d.remove("__type");
+                let meta_fields = data.as_mut().and_then(|d| {
+                    let meta_field = d.remove("_meta");
+                    let schema_field = d.remove("__schema");
+                    let type_field = d.remove("__type");
 
-                        // combine the fields into a vector
-                        let mut meta_fields = Vec::new();
+                    // combine the fields into a vector
+                    let mut meta_fields = Vec::new();
 
-                        if let Some(meta_field) = meta_field {
-                            meta_fields.push((Word::from("_meta"), meta_field));
-                        }
-                        if let Some(schema_field) = schema_field {
-                            meta_fields.push((Word::from("__schema"), schema_field));
-                        }
-                        if let Some(type_field) = type_field {
-                            meta_fields.push((Word::from("__type"), type_field));
-                        }
+                    if let Some(meta_field) = meta_field {
+                        meta_fields.push((Word::from("_meta"), meta_field));
+                    }
+                    if let Some(schema_field) = schema_field {
+                        meta_fields.push((Word::from("__schema"), schema_field));
+                    }
+                    if let Some(type_field) = type_field {
+                        meta_fields.push((Word::from("__type"), type_field));
+                    }
 
-                        // return the object if it is not empty
-                        if meta_fields.is_empty() {
-                            None
-                        } else {
-                            Some(Object::from_iter(meta_fields))
-                        }
-                    });
+                    // return the object if it is not empty
+                    if meta_fields.is_empty() {
+                        None
+                    } else {
+                        Some(Object::from_iter(meta_fields))
+                    }
+                });
 
                 result.set_data(meta_fields);
             }

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -8,7 +8,10 @@ use graph::data::graphql::{object, ObjectOrInterface};
 use graph::data::query::{CacheStatus, Trace};
 use graph::data::value::{Object, Word};
 use graph::prelude::*;
-use graph::schema::{ast as sast, ApiSchema, META_FIELD_TYPE, META_FIELD_NAME, INTROSPECTION_SCHEMA_FIELD_NAME, INTROSPECTION_TYPE_FIELD_NAME};
+use graph::schema::{
+    ast as sast, ApiSchema, INTROSPECTION_SCHEMA_FIELD_NAME, INTROSPECTION_TYPE_FIELD_NAME,
+    META_FIELD_NAME, META_FIELD_TYPE,
+};
 use graph::schema::{ErrorPolicy, BLOCK_FIELD_TYPE};
 
 use crate::execution::{ast as a, Query};
@@ -397,7 +400,8 @@ impl Resolver for StoreResolver {
                         meta_fields.push((Word::from(META_FIELD_NAME), meta_field));
                     }
                     if let Some(schema_field) = schema_field {
-                        meta_fields.push((Word::from(INTROSPECTION_SCHEMA_FIELD_NAME), schema_field));
+                        meta_fields
+                            .push((Word::from(INTROSPECTION_SCHEMA_FIELD_NAME), schema_field));
                     }
                     if let Some(type_field) = type_field {
                         meta_fields.push((Word::from(INTROSPECTION_TYPE_FIELD_NAME), type_field));

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -8,7 +8,7 @@ use graph::data::graphql::{object, ObjectOrInterface};
 use graph::data::query::{CacheStatus, Trace};
 use graph::data::value::{Object, Word};
 use graph::prelude::*;
-use graph::schema::{ast as sast, ApiSchema, META_FIELD_TYPE};
+use graph::schema::{ast as sast, ApiSchema, META_FIELD_TYPE, META_FIELD_NAME, INTROSPECTION_SCHEMA_FIELD_NAME, INTROSPECTION_TYPE_FIELD_NAME};
 use graph::schema::{ErrorPolicy, BLOCK_FIELD_TYPE};
 
 use crate::execution::{ast as a, Query};
@@ -386,21 +386,21 @@ impl Resolver for StoreResolver {
 
                 // Only keep the _meta, __schema and __type fields from the data
                 let meta_fields = data.as_mut().and_then(|d| {
-                    let meta_field = d.remove("_meta");
-                    let schema_field = d.remove("__schema");
-                    let type_field = d.remove("__type");
+                    let meta_field = d.remove(META_FIELD_NAME);
+                    let schema_field = d.remove(INTROSPECTION_SCHEMA_FIELD_NAME);
+                    let type_field = d.remove(INTROSPECTION_TYPE_FIELD_NAME);
 
                     // combine the fields into a vector
                     let mut meta_fields = Vec::new();
 
                     if let Some(meta_field) = meta_field {
-                        meta_fields.push((Word::from("_meta"), meta_field));
+                        meta_fields.push((Word::from(META_FIELD_NAME), meta_field));
                     }
                     if let Some(schema_field) = schema_field {
-                        meta_fields.push((Word::from("__schema"), schema_field));
+                        meta_fields.push((Word::from(INTROSPECTION_SCHEMA_FIELD_NAME), schema_field));
                     }
                     if let Some(type_field) = type_field {
-                        meta_fields.push((Word::from("__type"), type_field));
+                        meta_fields.push((Word::from(INTROSPECTION_TYPE_FIELD_NAME), type_field));
                     }
 
                     // return the object if it is not empty

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -382,12 +382,38 @@ impl Resolver for StoreResolver {
             // Note that the meta field could have been queried under a different response key,
             // or a different field queried under the response key `_meta`.
             ErrorPolicy::Deny => {
-                let data = result.take_data();
-                let meta =
-                    data.and_then(|mut d| d.remove("_meta").map(|m| ("_meta".to_string(), m)));
-                result.set_data(
-                    meta.map(|(key, value)| Object::from_iter(Some((Word::from(key), value)))),
-                );
+                let mut data = result.take_data();
+
+                // Only keep the _meta, __schema and __type fields from the data
+                let meta_fields = data
+                    .as_mut()
+                    .and_then(|d| {
+                        let meta_field = d.remove("_meta");
+                        let schema_field = d.remove("__schema");
+                        let type_field = d.remove("__type");
+
+                        // combine the fields into a vector
+                        let mut meta_fields = Vec::new();
+
+                        if let Some(meta_field) = meta_field {
+                            meta_fields.push((Word::from("_meta"), meta_field));
+                        }
+                        if let Some(schema_field) = schema_field {
+                            meta_fields.push((Word::from("__schema"), schema_field));
+                        }
+                        if let Some(type_field) = type_field {
+                            meta_fields.push((Word::from("__type"), type_field));
+                        }
+
+                        // return the object if it is not empty
+                        if meta_fields.is_empty() {
+                            None
+                        } else {
+                            Some(Object::from_iter(meta_fields))
+                        }
+                    });
+
+                result.set_data(meta_fields);
             }
             ErrorPolicy::Allow => (),
         }

--- a/store/test-store/tests/graphql/query.rs
+++ b/store/test-store/tests/graphql/query.rs
@@ -2579,6 +2579,45 @@ fn non_fatal_errors() {
         });
         assert_eq!(expected, serde_json::to_value(&result).unwrap());
 
+        // Introspection queries are not affected.
+        let query =
+            "query { __schema { queryType { name } } __type(name: \"Musician\") { name }  }";
+        let result = execute_query(&deployment, query).await;
+        let expected = json!({
+            "data": {
+                "__schema": {
+                    "queryType": {
+                        "name": "Query"
+                    }
+                },
+                "__type": {
+                    "name": "Musician"
+                }
+            },
+            "errors": [
+                {
+                    "message": "indexing_error"
+                }
+            ]
+        });
+        assert_eq!(expected, serde_json::to_value(&result).unwrap());
+
+        let query = "query { __type(name: \"Musician\") { name } }";
+        let result = execute_query(&deployment, query).await;
+        let expected = json!({
+            "data": {
+                "__type": {
+                    "name": "Musician"
+                }
+            },
+            "errors": [
+                {
+                    "message": "indexing_error"
+                }
+            ]
+        });
+        assert_eq!(expected, serde_json::to_value(&result).unwrap());
+
         // With `allow`, the error remains but the data is included.
         let query = "query { musician(id: \"m1\", subgraphError: allow) { id } }";
         let result = execute_query(&deployment, query).await;
@@ -2655,6 +2694,25 @@ fn deterministic_error() {
         let query = "query { musician(id: \"m1\") { id } }";
         let result = execute_query(&deployment, query).await;
         let expected = json!({
+            "errors": [
+                {
+                    "message": "indexing_error"
+                }
+            ]
+        });
+        assert_eq!(expected, serde_json::to_value(&result).unwrap());
+
+        // Introspection queries are not affected.
+        let query = "query { __schema { queryType { name } } }";
+        let result = execute_query(&deployment, query).await;
+        let expected = json!({
+            "data": {
+                "__schema": {
+                    "queryType": {
+                        "name": "Query"
+                    }
+                }
+            },
             "errors": [
                 {
                     "message": "indexing_error"


### PR DESCRIPTION
include `__schema` and `__type` part of the result when there is an indexing error and the error policy is deny.

Fixes #2443


----

There is another issue I found (could just be how tests are setup) but I wasn't really able to fix. In the example below if there is an indexing error this will return `null` but I would imagine that we return partial result i.e. `__schema` is returned in the `data` 
```graphql
query { musician(id: "m1") { id } __schema { queryType { name } } }
```

