### PR TITLE
Refactor `graphman rewind` to use pause and resume logic

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -1204,9 +1204,8 @@ async fn main() -> anyhow::Result<()> {
             deployments,
             start_block,
         } => {
-            let ct = ctx;
-            let notification_sender = ct.notification_sender();
-            let (store, primary) = ct.store_and_primary();
+            let notification_sender = ctx.notification_sender();
+            let (store, primary) = ctx.store_and_primary();
 
             commands::rewind::run(
                 primary,

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -923,19 +923,6 @@ impl Context {
         pools
     }
 
-    fn clone(&self) -> Self {
-        Self {
-            logger: self.logger.clone(),
-            node_id: self.node_id.clone(),
-            config: self.config.clone(),
-            ipfs_url: self.ipfs_url.clone(),
-            arweave_url: self.arweave_url.clone(),
-            fork_base: self.fork_base.clone(),
-            registry: self.registry.clone(),
-            prometheus_registry: self.prometheus_registry.clone(),
-        }
-    }
-
     async fn store_builder(&self) -> StoreBuilder {
         StoreBuilder::new(
             &self.logger,
@@ -1194,7 +1181,7 @@ async fn main() -> anyhow::Result<()> {
             let locator = &deployment.locate_unique(&pool)?;
             commands::assign::pause_or_resume(pool, &sender, locator, true)
         }
-        }
+
         Resume { deployment } => {
             let sender = ctx.notification_sender();
             let pool = ctx.primary_pool();

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -1185,23 +1185,16 @@ async fn main() -> anyhow::Result<()> {
         Resume { deployment } => {
             let sender = ctx.notification_sender();
             let pool = ctx.primary_pool();
-            commands::assign::pause_or_resume(
-                pool.clone(),
-                &sender,
-                &deployment.locate_unique(&pool).unwrap(),
-                false,
-            )
+            let locator = &deployment.locate_unique(&pool).unwrap();
+
+            commands::assign::pause_or_resume(pool, &sender, locator, false)
         }
         Restart { deployment, sleep } => {
-            let ctx_clone = ctx.clone();
             let sender = ctx.notification_sender();
             let pool = ctx.primary_pool();
-            commands::assign::restart(
-                ctx_clone.primary_pool(),
-                &sender,
-                &deployment.locate_unique(&pool).unwrap(),
-                sleep,
-            )
+            let locator = &deployment.locate_unique(&pool).unwrap();
+
+            commands::assign::restart(pool, &sender, locator, sleep)
         }
         Rewind {
             force,
@@ -1211,8 +1204,9 @@ async fn main() -> anyhow::Result<()> {
             deployments,
             start_block,
         } => {
-            let ctx_clone = ctx.clone();
-            let (store, primary) = ctx.store_and_primary();
+            let ct = ctx;
+            let notification_sender = ct.notification_sender();
+            let (store, primary) = ct.store_and_primary();
 
             commands::rewind::run(
                 primary,
@@ -1220,7 +1214,7 @@ async fn main() -> anyhow::Result<()> {
                 deployments,
                 block_hash,
                 block_number,
-                &ctx_clone.notification_sender(),
+                &notification_sender,
                 force,
                 sleep,
                 start_block,

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -811,7 +811,6 @@ impl From<Opt> for config::Opt {
 
 /// Utilities to interact mostly with the store and build the parts of the
 /// store we need for specific commands
-#[derive(Clone)]
 struct Context {
     logger: Logger,
     node_id: NodeId,

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -1191,12 +1191,9 @@ async fn main() -> anyhow::Result<()> {
         Pause { deployment } => {
             let sender = ctx.notification_sender();
             let pool = ctx.primary_pool();
-            commands::assign::pause_or_resume(
-                ctx_clone.primary_pool(),
-                &sender,
-                &deployment.locate_unique(&pool).unwrap(),
-                true,
-            )
+            let locator = &deployment.locate_unique(&pool)?;
+            commands::assign::pause_or_resume(pool, &sender, locator, true)
+        }
         }
         Resume { deployment } => {
             let sender = ctx.notification_sender();

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -1189,8 +1189,6 @@ async fn main() -> anyhow::Result<()> {
             commands::assign::reassign(ctx.primary_pool(), &sender, &deployment, node)
         }
         Pause { deployment } => {
-            let ctx_clone = ctx.clone();
-
             let sender = ctx.notification_sender();
             let pool = ctx.primary_pool();
             commands::assign::pause_or_resume(

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -79,10 +79,8 @@ pub fn pause_or_resume(
     locator: &DeploymentLocator,
     should_pause: bool,
 ) -> Result<(), Error> {
-    let locator = search.locate_unique(&primary)?;
-
     let conn = primary.get()?;
-    let conn = catalog::Connection::new(conn);
+    let mut conn = catalog::Connection::new(conn);
 
     let site = conn
         .locate_site(locator.clone())?

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -79,8 +79,8 @@ pub fn pause_or_resume(
     locator: &DeploymentLocator,
     should_pause: bool,
 ) -> Result<(), Error> {
-    let conn = primary.get()?;
-    let mut conn = catalog::Connection::new(conn);
+    let pconn = primary.get()?;
+    let mut conn = catalog::Connection::new(pconn);
 
     let site = conn
         .locate_site(locator.clone())?

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -1,3 +1,4 @@
+use graph::components::store::DeploymentLocator;
 use graph::prelude::{anyhow::anyhow, Error, NodeId, StoreEvent};
 use graph_store_postgres::{
     command_support::catalog, connection_pool::ConnectionPool, NotificationSender,
@@ -75,13 +76,13 @@ pub fn reassign(
 pub fn pause_or_resume(
     primary: ConnectionPool,
     sender: &NotificationSender,
-    search: &DeploymentSearch,
+    locator: &DeploymentLocator,
     should_pause: bool,
 ) -> Result<(), Error> {
     let locator = search.locate_unique(&primary)?;
 
-    let pconn = primary.get()?;
-    let mut conn = catalog::Connection::new(pconn);
+    let conn = primary.get()?;
+    let conn = catalog::Connection::new(conn);
 
     let site = conn
         .locate_site(locator.clone())?
@@ -115,15 +116,15 @@ pub fn pause_or_resume(
 pub fn restart(
     primary: ConnectionPool,
     sender: &NotificationSender,
-    search: &DeploymentSearch,
+    locator: &DeploymentLocator,
     sleep: Duration,
 ) -> Result<(), Error> {
-    pause_or_resume(primary.clone(), sender, search, true)?;
+    pause_or_resume(primary.clone(), sender, locator, true)?;
     println!(
         "Waiting {}s to make sure pausing was processed",
         sleep.as_secs()
     );
     thread::sleep(sleep);
-    pause_or_resume(primary, sender, search, false)?;
+    pause_or_resume(primary, sender, locator, false)?;
     Ok(())
 }

--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -5,8 +5,7 @@ use std::{collections::HashSet, convert::TryFrom};
 
 use graph::anyhow::bail;
 use graph::components::store::{BlockStore as _, ChainStore as _};
-use graph::prelude::serde_json::de;
-use graph::prelude::{anyhow, BlockNumber, BlockPtr, NodeId, SubgraphStore};
+use graph::prelude::{anyhow, BlockNumber, BlockPtr};
 use graph_store_postgres::{connection_pool::ConnectionPool, Store};
 use graph_store_postgres::{BlockStore, NotificationSender};
 
@@ -108,12 +107,7 @@ pub async fn run(
 
     println!("Pausing deployments");
     for deployment in &deployments {
-        let search = match searches.iter().find(|s| s.locate_unique(&primary).is_ok()) {
-            Some(s) => s,
-            None => bail!("failed to find search for deployment {:?}", deployment),
-        };
-
-        let paused = pause_or_resume(primary.clone(), &sender, search, true);
+        let paused = pause_or_resume(primary.clone(), &sender, &deployment.locator(), true);
 
         if paused.is_ok() {
             // There's no good way to tell that a subgraph has in fact stopped
@@ -155,12 +149,7 @@ pub async fn run(
 
     println!("Resuming deployments");
     for deployment in &deployments {
-        let search = match searches.iter().find(|s| s.locate_unique(&primary).is_ok()) {
-            Some(s) => s,
-            None => bail!("failed to find search for deployment {:?}", deployment),
-        };
-
-        pause_or_resume(primary.clone(), &sender, search, false)?;
+        pause_or_resume(primary.clone(), &sender, &deployment.locator(), false)?;
     }
     Ok(())
 }

--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -67,8 +67,6 @@ pub async fn run(
     sleep: Duration,
     start_block: bool,
 ) -> Result<(), anyhow::Error> {
-    const PAUSED: &str = "paused_";
-
     // Sanity check
     if !start_block && (block_hash.is_none() || block_number.is_none()) {
         bail!("--block-hash and --block-number must be specified when --start-block is not set");

--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -106,15 +106,16 @@ pub async fn run(
     println!("Pausing deployments");
     for deployment in &deployments {
         pause_or_resume(primary.clone(), &sender, &deployment.locator(), true)?;
-
-        // There's no good way to tell that a subgraph has in fact stopped
-        // indexing. We sleep and hope for the best.
-        println!(
-            "\nWaiting {}s to make sure pausing was processed",
-            sleep.as_secs()
-        );
-        thread::sleep(sleep);
     }
+
+    // There's no good way to tell that a subgraph has in fact stopped
+    // indexing. We sleep and hope for the best.
+    println!(
+        "\nWaiting {}s to make sure pausing was processed",
+        sleep.as_secs()
+    );
+    thread::sleep(sleep);
+
     println!("\nRewinding deployments");
     for deployment in &deployments {
         let loc = deployment.locator();

--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -75,15 +75,20 @@ pub async fn run(
     let subgraph_store = store.subgraph_store();
     let block_store = store.block_store();
 
-    let deployments = searches
-        .iter()
-        .map(|search| search.lookup(&primary))
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+    let mut deployments = Vec::new();
+    for search in &searches {
+        let results = search.lookup(&primary)?;
+        if results.len() > 1 {
+            bail!(
+                "Multiple deployments found for the search : {}. Try using the id of the deployment (eg: sgd143) to uniquely identify the deployment.",
+                search
+            );
+        }
+        deployments.extend(results);
+    }
+
     if deployments.is_empty() {
-        println!("nothing to do");
+        println!("No deployments found");
         return Ok(());
     }
 

--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -107,17 +107,15 @@ pub async fn run(
 
     println!("Pausing deployments");
     for deployment in &deployments {
-        let paused = pause_or_resume(primary.clone(), &sender, &deployment.locator(), true)?;
+        pause_or_resume(primary.clone(), &sender, &deployment.locator(), true)?;
 
-        if paused.is_ok() {
-            // There's no good way to tell that a subgraph has in fact stopped
-            // indexing. We sleep and hope for the best.
-            println!(
-                "\nWaiting {}s to make sure pausing was processed",
-                sleep.as_secs()
-            );
-            thread::sleep(sleep);
-        }
+        // There's no good way to tell that a subgraph has in fact stopped
+        // indexing. We sleep and hope for the best.
+        println!(
+            "\nWaiting {}s to make sure pausing was processed",
+            sleep.as_secs()
+        );
+        thread::sleep(sleep);
     }
     println!("\nRewinding deployments");
     for deployment in &deployments {

--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -107,7 +107,7 @@ pub async fn run(
 
     println!("Pausing deployments");
     for deployment in &deployments {
-        let paused = pause_or_resume(primary.clone(), &sender, &deployment.locator(), true);
+        let paused = pause_or_resume(primary.clone(), &sender, &deployment.locator(), true)?;
 
         if paused.is_ok() {
             // There's no good way to tell that a subgraph has in fact stopped


### PR DESCRIPTION
This PR refactors the `graphman rewind` command to use the pause and resume function. 