### PR TITLE
core, graph: Add a metric to capture entire processing time for a block

### DIFF
--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -102,6 +102,10 @@ impl StopwatchMetrics {
             self.inner.lock().unwrap().end_section(id)
         }
     }
+
+    pub fn shard(&self) -> String {
+        self.inner.lock().unwrap().shard.to_string()
+    }
 }
 
 /// We want to account for all subgraph indexing time, based on "wall clock" time. To do this we

--- a/graph/src/components/metrics/subgraph.rs
+++ b/graph/src/components/metrics/subgraph.rs
@@ -4,6 +4,7 @@ use crate::blockchain::block_stream::BlockStreamMetrics;
 use crate::prelude::{Gauge, Histogram, HostMetrics};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use super::stopwatch::StopwatchMetrics;
 use super::MetricsRegistry;
@@ -16,6 +17,8 @@ pub struct SubgraphInstanceMetrics {
 
     pub stopwatch: StopwatchMetrics,
     trigger_processing_duration: Box<Histogram>,
+    blocks_processed_secs: Box<Counter>,
+    blocks_processed_count: Box<Counter>,
 }
 
 impl SubgraphInstanceMetrics {
@@ -65,6 +68,24 @@ impl SubgraphInstanceMetrics {
             )
             .expect("failed to create firehose_connection_errors counter");
 
+        let labels = HashMap::from_iter([
+            ("deployment".to_string(), subgraph_hash.to_string()),
+            ("shard".to_string(), stopwatch.shard().to_string()),
+        ]);
+        let blocks_processed_secs = registry
+            .new_counter_with_labels(
+                "deployment_blocks_processed_secs",
+                "Measures the time spent processing blocks",
+                labels.clone(),
+            )
+            .expect("failed to create blocks_processed_secs gauge");
+        let blocks_processed_count = registry
+            .new_counter_with_labels(
+                "deployment_blocks_processed_count",
+                "Measures the number of blocks processed",
+                labels,
+            )
+            .expect("failed to create blocks_processed_count counter");
         Self {
             block_trigger_count,
             block_processing_duration,
@@ -72,11 +93,20 @@ impl SubgraphInstanceMetrics {
             block_ops_transaction_duration,
             firehose_connection_errors,
             stopwatch,
+            blocks_processed_secs,
+            blocks_processed_count,
         }
     }
 
     pub fn observe_trigger_processing_duration(&self, duration: f64) {
         self.trigger_processing_duration.observe(duration);
+    }
+
+    pub fn observe_block_processed(&self, duration: Duration, block_done: bool) {
+        self.blocks_processed_secs.inc_by(duration.as_secs_f64());
+        if block_done {
+            self.blocks_processed_count.inc();
+        }
     }
 
     pub fn unregister(&self, registry: Arc<MetricsRegistry>) {


### PR DESCRIPTION
We don't have a metric that accurately reflects the time it takes to process a block. This PR introduces two new metrics for each deployment, one for the total time taken to process a block, and one for the number of blocks that should make it possible to calculate an overall processing speed. The metrics we have only cover a specific section of processing (and I am not sure how useful the histograms in `SubgraphInstanceMetrics` actually are)

There's a bit of handwaving since we can't account for the time a task is not actively running with this, but it should give us a reasonably close idea of overall timing.