### PR TITLE
graph: Exclude Self from ObjectType.share_interfaces()

### DIFF
--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -117,7 +117,8 @@ impl EntityType {
     }
 
     /// Return a list of all entity types that implement one of the
-    /// interfaces that `self` implements
+    /// interfaces that `self` implements; the result does not include
+    /// `self`
     pub fn share_interfaces(&self) -> Result<Vec<EntityType>, Error> {
         self.schema.share_interfaces(self.atom)
     }


### PR DESCRIPTION
The conflicting entity check in DeploymentStore expects that the type itself is not in the list of types that share an interface; if it is, the check causes spurious failures when entities are updated.

