### PR TITLE
fix ethereum codec: should not be checking block header parent with all 0s

### DIFF
--- a/chain/ethereum/src/codec.rs
+++ b/chain/ethereum/src/codec.rs
@@ -395,6 +395,7 @@ impl BlockHeader {
     pub fn parent_ptr(&self) -> Option<BlockPtr> {
         match self.parent_hash.len() {
             0 => None,
+            _ if self.parent_hash.iter().all(|x| *x == 0) => None,
             _ => Some(BlockPtr::from((
                 H256::from_slice(self.parent_hash.as_ref()),
                 self.number - 1,


### PR DESCRIPTION
When checking the block parent header, ignore header with 32 * [0] (it is actually not length 0 when on genesis block)
This could panic if the head block of the chain happens to be the genesis, ex: on a local dev chain