### PR TITLE
fix: Fix `deployment_running_count` metric

### DIFF
--- a/core/src/subgraph/context/mod.rs
+++ b/core/src/subgraph/context/mod.rs
@@ -52,8 +52,10 @@ impl SubgraphKeepAlive {
         self.sg_metrics.running_count.dec();
     }
     pub fn insert(&self, deployment_id: DeploymentId, guard: CancelGuard) {
-        self.alive_map.write().unwrap().insert(deployment_id, guard);
-        self.sg_metrics.running_count.inc();
+        let old = self.alive_map.write().unwrap().insert(deployment_id, guard);
+        if old.is_none() {
+            self.sg_metrics.running_count.inc();
+        }
     }
 }
 


### PR DESCRIPTION
#5083 exposed this metrics issue, right now it's getting incremented on every block stream restart.