### PR TITLE
core: Fix Action::block_finished

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -1066,8 +1066,8 @@ impl Action {
     /// Return `true` if the action indicates that we are done with a block
     fn block_finished(&self) -> bool {
         match self {
-            Action::Continue | Action::Restart => false,
-            Action::Stop => true,
+            Action::Restart => false,
+            Action::Continue | Action::Stop => true,
         }
     }
 }


### PR DESCRIPTION
We classified a `Continue` action as 'block not finished'. That would lead to use not recording progress properly in the
deployment_blocks_process_count metric making it pretty much useless.

