### PR TITLE
Improve substreams error handling

### DIFF
--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -95,7 +95,7 @@ impl BlockStreamBuilder<Chain> for NearStreamBuilder {
             deployment.hash,
             chain.chain_client(),
             subgraph_current_block,
-            block_cursor.as_ref().clone(),
+            block_cursor.clone(),
             mapper,
             package.modules.clone(),
             NEAR_FILTER_MODULE_NAME.to_string(),

--- a/chain/substreams/examples/substreams.rs
+++ b/chain/substreams/examples/substreams.rs
@@ -1,5 +1,5 @@
 use anyhow::{format_err, Context, Error};
-use graph::blockchain::block_stream::BlockStreamEvent;
+use graph::blockchain::block_stream::{BlockStreamEvent, FirehoseCursor};
 use graph::blockchain::client::ChainClient;
 use graph::blockchain::substreams_block_stream::SubstreamsBlockStream;
 use graph::endpoint::EndpointMetrics;
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Error> {
             DeploymentHash::new("substreams".to_string()).unwrap(),
             client,
             None,
-            None,
+            FirehoseCursor::None,
             Arc::new(Mapper {
                 schema: None,
                 skip_empty_blocks: false,

--- a/chain/substreams/src/block_ingestor.rs
+++ b/chain/substreams/src/block_ingestor.rs
@@ -2,6 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use crate::mapper::Mapper;
 use anyhow::{Context, Error};
+use graph::blockchain::block_stream::{BlockStreamError, FirehoseCursor};
 use graph::blockchain::{
     client::ChainClient, substreams_block_stream::SubstreamsBlockStream, BlockIngestor,
 };
@@ -65,11 +66,12 @@ impl SubstreamsBlockIngestor {
     /// Consumes the incoming stream of blocks infinitely until it hits an error. In which case
     /// the error is logged right away and the latest available cursor is returned
     /// upstream for future consumption.
+    /// If an error is returned it indicates a fatal/deterministic error which should not be retried.
     async fn process_blocks(
         &self,
-        cursor: String,
+        cursor: FirehoseCursor,
         mut stream: SubstreamsBlockStream<super::Chain>,
-    ) -> String {
+    ) -> Result<FirehoseCursor, BlockStreamError> {
         let mut latest_cursor = cursor;
 
         while let Some(message) = stream.next().await {
@@ -90,6 +92,9 @@ impl SubstreamsBlockIngestor {
                     trace!(self.logger, "Received undo block to ingest, skipping");
                     continue;
                 }
+                Err(e) if e.is_deterministic() => {
+                    return Err(e);
+                }
                 Err(e) => {
                     info!(
                         self.logger,
@@ -105,14 +110,15 @@ impl SubstreamsBlockIngestor {
                 break;
             }
 
-            latest_cursor = cursor.to_string()
+            latest_cursor = cursor
         }
 
         error!(
             self.logger,
             "Stream blocks complete unexpectedly, expecting stream to always stream blocks"
         );
-        latest_cursor
+
+        Ok(latest_cursor)
     }
 
     async fn process_new_block(
@@ -139,7 +145,7 @@ impl BlockIngestor for SubstreamsBlockIngestor {
             schema: None,
             skip_empty_blocks: false,
         });
-        let mut latest_cursor = self.fetch_head_cursor().await;
+        let mut latest_cursor = FirehoseCursor::from(self.fetch_head_cursor().await);
         let mut backoff =
             ExponentialBackoff::new(Duration::from_millis(250), Duration::from_secs(30));
         let package = Package::decode(SUBSTREAMS_HEAD_TRACKER_BYTES.to_vec().as_ref()).unwrap();
@@ -149,7 +155,7 @@ impl BlockIngestor for SubstreamsBlockIngestor {
                 DeploymentHash::default(),
                 self.client.cheap_clone(),
                 None,
-                Some(latest_cursor.clone()),
+                latest_cursor.clone(),
                 mapper.cheap_clone(),
                 package.modules.clone(),
                 "map_blocks".to_string(),
@@ -160,7 +166,21 @@ impl BlockIngestor for SubstreamsBlockIngestor {
             );
 
             // Consume the stream of blocks until an error is hit
-            latest_cursor = self.process_blocks(latest_cursor, stream).await;
+            // If the error is retryable it will print the error and return the cursor
+            // therefore if we get an error here it has to be a fatal error.
+            // This is a bit brittle and should probably be improved at some point.
+            let res = self.process_blocks(latest_cursor, stream).await;
+            match res {
+                Ok(cursor) => latest_cursor = cursor,
+                Err(BlockStreamError::Fatal(e)) => {
+                    error!(
+                        self.logger,
+                        "fatal error while ingesting substream blocks: {}", e
+                    );
+                    return;
+                }
+                _ => unreachable!("Nobody should ever see this error message, something is wrong"),
+            }
 
             // If we reach this point, we must wait a bit before retrying
             backoff.sleep_async().await;

--- a/chain/substreams/src/block_stream.rs
+++ b/chain/substreams/src/block_stream.rs
@@ -53,7 +53,7 @@ impl BlockStreamBuilderTrait<Chain> for BlockStreamBuilder {
                 deployment.hash,
                 chain.chain_client(),
                 subgraph_current_block,
-                block_cursor.as_ref().clone(),
+                block_cursor.clone(),
                 Arc::new(WasmBlockMapper {
                     handler: handler.clone(),
                 }),
@@ -69,7 +69,7 @@ impl BlockStreamBuilderTrait<Chain> for BlockStreamBuilder {
                 deployment.hash,
                 chain.chain_client(),
                 subgraph_current_block,
-                block_cursor.as_ref().clone(),
+                block_cursor.clone(),
                 Arc::new(Mapper {
                     schema: Some(schema),
                     skip_empty_blocks: true,

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -26,7 +26,7 @@ pub const FIREHOSE_BUFFER_STREAM_SIZE: usize = 1;
 pub const SUBSTREAMS_BUFFER_STREAM_SIZE: usize = 1;
 
 pub struct BufferedBlockStream<C: Blockchain> {
-    inner: Pin<Box<dyn Stream<Item = Result<BlockStreamEvent<C>, Error>> + Send>>,
+    inner: Pin<Box<dyn Stream<Item = Result<BlockStreamEvent<C>, BlockStreamError>> + Send>>,
 }
 
 impl<C: Blockchain + 'static> BufferedBlockStream<C> {
@@ -34,13 +34,14 @@ impl<C: Blockchain + 'static> BufferedBlockStream<C> {
         size_hint: usize,
         stream: Box<dyn BlockStream<C>>,
     ) -> Box<dyn BlockStream<C>> {
-        let (sender, receiver) = mpsc::channel::<Result<BlockStreamEvent<C>, Error>>(size_hint);
+        let (sender, receiver) =
+            mpsc::channel::<Result<BlockStreamEvent<C>, BlockStreamError>>(size_hint);
         crate::spawn(async move { BufferedBlockStream::stream_blocks(stream, sender).await });
 
         Box::new(BufferedBlockStream::new(receiver))
     }
 
-    pub fn new(mut receiver: Receiver<Result<BlockStreamEvent<C>, Error>>) -> Self {
+    pub fn new(mut receiver: Receiver<Result<BlockStreamEvent<C>, BlockStreamError>>) -> Self {
         let inner = stream! {
             loop {
                 let event = match receiver.recv().await {
@@ -59,7 +60,7 @@ impl<C: Blockchain + 'static> BufferedBlockStream<C> {
 
     pub async fn stream_blocks(
         mut stream: Box<dyn BlockStream<C>>,
-        sender: Sender<Result<BlockStreamEvent<C>, Error>>,
+        sender: Sender<Result<BlockStreamEvent<C>, BlockStreamError>>,
     ) -> Result<(), Error> {
         while let Some(event) = stream.next().await {
             match sender.send(event).await {
@@ -84,7 +85,7 @@ impl<C: Blockchain> BlockStream<C> for BufferedBlockStream<C> {
 }
 
 impl<C: Blockchain> Stream for BufferedBlockStream<C> {
-    type Item = Result<BlockStreamEvent<C>, Error>;
+    type Item = Result<BlockStreamEvent<C>, BlockStreamError>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -95,7 +96,7 @@ impl<C: Blockchain> Stream for BufferedBlockStream<C> {
 }
 
 pub trait BlockStream<C: Blockchain>:
-    Stream<Item = Result<BlockStreamEvent<C>, Error>> + Unpin + Send
+    Stream<Item = Result<BlockStreamEvent<C>, BlockStreamError>> + Unpin + Send
 {
     fn buffer_size_hint(&self) -> usize;
 }
@@ -482,6 +483,20 @@ pub enum SubstreamsError {
     UnexpectedStoreDeltaOutput,
 }
 
+#[derive(Debug, Error)]
+pub enum BlockStreamError {
+    #[error("block stream error")]
+    Unknown(#[from] anyhow::Error),
+    #[error("block stream fatal error")]
+    Fatal(String),
+}
+
+impl BlockStreamError {
+    pub fn is_deterministic(&self) -> bool {
+        matches!(self, Self::Fatal(_))
+    }
+}
+
 #[derive(Debug)]
 pub enum BlockStreamEvent<C: Blockchain> {
     // The payload is the block the subgraph should revert to, so it becomes the new subgraph head.
@@ -576,7 +591,6 @@ pub trait ChainHeadUpdateListener: Send + Sync + 'static {
 mod test {
     use std::{collections::HashSet, task::Poll};
 
-    use anyhow::Error;
     use futures03::{Stream, StreamExt, TryStreamExt};
 
     use crate::{
@@ -585,7 +599,8 @@ mod test {
     };
 
     use super::{
-        BlockStream, BlockStreamEvent, BlockWithTriggers, BufferedBlockStream, FirehoseCursor,
+        BlockStream, BlockStreamError, BlockStreamEvent, BlockWithTriggers, BufferedBlockStream,
+        FirehoseCursor,
     };
 
     #[derive(Debug)]
@@ -600,7 +615,7 @@ mod test {
     }
 
     impl Stream for TestStream {
-        type Item = Result<BlockStreamEvent<MockBlockchain>, Error>;
+        type Item = Result<BlockStreamEvent<MockBlockchain>, BlockStreamError>;
 
         fn poll_next(
             mut self: std::pin::Pin<&mut Self>,

--- a/graph/src/blockchain/firehose_block_stream.rs
+++ b/graph/src/blockchain/firehose_block_stream.rs
@@ -1,5 +1,5 @@
 use super::block_stream::{
-    BlockStream, BlockStreamEvent, FirehoseMapper, FIREHOSE_BUFFER_STREAM_SIZE,
+    BlockStream, BlockStreamError, BlockStreamEvent, FirehoseMapper, FIREHOSE_BUFFER_STREAM_SIZE,
 };
 use super::client::ChainClient;
 use super::Blockchain;
@@ -100,7 +100,7 @@ impl FirehoseBlockStreamMetrics {
 }
 
 pub struct FirehoseBlockStream<C: Blockchain> {
-    stream: Pin<Box<dyn Stream<Item = Result<BlockStreamEvent<C>, Error>> + Send>>,
+    stream: Pin<Box<dyn Stream<Item = Result<BlockStreamEvent<C>, BlockStreamError>> + Send>>,
 }
 
 impl<C> FirehoseBlockStream<C>
@@ -156,7 +156,7 @@ fn stream_blocks<C: Blockchain, F: FirehoseMapper<C>>(
     subgraph_current_block: Option<BlockPtr>,
     logger: Logger,
     metrics: FirehoseBlockStreamMetrics,
-) -> impl Stream<Item = Result<BlockStreamEvent<C>, Error>> {
+) -> impl Stream<Item = Result<BlockStreamEvent<C>, BlockStreamError>> {
     let mut subgraph_current_block = subgraph_current_block;
     let mut start_block_num = subgraph_current_block
         .as_ref()
@@ -406,7 +406,7 @@ async fn process_firehose_response<C: Blockchain, F: FirehoseMapper<C>>(
 }
 
 impl<C: Blockchain> Stream for FirehoseBlockStream<C> {
-    type Item = Result<BlockStreamEvent<C>, Error>;
+    type Item = Result<BlockStreamEvent<C>, BlockStreamError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.stream.poll_next_unpin(cx)

--- a/graph/src/ext/futures.rs
+++ b/graph/src/ext/futures.rs
@@ -1,3 +1,4 @@
+use crate::blockchain::block_stream::BlockStreamError;
 use crate::prelude::tokio::macros::support::Poll;
 use crate::prelude::{Pin, StoreError};
 use futures03::channel::oneshot;
@@ -310,6 +311,12 @@ impl From<diesel::result::Error> for CancelableError<anyhow::Error> {
 impl From<diesel::result::Error> for CancelableError<StoreError> {
     fn from(e: diesel::result::Error) -> Self {
         Self::Error(e.into())
+    }
+}
+
+impl From<BlockStreamError> for CancelableError<BlockStreamError> {
+    fn from(e: BlockStreamError) -> Self {
+        Self::Error(e)
     }
 }
 

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -748,10 +748,7 @@ fn insert_subgraph_error(conn: &PgConnection, error: &SubgraphError) -> anyhow::
     } = error;
 
     let block_num = match &block_ptr {
-        None => {
-            assert_eq!(*deterministic, false);
-            crate::block_range::BLOCK_UNVERSIONED
-        }
+        None => crate::block_range::BLOCK_UNVERSIONED,
         Some(block) => crate::block_range::block_number(block),
     };
 


### PR DESCRIPTION
- Surface substreams errors
- Fail subgraph if a substreams error is marked as deterministic
- Consider substreams errors deterministic if `Code::InvalidArgument` is returned as the grpc status code
- Replace a few `Option<String>` with `FirehoseCursor`.
- Remove deterministic error on None block assertion