### PR TITLE
monitoring: Downgrade 'Entity cache statistics' log to trace

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -501,7 +501,7 @@ where
             .map_err(|e| BlockProcessingError::Unknown(e.into()))?;
         section.end();
 
-        debug!(self.logger, "Entity cache statistics";
+        trace!(self.logger, "Entity cache statistics";
             "weight" => evict_stats.new_weight,
             "evicted_weight" => evict_stats.evicted_weight,
             "count" => evict_stats.new_count,
@@ -1239,7 +1239,7 @@ where
             .map_err(|e| BlockProcessingError::Unknown(e.into()))?;
         section.end();
 
-        debug!(self.logger, "Entity cache statistics";
+        trace!(self.logger, "Entity cache statistics";
             "weight" => evict_stats.new_weight,
             "evicted_weight" => evict_stats.evicted_weight,
             "count" => evict_stats.new_count,


### PR DESCRIPTION
It has interesting info but it logs very frequently and isn't actually read often. Better left outside the default logs.