### PR TITLE
Add a graph-node-napi crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +909,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e"
+dependencies = [
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,7 +967,7 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1812,6 +1831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "graph-node-napi"
+version = "0.1.0"
+dependencies = [
+ "graph",
+ "napi",
+ "napi-derive",
+]
+
+[[package]]
 name = "graph-runtime-derive"
 version = "0.33.0"
 dependencies = [
@@ -2644,6 +2672,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
+name = "libloading"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,6 +2915,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "napi"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1133249c46e92da921bafc8aba4912bf84d6c475f7625183772ed2d0844dc3a7"
+dependencies = [
+ "bitflags 2.4.0",
+ "ctor",
+ "napi-derive",
+ "napi-sys",
+ "once_cell",
+]
+
+[[package]]
+name = "napi-derive"
+version = "2.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b5af262f1d8e660742eb722abc7113a5b3c3de4144d0ef23ede2518672ceff1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "convert_case 0.6.0",
+ "napi-derive-backend",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "napi-derive-backend"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea236321b521d6926213a2021e407b0562e28a257c037a45919e414d2cdb4f8"
+dependencies = [
+ "convert_case 0.6.0",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "semver",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "napi-sys"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2503fa6af34dc83fb74888df8b22afe933b58d37daf7d80424b1c60c68196b8b"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2973,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -5082,6 +5171,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "core",
     "chain/*",
     "graphql",
+    "napi",
     "node",
     "runtime/*",
     "server/*",
@@ -38,4 +39,3 @@ incremental = false
 lto = true
 opt-level = 's'
 strip = "debuginfo"
-

--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -52,6 +52,8 @@ impl fmt::Display for Strings {
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum SchemaValidationError {
+    #[error("Invalid schema: {0}")]
+    InvalidSchema(String),
     #[error("Interface `{0}` not defined")]
     InterfaceUndefined(String),
 

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "graph-node-napi"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+graph = { path = "../graph" }
+napi = "2.14.1"
+napi-derive = "2.14.4"

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -4,7 +4,7 @@ use napi_derive::napi;
 use graph::{data::subgraph::DeploymentHash, schema::InputSchema};
 
 #[napi]
-pub fn validate_schema(schema: String, id: String) -> n::Result<String> {
+pub fn validate_schema(schema: String, id: String) -> n::Result<Vec<String>> {
     let id = match DeploymentHash::new(id) {
         Ok(id) => id,
         Err(e) => {
@@ -14,9 +14,9 @@ pub fn validate_schema(schema: String, id: String) -> n::Result<String> {
             ))
         }
     };
-    let res = InputSchema::parse(&schema, id);
-    match res {
-        Ok(_) => Ok("ok".to_string()),
-        Err(e) => Err(n::Error::new(n::Status::GenericFailure, e.to_string())),
-    }
+    let errs = InputSchema::validate(&schema, id)
+        .into_iter()
+        .map(|e| e.to_string())
+        .collect();
+    Ok(errs)
 }

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -1,0 +1,22 @@
+use napi::bindgen_prelude as n;
+use napi_derive::napi;
+
+use graph::{data::subgraph::DeploymentHash, schema::InputSchema};
+
+#[napi]
+pub fn validate_schema(schema: String, id: String) -> n::Result<String> {
+    let id = match DeploymentHash::new(id) {
+        Ok(id) => id,
+        Err(e) => {
+            return Err(n::Error::new(
+                n::Status::InvalidArg,
+                format!("Invalid deployment hash {e}"),
+            ))
+        }
+    };
+    let res = InputSchema::parse(&schema, id);
+    match res {
+        Ok(_) => Ok("ok".to_string()),
+        Err(e) => Err(n::Error::new(n::Status::GenericFailure, e.to_string())),
+    }
+}


### PR DESCRIPTION
This crate exposes graph-node functionality for Node's N-API

Currently it offers a single `validate_schema` function which returns schema validation errors.