### PR TITLE
core, graph, store: Do not use recent blocks cache for chain head

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -750,7 +750,7 @@ where
                 if !self.state.synced
                     && close_to_chain_head(
                         &block_ptr,
-                        self.inputs.chain.chain_store().cached_head_ptr().await?,
+                        self.inputs.chain.chain_store().chain_head_ptr().await?,
                         // We consider a subgraph synced when it's at most 1 block behind the
                         // chain head.
                         1,
@@ -1305,7 +1305,7 @@ where
             && !self.state.synced
             && !close_to_chain_head(
                 &block_ptr,
-                self.inputs.chain.chain_store().cached_head_ptr().await?,
+                self.inputs.chain.chain_store().chain_head_ptr().await?,
                 // The "skip ptr updates timer" is ignored when a subgraph is at most 1000 blocks
                 // behind the chain head.
                 1000,

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -439,9 +439,6 @@ pub trait ChainStore: Send + Sync + 'static {
     /// The head block pointer will be None on initial set up.
     async fn chain_head_ptr(self: Arc<Self>) -> Result<Option<BlockPtr>, Error>;
 
-    /// In-memory time cached version of `chain_head_ptr`.
-    async fn cached_head_ptr(self: Arc<Self>) -> Result<Option<BlockPtr>, Error>;
-
     /// Get the current head block cursor for this chain.
     ///
     /// The head block cursor will be None on initial set up.

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -1828,13 +1828,6 @@ impl ChainStoreTrait for ChainStore {
             .await?)
     }
 
-    async fn cached_head_ptr(self: Arc<Self>) -> Result<Option<BlockPtr>, Error> {
-        match self.recent_blocks_cache.chain_head_ptr() {
-            Some(head) => Ok(Some(head)),
-            None => self.chain_head_ptr().await,
-        }
-    }
-
     fn chain_head_cursor(&self) -> Result<Option<String>, Error> {
         use public::ethereum_networks::dsl::*;
 
@@ -2210,11 +2203,6 @@ mod recent_blocks_cache {
                     capacity,
                 }),
             }
-        }
-
-        pub fn chain_head_ptr(&self) -> Option<BlockPtr> {
-            let inner = self.inner.read();
-            inner.chain_head().cloned()
         }
 
         pub fn clear(&self) {


### PR DESCRIPTION
With recent changes where the recent blocks cache gets populated on index nodes that are not the block ingestor (#5059), the recent blocks cache can have a notion of chain head pointer that is very far behind the actual chain head pointer. In fact, there is no safe way to get the real chain head pointer from the cache.

A side-effect of using the wrong chain head pointer is that a subgraph gets marked as synced too early, which in turn turns off write batching.

Caching the chain head pointer is also a bit of a premature optimization as looking up the chain head pointer should be very cheap as it does a lookup in the very small `ethereum_networks` table.

If we do want to cache the chain head pointer, we will have to use the ChainHeadUpdate notifications to update such a cache.

