### PR TITLE
More `InputSchema` refactorings

### DIFF
--- a/graph/src/data/store/id.rs
+++ b/graph/src/data/store/id.rs
@@ -19,7 +19,7 @@ use crate::{
     schema::EntityType,
 };
 
-use super::{scalar, Value, ID};
+use super::{scalar, Value, ValueType, ID};
 
 /// The types that can be used for the `id` of an entity
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -59,6 +59,24 @@ impl<'a> TryFrom<&s::ObjectType> for IdType {
                 obj_type.name,
                 s
             )),
+        }
+    }
+}
+
+impl TryFrom<&s::Type> for IdType {
+    type Error = StoreError;
+
+    fn try_from(field_type: &s::Type) -> Result<Self, Self::Error> {
+        let name = field_type.get_base_type();
+
+        match name.parse()? {
+            ValueType::String => Ok(IdType::String),
+            ValueType::Bytes => Ok(IdType::Bytes),
+            _ => Err(anyhow!(
+                "The `id` field has type `{}` but only `String`, `Bytes`, and `ID` are allowed",
+                &name
+            )
+            .into()),
         }
     }
 }

--- a/graph/src/data/store/id.rs
+++ b/graph/src/data/store/id.rs
@@ -49,7 +49,11 @@ impl<'a> TryFrom<&s::ObjectType> for IdType {
     type Error = Error;
 
     fn try_from(obj_type: &s::ObjectType) -> Result<Self, Self::Error> {
-        let base_type = obj_type.field(&*ID).unwrap().field_type.get_base_type();
+        let base_type = obj_type
+            .field(&*ID)
+            .ok_or_else(|| anyhow!("Type {} does not have an `id` field", obj_type.name))?
+            .field_type
+            .get_base_type();
 
         match base_type {
             "ID" | "String" => Ok(IdType::String),

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -171,7 +171,7 @@ impl Object {
         ObjectIter::new(self)
     }
 
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.0.len()
     }
 

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -184,6 +184,11 @@ pub struct EnvVars {
     /// Set by the flag `GRAPH_ENABLE_GAS_METRICS`. Whether to enable
     /// gas metrics. Off by default.
     pub enable_gas_metrics: bool,
+    /// Set by the env var `GRAPH_EXPERIMENTAL_TIMESERIES`. Defaults to true
+    /// for debug builds and false for release builds. This default behavior
+    /// is there to simplify development and will be changed to `false` when
+    /// we get closer to release
+    pub enable_timeseries: bool,
 }
 
 impl EnvVars {
@@ -247,6 +252,7 @@ impl EnvVars {
             subgraph_settings: inner.subgraph_settings,
             prefer_substreams_block_streams: inner.prefer_substreams_block_streams,
             enable_gas_metrics: inner.enable_gas_metrics.0,
+            enable_timeseries: inner.enable_timeseries.unwrap_or(cfg!(debug_assertions)),
         })
     }
 
@@ -374,9 +380,10 @@ struct Inner {
         default = "false"
     )]
     prefer_substreams_block_streams: bool,
-
     #[envconfig(from = "GRAPH_ENABLE_GAS_METRICS", default = "false")]
     enable_gas_metrics: EnvVarBoolean,
+    #[envconfig(from = "GRAPH_EXPERIMENTAL_TIMESERIES")]
+    enable_timeseries: Option<bool>,
 }
 
 #[derive(Clone, Debug)]

--- a/graph/src/schema/api.rs
+++ b/graph/src/schema/api.rs
@@ -326,7 +326,7 @@ fn add_introspection_schema(schema: &mut Document) {
 /// The input schema should only have type/enum/interface/union definitions
 /// and must not include a root Query type. This Query type is derived, with
 /// all its fields and their input arguments, based on the existing types.
-pub fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
+pub(in crate::schema) fn api_schema(input_schema: &Document) -> Result<Document, APISchemaError> {
     // Refactor: Take `input_schema` by value.
     let object_types = input_schema.get_object_type_definitions();
     let interface_types = input_schema.get_interface_type_definitions();

--- a/graph/src/schema/ast.rs
+++ b/graph/src/schema/ast.rs
@@ -442,7 +442,7 @@ fn entity_validation() {
         let id = thing.id();
         let key = THING_TYPE.key(id.clone());
 
-        let err = thing.validate(&SCHEMA, &key);
+        let err = thing.validate(&key);
         if errmsg.is_empty() {
             assert!(
                 err.is_ok(),

--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -12,7 +12,10 @@ use crate::{
     util::intern::Atom,
 };
 
-use super::{input_schema::POI_OBJECT, EntityKey, InputSchema};
+use super::{
+    input_schema::{ObjectType, POI_OBJECT},
+    EntityKey, InputSchema, InterfaceType,
+};
 
 /// The type name of an entity. This is the string that is used in the
 /// subgraph's GraphQL schema as `type NAME @entity { .. }`
@@ -23,7 +26,7 @@ use super::{input_schema::POI_OBJECT, EntityKey, InputSchema};
 #[derive(Clone)]
 pub struct EntityType {
     schema: InputSchema,
-    pub atom: Atom,
+    pub(in crate::schema) atom: Atom,
 }
 
 impl EntityType {
@@ -52,8 +55,8 @@ impl EntityType {
         self.schema.id_type(self.atom)
     }
 
-    pub fn object_type(&self) -> Option<&s::ObjectType> {
-        self.schema.find_object_type(self)
+    pub fn object_type(&self) -> Option<&ObjectType> {
+        self.schema.find_object_type(self.atom)
     }
 
     /// Create a key from this type for an onchain entity
@@ -107,6 +110,16 @@ impl EntityType {
 
     fn same_pool(&self, other: &EntityType) -> bool {
         Arc::ptr_eq(self.schema.pool(), other.schema.pool())
+    }
+
+    pub fn interfaces(&self) -> impl Iterator<Item = &InterfaceType> {
+        self.schema.interfaces(self.atom)
+    }
+
+    /// Return a list of all entity types that implement one of the
+    /// interfaces that `self` implements
+    pub fn share_interfaces(&self) -> Result<Vec<EntityType>, Error> {
+        self.schema.share_interfaces(self.atom)
     }
 }
 

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -544,19 +544,29 @@ mod validations {
         },
         prelude::s,
         schema::{
-            FulltextAlgorithm, FulltextLanguage, Schema, SchemaValidationError, Strings,
-            SCHEMA_TYPE_NAME,
+            FulltextAlgorithm, FulltextLanguage, Schema as BaseSchema, SchemaValidationError,
+            Strings, SCHEMA_TYPE_NAME,
         },
     };
 
-    pub(super) fn validate(schema: &Schema) -> Result<(), Vec<SchemaValidationError>> {
+    /// Helper struct for validations
+    struct Schema<'a> {
+        schema: &'a BaseSchema,
+        subgraph_schema_type: Option<&'a s::ObjectType>,
+        // All entity types, excluding the subgraph schema type
+        entity_types: Vec<&'a s::ObjectType>,
+    }
+
+    pub(super) fn validate(schema: &BaseSchema) -> Result<(), Vec<SchemaValidationError>> {
+        let schema = Schema::new(schema);
+
         let mut errors: Vec<SchemaValidationError> = [
-            validate_schema_types(schema),
-            validate_derived_from(schema),
-            validate_schema_type_has_no_fields(schema),
-            validate_directives_on_schema_type(schema),
-            validate_reserved_types_usage(schema),
-            validate_interface_id_type(schema),
+            schema.validate_no_extra_types(),
+            schema.validate_derived_from(),
+            schema.validate_schema_type_has_no_fields(),
+            schema.validate_directives_on_schema_type(),
+            schema.validate_reserved_types_usage(),
+            schema.validate_interface_id_type(),
         ]
         .into_iter()
         .filter(Result::is_err)
@@ -564,9 +574,9 @@ mod validations {
         .map(Result::unwrap_err)
         .collect();
 
-        errors.append(&mut validate_id_types(schema));
-        errors.append(&mut validate_fields(schema));
-        errors.append(&mut validate_fulltext_directives(schema));
+        errors.append(&mut schema.validate_entity_type_ids());
+        errors.append(&mut schema.validate_fields());
+        errors.append(&mut schema.validate_fulltext_directives());
 
         if errors.is_empty() {
             Ok(())
@@ -575,25 +585,34 @@ mod validations {
         }
     }
 
-    fn validate_schema_type_has_no_fields(schema: &Schema) -> Result<(), SchemaValidationError> {
-        match schema
-            .subgraph_schema_object_type()
-            .and_then(|subgraph_schema_type| {
+    impl<'a> Schema<'a> {
+        fn new(schema: &'a BaseSchema) -> Self {
+            let subgraph_schema_type = schema.subgraph_schema_object_type();
+            let mut entity_types = schema.document.get_object_type_definitions();
+            entity_types.retain(|obj_type| obj_type.name != SCHEMA_TYPE_NAME);
+
+            Schema {
+                schema,
+                subgraph_schema_type,
+                entity_types,
+            }
+        }
+
+        fn validate_schema_type_has_no_fields(&self) -> Result<(), SchemaValidationError> {
+            match self.subgraph_schema_type.and_then(|subgraph_schema_type| {
                 if !subgraph_schema_type.fields.is_empty() {
                     Some(SchemaValidationError::SchemaTypeWithFields)
                 } else {
                     None
                 }
             }) {
-            Some(err) => Err(err),
-            None => Ok(()),
+                Some(err) => Err(err),
+                None => Ok(()),
+            }
         }
-    }
 
-    fn validate_directives_on_schema_type(schema: &Schema) -> Result<(), SchemaValidationError> {
-        match schema
-            .subgraph_schema_object_type()
-            .and_then(|subgraph_schema_type| {
+        fn validate_directives_on_schema_type(&self) -> Result<(), SchemaValidationError> {
+            match self.subgraph_schema_type.and_then(|subgraph_schema_type| {
                 if subgraph_schema_type
                     .directives
                     .iter()
@@ -606,132 +625,124 @@ mod validations {
                     None
                 }
             }) {
-            Some(err) => Err(err),
-            None => Ok(()),
+                Some(err) => Err(err),
+                None => Ok(()),
+            }
         }
-    }
 
-    fn validate_fulltext_directives(schema: &Schema) -> Vec<SchemaValidationError> {
-        subgraph_schema_object_type(schema).map_or(vec![], |subgraph_schema_type| {
-            subgraph_schema_type
+        fn validate_fulltext_directives(&self) -> Vec<SchemaValidationError> {
+            self.subgraph_schema_type
+                .map_or(vec![], |subgraph_schema_type| {
+                    subgraph_schema_type
+                        .directives
+                        .iter()
+                        .filter(|directives| directives.name.eq("fulltext"))
+                        .fold(vec![], |mut errors, fulltext| {
+                            errors.extend(self.validate_fulltext_directive_name(fulltext));
+                            errors.extend(self.validate_fulltext_directive_language(fulltext));
+                            errors.extend(self.validate_fulltext_directive_algorithm(fulltext));
+                            errors.extend(self.validate_fulltext_directive_includes(fulltext));
+                            errors
+                        })
+                })
+        }
+
+        fn validate_fulltext_directive_name(
+            &self,
+            fulltext: &s::Directive,
+        ) -> Vec<SchemaValidationError> {
+            let name = match fulltext.argument("name") {
+                Some(s::Value::String(name)) => name,
+                _ => return vec![SchemaValidationError::FulltextNameUndefined],
+            };
+
+            // Validate that the fulltext field doesn't collide with any top-level Query fields
+            // generated for entity types. The field name conversions should always align with those used
+            // to create the field names in `graphql::schema::api::query_fields_for_type()`.
+            if self.entity_types.iter().any(|typ| {
+                typ.fields.iter().any(|field| {
+                    name == &field.name.as_str().to_camel_case()
+                        || name == &field.name.to_plural().to_camel_case()
+                        || field.name.eq(name)
+                })
+            }) {
+                return vec![SchemaValidationError::FulltextNameCollision(
+                    name.to_string(),
+                )];
+            }
+
+            // Validate that each fulltext directive has a distinct name
+            if self
+                .subgraph_schema_type
+                .unwrap()
                 .directives
                 .iter()
-                .filter(|directives| directives.name.eq("fulltext"))
-                .fold(vec![], |mut errors, fulltext| {
-                    errors.extend(validate_fulltext_directive_name(schema, fulltext));
-                    errors.extend(validate_fulltext_directive_language(fulltext));
-                    errors.extend(validate_fulltext_directive_algorithm(fulltext));
-                    errors.extend(validate_fulltext_directive_includes(schema, fulltext));
-                    errors
+                .filter(|directive| directive.name.eq("fulltext"))
+                .filter_map(|fulltext| {
+                    // Collect all @fulltext directives with the same name
+                    match fulltext.argument("name") {
+                        Some(s::Value::String(n)) if name.eq(n) => Some(n.as_str()),
+                        _ => None,
+                    }
                 })
-        })
-    }
-
-    fn validate_fulltext_directive_name(
-        schema: &Schema,
-        fulltext: &s::Directive,
-    ) -> Vec<SchemaValidationError> {
-        let name = match fulltext.argument("name") {
-            Some(s::Value::String(name)) => name,
-            _ => return vec![SchemaValidationError::FulltextNameUndefined],
-        };
-
-        let local_types: Vec<&s::ObjectType> = schema
-            .document
-            .get_object_type_definitions()
-            .into_iter()
-            .collect();
-
-        // Validate that the fulltext field doesn't collide with any top-level Query fields
-        // generated for entity types. The field name conversions should always align with those used
-        // to create the field names in `graphql::schema::api::query_fields_for_type()`.
-        if local_types.iter().any(|typ| {
-            typ.fields.iter().any(|field| {
-                name == &field.name.as_str().to_camel_case()
-                    || name == &field.name.to_plural().to_camel_case()
-                    || field.name.eq(name)
-            })
-        }) {
-            return vec![SchemaValidationError::FulltextNameCollision(
-                name.to_string(),
-            )];
+                .count()
+                > 1
+            {
+                vec![SchemaValidationError::FulltextNameConflict(
+                    name.to_string(),
+                )]
+            } else {
+                vec![]
+            }
         }
 
-        // Validate that each fulltext directive has a distinct name
-        if schema
-            .subgraph_schema_object_type()
-            .unwrap()
-            .directives
-            .iter()
-            .filter(|directive| directive.name.eq("fulltext"))
-            .filter_map(|fulltext| {
-                // Collect all @fulltext directives with the same name
-                match fulltext.argument("name") {
-                    Some(s::Value::String(n)) if name.eq(n) => Some(n.as_str()),
-                    _ => None,
-                }
-            })
-            .count()
-            > 1
-        {
-            vec![SchemaValidationError::FulltextNameConflict(
-                name.to_string(),
-            )]
-        } else {
-            vec![]
+        fn validate_fulltext_directive_language(
+            &self,
+            fulltext: &s::Directive,
+        ) -> Vec<SchemaValidationError> {
+            let language = match fulltext.argument("language") {
+                Some(s::Value::Enum(language)) => language,
+                _ => return vec![SchemaValidationError::FulltextLanguageUndefined],
+            };
+            match FulltextLanguage::try_from(language.as_str()) {
+                Ok(_) => vec![],
+                Err(_) => vec![SchemaValidationError::FulltextLanguageInvalid(
+                    language.to_string(),
+                )],
+            }
         }
-    }
 
-    fn validate_fulltext_directive_language(fulltext: &s::Directive) -> Vec<SchemaValidationError> {
-        let language = match fulltext.argument("language") {
-            Some(s::Value::Enum(language)) => language,
-            _ => return vec![SchemaValidationError::FulltextLanguageUndefined],
-        };
-        match FulltextLanguage::try_from(language.as_str()) {
-            Ok(_) => vec![],
-            Err(_) => vec![SchemaValidationError::FulltextLanguageInvalid(
-                language.to_string(),
-            )],
+        fn validate_fulltext_directive_algorithm(
+            &self,
+            fulltext: &s::Directive,
+        ) -> Vec<SchemaValidationError> {
+            let algorithm = match fulltext.argument("algorithm") {
+                Some(s::Value::Enum(algorithm)) => algorithm,
+                _ => return vec![SchemaValidationError::FulltextAlgorithmUndefined],
+            };
+            match FulltextAlgorithm::try_from(algorithm.as_str()) {
+                Ok(_) => vec![],
+                Err(_) => vec![SchemaValidationError::FulltextAlgorithmInvalid(
+                    algorithm.to_string(),
+                )],
+            }
         }
-    }
 
-    fn validate_fulltext_directive_algorithm(
-        fulltext: &s::Directive,
-    ) -> Vec<SchemaValidationError> {
-        let algorithm = match fulltext.argument("algorithm") {
-            Some(s::Value::Enum(algorithm)) => algorithm,
-            _ => return vec![SchemaValidationError::FulltextAlgorithmUndefined],
-        };
-        match FulltextAlgorithm::try_from(algorithm.as_str()) {
-            Ok(_) => vec![],
-            Err(_) => vec![SchemaValidationError::FulltextAlgorithmInvalid(
-                algorithm.to_string(),
-            )],
-        }
-    }
+        fn validate_fulltext_directive_includes(
+            &self,
+            fulltext: &s::Directive,
+        ) -> Vec<SchemaValidationError> {
+            // Validate that each entity in fulltext.include exists
+            let includes = match fulltext.argument("include") {
+                Some(s::Value::List(includes)) if !includes.is_empty() => includes,
+                _ => return vec![SchemaValidationError::FulltextIncludeUndefined],
+            };
 
-    fn validate_fulltext_directive_includes(
-        schema: &Schema,
-        fulltext: &s::Directive,
-    ) -> Vec<SchemaValidationError> {
-        // Only allow fulltext directive on local types
-        let local_types: Vec<&s::ObjectType> = schema
-            .document
-            .get_object_type_definitions()
-            .into_iter()
-            .collect();
-
-        // Validate that each entity in fulltext.include exists
-        let includes = match fulltext.argument("include") {
-            Some(s::Value::List(includes)) if !includes.is_empty() => includes,
-            _ => return vec![SchemaValidationError::FulltextIncludeUndefined],
-        };
-
-        for include in includes {
-            match include.as_object() {
-                None => return vec![SchemaValidationError::FulltextIncludeObjectMissing],
-                Some(include_entity) => {
-                    let (entity, fields) =
+            for include in includes {
+                match include.as_object() {
+                    None => return vec![SchemaValidationError::FulltextIncludeObjectMissing],
+                    Some(include_entity) => {
+                        let (entity, fields) =
                         match (include_entity.get("entity"), include_entity.get("fields")) {
                             (Some(s::Value::String(entity)), Some(s::Value::List(fields))) => {
                                 (entity, fields)
@@ -739,18 +750,21 @@ mod validations {
                             _ => return vec![SchemaValidationError::FulltextIncludeEntityMissingOrIncorrectAttributes],
                         };
 
-                    // Validate the included entity type is one of the local types
-                    let entity_type = match local_types
-                        .iter()
-                        .cloned()
-                        .find(|typ| typ.name[..].eq(entity))
-                    {
-                        None => return vec![SchemaValidationError::FulltextIncludedEntityNotFound],
-                        Some(t) => t.clone(),
-                    };
+                        // Validate the included entity type is one of the local types
+                        let entity_type = match self
+                            .entity_types
+                            .iter()
+                            .cloned()
+                            .find(|typ| typ.name[..].eq(entity))
+                        {
+                            None => {
+                                return vec![SchemaValidationError::FulltextIncludedEntityNotFound]
+                            }
+                            Some(t) => t,
+                        };
 
-                    for field_value in fields {
-                        let field_name = match field_value {
+                        for field_value in fields {
+                            let field_name = match field_value {
                             s::Value::Object(field_map) => match field_map.get("name") {
                                 Some(s::Value::String(name)) => name,
                                 _ => return vec![SchemaValidationError::FulltextIncludedFieldMissingRequiredProperty],
@@ -758,8 +772,8 @@ mod validations {
                             _ => return vec![SchemaValidationError::FulltextIncludeEntityMissingOrIncorrectAttributes],
                         };
 
-                        // Validate the included field is a String field on the local entity types specified
-                        if !&entity_type
+                            // Validate the included field is a String field on the local entity types specified
+                            if !&entity_type
                             .fields
                             .iter()
                             .any(|field| {
@@ -771,316 +785,307 @@ mod validations {
                                 field_name.clone(),
                             )];
                         };
-                    }
-                }
-            }
-        }
-        // Fulltext include validations all passed, so we return an empty vector
-        vec![]
-    }
-
-    fn validate_fields(schema: &Schema) -> Vec<SchemaValidationError> {
-        let local_types = schema.document.get_object_and_interface_type_fields();
-        let local_enums = schema
-            .document
-            .get_enum_definitions()
-            .iter()
-            .map(|enu| enu.name.clone())
-            .collect::<Vec<String>>();
-        local_types
-            .iter()
-            .fold(vec![], |errors, (type_name, fields)| {
-                fields.iter().fold(errors, |mut errors, field| {
-                    let base = field.field_type.get_base_type();
-                    if ValueType::is_scalar(base) {
-                        return errors;
-                    }
-                    if local_types.contains_key(base) {
-                        return errors;
-                    }
-                    if local_enums.iter().any(|enu| enu.eq(base)) {
-                        return errors;
-                    }
-                    errors.push(SchemaValidationError::FieldTypeUnknown(
-                        type_name.to_string(),
-                        field.name.to_string(),
-                        base.to_string(),
-                    ));
-                    errors
-                })
-            })
-    }
-
-    /// 1. All object types besides `_Schema_` must have an id field
-    /// 2. The id field must be recognized by IdType
-    fn validate_id_types(schema: &Schema) -> Vec<SchemaValidationError> {
-        schema
-            .document
-            .get_object_type_definitions()
-            .into_iter()
-            .filter(|obj_type| obj_type.name.ne(SCHEMA_TYPE_NAME))
-            .fold(vec![], |mut errors, object_type| {
-                match object_type.field(&*ID) {
-                    None => errors.push(SchemaValidationError::IdFieldMissing(
-                        object_type.name.clone(),
-                    )),
-                    Some(_) => {
-                        if let Err(e) = IdType::try_from(object_type) {
-                            errors.push(SchemaValidationError::IllegalIdType(e.to_string()));
                         }
                     }
                 }
-                errors
-            })
-    }
-
-    /// Checks if the schema is using types that are reserved
-    /// by `graph-node`
-    fn validate_reserved_types_usage(schema: &Schema) -> Result<(), SchemaValidationError> {
-        let document = &schema.document;
-        let object_types: Vec<_> = document
-            .get_object_type_definitions()
-            .into_iter()
-            .map(|obj_type| &obj_type.name)
-            .collect();
-
-        let interface_types: Vec<_> = document
-            .get_interface_type_definitions()
-            .into_iter()
-            .map(|iface_type| &iface_type.name)
-            .collect();
-
-        // TYPE_NAME_filter types for all object and interface types
-        let mut filter_types: Vec<String> = object_types
-            .iter()
-            .chain(interface_types.iter())
-            .map(|type_name| format!("{}_filter", type_name))
-            .collect();
-
-        // TYPE_NAME_orderBy types for all object and interface types
-        let mut order_by_types: Vec<_> = object_types
-            .iter()
-            .chain(interface_types.iter())
-            .map(|type_name| format!("{}_orderBy", type_name))
-            .collect();
-
-        let mut reserved_types: Vec<String> = vec![
-            // The built-in scalar types
-            "Boolean".into(),
-            "ID".into(),
-            "Int".into(),
-            "BigDecimal".into(),
-            "String".into(),
-            "Bytes".into(),
-            "BigInt".into(),
-            // Reserved Query and Subscription types
-            "Query".into(),
-            "Subscription".into(),
-        ];
-
-        reserved_types.append(&mut filter_types);
-        reserved_types.append(&mut order_by_types);
-
-        // `reserved_types` will now only contain
-        // the reserved types that the given schema *is* using.
-        //
-        // That is, if the schema is compliant and not using any reserved
-        // types, then it'll become an empty vector
-        reserved_types.retain(|reserved_type| document.get_named_type(reserved_type).is_some());
-
-        if reserved_types.is_empty() {
-            Ok(())
-        } else {
-            Err(SchemaValidationError::UsageOfReservedTypes(Strings(
-                reserved_types,
-            )))
-        }
-    }
-
-    fn validate_schema_types(schema: &Schema) -> Result<(), SchemaValidationError> {
-        let types_without_entity_directive = schema
-            .document
-            .get_object_type_definitions()
-            .iter()
-            .filter(|t| t.find_directive("entity").is_none() && !t.name.eq(SCHEMA_TYPE_NAME))
-            .map(|t| t.name.clone())
-            .collect::<Vec<_>>();
-        if types_without_entity_directive.is_empty() {
-            Ok(())
-        } else {
-            Err(SchemaValidationError::EntityDirectivesMissing(Strings(
-                types_without_entity_directive,
-            )))
-        }
-    }
-
-    fn validate_derived_from(schema: &Schema) -> Result<(), SchemaValidationError> {
-        // Helper to construct a DerivedFromInvalid
-        fn invalid(
-            object_type: &s::ObjectType,
-            field_name: &str,
-            reason: &str,
-        ) -> SchemaValidationError {
-            SchemaValidationError::InvalidDerivedFrom(
-                object_type.name.clone(),
-                field_name.to_owned(),
-                reason.to_owned(),
-            )
+            }
+            // Fulltext include validations all passed, so we return an empty vector
+            vec![]
         }
 
-        let type_definitions = schema.document.get_object_type_definitions();
-        let object_and_interface_type_fields =
-            schema.document.get_object_and_interface_type_fields();
-
-        // Iterate over all derived fields in all entity types; include the
-        // interface types that the entity with the `@derivedFrom` implements
-        // and the `field` argument of @derivedFrom directive
-        for (object_type, interface_types, field, target_field) in type_definitions
-            .clone()
-            .iter()
-            .flat_map(|object_type| {
-                object_type
-                    .fields
-                    .iter()
-                    .map(move |field| (object_type, field))
-            })
-            .filter_map(|(object_type, field)| {
-                field.find_directive("derivedFrom").map(|directive| {
-                    (
-                        object_type,
-                        object_type
-                            .implements_interfaces
-                            .iter()
-                            .filter(|iface| {
-                                // Any interface that has `field` can be used
-                                // as the type of the field
-                                schema
-                                    .document
-                                    .find_interface(iface)
-                                    .map(|iface| {
-                                        iface
-                                            .fields
-                                            .iter()
-                                            .any(|ifield| ifield.name.eq(&field.name))
-                                    })
-                                    .unwrap_or(false)
-                            })
-                            .collect::<Vec<_>>(),
-                        field,
-                        directive.argument("field"),
-                    )
+        fn validate_fields(&self) -> Vec<SchemaValidationError> {
+            let local_types = self.schema.document.get_object_and_interface_type_fields();
+            let local_enums = self
+                .schema
+                .document
+                .get_enum_definitions()
+                .iter()
+                .map(|enu| enu.name.clone())
+                .collect::<Vec<String>>();
+            local_types
+                .iter()
+                .fold(vec![], |errors, (type_name, fields)| {
+                    fields.iter().fold(errors, |mut errors, field| {
+                        let base = field.field_type.get_base_type();
+                        if ValueType::is_scalar(base) {
+                            return errors;
+                        }
+                        if local_types.contains_key(base) {
+                            return errors;
+                        }
+                        if local_enums.iter().any(|enu| enu.eq(base)) {
+                            return errors;
+                        }
+                        errors.push(SchemaValidationError::FieldTypeUnknown(
+                            type_name.to_string(),
+                            field.name.to_string(),
+                            base.to_string(),
+                        ));
+                        errors
+                    })
                 })
-            })
-        {
-            // Turn `target_field` into the string name of the field
-            let target_field = target_field.ok_or_else(|| {
-                invalid(
-                    object_type,
-                    &field.name,
-                    "the @derivedFrom directive must have a `field` argument",
-                )
-            })?;
-            let target_field = match target_field {
-                s::Value::String(s) => s,
-                _ => {
-                    return Err(invalid(
-                        object_type,
-                        &field.name,
-                        "the @derivedFrom `field` argument must be a string",
-                    ))
-                }
-            };
+        }
 
-            // Check that the type we are deriving from exists
-            let target_type_name = field.field_type.get_base_type();
-            let target_fields = object_and_interface_type_fields
-                .get(target_type_name)
-                .ok_or_else(|| {
+        /// 1. All object types besides `_Schema_` must have an id field
+        /// 2. The id field must be recognized by IdType
+        fn validate_entity_type_ids(&self) -> Vec<SchemaValidationError> {
+            self.entity_types
+                .iter()
+                .fold(vec![], |mut errors, object_type| {
+                    match object_type.field(&*ID) {
+                        None => errors.push(SchemaValidationError::IdFieldMissing(
+                            object_type.name.clone(),
+                        )),
+                        Some(_) => {
+                            if let Err(e) = IdType::try_from(*object_type) {
+                                errors.push(SchemaValidationError::IllegalIdType(e.to_string()));
+                            }
+                        }
+                    }
+                    errors
+                })
+        }
+
+        /// Checks if the schema is using types that are reserved
+        /// by `graph-node`
+        fn validate_reserved_types_usage(&self) -> Result<(), SchemaValidationError> {
+            let document = &self.schema.document;
+            let object_types: Vec<_> = document
+                .get_object_type_definitions()
+                .into_iter()
+                .map(|obj_type| &obj_type.name)
+                .collect();
+
+            let interface_types: Vec<_> = document
+                .get_interface_type_definitions()
+                .into_iter()
+                .map(|iface_type| &iface_type.name)
+                .collect();
+
+            // TYPE_NAME_filter types for all object and interface types
+            let mut filter_types: Vec<String> = object_types
+                .iter()
+                .chain(interface_types.iter())
+                .map(|type_name| format!("{}_filter", type_name))
+                .collect();
+
+            // TYPE_NAME_orderBy types for all object and interface types
+            let mut order_by_types: Vec<_> = object_types
+                .iter()
+                .chain(interface_types.iter())
+                .map(|type_name| format!("{}_orderBy", type_name))
+                .collect();
+
+            let mut reserved_types: Vec<String> = vec![
+                // The built-in scalar types
+                "Boolean".into(),
+                "ID".into(),
+                "Int".into(),
+                "BigDecimal".into(),
+                "String".into(),
+                "Bytes".into(),
+                "BigInt".into(),
+                // Reserved Query and Subscription types
+                "Query".into(),
+                "Subscription".into(),
+            ];
+
+            reserved_types.append(&mut filter_types);
+            reserved_types.append(&mut order_by_types);
+
+            // `reserved_types` will now only contain
+            // the reserved types that the given schema *is* using.
+            //
+            // That is, if the schema is compliant and not using any reserved
+            // types, then it'll become an empty vector
+            reserved_types.retain(|reserved_type| document.get_named_type(reserved_type).is_some());
+
+            if reserved_types.is_empty() {
+                Ok(())
+            } else {
+                Err(SchemaValidationError::UsageOfReservedTypes(Strings(
+                    reserved_types,
+                )))
+            }
+        }
+
+        fn validate_no_extra_types(&self) -> Result<(), SchemaValidationError> {
+            let types_without_entity_directive = self
+                .schema
+                .document
+                .get_object_type_definitions()
+                .iter()
+                .filter(|t| t.find_directive("entity").is_none() && !t.name.eq(SCHEMA_TYPE_NAME))
+                .map(|t| t.name.clone())
+                .collect::<Vec<_>>();
+            if types_without_entity_directive.is_empty() {
+                Ok(())
+            } else {
+                Err(SchemaValidationError::EntityDirectivesMissing(Strings(
+                    types_without_entity_directive,
+                )))
+            }
+        }
+
+        fn validate_derived_from(&self) -> Result<(), SchemaValidationError> {
+            // Helper to construct a DerivedFromInvalid
+            fn invalid(
+                object_type: &s::ObjectType,
+                field_name: &str,
+                reason: &str,
+            ) -> SchemaValidationError {
+                SchemaValidationError::InvalidDerivedFrom(
+                    object_type.name.clone(),
+                    field_name.to_owned(),
+                    reason.to_owned(),
+                )
+            }
+
+            let object_and_interface_type_fields =
+                self.schema.document.get_object_and_interface_type_fields();
+
+            // Iterate over all derived fields in all entity types; include the
+            // interface types that the entity with the `@derivedFrom` implements
+            // and the `field` argument of @derivedFrom directive
+            for (object_type, interface_types, field, target_field) in self
+                .entity_types
+                .iter()
+                .flat_map(|object_type| {
+                    object_type
+                        .fields
+                        .iter()
+                        .map(move |field| (object_type, field))
+                })
+                .filter_map(|(object_type, field)| {
+                    field.find_directive("derivedFrom").map(|directive| {
+                        (
+                            object_type,
+                            object_type
+                                .implements_interfaces
+                                .iter()
+                                .filter(|iface| {
+                                    // Any interface that has `field` can be used
+                                    // as the type of the field
+                                    self.schema
+                                        .document
+                                        .find_interface(iface)
+                                        .map(|iface| {
+                                            iface
+                                                .fields
+                                                .iter()
+                                                .any(|ifield| ifield.name.eq(&field.name))
+                                        })
+                                        .unwrap_or(false)
+                                })
+                                .collect::<Vec<_>>(),
+                            field,
+                            directive.argument("field"),
+                        )
+                    })
+                })
+            {
+                // Turn `target_field` into the string name of the field
+                let target_field = target_field.ok_or_else(|| {
                     invalid(
                         object_type,
                         &field.name,
-                        "type must be an existing entity or interface",
+                        "the @derivedFrom directive must have a `field` argument",
                     )
                 })?;
+                let target_field = match target_field {
+                    s::Value::String(s) => s,
+                    _ => {
+                        return Err(invalid(
+                            object_type,
+                            &field.name,
+                            "the @derivedFrom `field` argument must be a string",
+                        ))
+                    }
+                };
 
-            // Check that the type we are deriving from has a field with the
-            // right name and type
-            let target_field = target_fields
-                .iter()
-                .find(|field| field.name.eq(target_field))
-                .ok_or_else(|| {
-                    let msg = format!(
-                        "field `{}` does not exist on type `{}`",
-                        target_field, target_type_name
-                    );
-                    invalid(object_type, &field.name, &msg)
-                })?;
+                // Check that the type we are deriving from exists
+                let target_type_name = field.field_type.get_base_type();
+                let target_fields = object_and_interface_type_fields
+                    .get(target_type_name)
+                    .ok_or_else(|| {
+                        invalid(
+                            object_type,
+                            &field.name,
+                            "type must be an existing entity or interface",
+                        )
+                    })?;
 
-            // The field we are deriving from has to point back to us; as an
-            // exception, we allow deriving from the `id` of another type.
-            // For that, we will wind up comparing the `id`s of the two types
-            // when we query, and just assume that that's ok.
-            let target_field_type = target_field.field_type.get_base_type();
-            if target_field_type != object_type.name
-                && &target_field.name != ID.as_str()
-                && !interface_types
+                // Check that the type we are deriving from has a field with the
+                // right name and type
+                let target_field = target_fields
                     .iter()
-                    .any(|iface| target_field_type.eq(iface.as_str()))
-            {
-                fn type_signatures(name: &str) -> Vec<String> {
-                    vec![
-                        format!("{}", name),
-                        format!("{}!", name),
-                        format!("[{}!]", name),
-                        format!("[{}!]!", name),
-                    ]
-                }
+                    .find(|field| field.name.eq(target_field))
+                    .ok_or_else(|| {
+                        let msg = format!(
+                            "field `{}` does not exist on type `{}`",
+                            target_field, target_type_name
+                        );
+                        invalid(object_type, &field.name, &msg)
+                    })?;
 
-                let mut valid_types = type_signatures(&object_type.name);
-                valid_types.extend(
-                    interface_types
+                // The field we are deriving from has to point back to us; as an
+                // exception, we allow deriving from the `id` of another type.
+                // For that, we will wind up comparing the `id`s of the two types
+                // when we query, and just assume that that's ok.
+                let target_field_type = target_field.field_type.get_base_type();
+                if target_field_type != object_type.name
+                    && &target_field.name != ID.as_str()
+                    && !interface_types
                         .iter()
-                        .flat_map(|iface| type_signatures(iface)),
-                );
-                let valid_types = valid_types.join(", ");
+                        .any(|iface| target_field_type.eq(iface.as_str()))
+                {
+                    fn type_signatures(name: &str) -> Vec<String> {
+                        vec![
+                            format!("{}", name),
+                            format!("{}!", name),
+                            format!("[{}!]", name),
+                            format!("[{}!]!", name),
+                        ]
+                    }
 
-                let msg = format!(
+                    let mut valid_types = type_signatures(&object_type.name);
+                    valid_types.extend(
+                        interface_types
+                            .iter()
+                            .flat_map(|iface| type_signatures(iface)),
+                    );
+                    let valid_types = valid_types.join(", ");
+
+                    let msg = format!(
                     "field `{tf}` on type `{tt}` must have one of the following types: {valid_types}",
                     tf = target_field.name,
                     tt = target_type_name,
                     valid_types = valid_types,
                 );
-                return Err(invalid(object_type, &field.name, &msg));
+                    return Err(invalid(object_type, &field.name, &msg));
+                }
             }
+            Ok(())
         }
-        Ok(())
-    }
 
-    fn validate_interface_id_type(schema: &Schema) -> Result<(), SchemaValidationError> {
-        for (intf, obj_types) in &schema.types_for_interface {
-            let id_types: HashSet<&str> = HashSet::from_iter(
-                obj_types
-                    .iter()
-                    .filter_map(|obj_type| obj_type.field(&*ID))
-                    .map(|f| f.field_type.get_base_type())
-                    .map(|name| if name == "ID" { "String" } else { name }),
-            );
-            if id_types.len() > 1 {
-                return Err(SchemaValidationError::InterfaceImplementorsMixId(
-                    intf.to_string(),
-                    id_types.iter().join(", "),
-                ));
+        fn validate_interface_id_type(&self) -> Result<(), SchemaValidationError> {
+            for (intf, obj_types) in &self.schema.types_for_interface {
+                let id_types: HashSet<&str> = HashSet::from_iter(
+                    obj_types
+                        .iter()
+                        .filter_map(|obj_type| obj_type.field(&*ID))
+                        .map(|f| f.field_type.get_base_type())
+                        .map(|name| if name == "ID" { "String" } else { name }),
+                );
+                if id_types.len() > 1 {
+                    return Err(SchemaValidationError::InterfaceImplementorsMixId(
+                        intf.to_string(),
+                        id_types.iter().join(", "),
+                    ));
+                }
             }
+            Ok(())
         }
-        Ok(())
-    }
-
-    fn subgraph_schema_object_type(schema: &Schema) -> Option<&s::ObjectType> {
-        schema
-            .document
-            .get_object_type_definitions()
-            .into_iter()
-            .find(|object_type| object_type.name.eq(SCHEMA_TYPE_NAME))
     }
 
     #[cfg(test)]
@@ -1089,9 +1094,9 @@ mod validations {
 
         use super::*;
 
-        fn parse(schema: &str) -> Schema {
+        fn parse(schema: &str) -> BaseSchema {
             let hash = DeploymentHash::new("test").unwrap();
-            Schema::parse(schema, hash).unwrap()
+            BaseSchema::parse(schema, hash).unwrap()
         }
 
         #[test]
@@ -1136,7 +1141,8 @@ mod validations {
                 x: Int
             }}"
                 );
-                let schema = Schema::parse(&schema, DeploymentHash::new("dummy").unwrap()).unwrap();
+                let schema =
+                    BaseSchema::parse(&schema, DeploymentHash::new("dummy").unwrap()).unwrap();
                 let res = validate(&schema);
                 if ok {
                     assert!(matches!(res, Ok(_)));
@@ -1176,8 +1182,9 @@ type Account implements Address @entity { id: ID!, txn: Transaction! @derivedFro
                 let document = graphql_parser::parse_schema(&raw)
                     .expect("Failed to parse raw schema")
                     .into_static();
-                let schema = Schema::new(DeploymentHash::new("id").unwrap(), document).unwrap();
-                match validate_derived_from(&schema) {
+                let schema = BaseSchema::new(DeploymentHash::new("id").unwrap(), document).unwrap();
+                let schema = Schema::new(&schema);
+                match schema.validate_derived_from() {
                     Err(ref e) => match e {
                         SchemaValidationError::InvalidDerivedFrom(_, _, msg) => {
                             assert_eq!(errmsg, msg)
@@ -1231,9 +1238,10 @@ type _Schema_ { id: ID! }";
 
             let document =
                 graphql_parser::parse_schema(ROOT_SCHEMA).expect("Failed to parse root schema");
-            let schema = Schema::new(DeploymentHash::new("id").unwrap(), document).unwrap();
+            let schema = BaseSchema::new(DeploymentHash::new("id").unwrap(), document).unwrap();
+            let schema = Schema::new(&schema);
             assert_eq!(
-                validate_schema_type_has_no_fields(&schema).expect_err(
+                schema.validate_schema_type_has_no_fields().expect_err(
                     "Expected validation to fail due to fields defined on the reserved type"
                 ),
                 SchemaValidationError::SchemaTypeWithFields
@@ -1247,9 +1255,10 @@ type _Schema_ @illegal";
 
             let document =
                 graphql_parser::parse_schema(ROOT_SCHEMA).expect("Failed to parse root schema");
-            let schema = Schema::new(DeploymentHash::new("id").unwrap(), document).unwrap();
+            let schema = BaseSchema::new(DeploymentHash::new("id").unwrap(), document).unwrap();
+            let schema = Schema::new(&schema);
             assert_eq!(
-                validate_directives_on_schema_type(&schema).expect_err(
+                schema.validate_directives_on_schema_type().expect_err(
                     "Expected validation to fail due to extra imports defined on the reserved type"
                 ),
                 SchemaValidationError::InvalidSchemaTypeDirectives
@@ -1271,8 +1280,9 @@ type A @entity {
 
             let document =
                 graphql_parser::parse_schema(ROOT_SCHEMA).expect("Failed to parse root schema");
-            let schema = Schema::new(DeploymentHash::new("id").unwrap(), document).unwrap();
-            assert_eq!(validate_fields(&schema).len(), 0);
+            let schema = BaseSchema::new(DeploymentHash::new("id").unwrap(), document).unwrap();
+            let schema = Schema::new(&schema);
+            assert_eq!(schema.validate_fields().len(), 0);
         }
 
         #[test]
@@ -1299,7 +1309,7 @@ type A @entity {
                     reserved_type
                 );
 
-                let schema = Schema::parse(&schema, dummy_hash.clone()).unwrap();
+                let schema = BaseSchema::parse(&schema, dummy_hash.clone()).unwrap();
 
                 let errors = validate(&schema).unwrap_err();
                 for error in errors {
@@ -1330,7 +1340,7 @@ type A @entity {
 
             let dummy_hash = DeploymentHash::new("dummy").unwrap();
 
-            let schema = Schema::parse(SCHEMA, dummy_hash).unwrap();
+            let schema = BaseSchema::parse(SCHEMA, dummy_hash).unwrap();
 
             let errors = validate(&schema).unwrap_err();
 
@@ -1378,9 +1388,9 @@ type Gravatar @entity {
 }"#;
 
             let document = graphql_parser::parse_schema(SCHEMA).expect("Failed to parse schema");
-            let schema = Schema::new(DeploymentHash::new("id1").unwrap(), document).unwrap();
-
-            assert_eq!(validate_fulltext_directives(&schema), vec![]);
+            let schema = BaseSchema::new(DeploymentHash::new("id1").unwrap(), document).unwrap();
+            let schema = Schema::new(&schema);
+            assert_eq!(schema.validate_fulltext_directives(), vec![]);
         }
     }
 }

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -15,7 +15,7 @@ use crate::data::store::{
 use crate::data::value::Word;
 use crate::prelude::q::Value;
 use crate::prelude::{s, DeploymentHash};
-use crate::schema::api_schema;
+use crate::schema::api::api_schema;
 use crate::util::intern::{Atom, AtomPool};
 
 use super::fulltext::FulltextDefinition;

--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -28,7 +28,7 @@ pub use api::{ApiSchema, ErrorPolicy};
 pub use entity_key::EntityKey;
 pub use entity_type::{AsEntityTypeName, EntityType};
 pub use fulltext::{FulltextAlgorithm, FulltextConfig, FulltextDefinition, FulltextLanguage};
-pub use input_schema::InputSchema;
+pub use input_schema::{Field, InputSchema, InterfaceType, ObjectType};
 
 pub const SCHEMA_TYPE_NAME: &str = "_Schema_";
 pub const INTROSPECTION_SCHEMA_FIELD_NAME: &str = "__schema";

--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -22,7 +22,7 @@ mod entity_type;
 mod fulltext;
 mod input_schema;
 
-pub use api::{api_schema, is_introspection_field, APISchemaError, INTROSPECTION_QUERY_TYPE};
+pub use api::{is_introspection_field, APISchemaError, INTROSPECTION_QUERY_TYPE};
 
 pub use api::{ApiSchema, ErrorPolicy};
 pub use entity_key::EntityKey;

--- a/graphql/examples/schema.rs
+++ b/graphql/examples/schema.rs
@@ -1,9 +1,8 @@
-use graphql_parser::parse_schema;
+use graph::prelude::DeploymentHash;
+use graph::schema::InputSchema;
 use std::env;
 use std::fs;
 use std::process::exit;
-
-use graph::schema::api_schema;
 
 pub fn usage(msg: &str) -> ! {
     println!("{}", msg);
@@ -30,11 +29,9 @@ pub fn main() {
         _ => usage("too many arguments"),
     };
     let schema = ensure(fs::read_to_string(schema), "Can not read schema file");
-    let schema = ensure(
-        parse_schema(&schema).map(|v| v.into_static()),
-        "Failed to parse schema",
-    );
-    let schema = ensure(api_schema(&schema), "Failed to convert to API schema");
+    let id = DeploymentHash::new("unknown").unwrap();
+    let schema = ensure(InputSchema::parse(&schema, id), "Failed to parse schema");
+    let schema = ensure(schema.api_schema(), "Failed to convert to API schema");
 
-    println!("{}", schema);
+    println!("{}", schema.schema().document);
 }

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -799,7 +799,7 @@ mod tests {
             s::{self, Directive, Field, InputValue, ObjectType, Type, Value as SchemaValue},
             EntityOrder,
         },
-        schema::{ApiSchema, InputSchema, Schema},
+        schema::InputSchema,
     };
     use graphql_parser::Pos;
     use std::{collections::BTreeMap, iter::FromIterator, sync::Arc};
@@ -900,19 +900,6 @@ mod tests {
     }
 
     fn build_default_schema() -> SchemaPair {
-        // These schemas are somewhat nonsensical and just good enough to
-        // run the tests. The `API_SCHEMA` does not look like anything that
-        // would be generated from the `INPUT_SCHEMA`
-        const API_SCHEMA: &str = r#"
-        type Query {
-            aField(first: Int, skip: Int): [SomeType]
-        }
-
-        type SomeType @entity {
-            id: ID!
-            name: String!
-        }
-    "#;
         const INPUT_SCHEMA: &str = r#"
         type Entity1 @entity { id: ID! }
         type Entity2 @entity { id: ID! }
@@ -925,11 +912,7 @@ mod tests {
 
         let id = DeploymentHash::new("id").unwrap();
         let input_schema = InputSchema::parse(INPUT_SCHEMA, id.clone()).unwrap();
-        let api_schema = graphql_parser::parse_schema(API_SCHEMA)
-            .expect("Failed to parse raw schema")
-            .into_static();
-        let api_schema = Schema::new(id, api_schema).unwrap();
-        let api_schema = ApiSchema::from_graphql_schema(api_schema).unwrap();
+        let api_schema = input_schema.api_schema().unwrap();
 
         SchemaPair {
             input: input_schema,

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -27,7 +27,6 @@ use lru_time_cache::LruCache;
 use rand::{seq::SliceRandom, thread_rng};
 use std::collections::{BTreeMap, HashMap};
 use std::convert::Into;
-use std::iter::FromIterator;
 use std::ops::Bound;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -289,18 +288,8 @@ impl DeploymentStore {
         // if that's Fred the Dog, Fred the Cat or both.
         //
         // This assumes that there are no concurrent writes to a subgraph.
-        let schema = self.subgraph_info_with_conn(conn, &layout.site)?.input;
         let entity_type_str = entity_type.to_string();
-        let types_with_shared_interface = Vec::from_iter(
-            schema
-                .interfaces_for_type(entity_type.as_str())
-                .into_iter()
-                .flatten()
-                .flat_map(|interface| schema.types_for_interface(interface))
-                .flatten()
-                .map(|object_type| schema.entity_type(object_type).unwrap())
-                .filter(|type_name| type_name != entity_type),
-        );
+        let types_with_shared_interface = entity_type.share_interfaces()?;
 
         if !types_with_shared_interface.is_empty() {
             if let Some(conflicting_entity) =

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1009,7 +1009,7 @@ impl ColumnType {
         id_types: &IdTypeMap,
         is_existing_text_column: bool,
     ) -> Result<ColumnType, StoreError> {
-        let name = named_type(field_type);
+        let name = field_type.get_base_type();
 
         // See if its an object type defined in the schema
         if let Some(id_type) = schema
@@ -1193,7 +1193,7 @@ impl Column {
     }
 
     pub fn is_fulltext(&self) -> bool {
-        named_type(&self.field_type) == "fulltext"
+        self.field_type.get_base_type() == "fulltext"
     }
 
     pub fn is_reference(&self) -> bool {
@@ -1394,18 +1394,8 @@ impl Table {
     }
 }
 
-/// Return the enclosed named type for a field type, i.e., the type after
-/// stripping List and NonNull.
-fn named_type(field_type: &q::Type) -> &str {
-    match field_type {
-        q::Type::NamedType(name) => name.as_str(),
-        q::Type::ListType(child) => named_type(child),
-        q::Type::NonNullType(child) => named_type(child),
-    }
-}
-
 fn is_object_type(field_type: &q::Type, enums: &EnumMap) -> bool {
-    let name = named_type(field_type);
+    let name = field_type.get_base_type();
 
     !enums.contains_key(name) && !ValueType::is_scalar(name)
 }

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -783,7 +783,6 @@ impl Layout {
             let removed = RevertRemoveQuery::new(table, block)
                 .get_results(conn)?
                 .into_iter()
-                .map(|data| data.id)
                 .collect::<HashSet<_>>();
             // Make the versions current that existed at `block - 1` but that
             // are not current yet. Those are the ones that were updated or
@@ -794,7 +793,6 @@ impl Layout {
                 RevertClampQuery::new(table, block - 1)?
                     .get_results(conn)?
                     .into_iter()
-                    .map(|data| data.id)
                     .collect::<HashSet<_>>()
             };
             // Adjust the entity count; we can tell which operation was

--- a/store/postgres/src/relational/ddl.rs
+++ b/store/postgres/src/relational/ddl.rs
@@ -45,9 +45,10 @@ impl Layout {
     }
 
     pub(crate) fn write_enum_ddl(&self, out: &mut dyn Write) -> Result<(), fmt::Error> {
-        for (name, values) in &self.enums {
+        for name in self.input_schema.enum_types() {
+            let values = self.input_schema.enum_values(name).unwrap();
             let mut sep = "";
-            let name = SqlName::from(name.as_str());
+            let name = SqlName::from(name);
             write!(
                 out,
                 "create type {}.{}\n    as enum (",

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -741,19 +741,17 @@ fn scoped_get() {
 fn no_internal_keys() {
     run_store_test(|mut cache, _, _, writable| async move {
         #[track_caller]
-        fn check(schema: &InputSchema, key: &EntityKey, entity: &Entity) {
+        fn check(key: &EntityKey, entity: &Entity) {
             // Validate checks that all attributes are actually declared in
             // the schema
-            entity.validate(schema, key).expect("the entity is valid");
+            entity.validate(key).expect("the entity is valid");
         }
         let key = WALLET_TYPE.parse_key("1").unwrap();
 
-        let schema = cache.schema.cheap_clone();
-
         let wallet = writable.get(&key).unwrap().unwrap();
-        check(&schema, &key, &wallet);
+        check(&key, &wallet);
 
         let wallet = cache.get(&key, GetScope::Store).unwrap().unwrap();
-        check(&schema, &key, &wallet);
+        check(&key, &wallet);
     });
 }

--- a/store/test-store/tests/graphql/introspection.rs
+++ b/store/test-store/tests/graphql/introspection.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use graph::components::store::QueryPermit;
-use graph::data::graphql::{object, object_value, ObjectOrInterface};
+use graph::data::graphql::{object_value, ObjectOrInterface};
 use graph::data::query::Trace;
 use graph::prelude::{
     async_trait, o, r, s, serde_json, slog, tokio, DeploymentHash, Logger, Query,

--- a/store/test-store/tests/graphql/mock_introspection.json
+++ b/store/test-store/tests/graphql/mock_introspection.json
@@ -1,0 +1,1847 @@
+{
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": null,
+      "subscriptionType": {
+        "name": "Subscription"
+      },
+      "types": [
+        {
+          "kind": "SCALAR",
+          "name": "BigDecimal",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "BigInt",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "BlockChangedFilter",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "number_gte",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "Block_height",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "hash",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Bytes",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "number",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "number_gte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Bytes",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "4 bytes signed integer\n",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int8",
+          "description": "8 bytes signed integer\n",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Node",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "Node_filter",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_not",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_gt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_lt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_gte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_lte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_in",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_not_in",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "_change_block",
+              "description": "Filter for the block changed event.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BlockChangedFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "and",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Node_filter",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "or",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Node_filter",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "Node_orderBy",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "id",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "OrderDirection",
+          "description": "Defines the order direction, either ascending or descending",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "asc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "desc",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": null,
+          "fields": [
+            {
+              "name": "user",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "block",
+                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Block_height",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "subgraphError",
+                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "_SubgraphErrorPolicy_",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "deny"
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "users",
+              "description": null,
+              "args": [
+                {
+                  "name": "skip",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "0"
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "100"
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "User_orderBy",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderDirection",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "OrderDirection",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "User_filter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "block",
+                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Block_height",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "subgraphError",
+                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "_SubgraphErrorPolicy_",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "deny"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "User",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "block",
+                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Block_height",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "subgraphError",
+                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "_SubgraphErrorPolicy_",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "deny"
+                }
+              ],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Node",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": null,
+              "args": [
+                {
+                  "name": "skip",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "0"
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "100"
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "Node_orderBy",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderDirection",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "OrderDirection",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Node_filter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "block",
+                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Block_height",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "subgraphError",
+                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "_SubgraphErrorPolicy_",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "deny"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INTERFACE",
+                      "name": "Node",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "_meta",
+              "description": "Access to subgraph metadata",
+              "args": [
+                {
+                  "name": "block",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Block_height",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "_Meta_",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "Role",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "USER",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ADMIN",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Subscription",
+          "description": null,
+          "fields": [
+            {
+              "name": "user",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "block",
+                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Block_height",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "subgraphError",
+                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "_SubgraphErrorPolicy_",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "deny"
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "users",
+              "description": null,
+              "args": [
+                {
+                  "name": "skip",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "0"
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "100"
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "User_orderBy",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderDirection",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "OrderDirection",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "User_filter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "block",
+                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Block_height",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "subgraphError",
+                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "_SubgraphErrorPolicy_",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "deny"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "User",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "block",
+                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Block_height",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "subgraphError",
+                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "_SubgraphErrorPolicy_",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "deny"
+                }
+              ],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Node",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": null,
+              "args": [
+                {
+                  "name": "skip",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "0"
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": "100"
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "Node_orderBy",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderDirection",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "OrderDirection",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Node_filter",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "block",
+                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Block_height",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "subgraphError",
+                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "_SubgraphErrorPolicy_",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "deny"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INTERFACE",
+                      "name": "Node",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "_meta",
+              "description": "Access to subgraph metadata",
+              "args": [
+                {
+                  "name": "block",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Block_height",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "_Meta_",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "User",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Role",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "User_filter",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_not",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_gt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_lt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_gte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_lte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_in",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id_not_in",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_not",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_gt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_lt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_gte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_lte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_in",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_not_in",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_contains",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_contains_nocase",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_not_contains",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_not_contains_nocase",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_starts_with",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_starts_with_nocase",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_not_starts_with",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_not_starts_with_nocase",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_ends_with",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_ends_with_nocase",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_not_ends_with",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name_not_ends_with_nocase",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "role",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "Role",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "role_not",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "Role",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "role_in",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "Role",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "role_not_in",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "Role",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "_change_block",
+              "description": "Filter for the block changed event.",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BlockChangedFilter",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "and",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "User_filter",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "or",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "User_filter",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "User_orderBy",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "id",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "_Block_",
+          "description": null,
+          "fields": [
+            {
+              "name": "hash",
+              "description": "The hash of the block",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Bytes",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "number",
+              "description": "The block number",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "timestamp",
+              "description": "Integer representation of the timestamp stored in blocks for the chain",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "_Meta_",
+          "description": "The type for the top-level _meta field",
+          "fields": [
+            {
+              "name": "block",
+              "description": "Information about a specific subgraph block. The hash of the block\nwill be null if the _meta field has a block constraint that asks for\na block number. It will be filled if the _meta field has no block constraint\nand therefore asks for the latest  block\n",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "_Block_",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deployment",
+              "description": "The deployment ID",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasIndexingErrors",
+              "description": "If `true`, the subgraph encountered indexing errors at some past block",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "_SubgraphErrorPolicy_",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "allow",
+              "description": "Data will be returned even if the subgraph has indexing errors",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deny",
+              "description": "If the subgraph has indexing errors, data will be omitted. The default.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "language",
+          "description": null,
+          "locations": [
+            "FIELD_DEFINITION"
+          ],
+          "args": [
+            {
+              "name": "language",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"English\""
+            }
+          ]
+        },
+        {
+          "name": "skip",
+          "description": null,
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "include",
+          "description": null,
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "entity",
+          "description": "Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive.",
+          "locations": [
+            "OBJECT"
+          ],
+          "args": []
+        },
+        {
+          "name": "subgraphId",
+          "description": "Defined a Subgraph ID for an object type",
+          "locations": [
+            "OBJECT"
+          ],
+          "args": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "derivedFrom",
+          "description": "creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API.",
+          "locations": [
+            "FIELD_DEFINITION"
+          ],
+          "args": [
+            {
+              "name": "field",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
This is all groundwork for aggregations; in an effort to not produce a gigantic PR, I am putting up somewhat smaller ones. The biggest change this PR introduces is our own structs for object and interface type that are easier/saner to work with than the raw GraphQL AST