### PR TITLE
fix: Increase RPC base backoff

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -490,6 +490,7 @@ impl EthereumAdapter {
                         "stack limit reached 1024",
                         // See f0af4ab0-6b7c-4b68-9141-5b79346a5f61 for why the gas limit is considered deterministic.
                         "out of gas",
+                        "stack underflow",
                     ];
 
                     let env_geth_call_errors = ENV_VARS.geth_eth_call_errors.iter();

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -354,7 +354,7 @@ pub fn retry_strategy(
     max_delay: Duration,
 ) -> Box<dyn Iterator<Item = Duration> + Send> {
     // Exponential backoff, but with a maximum
-    let backoff = ExponentialBackoff::from_millis(2)
+    let backoff = ExponentialBackoff::from_millis(10)
         .max_delay(Duration::from_millis(
             // This should be fine, if the value is too high it will crash during
             // testing.


### PR DESCRIPTION
Graph Node tends to spam failing network requests of different kinds, often giving the impression that we have no backoff at all. Starting at a slightly higher base backoff might help.

Also add a newly discovered deterministic Geth error.