### PR TITLE
Fix an issue with API schema generation for interfaces

### DIFF
--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -485,7 +485,7 @@ impl InputSchema {
     /// `InputSchema`
     pub fn api_schema(&self) -> Result<ApiSchema, anyhow::Error> {
         let mut schema = self.inner.schema.clone();
-        schema.document = api_schema(&self.inner.schema.document)?;
+        schema.document = api_schema(&self.inner.schema)?;
         schema.add_subgraph_id_directives(schema.id.clone());
         ApiSchema::from_api_schema(schema)
     }


### PR DESCRIPTION
The code that determined the id type of an interface was completely wrong, and panicked to boot.

In general, the API schema generation code needs a good rewrite as it's a complete mess of hard-to-follow navigation of a raw GraphQL AST when it should make use of the more accessible information in `InputSchema`