### PR TITLE
Support cumulative aggregations

### DIFF
--- a/docs/aggregations.md
+++ b/docs/aggregations.md
@@ -78,7 +78,7 @@ type TokenStats @aggregation(intervals: ["hour", "day"], source: "TokenData") {
   token: Token!
   totalVolume: BigDecimal! @aggregate(fn: "sum", arg: "amount")
   priceUSD: BigDecimal! @aggregate(fn: "last", arg: "priceUSD")
-  count: Int8! @aggregate(fn: "count")
+  count: Int8! @aggregate(fn: "count", cumulative: true)
 }
 ```
 
@@ -87,10 +87,11 @@ _dimensions_, and fields with the `@aggregate` directive are called
 _aggregates_. A timeseries type really represents many timeseries, one for
 each combination of values for the dimensions.
 
-**TODO** As written, this supports buckets that start at zero with every new
-hour/day. We also want to support cumulative statistics, i.e., snapshotting
-of time series where a new bucket starts with the values of the previous
-bucket.
+Each `@aggregate` by default starts at 0 for each new bucket and therefore
+just aggregates over the time interval for the bucket. The `@aggregate`
+directive also accepts a boolean flag `cumulative` that indicates whether
+the aggregation should be cumulative. Cumulative aggregations aggregate over
+the entire timeseries up to the end of the time interval for the bucket.
 
 **TODO** Since average is a little more complicated to handle for cumulative
 aggregations, and it doesn't seem like it used in practice, we won't

--- a/graph/src/schema/input_schema.rs
+++ b/graph/src/schema/input_schema.rs
@@ -775,7 +775,7 @@ impl Arg {
 pub struct Aggregate {
     pub name: Word,
     pub func: AggregateFn,
-    pub arg: Option<Arg>,
+    pub arg: Arg,
     pub field_type: s::Type,
     pub value_type: ValueType,
     pub cumulative: bool,
@@ -796,10 +796,15 @@ impl Aggregate {
             .unwrap()
             .parse()
             .unwrap();
+        // The only aggregation function we have that doesn't take an
+        // argument is `count`; we just pretend that the user wanted to
+        // `count(id)`. When we form a query, we ignore the argument for
+        // `count`
         let arg = dir
             .argument("arg")
             .map(|arg| Word::from(arg.as_str().unwrap()))
-            .map(|arg| Arg::new(arg, src_type));
+            .map(|arg| Arg::new(arg, src_type))
+            .unwrap_or_else(|| Arg::new(ID.clone(), src_type));
         let cumulative = dir
             .argument(kw::CUMULATIVE)
             .map(|arg| match arg {

--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -173,6 +173,8 @@ pub enum SchemaValidationError {
     AggregationNonMatchingArg(String, String, String, String, String),
     #[error("Field {1} in aggregation {0} has arg `{3}` but that is not a numeric field in {2}")]
     AggregationNonNumericArg(String, String, String, String),
+    #[error("Field {1} in aggregation {0} has an invalid value for `cumulative`. It needs to be a boolean")]
+    AggregationInvalidCumulative(String, String),
     #[error("Aggregations are not supported with spec version {0}; please migrate the subgraph to the latest version")]
     AggregationsNotSupported(Version),
     #[error("Using Int8 as the type for the `id` field is not supported with spec version {0}; please migrate the subgraph to the latest version")]

--- a/graph/src/schema/test_schemas/ts_invalid_cumulative.graphql
+++ b/graph/src/schema/test_schemas/ts_invalid_cumulative.graphql
@@ -1,0 +1,12 @@
+# fail: AggregationInvalidCumulative("Stats", "sum")
+type Data @entity(timeseries: true) {
+  id: Int8!
+  timestamp: Int8!
+  price: BigDecimal!
+}
+
+type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
+  id: Int8!
+  timestamp: Int8!
+  sum: BigDecimal! @aggregate(fn: "sum", arg: "price", cumulative: "maybe")
+}

--- a/graph/src/schema/test_schemas/ts_valid_cumulative.graphql
+++ b/graph/src/schema/test_schemas/ts_valid_cumulative.graphql
@@ -1,0 +1,12 @@
+# valid: Minimal example
+type Data @entity(timeseries: true) {
+  id: Int8!
+  timestamp: Int8!
+  price: BigDecimal!
+}
+
+type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
+  id: Int8!
+  timestamp: Int8!
+  sum: BigDecimal! @aggregate(fn: "sum", arg: "price", cumulative: true)
+}

--- a/store/postgres/src/relational/ddl.rs
+++ b/store/postgres/src/relational/ddl.rs
@@ -147,11 +147,11 @@ impl Table {
         let (int4, int8) = catalog.minmax_ops();
 
         if self.immutable {
+            // For immutable entities, a simple BTree on block$ is sufficient
             write!(
                 out,
-                "create index brin_{table_name}\n    \
-                on {qname}\n \
-                   using brin({block} {int4}, vid {int8});\n",
+                "create index {table_name}_block\n    \
+                on {qname}({block});\n",
                 table_name = self.name,
                 qname = self.qualified_name,
                 block = BLOCK_COLUMN

--- a/store/postgres/src/relational/ddl_tests.rs
+++ b/store/postgres/src/relational/ddl_tests.rs
@@ -381,9 +381,8 @@ create table "sgd0815"."song" (
 
         unique(id)
 );
-create index brin_song
-    on "sgd0815"."song"
- using brin(block$ int4_minmax_ops, vid int8_minmax_ops);
+create index song_block
+    on "sgd0815"."song"(block$);
 create index attr_2_0_song_title
     on "sgd0815"."song" using btree(left("title", 256));
 create index attr_2_1_song_written_by
@@ -643,9 +642,8 @@ create table "sgd0815"."data" (
     "amount"             numeric not null,
     unique(id)
 );
-create index brin_data
-    on "sgd0815"."data"
- using brin(block$ int4_minmax_ops, vid int8_minmax_ops);
+create index data_block
+    on "sgd0815"."data"(block$);
 create index attr_0_0_data_timestamp
     on "sgd0815"."data" using btree("timestamp");
 create index attr_0_1_data_amount
@@ -660,9 +658,8 @@ create table "sgd0815"."stats_hour" (
     "max_price"          numeric not null,
     unique(id)
 );
-create index brin_stats_hour
-    on "sgd0815"."stats_hour"
- using brin(block$ int4_minmax_ops, vid int8_minmax_ops);
+create index stats_hour_block
+    on "sgd0815"."stats_hour"(block$);
 create index attr_1_0_stats_hour_timestamp
     on "sgd0815"."stats_hour" using btree("timestamp");
 create index attr_1_1_stats_hour_volume
@@ -679,9 +676,8 @@ create table "sgd0815"."stats_day" (
     "max_price"          numeric not null,
     unique(id)
 );
-create index brin_stats_day
-    on "sgd0815"."stats_day"
- using brin(block$ int4_minmax_ops, vid int8_minmax_ops);
+create index stats_day_block
+    on "sgd0815"."stats_day"(block$);
 create index attr_2_0_stats_day_timestamp
     on "sgd0815"."stats_day" using btree("timestamp");
 create index attr_2_1_stats_day_volume


### PR DESCRIPTION
This PR allows aggregates that are cumulative from the beginning of time rather than just within a time interval. That is indicated by declaring the aggregate as `@aggregate(fn: "sum", arg:"amount", cumulative: true)`

Check the docs in ./docs/aggregation.md for more details.

Note that this PR is on top of PR #5208 