### PR TITLE
Remove hack in chain_head_listener

### DIFF
--- a/graph/src/util/timed_rw_lock.rs
+++ b/graph/src/util/timed_rw_lock.rs
@@ -36,6 +36,10 @@ impl<T> TimedRwLock<T> {
         }
     }
 
+    pub fn try_read(&self) -> Option<parking_lot::RwLockReadGuard<T>> {
+        self.lock.try_read()
+    }
+
     pub fn read(&self, logger: &Logger) -> parking_lot::RwLockReadGuard<T> {
         loop {
             let mut elapsed = Duration::from_secs(0);


### PR DESCRIPTION
This was added in a time when we were having problems with receiving chain head updates and were trying workarounds. This one had a hypothesis of a deadlock in tokio Watch::send. I was never able to corroborate this, no other tokio user ever reported something like this and improvements have since been made to the internals of `Watch`. So there isn't much justification for keeping this hack.

