### PR TITLE
fix(logs): Fix for ElasticSearch 8.X

### DIFF
--- a/graph/src/log/elastic.rs
+++ b/graph/src/log/elastic.rs
@@ -139,8 +139,6 @@ pub struct ElasticDrainConfig {
     pub general: ElasticLoggingConfig,
     /// The Elasticsearch index to log to.
     pub index: String,
-    /// The Elasticsearch type to use for logs.
-    pub document_type: String,
     /// The name of the custom object id that the drain is for.
     pub custom_id_key: String,
     /// The custom id for the object that the drain is for.
@@ -156,8 +154,7 @@ pub struct ElasticDrainConfig {
 /// Writes logs to Elasticsearch using the following format:
 /// ```ignore
 /// {
-///   "_index": "subgraph-logs"
-///   "_type": "log",
+///   "_index": "subgraph-logs",
 ///   "_id": "Qmb31zcpzqga7ERaUTp83gVdYcuBasz4rXUHFufikFTJGU-2018-11-08T00:54:52.589258000Z",
 ///   "_source": {
 ///     "level": "debug",
@@ -245,7 +242,6 @@ impl ElasticDrain {
                             let action_line = json!({
                                 "index": {
                                     "_index": config.index,
-                                    "_type": config.document_type,
                                     "_id": log.id,
                                 }
                             })

--- a/graph/src/log/factory.rs
+++ b/graph/src/log/factory.rs
@@ -72,7 +72,6 @@ impl LoggerFactory {
                                 ElasticDrainConfig {
                                     general: elastic_config,
                                     index: config.index,
-                                    document_type: String::from("log"),
                                     custom_id_key: String::from("componentId"),
                                     custom_id_value: component.to_string(),
                                     flush_interval: ENV_VARS.elastic_search_flush_interval,
@@ -103,7 +102,6 @@ impl LoggerFactory {
                         ElasticDrainConfig {
                             general: elastic_config,
                             index: String::from("subgraph-logs"),
-                            document_type: String::from("log"),
                             custom_id_key: String::from("subgraphId"),
                             custom_id_value: loc.hash.to_string(),
                             flush_interval: ENV_VARS.elastic_search_flush_interval,


### PR DESCRIPTION
ElasticSearch has dropped support for the `_type` field