### PR TITLE
Make batching conditional on caught-up status

### DIFF
--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -451,15 +451,12 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             stream: block_stream_metrics,
         };
 
-        let is_deployment_synced = inputs.store.is_deployment_synced().await?;
-
         Ok(SubgraphRunner::new(
             inputs,
             ctx,
             logger.cheap_clone(),
             metrics,
             env_vars,
-            is_deployment_synced,
         ))
     }
 

--- a/core/src/subgraph/state.rs
+++ b/core/src/subgraph/state.rs
@@ -6,8 +6,6 @@ use std::time::Instant;
 pub struct IndexingState {
     /// `true` -> `false` on the first run
     pub should_try_unfail_non_deterministic: bool,
-    /// `false` -> `true` once it reaches chain head
-    pub synced: bool,
     /// Backoff used for the retry mechanism on non-deterministic errors
     pub backoff: ExponentialBackoff,
     /// Related to field above `backoff`

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -338,16 +338,15 @@ pub trait WritableStore: ReadStore + DeploymentCursorTracker {
         deterministic_errors: Vec<SubgraphError>,
         offchain_to_remove: Vec<StoredDynamicDataSource>,
         is_non_fatal_errors_active: bool,
+        is_caught_up_with_chain_head: bool,
     ) -> Result<(), StoreError>;
 
-    /// The deployment `id` finished syncing, mark it as synced in the database
-    /// and promote it to the current version in the subgraphs where it was the
-    /// pending version so far
+    /// Force synced status, used for testing.
     fn deployment_synced(&self) -> Result<(), StoreError>;
 
-    /// Return true if the deployment with the given id is fully synced,
-    /// and return false otherwise. Errors from the store are passed back up
-    async fn is_deployment_synced(&self) -> Result<bool, StoreError>;
+    /// Return true if the deployment with the given id is fully synced, and return false otherwise.
+    /// Cheap, cached operation.
+    fn is_deployment_synced(&self) -> bool;
 
     fn unassign_subgraph(&self) -> Result<(), StoreError>;
 

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -299,6 +299,7 @@ pub async fn transact_errors(
             errs,
             Vec::new(),
             is_non_fatal_errors_active,
+            false,
         )
         .await?;
     flush(deployment).await
@@ -380,6 +381,7 @@ pub async fn transact_entities_and_dynamic_data_sources(
             data_sources,
             Vec::new(),
             Vec::new(),
+            false,
             false,
         )
         .await

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -136,11 +136,12 @@ impl WritableStore for MockStore {
         _: Vec<SubgraphError>,
         _: Vec<StoredDynamicDataSource>,
         _: bool,
+        _: bool,
     ) -> Result<(), StoreError> {
         unimplemented!()
     }
 
-    async fn is_deployment_synced(&self) -> Result<bool, StoreError> {
+    fn is_deployment_synced(&self) -> bool {
         unimplemented!()
     }
 

--- a/store/test-store/tests/postgres/aggregation.rs
+++ b/store/test-store/tests/postgres/aggregation.rs
@@ -108,6 +108,7 @@ pub async fn insert(
             Vec::new(),
             Vec::new(),
             false,
+            false,
         )
         .await
 }

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -1544,6 +1544,7 @@ fn handle_large_string_with_index() {
                 Vec::new(),
                 Vec::new(),
                 false,
+                false,
             )
             .await
             .expect("Failed to insert large text");
@@ -1646,6 +1647,7 @@ fn handle_large_bytea_with_index() {
                 Vec::new(),
                 Vec::new(),
                 Vec::new(),
+                false,
                 false,
             )
             .await


### PR DESCRIPTION
This takes a different approach to PR https://github.com/graphprotocol/graph-node/pull/5198. Importantly, it will properly disable batching if the subgraph is caught up with the chain, regardless of the 'synced' flag status, fixing a regression.

It separates the related concepts of synced and caught-up, and moves handling that into transact_block_operations`. This nicely allows us to resume batching once caught up.