### PR TITLE
metrics: Add metric for query blocks behind

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -57,6 +57,9 @@ the **maximum size of a query result** (in CacheWeight)
 the **size of the result of successful GraphQL queries** (in CacheWeight)
 - `query_semaphore_wait_ms`
 Moving **average of time spent on waiting for postgres query semaphore**
+- `query_blocks_behind`
+A histogram for how many blocks behind the subgraph head queries are being made at.
+This helps inform pruning decisions.
 - `query_kill_rate`
 The rate at which the load manager kills queries
 - `registered_metrics`

--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -49,4 +49,5 @@ pub trait GraphQLMetrics: Send + Sync + 'static {
     fn observe_query_parsing(&self, duration: Duration, results: &QueryResults);
     fn observe_query_validation(&self, duration: Duration, id: &DeploymentHash);
     fn observe_query_validation_error(&self, error_codes: Vec<&str>, id: &DeploymentHash);
+    fn observe_query_blocks_behind(&self, blocks_behind: i32, id: &DeploymentHash);
 }

--- a/server/http/src/service.rs
+++ b/server/http/src/service.rs
@@ -488,6 +488,7 @@ mod tests {
         fn observe_query_parsing(&self, _duration: Duration, _results: &QueryResults) {}
         fn observe_query_validation(&self, _duration: Duration, _id: &DeploymentHash) {}
         fn observe_query_validation_error(&self, _error_codes: Vec<&str>, _id: &DeploymentHash) {}
+        fn observe_query_blocks_behind(&self, _blocks_behind: i32, _id: &DeploymentHash) {}
     }
 
     #[async_trait]

--- a/server/http/tests/server.rs
+++ b/server/http/tests/server.rs
@@ -20,6 +20,7 @@ impl GraphQLMetrics for TestGraphQLMetrics {
     fn observe_query_parsing(&self, _duration: Duration, _results: &QueryResults) {}
     fn observe_query_validation(&self, _duration: Duration, _id: &DeploymentHash) {}
     fn observe_query_validation_error(&self, _error_codes: Vec<&str>, _id: &DeploymentHash) {}
+    fn observe_query_blocks_behind(&self, _blocks_behind: i32, _id: &DeploymentHash) {}
 }
 
 /// A simple stupid query runner for testing.

--- a/server/index-node/src/service.rs
+++ b/server/index-node/src/service.rs
@@ -28,6 +28,7 @@ impl GraphQLMetrics for NoopGraphQLMetrics {
     fn observe_query_parsing(&self, _duration: Duration, _results: &QueryResults) {}
     fn observe_query_validation(&self, _duration: Duration, _id: &DeploymentHash) {}
     fn observe_query_validation_error(&self, _error_codes: Vec<&str>, _id: &DeploymentHash) {}
+    fn observe_query_blocks_behind(&self, _blocks_behind: i32, _id: &DeploymentHash) {}
 }
 
 /// An asynchronous response to a GraphQL request.


### PR DESCRIPTION
A small thing but should be great help for pruning decisions. Note that this will not record for queries that are refused due to being behind the minimum block, so there is a bit of "survivorship bias".