### PR TITLE
graph, graphql, store: Coerce Int8 values to ints

### DIFF
--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -518,7 +518,7 @@ impl From<Value> for r::Value {
         match value {
             Value::String(s) => r::Value::String(s),
             Value::Int(i) => r::Value::Int(i as i64),
-            Value::Int8(i) => r::Value::String(i.to_string()),
+            Value::Int8(i) => r::Value::Int(i),
             Value::BigDecimal(d) => r::Value::String(d.to_string()),
             Value::Bool(b) => r::Value::Boolean(b),
             Value::Null => r::Value::Null,

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -348,8 +348,11 @@ impl Value {
                     Err(Value::Int(num))
                 }
             }
-            ("Int8", Value::Int(num)) => Ok(Value::String(num.to_string())),
-            ("Int8", Value::String(num)) => Ok(Value::String(num)),
+            ("Int8", Value::Int(num)) => Ok(Value::Int(num)),
+            ("Int8", Value::String(num)) => match num.parse::<i64>() {
+                Ok(num) => Ok(Value::Int(num)),
+                Err(_) => Err(Value::String(num)),
+            },
             ("String", Value::String(s)) => Ok(Value::String(s)),
             ("ID", Value::String(s)) => Ok(Value::String(s)),
             ("ID", Value::Int(n)) => Ok(Value::String(n.to_string())),

--- a/graphql/src/values/coercion.rs
+++ b/graphql/src/values/coercion.rs
@@ -406,11 +406,11 @@ mod tests {
 
         assert_eq!(
             coerce_to_definition(Value::Int(1234.into()), "", &resolver),
-            Ok(Value::String("1234".to_string()))
+            Ok(Value::Int(1234))
         );
         assert_eq!(
             coerce_to_definition(Value::Int((-1234_i32).into()), "", &resolver,),
-            Ok(Value::String("-1234".to_string()))
+            Ok(Value::Int(-1234))
         );
     }
 

--- a/store/test-store/tests/graphql/query.rs
+++ b/store/test-store/tests/graphql/query.rs
@@ -722,10 +722,10 @@ fn can_query_one_to_one_relationship() {
         let s = id_type.songs();
         let exp = object! {
             musicians: vec![
-                object! { name: "John", mainBand: object! { name: "The Musicians" }, favoriteCount: "10" },
-                object! { name: "Lisa", mainBand: object! { name: "The Musicians" }, favoriteCount: "100" },
-                object! { name: "Tom",  mainBand: object! { name: "The Amateurs" }, favoriteCount: "5" },
-                object! { name: "Valerie", mainBand: r::Value::Null, favoriteCount: "20" }
+                object! { name: "John", mainBand: object! { name: "The Musicians" }, favoriteCount: 10 },
+                object! { name: "Lisa", mainBand: object! { name: "The Musicians" }, favoriteCount: 100 },
+                object! { name: "Tom",  mainBand: object! { name: "The Amateurs" }, favoriteCount: 5 },
+                object! { name: "Valerie", mainBand: r::Value::Null, favoriteCount: 20 }
             ],
             songStats: vec![
                 object! {


### PR DESCRIPTION
Previously, they were coerced to strings which ultimately leads to errors when lists of int8 are used in queries

@dotansimha Do you remember why `Int8` was initially coerced into `String` in a lot of places? The whole topic of coercion is really confusing to me; part of it is because the `Value` of `graphql-parser` can't represent all the values we deal with internally (like bytes or int4 vs int8) and so you are forever trying to figure out if a string is really a string or whether it's a byte array. The other part is that coercion happens all over the place and it's really hard to draw a line between 'here we are dealing with values that have fairly random types and aren't checked yet' vs 'these values have been properly checked and express the proper type'. I wonder if we should expand the `r::Value` type to faithfully represent all value types, and take the conversion from `q::Value` to `r::Value` as the point where we go from unchecked to checked.