### PR TITLE
Add some tests for the recent blocks cache

### DIFF
--- a/store/test-store/src/block_store.rs
+++ b/store/test-store/src/block_store.rs
@@ -159,19 +159,20 @@ impl BlockchainBlock for FakeBlock {
     }
 }
 
-pub type FakeBlockList<'a> = Vec<&'static FakeBlock>;
+pub type FakeBlockList = Vec<&'static FakeBlock>;
 
 /// Store the given chain as the blocks for the `network` set the
 /// network's genesis block to `genesis_hash`, and head block to
 /// `null`
-pub fn set_chain(chain: FakeBlockList, network: &str) {
+pub async fn set_chain(chain: FakeBlockList, network: &str) {
     let store = crate::store::STORE
         .block_store()
         .chain_store(network)
         .unwrap();
-    let chain: Vec<&dyn BlockchainBlock> = chain
+    let chain: Vec<Arc<dyn BlockchainBlock>> = chain
         .iter()
-        .map(|block| *block as &dyn BlockchainBlock)
+        .cloned()
+        .map(|block| Arc::new(block.clone()) as Arc<dyn BlockchainBlock>)
         .collect();
-    store.set_chain(&GENESIS_BLOCK.hash, chain);
+    store.set_chain(&GENESIS_BLOCK.hash, chain).await;
 }

--- a/store/test-store/src/block_store.rs
+++ b/store/test-store/src/block_store.rs
@@ -164,7 +164,7 @@ pub type FakeBlockList = Vec<&'static FakeBlock>;
 /// Store the given chain as the blocks for the `network` set the
 /// network's genesis block to `genesis_hash`, and head block to
 /// `null`
-pub async fn set_chain(chain: FakeBlockList, network: &str) {
+pub async fn set_chain(chain: FakeBlockList, network: &str) -> Vec<(BlockPtr, BlockHash)> {
     let store = crate::store::STORE
         .block_store()
         .chain_store(network)
@@ -174,5 +174,5 @@ pub async fn set_chain(chain: FakeBlockList, network: &str) {
         .cloned()
         .map(|block| Arc::new(block.clone()) as Arc<dyn BlockchainBlock>)
         .collect();
-    store.set_chain(&GENESIS_BLOCK.hash, chain).await;
+    store.set_chain(&GENESIS_BLOCK.hash, chain).await
 }

--- a/store/test-store/tests/graphql/query.rs
+++ b/store/test-store/tests/graphql/query.rs
@@ -177,13 +177,13 @@ async fn setup(
     use test_store::block_store::{self, BLOCK_ONE, BLOCK_TWO, GENESIS_BLOCK};
 
     /// Make sure we get rid of all subgraphs once for the entire test run
-    fn global_init() {
+    async fn global_init() {
         lazy_static! {
             static ref STORE_CLEAN: AtomicBool = AtomicBool::new(false);
         }
         if !STORE_CLEAN.load(Ordering::SeqCst) {
             let chain = vec![&*GENESIS_BLOCK, &*BLOCK_ONE, &*BLOCK_TWO];
-            block_store::set_chain(chain, NETWORK_NAME);
+            block_store::set_chain(chain, NETWORK_NAME).await;
             test_store::remove_subgraphs();
             STORE_CLEAN.store(true, Ordering::SeqCst);
         }
@@ -213,7 +213,7 @@ async fn setup(
         insert_test_entities(store.subgraph_store().as_ref(), manifest, id_type).await
     }
 
-    global_init();
+    global_init().await;
     let id = DeploymentHash::new(id).unwrap();
     let loc = store.subgraph_store().active_locator(&id).unwrap();
 

--- a/store/test-store/tests/postgres/chain_head.rs
+++ b/store/test-store/tests/postgres/chain_head.rs
@@ -1,6 +1,8 @@
 //! Test ChainStore implementation of Store, in particular, how
 //! the chain head pointer gets updated in various situations
 
+use graph::blockchain::{BlockHash, BlockPtr};
+use graph::env::ENV_VARS;
 use graph::prelude::futures03::executor;
 use std::future::Future;
 use std::sync::Arc;
@@ -46,17 +48,20 @@ where
 
 fn run_test_async<R, F>(chain: FakeBlockList, test: F)
 where
-    F: Fn(Arc<DieselChainStore>, Arc<DieselStore>) -> R + Send + Sync + 'static,
+    F: Fn(Arc<DieselChainStore>, Arc<DieselStore>, Vec<(BlockPtr, BlockHash)>) -> R
+        + Send
+        + Sync
+        + 'static,
     R: Future<Output = ()> + Send + 'static,
 {
     run_test_sequentially(|store| async move {
         for name in &[NETWORK_NAME, FAKE_NETWORK_SHARED] {
-            block_store::set_chain(chain.clone(), name).await;
+            let cached = block_store::set_chain(chain.clone(), name).await;
 
             let chain_store = store.block_store().chain_store(name).expect("chain store");
 
             // Run test
-            test(chain_store.cheap_clone(), store.clone()).await;
+            test(chain_store.cheap_clone(), store.clone(), cached).await;
         }
     });
 }
@@ -66,12 +71,15 @@ where
 /// `attempt_chain_head_update` and check its result. Check that the new head
 /// is the one indicated in `head_exp`. If `missing` is not `None`, check that
 /// `attempt_chain_head_update` reports that block as missing
-fn check_chain_head_update(
+fn check_chain_head_update_cache(
     chain: FakeBlockList,
     head_exp: Option<&'static FakeBlock>,
     missing: Option<&'static str>,
+    cached_exp: usize,
 ) {
-    run_test_async(chain, move |store, _| async move {
+    let cached_exp = ENV_VARS.store.recent_blocks_cache_capacity.min(cached_exp);
+
+    run_test_async(chain, move |store, _, cached| async move {
         let missing_act: Vec<_> = store
             .clone()
             .attempt_chain_head_update(ANCESTOR_COUNT)
@@ -90,7 +98,35 @@ fn check_chain_head_update(
             .expect("chain_head_ptr failed")
             .map(|ebp| ebp.hash_hex());
         assert_eq!(head_hash_exp, head_hash_act);
+
+        assert_eq!(cached_exp, cached.len());
     })
+}
+
+fn check_chain_head_update(
+    chain: FakeBlockList,
+    head_exp: Option<&'static FakeBlock>,
+    missing: Option<&'static str>,
+) {
+    let cached_exp = chain
+        .iter()
+        .filter(|block| block.number != 0)
+        .fold((0, None), |(len, parent_hash), block| {
+            match (len, parent_hash) {
+                (0, None) => (1, Some(&block.hash)),
+                (0, Some(_)) | (_, None) => unreachable!(),
+                (len, Some(parent_hash)) => {
+                    if &block.parent_hash == parent_hash {
+                        (len + 1, Some(&block.hash))
+                    } else {
+                        (1, Some(&block.hash))
+                    }
+                }
+            }
+        })
+        .0;
+
+    check_chain_head_update_cache(chain, head_exp, missing, cached_exp);
 }
 
 #[test]
@@ -117,7 +153,7 @@ fn genesis_plus_one_with_sibling() {
     // Two valid blocks at the same height should give an error, but
     // we currently get one of them at random
     let chain = vec![&*GENESIS_BLOCK, &*BLOCK_ONE, &*BLOCK_ONE_SIBLING];
-    check_chain_head_update(chain, Some(&*BLOCK_ONE), None);
+    check_chain_head_update_cache(chain, Some(&*BLOCK_ONE), None, 1);
 }
 
 #[test]
@@ -135,7 +171,7 @@ fn long_chain() {
         &*BLOCK_FOUR,
         &*BLOCK_FIVE,
     ];
-    check_chain_head_update(chain, Some(&*BLOCK_FIVE), None);
+    check_chain_head_update_cache(chain, Some(&*BLOCK_FIVE), None, 5);
 }
 
 #[test]
@@ -163,7 +199,7 @@ fn long_chain_with_uncles() {
         &*BLOCK_THREE_NO_PARENT,
         &*BLOCK_FOUR,
     ];
-    check_chain_head_update(chain, Some(&*BLOCK_FOUR), None);
+    check_chain_head_update_cache(chain, Some(&*BLOCK_FOUR), None, 4);
 }
 
 #[test]
@@ -171,7 +207,7 @@ fn test_get_block_number() {
     let chain = vec![&*GENESIS_BLOCK, &*BLOCK_ONE, &*BLOCK_TWO];
     let subgraph = DeploymentHash::new("nonExistentSubgraph").unwrap();
 
-    run_test_async(chain, move |_, subgraph_store| {
+    run_test_async(chain, move |_, subgraph_store, _| {
         let subgraph = subgraph.cheap_clone();
         async move {
             create_test_subgraph(&subgraph, "type Dummy @entity { id: ID! }").await;
@@ -379,7 +415,7 @@ fn eth_call_cache() {
 /// Tests only query correctness. No data is involved.
 fn test_transaction_receipts_in_block_function() {
     let chain = vec![];
-    run_test_async(chain, move |store, _| async move {
+    run_test_async(chain, move |store, _, _| async move {
         let receipts = store
             .transaction_receipts_in_block(&H256::zero())
             .await

--- a/store/test-store/tests/postgres/chain_head.rs
+++ b/store/test-store/tests/postgres/chain_head.rs
@@ -33,7 +33,7 @@ where
 {
     run_test_sequentially(|store| async move {
         for name in &[NETWORK_NAME, FAKE_NETWORK_SHARED] {
-            block_store::set_chain(chain.clone(), name);
+            block_store::set_chain(chain.clone(), name).await;
 
             let chain_store = store.block_store().chain_store(name).expect("chain store");
 
@@ -51,7 +51,7 @@ where
 {
     run_test_sequentially(|store| async move {
         for name in &[NETWORK_NAME, FAKE_NETWORK_SHARED] {
-            block_store::set_chain(chain.clone(), name);
+            block_store::set_chain(chain.clone(), name).await;
 
             let chain_store = store.block_store().chain_store(name).expect("chain store");
 

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -1946,7 +1946,8 @@ fn cleanup_cached_blocks() {
         block_store::set_chain(
             vec![&*GENESIS_BLOCK, &*BLOCK_ONE, &*BLOCK_TWO, &*BLOCK_THREE],
             NETWORK_NAME,
-        );
+        )
+        .await;
         let chain_store = store
             .block_store()
             .chain_store(NETWORK_NAME)
@@ -1977,7 +1978,8 @@ fn parse_timestamp() {
                 &*BLOCK_THREE_TIMESTAMP,
             ],
             NETWORK_NAME,
-        );
+        )
+        .await;
         let chain_store = store
             .block_store()
             .chain_store(NETWORK_NAME)
@@ -2010,7 +2012,8 @@ fn parse_timestamp_firehose() {
                 &*BLOCK_THREE_TIMESTAMP_FIREHOSE,
             ],
             NETWORK_NAME,
-        );
+        )
+        .await;
         let chain_store = store
             .block_store()
             .chain_store(NETWORK_NAME)
@@ -2043,7 +2046,8 @@ fn parse_null_timestamp() {
                 &*BLOCK_THREE_NO_TIMESTAMP,
             ],
             NETWORK_NAME,
-        );
+        )
+        .await;
         let chain_store = store
             .block_store()
             .chain_store(NETWORK_NAME)

--- a/store/test-store/tests/postgres/subgraph.rs
+++ b/store/test-store/tests/postgres/subgraph.rs
@@ -458,7 +458,7 @@ fn version_info() {
     async fn setup() -> DeploymentLocator {
         let id = DeploymentHash::new(NAME).unwrap();
         remove_subgraphs();
-        block_store::set_chain(vec![], NETWORK_NAME);
+        block_store::set_chain(vec![], NETWORK_NAME).await;
         create_test_subgraph(&id, SUBGRAPH_GQL).await
     }
 
@@ -500,7 +500,7 @@ fn subgraph_features() {
         let id = DeploymentHash::new(NAME).unwrap();
 
         remove_subgraphs();
-        block_store::set_chain(vec![], NETWORK_NAME);
+        block_store::set_chain(vec![], NETWORK_NAME).await;
         create_test_subgraph_with_features(&id, SUBGRAPH_GQL).await;
 
         let DeploymentFeatures {


### PR DESCRIPTION
I was hoping that these tests would illuminate why the recent blocks cache isn't very effective in practice, but it seems to work as expected. We should probably add some more direct tests for the recent blocks cache on top of these.