### PR TITLE
perf(prune): Only analyze when rebuilding

### DIFF
--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1470,7 +1470,7 @@ impl Table {
 
     pub(crate) fn analyze(&self, conn: &PgConnection) -> Result<(), StoreError> {
         let table_name = &self.qualified_name;
-        let sql = format!("analyze {table_name}");
+        let sql = format!("analyze (skip_locked) {table_name}");
         conn.execute(&sql)?;
         Ok(())
     }

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -449,6 +449,10 @@ impl Layout {
                         Ok(())
                     })?;
                     reporter.finish_switch();
+
+                    // Analyze the new tables
+                    let tables = prunable_tables.iter().map(|(table, _)| *table).collect();
+                    self.analyze_tables(conn, reporter, tables, cancel)?;
                 }
                 PruningStrategy::Delete => {
                     // Delete all entity versions whose range was closed
@@ -494,10 +498,6 @@ impl Layout {
         for (table, _) in &prunable_tables {
             catalog::set_last_pruned_block(conn, &self.site, &table.name, req.earliest_block)?;
         }
-
-        // Analyze the new tables
-        let tables = prunable_tables.iter().map(|(table, _)| *table).collect();
-        self.analyze_tables(conn, reporter, tables, cancel)?;
 
         reporter.finish();
 

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -449,10 +449,6 @@ impl Layout {
                         Ok(())
                     })?;
                     reporter.finish_switch();
-
-                    // Analyze the new tables
-                    let tables = prunable_tables.iter().map(|(table, _)| *table).collect();
-                    self.analyze_tables(conn, reporter, tables, cancel)?;
                 }
                 PruningStrategy::Delete => {
                     // Delete all entity versions whose range was closed
@@ -498,6 +494,10 @@ impl Layout {
         for (table, _) in &prunable_tables {
             catalog::set_last_pruned_block(conn, &self.site, &table.name, req.earliest_block)?;
         }
+
+        // Analyze the new tables
+        let tables = prunable_tables.iter().map(|(table, _)| *table).collect();
+        self.analyze_tables(conn, reporter, tables, cancel)?;
 
         reporter.finish();
 


### PR DESCRIPTION
When pruning by delete, it's overzealous to analyze. When combined with auto-prune on large tables, I've seen shards struggle with one long analyze after the other.

It can also conflict with the lock for autovacuum and result in a long running transaction waiting for the lock.

