### PR TITLE
ethereum: Restore GRAPH_ETH_CALL_GAS environment variable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Environment Variables
+
+- Restored `GRAPH_ETH_CALL_GAS` to support networks with lower gas limit cap, its default value
+  is set to 50 million.
+  
 ## v0.34.0
 ### What's New
 

--- a/chain/ethereum/src/env.rs
+++ b/chain/ethereum/src/env.rs
@@ -86,7 +86,7 @@ pub struct EnvVars {
     pub eth_call_no_gas: Vec<String>,
     /// Gas limit for `eth_call`. Default value of 50_000_000 is a protocol-wide parameter so this
     /// should be changed only for debugging purposes or when you have confirmed that your network uses
-    /// a lower gas limit. 
+    /// a lower gas limit.
     /// Default value was chosen because it is the Geth default
     /// https://github.com/ethereum/go-ethereum/blob/e4b687cf462870538743b3218906940ae590e7fd/eth/ethconfig/config.go#L91.
     /// If set to something higher then Geth will silently override the gas limit with the default.

--- a/chain/ethereum/src/env.rs
+++ b/chain/ethereum/src/env.rs
@@ -84,6 +84,14 @@ pub struct EnvVars {
     /// This is a comma separated list of chain ids for which the gas field will not be set
     /// when calling `eth_call`.
     pub eth_call_no_gas: Vec<String>,
+    /// Gas limit for `eth_call`. Default value of 50_000_000 is a protocol-wide parameter so this
+    /// should be changed only for debugging purposes or when you have confirmed that your network uses
+    /// a lower gas limit. 
+    /// Default value was chosen because it is the Geth default
+    /// https://github.com/ethereum/go-ethereum/blob/e4b687cf462870538743b3218906940ae590e7fd/eth/ethconfig/config.go#L91.
+    /// If set to something higher then Geth will silently override the gas limit with the default.
+    // See also f0af4ab0-6b7c-4b68-9141-5b79346a5f61.
+    pub eth_call_gas: u32,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -130,6 +138,7 @@ impl From<Inner> for EnvVars {
                 .filter(|s| !s.is_empty())
                 .map(str::to_string)
                 .collect(),
+            eth_call_gas: x.eth_call_gas,
         }
     }
 }
@@ -177,4 +186,6 @@ struct Inner {
     genesis_block_number: u64,
     #[envconfig(from = "GRAPH_ETH_CALL_NO_GAS", default = "421613")]
     eth_call_no_gas: String,
+    #[envconfig(from = "ETH_CALL_GAS", default = "50000000")]
+    eth_call_gas: u32,
 }

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -27,16 +27,6 @@ use graph_runtime_wasm::asc_abi::class::{AscEnumArray, EthereumValueKind};
 
 use super::abi::{AscUnresolvedContractCall, AscUnresolvedContractCall_0_0_4};
 
-/// Gas limit for `eth_call`. The value of 50_000_000 is a protocol-wide parameter so this
-/// should be changed only for debugging purposes and never on an indexer in the network. This
-/// value was chosen because it is the Geth default
-/// https://github.com/ethereum/go-ethereum/blob/e4b687cf462870538743b3218906940ae590e7fd/eth/ethconfig/config.go#L91.
-/// It is not safe to set something higher because Geth will silently override the gas limit
-/// with the default. This means that we do not support indexing against a Geth node with
-/// `RPCGasCap` set below 50 million.
-// See also f0af4ab0-6b7c-4b68-9141-5b79346a5f61.
-const ETH_CALL_GAS: u32 = 50_000_000;
-
 // When making an ethereum call, the maximum ethereum gas is ETH_CALL_GAS which is 50 million. One
 // unit of Ethereum gas is at least 100ns according to these benchmarks [1], so 1000 of our gas. In
 // the worst case an Ethereum call could therefore consume 50 billion of our gas. However the
@@ -68,7 +58,7 @@ impl blockchain::RuntimeAdapter<Chain> for RuntimeAdapter {
         let eth_call_gas = if should_skip_gas {
             None
         } else {
-            Some(ETH_CALL_GAS)
+            Some(ENV_VARS.eth_call_gas)
         };
 
         let ethereum_call = HostFn {


### PR DESCRIPTION
Solves #4973 
Basically, reverts changes introduced [here](https://github.com/graphprotocol/graph-node/commit/06a6abab734db3b8f91482196e4bb6fb0bbd2c80)
