### PR TITLE
fix(graphql): remove duplicated input type in meta schema

### DIFF
--- a/graph/src/schema/meta.graphql
+++ b/graph/src/schema/meta.graphql
@@ -56,12 +56,6 @@ input BlockChangedFilter {
   number_gte: Int!
 }
 
-input Block_height {
-  hash: Bytes
-  number: Int
-  number_gte: Int
-}
-
 type _Block_ {
   "The hash of the block"
   hash: Bytes


### PR DESCRIPTION
I was trying to import this `meta.graphql` schema remotely in GraphQL CLI for some validation work and saw that we are re-declaring the same input type which is invalid.
