### PR TITLE
Fix data source rewind across more than one block

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -793,15 +793,7 @@ where
                     }
                 }
 
-                if matches!(action, Action::Restart) {
-                    // Cancel the stream for real
-                    self.ctx.instances.remove(&self.inputs.deployment.id);
-
-                    // And restart the subgraph
-                    return Ok(Action::Restart);
-                }
-
-                return Ok(Action::Continue);
+                return Ok(action);
             }
             Err(BlockProcessingError::Canceled) => {
                 debug!(self.logger, "Subgraph block stream shut down cleanly");
@@ -859,9 +851,6 @@ where
                         }
 
                         // Retry logic below:
-
-                        // Cancel the stream for real.
-                        self.ctx.instances.remove(&self.inputs.deployment.id);
 
                         let message = format!("{:#}", e).replace('\n', "\t");
                         error!(self.logger, "Subgraph failed with non-deterministic error: {}", message;

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -88,13 +88,13 @@ where
     /// be removed. The same thing also applies to the block cache.
     /// This function must be called before continuing to process in order to avoid
     /// duplicated host insertion and POI issues with dirty entity changes.
-    fn revert_state(&mut self, block_number: BlockNumber) -> Result<(), Error> {
+    fn revert_state_to(&mut self, block_number: BlockNumber) -> Result<(), Error> {
         self.state.entity_lfu_cache = LfuCache::new();
 
-        // 1. Revert all hosts(created by DDS) up to block_number inclusively.
+        // 1. Revert all hosts(created by DDS) at a block higher than `block_number`.
         // 2. Unmark any offchain data sources that were marked done on the blocks being removed.
         // When no offchain datasources are present, 2. should be a noop.
-        self.ctx.revert_data_sources(block_number)?;
+        self.ctx.revert_data_sources(block_number + 1)?;
         Ok(())
     }
 
@@ -252,7 +252,7 @@ where
                         if let Some(store) = store.restart().await? {
                             let last_good_block =
                                 store.block_ptr().map(|ptr| ptr.number).unwrap_or(0);
-                            self.revert_state(last_good_block)?;
+                            self.revert_state_to(last_good_block)?;
                             self.inputs = Arc::new(self.inputs.with_store(store));
                             self.state.synced = self.inputs.store.is_deployment_synced().await?;
                         }
@@ -803,7 +803,6 @@ where
             // Handle unexpected stream errors by marking the subgraph as failed.
             Err(e) => {
                 self.metrics.stream.deployment_failed.set(1.0);
-                self.revert_state(block_ptr.block_number())?;
 
                 let message = format!("{:#}", e).replace('\n', "\t");
                 let err = anyhow!("{}, code: {}", message, LogCode::SubgraphSyncingFailure);
@@ -1350,7 +1349,7 @@ where
             .deployment_head
             .set(subgraph_ptr.number as f64);
 
-        self.revert_state(subgraph_ptr.number)?;
+        self.revert_state_to(revert_to_ptr.number)?;
 
         let needs_restart: bool = self.needs_restart(revert_to_ptr, subgraph_ptr);
 

--- a/store/postgres/src/dynds/mod.rs
+++ b/store/postgres/src/dynds/mod.rs
@@ -36,13 +36,13 @@ pub(crate) fn insert(
     }
 }
 
-pub(crate) fn revert_to(
+pub(crate) fn revert(
     conn: &PgConnection,
     site: &Site,
     block: BlockNumber,
 ) -> Result<(), StoreError> {
     match site.schema_version.private_data_sources() {
-        true => DataSourcesTable::new(site.namespace.clone()).revert_to(conn, block),
+        true => DataSourcesTable::new(site.namespace.clone()).revert(conn, block),
         false => shared::revert(conn, &site.deployment, block),
     }
 }

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -832,7 +832,7 @@ impl Layout {
         site: &Site,
         block: BlockNumber,
     ) -> Result<(), StoreError> {
-        crate::dynds::revert_to(conn, site, block)?;
+        crate::dynds::revert(conn, site, block)?;
         crate::deployment::revert_subgraph_errors(conn, &site.deployment, block)?;
 
         Ok(())

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -85,21 +85,23 @@ pub fn generate_empty_blocks_for_range(
     parent_ptr: BlockPtr,
     start: i32,
     end: i32,
-) -> Vec<BlockWithTriggers<graph_chain_ethereum::Chain>> {
-    (start + 1..end + 1).fold(
-        vec![empty_block(parent_ptr.clone(), test_ptr(start))],
-        |mut blocks, i| {
-            let parent_ptr = blocks.last().unwrap().ptr().clone();
-            blocks.push(empty_block(parent_ptr, test_ptr(i)));
-            blocks
-        },
-    )
+    add_to_hash: u64, // Use to differentiate forks
+) -> Vec<BlockWithTriggers<Chain>> {
+    let mut blocks: Vec<BlockWithTriggers<Chain>> = vec![];
+
+    for i in start..(end + 1) {
+        let parent_ptr = blocks.last().map(|b| b.ptr()).unwrap_or(parent_ptr.clone());
+        let ptr = BlockPtr {
+            number: i,
+            hash: H256::from_low_u64_be(i as u64 + add_to_hash).into(),
+        };
+        blocks.push(empty_block(parent_ptr, ptr));
+    }
+
+    blocks
 }
 
-pub fn empty_block(
-    parent_ptr: BlockPtr,
-    ptr: BlockPtr,
-) -> BlockWithTriggers<graph_chain_ethereum::Chain> {
+pub fn empty_block(parent_ptr: BlockPtr, ptr: BlockPtr) -> BlockWithTriggers<Chain> {
     assert!(ptr != parent_ptr);
     assert!(ptr.number > parent_ptr.number);
 


### PR DESCRIPTION
#4810 was wrong. And that wasn't the only thing, the way the runner reverted in-memory state also didn't seem quite right. This adds a test which uncovered these issues. Should resolve #4994, unless that was hitting the assert for a different cause.

Needs an integration cluster run, of course.