### PR TITLE
Support expressions in the `arg` of `@aggregate`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ dependencies = [
  "slog-async",
  "slog-envlogger",
  "slog-term",
+ "sqlparser",
  "stable-hash 0.3.4",
  "stable-hash 0.4.4",
  "strum_macros",
@@ -4105,6 +4106,15 @@ name = "sptr"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
+
+[[package]]
+name = "sqlparser"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95c4bae5aba7cd30bd506f7140026ade63cff5afd778af8854026f9606bf5d4"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "stable-hash"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -88,6 +88,7 @@ web3 = { git = "https://github.com/graphprotocol/rust-web3", branch = "graph-pat
     "arbitrary_precision",
 ] }
 serde_plain = "1.0.2"
+sqlparser = "0.43.1"
 
 [dev-dependencies]
 clap = { version = "3.2.25", features = ["derive", "env"] }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -51,6 +51,7 @@ pub use petgraph;
 pub use prometheus;
 pub use semver;
 pub use slog;
+pub use sqlparser;
 pub use stable_hash;
 pub use stable_hash_legacy;
 pub use tokio;

--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -11,10 +11,7 @@ use crate::{
     util::intern::Atom,
 };
 
-use super::{
-    input_schema::{ObjectType, POI_OBJECT},
-    EntityKey, Field, InputSchema, InterfaceType,
-};
+use super::{EntityKey, Field, InputSchema, InterfaceType, ObjectType, POI_OBJECT};
 
 /// A reference to a type in the input schema. It should mostly be the
 /// reference to a concrete entity type, either one declared with `@entity`

--- a/graph/src/schema/input/mod.rs
+++ b/graph/src/schema/input/mod.rs
@@ -3043,7 +3043,7 @@ type Gravatar @entity {
                         if errs.iter().any(|err| {
                             err.to_string().contains(&msg) || format!("{err:?}").contains(&msg)
                         }) {
-                            println!("{file_name} failed as expected: {errs:?}",)
+                            // println!("{file_name} failed as expected: {errs:?}",)
                         } else {
                             let msgs: Vec<_> = errs.iter().map(|err| err.to_string()).collect();
                             panic!(
@@ -3052,7 +3052,7 @@ type Gravatar @entity {
                         }
                     }
                     (true, Ok(_)) => {
-                        println!("{file_name} validated as expected")
+                        // println!("{file_name} validated as expected")
                     }
                 }
             }

--- a/graph/src/schema/input/mod.rs
+++ b/graph/src/schema/input/mod.rs
@@ -23,8 +23,8 @@ use crate::prelude::{s, DeploymentHash};
 use crate::schema::api::api_schema;
 use crate::util::intern::{Atom, AtomPool};
 
-use super::fulltext::FulltextDefinition;
-use super::{ApiSchema, AsEntityTypeName, EntityType, Schema};
+use crate::schema::fulltext::FulltextDefinition;
+use crate::schema::{ApiSchema, AsEntityTypeName, EntityType, Schema};
 
 /// The name of the PoI entity type
 pub(crate) const POI_OBJECT: &str = "Poi$";
@@ -1675,7 +1675,7 @@ mod validations {
         },
         prelude::s,
         schema::{
-            input_schema::{kw, AggregateFn, AggregationInterval},
+            input::{kw, AggregateFn, AggregationInterval},
             FulltextAlgorithm, FulltextLanguage, Schema as BaseSchema, SchemaValidationError,
             SchemaValidationError as Err, Strings, SCHEMA_TYPE_NAME,
         },
@@ -3074,7 +3074,7 @@ mod tests {
         data::store::ID,
         prelude::DeploymentHash,
         schema::{
-            input_schema::{POI_DIGEST, POI_OBJECT},
+            input::{POI_DIGEST, POI_OBJECT},
             EntityType,
         },
     };

--- a/graph/src/schema/input/mod.rs
+++ b/graph/src/schema/input/mod.rs
@@ -753,13 +753,21 @@ impl AggregationMapping {
     }
 }
 
+/// The `@aggregate` annotation in an aggregation. The annotation controls
+/// how values from the source table are aggregated
 #[derive(PartialEq, Debug)]
 pub struct Aggregate {
+    /// The name of the aggregate field in the aggregation
     pub name: Word,
+    /// The function used to aggregate the values
     pub func: AggregateFn,
+    /// The field to aggregate in the source table
     pub arg: Word,
+    /// The type of the field `name` in the aggregation
     pub field_type: s::Type,
+    /// The `ValueType` corresponding to `field_type`
     pub value_type: ValueType,
+    /// Whether the aggregation is cumulative
     pub cumulative: bool,
 }
 

--- a/graph/src/schema/input/mod.rs
+++ b/graph/src/schema/input/mod.rs
@@ -753,22 +753,11 @@ impl AggregationMapping {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
-pub struct Arg {
-    pub name: Word,
-}
-
-impl Arg {
-    fn new(name: Word) -> Self {
-        Self { name }
-    }
-}
-
 #[derive(PartialEq, Debug)]
 pub struct Aggregate {
     pub name: Word,
     pub func: AggregateFn,
-    pub arg: Arg,
+    pub arg: Word,
     pub field_type: s::Type,
     pub value_type: ValueType,
     pub cumulative: bool,
@@ -790,8 +779,7 @@ impl Aggregate {
         let arg = dir
             .argument("arg")
             .map(|arg| Word::from(arg.as_str().unwrap()))
-            .map(|arg| Arg::new(arg))
-            .unwrap_or_else(|| Arg::new(ID.clone()));
+            .unwrap_or_else(|| ID.clone());
         let cumulative = dir
             .argument(kw::CUMULATIVE)
             .map(|arg| match arg {

--- a/graph/src/schema/input/sqlexpr.rs
+++ b/graph/src/schema/input/sqlexpr.rs
@@ -1,0 +1,323 @@
+//! Tools for parsing SQL expressions
+use sqlparser::ast as p;
+use sqlparser::dialect::PostgreSqlDialect;
+use sqlparser::parser::{Parser as SqlParser, ParserError};
+use sqlparser::tokenizer::Tokenizer;
+
+use crate::schema::SchemaValidationError;
+
+pub(crate) trait CheckIdentFn: Fn(&str) -> Result<(), SchemaValidationError> {}
+
+impl<T> CheckIdentFn for T where T: Fn(&str) -> Result<(), SchemaValidationError> {}
+
+/// Parse a SQL expression and check that it only uses whitelisted
+/// operations and functions. The `check_ident` function is called for each
+/// identifier in the expression
+pub(crate) fn parse<F: CheckIdentFn>(
+    sql: &str,
+    check_ident: F,
+) -> Result<(), Vec<SchemaValidationError>> {
+    let mut validator = Validator {
+        check_ident,
+        errors: Vec::new(),
+    };
+    VisitExpr::visit(sql, &mut validator)
+        .map(|_| ())
+        .map_err(|()| validator.errors)
+}
+
+/// A visitor for `VistExpr` that gets called for the constructs for which
+/// we need different behavior between validation and query generation in
+/// `store/postgres/src/relational/rollup.rs`. Note that the visitor can
+/// mutate both itself (e.g., to store errors) and the expression it is
+/// visiting.
+pub trait ExprVisitor {
+    /// Visit an identifier (column name). Must return `Err` if the
+    /// identifier is not allowed
+    fn visit_ident(&mut self, ident: &mut p::Ident) -> Result<(), ()>;
+    /// Visit a function name. Must return `Err` if the function is not
+    /// allowed
+    fn visit_func_name(&mut self, func: &mut p::Ident) -> Result<(), ()>;
+    /// Called when we encounter a construct that is not supported like a
+    /// subquery
+    fn not_supported(&mut self, msg: String);
+    /// Called if the SQL expression we are visiting has SQL syntax errors
+    fn parse_error(&mut self, e: sqlparser::parser::ParserError);
+}
+
+pub struct VisitExpr<'a> {
+    visitor: Box<&'a mut dyn ExprVisitor>,
+}
+
+impl<'a> VisitExpr<'a> {
+    fn nope(&mut self, construct: &str) -> Result<(), ()> {
+        self.not_supported(format!("Expressions using {construct} are not supported"))
+    }
+
+    fn illegal_function(&mut self, msg: String) -> Result<(), ()> {
+        self.not_supported(format!("Illegal function: {msg}"))
+    }
+
+    fn not_supported(&mut self, msg: String) -> Result<(), ()> {
+        self.visitor.not_supported(msg);
+        Err(())
+    }
+
+    /// Parse `sql` into an expression and traverse it, calling back into
+    /// `visitor` at the appropriate places. Return the parsed expression,
+    /// which might have been changed by the visitor, on success. On error,
+    /// return `Err(())`. The visitor will know the details of the error
+    /// since this can only happen if `visit_ident` or `visit_func_name`
+    /// returned an error, or `parse_error` or `not_supported` was called.
+    pub fn visit(sql: &str, visitor: &'a mut dyn ExprVisitor) -> Result<p::Expr, ()> {
+        let dialect = PostgreSqlDialect {};
+
+        let mut parser = SqlParser::new(&dialect);
+        let tokens = Tokenizer::new(&dialect, sql)
+            .with_unescape(true)
+            .tokenize_with_location()
+            .unwrap();
+        parser = parser.with_tokens_with_locations(tokens);
+        let mut visit = VisitExpr {
+            visitor: Box::new(visitor),
+        };
+        let mut expr = match parser.parse_expr() {
+            Ok(expr) => expr,
+            Err(e) => {
+                visitor.parse_error(e);
+                return Err(());
+            }
+        };
+        visit.visit_expr(&mut expr).map(|()| expr)
+    }
+
+    fn visit_expr(&mut self, expr: &mut p::Expr) -> Result<(), ()> {
+        use p::Expr::*;
+
+        match expr {
+            Identifier(ident) => self.visitor.visit_ident(ident),
+            BinaryOp { left, op, right } => {
+                self.check_binary_op(op)?;
+                self.visit_expr(left)?;
+                self.visit_expr(right)?;
+                Ok(())
+            }
+            UnaryOp { op, expr } => {
+                self.check_unary_op(op)?;
+                self.visit_expr(expr)?;
+                Ok(())
+            }
+            Function(func) => self.visit_func(func),
+            Value(_) => Ok(()),
+            CompoundIdentifier(_) => self.nope("CompoundIdentifier"),
+            JsonAccess { .. } => self.nope("JsonAccess"),
+            CompositeAccess { .. } => self.nope("CompositeAccess"),
+            IsFalse(_) => self.nope("IsFalse"),
+            IsNotFalse(_) => self.nope("IsNotFalse"),
+            IsTrue(_) => self.nope("IsTrue"),
+            IsNotTrue(_) => self.nope("IsNotTrue"),
+            IsNull(_) => self.nope("IsNull"),
+            IsNotNull(_) => self.nope("IsNotNull"),
+            IsUnknown(_) => self.nope("IsUnknown"),
+            IsNotUnknown(_) => self.nope("IsNotUnknown"),
+            IsDistinctFrom(_, _) => self.nope("IsDistinctFrom"),
+            IsNotDistinctFrom(_, _) => self.nope("IsNotDistinctFrom"),
+            InList { .. } => self.nope("InList"),
+            InSubquery { .. } => self.nope("InSubquery"),
+            InUnnest { .. } => self.nope("InUnnest"),
+            Between { .. } => self.nope("Between"),
+            Like { .. } => self.nope("Like"),
+            ILike { .. } => self.nope("ILike"),
+            SimilarTo { .. } => self.nope("SimilarTo"),
+            RLike { .. } => self.nope("RLike"),
+            AnyOp { .. } => self.nope("AnyOp"),
+            AllOp { .. } => self.nope("AllOp"),
+            Convert { .. } => self.nope("Convert"),
+            Cast { .. } => self.nope("Cast"),
+            TryCast { .. } => self.nope("TryCast"),
+            SafeCast { .. } => self.nope("SafeCast"),
+            AtTimeZone { .. } => self.nope("AtTimeZone"),
+            Extract { .. } => self.nope("Extract"),
+            Ceil { .. } => self.nope("Ceil"),
+            Floor { .. } => self.nope("Floor"),
+            Position { .. } => self.nope("Position"),
+            Substring { .. } => self.nope("Substring"),
+            Trim { .. } => self.nope("Trim"),
+            Overlay { .. } => self.nope("Overlay"),
+            Collate { .. } => self.nope("Collate"),
+            Nested(_) => self.nope("Nested"),
+            IntroducedString { .. } => self.nope("IntroducedString"),
+            TypedString { .. } => self.nope("TypedString"),
+            MapAccess { .. } => self.nope("MapAccess"),
+            AggregateExpressionWithFilter { .. } => self.nope("AggregateExpressionWithFilter"),
+            Case { .. } => self.nope("Case"),
+            Exists { .. } => self.nope("Exists"),
+            Subquery(_) => self.nope("Subquery"),
+            ArraySubquery(_) => self.nope("ArraySubquery"),
+            ListAgg(_) => self.nope("ListAgg"),
+            ArrayAgg(_) => self.nope("ArrayAgg"),
+            GroupingSets(_) => self.nope("GroupingSets"),
+            Cube(_) => self.nope("Cube"),
+            Rollup(_) => self.nope("Rollup"),
+            Tuple(_) => self.nope("Tuple"),
+            Struct { .. } => self.nope("Struct"),
+            Named { .. } => self.nope("Named"),
+            ArrayIndex { .. } => self.nope("ArrayIndex"),
+            Array(_) => self.nope("Array"),
+            Interval(_) => self.nope("Interval"),
+            MatchAgainst { .. } => self.nope("MatchAgainst"),
+            Wildcard => self.nope("Wildcard"),
+            QualifiedWildcard(_) => self.nope("QualifiedWildcard"),
+        }
+    }
+
+    fn visit_func(&mut self, func: &mut p::Function) -> Result<(), ()> {
+        let p::Function {
+            name,
+            args: pargs,
+            filter,
+            null_treatment,
+            over,
+            distinct: _,
+            special: _,
+            order_by,
+        } = func;
+
+        if filter.is_some() || null_treatment.is_some() || over.is_some() || !order_by.is_empty() {
+            return self.illegal_function(format!("call to {name} uses an illegal feature"));
+        }
+
+        let idents = &mut name.0;
+        if idents.len() != 1 {
+            return self.illegal_function(format!(
+                "function name {name} uses a qualified name with '.'"
+            ));
+        }
+        self.visitor.visit_func_name(&mut idents[0])?;
+        for arg in pargs {
+            use p::FunctionArg::*;
+            match arg {
+                Named { .. } => {
+                    return self.illegal_function(format!("call to {name} uses a named argument"));
+                }
+                Unnamed(arg) => match arg {
+                    p::FunctionArgExpr::Expr(expr) => {
+                        self.visit_expr(expr)?;
+                    }
+                    p::FunctionArgExpr::QualifiedWildcard(_) | p::FunctionArgExpr::Wildcard => {
+                        return self
+                            .illegal_function(format!("call to {name} uses a wildcard argument"));
+                    }
+                },
+            };
+        }
+        Ok(())
+    }
+
+    fn check_binary_op(&mut self, op: &p::BinaryOperator) -> Result<(), ()> {
+        use p::BinaryOperator::*;
+        match op {
+            Plus | Minus | Multiply | Divide | Modulo => Ok(()),
+            StringConcat
+            | Gt
+            | Lt
+            | GtEq
+            | LtEq
+            | Spaceship
+            | Eq
+            | NotEq
+            | And
+            | Or
+            | Xor
+            | BitwiseOr
+            | BitwiseAnd
+            | BitwiseXor
+            | DuckIntegerDivide
+            | MyIntegerDivide
+            | Custom(_)
+            | PGBitwiseXor
+            | PGBitwiseShiftLeft
+            | PGBitwiseShiftRight
+            | PGExp
+            | PGOverlap
+            | PGRegexMatch
+            | PGRegexIMatch
+            | PGRegexNotMatch
+            | PGRegexNotIMatch
+            | PGLikeMatch
+            | PGILikeMatch
+            | PGNotLikeMatch
+            | PGNotILikeMatch
+            | PGStartsWith
+            | PGCustomBinaryOperator(_) => {
+                self.not_supported(format!("binary operator {op} is not supported"))
+            }
+        }
+    }
+
+    fn check_unary_op(&mut self, op: &p::UnaryOperator) -> Result<(), ()> {
+        use p::UnaryOperator::*;
+        match op {
+            Plus | Minus => Ok(()),
+            Not | PGBitwiseNot | PGSquareRoot | PGCubeRoot | PGPostfixFactorial
+            | PGPrefixFactorial | PGAbs => {
+                self.not_supported(format!("unary operator {op} is not supported"))
+            }
+        }
+    }
+}
+
+/// An `ExprVisitor` that validates an expression
+struct Validator<F> {
+    check_ident: F,
+    errors: Vec<SchemaValidationError>,
+}
+
+const FN_WHITELIST: [&'static str; 14] = [
+    // Clearly deterministic functions from
+    // https://www.postgresql.org/docs/current/functions-math.html, Table
+    // 9.5. We could also add trig functions (Table 9.7 and 9.8), but under
+    // no circumstances random functions from Table 9.6
+    "abs", "ceil", "ceiling", "div", "floor", "gcd", "lcm", "mod", "power", "sign",
+    // Conditional functions from
+    // https://www.postgresql.org/docs/current/functions-conditional.html.
+    "coalesce", "nullif", "greatest", "least",
+];
+
+impl<F: CheckIdentFn> ExprVisitor for Validator<F> {
+    fn visit_ident(&mut self, ident: &mut p::Ident) -> Result<(), ()> {
+        match (self.check_ident)(&ident.value) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                self.errors.push(e);
+                Err(())
+            }
+        }
+    }
+
+    fn visit_func_name(&mut self, func: &mut p::Ident) -> Result<(), ()> {
+        let p::Ident { value, quote_style } = &func;
+        let whitelisted = match quote_style {
+            Some(_) => FN_WHITELIST.contains(&value.as_str()),
+            None => FN_WHITELIST
+                .iter()
+                .any(|name| name.eq_ignore_ascii_case(value)),
+        };
+        if whitelisted {
+            Ok(())
+        } else {
+            self.not_supported(format!("Function {func} is not supported"));
+            Err(())
+        }
+    }
+
+    fn not_supported(&mut self, msg: String) {
+        self.errors
+            .push(SchemaValidationError::ExprNotSupported(msg));
+    }
+
+    fn parse_error(&mut self, e: ParserError) {
+        self.errors
+            .push(SchemaValidationError::ExprParseError(e.to_string()));
+    }
+}

--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -29,6 +29,7 @@ pub use api::{ApiSchema, ErrorPolicy};
 pub use entity_key::EntityKey;
 pub use entity_type::{AsEntityTypeName, EntityType};
 pub use fulltext::{FulltextAlgorithm, FulltextConfig, FulltextDefinition, FulltextLanguage};
+pub use input::sqlexpr::{ExprVisitor, VisitExpr};
 pub(crate) use input::POI_OBJECT;
 pub use input::{
     kw, Aggregate, AggregateFn, Aggregation, AggregationInterval, AggregationMapping, Field,
@@ -180,6 +181,12 @@ pub enum SchemaValidationError {
     AggregationsNotSupported(Version),
     #[error("Using Int8 as the type for the `id` field is not supported with spec version {0}; please migrate the subgraph to the latest version")]
     IdTypeInt8NotSupported(Version),
+    #[error("{0}")]
+    ExprNotSupported(String),
+    #[error("Expressions can't us the function {0}")]
+    ExprIllegalFunction(String),
+    #[error("Failed to parse expression: {0}")]
+    ExprParseError(String),
 }
 
 /// A validated and preprocessed GraphQL schema for a subgraph.

--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -21,7 +21,7 @@ pub mod ast;
 mod entity_key;
 mod entity_type;
 mod fulltext;
-mod input_schema;
+mod input;
 
 pub use api::{is_introspection_field, APISchemaError, INTROSPECTION_QUERY_TYPE};
 
@@ -29,7 +29,8 @@ pub use api::{ApiSchema, ErrorPolicy};
 pub use entity_key::EntityKey;
 pub use entity_type::{AsEntityTypeName, EntityType};
 pub use fulltext::{FulltextAlgorithm, FulltextConfig, FulltextDefinition, FulltextLanguage};
-pub use input_schema::{
+pub(crate) use input::POI_OBJECT;
+pub use input::{
     kw, Aggregate, AggregateFn, Aggregation, AggregationInterval, AggregationMapping, Field,
     InputSchema, InterfaceType, ObjectOrInterface, ObjectType, TypeKind,
 };

--- a/graph/src/schema/test_schemas/ts_expr_random.graphql
+++ b/graph/src/schema/test_schemas/ts_expr_random.graphql
@@ -1,0 +1,14 @@
+# fail: ExprNotSupported("Function random is not supported")
+# Random must not be allowed as it would introduce nondeterministic behavior
+type Data @entity(timeseries: true) {
+  id: Int8!
+  timestamp: Int8!
+  price0: BigDecimal!
+  price1: BigDecimal!
+}
+
+type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
+  id: Int8!
+  timestamp: Int8!
+  max_price: BigDecimal! @aggregate(fn: "max", arg: "random()")
+}

--- a/graph/src/schema/test_schemas/ts_expr_simple.graphql
+++ b/graph/src/schema/test_schemas/ts_expr_simple.graphql
@@ -14,4 +14,12 @@ type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   price0_sq: BigDecimal! @aggregate(fn: "sum", arg: "power(price0, 2)")
   sum_sq: BigDecimal! @aggregate(fn: "sum", arg: "price0 * price0")
   sum_sq_cross: BigDecimal! @aggregate(fn: "sum", arg: "price0 * price1")
+
+  max_some: BigDecimal!
+    @aggregate(
+      fn: "max"
+      arg: "case when price0 > price1 then price0 else 0 end"
+    )
+
+  max_cast: BigDecimal! @aggregate(fn: "sum", arg: "(price0/7)::int4")
 }

--- a/graph/src/schema/test_schemas/ts_expr_simple.graphql
+++ b/graph/src/schema/test_schemas/ts_expr_simple.graphql
@@ -1,0 +1,17 @@
+# valid: Minimal example
+type Data @entity(timeseries: true) {
+  id: Int8!
+  timestamp: Int8!
+  price0: BigDecimal!
+  price1: BigDecimal!
+}
+
+type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
+  id: Int8!
+  timestamp: Int8!
+  max_price: BigDecimal! @aggregate(fn: "max", arg: "greatest(price0, price1)")
+  abs_price: BigDecimal! @aggregate(fn: "sum", arg: "abs(price0) + abs(price1)")
+  price0_sq: BigDecimal! @aggregate(fn: "sum", arg: "power(price0, 2)")
+  sum_sq: BigDecimal! @aggregate(fn: "sum", arg: "price0 * price0")
+  sum_sq_cross: BigDecimal! @aggregate(fn: "sum", arg: "price0 * price1")
+}

--- a/graph/src/schema/test_schemas/ts_expr_syntax_err.graphql
+++ b/graph/src/schema/test_schemas/ts_expr_syntax_err.graphql
@@ -1,0 +1,13 @@
+# fail: ExprParseError("sql parser error: Expected an expression:, found: EOF")
+type Data @entity(timeseries: true) {
+  id: Int8!
+  timestamp: Int8!
+  price0: BigDecimal!
+  price1: BigDecimal!
+}
+
+type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
+  id: Int8!
+  timestamp: Int8!
+  max_price: BigDecimal! @aggregate(fn: "max", arg: "greatest(price0,")
+}

--- a/store/postgres/src/relational/rollup.rs
+++ b/store/postgres/src/relational/rollup.rs
@@ -82,7 +82,7 @@ impl<'a> Agg<'a> {
         src_table: &'a Table,
         agg_table: &'a Table,
     ) -> Result<Self, StoreError> {
-        let src_column = src_table.column_for_field(&aggregate.arg.name)?;
+        let src_column = src_table.column_for_field(&aggregate.arg)?;
         let agg_column = agg_table.column_for_field(&aggregate.name)?;
         Ok(Self {
             aggregate,


### PR DESCRIPTION
It is now possible to use a restricted subset of SQL expressions in the `arg` of `@aggregate` annotations. Some examples of what's possible now:

* `@aggregate(fn: "sum", arg: "price * amount")`
*  `@aggregate(fn: "max", arg: "greatest(amount0, amount1)")`
* even conditional aggregations like `@aggregate(fn: "sum", arg: "case when amount0 > amount1 then amount0 else 0 end")`

This will help reduce the values that a timeseries needs to store; without this addition, all of the above would have required that mappings calculate these expressions and store them in a separate field in the timeseries.