### PR TITLE
Queries for aggregations

### DIFF
--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -218,7 +218,7 @@ where
                     write_poi_event(
                         proof_of_indexing,
                         &ProofOfIndexingEvent::SetEntity {
-                            entity_type: key.entity_type.as_str(),
+                            entity_type: key.entity_type.typename(),
                             id: &key.entity_id.to_string(),
                             data: &entity,
                         },
@@ -236,7 +236,7 @@ where
                     write_poi_event(
                         proof_of_indexing,
                         &ProofOfIndexingEvent::RemoveEntity {
-                            entity_type: entity_type.as_str(),
+                            entity_type: entity_type.typename(),
                             id: &id.to_string(),
                         },
                         causality_region,

--- a/docs/aggregations.md
+++ b/docs/aggregations.md
@@ -160,11 +160,13 @@ accepts the following arguments:
 - A mandatory `interval`
 - An optional `current` to indicate whether to include the current,
   partially filled bucket in the response. Can be either `ignore` (the
-  default) or `include`
-- Optional `timestamp_{gte|gt|lt|lte|eq}` filters to restrict the range of
-  timestamps to return
-- Timeseries are always sorted by the dimensions in the order in which they
-  are declared in the schema and the `timestamp` in descending order
+  default) or `include` (still **TODO** and not implemented)
+- Optional `timestamp_{gte|gt|lt|lte|eq|in}` filters to restrict the range
+  of timestamps to return
+- Timeseries are always sorted by `timestamp` and `id` in descending order
+
+**TODO** It would be nicer to sort by the dimensions and `timestamp`, but we
+don't have the internal plumbing for multi-column sort in place.
 
 ```graphql
 token_stats(interval: "hour",

--- a/graph/src/blockchain/types.rs
+++ b/graph/src/blockchain/types.rs
@@ -348,10 +348,12 @@ impl BlockTime {
         )
     }
 
-    /// Construct a block time for tests where blocks are exactly 10s apart
+    /// Construct a block time for tests where blocks are exactly 45 minutes
+    /// apart. We use that big a timespan to make it easier to trigger
+    /// hourly rollups in tests
     #[cfg(debug_assertions)]
     pub fn for_test(ptr: &BlockPtr) -> Self {
-        Self::since_epoch(ptr.number as i64 * 10, 0)
+        Self::since_epoch(ptr.number as i64 * 45 * 60, 0)
     }
 
     pub fn as_secs_since_epoch(&self) -> i64 {

--- a/graph/src/components/store/err.rs
+++ b/graph/src/components/store/err.rs
@@ -1,6 +1,5 @@
 use super::{BlockNumber, DeploymentSchemaVersion};
 use crate::prelude::QueryExecutionError;
-use crate::util::intern::Error as InternError;
 use crate::{data::store::EntityValidationError, prelude::DeploymentHash};
 
 use anyhow::{anyhow, Error};
@@ -19,8 +18,8 @@ pub enum StoreError {
          which has an interface in common with `{0}`, exists with the same ID"
     )]
     ConflictingId(String, String, String), // (entity, id, conflicting_entity)
-    #[error("unknown field '{0}'")]
-    UnknownField(String),
+    #[error("table '{0}' does not have a field '{1}'")]
+    UnknownField(String, String),
     #[error("unknown table '{0}'")]
     UnknownTable(String),
     #[error("entity type '{0}' does not have an attribute '{0}'")]
@@ -93,7 +92,7 @@ impl Clone for StoreError {
             Self::ConflictingId(arg0, arg1, arg2) => {
                 Self::ConflictingId(arg0.clone(), arg1.clone(), arg2.clone())
             }
-            Self::UnknownField(arg0) => Self::UnknownField(arg0.clone()),
+            Self::UnknownField(arg0, arg1) => Self::UnknownField(arg0.clone(), arg1.clone()),
             Self::UnknownTable(arg0) => Self::UnknownTable(arg0.clone()),
             Self::UnknownAttribute(arg0, arg1) => {
                 Self::UnknownAttribute(arg0.clone(), arg1.clone())
@@ -170,13 +169,5 @@ impl From<QueryExecutionError> for StoreError {
 impl From<std::fmt::Error> for StoreError {
     fn from(e: std::fmt::Error) -> Self {
         StoreError::Unknown(anyhow!("{}", e.to_string()))
-    }
-}
-
-impl From<InternError> for StoreError {
-    fn from(e: InternError) -> Self {
-        match e {
-            InternError::NotInterned(key) => StoreError::UnknownField(key),
-        }
     }
 }

--- a/graph/src/data/graphql/ext.rs
+++ b/graph/src/data/graphql/ext.rs
@@ -313,7 +313,16 @@ impl ValueExt for Value {
 
 pub trait DirectiveFinder {
     fn find_directive(&self, name: &str) -> Option<&Directive>;
-    fn is_derived(&self) -> bool;
+
+    fn is_derived(&self) -> bool {
+        self.find_directive("derivedFrom").is_some()
+    }
+
+    fn derived_from(&self) -> Option<&str> {
+        self.find_directive("derivedFrom")
+            .and_then(|directive| directive.argument("field"))
+            .and_then(|value| value.as_str())
+    }
 }
 
 impl DirectiveFinder for ObjectType {
@@ -322,12 +331,6 @@ impl DirectiveFinder for ObjectType {
             .iter()
             .find(|directive| directive.name.eq(&name))
     }
-
-    fn is_derived(&self) -> bool {
-        let is_derived = |directive: &Directive| directive.name.eq("derivedFrom");
-
-        self.directives.iter().any(is_derived)
-    }
 }
 
 impl DirectiveFinder for Field {
@@ -335,12 +338,6 @@ impl DirectiveFinder for Field {
         self.directives
             .iter()
             .find(|directive| directive.name.eq(name))
-    }
-
-    fn is_derived(&self) -> bool {
-        let is_derived = |directive: &Directive| directive.name.eq("derivedFrom");
-
-        self.directives.iter().any(is_derived)
     }
 }
 

--- a/graph/src/data/graphql/ext.rs
+++ b/graph/src/data/graphql/ext.rs
@@ -1,4 +1,5 @@
 use anyhow::Error;
+use inflector::Inflector;
 
 use super::ObjectOrInterface;
 use crate::prelude::s::{
@@ -378,15 +379,33 @@ impl TypeDefinitionExt for TypeDefinition {
     }
 }
 
+/// Return the singular and plural names for `name` for use in queries
+pub fn camel_cased_names(name: &str) -> (String, String) {
+    let singular = name.to_camel_case();
+    let mut plural = name.to_plural().to_camel_case();
+    if plural == singular {
+        plural.push_str("_collection");
+    }
+    (singular, plural)
+}
+
 pub trait FieldExt {
     // Return `true` if this is the name of one of the query fields from the
     // introspection schema
     fn is_introspection(&self) -> bool;
+
+    /// Return the singular and plural names for this field for use in
+    /// queries
+    fn camel_cased_names(&self) -> (String, String);
 }
 
 impl FieldExt for Field {
     fn is_introspection(&self) -> bool {
         &self.name == "__schema" || &self.name == "__type"
+    }
+
+    fn camel_cased_names(&self) -> (String, String) {
+        camel_cased_names(&self.name)
     }
 }
 

--- a/graph/src/data/graphql/ext.rs
+++ b/graph/src/data/graphql/ext.rs
@@ -3,7 +3,7 @@ use inflector::Inflector;
 
 use super::ObjectOrInterface;
 use crate::prelude::s::{
-    Definition, Directive, Document, EnumType, Field, InterfaceType, ObjectType, Type,
+    self, Definition, Directive, Document, EnumType, Field, InterfaceType, ObjectType, Type,
     TypeDefinition, Value,
 };
 use crate::prelude::{ValueType, ENV_VARS};
@@ -397,6 +397,8 @@ pub trait FieldExt {
     /// Return the singular and plural names for this field for use in
     /// queries
     fn camel_cased_names(&self) -> (String, String);
+
+    fn argument(&self, name: &str) -> Option<&s::InputValue>;
 }
 
 impl FieldExt for Field {
@@ -406,6 +408,10 @@ impl FieldExt for Field {
 
     fn camel_cased_names(&self) -> (String, String) {
         camel_cased_names(&self.name)
+    }
+
+    fn argument(&self, name: &str) -> Option<&s::InputValue> {
+        self.arguments.iter().find(|iv| &iv.name == name)
     }
 }
 

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -77,6 +77,7 @@ pub enum QueryExecutionError {
     DeploymentNotFound(String),
     IdMissing,
     IdNotString,
+    ConstraintViolation(String),
 }
 
 impl QueryExecutionError {
@@ -136,7 +137,8 @@ impl QueryExecutionError {
             | ResultTooBig(_, _)
             | DeploymentNotFound(_)
             | IdMissing
-            | IdNotString => false,
+            | IdNotString
+            | ConstraintViolation(_) => false,
         }
     }
 }
@@ -286,6 +288,7 @@ impl fmt::Display for QueryExecutionError {
             DeploymentNotFound(id_or_name) => write!(f, "deployment `{}` does not exist", id_or_name),
             IdMissing => write!(f, "entity is missing an `id` attribute"),
             IdNotString => write!(f, "entity `id` attribute is not a string"),
+            ConstraintViolation(msg) => write!(f, "internal constraint violated: {}", msg),
         }
     }
 }
@@ -317,6 +320,7 @@ impl From<StoreError> for QueryExecutionError {
             StoreError::ChildFilterNestingNotSupportedError(attr, filter) => {
                 QueryExecutionError::ChildFilterNestingNotSupportedError(attr, filter)
             }
+            StoreError::ConstraintViolation(msg) => QueryExecutionError::ConstraintViolation(msg),
             _ => QueryExecutionError::StoreError(CloneableAnyhowError(Arc::new(e.into()))),
         }
     }

--- a/graph/src/data/store/id.rs
+++ b/graph/src/data/store/id.rs
@@ -18,7 +18,6 @@ use crate::{
     data::value::Word,
     prelude::{CacheWeight, QueryExecutionError},
     runtime::gas::{Gas, GasSizeOf},
-    schema::EntityType,
 };
 
 use super::{scalar, Value, ValueType, ID};
@@ -343,10 +342,9 @@ impl IdList {
     /// Turn a list of ids into an `IdList` and check that they are all the
     /// same type
     pub fn try_from_iter<I: Iterator<Item = Id>>(
-        entity_type: &EntityType,
+        id_type: IdType,
         mut iter: I,
     ) -> Result<Self, QueryExecutionError> {
-        let id_type = entity_type.id_type()?;
         match id_type {
             IdType::String => {
                 let ids: Vec<Word> = iter.try_fold(vec![], |mut ids, id| match id {

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -931,7 +931,7 @@ impl Entity {
         })?;
 
         for field in object_type.fields.iter() {
-            match (self.get(&field.name), field.is_derived) {
+            match (self.get(&field.name), field.is_derived()) {
                 (Some(value), false) => {
                     let scalar_type = &field.value_type;
                     if field.field_type.is_list() {

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -55,7 +55,7 @@ impl SubscriptionFilter {
                     entity_type,
                     ..
                 },
-            ) => subgraph_id == eid && entity_type == etype.as_str(),
+            ) => subgraph_id == eid && entity_type == etype.typename(),
             (Self::Assignment, EntityChange::Assignment { .. }) => true,
             _ => false,
         }

--- a/graph/src/data_source/mod.rs
+++ b/graph/src/data_source/mod.rs
@@ -68,7 +68,7 @@ impl fmt::Display for EntityTypeAccess {
         match self {
             Self::Any => write!(f, "Any"),
             Self::Restriced(entities) => {
-                let strings = entities.iter().map(|e| e.as_str()).collect::<Vec<_>>();
+                let strings = entities.iter().map(|e| e.typename()).collect::<Vec<_>>();
                 write!(f, "{}", strings.join(", "))
             }
         }

--- a/graph/src/schema/api.rs
+++ b/graph/src/schema/api.rs
@@ -17,7 +17,7 @@ use crate::schema::{ast, META_FIELD_NAME, META_FIELD_TYPE};
 use crate::data::graphql::ext::{DefinitionExt, DirectiveExt, DocumentExt, ValueExt};
 use crate::prelude::{q, r, s, DeploymentHash};
 
-use super::{Field, InputSchema, Schema, SCHEMA_TYPE_NAME};
+use super::{Field, InputSchema, Schema};
 
 #[derive(Error, Debug)]
 pub enum APISchemaError {
@@ -357,16 +357,6 @@ pub(in crate::schema) fn api_schema(
     add_field_arguments(&mut api.document, &input_schema.schema().document)?;
     add_query_type(&mut api.document, input_schema)?;
     add_subscription_type(&mut api.document, input_schema)?;
-
-    // Remove the `_Schema_` type from the generated schema.
-    api.document.definitions.retain(|d| match d {
-        s::Definition::TypeDefinition(def @ s::TypeDefinition::Object(_)) => match def {
-            s::TypeDefinition::Object(t) if t.name.eq(SCHEMA_TYPE_NAME) => false,
-            _ => true,
-        },
-        _ => true,
-    });
-
     Ok(api.document)
 }
 

--- a/graph/src/schema/api.rs
+++ b/graph/src/schema/api.rs
@@ -1269,7 +1269,9 @@ fn query_fields_for_agg_type(type_name: &str) -> Vec<s::Field> {
         position: Pos::default(),
         description: Some(format!("The aggregation interval for the query")),
         name: "interval".to_string(),
-        value_type: s::Type::NonNullType(Box::new(s::Type::NamedType("String".to_string()))),
+        value_type: s::Type::NonNullType(Box::new(s::Type::NamedType(
+            "Aggregation_interval".to_string(),
+        ))),
         default_value: None,
         directives: vec![],
     };

--- a/graph/src/schema/api.rs
+++ b/graph/src/schema/api.rs
@@ -786,7 +786,7 @@ fn field_filter_input_values(
         Ok(match named_type {
             s::TypeDefinition::Object(_) | s::TypeDefinition::Interface(_) => {
                 let scalar_type = id_type_as_scalar(schema, named_type)?.unwrap();
-                let mut input_values = if field.is_derived {
+                let mut input_values = if field.is_derived() {
                     // Only add `where` filter fields for object and interface fields
                     // if they are not @derivedFrom
                     vec![]
@@ -975,7 +975,7 @@ fn field_list_filter_input_values(
     let (input_field_type, parent_type_name) = match typedef {
         s::TypeDefinition::Object(s::ObjectType { name, .. })
         | s::TypeDefinition::Interface(s::InterfaceType { name, .. }) => {
-            if field.is_derived {
+            if field.is_derived() {
                 (None, Some(name.clone()))
             } else {
                 let scalar_type = id_type_as_scalar(schema, typedef)?.unwrap();

--- a/graph/src/schema/api.rs
+++ b/graph/src/schema/api.rs
@@ -1,18 +1,21 @@
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
+use std::sync::Arc;
 
+use anyhow::Context;
 use graphql_parser::Pos;
 use inflector::Inflector;
 use lazy_static::lazy_static;
+use thiserror::Error;
 
+use crate::cheap_clone::CheapClone;
 use crate::data::graphql::{ObjectOrInterface, ObjectTypeExt};
 use crate::data::store::IdType;
+use crate::env::ENV_VARS;
 use crate::schema::{ast, META_FIELD_NAME, META_FIELD_TYPE};
 
 use crate::data::graphql::ext::{DefinitionExt, DirectiveExt, DocumentExt, ValueExt};
-use crate::prelude::s;
-use crate::prelude::*;
-use thiserror::Error;
+use crate::prelude::{q, r, s, DeploymentHash};
 
 use super::{InputSchema, Schema, SCHEMA_TYPE_NAME};
 

--- a/graph/src/schema/api.rs
+++ b/graph/src/schema/api.rs
@@ -381,7 +381,7 @@ fn init_api_schema(input_schema: &InputSchema) -> Result<Schema, APISchemaError>
             // `field_type`` could be an enum or scalar, in which case
             // `type_kind_str` will return `None``
             if let Some(ops) = input_schema
-                .type_kind_str(field_type)
+                .kind_of_declared_type(field_type)
                 .map(FilterOps::for_kind)
             {
                 field.arguments = ops.collection_arguments(field_type);

--- a/graph/src/schema/ast.rs
+++ b/graph/src/schema/ast.rs
@@ -10,6 +10,8 @@ use crate::data::graphql::{DirectiveExt, DocumentExt, ObjectOrInterface};
 use crate::prelude::anyhow::anyhow;
 use crate::prelude::{s, Error, ValueType};
 
+use super::AsEntityTypeName;
+
 pub enum FilterOp {
     Not,
     GreaterThan,
@@ -131,6 +133,12 @@ impl Deref for ObjectType {
 }
 
 impl CheapClone for ObjectType {}
+
+impl AsEntityTypeName for &ObjectType {
+    fn name(&self) -> &str {
+        &self.0.name
+    }
+}
 
 impl ObjectType {
     pub fn name(&self) -> &str {

--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use super::{
-    input_schema::{ObjectType, TypeKind, POI_OBJECT},
+    input_schema::{ObjectType, POI_OBJECT},
     EntityKey, InputSchema, InterfaceType,
 };
 
@@ -126,11 +126,11 @@ impl EntityType {
         self.schema.share_interfaces(self.atom)
     }
 
-    /// Return what kind of type `self` represents
-    pub fn kind(&self) -> TypeKind {
-        self.schema
-            .type_kind(self.atom)
-            .expect("the type must exist")
+    /// Return `true` if `self` is an object type, i.e., a type that is
+    /// declared with an `@entity` directive in the input schema. This
+    /// specifically excludes interfaces and aggregations.
+    pub fn is_object_type(&self) -> bool {
+        self.schema.is_object_type(self.atom)
     }
 }
 

--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use super::{
     input_schema::{ObjectType, POI_OBJECT},
-    EntityKey, InputSchema, InterfaceType,
+    EntityKey, Field, InputSchema, InterfaceType,
 };
 
 /// A reference to a type in the input schema. It should mostly be the
@@ -61,6 +61,10 @@ impl EntityType {
         self.schema.has_field(self.atom, field)
     }
 
+    pub fn field(&self, name: &str) -> Option<&Field> {
+        self.schema.field(self.atom, name)
+    }
+
     pub fn is_immutable(&self) -> bool {
         self.schema.is_immutable(self.atom)
     }
@@ -104,7 +108,8 @@ impl EntityType {
             .into_iter()
             .map(|id| self.parse_id(id))
             .collect::<Result<_, _>>()?;
-        IdList::try_from_iter(self, ids.into_iter()).map_err(|e| anyhow::anyhow!("error: {}", e))
+        IdList::try_from_iter(self.id_type()?, ids.into_iter())
+            .map_err(|e| anyhow::anyhow!("error: {}", e))
     }
 
     /// Parse the given `id` into an `Id` and construct a key for an onchain

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -1377,14 +1377,14 @@ fn atom_pool(document: &s::Document) -> AtomPool {
 mod validations {
     use std::{collections::HashSet, str::FromStr};
 
-    use inflector::Inflector;
     use itertools::Itertools;
     use semver::Version;
 
     use crate::{
         data::{
             graphql::{
-                ext::DirectiveFinder, DirectiveExt, DocumentExt, ObjectTypeExt, TypeExt, ValueExt,
+                ext::{DirectiveFinder, FieldExt},
+                DirectiveExt, DocumentExt, ObjectTypeExt, TypeExt, ValueExt,
             },
             store::{IdType, ValueType, ID},
             subgraph::SPEC_VERSION_1_1_0,
@@ -1520,9 +1520,8 @@ mod validations {
             // to create the field names in `graphql::schema::api::query_fields_for_type()`.
             if self.entity_types.iter().any(|typ| {
                 typ.fields.iter().any(|field| {
-                    name == &field.name.as_str().to_camel_case()
-                        || name == &field.name.to_plural().to_camel_case()
-                        || field.name.eq(name)
+                    let (singular, plural) = field.camel_cased_names();
+                    name == &singular || name == &plural || field.name.eq(name)
                 })
             }) {
                 return vec![SchemaValidationError::FulltextNameCollision(

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -1084,6 +1084,20 @@ impl InputSchema {
         }
     }
 
+    pub(in crate::schema) fn object_types(&self) -> impl Iterator<Item = &ObjectType> {
+        self.inner.type_infos.iter().filter_map(|ti| match ti {
+            TypeInfo::Object(obj_type) => Some(obj_type),
+            TypeInfo::Interface(_) | TypeInfo::Aggregation(_) => None,
+        })
+    }
+
+    pub(in crate::schema) fn interface_types(&self) -> impl Iterator<Item = &InterfaceType> {
+        self.inner.type_infos.iter().filter_map(|ti| match ti {
+            TypeInfo::Interface(intf_type) => Some(intf_type),
+            TypeInfo::Object(_) | TypeInfo::Aggregation(_) => None,
+        })
+    }
+
     /// Return a list of the names of all enum types
     pub fn enum_types(&self) -> impl Iterator<Item = &str> {
         self.inner.enum_map.names()

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -1084,18 +1084,40 @@ impl InputSchema {
         }
     }
 
-    pub(in crate::schema) fn object_types(&self) -> impl Iterator<Item = &ObjectType> {
-        self.inner.type_infos.iter().filter_map(|ti| match ti {
-            TypeInfo::Object(obj_type) => Some(obj_type),
-            TypeInfo::Interface(_) | TypeInfo::Aggregation(_) => None,
-        })
+    /// Return a list of all object types, i.e., types defined with an
+    /// `@entity` annotation. This does not include the type for the PoI
+    pub(in crate::schema) fn object_types(&self) -> impl Iterator<Item = (&str, &ObjectType)> {
+        self.inner
+            .type_infos
+            .iter()
+            .filter_map(|ti| match ti {
+                TypeInfo::Object(obj_type) => Some(obj_type),
+                TypeInfo::Interface(_) | TypeInfo::Aggregation(_) => None,
+            })
+            .map(|obj_type| {
+                let name = self.inner.pool.get(obj_type.name).unwrap();
+                (name, obj_type)
+            })
+            .filter(|(name, _)| {
+                // Filter out the POI object type
+                name != &POI_OBJECT
+            })
     }
 
-    pub(in crate::schema) fn interface_types(&self) -> impl Iterator<Item = &InterfaceType> {
-        self.inner.type_infos.iter().filter_map(|ti| match ti {
-            TypeInfo::Interface(intf_type) => Some(intf_type),
-            TypeInfo::Object(_) | TypeInfo::Aggregation(_) => None,
-        })
+    pub(in crate::schema) fn interface_types(
+        &self,
+    ) -> impl Iterator<Item = (&str, &InterfaceType)> {
+        self.inner
+            .type_infos
+            .iter()
+            .filter_map(|ti| match ti {
+                TypeInfo::Interface(intf_type) => Some(intf_type),
+                TypeInfo::Object(_) | TypeInfo::Aggregation(_) => None,
+            })
+            .map(|intf_type| {
+                let name = self.inner.pool.get(intf_type.name).unwrap();
+                (name, intf_type)
+            })
     }
 
     /// Return a list of the names of all enum types

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -898,7 +898,7 @@ impl InputSchema {
     /// `InputSchema`
     pub fn api_schema(&self) -> Result<ApiSchema, anyhow::Error> {
         let mut schema = self.inner.schema.clone();
-        schema.document = api_schema(&self.inner.schema)?;
+        schema.document = api_schema(self)?;
         schema.add_subgraph_id_directives(schema.id.clone());
         ApiSchema::from_api_schema(schema)
     }

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -269,6 +269,10 @@ impl Field {
             s::Type::ListType(inner) => Self::scalar_value_type(schema, inner),
         }
     }
+
+    pub fn is_list(&self) -> bool {
+        self.field_type.is_list()
+    }
 }
 
 #[derive(PartialEq, Debug)]

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -1313,6 +1313,11 @@ impl InputSchema {
     pub(in crate::schema) fn type_kind(&self, atom: Atom) -> Option<TypeKind> {
         self.type_info(atom).ok().map(|ti| ti.kind())
     }
+
+    pub(in crate::schema) fn type_kind_str(&self, name: &str) -> Option<TypeKind> {
+        let name = self.inner.pool.lookup(name)?;
+        self.type_kind(name)
+    }
 }
 
 /// Create a new pool that contains the names of all the types defined

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -512,7 +512,15 @@ impl InterfaceType {
         let fields = interface_type
             .fields
             .iter()
-            .map(|field| Field::new(schema, &field.name, &field.field_type, None))
+            .map(|field| {
+                // It's very unclear what it means for an interface field to
+                // be derived; but for legacy reasons, we need to allow it
+                // since the API schema does not contain certain filters for
+                // derived fields on interfaces that it would for
+                // non-derived fields
+                let derived_from = field.derived_from().map(|name| Word::from(name));
+                Field::new(schema, &field.name, &field.field_type, derived_from)
+            })
             .collect();
         let name = pool
             .lookup(&interface_type.name)

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -953,7 +953,7 @@ impl InputSchema {
             .inner
             .schema
             .document
-            .get_object_type_definition(key.entity_type.as_str())
+            .get_object_type_definition(key.entity_type.typename())
             .ok_or_else(|| field_err(key, "unknown entity type"))?
             .field(&key.entity_field)
             .ok_or_else(|| field_err(key, "unknown field"))?;
@@ -1333,6 +1333,11 @@ impl InputSchema {
             TypeInfo::Object(obj_type) => obj_type.name == atom,
             _ => false,
         })
+    }
+
+    pub(crate) fn typename(&self, atom: Atom) -> &str {
+        let name = self.type_info(atom).unwrap().name();
+        self.inner.pool.get(name).unwrap()
     }
 }
 
@@ -2852,10 +2857,10 @@ mod tests {
     fn entity_type() {
         let schema = make_schema();
 
-        assert_eq!("Thing", schema.entity_type("Thing").unwrap().as_str());
+        assert_eq!("Thing", schema.entity_type("Thing").unwrap().typename());
 
         let poi = schema.entity_type(POI_OBJECT).unwrap();
-        assert_eq!(POI_OBJECT, poi.as_str());
+        assert_eq!(POI_OBJECT, poi.typename());
         assert!(poi.has_field(schema.pool().lookup(&ID).unwrap()));
         assert!(poi.has_field(schema.pool().lookup(POI_DIGEST).unwrap()));
         assert!(poi.object_type().is_ok());

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -1537,7 +1537,7 @@ impl InputSchema {
     }
 
     /// Return an `EntityType` that either references the object type `name`
-    /// or, if `name` refernces an aggregation, return the object type of
+    /// or, if `name` references an aggregation, return the object type of
     /// that aggregation for the given `interval`
     pub fn object_or_aggregation(
         &self,

--- a/graph/src/schema/meta.graphql
+++ b/graph/src/schema/meta.graphql
@@ -1,7 +1,9 @@
 # GraphQL core functionality
 scalar Boolean
 scalar ID
-""" 4 bytes signed integer """
+"""
+4 bytes signed integer
+"""
 scalar Int
 scalar Float
 scalar String
@@ -24,7 +26,9 @@ directive @derivedFrom(field: String!) on FIELD_DEFINITION
 scalar BigDecimal
 scalar Bytes
 scalar BigInt
-""" 8 bytes signed integer """
+"""
+8 bytes signed integer
+"""
 scalar Int8
 
 # The type names are purposely awkward to minimize the risk of them
@@ -59,13 +63,13 @@ type _Block_ {
   hash: Bytes
   "The block number"
   number: Int!
-  "Integer representation of the timestamp stored in blocks for the chain" 
+  "Integer representation of the timestamp stored in blocks for the chain"
   timestamp: Int
 }
 
 enum _SubgraphErrorPolicy_ {
   "Data will be returned even if the subgraph has indexing errors"
-  allow,
+  allow
 
   "If the subgraph has indexing errors, data will be omitted. The default."
   deny
@@ -78,7 +82,7 @@ input Block_height {
   "Value containing a block number"
   number: Int
   """
-  Value containing the minimum block number. 
+  Value containing the minimum block number.
   In the case of `number_gte`, the query will be executed on the latest block only if
   the subgraph has progressed to or past the minimum block number.
   Defaults to the latest block when omitted.
@@ -90,4 +94,9 @@ input Block_height {
 enum OrderDirection {
   asc
   desc
+}
+
+enum Aggregation_interval {
+  hour
+  day
 }

--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -30,8 +30,8 @@ pub use entity_key::EntityKey;
 pub use entity_type::{AsEntityTypeName, EntityType};
 pub use fulltext::{FulltextAlgorithm, FulltextConfig, FulltextDefinition, FulltextLanguage};
 pub use input_schema::{
-    Aggregate, AggregateFn, Aggregation, AggregationInterval, AggregationMapping, Field,
-    InputSchema, InterfaceType, ObjectType, TypeKind,
+    kw, Aggregate, AggregateFn, Aggregation, AggregationInterval, AggregationMapping, Field,
+    InputSchema, InterfaceType, ObjectOrInterface, ObjectType, TypeKind,
 };
 
 pub const SCHEMA_TYPE_NAME: &str = "_Schema_";

--- a/graphql/src/store/mod.rs
+++ b/graphql/src/store/mod.rs
@@ -2,5 +2,4 @@ mod prefetch;
 mod query;
 mod resolver;
 
-//pub use self::query::parse_subgraph_id;
 pub use self::resolver::StoreResolver;

--- a/graphql/src/store/mod.rs
+++ b/graphql/src/store/mod.rs
@@ -2,5 +2,5 @@ mod prefetch;
 mod query;
 mod resolver;
 
-pub use self::query::parse_subgraph_id;
+//pub use self::query::parse_subgraph_id;
 pub use self::resolver::StoreResolver;

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -413,7 +413,7 @@ impl<'a> Join<'a> {
         for cond in &self.conds {
             let mut parents_by_id = parents
                 .iter()
-                .filter(|parent| parent.typename() == cond.parent_type.as_str())
+                .filter(|parent| parent.typename() == cond.parent_type.typename())
                 .filter_map(|parent| parent.id(schema).ok().map(|id| (id, &**parent)))
                 .collect::<Vec<_>>();
 

--- a/graphql/src/store/prefetch.rs
+++ b/graphql/src/store/prefetch.rs
@@ -681,7 +681,6 @@ impl<'a> Loader<'a> {
             join.child_type(),
             self.resolver.block_number(),
             field,
-            self.ctx.query.schema.types_for_interface(),
             self.ctx.max_first,
             self.ctx.max_skip,
             &super::query::SchemaPair {

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
+use std::collections::{BTreeSet, HashSet, VecDeque};
 use std::mem::discriminant;
 use std::sync::Arc;
 
@@ -39,7 +39,6 @@ pub(crate) fn build_query<'a>(
     entity: impl Into<ObjectOrInterface<'a>>,
     block: BlockNumber,
     field: &a::Field,
-    types_for_interface: &'a BTreeMap<String, Vec<s::ObjectType>>,
     max_first: u32,
     max_skip: u32,
     schema: &SchemaPair,
@@ -51,7 +50,8 @@ pub(crate) fn build_query<'a>(
             let entity_type = schema.input.entity_type(*object).unwrap();
             vec![(entity_type, selected_columns)]
         }
-        ObjectOrInterface::Interface(interface) => types_for_interface[&interface.name]
+        ObjectOrInterface::Interface(interface) => schema.api.types_for_interface()
+            [&interface.name]
             .iter()
             .map(|o| {
                 let selected_columns = field.selected_attrs(o);
@@ -809,7 +809,7 @@ mod tests {
         schema::InputSchema,
     };
     use graphql_parser::Pos;
-    use std::{collections::BTreeMap, iter::FromIterator, sync::Arc};
+    use std::{iter::FromIterator, sync::Arc};
 
     use super::{a, build_query, SchemaPair};
 
@@ -936,7 +936,6 @@ mod tests {
                 &object("Entity1"),
                 BLOCK_NUMBER_MAX,
                 &default_field(),
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema,
@@ -953,7 +952,6 @@ mod tests {
                 &object("Entity2"),
                 BLOCK_NUMBER_MAX,
                 &default_field(),
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema,
@@ -975,7 +973,6 @@ mod tests {
                 &default_object(),
                 BLOCK_NUMBER_MAX,
                 &default_field(),
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema,
@@ -995,7 +992,6 @@ mod tests {
                 &default_object(),
                 BLOCK_NUMBER_MAX,
                 &field,
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema,
@@ -1011,7 +1007,6 @@ mod tests {
                 &default_object(),
                 BLOCK_NUMBER_MAX,
                 &field,
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema,
@@ -1031,7 +1026,6 @@ mod tests {
                 &default_object(),
                 BLOCK_NUMBER_MAX,
                 &field,
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema,
@@ -1047,7 +1041,6 @@ mod tests {
                 &default_object(),
                 BLOCK_NUMBER_MAX,
                 &field,
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema,
@@ -1070,7 +1063,6 @@ mod tests {
                 &default_object(),
                 BLOCK_NUMBER_MAX,
                 &field,
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema,
@@ -1089,7 +1081,6 @@ mod tests {
                 &default_object(),
                 BLOCK_NUMBER_MAX,
                 &field,
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema,
@@ -1111,7 +1102,6 @@ mod tests {
                 &default_object(),
                 BLOCK_NUMBER_MAX,
                 &field,
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema
@@ -1131,7 +1121,6 @@ mod tests {
                 &default_object(),
                 BLOCK_NUMBER_MAX,
                 &field,
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema
@@ -1150,7 +1139,6 @@ mod tests {
                 &default_object(),
                 BLOCK_NUMBER_MAX,
                 &default_field(),
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema
@@ -1172,7 +1160,6 @@ mod tests {
                 &default_object(),
                 BLOCK_NUMBER_MAX,
                 &field,
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema
@@ -1204,7 +1191,6 @@ mod tests {
                 },
                 BLOCK_NUMBER_MAX,
                 &query_field,
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema
@@ -1239,7 +1225,6 @@ mod tests {
                 },
                 BLOCK_NUMBER_MAX,
                 &query_field,
-                &BTreeMap::new(),
                 std::u32::MAX,
                 std::u32::MAX,
                 &schema

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -1,12 +1,21 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::mem::discriminant;
+use std::sync::Arc;
 
+use graph::cheap_clone::CheapClone;
+use graph::components::store::{
+    BlockNumber, Child, EntityCollection, EntityFilter, EntityOrder, EntityOrderByChild,
+    EntityOrderByChildInfo, EntityQuery, EntityRange,
+};
 use graph::data::graphql::ext::DirectiveFinder;
 use graph::data::graphql::ObjectOrInterface;
 use graph::data::graphql::TypeExt as _;
+use graph::data::query::QueryExecutionError;
+use graph::data::store::{Attribute, SubscriptionFilter, Value, ValueType};
+use graph::data::subgraph::DeploymentHash;
 use graph::data::value::Object;
 use graph::data::value::Value as DataValue;
-use graph::prelude::*;
+use graph::prelude::{r, s, TryFromValue, ENV_VARS};
 use graph::schema::ast::{self as sast, FilterOp};
 use graph::schema::{ApiSchema, EntityType, InputSchema};
 

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -1642,10 +1642,16 @@ async fn test_store_ts() {
     let err = host
         .store_setv(STATS, SID, vec![("amount", b20)])
         .expect_err("store_set must fail for aggregations");
-    err_says(err, "entity type `Stats` does not exist in hostStoreTs");
+    err_says(
+        err,
+        "Cannot set entity of type `Stats`. The type must be an @entity type",
+    );
 
     let err = host
         .store_get(STATS, SID)
         .expect_err("store_get must fail for timeseries");
-    err_says(err, "entity type `Stats` does not exist in hostStoreTs");
+    err_says(
+        err,
+        "Cannot get entity of type `Stats`. The type must be an @entity type",
+    );
 }

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -304,7 +304,7 @@ impl<C: Blockchain> HostExports<C> {
         write_poi_event(
             proof_of_indexing,
             &ProofOfIndexingEvent::SetEntity {
-                entity_type: &key.entity_type.as_str(),
+                entity_type: &key.entity_type.typename(),
                 id: &key.entity_id.to_string(),
                 data: &entity,
             },

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use graph::data::subgraph::API_VERSION_0_0_8;
 use graph::data::value::Word;
 
-use graph::schema::{EntityType, TypeKind};
+use graph::schema::EntityType;
 use never::Never;
 use semver::Version;
 use wasmtime::Trap;
@@ -202,14 +202,13 @@ impl<C: Blockchain> HostExports<C> {
 
     /// Ensure that `entity_type` is of the right kind
     fn expect_object_type(entity_type: &EntityType, op: &str) -> Result<(), HostExportError> {
-        if entity_type.kind() != TypeKind::Object {
-            Err(HostExportError::Deterministic(anyhow!(
-                "Cannot {op} entity of type `{}`. The type must be an @entity type",
-                entity_type.as_str()
-            )))
-        } else {
-            Ok(())
+        if entity_type.is_object_type() {
+            return Ok(());
         }
+        Err(HostExportError::Deterministic(anyhow!(
+            "Cannot {op} entity of type `{}`. The type must be an @entity type",
+            entity_type.as_str()
+        )))
     }
 
     pub(crate) fn store_set(

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -1092,7 +1092,7 @@ pub fn create_deployment(
     let entities_with_causality_region = Vec::from_iter(
         entities_with_causality_region
             .into_iter()
-            .map(|et| et.as_str().to_owned()),
+            .map(|et| et.typename().to_owned()),
     );
 
     let deployment_values = (

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1903,7 +1903,7 @@ fn resolve_column<'a>(table: &'a Table, field: &str) -> Result<(&'a SqlName, Str
             let sql_name = SqlName::from(field);
             table
                 .column(&sql_name)
-                .ok_or_else(|| StoreError::UnknownField(field.to_string()))
+                .ok_or_else(|| StoreError::UnknownField(table.name.to_string(), field.to_string()))
         })
         .map(|column| {
             let index_expr =

--- a/store/postgres/src/fork.rs
+++ b/store/postgres/src/fork.rs
@@ -177,7 +177,7 @@ query Query ($id: String) {{
         let map: HashMap<Word, Value> = {
             let mut map = HashMap::new();
             for f in fields {
-                if f.is_derived {
+                if f.is_derived() {
                     // Derived fields are not resolved, so it's safe to ignore them.
                     continue;
                 }
@@ -263,10 +263,10 @@ mod tests {
 
         let schema = schema.schema();
         vec![
-            Field::new(schema, "id", &non_null_type("ID"), false),
-            Field::new(schema, "owner", &non_null_type("Bytes"), false),
-            Field::new(schema, "displayName", &non_null_type("String"), false),
-            Field::new(schema, "imageUrl", &non_null_type("String"), false),
+            Field::new(schema, "id", &non_null_type("ID"), None),
+            Field::new(schema, "owner", &non_null_type("Bytes"), None),
+            Field::new(schema, "displayName", &non_null_type("String"), None),
+            Field::new(schema, "imageUrl", &non_null_type("String"), None),
         ]
     }
 

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1330,7 +1330,9 @@ pub(crate) const VID_COLUMN: &str = "vid";
 
 #[derive(Debug, Clone)]
 pub struct Table {
-    /// The name of the GraphQL object type ('Thing')
+    /// The reference to the underlying type in the input schema. For
+    /// aggregations, this is the object type for a specific interval, like
+    /// `Stats_hour`, not the overall aggregation type `Stats`.
     pub object: EntityType,
     /// The name of the database table for this type ('thing'), snakecased
     /// version of `object`

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -753,7 +753,7 @@ impl Layout {
             let entity_keys: Vec<_> = rows.iter().map(|row| row.id()).collect();
             // FIXME: we clone all the ids here
             let entity_keys = IdList::try_from_iter(
-                &group.entity_type,
+                group.entity_type.id_type()?,
                 entity_keys.into_iter().map(|id| id.to_owned()),
             )?;
             ClampRangeQuery::new(table, &entity_keys, block)?.execute(conn)?;
@@ -799,7 +799,7 @@ impl Layout {
             for chunk in ids.chunks(DELETE_OPERATION_CHUNK_SIZE) {
                 // FIXME: we clone all the ids here
                 let chunk = IdList::try_from_iter(
-                    &group.entity_type,
+                    group.entity_type.id_type()?,
                     chunk.into_iter().map(|id| (*id).to_owned()),
                 )?;
                 count += ClampRangeQuery::new(table, &chunk, block)?.execute(conn)?
@@ -1382,7 +1382,7 @@ impl Table {
         let columns = object_type
             .fields
             .into_iter()
-            .filter(|field| !field.is_derived)
+            .filter(|field| !field.is_derived())
             .map(|field| Column::new(schema, &table_name, field, catalog))
             .chain(fulltexts.iter().map(Column::new_fulltext))
             .collect::<Result<Vec<Column>, StoreError>>()?;
@@ -1440,7 +1440,7 @@ impl Table {
         self.columns
             .iter()
             .find(|column| column.field == field)
-            .ok_or_else(|| StoreError::UnknownField(field.to_string()))
+            .ok_or_else(|| StoreError::UnknownField(self.name.to_string(), field.to_string()))
     }
 
     fn can_copy_from(&self, source: &Self) -> Vec<String> {

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -482,6 +482,7 @@ impl EntityData {
         parent_type: Option<&ColumnType>,
     ) -> Result<T, StoreError> {
         let entity_type = layout.input_schema.entity_type(&self.entity)?;
+        let typename = entity_type.typename();
         let table = layout.table_for_entity(&entity_type)?;
 
         use serde_json::Value as j;
@@ -512,9 +513,12 @@ impl EntityData {
                     })
                     .transpose()?;
                 let map = map;
-                let typname = std::iter::once(self.entity).filter_map(move |e| {
+                let typname = std::iter::once(typename).filter_map(move |e| {
                     if T::WITH_INTERNAL_KEYS {
-                        Some(Ok((Word::from("__typename"), T::Value::from_string(e))))
+                        Some(Ok((
+                            Word::from("__typename"),
+                            T::Value::from_string(e.to_string()),
+                        )))
                     } else {
                         None
                     }

--- a/store/test-store/tests/graphql/introspection.rs
+++ b/store/test-store/tests/graphql/introspection.rs
@@ -1,3 +1,5 @@
+use std::fs::File;
+use std::io::Write;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -138,6 +140,78 @@ async fn introspection_query(schema: Arc<ApiSchema>, query: &str) -> QueryResult
     QueryResult::from(result)
 }
 
+fn compare(a: &r::Value, b: &r::Value, path: &mut Vec<String>) -> Option<(r::Value, r::Value)> {
+    fn different(a: &r::Value, b: &r::Value) -> Option<(r::Value, r::Value)> {
+        Some((a.clone(), b.clone()))
+    }
+
+    match a {
+        r::Value::Int(_) | r::Value::Float(_) | r::Value::Boolean(_) | r::Value::Null => {
+            if a != b {
+                different(a, b)
+            } else {
+                None
+            }
+        }
+        r::Value::List(la) => match b {
+            r::Value::List(lb) => {
+                for (i, (va, vb)) in la.iter().zip(lb.iter()).enumerate() {
+                    path.push(i.to_string());
+                    let res = compare(va, vb, path);
+                    if res.is_some() {
+                        return res;
+                    }
+                    path.pop();
+                }
+                if la.len() > lb.len() {
+                    path.push(lb.len().to_string());
+                    return different(&la[lb.len()], &r::Value::Null);
+                }
+                if lb.len() > la.len() {
+                    path.push(la.len().to_string());
+                    return different(&r::Value::Null, &lb[la.len()]);
+                }
+                return None;
+            }
+            _ => different(a, b),
+        },
+        r::Value::String(sa) | r::Value::Enum(sa) => match b {
+            r::Value::String(sb) | r::Value::Enum(sb) => {
+                if sa != sb {
+                    different(a, b)
+                } else {
+                    None
+                }
+            }
+            _ => different(a, b),
+        },
+        r::Value::Object(oa) => match b {
+            r::Value::Object(ob) => {
+                if oa.len() != ob.len() {
+                    return different(a, b);
+                }
+                for (ka, va) in oa.iter() {
+                    match ob.get(ka) {
+                        Some(vb) => {
+                            path.push(ka.to_string());
+                            let res = compare(va, vb, path);
+                            if res.is_some() {
+                                return res;
+                            }
+                            path.pop();
+                        }
+                        None => {
+                            return different(va, &r::Value::Null);
+                        }
+                    }
+                }
+                return None;
+            }
+            _ => different(a, b),
+        },
+    }
+}
+
 /// Compare two values and consider them the same if they are identical with
 /// some special treatment meant to mimic what GraphQL users care about in
 /// the resulting JSON value
@@ -149,50 +223,35 @@ async fn introspection_query(schema: Arc<ApiSchema>, query: &str) -> QueryResult
 /// (2) Enums and Strings are the same if they have the same string value
 #[track_caller]
 fn same_value(a: &r::Value, b: &r::Value) -> bool {
-    match a {
-        r::Value::Int(_) | r::Value::Float(_) | r::Value::Boolean(_) | r::Value::Null => a == b,
-        r::Value::List(la) => match b {
-            r::Value::List(lb) => {
-                if la.len() != lb.len() {
-                    return false;
-                }
-                for i in 0..la.len() {
-                    if !same_value(&la[i], &lb[i]) {
-                        return false;
-                    }
-                }
-                return true;
-            }
-            _ => false,
-        },
-        r::Value::String(sa) | r::Value::Enum(sa) => match b {
-            r::Value::String(sb) | r::Value::Enum(sb) => sa == sb,
-            _ => {
-                println!("STRING/ENUM: {} != {}", sa, b);
-                false
-            }
-        },
-        r::Value::Object(oa) => match b {
-            r::Value::Object(ob) => {
-                if oa.len() != ob.len() {
-                    return false;
-                }
-                for (ka, va) in oa.iter() {
-                    match ob.get(ka) {
-                        Some(vb) => {
-                            if !same_value(va, vb) {
-                                return false;
-                            }
-                        }
-                        None => {
-                            return false;
-                        }
-                    }
-                }
-                return true;
-            }
-            _ => false,
-        },
+    let mut path = Vec::new();
+    if let Some((da, db)) = compare(a, b, &mut path) {
+        println!("Query results differ at path {}", path.join("."));
+        println!("Value A: {da}");
+        println!("Value B: {db}");
+        maybe_save(a);
+        false
+    } else {
+        true
+    }
+}
+
+/// Save `data` into `/tmp/introspection.json` if the environment variable
+/// `INTROSPECTION_SAVE` is set. When one of the tests in this file fails,
+/// use this to save the test output.
+///
+/// It's useful to reformat both that file and the expected value with `jq
+/// .` and then run `diff -u` on the formatted files to see where the
+/// discrepancies are, something like
+///
+/// ```bash
+/// diff -u <(jq . < store/test-store/tests/graphql/mock_introspection.json) \
+///         <(jq . /tmp/introspection.json)
+/// ```
+fn maybe_save(data: &r::Value) {
+    if std::env::var("INTROSPECTION_SAVE").is_ok() {
+        let json = serde_json::to_string_pretty(&data).unwrap();
+        let mut fp = File::create("/tmp/introspection.json").unwrap();
+        writeln!(fp, "{json}").unwrap();
     }
 }
 

--- a/store/test-store/tests/graphql/mock_introspection.json
+++ b/store/test-store/tests/graphql/mock_introspection.json
@@ -1,169 +1,288 @@
 {
-    "__schema": {
-      "queryType": {
-        "name": "Query"
+  "__schema": {
+    "queryType": {
+      "name": "Query"
+    },
+    "mutationType": null,
+    "subscriptionType": {
+      "name": "Subscription"
+    },
+    "types": [
+      {
+        "kind": "ENUM",
+        "name": "Aggregation_interval",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "hour",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
       },
-      "mutationType": null,
-      "subscriptionType": {
-        "name": "Subscription"
+      {
+        "kind": "SCALAR",
+        "name": "BigDecimal",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
       },
-      "types": [
-        {
-          "kind": "SCALAR",
-          "name": "BigDecimal",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "BigInt",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "BlockChangedFilter",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "number_gte",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "Block_height",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "hash",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Bytes",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "number",
-              "description": null,
-              "type": {
+      {
+        "kind": "SCALAR",
+        "name": "BigInt",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "BlockChangedFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "number_gte",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             },
-            {
-              "name": "number_gte",
-              "description": null,
-              "type": {
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "Block_height",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "hash",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Bytes",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "number",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "number_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Boolean",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Bytes",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Float",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "ID",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Int",
+        "description": "4 bytes signed integer\n",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Int8",
+        "description": "8 bytes signed integer\n",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INTERFACE",
+        "name": "Node",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "ID",
                 "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Boolean",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Bytes",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Float",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "ID",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Int",
-          "description": "4 bytes signed integer\n",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Int8",
-          "description": "8 bytes signed integer\n",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INTERFACE",
-          "name": "Node",
-          "description": null,
-          "fields": [
-            {
-              "name": "id",
-              "description": null,
-              "args": [],
-              "type": {
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "User",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "Node_filter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
@@ -171,95 +290,274 @@
                   "name": "ID",
                   "ofType": null
                 }
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "_change_block",
+            "description": "Filter for the block changed event.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BlockChangedFilter",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "Node_filter",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "Node_filter",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "Node_orderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "id",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "OrderDirection",
+        "description": "Defines the order direction, either ascending or descending",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "asc",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "desc",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Query",
+        "description": null,
+        "fields": [
+          {
+            "name": "user",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": [
-            {
+              {
+                "name": "block",
+                "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Block_height",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "subgraphError",
+                "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "_SubgraphErrorPolicy_",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "deny"
+              }
+            ],
+            "type": {
               "kind": "OBJECT",
               "name": "User",
               "ofType": null
-            }
-          ]
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "Node_filter",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "id",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "defaultValue": null
             },
-            {
-              "name": "id_not",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "users",
+            "description": null,
+            "args": [
+              {
+                "name": "skip",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "0"
               },
-              "defaultValue": null
-            },
-            {
-              "name": "id_gt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100"
               },
-              "defaultValue": null
-            },
-            {
-              "name": "id_lt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "User_orderBy",
+                  "ofType": null
+                },
+                "defaultValue": null
               },
-              "defaultValue": null
-            },
-            {
-              "name": "id_gte",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
+              {
+                "name": "orderDirection",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "OrderDirection",
+                  "ofType": null
+                },
+                "defaultValue": null
               },
-              "defaultValue": null
-            },
-            {
-              "name": "id_lte",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "User_filter",
+                  "ofType": null
+                },
+                "defaultValue": null
               },
-              "defaultValue": null
-            },
-            {
-              "name": "id_in",
-              "description": null,
-              "type": {
+              {
+                "name": "block",
+                "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Block_height",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "subgraphError",
+                "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "_SubgraphErrorPolicy_",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "deny"
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
                 "kind": "LIST",
                 "name": null,
                 "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "User",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
@@ -267,17 +565,216 @@
                     "name": "ID",
                     "ofType": null
                   }
-                }
+                },
+                "defaultValue": null
               },
-              "defaultValue": null
+              {
+                "name": "block",
+                "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Block_height",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "subgraphError",
+                "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "_SubgraphErrorPolicy_",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "deny"
+              }
+            ],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
             },
-            {
-              "name": "id_not_in",
-              "description": null,
-              "type": {
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [
+              {
+                "name": "skip",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "0"
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100"
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "Node_orderBy",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderDirection",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "OrderDirection",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Node_filter",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "block",
+                "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Block_height",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "subgraphError",
+                "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "_SubgraphErrorPolicy_",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "deny"
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
                 "kind": "LIST",
                 "name": null,
                 "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "Node",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_meta",
+            "description": "Access to subgraph metadata",
+            "args": [
+              {
+                "name": "block",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Block_height",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "_Meta_",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "Role",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "USER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ADMIN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "String",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Subscription",
+        "description": null,
+        "fields": [
+          {
+            "name": "user",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
@@ -285,804 +782,458 @@
                     "name": "ID",
                     "ofType": null
                   }
-                }
+                },
+                "defaultValue": null
               },
-              "defaultValue": null
-            },
-            {
-              "name": "_change_block",
-              "description": "Filter for the block changed event.",
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "BlockChangedFilter",
-                "ofType": null
+              {
+                "name": "block",
+                "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Block_height",
+                  "ofType": null
+                },
+                "defaultValue": null
               },
-              "defaultValue": null
+              {
+                "name": "subgraphError",
+                "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "_SubgraphErrorPolicy_",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "deny"
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
             },
-            {
-              "name": "and",
-              "description": null,
-              "type": {
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "users",
+            "description": null,
+            "args": [
+              {
+                "name": "skip",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "0"
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100"
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "User_orderBy",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderDirection",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "OrderDirection",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "User_filter",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "block",
+                "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Block_height",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "subgraphError",
+                "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "_SubgraphErrorPolicy_",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "deny"
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
                 "kind": "LIST",
                 "name": null,
                 "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "User",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "block",
+                "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Block_height",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "subgraphError",
+                "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "_SubgraphErrorPolicy_",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "deny"
+              }
+            ],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [
+              {
+                "name": "skip",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "0"
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100"
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "Node_orderBy",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderDirection",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "OrderDirection",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "Node_filter",
                   "ofType": null
-                }
+                },
+                "defaultValue": null
               },
-              "defaultValue": null
-            },
-            {
-              "name": "or",
-              "description": null,
-              "type": {
+              {
+                "name": "block",
+                "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Block_height",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "subgraphError",
+                "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "_SubgraphErrorPolicy_",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "deny"
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
                 "kind": "LIST",
                 "name": null,
                 "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "Node",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_meta",
+            "description": "Access to subgraph metadata",
+            "args": [
+              {
+                "name": "block",
+                "description": null,
+                "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "Node_filter",
+                  "name": "Block_height",
                   "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "Node_orderBy",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "id",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "OrderDirection",
-          "description": "Defines the order direction, either ascending or descending",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "asc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "_Meta_",
+              "ofType": null
             },
-            {
-              "name": "desc",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Query",
-          "description": null,
-          "fields": [
-            {
-              "name": "user",
-              "description": null,
-              "args": [
-                {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "block",
-                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Block_height",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "subgraphError",
-                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "_SubgraphErrorPolicy_",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "deny"
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "User",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "User",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
-            {
-              "name": "users",
-              "description": null,
-              "args": [
-                {
-                  "name": "skip",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "0"
-                },
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "100"
-                },
-                {
-                  "name": "orderBy",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "User_orderBy",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "orderDirection",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "OrderDirection",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "where",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "User_filter",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "block",
-                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Block_height",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "subgraphError",
-                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "_SubgraphErrorPolicy_",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "deny"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "User",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": null,
-              "args": [
-                {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "block",
-                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Block_height",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "subgraphError",
-                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "_SubgraphErrorPolicy_",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "deny"
-                }
-              ],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "Node",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
-            {
-              "name": "nodes",
-              "description": null,
-              "args": [
-                {
-                  "name": "skip",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "0"
-                },
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "100"
-                },
-                {
-                  "name": "orderBy",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "Node_orderBy",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "orderDirection",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "OrderDirection",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "where",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Node_filter",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "block",
-                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Block_height",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "subgraphError",
-                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "_SubgraphErrorPolicy_",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "deny"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INTERFACE",
-                      "name": "Node",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "_meta",
-              "description": "Access to subgraph metadata",
-              "args": [
-                {
-                  "name": "block",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Block_height",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "_Meta_",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "role",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "Role",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "Role",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "USER",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
-            {
-              "name": "ADMIN",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "String",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Subscription",
-          "description": null,
-          "fields": [
-            {
-              "name": "user",
-              "description": null,
-              "args": [
-                {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "block",
-                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Block_height",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "subgraphError",
-                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "_SubgraphErrorPolicy_",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "deny"
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "User",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "User_filter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
-            {
-              "name": "users",
-              "description": null,
-              "args": [
-                {
-                  "name": "skip",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "0"
-                },
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "100"
-                },
-                {
-                  "name": "orderBy",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "User_orderBy",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "orderDirection",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "OrderDirection",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "where",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "User_filter",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "block",
-                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Block_height",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "subgraphError",
-                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "_SubgraphErrorPolicy_",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "deny"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "User",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+            "defaultValue": null
+          },
+          {
+            "name": "id_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
-            {
-              "name": "node",
-              "description": null,
-              "args": [
-                {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "block",
-                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Block_height",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "subgraphError",
-                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "_SubgraphErrorPolicy_",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "deny"
-                }
-              ],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "Node",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+            "defaultValue": null
+          },
+          {
+            "name": "id_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
-            {
-              "name": "nodes",
-              "description": null,
-              "args": [
-                {
-                  "name": "skip",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "0"
-                },
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": "100"
-                },
-                {
-                  "name": "orderBy",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "Node_orderBy",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "orderDirection",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "OrderDirection",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "where",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Node_filter",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "block",
-                  "description": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Block_height",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "subgraphError",
-                  "description": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "_SubgraphErrorPolicy_",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": "deny"
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INTERFACE",
-                      "name": "Node",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+            "defaultValue": null
+          },
+          {
+            "name": "id_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
-            {
-              "name": "_meta",
-              "description": "Access to subgraph metadata",
-              "args": [
-                {
-                  "name": "block",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Block_height",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "_Meta_",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "User",
-          "description": null,
-          "fields": [
-            {
-              "name": "id",
-              "description": null,
-              "args": [],
-              "type": {
+            "defaultValue": null
+          },
+          {
+            "name": "id_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
@@ -1090,15 +1241,95 @@
                   "name": "ID",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
+            "defaultValue": null
+          },
+          {
+            "name": "id_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
@@ -1106,15 +1337,175 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
-            {
-              "name": "role",
-              "description": null,
-              "args": [],
-              "type": {
+            "defaultValue": null
+          },
+          {
+            "name": "name_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_contains_nocase",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_not_contains_nocase",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_starts_with",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_starts_with_nocase",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_not_starts_with",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_not_starts_with_nocase",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_ends_with",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_ends_with_nocase",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_not_ends_with",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_not_ends_with_nocase",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "role",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "Role",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "role_not",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "Role",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "role_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
@@ -1122,726 +1513,358 @@
                   "name": "Role",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            }
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "User_filter",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "id",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "defaultValue": null
+              }
             },
-            {
-              "name": "id_not",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "id_gt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "id_lt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "id_gte",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "id_lte",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "id_in",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "id_not_in",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_not",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_gt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_lt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_gte",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_lte",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_in",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_not_in",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_contains",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_contains_nocase",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_not_contains",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_not_contains_nocase",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_starts_with",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_starts_with_nocase",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_not_starts_with",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_not_starts_with_nocase",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_ends_with",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_ends_with_nocase",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_not_ends_with",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "name_not_ends_with_nocase",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "role",
-              "description": null,
-              "type": {
-                "kind": "ENUM",
-                "name": "Role",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "role_not",
-              "description": null,
-              "type": {
-                "kind": "ENUM",
-                "name": "Role",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "role_in",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "Role",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "role_not_in",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "Role",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "_change_block",
-              "description": "Filter for the block changed event.",
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "BlockChangedFilter",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "and",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "User_filter",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "or",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "User_filter",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "User_orderBy",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "id",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "role",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "_Block_",
-          "description": null,
-          "fields": [
-            {
-              "name": "hash",
-              "description": "The hash of the block",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Bytes",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "number",
-              "description": "The block number",
-              "args": [],
-              "type": {
+            "defaultValue": null
+          },
+          {
+            "name": "role_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
+                  "kind": "ENUM",
+                  "name": "Role",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
-            {
-              "name": "timestamp",
-              "description": "Integer representation of the timestamp stored in blocks for the chain",
-              "args": [],
-              "type": {
+            "defaultValue": null
+          },
+          {
+            "name": "_change_block",
+            "description": "Filter for the block changed event.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BlockChangedFilter",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "User_filter",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "User_filter",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "User_orderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "id",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "role",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "_Block_",
+        "description": null,
+        "fields": [
+          {
+            "name": "hash",
+            "description": "The hash of the block",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Bytes",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "number",
+            "description": "The block number",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "_Meta_",
-          "description": "The type for the top-level _meta field",
-          "fields": [
-            {
-              "name": "block",
-              "description": "Information about a specific subgraph block. The hash of the block\nwill be null if the _meta field has a block constraint that asks for\na block number. It will be filled if the _meta field has no block constraint\nand therefore asks for the latest  block\n",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "_Block_",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
-            {
-              "name": "deployment",
-              "description": "The deployment ID",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": "Integer representation of the timestamp stored in blocks for the chain",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
-            {
-              "name": "hasIndexingErrors",
-              "description": "If `true`, the subgraph encountered indexing errors at some past block",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "_SubgraphErrorPolicy_",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "allow",
-              "description": "Data will be returned even if the subgraph has indexing errors",
-              "isDeprecated": false,
-              "deprecationReason": null
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "_Meta_",
+        "description": "The type for the top-level _meta field",
+        "fields": [
+          {
+            "name": "block",
+            "description": "Information about a specific subgraph block. The hash of the block\nwill be null if the _meta field has a block constraint that asks for\na block number. It will be filled if the _meta field has no block constraint\nand therefore asks for the latest  block\n",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "_Block_",
+                "ofType": null
+              }
             },
-            {
-              "name": "deny",
-              "description": "If the subgraph has indexing errors, data will be omitted. The default.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        }
-      ],
-      "directives": [
-        {
-          "name": "language",
-          "description": null,
-          "locations": [
-            "FIELD_DEFINITION"
-          ],
-          "args": [
-            {
-              "name": "language",
-              "description": null,
-              "type": {
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deployment",
+            "description": "The deployment ID",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": "\"English\""
-            }
-          ]
-        },
-        {
-          "name": "skip",
-          "description": null,
-          "locations": [
-            "FIELD",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT"
-          ],
-          "args": [
-            {
-              "name": "if",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ]
-        },
-        {
-          "name": "include",
-          "description": null,
-          "locations": [
-            "FIELD",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT"
-          ],
-          "args": [
-            {
-              "name": "if",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ]
-        },
-        {
-          "name": "entity",
-          "description": "Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive.",
-          "locations": [
-            "OBJECT"
-          ],
-          "args": []
-        },
-        {
-          "name": "subgraphId",
-          "description": "Defined a Subgraph ID for an object type",
-          "locations": [
-            "OBJECT"
-          ],
-          "args": [
-            {
-              "name": "id",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ]
-        },
-        {
-          "name": "derivedFrom",
-          "description": "creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API.",
-          "locations": [
-            "FIELD_DEFINITION"
-          ],
-          "args": [
-            {
-              "name": "field",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ]
-        }
-      ]
-    }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasIndexingErrors",
+            "description": "If `true`, the subgraph encountered indexing errors at some past block",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "_SubgraphErrorPolicy_",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "allow",
+            "description": "Data will be returned even if the subgraph has indexing errors",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deny",
+            "description": "If the subgraph has indexing errors, data will be omitted. The default.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      }
+    ],
+    "directives": [
+      {
+        "name": "language",
+        "description": null,
+        "locations": [
+          "FIELD_DEFINITION"
+        ],
+        "args": [
+          {
+            "name": "language",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": "\"English\""
+          }
+        ]
+      },
+      {
+        "name": "skip",
+        "description": null,
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
+        "args": [
+          {
+            "name": "if",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ]
+      },
+      {
+        "name": "include",
+        "description": null,
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
+        "args": [
+          {
+            "name": "if",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ]
+      },
+      {
+        "name": "entity",
+        "description": "Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive.",
+        "locations": [
+          "OBJECT"
+        ],
+        "args": []
+      },
+      {
+        "name": "subgraphId",
+        "description": "Defined a Subgraph ID for an object type",
+        "locations": [
+          "OBJECT"
+        ],
+        "args": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ]
+      },
+      {
+        "name": "derivedFrom",
+        "description": "creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API.",
+        "locations": [
+          "FIELD_DEFINITION"
+        ],
+        "args": [
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ]
+      }
+    ]
   }
+}

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -290,7 +290,7 @@ fn find_many() {
 
         let mut id_map = BTreeMap::default();
         let ids = IdList::try_from_iter(
-            &*THING_TYPE,
+            THING_TYPE.id_type().unwrap(),
             vec![ID, ID2, "badd"]
                 .into_iter()
                 .map(|id| THING_TYPE.parse_id(id).unwrap()),


### PR DESCRIPTION
This PR enables querying of aggregations through the GraphQL interface. It required a major rework of the GraphQL query infrastructure as prefetch now needs to translate from types in the API schema to types in the InputSchema as the concrete types for the aggregations do not exist in the API schema.
    
Before, we relied a lot on the fact that the API schema contained the same types as the input schema with the exact same names and structure. But conceptually, prefetch and query building deals with types from the input schema as that describes how data is ultimately stored in the database.

To try this out, deploy the [`aggregation-example`](https://github.com/graphprotocol/common-subgraphs/tree/main/aggregation-example) subgraph that builds aggregations over ethereum block numbers as those are easy to check.